### PR TITLE
Use `k8s.pod.ip` to record resource IP instead of just `ip`

### DIFF
--- a/processor/k8sprocessor/processor_test.go
+++ b/processor/k8sprocessor/processor_test.go
@@ -55,7 +55,7 @@ func TestIPDetection(t *testing.T) {
 
 	require.Len(t, next.data, 1)
 	require.NotNil(t, next.data[0].Resource)
-	assert.Equal(t, next.data[0].Resource.Labels["ip"], "1.1.1.1")
+	assert.Equal(t, next.data[0].Resource.Labels["k8s.pod.ip"], "1.1.1.1")
 }
 
 func TestNoIP(t *testing.T) {
@@ -113,7 +113,7 @@ func TestJaegerIP(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, next.data, 2)
 	assert.NotNil(t, next.data[1].Resource)
-	assert.Equal(t, next.data[1].Resource.Labels["ip"], "1.1.1.1")
+	assert.Equal(t, next.data[1].Resource.Labels["k8s.pod.ip"], "1.1.1.1")
 }
 
 func TestAddLabels(t *testing.T) {
@@ -148,7 +148,7 @@ func TestAddLabels(t *testing.T) {
 		require.Len(t, next.data, i+1)
 		td := next.data[i]
 		require.NotNil(t, td.Resource)
-		assert.Equal(t, td.Resource.Labels["ip"], ip)
+		assert.Equal(t, td.Resource.Labels["k8s.pod.ip"], ip)
 		for k, v := range attrs {
 			vv, ok := td.Resource.Labels[k]
 			assert.True(t, ok)


### PR DESCRIPTION
**Description:** Use `k8s.pod.ip` to record resource IP instead of just `ip` 
Since the k8s processor prefixes all labels with `k8s.*.`, adding the
same prefix to the IP label. We'll still continue to look for the `ip`
label on resource/node when we can't find the IP by other means but will
only write the IP back to `k8s.pod.ip`.

**Testing:** Tested locally and updated unit tests
