### PR TITLE
Give more RAM room for SAPM E2E test

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -51,7 +51,7 @@ func TestTrace10kSPS(t *testing.T) {
 			NewSapmDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 71,
-				ExpectedMaxRAM: 105,
+				ExpectedMaxRAM: 140,
 			},
 		},
 	}


### PR DESCRIPTION
We were very close to the limit and sometimes it failed. Increased to give more room.