### PR TITLE
Add end-to-end test execution to Continuous Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,3 +16,7 @@ jobs:
       - run:
           name: Verify
           command: make ci
+      - store_artifacts:
+          path: testbed/tests/results
+      - store_test_results:
+          path: testbed/tests/results/junit

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ e2e-test: otelcontribcol
 
 .PHONY: ci
 ci: all test-with-cover
+	$(MAKE) -C testbed install-tools
+	$(MAKE) -C testbed runtests
 
 .PHONY: test-with-cover
 test-with-cover:

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -291,6 +291,7 @@ github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBv
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
- Now end-to-end tests from the Testbed are executed as part of CirleCI build.
- Test summary are published in CircleCI using JUnit format:
- All test result files (e.g. logs) are published as CircleCO artifacts:
  https://circleci.com/gh/open-telemetry/opentelemetry-collector-contrib/169#artifacts/containers/0