### PR TITLE
[tiny]: Remove Trace/Metric source method that is not used anymore.

### DIFF
--- a/receiver/carbonreceiver/receiver.go
+++ b/receiver/carbonreceiver/receiver.go
@@ -53,10 +53,6 @@ type carbonReceiver struct {
 
 var _ receiver.MetricsReceiver = (*carbonReceiver)(nil)
 
-func (r *carbonReceiver) MetricsSource() string {
-	return "Carbon"
-}
-
 // New creates the Carbon receiver with the given configuration.
 func New(
 	logger *zap.Logger,

--- a/receiver/collectdreceiver/receiver.go
+++ b/receiver/collectdreceiver/receiver.go
@@ -79,13 +79,6 @@ func New(
 	return r, nil
 }
 
-const metricsSource string = "CollectD"
-
-// MetricsSource returns the name of the trace data source.
-func (cdr *collectdReceiver) MetricsSource() string {
-	return metricsSource
-}
-
 // StartMetricsReception starts an HTTP server that can process CollectD JSON requests.
 func (cdr *collectdReceiver) Start(host component.Host) error {
 	cdr.Lock()

--- a/receiver/sapmreceiver/trace_receiver.go
+++ b/receiver/sapmreceiver/trace_receiver.go
@@ -162,11 +162,6 @@ func (sr *sapmReceiver) HTTPHandlerFunc(rw http.ResponseWriter, req *http.Reques
 	rw.Write(gzipBuffer.Bytes())
 }
 
-// TraceSource implements receiver.TraceReceiver.TraceSource() and returns a tag describing the source format
-func (sr *sapmReceiver) TraceSource() string {
-	return traceSource
-}
-
 // StartTraceReception starts the sapmReceiver's server
 func (sr *sapmReceiver) Start(host component.Host) error {
 	sr.mu.Lock()

--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -84,10 +84,6 @@ type sfxReceiver struct {
 
 var _ receiver.MetricsReceiver = (*sfxReceiver)(nil)
 
-func (r *sfxReceiver) MetricsSource() string {
-	return "SignalFx"
-}
-
 // New creates the SignalFx receiver with the given configuration.
 func New(
 	logger *zap.Logger,

--- a/receiver/zipkinscribereceiver/receiver.go
+++ b/receiver/zipkinscribereceiver/receiver.go
@@ -72,13 +72,6 @@ func New(
 	return r, nil
 }
 
-const traceSource string = "Zipkin-Scribe"
-
-// TraceSource returns the name of the trace data source.
-func (r *scribeReceiver) TraceSource() string {
-	return traceSource
-}
-
 func (r *scribeReceiver) Start(host component.Host) error {
 	r.Lock()
 	defer r.Unlock()


### PR DESCRIPTION
These were already removed on core repo.