### PR TITLE
attach_to_workspace command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: 2
 
+commands:
+  attach_to_workspace:
+    steps:
+      - attach_workspace:
+          at: ~/
+
 workflows:
   version: 2
   build-publish:
@@ -67,8 +73,7 @@ jobs:
     docker:
       - image: cimg/go:1.14
     steps:
-      - attach_workspace:
-          at: .
+      - attach_to_workspace
       - setup_remote_docker
       - run:
           name: Build image


### PR DESCRIPTION
This is not a built in and needs to be defined before it can be used.

**Description:** 
`attach_to_workspace` is not a built in and needs to be defined before it can be used.
