### PR TITLE
Fix passthrough mode k8sprocessor init

### DIFF
--- a/processor/k8sprocessor/processor.go
+++ b/processor/k8sprocessor/processor.go
@@ -16,6 +16,7 @@ package k8sprocessor
 
 import (
 	"context"
+	"errors"
 
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/open-telemetry/opentelemetry-collector/client"
@@ -75,12 +76,18 @@ func (kp *kubernetesprocessor) GetCapabilities() processor.Capabilities {
 }
 
 func (kp *kubernetesprocessor) Start(host component.Host) error {
-	go kp.kc.Start()
+	if kp.kc != nil {
+		go kp.kc.Start()
+	} else if !kp.passthroughMode {
+		return errors.New("KubeClient not initialized and not in passthrough mode")
+	}
 	return nil
 }
 
 func (kp *kubernetesprocessor) Shutdown() error {
-	kp.kc.Stop()
+	if kp.kc != nil {
+		kp.kc.Stop()
+	}
 	return nil
 }
 

--- a/processor/k8sprocessor/processor.go
+++ b/processor/k8sprocessor/processor.go
@@ -16,8 +16,6 @@ package k8sprocessor
 
 import (
 	"context"
-	"errors"
-
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/open-telemetry/opentelemetry-collector/client"
 	"github.com/open-telemetry/opentelemetry-collector/component"
@@ -76,16 +74,14 @@ func (kp *kubernetesprocessor) GetCapabilities() processor.Capabilities {
 }
 
 func (kp *kubernetesprocessor) Start(host component.Host) error {
-	if kp.kc != nil {
+	if !kp.passthroughMode {
 		go kp.kc.Start()
-	} else if !kp.passthroughMode {
-		return errors.New("KubeClient not initialized and not in passthrough mode")
 	}
 	return nil
 }
 
 func (kp *kubernetesprocessor) Shutdown() error {
-	if kp.kc != nil {
+	if !kp.passthroughMode {
 		kp.kc.Stop()
 	}
 	return nil

--- a/processor/k8sprocessor/processor.go
+++ b/processor/k8sprocessor/processor.go
@@ -16,6 +16,7 @@ package k8sprocessor
 
 import (
 	"context"
+
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/open-telemetry/opentelemetry-collector/client"
 	"github.com/open-telemetry/opentelemetry-collector/component"

--- a/processor/k8sprocessor/processor_test.go
+++ b/processor/k8sprocessor/processor_test.go
@@ -20,6 +20,7 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	"github.com/open-telemetry/opentelemetry-collector/client"
+	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exportertest"
 	"github.com/open-telemetry/opentelemetry-collector/processor"
@@ -155,6 +156,23 @@ func TestAddLabels(t *testing.T) {
 		}
 		i++
 	}
+}
+
+func TestPassthroughStart(t *testing.T) {
+	next := &testConsumer{}
+	opts := []Option{WithPassthrough()}
+
+	p, err := NewTraceProcessor(
+		zap.NewNop(),
+		next,
+		kube.NewFakeClient,
+		opts...,
+	)
+	require.NoError(t, err)
+
+	// Just make sure this doesn't fail when Passthrough is enabled
+	p.Start(component.NewMockHost())
+	p.Shutdown()
 }
 
 func fakeClientFromProcessor(t *testing.T, p processor.TraceProcessor) *kube.FakeClient {


### PR DESCRIPTION
**Description:** 

Fixing a bug - when `passthrough` mode was enabled, the processor Start function
still expected having KubeClient initialized (which is not being used) causing a segfault

**Link to tracking Issue:** N/A

**Testing:** Unit test for the case added

**Documentation:** N/A