### PR TITLE
Fix Redis metric types; add server_name label

### DIFF
--- a/receiver/redisreceiver/README.md
+++ b/receiver/redisreceiver/README.md
@@ -46,7 +46,7 @@ Example configuration:
 receivers:
   redis:
     endpoint: "localhost:6379"
-    server_name: "my-test-redis"
+    service_name: "my-test-redis"
     collection_interval: 10s
     password: $REDIS_PASSWORD
 ```
@@ -68,13 +68,13 @@ e.g. "1h30m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 _Required._
 
-### server_name
+### service_name
 
-The name of the Redis server. If present, this value will be added as a
-`server_name` Resource label. Useful for distinguishing between multiple
-Redis servers.
+The logical name of the Redis server. This value will be added as a
+`service.name` Resource label and may end up as a dimension on exported
+metrics, depending on the exporter.
 
-_Optional._
+_Required._
 
 ### password
 
@@ -90,6 +90,7 @@ the following:
 receivers:
   redis:
     endpoint: "localhost:6379"
+    service_name: "my-test-redis"
     collection_interval: 10s
     password: $REDIS_PASSWORD
 ```

--- a/receiver/redisreceiver/README.md
+++ b/receiver/redisreceiver/README.md
@@ -46,6 +46,7 @@ Example configuration:
 receivers:
   redis:
     endpoint: "localhost:6379"
+    server_name: "my-test-redis"
     collection_interval: 10s
     password: $REDIS_PASSWORD
 ```
@@ -66,6 +67,14 @@ This value must be a string readable by Golang's `ParseDuration` function:
 e.g. "1h30m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 _Required._
+
+### server_name
+
+The name of the Redis server. If present, this value will be added as a
+`server_name` Resource label. Useful for distinguishing between multiple
+Redis servers.
+
+_Optional._
 
 ### password
 

--- a/receiver/redisreceiver/README.md
+++ b/receiver/redisreceiver/README.md
@@ -46,7 +46,7 @@ Example configuration:
 receivers:
   redis:
     endpoint: "localhost:6379"
-    service_name: "my-test-redis"
+    service.name: "my-test-redis"
     collection_interval: 10s
     password: $REDIS_PASSWORD
 ```
@@ -68,7 +68,7 @@ e.g. "1h30m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 _Required._
 
-### service_name
+### service.name
 
 The logical name of the Redis server. This value will be added as a
 `service.name` Resource label and may end up as a dimension on exported
@@ -90,7 +90,7 @@ the following:
 receivers:
   redis:
     endpoint: "localhost:6379"
-    service_name: "my-test-redis"
+    service.name: "my-test-redis"
     collection_interval: 10s
     password: $REDIS_PASSWORD
 ```

--- a/receiver/redisreceiver/README.md
+++ b/receiver/redisreceiver/README.md
@@ -46,7 +46,7 @@ Example configuration:
 receivers:
   redis:
     endpoint: "localhost:6379"
-    service.name: "my-test-redis"
+    service_name: "my-test-redis"
     collection_interval: 10s
     password: $REDIS_PASSWORD
 ```
@@ -68,10 +68,10 @@ e.g. "1h30m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 _Required._
 
-### service.name
+### service_name
 
 The logical name of the Redis server. This value will be added as a
-`service.name` Resource label and may end up as a dimension on exported
+`service_name` Resource label and may end up as a dimension on exported
 metrics, depending on the exporter.
 
 _Required._
@@ -90,7 +90,7 @@ the following:
 receivers:
   redis:
     endpoint: "localhost:6379"
-    service.name: "my-test-redis"
+    service_name: "my-test-redis"
     collection_interval: 10s
     password: $REDIS_PASSWORD
 ```

--- a/receiver/redisreceiver/config.go
+++ b/receiver/redisreceiver/config.go
@@ -24,6 +24,9 @@ type config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 	// The duration between Redis metric fetches.
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
+	// The optional name of the Redis server. If present, this value will be added
+	// as a "server_name" Resource label.
+	ServerName string `mapstructure:"server_name"`
 	// Optional password. Must match the password specified in the
 	// requirepass server configuration option.
 	Password string `mapstructure:"password"`

--- a/receiver/redisreceiver/config.go
+++ b/receiver/redisreceiver/config.go
@@ -26,7 +26,10 @@ type config struct {
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
 	// The logical name of the Redis server. This value will be added as a
 	// "service.name" Resource label.
-	ServiceName string `mapstructure:"service_name"`
+	ServiceName string `mapstructure:"service.name"`
+
+	// TODO allow users to add additional resource key value pairs?
+
 	// Optional password. Must match the password specified in the
 	// requirepass server configuration option.
 	Password string `mapstructure:"password"`

--- a/receiver/redisreceiver/config.go
+++ b/receiver/redisreceiver/config.go
@@ -24,9 +24,9 @@ type config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 	// The duration between Redis metric fetches.
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
-	// The optional name of the Redis server. If present, this value will be added
-	// as a "server_name" Resource label.
-	ServerName string `mapstructure:"server_name"`
+	// The logical name of the Redis server. This value will be added as a
+	// "service.name" Resource label.
+	ServiceName string `mapstructure:"service_name"`
 	// Optional password. Must match the password specified in the
 	// requirepass server configuration option.
 	Password string `mapstructure:"password"`

--- a/receiver/redisreceiver/config.go
+++ b/receiver/redisreceiver/config.go
@@ -26,7 +26,7 @@ type config struct {
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
 	// The logical name of the Redis server. This value will be added as a
 	// "service.name" Resource label.
-	ServiceName string `mapstructure:"service.name"`
+	ServiceName string `mapstructure:"service_name"`
 
 	// TODO allow users to add additional resource key value pairs?
 

--- a/receiver/redisreceiver/metric_functions.go
+++ b/receiver/redisreceiver/metric_functions.go
@@ -77,7 +77,7 @@ func uptimeInSeconds() *redisMetric {
 		key:    "uptime_in_seconds",
 		name:   "redis/uptime",
 		units:  "s",
-		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
 	}
 }
 
@@ -86,8 +86,8 @@ func usedCPUSys() *redisMetric {
 		key:    "used_cpu_sys",
 		name:   "redis/cpu/time",
 		units:  "s",
-		mdType: metricspb.MetricDescriptor_GAUGE_DOUBLE,
-		labels: map[string]string{"state": "sys"},
+		mdType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
+		labels: map[string]string{"state": "sys"}, // todo `state`?
 	}
 }
 
@@ -96,7 +96,7 @@ func usedCPUUser() *redisMetric {
 		key:    "used_cpu_user",
 		name:   "redis/cpu/time",
 		units:  "s",
-		mdType: metricspb.MetricDescriptor_GAUGE_DOUBLE,
+		mdType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
 		labels: map[string]string{"state": "user"},
 	}
 }
@@ -106,7 +106,7 @@ func usedCPUSysChildren() *redisMetric {
 		key:    "used_cpu_sys_children",
 		name:   "redis/cpu/time",
 		units:  "s",
-		mdType: metricspb.MetricDescriptor_GAUGE_DOUBLE,
+		mdType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
 		labels: map[string]string{"state": "children"},
 	}
 }

--- a/receiver/redisreceiver/metric_functions.go
+++ b/receiver/redisreceiver/metric_functions.go
@@ -70,17 +70,16 @@ func getDefaultRedisMetrics() []*redisMetric {
 	}
 }
 
-// Number of seconds since Redis server start
 func uptimeInSeconds() *redisMetric {
 	return &redisMetric{
 		key:    "uptime_in_seconds",
 		name:   "redis/uptime",
 		units:  "s",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		desc: "Number of seconds since Redis server start",
 	}
 }
 
-// System CPU consumed by the Redis server in seconds since server start
 func usedCPUSys() *redisMetric {
 	return &redisMetric{
 		key:    "used_cpu_sys",
@@ -88,10 +87,10 @@ func usedCPUSys() *redisMetric {
 		units:  "s",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
 		labels: map[string]string{"state": "sys"}, // todo `state`?
+		desc: "System CPU consumed by the Redis server in seconds since server start",
 	}
 }
 
-// User CPU consumed by the Redis server in seconds since server start
 func usedCPUUser() *redisMetric {
 	return &redisMetric{
 		key:    "used_cpu_user",
@@ -99,10 +98,10 @@ func usedCPUUser() *redisMetric {
 		units:  "s",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
 		labels: map[string]string{"state": "user"},
+		desc: "User CPU consumed by the Redis server in seconds since server start",
 	}
 }
 
-// User CPU consumed by the background processes in seconds since server start
 func usedCPUSysChildren() *redisMetric {
 	return &redisMetric{
 		key:    "used_cpu_sys_children",
@@ -110,230 +109,230 @@ func usedCPUSysChildren() *redisMetric {
 		units:  "s",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
 		labels: map[string]string{"state": "children"},
+		desc: "User CPU consumed by the background processes in seconds since server start",
 	}
 }
 
-// Number of client connections (excluding connections from replicas)
 func connectedClients() *redisMetric {
 	return &redisMetric{
 		key:    "connected_clients",
 		name:   "redis/clients/connected",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		desc: "Number of client connections (excluding connections from replicas)",
 	}
 }
 
-// Biggest input buffer among current client connections
 func clientRecentMaxInputBuffer() *redisMetric {
 	return &redisMetric{
 		key:    "client_recent_max_input_buffer",
 		name:   "redis/clients/max_input_buffer",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		desc: "Biggest input buffer among current client connections",
 	}
 }
 
-// Longest output list among current client connections
 func clientRecentMaxOutputBuffer() *redisMetric {
 	return &redisMetric{
 		key:    "client_recent_max_output_buffer",
 		name:   "redis/clients/max_output_buffer",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		desc: "Longest output list among current client connections",
 	}
 }
 
-// Number of clients pending on a blocking call
 func blockedClients() *redisMetric {
 	return &redisMetric{
 		key:    "blocked_clients",
 		name:   "redis/clients/blocked",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		desc: "Number of clients pending on a blocking call",
 	}
 }
 
-// Total number of key expiration events
 func expiredKeys() *redisMetric {
 	return &redisMetric{
 		key:    "expired_keys",
 		name:   "redis/keys/expired",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		desc: "Total number of key expiration events",
 	}
 }
 
-// Number of evicted keys due to maxmemory limit
 func evictedKeys() *redisMetric {
 	return &redisMetric{
 		key:    "evicted_keys",
 		name:   "redis/keys/evicted",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		desc: "Number of evicted keys due to maxmemory limit",
 	}
 }
 
-// Total number of connections accepted by the server
 func totalConnectionsReceived() *redisMetric {
 	return &redisMetric{
 		key:    "total_connections_received",
 		name:   "redis/connections/received",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		desc: "Total number of connections accepted by the server",
 	}
 }
 
-// Number of connections rejected because of maxclients limit
 func rejectedConnections() *redisMetric {
 	return &redisMetric{
 		key:    "rejected_connections",
 		name:   "redis/connections/rejected",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		desc: "Number of connections rejected because of maxclients limit",
 	}
 }
 
-// Total number of bytes allocated by Redis using its allocator
 func usedMemory() *redisMetric {
 	return &redisMetric{
 		key:    "used_memory",
 		name:   "redis/memory/used",
 		units:  "By",
-		desc:   "memory used",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		desc: "Total number of bytes allocated by Redis using its allocator",
 	}
 }
 
-// Peak memory consumed by Redis (in bytes)
 func usedMemoryPeak() *redisMetric {
 	return &redisMetric{
 		key:    "used_memory_peak",
 		name:   "redis/memory/peak",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "By",
+		desc: "Peak memory consumed by Redis (in bytes)",
 	}
 }
 
-// Number of bytes that Redis allocated as seen by the operating system
 func usedMemoryRss() *redisMetric {
 	return &redisMetric{
 		key:    "used_memory_rss",
 		name:   "redis/memory/rss",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "By",
+		desc: "Number of bytes that Redis allocated as seen by the operating system",
 	}
 }
 
-// Number of bytes used by the Lua engine
 func usedMemoryLua() *redisMetric {
 	return &redisMetric{
 		key:    "used_memory_lua",
 		name:   "redis/memory/lua",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "By",
+		desc: "Number of bytes used by the Lua engine",
 	}
 }
 
-// Ratio between used_memory_rss and used_memory
 func memFragmentationRatio() *redisMetric {
 	return &redisMetric{
 		key:    "mem_fragmentation_ratio",
 		name:   "redis/memory/fragmentation_ratio",
 		mdType: metricspb.MetricDescriptor_GAUGE_DOUBLE,
+		desc: "Ratio between used_memory_rss and used_memory",
 	}
 }
 
-// Number of changes since the last dump
 func rdbChangesSinceLastSave() *redisMetric {
 	return &redisMetric{
 		key:    "rdb_changes_since_last_save",
 		name:   "redis/rdb/changes_since_last_save",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		desc: "Number of changes since the last dump",
 	}
 }
 
-// Number of commands processed per second
 func instantaneousOpsPerSec() *redisMetric {
 	return &redisMetric{
 		key:    "instantaneous_ops_per_sec",
 		name:   "redis/commands",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "{ops}/s",
+		desc: "Number of commands processed per second",
 	}
 }
 
-// Total number of commands processed by the server
 func totalCommandsProcessed() *redisMetric {
 	return &redisMetric{
 		key:    "total_commands_processed",
 		name:   "redis/commands/processed",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		desc: "Total number of commands processed by the server",
 	}
 }
 
-// The total number of bytes read from the network
 func totalNetInputBytes() *redisMetric {
 	return &redisMetric{
 		key:    "total_net_input_bytes",
 		name:   "redis/net/input",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
 		units:  "By",
+		desc: "The total number of bytes read from the network",
 	}
 }
 
-// The total number of bytes written to the network
 func totalNetOutputBytes() *redisMetric {
 	return &redisMetric{
 		key:    "total_net_output_bytes",
 		name:   "redis/net/output",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
 		units:  "By",
+		desc: "The total number of bytes written to the network",
 	}
 }
 
-// Number of successful lookup of keys in the main dictionary
 func keyspaceHits() *redisMetric {
 	return &redisMetric{
 		key:    "keyspace_hits",
 		name:   "redis/keyspace/hits",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		desc: "Number of successful lookup of keys in the main dictionary",
 	}
 }
 
-// Number of failed lookup of keys in the main dictionary
 func keyspaceMisses() *redisMetric {
 	return &redisMetric{
 		key:    "keyspace_misses",
 		name:   "redis/keyspace/misses",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		desc: "Number of failed lookup of keys in the main dictionary",
 	}
 }
 
-// Duration of the latest fork operation in microseconds
 func latestForkUsec() *redisMetric {
 	return &redisMetric{
 		key:    "latest_fork_usec",
 		name:   "redis/latest_fork",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "us",
+		desc: "Duration of the latest fork operation in microseconds",
 	}
 }
 
-// Number of connected replicas
 func connectedSlaves() *redisMetric {
 	return &redisMetric{
 		key:    "connected_slaves",
 		name:   "redis/slaves/connected",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		desc: "Number of connected replicas",
 	}
 }
 
-// The master offset of the replication backlog buffer
 func replBacklogFirstByteOffset() *redisMetric {
 	return &redisMetric{
 		key:    "repl_backlog_first_byte_offset",
 		name:   "redis/replication/backlog_first_byte_offset",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		desc: "The master offset of the replication backlog buffer",
 	}
 }
 
-// The server's current replication offset
 func masterReplOffset() *redisMetric {
 	return &redisMetric{
 		key:    "master_repl_offset",
 		name:   "redis/replication/offset",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
+		desc: "The server's current replication offset",
 	}
 }

--- a/receiver/redisreceiver/metric_functions.go
+++ b/receiver/redisreceiver/metric_functions.go
@@ -51,8 +51,6 @@ func getDefaultRedisMetrics() []*redisMetric {
 
 		instantaneousOpsPerSec(),
 
-		rdbBgsaveInProgress(),
-
 		totalConnectionsReceived(),
 		totalCommandsProcessed(),
 
@@ -72,6 +70,7 @@ func getDefaultRedisMetrics() []*redisMetric {
 	}
 }
 
+// Number of seconds since Redis server start
 func uptimeInSeconds() *redisMetric {
 	return &redisMetric{
 		key:    "uptime_in_seconds",
@@ -81,6 +80,7 @@ func uptimeInSeconds() *redisMetric {
 	}
 }
 
+// System CPU consumed by the Redis server in seconds since server start
 func usedCPUSys() *redisMetric {
 	return &redisMetric{
 		key:    "used_cpu_sys",
@@ -91,6 +91,7 @@ func usedCPUSys() *redisMetric {
 	}
 }
 
+// User CPU consumed by the Redis server in seconds since server start
 func usedCPUUser() *redisMetric {
 	return &redisMetric{
 		key:    "used_cpu_user",
@@ -101,6 +102,7 @@ func usedCPUUser() *redisMetric {
 	}
 }
 
+// User CPU consumed by the background processes in seconds since server start
 func usedCPUSysChildren() *redisMetric {
 	return &redisMetric{
 		key:    "used_cpu_sys_children",
@@ -111,6 +113,7 @@ func usedCPUSysChildren() *redisMetric {
 	}
 }
 
+// Number of client connections (excluding connections from replicas)
 func connectedClients() *redisMetric {
 	return &redisMetric{
 		key:    "connected_clients",
@@ -119,6 +122,7 @@ func connectedClients() *redisMetric {
 	}
 }
 
+// Biggest input buffer among current client connections
 func clientRecentMaxInputBuffer() *redisMetric {
 	return &redisMetric{
 		key:    "client_recent_max_input_buffer",
@@ -127,6 +131,7 @@ func clientRecentMaxInputBuffer() *redisMetric {
 	}
 }
 
+// Longest output list among current client connections
 func clientRecentMaxOutputBuffer() *redisMetric {
 	return &redisMetric{
 		key:    "client_recent_max_output_buffer",
@@ -135,6 +140,7 @@ func clientRecentMaxOutputBuffer() *redisMetric {
 	}
 }
 
+// Number of clients pending on a blocking call
 func blockedClients() *redisMetric {
 	return &redisMetric{
 		key:    "blocked_clients",
@@ -143,6 +149,7 @@ func blockedClients() *redisMetric {
 	}
 }
 
+// Total number of key expiration events
 func expiredKeys() *redisMetric {
 	return &redisMetric{
 		key:    "expired_keys",
@@ -151,6 +158,7 @@ func expiredKeys() *redisMetric {
 	}
 }
 
+// Number of evicted keys due to maxmemory limit
 func evictedKeys() *redisMetric {
 	return &redisMetric{
 		key:    "evicted_keys",
@@ -159,6 +167,7 @@ func evictedKeys() *redisMetric {
 	}
 }
 
+// Total number of connections accepted by the server
 func totalConnectionsReceived() *redisMetric {
 	return &redisMetric{
 		key:    "total_connections_received",
@@ -167,6 +176,7 @@ func totalConnectionsReceived() *redisMetric {
 	}
 }
 
+// Number of connections rejected because of maxclients limit
 func rejectedConnections() *redisMetric {
 	return &redisMetric{
 		key:    "rejected_connections",
@@ -175,6 +185,7 @@ func rejectedConnections() *redisMetric {
 	}
 }
 
+// Total number of bytes allocated by Redis using its allocator
 func usedMemory() *redisMetric {
 	return &redisMetric{
 		key:    "used_memory",
@@ -185,6 +196,7 @@ func usedMemory() *redisMetric {
 	}
 }
 
+// Peak memory consumed by Redis (in bytes)
 func usedMemoryPeak() *redisMetric {
 	return &redisMetric{
 		key:    "used_memory_peak",
@@ -194,6 +206,7 @@ func usedMemoryPeak() *redisMetric {
 	}
 }
 
+// Number of bytes that Redis allocated as seen by the operating system
 func usedMemoryRss() *redisMetric {
 	return &redisMetric{
 		key:    "used_memory_rss",
@@ -203,6 +216,7 @@ func usedMemoryRss() *redisMetric {
 	}
 }
 
+// Number of bytes used by the Lua engine
 func usedMemoryLua() *redisMetric {
 	return &redisMetric{
 		key:    "used_memory_lua",
@@ -212,6 +226,7 @@ func usedMemoryLua() *redisMetric {
 	}
 }
 
+// Ratio between used_memory_rss and used_memory
 func memFragmentationRatio() *redisMetric {
 	return &redisMetric{
 		key:    "mem_fragmentation_ratio",
@@ -220,6 +235,7 @@ func memFragmentationRatio() *redisMetric {
 	}
 }
 
+// Number of changes since the last dump
 func rdbChangesSinceLastSave() *redisMetric {
 	return &redisMetric{
 		key:    "rdb_changes_since_last_save",
@@ -228,14 +244,7 @@ func rdbChangesSinceLastSave() *redisMetric {
 	}
 }
 
-func rdbBgsaveInProgress() *redisMetric {
-	return &redisMetric{
-		key:    "rdb_bgsave_in_progress",
-		name:   "redis/rdb/bgsave_in_progress",
-		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-	}
-}
-
+// Number of commands processed per second
 func instantaneousOpsPerSec() *redisMetric {
 	return &redisMetric{
 		key:    "instantaneous_ops_per_sec",
@@ -245,6 +254,7 @@ func instantaneousOpsPerSec() *redisMetric {
 	}
 }
 
+// Total number of commands processed by the server
 func totalCommandsProcessed() *redisMetric {
 	return &redisMetric{
 		key:    "total_commands_processed",
@@ -253,6 +263,7 @@ func totalCommandsProcessed() *redisMetric {
 	}
 }
 
+// The total number of bytes read from the network
 func totalNetInputBytes() *redisMetric {
 	return &redisMetric{
 		key:    "total_net_input_bytes",
@@ -262,6 +273,7 @@ func totalNetInputBytes() *redisMetric {
 	}
 }
 
+// The total number of bytes written to the network
 func totalNetOutputBytes() *redisMetric {
 	return &redisMetric{
 		key:    "total_net_output_bytes",
@@ -271,6 +283,7 @@ func totalNetOutputBytes() *redisMetric {
 	}
 }
 
+// Number of successful lookup of keys in the main dictionary
 func keyspaceHits() *redisMetric {
 	return &redisMetric{
 		key:    "keyspace_hits",
@@ -279,6 +292,7 @@ func keyspaceHits() *redisMetric {
 	}
 }
 
+// Number of failed lookup of keys in the main dictionary
 func keyspaceMisses() *redisMetric {
 	return &redisMetric{
 		key:    "keyspace_misses",
@@ -287,6 +301,7 @@ func keyspaceMisses() *redisMetric {
 	}
 }
 
+// Duration of the latest fork operation in microseconds
 func latestForkUsec() *redisMetric {
 	return &redisMetric{
 		key:    "latest_fork_usec",
@@ -296,6 +311,7 @@ func latestForkUsec() *redisMetric {
 	}
 }
 
+// Number of connected replicas
 func connectedSlaves() *redisMetric {
 	return &redisMetric{
 		key:    "connected_slaves",
@@ -304,6 +320,7 @@ func connectedSlaves() *redisMetric {
 	}
 }
 
+// The master offset of the replication backlog buffer
 func replBacklogFirstByteOffset() *redisMetric {
 	return &redisMetric{
 		key:    "repl_backlog_first_byte_offset",
@@ -312,6 +329,7 @@ func replBacklogFirstByteOffset() *redisMetric {
 	}
 }
 
+// The server's current replication offset
 func masterReplOffset() *redisMetric {
 	return &redisMetric{
 		key:    "master_repl_offset",

--- a/receiver/redisreceiver/metric_functions.go
+++ b/receiver/redisreceiver/metric_functions.go
@@ -76,7 +76,7 @@ func uptimeInSeconds() *redisMetric {
 		name:   "redis/uptime",
 		units:  "s",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-		desc: "Number of seconds since Redis server start",
+		desc:   "Number of seconds since Redis server start",
 	}
 }
 
@@ -87,7 +87,7 @@ func usedCPUSys() *redisMetric {
 		units:  "s",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
 		labels: map[string]string{"state": "sys"}, // todo `state`?
-		desc: "System CPU consumed by the Redis server in seconds since server start",
+		desc:   "System CPU consumed by the Redis server in seconds since server start",
 	}
 }
 
@@ -98,7 +98,7 @@ func usedCPUUser() *redisMetric {
 		units:  "s",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
 		labels: map[string]string{"state": "user"},
-		desc: "User CPU consumed by the Redis server in seconds since server start",
+		desc:   "User CPU consumed by the Redis server in seconds since server start",
 	}
 }
 
@@ -109,7 +109,7 @@ func usedCPUSysChildren() *redisMetric {
 		units:  "s",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
 		labels: map[string]string{"state": "children"},
-		desc: "User CPU consumed by the background processes in seconds since server start",
+		desc:   "User CPU consumed by the background processes in seconds since server start",
 	}
 }
 
@@ -118,7 +118,7 @@ func connectedClients() *redisMetric {
 		key:    "connected_clients",
 		name:   "redis/clients/connected",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-		desc: "Number of client connections (excluding connections from replicas)",
+		desc:   "Number of client connections (excluding connections from replicas)",
 	}
 }
 
@@ -127,7 +127,7 @@ func clientRecentMaxInputBuffer() *redisMetric {
 		key:    "client_recent_max_input_buffer",
 		name:   "redis/clients/max_input_buffer",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-		desc: "Biggest input buffer among current client connections",
+		desc:   "Biggest input buffer among current client connections",
 	}
 }
 
@@ -136,7 +136,7 @@ func clientRecentMaxOutputBuffer() *redisMetric {
 		key:    "client_recent_max_output_buffer",
 		name:   "redis/clients/max_output_buffer",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-		desc: "Longest output list among current client connections",
+		desc:   "Longest output list among current client connections",
 	}
 }
 
@@ -145,7 +145,7 @@ func blockedClients() *redisMetric {
 		key:    "blocked_clients",
 		name:   "redis/clients/blocked",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-		desc: "Number of clients pending on a blocking call",
+		desc:   "Number of clients pending on a blocking call",
 	}
 }
 
@@ -154,7 +154,7 @@ func expiredKeys() *redisMetric {
 		key:    "expired_keys",
 		name:   "redis/keys/expired",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-		desc: "Total number of key expiration events",
+		desc:   "Total number of key expiration events",
 	}
 }
 
@@ -163,7 +163,7 @@ func evictedKeys() *redisMetric {
 		key:    "evicted_keys",
 		name:   "redis/keys/evicted",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-		desc: "Number of evicted keys due to maxmemory limit",
+		desc:   "Number of evicted keys due to maxmemory limit",
 	}
 }
 
@@ -172,7 +172,7 @@ func totalConnectionsReceived() *redisMetric {
 		key:    "total_connections_received",
 		name:   "redis/connections/received",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-		desc: "Total number of connections accepted by the server",
+		desc:   "Total number of connections accepted by the server",
 	}
 }
 
@@ -181,7 +181,7 @@ func rejectedConnections() *redisMetric {
 		key:    "rejected_connections",
 		name:   "redis/connections/rejected",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-		desc: "Number of connections rejected because of maxclients limit",
+		desc:   "Number of connections rejected because of maxclients limit",
 	}
 }
 
@@ -191,7 +191,7 @@ func usedMemory() *redisMetric {
 		name:   "redis/memory/used",
 		units:  "By",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-		desc: "Total number of bytes allocated by Redis using its allocator",
+		desc:   "Total number of bytes allocated by Redis using its allocator",
 	}
 }
 
@@ -201,7 +201,7 @@ func usedMemoryPeak() *redisMetric {
 		name:   "redis/memory/peak",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "By",
-		desc: "Peak memory consumed by Redis (in bytes)",
+		desc:   "Peak memory consumed by Redis (in bytes)",
 	}
 }
 
@@ -211,7 +211,7 @@ func usedMemoryRss() *redisMetric {
 		name:   "redis/memory/rss",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "By",
-		desc: "Number of bytes that Redis allocated as seen by the operating system",
+		desc:   "Number of bytes that Redis allocated as seen by the operating system",
 	}
 }
 
@@ -221,7 +221,7 @@ func usedMemoryLua() *redisMetric {
 		name:   "redis/memory/lua",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "By",
-		desc: "Number of bytes used by the Lua engine",
+		desc:   "Number of bytes used by the Lua engine",
 	}
 }
 
@@ -230,7 +230,7 @@ func memFragmentationRatio() *redisMetric {
 		key:    "mem_fragmentation_ratio",
 		name:   "redis/memory/fragmentation_ratio",
 		mdType: metricspb.MetricDescriptor_GAUGE_DOUBLE,
-		desc: "Ratio between used_memory_rss and used_memory",
+		desc:   "Ratio between used_memory_rss and used_memory",
 	}
 }
 
@@ -239,7 +239,7 @@ func rdbChangesSinceLastSave() *redisMetric {
 		key:    "rdb_changes_since_last_save",
 		name:   "redis/rdb/changes_since_last_save",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-		desc: "Number of changes since the last dump",
+		desc:   "Number of changes since the last dump",
 	}
 }
 
@@ -249,7 +249,7 @@ func instantaneousOpsPerSec() *redisMetric {
 		name:   "redis/commands",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "{ops}/s",
-		desc: "Number of commands processed per second",
+		desc:   "Number of commands processed per second",
 	}
 }
 
@@ -258,7 +258,7 @@ func totalCommandsProcessed() *redisMetric {
 		key:    "total_commands_processed",
 		name:   "redis/commands/processed",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-		desc: "Total number of commands processed by the server",
+		desc:   "Total number of commands processed by the server",
 	}
 }
 
@@ -268,7 +268,7 @@ func totalNetInputBytes() *redisMetric {
 		name:   "redis/net/input",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
 		units:  "By",
-		desc: "The total number of bytes read from the network",
+		desc:   "The total number of bytes read from the network",
 	}
 }
 
@@ -278,7 +278,7 @@ func totalNetOutputBytes() *redisMetric {
 		name:   "redis/net/output",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
 		units:  "By",
-		desc: "The total number of bytes written to the network",
+		desc:   "The total number of bytes written to the network",
 	}
 }
 
@@ -287,7 +287,7 @@ func keyspaceHits() *redisMetric {
 		key:    "keyspace_hits",
 		name:   "redis/keyspace/hits",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-		desc: "Number of successful lookup of keys in the main dictionary",
+		desc:   "Number of successful lookup of keys in the main dictionary",
 	}
 }
 
@@ -296,7 +296,7 @@ func keyspaceMisses() *redisMetric {
 		key:    "keyspace_misses",
 		name:   "redis/keyspace/misses",
 		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-		desc: "Number of failed lookup of keys in the main dictionary",
+		desc:   "Number of failed lookup of keys in the main dictionary",
 	}
 }
 
@@ -306,7 +306,7 @@ func latestForkUsec() *redisMetric {
 		name:   "redis/latest_fork",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 		units:  "us",
-		desc: "Duration of the latest fork operation in microseconds",
+		desc:   "Duration of the latest fork operation in microseconds",
 	}
 }
 
@@ -315,7 +315,7 @@ func connectedSlaves() *redisMetric {
 		key:    "connected_slaves",
 		name:   "redis/slaves/connected",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-		desc: "Number of connected replicas",
+		desc:   "Number of connected replicas",
 	}
 }
 
@@ -324,7 +324,7 @@ func replBacklogFirstByteOffset() *redisMetric {
 		key:    "repl_backlog_first_byte_offset",
 		name:   "redis/replication/backlog_first_byte_offset",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-		desc: "The master offset of the replication backlog buffer",
+		desc:   "The master offset of the replication backlog buffer",
 	}
 }
 
@@ -333,6 +333,6 @@ func masterReplOffset() *redisMetric {
 		key:    "master_repl_offset",
 		name:   "redis/replication/offset",
 		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
-		desc: "The server's current replication offset",
+		desc:   "The server's current replication offset",
 	}
 }

--- a/receiver/redisreceiver/proto.go
+++ b/receiver/redisreceiver/proto.go
@@ -24,11 +24,15 @@ import (
 
 // Helper functions that produce protobuf
 
-func newMetricsData(protoMetrics []*metricspb.Metric) *consumerdata.MetricsData {
+func newMetricsData(protoMetrics []*metricspb.Metric, serverName string) *consumerdata.MetricsData {
+	labels := map[string]string{"type": typeStr}
+	if serverName != "" {
+		labels["server_name"] = serverName
+	}
 	return &consumerdata.MetricsData{
 		Resource: &resourcepb.Resource{
 			Type:   typeStr,
-			Labels: map[string]string{"type": typeStr},
+			Labels: labels,
 		},
 		Metrics: protoMetrics,
 	}
@@ -46,7 +50,7 @@ func buildKeyspaceKeysMetric(k *keyspace, t *timeBundle) *metricspb.Metric {
 	m := &redisMetric{
 		name:   "redis/db/keys",
 		labels: map[string]string{"db": k.db},
-		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 	}
 	pt := &metricspb.Point{Value: &metricspb.Point_Int64Value{Int64Value: int64(k.keys)}}
 	return newProtoMetric(m, pt, t)
@@ -56,7 +60,7 @@ func buildKeyspaceExpiresMetric(k *keyspace, t *timeBundle) *metricspb.Metric {
 	m := &redisMetric{
 		name:   "redis/db/expires",
 		labels: map[string]string{"db": k.db},
-		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 	}
 	pt := &metricspb.Point{Value: &metricspb.Point_Int64Value{Int64Value: int64(k.expires)}}
 	return newProtoMetric(m, pt, t)
@@ -67,7 +71,7 @@ func buildKeyspaceTTLMetric(k *keyspace, t *timeBundle) *metricspb.Metric {
 		name:   "redis/db/avg_ttl",
 		units:  "ms",
 		labels: map[string]string{"db": k.db},
-		mdType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+		mdType: metricspb.MetricDescriptor_GAUGE_INT64,
 	}
 	pt := &metricspb.Point{Value: &metricspb.Point_Int64Value{Int64Value: int64(k.avgTTL)}}
 	return newProtoMetric(m, pt, t)

--- a/receiver/redisreceiver/proto.go
+++ b/receiver/redisreceiver/proto.go
@@ -24,15 +24,11 @@ import (
 
 // Helper functions that produce protobuf
 
-func newMetricsData(protoMetrics []*metricspb.Metric, serverName string) *consumerdata.MetricsData {
-	labels := map[string]string{"type": typeStr}
-	if serverName != "" {
-		labels["server_name"] = serverName
-	}
+func newMetricsData(protoMetrics []*metricspb.Metric, serviceName string) *consumerdata.MetricsData {
 	return &consumerdata.MetricsData{
 		Resource: &resourcepb.Resource{
 			Type:   typeStr,
-			Labels: labels,
+			Labels: map[string]string{"service.name": serviceName},
 		},
 		Metrics: protoMetrics,
 	}

--- a/receiver/redisreceiver/proto_test.go
+++ b/receiver/redisreceiver/proto_test.go
@@ -25,13 +25,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServerName(t *testing.T) {
-	md := getMetricData(t, usedMemory(), "")
-	_, found := md.Resource.Labels["server_name"]
-	require.False(t, found)
-	md = getMetricData(t, usedMemory(), "x")
-	val := md.Resource.Labels["server_name"]
-	require.Equal(t, "x", val)
+func TestServiceName(t *testing.T) {
+	const serviceName = "foo-service"
+	md := getMetricData(t, usedMemory(), serviceName)
+	val := md.Resource.Labels["service.name"]
+	require.Equal(t, serviceName, val)
 }
 
 func TestMemoryMetric(t *testing.T) {

--- a/receiver/redisreceiver/proto_test.go
+++ b/receiver/redisreceiver/proto_test.go
@@ -38,7 +38,11 @@ func TestMemoryMetric(t *testing.T) {
 	require.NotNil(t, md.Resource)
 	metric := md.Metrics[0]
 	require.Equal(t, "redis/memory/used", metric.MetricDescriptor.Name)
-	require.Equal(t, "memory used", metric.MetricDescriptor.Description)
+	require.Equal(
+		t,
+		"Total number of bytes allocated by Redis using its allocator",
+		metric.MetricDescriptor.Description,
+	)
 	require.Equal(t, "By", metric.MetricDescriptor.Unit)
 	require.Equal(t, metricspb.MetricDescriptor_GAUGE_INT64, metric.MetricDescriptor.Type)
 	requireIntPtEqual(t, 854160, metric)

--- a/receiver/redisreceiver/proto_test.go
+++ b/receiver/redisreceiver/proto_test.go
@@ -25,8 +25,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestServerName(t *testing.T) {
+	md := getMetricData(t, usedMemory(), "")
+	_, found := md.Resource.Labels["server_name"]
+	require.False(t, found)
+	md = getMetricData(t, usedMemory(), "x")
+	val := md.Resource.Labels["server_name"]
+	require.Equal(t, "x", val)
+}
+
 func TestMemoryMetric(t *testing.T) {
-	md := getMetricData(t, usedMemory())
+	md := getMetricData(t, usedMemory(), "")
 	require.Equal(t, 1, len(md.Metrics))
 	require.NotNil(t, md.Resource)
 	metric := md.Metrics[0]
@@ -38,15 +47,15 @@ func TestMemoryMetric(t *testing.T) {
 }
 
 func TestUptimeInSeconds(t *testing.T) {
-	metric := getProtoMetric(t, uptimeInSeconds())
+	metric := getProtoMetric(t, uptimeInSeconds(), "")
 	require.Equal(t, "s", metric.MetricDescriptor.Unit)
 	requireIntPtEqual(t, 104946, metric)
 }
 
 func TestUsedCpuSys(t *testing.T) {
-	md := getMetricData(t, usedCPUSys())
+	md := getMetricData(t, usedCPUSys(), "")
 	metric := md.Metrics[0]
-	require.Equal(t, metricspb.MetricDescriptor_GAUGE_DOUBLE, metric.MetricDescriptor.Type)
+	require.Equal(t, metricspb.MetricDescriptor_CUMULATIVE_DOUBLE, metric.MetricDescriptor.Type)
 	require.Equal(t, "s", metric.MetricDescriptor.Unit)
 	requireDoublePtEqual(t, 185.649184, metric)
 }
@@ -84,21 +93,21 @@ func TestKeyspaceMetrics(t *testing.T) {
 	require.Equal(t, "redis/db/keys", metric.MetricDescriptor.Name)
 	require.Equal(t, "db", metric.MetricDescriptor.LabelKeys[0].Key)
 	require.Equal(t, "0", metric.Timeseries[0].LabelValues[0].Value)
-	require.Equal(t, metricspb.MetricDescriptor_CUMULATIVE_INT64, metric.MetricDescriptor.Type)
+	require.Equal(t, metricspb.MetricDescriptor_GAUGE_INT64, metric.MetricDescriptor.Type)
 	require.Equal(t, &metricspb.Point_Int64Value{Int64Value: 1}, metric.Timeseries[0].Points[0].Value)
 
 	metric = m[1]
 	require.Equal(t, "redis/db/expires", metric.MetricDescriptor.Name)
 	require.Equal(t, "db", metric.MetricDescriptor.LabelKeys[0].Key)
 	require.Equal(t, "0", metric.Timeseries[0].LabelValues[0].Value)
-	require.Equal(t, metricspb.MetricDescriptor_CUMULATIVE_INT64, metric.MetricDescriptor.Type)
+	require.Equal(t, metricspb.MetricDescriptor_GAUGE_INT64, metric.MetricDescriptor.Type)
 	require.Equal(t, &metricspb.Point_Int64Value{Int64Value: 2}, metric.Timeseries[0].Points[0].Value)
 
 	metric = m[2]
 	require.Equal(t, "redis/db/avg_ttl", metric.MetricDescriptor.Name)
 	require.Equal(t, "db", metric.MetricDescriptor.LabelKeys[0].Key)
 	require.Equal(t, "0", metric.Timeseries[0].LabelValues[0].Value)
-	require.Equal(t, metricspb.MetricDescriptor_CUMULATIVE_INT64, metric.MetricDescriptor.Type)
+	require.Equal(t, metricspb.MetricDescriptor_GAUGE_INT64, metric.MetricDescriptor.Type)
 	require.Equal(t, &metricspb.Point_Int64Value{Int64Value: 3}, metric.Timeseries[0].Points[0].Value)
 }
 
@@ -134,20 +143,20 @@ func fetchMetrics(redisMetrics []*redisMetric) ([]*metricspb.Metric, []error, er
 	return protoMetrics, warnings, nil
 }
 
-func getProtoMetric(t *testing.T, redisMetric *redisMetric) *metricspb.Metric {
-	md := getMetricData(t, redisMetric)
+func getProtoMetric(t *testing.T, redisMetric *redisMetric, serverName string) *metricspb.Metric {
+	md := getMetricData(t, redisMetric, serverName)
 	metric := md.Metrics[0]
 	return metric
 }
 
-func getMetricData(t *testing.T, metric *redisMetric) *consumerdata.MetricsData {
-	md, warnings, err := getMetricDataErr(metric)
+func getMetricData(t *testing.T, metric *redisMetric, serverName string) *consumerdata.MetricsData {
+	md, warnings, err := getMetricDataErr(metric, serverName)
 	require.Nil(t, err)
 	require.Nil(t, warnings)
 	return md
 }
 
-func getMetricDataErr(metric *redisMetric) (*consumerdata.MetricsData, []error, error) {
+func getMetricDataErr(metric *redisMetric, serverName string) (*consumerdata.MetricsData, []error, error) {
 	redisMetrics := []*redisMetric{metric}
 	svc := newRedisSvc(newFakeClient())
 	info, err := svc.info()
@@ -155,7 +164,7 @@ func getMetricDataErr(metric *redisMetric) (*consumerdata.MetricsData, []error, 
 		return nil, nil, err
 	}
 	protoMetrics, warnings := info.buildFixedProtoMetrics(redisMetrics, getDefaultTimeBundle())
-	md := newMetricsData(protoMetrics)
+	md := newMetricsData(protoMetrics, serverName)
 	return md, warnings, nil
 }
 

--- a/receiver/redisreceiver/receiver.go
+++ b/receiver/redisreceiver/receiver.go
@@ -50,7 +50,7 @@ func (r *redisReceiver) Start(ctx context.Context, host component.Host) error {
 		Addr:     r.config.Endpoint,
 		Password: r.config.Password,
 	})
-	redisRunnable := newRedisRunnable(ctx, client, r.config.ServerName, r.consumer, r.logger)
+	redisRunnable := newRedisRunnable(ctx, client, r.config.ServiceName, r.consumer, r.logger)
 	r.intervalRunner = interval.NewRunner(r.config.CollectionInterval, redisRunnable)
 
 	go func() {

--- a/receiver/redisreceiver/receiver.go
+++ b/receiver/redisreceiver/receiver.go
@@ -50,7 +50,7 @@ func (r *redisReceiver) Start(ctx context.Context, host component.Host) error {
 		Addr:     r.config.Endpoint,
 		Password: r.config.Password,
 	})
-	redisRunnable := newRedisRunnable(ctx, client, r.consumer, r.logger)
+	redisRunnable := newRedisRunnable(ctx, client, r.config.ServerName, r.consumer, r.logger)
 	r.intervalRunner = interval.NewRunner(r.config.CollectionInterval, redisRunnable)
 
 	go func() {

--- a/receiver/redisreceiver/redis_runnable.go
+++ b/receiver/redisreceiver/redis_runnable.go
@@ -36,16 +36,19 @@ type redisRunnable struct {
 	redisMetrics    []*redisMetric
 	logger          *zap.Logger
 	timeBundle      *timeBundle
+	serverName      string
 }
 
 func newRedisRunnable(
 	ctx context.Context,
 	client client,
+	serverName string,
 	metricsConsumer consumer.MetricsConsumerOld,
 	logger *zap.Logger,
 ) *redisRunnable {
 	return &redisRunnable{
 		ctx:             ctx,
+		serverName:      serverName,
 		redisSvc:        newRedisSvc(client),
 		metricsConsumer: metricsConsumer,
 		logger:          logger,
@@ -104,7 +107,7 @@ func (r *redisRunnable) Run() error {
 		)
 	}
 
-	md := newMetricsData(metrics)
+	md := newMetricsData(metrics, r.serverName)
 
 	err = r.metricsConsumer.ConsumeMetricsData(r.ctx, *md)
 	numTimeSeries, numPoints := obsreport.CountMetricPoints(*md)

--- a/receiver/redisreceiver/redis_runnable.go
+++ b/receiver/redisreceiver/redis_runnable.go
@@ -36,19 +36,19 @@ type redisRunnable struct {
 	redisMetrics    []*redisMetric
 	logger          *zap.Logger
 	timeBundle      *timeBundle
-	serverName      string
+	serviceName     string
 }
 
 func newRedisRunnable(
 	ctx context.Context,
 	client client,
-	serverName string,
+	serviceName string,
 	metricsConsumer consumer.MetricsConsumerOld,
 	logger *zap.Logger,
 ) *redisRunnable {
 	return &redisRunnable{
 		ctx:             ctx,
-		serverName:      serverName,
+		serviceName:     serviceName,
 		redisSvc:        newRedisSvc(client),
 		metricsConsumer: metricsConsumer,
 		logger:          logger,
@@ -107,7 +107,7 @@ func (r *redisRunnable) Run() error {
 		)
 	}
 
-	md := newMetricsData(metrics, r.serverName)
+	md := newMetricsData(metrics, r.serviceName)
 
 	err = r.metricsConsumer.ConsumeMetricsData(r.ctx, *md)
 	numTimeSeries, numPoints := obsreport.CountMetricPoints(*md)

--- a/receiver/redisreceiver/redis_runnable_test.go
+++ b/receiver/redisreceiver/redis_runnable_test.go
@@ -26,7 +26,7 @@ import (
 func TestRedisRunnable(t *testing.T) {
 	consumer := &fakeMetricsConsumer{}
 	logger, _ := zap.NewDevelopment()
-	runner := newRedisRunnable(context.Background(), newFakeClient(), consumer, logger)
+	runner := newRedisRunnable(context.Background(), newFakeClient(), "", consumer, logger)
 	err := runner.Setup()
 	require.Nil(t, err)
 	err = runner.Run()


### PR DESCRIPTION
In preparing for a demo I noticed that some metric types were wrong (might have fallen through the cracks when I was dealing with merge issues on the Redis PR). Fixed those and added an optional server_name config value that will get applied as a Resource label, if present, for distinguishing between multiple Redis servers.