### PR TITLE
Remove enable tracing and metrics config from Stackdriver exporter

### DIFF
--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -20,8 +20,6 @@ import "github.com/open-telemetry/opentelemetry-service/config/configmodels"
 type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	ProjectID                     string                   `mapstructure:"project"`
-	EnableTracing                 bool                     `mapstructure:"enable-tracing"`
-	EnableMetrics                 bool                     `mapstructure:"enable-metrics"`
 	Prefix                        string                   `mapstructure:"metric-prefix"`
 	Endpoint                      string                   `mapstructure:"endpoint"`
 	NumOfWorkers                  int                      `mapstructure:"number-of-workers"`

--- a/exporter/stackdriverexporter/config_test.go
+++ b/exporter/stackdriverexporter/config_test.go
@@ -48,8 +48,6 @@ func TestLoadConfig(t *testing.T) {
 		&Config{
 			ExporterSettings: configmodels.ExporterSettings{TypeVal: typeStr, NameVal: "stackdriver/customname"},
 			ProjectID:        "my-project",
-			EnableTracing:    true,
-			EnableMetrics:    true,
 			Prefix:           "prefix",
 			Endpoint:         "test-endpoint",
 		})

--- a/exporter/stackdriverexporter/factory.go
+++ b/exporter/stackdriverexporter/factory.go
@@ -48,17 +48,11 @@ func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
 // CreateTraceExporter creates a trace exporter based on this config.
 func (f *Factory) CreateTraceExporter(logger *zap.Logger, cfg configmodels.Exporter) (exporter.TraceExporter, error) {
 	eCfg := cfg.(*Config)
-	if !eCfg.EnableTracing {
-		return nil, nil
-	}
 	return newStackdriverTraceExporter(eCfg)
 }
 
 // CreateMetricsExporter creates a metrics exporter based on this config.
 func (f *Factory) CreateMetricsExporter(logger *zap.Logger, cfg configmodels.Exporter) (exporter.MetricsExporter, error) {
 	eCfg := cfg.(*Config)
-	if !eCfg.EnableMetrics {
-		return nil, nil
-	}
 	return newStackdriverMetricsExporter(eCfg)
 }

--- a/exporter/stackdriverexporter/factory_test.go
+++ b/exporter/stackdriverexporter/factory_test.go
@@ -30,10 +30,14 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateExporter(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
+	eCfg := cfg.(*Config)
+	eCfg.ProjectID = "test"
 
-	_, err := factory.CreateTraceExporter(zap.NewNop(), cfg)
+	te, err := factory.CreateTraceExporter(zap.NewNop(), eCfg)
 	assert.Nil(t, err)
+	assert.NotNil(t, te, "failed to create trace exporter")
 
-	_, err = factory.CreateMetricsExporter(zap.NewNop(), cfg)
+	me, err := factory.CreateMetricsExporter(zap.NewNop(), eCfg)
 	assert.Nil(t, err)
+	assert.NotNil(t, me, "failed to create metrics exporter")
 }

--- a/exporter/stackdriverexporter/factory_test.go
+++ b/exporter/stackdriverexporter/factory_test.go
@@ -15,6 +15,7 @@
 package stackdriverexporter
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,9 @@ func TestCreateDefaultConfig(t *testing.T) {
 }
 
 func TestCreateExporter(t *testing.T) {
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" {
+		t.Skip("Default credentials not set, skip creating Stackdriver exporter")
+	}
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	eCfg := cfg.(*Config)

--- a/exporter/stackdriverexporter/testdata/config.yaml
+++ b/exporter/stackdriverexporter/testdata/config.yaml
@@ -8,8 +8,6 @@ exporters:
   stackdriver:
   stackdriver/customname:
     project: my-project
-    enable-tracing: true
-    enable-metrics: true
     metric-prefix: prefix
     endpoint: test-endpoint
   stackdriver/disabled: # will be ignored


### PR DESCRIPTION
These two configs are unnecessary. They can be inferred from the
type of pipeline of Stackdriver exporter.