### PR TITLE
Added gotidy CI check & fixed k8s dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,15 @@ e2e-test: otelcontribcol
 	$(MAKE) -C testbed runtests
 
 .PHONY: ci
-ci: all test-with-cover
+ci: gomod-check all test-with-cover
 	$(MAKE) -C testbed install-tools
 	$(MAKE) -C testbed runtests
+
+.PHONY: gomod-check
+gomod-check:
+	@go mod download
+	$(MAKE) gotidy
+	@git diff --exit-code || (echo 'Go modules are not tidied up. Run `make gotidy` and commit the changes.' && exit 1)
 
 .PHONY: test-with-cover
 test-with-cover:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -7,8 +7,8 @@ ALL_SRC_AND_DOC := $(shell find . \( -name "*.md" -o -name "*.go" -o -name "*.ya
 
 # ALL_PKGS is used with 'go cover'
 ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))))
-# ALL_TEST_DIRS includes ./* dirs (excludes . dir)
-ALL_TEST_DIRS := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./' )
+# ALL_TEST_DIRS includes ./* dirs
+ALL_TEST_DIRS := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort )
 
 GOTEST_OPT?= -race -timeout 30s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic

--- a/exporter/awsxrayexporter/go.sum
+++ b/exporter/awsxrayexporter/go.sum
@@ -51,8 +51,6 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1C
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7 h1:Fv9bK1Q+ly/ROk4aJsVMeuIwPel4bEnD8EPiI91nZMg=
 github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/apache/thrift v0.12.0 h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=
-github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 h1:G1bPvciwNyF7IUmKXNt9Ak3m6u9DE1rF+RmtIkBpVdA=

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -498,8 +498,6 @@ github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191205212659-419ed6
 github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191209163440-5d463fe48816/go.mod h1:WxiK9mcisb/hM6M6+2BRV/VIU2c8VzlCRJED2S1MWns=
 github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191217213608-3cac55bf869f h1:IeYV2aOZ77BK2lTJIYHbwDeOZUQfm57M77b/pM3iCPE=
 github.com/open-telemetry/opentelemetry-collector v0.2.1-0.20191217213608-3cac55bf869f/go.mod h1:WxiK9mcisb/hM6M6+2BRV/VIU2c8VzlCRJED2S1MWns=
-github.com/open-telemetry/opentelemetry-collector-contrib v0.0.0-20191217233418-a191cedc5fcb h1:NETfrN6rsW7XLYXbpSCkiCokFkC//T0zCrSUS2C9VqE=
-github.com/open-telemetry/opentelemetry-collector-contrib v0.0.0-20191218001153-5afd395c9acf h1:mV/d4vAe7tbOM9PD/+uXAwby4DFFfURgxuiPKUKrsJE=
 github.com/open-telemetry/opentelemetry-collector/testbed v0.0.0-20191217213608-3cac55bf869f h1:ld2HWYL6js8ApHhc4mWQ+LXDEeDPZEpPTSJrPEwhZvQ=
 github.com/open-telemetry/opentelemetry-collector/testbed v0.0.0-20191217213608-3cac55bf869f/go.mod h1:0x5LWC/8hyS8Q8fCi0elhTYf9S94RzRX6ZgL7EiYvlQ=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=


### PR DESCRIPTION
1. Added a CI check to ensure all PRs run `go mod tidy` before
sumitting.

2. k8s.io/client-go v12.0.0 is problematic as it is not a valid Go module.
Added a replace directive that fixes it for all known versions of Go
irrespective of whether one is using a proxy or fetching directly.