### PR TITLE
Pin signalfxreceiver dependency to signalfxexporter to exact commit

### DIFF
--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
 	github.com/open-telemetry/opentelemetry-collector v0.2.2
-	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.0.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.0.0-20200110233337-37711984b8d4
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.0-20190530013331-054be550cb49
 	github.com/stretchr/testify v1.4.0
 	go.opencensus.io v0.22.1

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -515,6 +515,7 @@ github.com/open-telemetry/opentelemetry-collector v0.2.0-0.20200110151913-977707
 github.com/open-telemetry/opentelemetry-collector v0.2.2 h1:fByPHI/xDbTw3X36/OiEr30Hu69/Xdwd4SEdy1WrIIY=
 github.com/open-telemetry/opentelemetry-collector v0.2.2/go.mod h1:WxiK9mcisb/hM6M6+2BRV/VIU2c8VzlCRJED2S1MWns=
 github.com/open-telemetry/opentelemetry-collector-contrib v0.0.0-20200108235032-fc49e9a799fb h1:19gs8qZpWRFwC8lVVpvFMbrZ20QOZ9GFEvwMqZqV4aI=
+github.com/open-telemetry/opentelemetry-collector-contrib v0.0.1 h1:4DEH+15Hg4qMmOjD35w4+dwEhYpsEvDH/XqBVeCFPlA=
 github.com/open-telemetry/opentelemetry-collector/testbed v0.0.0-20200110193345-9f801c5b8d9f h1:HnaCRgCuhUBlVyJaLY+3e4b6gSSpvF9F0Hdg/z4P/Dk=
 github.com/open-telemetry/opentelemetry-collector/testbed v0.0.0-20200110193345-9f801c5b8d9f/go.mod h1:ENTpOKAOQO8D9w18NdsydhyZGjoZTPtUpY++a5hc6kk=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=


### PR DESCRIPTION
The dependency was not pinned and is causing problems if another repository
imports signalfxreceiver because go build cannot locate signalfxexporter@v0.0.0
(we get error "unknown revision exporter/signalfxexporter/v0.0.0").

This should fix the problem.