### PR TITLE
Fix redis crash

### DIFF
--- a/receiver/redisreceiver/factory.go
+++ b/receiver/redisreceiver/factory.go
@@ -34,22 +34,22 @@ var _ component.ReceiverFactoryOld = (*Factory)(nil)
 type Factory struct {
 }
 
-func (f Factory) CustomUnmarshaler() component.CustomUnmarshaler {
+func (f *Factory) CustomUnmarshaler() component.CustomUnmarshaler {
 	return nil
 }
 
 // Type returns the type of this factory, "redis".
-func (f Factory) Type() configmodels.Type {
-	return configmodels.Type(typeStr)
+func (f *Factory) Type() configmodels.Type {
+	return typeStr
 }
 
 // CreateDefaultConfig creates a default config.
-func (f Factory) CreateDefaultConfig() configmodels.Receiver {
+func (f *Factory) CreateDefaultConfig() configmodels.Receiver {
 	return &config{}
 }
 
 // CreateTraceReceiver creates a trace Receiver. Not supported for now.
-func (f Factory) CreateTraceReceiver(
+func (f *Factory) CreateTraceReceiver(
 	ctx context.Context,
 	logger *zap.Logger,
 	cfg configmodels.Receiver,
@@ -60,7 +60,7 @@ func (f Factory) CreateTraceReceiver(
 }
 
 // CreateMetricsReceiver creates a Redis metrics receiver.
-func (f Factory) CreateMetricsReceiver(
+func (f *Factory) CreateMetricsReceiver(
 	logger *zap.Logger,
 	cfg configmodels.Receiver,
 	consumer consumer.MetricsConsumerOld,

--- a/receiver/redisreceiver/receiver.go
+++ b/receiver/redisreceiver/receiver.go
@@ -45,7 +45,7 @@ func newRedisReceiver(
 }
 
 // Set up and kick off the interval runner.
-func (r redisReceiver) Start(ctx context.Context, host component.Host) error {
+func (r *redisReceiver) Start(ctx context.Context, host component.Host) error {
 	client := newRedisClient(&redis.Options{
 		Addr:     r.config.Endpoint,
 		Password: r.config.Password,
@@ -62,7 +62,7 @@ func (r redisReceiver) Start(ctx context.Context, host component.Host) error {
 	return nil
 }
 
-func (r redisReceiver) Shutdown(ctx context.Context) error {
+func (r *redisReceiver) Shutdown(ctx context.Context) error {
 	r.intervalRunner.Stop()
 	return nil
 }

--- a/receiver/redisreceiver/redis_svc.go
+++ b/receiver/redisreceiver/redis_svc.go
@@ -34,7 +34,7 @@ func newRedisSvc(client client) *redisSvc {
 }
 
 // Calls the Redis INFO command on the client and returns an `info` map.
-func (p redisSvc) info() (info, error) {
+func (p *redisSvc) info() (info, error) {
 	str, err := p.client.retrieveInfo()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Redis receiver was crashing on stop because the receiver was not a pointer so
Shutdown was just being passed zero values.

I looked through to see if there are any others that are missing pointer and
just found one other. Would be good to have another set of eyes to look
through.
