### PR TITLE
Expose more stackdriver options

### DIFF
--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -15,6 +15,8 @@
 package stackdriverexporter
 
 import (
+	"time"
+
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
 )
 
@@ -26,6 +28,9 @@ type Config struct {
 	Endpoint                      string                   `mapstructure:"endpoint"`
 	NumOfWorkers                  int                      `mapstructure:"number_of_workers"`
 	SkipCreateMetricDescriptor    bool                     `mapstructure:"skip_create_metric_descriptor"`
+	BundleDelayThreshold          time.Duration            `mapstructure:"bundle_delay_threshold"`
+	BundleCountThreshold          int                      `mapstructure:"bundle_count_threshold"`
+	TraceSpansBufferMaxBytes      int                      `mapstructure:"trace_spans_buffer_max_bytes"`
 	// Only has effect if Endpoint is not ""
 	UseInsecure bool `mapstructure:"use_insecure"`
 }

--- a/exporter/stackdriverexporter/config_test.go
+++ b/exporter/stackdriverexporter/config_test.go
@@ -17,6 +17,7 @@ package stackdriverexporter
 import (
 	"path"
 	"testing"
+	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector/config"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
@@ -52,5 +53,8 @@ func TestLoadConfig(t *testing.T) {
 			NumOfWorkers:               3,
 			SkipCreateMetricDescriptor: true,
 			UseInsecure:                true,
+			BundleDelayThreshold:       1 * time.Minute,
+			BundleCountThreshold:       42,
+			TraceSpansBufferMaxBytes:   1024,
 		})
 }

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -83,7 +83,10 @@ func newStackdriverExporter(cfg *Config) (*stackdriver.Exporter, error) {
 		// the project this is running on in GCP.
 		ProjectID: cfg.ProjectID,
 
-		MetricPrefix: cfg.Prefix,
+		MetricPrefix:             cfg.Prefix,
+		BundleDelayThreshold:     cfg.BundleDelayThreshold,
+		BundleCountThreshold:     cfg.BundleCountThreshold,
+		TraceSpansBufferMaxBytes: cfg.TraceSpansBufferMaxBytes,
 
 		// Set DefaultMonitoringLabels to an empty map to avoid getting the "opencensus_task" label
 		DefaultMonitoringLabels: &stackdriver.Labels{},

--- a/exporter/stackdriverexporter/testdata/config.yaml
+++ b/exporter/stackdriverexporter/testdata/config.yaml
@@ -13,6 +13,9 @@ exporters:
     number_of_workers: 3
     skip_create_metric_descriptor: true
     use_insecure: true
+    bundle_count_threshold: 42
+    bundle_delay_threshold: 1m
+    trace_spans_buffer_max_bytes: 1024
   stackdriver/disabled: # will be ignored
     disabled: true
 


### PR DESCRIPTION
Exposing more of the options, mainly we wanted the bundle count threshold to be upped from the default of 50.  