### PR TITLE
Fix publish dev image job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 commands:
   attach_to_workspace:
@@ -88,9 +88,10 @@ jobs:
       - store_test_results:
           path: testbed/tests/results/junit
       - persist_to_workspace:
-          root: .
+          root: ~/
           paths:
-            - .
+            - go
+            - project
   publish-stable:
     docker:
       - image: cimg/go:1.14


### PR DESCRIPTION
**Description:** 
This fixes the publish dev docker image job that runs on every commit to master.

- Updated CI config file version to 2.1
- Updated paths that are stored to the workspace