### PR TITLE
Support configuring Honeycomb exporter from environment

### DIFF
--- a/exporter/honeycombexporter/README.md
+++ b/exporter/honeycombexporter/README.md
@@ -4,8 +4,12 @@ This exporter supports sending trace data to [Honeycomb](https://www.honeycomb.i
 
 The following configuration options are supported:
 
-* `api_key` (Required): This is the API key (also called Write Key) for your Honeycomb account.
-* `dataset` (Required): The Honeycomb dataset that you want to send events to.
+* `api_key` (Required): This is the API key (also called Write Key) for your Honeycomb account. It is also possible to 
+  configure the API key via the `HONEYCOMB_WRITE_KEY` environment variable, but note that the value in the configuration 
+  file will override the environment variable.
+* `dataset` (Required): The Honeycomb dataset that you want to send events to. It is also possible to configure the 
+  dataset via the `HONEYCOMB_DATASET` environment variable, but note that the value in the configuration file will 
+  override the environment variable.
 * `api_url` (Optional): You can set the hostname to send events to. Useful for debugging, defaults to `https://api.honeycomb.io`
 Example:
 

--- a/exporter/honeycombexporter/factory.go
+++ b/exporter/honeycombexporter/factory.go
@@ -15,6 +15,8 @@
 package honeycombexporter
 
 import (
+	"os"
+
 	"github.com/open-telemetry/opentelemetry-collector/component"
 	"github.com/open-telemetry/opentelemetry-collector/config/configerror"
 	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
@@ -41,8 +43,8 @@ func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
 			TypeVal: typeStr,
 			NameVal: typeStr,
 		},
-		APIKey:  "",
-		Dataset: "",
+		APIKey:  os.Getenv("HONEYCOMB_WRITE_KEY"),
+		Dataset: os.Getenv("HONEYCOMB_DATASET"),
 		APIURL:  "https://api.honeycomb.io",
 	}
 }


### PR DESCRIPTION
**Description:** To avoid storing the API key in plaintext inside the configuration file, this PR adds support for optionally reading the key from the environment.

**Link to tracking Issue:** N/A

**Testing:** A test has been added to ensure the desired behaviour, whereby the value inside the configuration file overrides the environment variable if set.

**Documentation:** The exporter README has been updated to reflect the new configuration behaviour and the available environment variables.