### PR TITLE
Add a link from README to contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+## Contributing
+
+If you would like to contribute please read OpenTelemetry Collector
+[contributing guidelines](https://github.com/open-telemetry/opentelemetry-collector/blob/master/CONTRIBUTING.md)
+before you begin your work.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
-# opentelemetry-collector-contrib
-Repository for OpenTelemetry Collector contributions that are not part of the
-core repository and distribution of the Collector.
+# OpenTelemetry Collector Contrib
+This is a repository for OpenTelemetry Collector contributions that are not part of the
+core repository and core distribution of the Collector.
+
+## Contributing
+
+If you would like to contribute please read [contributing guidelines](https://github.com/open-telemetry/opentelemetry-collector/blob/master/CONTRIBUTING.md)
+before you begin your work.


### PR DESCRIPTION
For now we link to CONTRIBUTING.md from core repo. This can be replaced
when we have more specific guidelines for the contrib repo.