### PR TITLE
Update OTelCol package

### DIFF
--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -20,8 +20,8 @@ import "github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	ProjectID                     string                   `mapstructure:"project"`
-	Prefix                        string                   `mapstructure:"metric-prefix"`
+	Prefix                        string                   `mapstructure:"metric_prefix"`
 	Endpoint                      string                   `mapstructure:"endpoint"`
-	NumOfWorkers                  int                      `mapstructure:"number-of-workers"`
-	SkipCreateMetricDescriptor    bool                     `mapstructure:"skip-create-metric-descriptor"`
+	NumOfWorkers                  int                      `mapstructure:"number_of_workers"`
+	SkipCreateMetricDescriptor    bool                     `mapstructure:"skip_create_metric_descriptor"`
 }

--- a/exporter/stackdriverexporter/factory_test.go
+++ b/exporter/stackdriverexporter/factory_test.go
@@ -20,12 +20,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 func TestCreateExporter(t *testing.T) {

--- a/exporter/stackdriverexporter/go.mod
+++ b/exporter/stackdriverexporter/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	// TODO: pin a released version
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8-0.20190917133925-4339afab4a99
-	github.com/open-telemetry/opentelemetry-collector v0.2.0
+	github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191016224815-dfabfb0c1d1e
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.10.0
 	google.golang.org/api v0.10.0

--- a/exporter/stackdriverexporter/go.sum
+++ b/exporter/stackdriverexporter/go.sum
@@ -329,6 +329,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/open-telemetry/opentelemetry-collector v0.2.0 h1:38/NrGdEEXufWqYFkW/6yeW3koRvb1QbE/2owKSNQvI=
 github.com/open-telemetry/opentelemetry-collector v0.2.0/go.mod h1:zZf9V+57o0Fd3ik5HzaHamVsWhudJTOwnKw9kJvWoDo=
+github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191016224815-dfabfb0c1d1e h1:poxNKN8teT8QjLK6LwKN52cNQEPqHIOEsmPJv5ssZUU=
+github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191016224815-dfabfb0c1d1e/go.mod h1:zZf9V+57o0Fd3ik5HzaHamVsWhudJTOwnKw9kJvWoDo=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=

--- a/exporter/stackdriverexporter/testdata/config.yaml
+++ b/exporter/stackdriverexporter/testdata/config.yaml
@@ -8,10 +8,10 @@ exporters:
   stackdriver:
   stackdriver/customname:
     project: my-project
-    metric-prefix: prefix
+    metric_prefix: prefix
     endpoint: test-endpoint
-    number-of-workers: 3
-    skip-create-metric-descriptor: true
+    number_of_workers: 3
+    skip_create_metric_descriptor: true
   stackdriver/disabled: # will be ignored
     disabled: true
 

--- a/receiver/zipkinscribereceiver/factory_test.go
+++ b/receiver/zipkinscribereceiver/factory_test.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"github.com/stretchr/testify/assert"
-
+	"github.com/open-telemetry/opentelemetry-collector/config/configcheck"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 )
@@ -30,6 +30,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := &Factory{}
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
+	assert.NoError(t, configcheck.ValidateConfig(cfg))
 }
 
 type mockTraceConsumer struct {

--- a/receiver/zipkinscribereceiver/go.mod
+++ b/receiver/zipkinscribereceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/jaegertracing/jaeger v1.14.0
 	github.com/omnition/scribe-go v1.0.0
-	github.com/open-telemetry/opentelemetry-collector v0.2.0
+	github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191016224815-dfabfb0c1d1e
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.10.0
 )

--- a/receiver/zipkinscribereceiver/go.sum
+++ b/receiver/zipkinscribereceiver/go.sum
@@ -322,6 +322,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/open-telemetry/opentelemetry-collector v0.2.0 h1:38/NrGdEEXufWqYFkW/6yeW3koRvb1QbE/2owKSNQvI=
 github.com/open-telemetry/opentelemetry-collector v0.2.0/go.mod h1:zZf9V+57o0Fd3ik5HzaHamVsWhudJTOwnKw9kJvWoDo=
+github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191016224815-dfabfb0c1d1e h1:poxNKN8teT8QjLK6LwKN52cNQEPqHIOEsmPJv5ssZUU=
+github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191016224815-dfabfb0c1d1e/go.mod h1:zZf9V+57o0Fd3ik5HzaHamVsWhudJTOwnKw9kJvWoDo=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/receiver/zipkinscribereceiver/receiver_test.go
+++ b/receiver/zipkinscribereceiver/receiver_test.go
@@ -77,7 +77,7 @@ func TestNewReceiver(t *testing.T) {
 
 func TestBadEncodedMessage(t *testing.T) {
 	sink := &mockTraceSink{}
-	traceReceiver, err := New(":0", "zipkin", sink)
+	traceReceiver, err := New("localhost:0", "zipkin", sink)
 	if err != nil {
 		t.Fatalf("Failed to create receiver: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestBadEncodedMessage(t *testing.T) {
 
 func TestNonEqualCategoryIsIgnored(t *testing.T) {
 	sink := &mockTraceSink{}
-	traceReceiver, err := New(":0", "not-zipkin", sink)
+	traceReceiver, err := New("localhost:0", "not-zipkin", sink)
 	if err != nil {
 		t.Fatalf("Failed to create receiver: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestNonEqualCategoryIsIgnored(t *testing.T) {
 }
 
 func TestScribeReceiverPortAlreadyInUse(t *testing.T) {
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed to open a port: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestScribeReceiverPortAlreadyInUse(t *testing.T) {
 }
 
 func TestScribeReceiverServer(t *testing.T) {
-	const endpoint = ":9410"
+	const endpoint = "localhost:9410"
 
 	messages := []*scribe.LogEntry{
 		{


### PR DESCRIPTION
Making this update requires to change the tags used in StackDriver config, since per enforcement from OTelCol all need to be using underscores instead of dashes. Opportunistic fix: avoided pop-ups on mac during tests for zipkinscribereceiver package.