### PR TITLE
Add support of Pod UID extraction to k8sprocessor

### DIFF
--- a/processor/k8sprocessor/config.go
+++ b/processor/k8sprocessor/config.go
@@ -44,7 +44,7 @@ type ExtractConfig struct {
 	// The field accepts a list of strings.
 	//
 	// Metadata fields supported right now are,
-	//   namespace, podName, deployment, cluster, node and startTime
+	//   namespace, podName, podUID, deployment, cluster, node and startTime
 	//
 	// Specifying anything other than these values will result in an error.
 	// By default all of the fields are extracted and added to spans.

--- a/processor/k8sprocessor/config_test.go
+++ b/processor/k8sprocessor/config_test.go
@@ -61,7 +61,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 			Passthrough: false,
 			Extract: ExtractConfig{
-				Metadata: []string{"podName", "deployment", "cluster", "namespace", "node", "startTime"},
+				Metadata: []string{"podName", "podUID", "deployment", "cluster", "namespace", "node", "startTime"},
 				Annotations: []FieldExtractConfig{
 					{TagName: "a1", Key: "annotation-one"},
 					{TagName: "a2", Key: "annotation-two", Regex: "field=(?P<value>.+)"},

--- a/processor/k8sprocessor/kube/client.go
+++ b/processor/k8sprocessor/kube/client.go
@@ -199,6 +199,11 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 		}
 	}
 
+	if c.Rules.PodUID {
+		uid := pod.GetUID()
+		tags[tagPodUID] = string(uid)
+	}
+
 	if c.Rules.Deployment {
 		// format: [deployment-name]-[Random-String-For-ReplicaSet]-[Random-String-For-Pod]
 		parts := c.deploymentRegex.FindStringSubmatch(pod.Name)

--- a/processor/k8sprocessor/kube/client_test.go
+++ b/processor/k8sprocessor/kube/client_test.go
@@ -129,6 +129,7 @@ func TestExtractionRules(t *testing.T) {
 	pod := &api_v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:              "auth-service-abc12-xyz3",
+			UID:               "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 			Namespace:         "ns1",
 			CreationTimestamp: meta_v1.Now(),
 			ClusterName:       "cluster1",
@@ -170,6 +171,7 @@ func TestExtractionRules(t *testing.T) {
 			Deployment: true,
 			Namespace:  true,
 			PodName:    true,
+			PodUID:     true,
 			Node:       true,
 			Cluster:    true,
 			StartTime:  true,
@@ -180,6 +182,7 @@ func TestExtractionRules(t *testing.T) {
 			"k8s.cluster.name":    "cluster1",
 			"k8s.node.name":       "node1",
 			"k8s.pod.name":        "auth-service-abc12-xyz3",
+			"k8s.pod.uid":         "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 			"k8s.pod.startTime":   pod.GetCreationTimestamp().String(),
 		},
 	}, {

--- a/processor/k8sprocessor/kube/kube.go
+++ b/processor/k8sprocessor/kube/kube.go
@@ -33,6 +33,7 @@ const (
 	tagNamespaceName  = "k8s.namespace.name"
 	tagNodeName       = "k8s.node.name"
 	tagPodName        = "k8s.pod.name"
+	tagPodUID         = "k8s.pod.uid"
 	tagStartTime      = "k8s.pod.startTime"
 )
 
@@ -107,6 +108,7 @@ type ExtractionRules struct {
 	Deployment bool
 	Namespace  bool
 	PodName    bool
+	PodUID     bool
 	Node       bool
 	Cluster    bool
 	StartTime  bool

--- a/processor/k8sprocessor/options.go
+++ b/processor/k8sprocessor/options.go
@@ -32,6 +32,7 @@ const (
 
 	metdataNamespace   = "namespace"
 	metadataPodName    = "podName"
+	metadataPodUID     = "podUID"
 	metadataStartTime  = "startTime"
 	metadataDeployment = "deployment"
 	metadataCluster    = "cluster"
@@ -52,12 +53,14 @@ func WithPassthrough() Option {
 }
 
 // WithExtractMetadata allows specifying options to control extraction of pod metadata.
+// If no fields explicitly provided, all metadata extracted by default.
 func WithExtractMetadata(fields ...string) Option {
 	return func(p *kubernetesprocessor) error {
 		if len(fields) == 0 {
 			fields = []string{
 				metdataNamespace,
 				metadataPodName,
+				metadataPodUID,
 				metadataStartTime,
 				metadataDeployment,
 				metadataCluster,
@@ -70,6 +73,8 @@ func WithExtractMetadata(fields ...string) Option {
 				p.rules.Namespace = true
 			case metadataPodName:
 				p.rules.PodName = true
+			case metadataPodUID:
+				p.rules.PodUID = true
 			case metadataStartTime:
 				p.rules.StartTime = true
 			case metadataDeployment:

--- a/processor/k8sprocessor/testdata/config.yaml
+++ b/processor/k8sprocessor/testdata/config.yaml
@@ -9,6 +9,7 @@ processors:
       metadata:
         # extract the following well-known metadata fields
         - podName
+        - podUID
         - deployment
         - cluster
         - namespace


### PR DESCRIPTION
This commit allows to extract k8s Pod UID and set it as "k8s.pod.uid" attribute according to OpenTelemetry conventions