### PR TITLE
Enable building only new tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,12 @@ workflows:
   version: 2
   build-publish:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /.*/
       - publish:
           requires:
             - build


### PR DESCRIPTION
CircleCI did not trigger new builds on just pushing new tags (without
new commits). This change should fix that.