### PR TITLE
Increase memory limit for Carbon E2E test

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -43,7 +43,7 @@ func TestMetric10kDPS(t *testing.T) {
 			NewCarbonDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 115,
-				ExpectedMaxRAM: 40,
+				ExpectedMaxRAM: 48,
 			},
 		},
 		{


### PR DESCRIPTION
There were few test pass failures due to previous limits.