### PR TITLE
Add ability to publish docker components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,18 @@
-
 version: 2
+
+workflows:
+  version: 2
+  build-publish:
+    jobs:
+      - build
+      - publish:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9].[0-9].[0-9]+.*/
 
 jobs:
   build:
@@ -16,7 +29,32 @@ jobs:
       - run:
           name: Verify
           command: make ci
+      - run:
+          name: Build collector 
+          command: make otelcontribcol
       - store_artifacts:
           path: testbed/tests/results
       - store_test_results:
           path: testbed/tests/results/junit
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+  publish:
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - attach_workspace:
+          at: .
+      - setup_remote_docker
+      - run:
+          name: Build image
+          command: |
+            make docker-otelcontribcol
+            docker tag otelcontribcol:latest omnition/opentelemetry-collector-contrib:${CIRCLE_TAG:1}
+            docker tag otelcontribcol:latest omnition/opentelemetry-collector-contrib:latest
+      - run:
+          name: Push image
+          command: |
+            docker push omnition/opentelemetry-collector-contrib:${CIRCLE_TAG:1}
+            docker push omnition/opentelemetry-collector-contrib:latest

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ core distribution of the Collector. Typically, these contributions are vendor
 specific receivers/exporters and/or components that are only
 useful to a relatively small number of users. 
 
+## Docker Images
+Docker images for all releases are published at https://hub.docker.com/r/omnition/opentelemetry-collector-contrib
+
 ## Contributing
 If you would like to contribute please read [contributing guidelines](https://github.com/open-telemetry/opentelemetry-collector/blob/master/CONTRIBUTING.md)
 before you begin your work.


### PR DESCRIPTION
Add ability to publish docker components

Enable automatic publishing git tags to docker hub.

Will publish to Omnition org on docker hub until the OpenTelemetry
project gets it's own docker hub org.