### PR TITLE
Migrate to Go1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     steps:
       - checkout
       - run:
@@ -47,7 +47,7 @@ jobs:
             - .
   publish:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     steps:
       - attach_workspace:
           at: .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib
 
-go 1.12
+go 1.13
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
We've been building core, contrib and some internal collectors with 1.13
for quite some time now and have resolved all issues that came with the
upgrade already. This should be a very safe change.

This will allow us to use leverage new features and fixes shipped by
1.13 such as updates to Go modules, error wrapping, etc.