### PR TITLE
Disable compression of SAPM exporter in E2E tests

### DIFF
--- a/testbed/tests/receivers.go
+++ b/testbed/tests/receivers.go
@@ -72,7 +72,8 @@ func (sr *SapmDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   sapm:
-    endpoint: "http://localhost:%d/v2/trace"`, sr.Port)
+    endpoint: "http://localhost:%d/v2/trace"
+    disable_compression: true`, sr.Port)
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.


### PR DESCRIPTION
We previously disabled compression when sending from testbed to Collector.
This also disables compression when sending from Collector to testbed.
