### PR TITLE
Fix sapmreceiver module name

### DIFF
--- a/receiver/sapmreceiver/go.mod
+++ b/receiver/sapmreceiver/go.mod
@@ -1,4 +1,4 @@
-module github.com/openlemetry-collector-contrib/receiver/sapmreceiver
+module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver
 
 go 1.12
 


### PR DESCRIPTION
Fixes the name of the sapmreceiver module.

Sorry for the very tiny PR but this is a bit annoying and prevent clean usage of the package outside of OTelColContrib