### PR TITLE
Organize make files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,5 @@
-# More exclusions can be added similar with: -not -path './testbed/*'
-ALL_SRC := $(shell find . -name '*.go' \
-                                -not -path './testbed/*' \
-                                -type f | sort)
+include ./Makefile.Common
 
-# All source code and documents. Used in spell check.
-ALL_SRC_AND_DOC := $(shell find . \( -name "*.md" -o -name "*.go" -o -name "*.yaml" \) \
-                                -type f | sort)
-
-# ALL_PKGS is used with 'go cover'
-ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
-
-GOTEST_OPT?= -race -timeout 30s
-GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
-GOTEST=go test
-GOFMT=gofmt
-GOIMPORTS=goimports
-GOLINT=golint
-GOVET=go vet
-GOOS=$(shell go env GOOS)
-ADDLICENCESE= addlicense
-MISSPELL=misspell -error
-MISSPELL_CORRECTION=misspell -w
-STATICCHECK=staticcheck
-IMPI=impi
 RUN_CONFIG=local/config.yaml
 
 GIT_SHA=$(shell git rev-parse --short HEAD)
@@ -33,24 +10,10 @@ BUILD_X2=-X $(BUILD_INFO_IMPORT_PATH).Version=$(VERSION)
 endif
 BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2}"
 
-all-pkgs:
-	@echo $(ALL_PKGS) | tr ' ' '\n' | sort
-
-all-srcs:
-	@echo $(ALL_SRC) | tr ' ' '\n' | sort
-
 .DEFAULT_GOAL := all
 
 .PHONY: all
-all: addlicense fmt impi vet lint goimports misspell staticcheck test otelcontribcol
-
-.PHONY: test
-test:
-	$(GOTEST) $(GOTEST_OPT) $(ALL_PKGS)
-
-.PHONY: benchmark
-benchmark:
-	$(GOTEST) -bench=. -run=notests $(ALL_PKGS)
+all: common otelcontribcol
 
 .PHONY: ci
 ci: all test-with-cover
@@ -63,71 +26,6 @@ test-with-cover:
 	go test -i $(ALL_PKGS)
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(ALL_PKGS)
 	go tool cover -html=coverage.txt -o coverage.html
-
-.PHONY: addlicense
-addlicense:
-	@ADDLICENCESEOUT=`$(ADDLICENCESE) -y 2019 -c 'OpenTelemetry Authors' $(ALL_SRC) 2>&1`; \
-		if [ "$$ADDLICENCESEOUT" ]; then \
-			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
-			echo "$$ADDLICENCESEOUT\n"; \
-			exit 1; \
-		else \
-			echo "Add License finished successfully"; \
-		fi
-
-.PHONY: fmt
-fmt:
-	@FMTOUT=`$(GOFMT) -s -l $(ALL_SRC) 2>&1`; \
-	if [ "$$FMTOUT" ]; then \
-		echo "$(GOFMT) FAILED => gofmt the following files:\n"; \
-		echo "$$FMTOUT\n"; \
-		exit 1; \
-	else \
-	    echo "Fmt finished successfully"; \
-	fi
-
-.PHONY: lint
-lint:
-	@LINTOUT=`$(GOLINT) $(ALL_PKGS) 2>&1`; \
-	if [ "$$LINTOUT" ]; then \
-		echo "$(GOLINT) FAILED => clean the following lint errors:\n"; \
-		echo "$$LINTOUT\n"; \
-		exit 1; \
-	else \
-	    echo "Lint finished successfully"; \
-	fi
-
-.PHONY: goimports
-goimports:
-	@IMPORTSOUT=`$(GOIMPORTS) -local github.com/open-telemetry/opentelemetry-collector-contrib -d . 2>&1`; \
-	if [ "$$IMPORTSOUT" ]; then \
-		echo "$(GOIMPORTS) FAILED => fix the following goimports errors:\n"; \
-		echo "$$IMPORTSOUT\n"; \
-		exit 1; \
-	else \
-	    echo "Goimports finished successfully"; \
-	fi
-
-.PHONY: misspell
-misspell:
-	$(MISSPELL) $(ALL_SRC_AND_DOC)
-
-.PHONY: misspell-correction
-misspell-correction:
-	$(MISSPELL_CORRECTION) $(ALL_SRC_AND_DOC)
-
-.PHONY: staticcheck
-staticcheck:
-	$(STATICCHECK) ./...
-
-.PHONY: vet
-vet:
-	@$(GOVET) ./...
-	@echo "Vet finished successfully"
-
-.PHONY: impi
-impi:
-	@$(IMPI) --local github.com/open-telemetry/opentelemetry-collector-contrib --scheme stdThirdPartyLocal ./...
 
 .PHONY: install-tools
 install-tools:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -1,11 +1,8 @@
-# More exclusions can be added similar with: -not -path './vendor/*'
 ALL_SRC := $(shell find . -name '*.go' \
-                                -not -path './vendor/*' \
                                 -type f | sort)
 
 # All source code and documents. Used in spell check.
 ALL_SRC_AND_DOC := $(shell find . \( -name "*.md" -o -name "*.go" -o -name "*.yaml" \) \
-                                -not -path './vendor/*' \
                                 -type f | sort)
 
 # ALL_PKGS is used with 'go cover'
@@ -23,6 +20,7 @@ ADDLICENCESE= addlicense
 MISSPELL=misspell -error
 MISSPELL_CORRECTION=misspell -w
 STATICCHECK=staticcheck
+IMPI=impi
 
 all-pkgs:
 	@echo $(ALL_PKGS) | tr ' ' '\n' | sort
@@ -30,14 +28,18 @@ all-pkgs:
 all-srcs:
 	@echo $(ALL_SRC) | tr ' ' '\n' | sort
 
-.DEFAULT_GOAL := addlicense-fmt-vet-lint-goimports-misspell-staticcheck-test
+.DEFAULT_GOAL := common
 
-.PHONY: addlicense-fmt-vet-lint-goimports-misspell-staticcheck-test
-addlicense-fmt-vet-lint-goimports-misspell-staticcheck-test: addlicense fmt vet lint goimports misspell staticcheck test
+.PHONY: common
+common: addlicense fmt impi vet lint goimports misspell staticcheck test
 
 .PHONY: test
 test:
 	$(GOTEST) $(GOTEST_OPT) $(ALL_PKGS)
+
+.PHONY: benchmark
+benchmark:
+	$(GOTEST) -bench=. -run=notests $(ALL_PKGS)
 
 .PHONY: addlicense
 addlicense:
@@ -74,7 +76,7 @@ lint:
 
 .PHONY: goimports
 goimports:
-	@IMPORTSOUT=`$(GOIMPORTS) -d . 2>&1`; \
+	@IMPORTSOUT=`$(GOIMPORTS) -local github.com/open-telemetry/opentelemetry-collector-contrib -d . 2>&1`; \
 	if [ "$$IMPORTSOUT" ]; then \
 		echo "$(GOIMPORTS) FAILED => fix the following goimports errors:\n"; \
 		echo "$$IMPORTSOUT\n"; \
@@ -99,3 +101,7 @@ staticcheck:
 vet:
 	@$(GOVET) ./...
 	@echo "Vet finished successfully"
+
+.PHONY: impi
+impi:
+	@$(IMPI) --local github.com/open-telemetry/opentelemetry-collector-contrib --scheme stdThirdPartyLocal ./...

--- a/receiver/collectdreceiver/collectd.go
+++ b/receiver/collectdreceiver/collectd.go
@@ -234,9 +234,7 @@ func labelsFromName(val *string) (instanceName string, toAddDims map[string]stri
 				}
 				piece := dimensions[prev:cindex]
 				tindex := strings.Index(piece, "=")
-				//lint:ignore S1004 staticcheck wants us to use strings.Contains instead of Index but we need to use
-				// the index later in the function in addition to checking for existence of char.
-				if tindex == -1 || strings.Index(piece[tindex+1:], "=") > -1 {
+				if tindex == -1 || strings.Contains(piece[tindex+1:], "=") {
 					return
 				}
 				working[piece[:tindex]] = piece[tindex+1:]

--- a/receiver/sapmreceiver/Makefile
+++ b/receiver/sapmreceiver/Makefile
@@ -1,0 +1,1 @@
+include ../../Makefile.Common

--- a/receiver/sapmreceiver/go.mod
+++ b/receiver/sapmreceiver/go.mod
@@ -1,4 +1,4 @@
-module github.com/optelemetry-collector-contrib/receiver/sapmreceiver
+module github.com/openlemetry-collector-contrib/receiver/sapmreceiver
 
 go 1.12
 

--- a/receiver/sapmreceiver/trace_receiver.go
+++ b/receiver/sapmreceiver/trace_receiver.go
@@ -159,7 +159,6 @@ func (sr *sapmReceiver) HTTPHandlerFunc(rw http.ResponseWriter, req *http.Reques
 	// write the successfully gzipped payload
 	rw.Header().Set(sapmprotocol.ContentEncodingHeaderName, sapmprotocol.GZipEncodingHeaderValue)
 	rw.Write(gzipBuffer.Bytes())
-	return
 }
 
 // TraceSource implements receiver.TraceReceiver.TraceSource() and returns a tag describing the source format


### PR DESCRIPTION
Move common parts of Makefile to Makefile.Common. Opportunistically add a Makefile to sapmreceiver and fix two staticcheck issues.

Fix #36