### PR TITLE
Fix build for go 1.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ local/
 
 # GoLand IDEA
 /.idea/
+*.iml
 
 # VS Code
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,12 @@ test-with-cover:
 	@echo Verifying that all packages have test files to count in coverage
 	@scripts/check-test-files.sh $(subst github.com/open-telemetry/opentelemetry-collector-contrib/,./,$(ALL_PKGS))
 	@echo pre-compiling tests
-	go test -i $(ALL_PKGS)
-	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) $(ALL_PKGS)
-	go tool cover -html=coverage.txt -o coverage.html
+	set -e; for dir in $(ALL_TEST_DIRS); do \
+	  echo "go test ./... + coverage in $${dir}"; \
+	  (cd "$${dir}" && \
+	    $(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./... && \
+	 	go tool cover -html=coverage.txt -o coverage.html ); \
+	done
 
 .PHONY: install-tools
 install-tools:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -7,6 +7,8 @@ ALL_SRC_AND_DOC := $(shell find . \( -name "*.md" -o -name "*.go" -o -name "*.ya
 
 # ALL_PKGS is used with 'go cover'
 ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
+# ALL_TEST_DIRS includes ./* dirs (excludes . dir)
+ALL_TEST_DIRS := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./' )
 
 GOTEST_OPT?= -race -timeout 30s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
@@ -35,7 +37,12 @@ common: addlicense fmt impi vet lint goimports misspell staticcheck test
 
 .PHONY: test
 test:
-	$(GOTEST) $(GOTEST_OPT) $(ALL_PKGS)
+	# $(GOTEST) $(GOTEST_OPT) $(ALL_TEST_DIRS)
+	set -e; for dir in $(ALL_TEST_DIRS); do \
+	  echo "go test ./... in $${dir}"; \
+	  (cd "$${dir}" && \
+	    $(GOTEST) ./... ); \
+	done
 
 .PHONY: benchmark
 benchmark:


### PR DESCRIPTION
fixes #47

The fix runs the tests in subdirectories. I had also added a merge script to merge the raw reports and convert it to html. This works except when a new module is added. It fails because the coverage tool tries to fetch the latest version of the new module from github and it doesn't exists. 
Here is the error I get
```
go tool cover -html=coverage.txt -o coverage.html
cover: no matching versions for query "latest"
make: *** [test-with-cover] Error 1
```
As a result, I removed the merge script. Reports are in each sub-directories.

This also fixes the [issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41#pullrequestreview-331601644) of not running the test for new modules in CI. 
