### PR TITLE
Add handling for spans received with nil attributes

### DIFF
--- a/exporter/awsxrayexporter/translator/http.go
+++ b/exporter/awsxrayexporter/translator/http.go
@@ -52,6 +52,10 @@ func makeHTTP(span *tracepb.Span) (map[string]string, *HTTPData) {
 		componentValue string
 	)
 
+	if span.Attributes == nil {
+		return filtered, nil
+	}
+
 	for key, value := range span.Attributes.AttributeMap {
 		switch key {
 		case semconventions.AttributeComponent:


### PR DESCRIPTION
**Description:** Collector panicked when it tried export of a span where attributes was nil

**Testing:** Added unit test with attributes set to nil

**Documentation:** None