### PR TITLE
Properly tag services for LightStep

### DIFF
--- a/exporter/lightstepexporter/go.mod
+++ b/exporter/lightstepexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/lightstep/opentelemetry-exporter-go v0.1.5
 	github.com/open-telemetry/opentelemetry-collector v0.2.7
 	github.com/stretchr/testify v1.4.0
+	go.opentelemetry.io/otel v0.2.3
 	go.uber.org/zap v1.14.0
 )
 

--- a/exporter/lightstepexporter/lightstep.go
+++ b/exporter/lightstepexporter/lightstep.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/exporter"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
 	"github.com/open-telemetry/opentelemetry-collector/oterr"
+	"go.opentelemetry.io/otel/api/core"
 )
 
 // LightStepExporter contains a pointer to a LightStep opentelemetry exporter.
@@ -58,6 +59,8 @@ func (e *LightStepExporter) pushTraceData(ctx context.Context, td consumerdata.T
 	for _, span := range td.Spans {
 		sd, err := lightstep.OCProtoSpanToOTelSpanData(span)
 		if err == nil {
+			lightStepServiceName := core.Key("lightstep.component_name")
+			sd.Attributes = append(sd.Attributes, lightStepServiceName.String(td.Node.ServiceInfo.Name))
 			e.exporter.ExportSpan(ctx, sd)
 			goodSpans++
 		} else {


### PR DESCRIPTION
This addresses an issue where individual service names were not being applied to spans.