### PR TITLE
[AzureMonitor] http.status_code and http.port should come as integer attributes

### DIFF
--- a/exporter/azuremonitorexporter/traceexporter_test.go
+++ b/exporter/azuremonitorexporter/traceexporter_test.go
@@ -45,11 +45,6 @@ func TestIdToHex(t *testing.T) {
 	assert.Equal(t, "23bf4de5a2f2d94b94aa5163e3a39119", hex)
 }
 
-func TestFormatParentChild(t *testing.T) {
-	assert.Equal(t, "|0000000000000000.00000000.", formatParentChild("", ""))
-	assert.Equal(t, "|foo.bar.", formatParentChild("foo", "bar"))
-}
-
 func TestSanitize(t *testing.T) {
 	sanitizeFunc := func() []string {
 		warnings := [4]string{
@@ -79,7 +74,7 @@ func TestSpanToRequestData_UnknownType(t *testing.T) {
 
 	data := spanToRequestData(&wireFormatSpan)
 
-	assert.Equal(t, "|"+defaultTraceIDAsHex+"."+defaultSpanIDAsHex+".", data.Id)
+	assert.Equal(t, defaultSpanIDAsHex, data.Id)
 	assert.Equal(t, "foo", data.Name)
 	assert.Equal(t, "00.00:00:01.000000", data.Duration)
 	assert.True(t, data.Success)
@@ -204,7 +199,7 @@ func TestSpanToRemoteDependencyData_UnknownType(t *testing.T) {
 
 	data := spanToRemoteDependencyData(&wireFormatSpan)
 
-	assert.Equal(t, "|"+defaultTraceIDAsHex+"."+defaultSpanIDAsHex+".", data.Id)
+	assert.Equal(t, defaultSpanIDAsHex, data.Id)
 	assert.Equal(t, "foo", data.Name)
 	assert.Equal(t, "00.00:00:01.000000", data.Duration)
 	assert.True(t, data.Success)


### PR DESCRIPTION
Per data semantics the following Span attribute values should be integers
- http.status_code
- http.port

However, I've added a fallback for these to string values if the integer values are not found. I've seen this before with the Zipkin receiver enabled. 

Other changes:
- Removing an old id format that is no longer necessary for backwards compatibility.