### PR TITLE
Fix publish dev2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,4 +116,4 @@ jobs:
       - setup_remote_docker
       - publish_docker_images:
           repo: opentelemetry-collector-contrib-dev
-          tag: ${CIRCLE_TAG:1}
+          tag: ${CIRCLE_SHA1}


### PR DESCRIPTION
**Description:** 
Use GIT commit SHA for dev images instead of tags.

I really need to go to sleep right now.