### PR TITLE
Add TEST_ARGS flag to E2E test execution

### DIFF
--- a/testbed/runtests.sh
+++ b/testbed/runtests.sh
@@ -10,7 +10,7 @@ PASS_COLOR=$(printf "\033[32mPASS\033[0m")
 FAIL_COLOR=$(printf "\033[31mFAIL\033[0m")
 TEST_COLORIZE="${SED} 's/PASS/${PASS_COLOR}/' | ${SED} 's/FAIL/${FAIL_COLOR}/'"
 
-TESTBED_CONFIG=local.yaml go test -v 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}"
+TESTBED_CONFIG=local.yaml go test -v ${TEST_ARGS} 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}"
 
 testStatus=${PIPESTATUS[0]}
 


### PR DESCRIPTION
The flag is passed to `go test` command. It allows for example to run a
single test if needed. For example to run TestTraceNoBackend10kSPSJaeger
execute this command:

make e2e-test TEST_ARGS="-run TestTraceNoBackend10kSPSJaeger"