### PR TITLE
Support node attributes in Honeycomb exporter

### DIFF
--- a/exporter/honeycombexporter/go.mod
+++ b/exporter/honeycombexporter/go.mod
@@ -3,7 +3,11 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeyc
 go 1.14
 
 require (
+	github.com/census-instrumentation/opencensus-proto v0.2.1
+	github.com/golang/protobuf v1.3.5
+	github.com/google/go-cmp v0.4.0
 	github.com/honeycombio/opentelemetry-exporter-go v0.3.1
+	github.com/klauspost/compress v1.10.2
 	github.com/open-telemetry/opentelemetry-collector v0.2.10
 	github.com/stretchr/testify v1.5.1
 	go.opentelemetry.io/otel v0.3.0

--- a/exporter/honeycombexporter/honeycomb.go
+++ b/exporter/honeycombexporter/honeycomb.go
@@ -61,6 +61,10 @@ func (e *HoneycombExporter) pushTraceData(ctx context.Context, td consumerdata.T
 		if err == nil {
 			serviceName := core.Key("service_name")
 			sd.Attributes = append(sd.Attributes, serviceName.String(td.Node.ServiceInfo.Name))
+			if !sd.ParentSpanID.IsValid() || sd.HasRemoteParent {
+				sd.Attributes = append(sd.Attributes,
+					convertNodeAttributes(td.Node.Attributes)...)
+			}
 			e.exporter.ExportSpan(ctx, sd)
 			goodSpans++
 		} else {
@@ -69,6 +73,16 @@ func (e *HoneycombExporter) pushTraceData(ctx context.Context, td consumerdata.T
 	}
 
 	return len(td.Spans) - goodSpans, oterr.CombineErrors(errs)
+}
+
+func convertNodeAttributes(attributes map[string]string) []core.KeyValue {
+	result := make([]core.KeyValue, len(attributes))
+	index := 0
+	for key, val := range attributes {
+		result[index] = core.Key(key).String(val)
+		index++
+	}
+	return result
 }
 
 func (e *HoneycombExporter) Shutdown() error {

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -1,0 +1,164 @@
+// Copyright 2019 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package honeycombexporter
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/klauspost/compress/zstd"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type honeycombData struct {
+	Data map[string]interface{} `json:"data"`
+}
+
+func TestExporter(t *testing.T) {
+	var got []honeycombData
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		uncompressed, err := zstd.NewReader(req.Body)
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+		defer req.Body.Close()
+		b, err := ioutil.ReadAll(uncompressed)
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+
+		var data []honeycombData
+		err = json.Unmarshal(b, &data)
+		if err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
+
+		got = append(got, data...)
+
+		rw.Write([]byte(`OK`))
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		APIKey:  "test",
+		Dataset: "test",
+		APIURL:  server.URL,
+	}
+
+	logger := zap.NewNop()
+	factory := Factory{}
+	exporter, err := factory.CreateTraceExporter(logger, &cfg)
+	require.NoError(t, err)
+
+	td := consumerdata.TraceData{
+		Node: &commonpb.Node{
+			ServiceInfo: &commonpb.ServiceInfo{Name: "test_service"},
+			Attributes: map[string]string{
+				"A": "B",
+			},
+		},
+		Spans: []*tracepb.Span{
+			{
+				TraceId:                 []byte{0x01},
+				SpanId:                  []byte{0x02},
+				Name:                    &tracepb.TruncatableString{Value: "root"},
+				Kind:                    tracepb.Span_SERVER,
+				SameProcessAsParentSpan: &wrappers.BoolValue{Value: true},
+			},
+			{
+				TraceId:                 []byte{0x01},
+				SpanId:                  []byte{0x03},
+				ParentSpanId:            []byte{0x02},
+				Name:                    &tracepb.TruncatableString{Value: "client"},
+				Kind:                    tracepb.Span_CLIENT,
+				SameProcessAsParentSpan: &wrappers.BoolValue{Value: true},
+			},
+			{
+				TraceId:                 []byte{0x01},
+				SpanId:                  []byte{0x04},
+				ParentSpanId:            []byte{0x03},
+				Name:                    &tracepb.TruncatableString{Value: "server"},
+				Kind:                    tracepb.Span_SERVER,
+				SameProcessAsParentSpan: &wrappers.BoolValue{Value: false},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	err = exporter.ConsumeTraceData(ctx, td)
+	require.NoError(t, err)
+	exporter.Shutdown()
+
+	want := []honeycombData{
+		{
+			Data: map[string]interface{}{
+				"duration_ms":       float64(0),
+				"has_remote_parent": false,
+				"name":              "root",
+				"service_name":      "test_service",
+				"status.code":       float64(0),
+				"status.message":    "OK",
+				"trace.span_id":     "0200000000000000",
+				"trace.trace_id":    "01000000-0000-0000-0000-000000000000",
+				"A":                 "B",
+			},
+		},
+		{
+			Data: map[string]interface{}{
+				"duration_ms":       float64(0),
+				"has_remote_parent": false,
+				"name":              "client",
+				"service_name":      "test_service",
+				"status.code":       float64(0),
+				"status.message":    "OK",
+				"trace.parent_id":   "0200000000000000",
+				"trace.span_id":     "0300000000000000",
+				"trace.trace_id":    "01000000-0000-0000-0000-000000000000",
+			},
+		},
+		{
+			Data: map[string]interface{}{
+				"duration_ms":       float64(0),
+				"has_remote_parent": true,
+				"name":              "server",
+				"service_name":      "test_service",
+				"status.code":       float64(0),
+				"status.message":    "OK",
+				"trace.parent_id":   "0300000000000000",
+				"trace.span_id":     "0400000000000000",
+				"trace.trace_id":    "01000000-0000-0000-0000-000000000000",
+				"A":                 "B",
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("otel span: (-want +got):\n%s", diff)
+	}
+}

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -17,7 +17,6 @@ package honeycombexporter
 import (
 	"context"
 	"encoding/json"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +24,7 @@ import (
 
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	"github.com/klauspost/compress/zstd"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 OpenTelemetry Authors
+// Copyright 2020 OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Description:** 
Adds support for adding Node attributes to spans sent to Honeycomb if the span is either the root span of the trace or has a remote parent (which means that the node information is likely to be different from the previous span in the trace).

**Testing:**

Added a test case for the Honeycomb exporter that uses a mock HttpServer to grab the output being sent to Honeycomb - this is several levels of abstraction from the code under test (the otel collector exporter calls the otel go exporter which calls libhoney to actually send the data) but could not identify a better way given the interface provided.

The test case has both a root span and a span with a remote parent which is unrealistic within a single call to the exporter but demonstrates that the attributes are included in both scenarios whilst the intermediate span show that the attributes are not added to every span in the trace.