### PR TITLE
Add support for plain text LightStep satellite pools

### DIFF
--- a/exporter/lightstepexporter/README.md
+++ b/exporter/lightstepexporter/README.md
@@ -5,17 +5,18 @@ This exporter supports sending trace data to [LightStep](https://www.lightstep.c
 The following configuration options are supported:
 
 * `access_token` (Required): The access token for your LightStep project.
-* `satellite_host` (Optional): Your LightStep Satellite Pool URL. Defaults to `https://ingest.lightstep.com`.
+* `satellite_host` (Optional): Your LightStep Satellite Pool Hostname. Defaults to `ingest.lightstep.com`.
 * `satellite_port` (Optional): Your LightStep Satellite Pool Port. Defaults to `443`.
 * `service_name` (Optional): The service name for spans reported by this collector. Defaults to `opentelemetry-collector`. 
-
+* `plain_text` (Optional): False for HTTPS LightStep Satellite Pools. Defaults to `False`.
 Example:
 
 ```yaml
 exporters:
     lightstep:
         access_token: "abcdef12345"
-        satellite_host: "https://my.satellite.pool.coolcat.com"
+        satellite_host: "my.satellite.pool.coolcat.com"
         satellite_port: 8000
         service_name: "myService"
+        plain_text: true
 ```

--- a/exporter/lightstepexporter/config.go
+++ b/exporter/lightstepexporter/config.go
@@ -21,10 +21,12 @@ type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	// AccessToken is your project access token in LightStep.
 	AccessToken string `mapstructure:"access_token"`
-	// SatelliteHost is the satellite pool URL.
+	// SatelliteHost is the satellite pool hostname.
 	SatelliteHost string `mapstructure:"satellite_host"`
 	// SatellitePort is the satellite pool port.
 	SatellitePort int `mapstructure:"satellite_port"`
 	// ServiceName is the LightStep service name for your spans.
 	ServiceName string `mapstructure:"service_name"`
+	// PlainText is true for plain text satellite pools.
+	PlainText bool `mapstructure:"plain_text"`
 }

--- a/exporter/lightstepexporter/config_test.go
+++ b/exporter/lightstepexporter/config_test.go
@@ -46,8 +46,9 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r1, &Config{
 		ExporterSettings: configmodels.ExporterSettings{TypeVal: typeStr, NameVal: "lightstep/customname"},
 		AccessToken:      "abcdef12345",
-		SatelliteHost:    "https://custom.lightstep.com",
+		SatelliteHost:    "custom.lightstep.com",
 		SatellitePort:    8000,
 		ServiceName:      "myService",
+		PlainText:        true,
 	})
 }

--- a/exporter/lightstepexporter/factory.go
+++ b/exporter/lightstepexporter/factory.go
@@ -42,9 +42,10 @@ func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
 			NameVal: typeStr,
 		},
 		AccessToken:   "",
-		SatelliteHost: "https://ingest.lightstep.com",
+		SatelliteHost: "ingest.lightstep.com",
 		SatellitePort: 443,
 		ServiceName:   "opentelemetry-collector",
+		PlainText:     false,
 	}
 }
 

--- a/exporter/lightstepexporter/lightstep.go
+++ b/exporter/lightstepexporter/lightstep.go
@@ -35,6 +35,7 @@ func newLightStepTraceExporter(cfg *Config) (exporter.TraceExporter, error) {
 		lightstep.WithHost(cfg.SatelliteHost),
 		lightstep.WithPort(cfg.SatellitePort),
 		lightstep.WithServiceName(cfg.ServiceName),
+		lightstep.WithPlainText(cfg.PlainText),
 	)
 
 	if err != nil {

--- a/exporter/lightstepexporter/testdata/config.yaml
+++ b/exporter/lightstepexporter/testdata/config.yaml
@@ -8,9 +8,10 @@ exporters:
   lightstep:
   lightstep/customname:
     access_token: "abcdef12345"
-    satellite_host: "https://custom.lightstep.com"
+    satellite_host: "custom.lightstep.com"
     satellite_port: 8000
     service_name: "myService"
+    plain_text: true
 
 service:
   pipelines:


### PR DESCRIPTION
* Added a plain_text configuration option to the LightStep exporter to support non-https pool types.
* Fix documentation & example configuration problems with LightStep satellite hosts.

**Description:**
Fixed a bug with the configuration examples. The LightStep client expects a hostname to be provided to `WithHost`, but a URL was provided.

Also added support for setting the plain text option on the client, which is required for the LS developer mode satellites.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/136

**Testing:**
Added `plain_text: true` to testdata and added `PlainText: true` to existing config assertion.

**Documentation:** 
Added documentation describing `plain_text` option and corrected documentation on `satellite_host` option.