### PR TITLE
Added a for-all make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ include ./Makefile.Common
 
 RUN_CONFIG=local/config.yaml
 
+CMD?=
 GIT_SHA=$(shell git rev-parse --short HEAD)
 BUILD_INFO_IMPORT_PATH=github.com/open-telemetry/opentelemetry-collector-contrib/internal/version
 BUILD_X1=-X $(BUILD_INFO_IMPORT_PATH).GitHash=$(GIT_SHA)
@@ -43,11 +44,16 @@ test-with-cover:
 
 .PHONY: gotidy
 gotidy:
-	go mod tidy
+	$(MAKE) for-all CMD="go mod tidy"
+
+
+.PHONY: for-all
+for-all:
+	@$${CMD}
 	@set -e; for dir in $(ALL_TEST_DIRS); do \
 	  (cd "$${dir}" && \
-	  	echo "tidying up $${dir}" && \
-	 	go mod tidy ); \
+	  	echo "running $${CMD} in $${dir}" && \
+	 	$${CMD} ); \
 	done
 
 


### PR DESCRIPTION
This allows to run the same command on all Go modules in the repository.

For example, to update a single dependency in all modules, one can run:

> make for-all CMD='go get github.com/dependncy@v1.10'