### PR TITLE
use go1.14, mirroring main -collector repo.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.13
+      - image: cimg/go:1.14
     steps:
       - checkout
       - run:
@@ -47,7 +47,7 @@ jobs:
             - .
   publish:
     docker:
-      - image: circleci/golang:1.13
+      - image: cimg/go:1.14
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - checkout
       - run:
           name: Install bazzar
-          command: sudo apt-get install bzr -y
+          command: sudo apt update && sudo apt-get install bzr -y
       - run:
           name: Install tools
           command: make install-tools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,12 +31,19 @@ jobs:
       - run:
           name: Install tools
           command: make install-tools
+      - restore_cache: # restores saved cache if no changes are detected since last run
+          keys:
+            - cimg-go-pkg-mod-{{ checksum "go.sum" }}
       - run:
           name: Verify
           command: make ci
       - run:
           name: Build collector 
           command: make otelcontribcol
+      - save_cache:
+          key: cimg-go-pkg-mod-{{ checksum "go.sum" }}
+          paths:
+            - "/home/circleci/go/pkg/mod"
       - store_artifacts:
           path: testbed/tests/results
       - store_test_results:

--- a/exporter/awsxrayexporter/go.mod
+++ b/exporter/awsxrayexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
 
-go 1.12
+go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.23.12

--- a/exporter/azuremonitorexporter/go.mod
+++ b/exporter/azuremonitorexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
 
-go 1.12
+go 1.14
 
 require (
 	cloud.google.com/go v0.45.1 // indirect

--- a/exporter/carbonexporter/go.mod
+++ b/exporter/carbonexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
 
-go 1.13
+go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1

--- a/exporter/honeycombexporter/go.mod
+++ b/exporter/honeycombexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexproter
 
-go 1.12
+go 1.14
 
 require (
 	github.com/honeycombio/opentelemetry-exporter-go v0.2.3

--- a/exporter/kinesisexporter/go.mod
+++ b/exporter/kinesisexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kinesisexporter
 
-go 1.12
+go 1.14
 
 require (
 	github.com/open-telemetry/opentelemetry-collector v0.2.8

--- a/exporter/lightstepexporter/go.mod
+++ b/exporter/lightstepexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lightstepexporter
 
-go 1.12
+go 1.14
 
 require (
 	github.com/lightstep/opentelemetry-exporter-go v0.1.5

--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
 
-go 1.12
+go 1.14
 
 require (
 	github.com/open-telemetry/opentelemetry-collector v0.2.8

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
 
-go 1.12
+go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1

--- a/exporter/stackdriverexporter/go.mod
+++ b/exporter/stackdriverexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stackdriverexporter
 
-go 1.12
+go 1.14
 
 require (
 	// TODO: pin a released version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib
 
-go 1.13
+go 1.14
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/processor/k8sprocessor/go.mod
+++ b/processor/k8sprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor
 
-go 1.13
+go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1

--- a/receiver/carbonreceiver/go.mod
+++ b/receiver/carbonreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
 
-go 1.13
+go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1

--- a/receiver/collectdreceiver/go.mod
+++ b/receiver/collectdreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
 
-go 1.12
+go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1

--- a/receiver/sapmreceiver/go.mod
+++ b/receiver/sapmreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver
 
-go 1.12
+go 1.14
 
 require (
 	cloud.google.com/go v0.49.0 // indirect

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
 
-go 1.12
+go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1

--- a/receiver/wavefrontreceiver/go.mod
+++ b/receiver/wavefrontreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
 
-go 1.13
+go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1

--- a/receiver/zipkinscribereceiver/go.mod
+++ b/receiver/zipkinscribereceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinscribereceiver
 
-go 1.12
+go 1.14
 
 require (
 	github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/testbed
 
-go 1.12
+go 1.14
 
 require (
 	github.com/open-telemetry/opentelemetry-collector v0.2.8

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -34,7 +34,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 29,
-				ExpectedMaxRAM: 65,
+				ExpectedMaxRAM: 70,
 			},
 		},
 		{
@@ -43,7 +43,7 @@ func TestMetric10kDPS(t *testing.T) {
 			NewCarbonDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 115,
-				ExpectedMaxRAM: 55,
+				ExpectedMaxRAM: 60,
 			},
 		},
 		{

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -42,7 +42,7 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 42,
-				ExpectedMaxRAM: 75,
+				ExpectedMaxRAM: 80,
 			},
 		},
 		{


### PR DESCRIPTION
**Description:**
Updates to go1.14 and circleci's cimg images.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/pull/661

**Testing:**
CircleCI should have us covered here.

**Documentation:**
No docs needed.