### PR TITLE
Replace 'service' by 'collector' on go.mod files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# opentelemetry-service-contrib
-Contrib repository for OpenTelemetry Service
+# opentelemetry-collector-contrib
+Repository for OpenTelemetry Collector contributions that are not part of the
+core repository and distribution of the Collector.

--- a/exporter/stackdriverexporter/go.mod
+++ b/exporter/stackdriverexporter/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-service-contrib/exporter/stackdriverexporter
+module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stackdriverexporter
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-service-contrib/exporter
+module github.com/open-telemetry/opentelemetry-collector-contrib
 
 go 1.12
 

--- a/receiver/zipkinscribereceiver/go.mod
+++ b/receiver/zipkinscribereceiver/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-service-contrib/receiver/zipkinscribereceiver
+module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinscribereceiver
 
 go 1.12
 


### PR DESCRIPTION
This is needed to have the import paths using collector instead of service. Opportunistic fix: similar update to README.md.