### PR TITLE
compile for linux/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ install-tools:
 
 .PHONY: otelcontribcol
 otelcontribcol:
-	GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/$(GOOS)/otelcontribcol $(BUILD_INFO) ./cmd/otelcontribcol
+	GO111MODULE=on CGO_ENABLED=0 go build -o ./bin/$(GOOS)_$(GOARCH)/otelcontribcol $(BUILD_INFO) ./cmd/otelcontribcol
 
 .PHONY: run
 run:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ e2e-test: otelcontribcol
 	$(MAKE) -C testbed runtests
 
 .PHONY: ci
-ci: all test-with-cover
+ci: all binaries-all-sys test-with-cover
 	$(MAKE) -C testbed install-tools
 	$(MAKE) -C testbed runtests
 
@@ -78,8 +78,8 @@ run:
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component
-	GOOS=linux $(MAKE) $(COMPONENT)
-	cp ./bin/linux/$(COMPONENT) ./cmd/$(COMPONENT)/
+	GOOS=linux GOARCH=amd64 $(MAKE) $(COMPONENT)
+	cp ./bin/linux_amd64/$(COMPONENT) ./cmd/$(COMPONENT)/
 	docker build -t $(COMPONENT) ./cmd/$(COMPONENT)/
 	rm ./cmd/$(COMPONENT)/$(COMPONENT)
 
@@ -98,6 +98,7 @@ binaries: otelcontribcol
 
 .PHONY: binaries-all-sys
 binaries-all-sys:
-	GOOS=darwin $(MAKE) binaries
-	GOOS=linux $(MAKE) binaries
-	GOOS=windows $(MAKE) binaries
+	GOOS=darwin  GOARCH=amd64 $(MAKE) binaries
+	GOOS=linux   GOARCH=amd64 $(MAKE) binaries
+	GOOS=linux   GOARCH=arm64 $(MAKE) binaries
+	GOOS=windows GOARCH=amd64 $(MAKE) binaries

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -18,6 +18,7 @@ GOIMPORTS=goimports
 GOLINT=golint
 GOVET=go vet
 GOOS=$(shell go env GOOS)
+GOARCH=$(shell go env GOARCH)
 ADDLICENCESE= addlicense
 MISSPELL=misspell -error
 MISSPELL_CORRECTION=misspell -w

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -25,5 +25,3 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbo
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver => ../receiver/sapmreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver => ../receiver/signalfxreceiver
-
-replace github.com/open-telemetry/opentelemetry-collector/testbed => ../../opentelemetry-collector/testbed

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver v0.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver v0.0.0
-	github.com/open-telemetry/opentelemetry-collector/testbed v0.0.0-20200325174335-c931b9875fd0
+	github.com/open-telemetry/opentelemetry-collector/testbed v0.0.0-20200325235920-6c32d115c19d
 	go.uber.org/zap v1.13.0
 )
 
@@ -25,3 +25,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbo
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver => ../receiver/sapmreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver => ../receiver/signalfxreceiver
+
+replace github.com/open-telemetry/opentelemetry-collector/testbed => ../../opentelemetry-collector/testbed

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -538,8 +538,6 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/open-telemetry/opentelemetry-collector v0.2.4-0.20200115225140-264426a9cae4/go.mod h1:WxiK9mcisb/hM6M6+2BRV/VIU2c8VzlCRJED2S1MWns=
 github.com/open-telemetry/opentelemetry-collector v0.2.8 h1:7VBVVxe9Ai2wHpjZYpFb7oGT/hOkzqq4UopMsNNCqwk=
 github.com/open-telemetry/opentelemetry-collector v0.2.8/go.mod h1:tuTJuW9GY1kBIZM5b0mX88FQO8851gK3Pz74rg21LRc=
-github.com/open-telemetry/opentelemetry-collector/testbed v0.0.0-20200325174335-c931b9875fd0 h1:gIzHGtsY4L973Vbx/5gwka5Qr0L0svnp51E35VTEhtQ=
-github.com/open-telemetry/opentelemetry-collector/testbed v0.0.0-20200325174335-c931b9875fd0/go.mod h1:G55/uUyBE4W1xqI0CUY5XfZ9LrgNaapl+4vI8xHk6Wo=
 github.com/open-telemetry/opentelemetry-proto v0.3.0 h1:+ASAtcayvoELyCF40+rdCMlBOhZIn5TPDez85zSYc30=
 github.com/open-telemetry/opentelemetry-proto v0.3.0/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=

--- a/testbed/tests/local.yaml
+++ b/testbed/tests/local.yaml
@@ -1,1 +1,1 @@
-agent: ../../bin/{{.GOOS}}/otelcontribcol
+agent: ../../bin/{{.GOOS}}_{{.GOARCH}}/otelcontribcol


### PR DESCRIPTION
**Description:**
Cross-compile for linux/arm64 as well as explicitly specifying the amd64 for the rest.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/pull/701

**Testing:**
Run circleci, verify it produces binaries.

**Documentation:**
No docs needed.