### PR TITLE
Give 30% margin for perf test limits

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -41,7 +41,7 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOCTraceDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 35,
+				ExpectedMaxCPU: 40,
 				ExpectedMaxRAM: 71,
 			},
 		},
@@ -50,7 +50,7 @@ func TestTrace10kSPS(t *testing.T) {
 			NewSapmDataSender(testbed.GetAvailablePort(t)),
 			NewSapmDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 67,
+				ExpectedMaxCPU: 71,
 				ExpectedMaxRAM: 105,
 			},
 		},


### PR DESCRIPTION
Perf tests are running on uncontrolled CI environment. We need some margin
to ensure they pass.

TODO: have a better solution with more controlled env for perf tests:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/89