### PR TITLE
Use same docker image in CircleCI for all jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,9 +94,9 @@ jobs:
   publish-dev:
     docker:
       - image: circleci/golang:1.14
+
     steps:
-      - attach_workspace:
-          at: .
+      - attach_to_workspace
       - setup_remote_docker
       - run:
           name: Build image


### PR DESCRIPTION
**Description:**
Make sure all jobs use the same docker image. We moved to `cimg/go:1.14` last week but looks like we missed one place.