### PR TITLE
Update stackdriver exporter to use the new batch api

### DIFF
--- a/exporter/stackdriverexporter/go.mod
+++ b/exporter/stackdriverexporter/go.mod
@@ -6,8 +6,13 @@ require (
 	// TODO: pin a released version
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8-0.20190917133925-4339afab4a99
 	github.com/open-telemetry/opentelemetry-collector v0.2.6
+	contrib.go.opencensus.io/exporter/stackdriver v0.13.0
+	github.com/census-instrumentation/opencensus-proto v0.2.1
+	github.com/golang/protobuf v1.3.2
 	github.com/stretchr/testify v1.4.0
+	go.opencensus.io v0.22.1
 	go.uber.org/zap v1.10.0
 	google.golang.org/api v0.10.0
+	google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51
 	google.golang.org/grpc v1.23.1
 )

--- a/exporter/stackdriverexporter/go.mod
+++ b/exporter/stackdriverexporter/go.mod
@@ -4,11 +4,10 @@ go 1.12
 
 require (
 	// TODO: pin a released version
-	contrib.go.opencensus.io/exporter/stackdriver v0.12.8-0.20190917133925-4339afab4a99
-	github.com/open-telemetry/opentelemetry-collector v0.2.6
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.0
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/golang/protobuf v1.3.2
+	github.com/open-telemetry/opentelemetry-collector v0.2.6
 	github.com/stretchr/testify v1.4.0
 	go.opencensus.io v0.22.1
 	go.uber.org/zap v1.10.0

--- a/exporter/stackdriverexporter/go.sum
+++ b/exporter/stackdriverexporter/go.sum
@@ -14,6 +14,8 @@ contrib.go.opencensus.io/exporter/ocagent v0.6.0/go.mod h1:zmKjrJcdo0aYcVS7bmEeS
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
 contrib.go.opencensus.io/exporter/stackdriver v0.12.8-0.20190917133925-4339afab4a99 h1:g+oCe0ua3NQ+78ZZ46eNinYj+cgNOMP04IidDxijjXM=
 contrib.go.opencensus.io/exporter/stackdriver v0.12.8-0.20190917133925-4339afab4a99/go.mod h1:XyyafDnFOsqoxHJgTFycKZMrRUrPThLh2iYTJF6uoO0=
+contrib.go.opencensus.io/exporter/stackdriver v0.13.0 h1:Jaz7WbqjtfoCPa1KbfisCX+P5aM3DizEY9pQMU0oAQo=
+contrib.go.opencensus.io/exporter/stackdriver v0.13.0/go.mod h1:z2tyTZtPmQ2HvWH4cOmVDgtY+1lomfKdbLnkJvZdc8c=
 contrib.go.opencensus.io/resource v0.1.2 h1:b4WFJV8u7/NzPWHeTqj3Ec2AW8OGhtJxC/hbphIOvbU=
 contrib.go.opencensus.io/resource v0.1.2/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 github.com/Azure/azure-sdk-for-go v23.2.0+incompatible h1:bch1RS060vGpHpY3zvQDV4rOiRw25J1zmR/B9a76aSA=

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
 	spandatatranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace/spandata"
+	"go.opencensus.io/trace"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 )
@@ -115,19 +116,26 @@ func (se *stackdriverExporter) pushMetricsData(ctx context.Context, md consumerd
 	return se.exporter.PushMetricsProto(ctx, md.Node, md.Resource, md.Metrics)
 }
 
-// TODO(songya): add an interface PushSpanProto to Stackdriver exporter and remove this method
-// pushTraceData is a wrapper method on StackdriverExporter.PushSpans
+// pushTraceData is a wrapper method on StackdriverExporter.PushTraceSpans
 func (se *stackdriverExporter) pushTraceData(ctx context.Context, td consumerdata.TraceData) (int, error) {
 	var errs []error
 	goodSpans := 0
+	spans := make([]*trace.SpanData, 0, len(td.Spans))
+
 	for _, span := range td.Spans {
 		sd, err := spandatatranslator.ProtoSpanToOCSpanData(span)
 		if err == nil {
-			se.exporter.ExportSpan(sd)
+			spans = append(spans, sd)
 			goodSpans++
 		} else {
 			errs = append(errs, err)
 		}
+	}
+
+	_, err := se.exporter.PushTraceSpans(ctx, td.Node, td.Resource, spans)
+	if err != nil {
+		goodSpans = 0
+		errs = append(errs, err)
 	}
 
 	return len(td.Spans) - goodSpans, oterr.CombineErrors(errs)

--- a/exporter/stackdriverexporter/stackdriver_test.go
+++ b/exporter/stackdriverexporter/stackdriver_test.go
@@ -1,0 +1,109 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stackdriverexporter
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cloudtracepb "google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
+	"google.golang.org/grpc"
+)
+
+func mustTS(t time.Time) *timestamp.Timestamp {
+	tt, err := ptypes.TimestampProto(t)
+	if err != nil {
+		panic(err)
+	}
+	return tt
+}
+
+type testServer struct {
+	ch chan *cloudtracepb.BatchWriteSpansRequest
+}
+
+func (ts *testServer) BatchWriteSpans(ctx context.Context, r *cloudtracepb.BatchWriteSpansRequest) (*empty.Empty, error) {
+	go func() {
+		ts.ch <- r
+	}()
+	return &empty.Empty{}, nil
+}
+
+// Creates a new span.
+func (ts *testServer) CreateSpan(context.Context, *cloudtracepb.Span) (*cloudtracepb.Span, error) {
+	return nil, nil
+}
+
+func TestStackdriverExport(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := grpc.NewServer()
+
+	reqCh := make(chan *cloudtracepb.BatchWriteSpansRequest)
+
+	cloudtracepb.RegisterTraceServiceServer(srv, &testServer{ch: reqCh})
+
+	lis, err := net.Listen("tcp", ":8080")
+	defer func() {
+		_ = lis.Close()
+	}()
+	require.NoError(t, err)
+
+	go srv.Serve(lis)
+
+	sde, err := newStackdriverTraceExporter(&Config{
+		ProjectID:   "idk",
+		Endpoint:    "127.0.0.1:8080",
+		UseInsecure: true,
+	})
+	require.NoError(t, err)
+
+	testTime := time.Now()
+
+	td := consumerdata.TraceData{
+		Resource: &resourcepb.Resource{},
+		Spans: []*tracepb.Span{
+			{
+				Name: &tracepb.TruncatableString{
+					Value: "foobar",
+				},
+				StartTime: mustTS(testTime),
+			},
+		},
+	}
+
+	err = sde.ConsumeTraceData(ctx, td)
+	assert.NoError(t, err)
+
+	select {
+	case <-time.After(10 * time.Second):
+		t.Errorf("test timed out")
+	case r := <-reqCh:
+		assert.Len(t, r.Spans, 1)
+		assert.Equal(t, "foobar", r.Spans[0].GetDisplayName().GetValue())
+		assert.Equal(t, mustTS(testTime), r.Spans[0].StartTime)
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ contrib.go.opencensus.io/exporter/prometheus v0.1.0 h1:SByaIoWwNgMdPSgl5sMqM2KDE
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
 contrib.go.opencensus.io/exporter/stackdriver v0.12.8-0.20190917133925-4339afab4a99 h1:g+oCe0ua3NQ+78ZZ46eNinYj+cgNOMP04IidDxijjXM=
 contrib.go.opencensus.io/exporter/stackdriver v0.12.8-0.20190917133925-4339afab4a99/go.mod h1:XyyafDnFOsqoxHJgTFycKZMrRUrPThLh2iYTJF6uoO0=
+contrib.go.opencensus.io/exporter/stackdriver v0.13.0 h1:Jaz7WbqjtfoCPa1KbfisCX+P5aM3DizEY9pQMU0oAQo=
+contrib.go.opencensus.io/exporter/stackdriver v0.13.0/go.mod h1:z2tyTZtPmQ2HvWH4cOmVDgtY+1lomfKdbLnkJvZdc8c=
 contrib.go.opencensus.io/resource v0.1.2 h1:b4WFJV8u7/NzPWHeTqj3Ec2AW8OGhtJxC/hbphIOvbU=
 contrib.go.opencensus.io/resource v0.1.2/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=


### PR DESCRIPTION
Push traces up synchronously with the new API in batch mode.  This should let us use the various processors to do retrying and batching rather then relying on the embedded use of Bundler in the exporter.

I'm a little worried there's no e2e test here though.  Should I write one?

