### PR TITLE
Fix running lint in individual modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ BUILD_X2=-X $(BUILD_INFO_IMPORT_PATH).Version=$(VERSION)
 endif
 BUILD_X3=-X github.com/open-telemetry/opentelemetry-collector/internal/version.BuildType=$(BUILD_TYPE)
 BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2} ${BUILD_X3}"
-LINT=golangci-lint
 STATIC_CHECK=staticcheck
 
 .DEFAULT_GOAL := all

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -19,6 +19,7 @@ ADDLICENCESE= addlicense
 MISSPELL=misspell -error
 MISSPELL_CORRECTION=misspell -w
 STATICCHECK=staticcheck
+LINT=golangci-lint
 IMPI=impi
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release


### PR DESCRIPTION
LINT defaults to [lint in make](https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html) so it was still running the old go program called `lint`. However this program isn't included in install-modules anymore. Set LINT in common so all includers get it.