### PR TITLE
Fix Honeycomb module name declared in go.mod

### DIFF
--- a/exporter/honeycombexporter/go.mod
+++ b/exporter/honeycombexporter/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexproter
+module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter
 
 go 1.12
 


### PR DESCRIPTION
**Description:** 
The module name for the Honeycomb exporter has a typo which results in errors when you try and import the module:

```
go get github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter
go: finding github.com/open-telemetry/opentelemetry-collector-contrib v0.2.8
go: finding github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter latest
go: downloading github.com/open-telemetry/opentelemetry-collector-contrib v0.2.8
go: downloading github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter v0.0.0-20200325202302-1c8462ae0047
go: extracting github.com/open-telemetry/opentelemetry-collector-contrib v0.2.8
go: extracting github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter v0.0.0-20200325202302-1c8462ae0047
go get: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter@v0.0.0-20200325202302-1c8462ae0047: parsing go.mod:
        module declares its path as: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexproter
                but was required as: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter
```
