### PR TITLE
Add dmitryax to CODEOWNERS since he is an approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @bogdandrutu @pjanotti @flands @songy23 @tigrannajaryan @owais @rghetia
+* @bogdandrutu @pjanotti @flands @songy23 @tigrannajaryan @owais @rghetia @dmitryax


### PR DESCRIPTION
dmitryax is already an approver on the Collector core:
https://github.com/open-telemetry/opentelemetry-collector/pull/895

This ensures he has the approving permission in this repo too.
