### PR TITLE
Fix zpages type data for SFx receiver

### DIFF
--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -155,7 +155,7 @@ func (r *sfxReceiver) Shutdown() error {
 
 func (r *sfxReceiver) handleReq(resp http.ResponseWriter, req *http.Request) {
 	ctx := obsreport.ReceiverContext(req.Context(), r.config.Name(), "http", r.config.Name())
-	ctx = obsreport.StartTraceDataReceiveOp(ctx, r.config.Name(), "http")
+	ctx = obsreport.StartMetricsReceiveOp(ctx, r.config.Name(), "http")
 
 	if req.Method != http.MethodPost {
 		r.failRequest(ctx, resp, http.StatusBadRequest, invalidMethodRespBody, nil)
@@ -255,6 +255,7 @@ func (r *sfxReceiver) failRequest(
 		traceStatus.Message = err.Error()
 	}
 	reqSpan.SetStatus(traceStatus)
+	reqSpan.End()
 
 	r.logger.Debug(
 		"SignalFx receiver request failed",

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -43,7 +43,7 @@ func TestMetric10kDPS(t *testing.T) {
 			NewCarbonDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 115,
-				ExpectedMaxRAM: 60,
+				ExpectedMaxRAM: 65,
 			},
 		},
 		{


### PR DESCRIPTION
**Description:** The issue was the use of incorrect `obsreport` function to start the operation. Since the other functions were correct this only affected the pages. Also upon inspection notice a missing cal to `span.End` if the receive operation ended before ingress data could be decoded.

**Testing:** Manual verification of zpages and metrics for SFx receiver.

Opened https://github.com/open-telemetry/opentelemetry-collector/issues/741 on core repo to provide test helpers plus consider some refactor to minimize chances of this type of typo being missed.