### PR TITLE
Updated end to end test expectations

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -33,8 +33,8 @@ func TestMetric10kDPS(t *testing.T) {
 			NewSFxMetricDataSender(testbed.GetAvailablePort(t)),
 			NewSFxMetricsDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 48,
-				ExpectedMaxRAM: 52,
+				ExpectedMaxCPU: 40,
+				ExpectedMaxRAM: 58,
 			},
 		},
 		{


### PR DESCRIPTION
Upgrading to Go1.13 has resulted in some tests changing the baseline
behaviour. This commit updates these expectations.

SignalFx metrics exporter/receiver started consuming more memory and
less CPU in end to end tests after upgrading to Go 1.13 which has
started to result in some builds failing when the tests don't match the
expectations. This commit updates the expected max numbers based on how
the collector performs when built with Go 1.13.

I think the reason behind the change in behaviour is this change that
shipped in Go 1.13: https://go-review.googlesource.com/c/go/+/166961

This change made sync.Pool a bit more GC friendly. After this change,
pooled objects are more likely to survice GC cycles and get collected
over two GC cycles instead of the pool being cleared after every single
GC. As expected this should result in less CPU being consumed at the
expense of slightly more memory which is exactly what we are noticing.

Moreover, there has been a similar change in behaviour in the SAPM
traces tests (less CPU, more memory) but not enough for any tests to
fail.

One thing SignalFX metrics and SAPM traces (exporters/receivers) have in
common is that both of them use sync.Pool to reduce allocations.
OpenCensus components don't use sync.Pool and as a result behave the
same in tests as they did with 1.12.

I don't have definite proof that this was the cause of change but all
evidence suggests so. I suggest we accept the new (and better) reality
and update the test expectation numbers.