### PR TITLE
sfxexporter refactor

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -12,7 +12,7 @@ The following configuration options can also be configured:
 
 - `headers` (no default): Headers to pass in the payload.
 - `timeout` (default = 5s): Amount of time to wait for a send operation to complete.
-- `url` (default = https://ingest.`realm`.signalfx.com/v2/datapoint): Destination
+- `ingest_url` (default = https://ingest.`realm`.signalfx.com/v2/datapoint): Destination
 where SignalFx metrics are sent. If this option is specified, `realm` is ignored.
 If path is not specified, `/v2/datapoint` is used.
 

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -15,6 +15,7 @@
 package signalfxexporter
 
 import (
+	"net/url"
 	"path"
 	"testing"
 	"time"
@@ -65,4 +66,77 @@ func TestLoadConfig(t *testing.T) {
 	te, err := factory.CreateMetricsExporter(zap.NewNop(), e1)
 	require.NoError(t, err)
 	require.NotNil(t, te)
+}
+
+func TestConfig_getOptionsFromConfig(t *testing.T) {
+	type fields struct {
+		ExporterSettings configmodels.ExporterSettings
+		AccessToken      string
+		Realm            string
+		IngestURL        string
+		Timeout          time.Duration
+		Headers          map[string]string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *exporterOptions
+		wantErr bool
+	}{
+		{
+			name: "Test URL overrides",
+			fields: fields{
+				Realm:     "us0",
+				IngestURL: "https://ingest.us1.signalfx.com/",
+			},
+			want: &exporterOptions{
+				ingestURL: &url.URL{
+					Scheme: "https",
+					Host:   "ingest.us1.signalfx.com",
+					Path:   "/v2/datapoint",
+				},
+				httpTimeout: 5 * time.Second,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test URL from Realm",
+			fields: fields{
+				Realm:   "us0",
+				Timeout: 10 * time.Second,
+			},
+			want: &exporterOptions{
+				ingestURL: &url.URL{
+					Scheme: "https",
+					Host:   "ingest.us0.signalfx.com",
+					Path:   "/v2/datapoint",
+				},
+				httpTimeout: 10 * time.Second,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Test empty config",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				ExporterSettings: tt.fields.ExporterSettings,
+				AccessToken:      tt.fields.AccessToken,
+				Realm:            tt.fields.Realm,
+				IngestURL:        tt.fields.IngestURL,
+				Timeout:          tt.fields.Timeout,
+				Headers:          tt.fields.Headers,
+			}
+			got, err := cfg.getOptionsFromConfig()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getOptionsFromConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/exporter/signalfxexporter/dpclient.go
+++ b/exporter/signalfxexporter/dpclient.go
@@ -1,0 +1,142 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalfxexporter
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
+	"github.com/open-telemetry/opentelemetry-collector/consumer/consumererror"
+	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
+	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf"
+	"go.uber.org/zap"
+)
+
+// sfxDPClient sends the data to the SignalFx backend.
+type sfxDPClient struct {
+	ingestURL *url.URL
+	headers   map[string]string
+	client    *http.Client
+	logger    *zap.Logger
+	zippers   sync.Pool
+}
+
+func (s *sfxDPClient) pushMetricsData(
+	ctx context.Context,
+	md consumerdata.MetricsData,
+) (droppedTimeSeries int, err error) {
+
+	sfxDataPoints, numDroppedTimeseries, err := metricDataToSingalFxV2(s.logger, md)
+	if err != nil {
+		return exporterhelper.NumTimeSeries(md), consumererror.Permanent(err)
+	}
+
+	body, compressed, err := s.encodeBody(sfxDataPoints)
+	if err != nil {
+		return exporterhelper.NumTimeSeries(md), consumererror.Permanent(err)
+	}
+
+	req, err := http.NewRequest("POST", s.ingestURL.String(), body)
+	if err != nil {
+		return exporterhelper.NumTimeSeries(md), consumererror.Permanent(err)
+	}
+
+	for k, v := range s.headers {
+		req.Header.Set(k, v)
+	}
+
+	if compressed {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return exporterhelper.NumTimeSeries(md), err
+	}
+
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+
+	// SignalFx accepts all 2XX codes.
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		err = fmt.Errorf(
+			"HTTP %d %q",
+			resp.StatusCode,
+			http.StatusText(resp.StatusCode))
+		return exporterhelper.NumTimeSeries(md), err
+	}
+
+	return numDroppedTimeseries, nil
+}
+
+func buildHeaders(config *Config) (map[string]string, error) {
+	headers := map[string]string{
+		"Connection":   "keep-alive",
+		"Content-Type": "application/x-protobuf",
+		"User-Agent":   "OpenTelemetry-Collector SignalFx Exporter/v0.0.1",
+	}
+
+	if config.AccessToken != "" {
+		headers["X-Sf-Token"] = config.AccessToken
+	}
+
+	// Add any custom headers from the config. They will override the pre-defined
+	// ones above in case of conflict, but, not the content encoding one since
+	// the latter one is defined according to the payload.
+	for k, v := range config.Headers {
+		headers[k] = v
+	}
+
+	return headers, nil
+}
+
+func (s *sfxDPClient) encodeBody(dps []*sfxpb.DataPoint) (bodyReader io.Reader, compressed bool, err error) {
+	msg := &sfxpb.DataPointUploadMessage{
+		Datapoints: dps,
+	}
+	body, err := proto.Marshal(msg)
+	if err != nil {
+		return nil, false, err
+	}
+	return s.getReader(body)
+}
+
+// avoid attempting to compress things that fit into a single ethernet frame
+func (s *sfxDPClient) getReader(b []byte) (io.Reader, bool, error) {
+	var err error
+	if len(b) > 1500 {
+		buf := new(bytes.Buffer)
+		w := s.zippers.Get().(*gzip.Writer)
+		defer s.zippers.Put(w)
+		w.Reset(buf)
+		_, err = w.Write(b)
+		if err == nil {
+			err = w.Close()
+			if err == nil {
+				return buf, true, nil
+			}
+		}
+	}
+	return bytes.NewReader(b), false, err
+}

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -15,24 +15,16 @@
 package signalfxexporter
 
 import (
-	"bytes"
 	"compress/gzip"
-	"context"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/open-telemetry/opentelemetry-collector/component"
-	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
-	"github.com/open-telemetry/opentelemetry-collector/consumer/consumererror"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
-	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf"
 	"go.uber.org/zap"
 )
 
@@ -69,7 +61,7 @@ func New(
 		return nil, err
 	}
 
-	s := &httpSender{
+	s := &sfxDPClient{
 		ingestURL: options.ingestURL,
 		headers:   headers,
 		client: &http.Client{
@@ -88,112 +80,4 @@ func New(
 		s.pushMetricsData)
 
 	return exp, err
-}
-
-// httpSender sends the data to the SignalFx backend.
-type httpSender struct {
-	ingestURL *url.URL
-	headers   map[string]string
-	client    *http.Client
-	logger    *zap.Logger
-	zippers   sync.Pool
-}
-
-func (s *httpSender) pushMetricsData(
-	ctx context.Context,
-	md consumerdata.MetricsData,
-) (droppedTimeSeries int, err error) {
-
-	sfxDataPoints, numDroppedTimeseries, err := metricDataToSingalFxV2(s.logger, md)
-	if err != nil {
-		return exporterhelper.NumTimeSeries(md), consumererror.Permanent(err)
-	}
-
-	body, compressed, err := s.encodeBody(sfxDataPoints)
-	if err != nil {
-		return exporterhelper.NumTimeSeries(md), consumererror.Permanent(err)
-	}
-
-	req, err := http.NewRequest("POST", s.ingestURL.String(), body)
-	if err != nil {
-		return exporterhelper.NumTimeSeries(md), consumererror.Permanent(err)
-	}
-
-	for k, v := range s.headers {
-		req.Header.Set(k, v)
-	}
-
-	if compressed {
-		req.Header.Set("Content-Encoding", "gzip")
-	}
-
-	resp, err := s.client.Do(req)
-	if err != nil {
-		return exporterhelper.NumTimeSeries(md), err
-	}
-
-	io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
-
-	// SignalFx accepts all 2XX codes.
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		err = fmt.Errorf(
-			"HTTP %d %q",
-			resp.StatusCode,
-			http.StatusText(resp.StatusCode))
-		return exporterhelper.NumTimeSeries(md), err
-	}
-
-	return numDroppedTimeseries, nil
-}
-
-func buildHeaders(config *Config) (map[string]string, error) {
-	headers := map[string]string{
-		"Connection":   "keep-alive",
-		"Content-Type": "application/x-protobuf",
-		"User-Agent":   "OpenTelemetry-Collector SignalFx Exporter/v0.0.1",
-	}
-
-	if config.AccessToken != "" {
-		headers["X-Sf-Token"] = config.AccessToken
-	}
-
-	// Add any custom headers from the config. They will override the pre-defined
-	// ones above in case of conflict, but, not the content encoding one since
-	// the latter one is defined according to the payload.
-	for k, v := range config.Headers {
-		headers[k] = v
-	}
-
-	return headers, nil
-}
-
-func (s *httpSender) encodeBody(dps []*sfxpb.DataPoint) (bodyReader io.Reader, compressed bool, err error) {
-	msg := &sfxpb.DataPointUploadMessage{
-		Datapoints: dps,
-	}
-	body, err := proto.Marshal(msg)
-	if err != nil {
-		return nil, false, err
-	}
-	return s.getReader(body)
-}
-
-// avoid attempting to compress things that fit into a single ethernet frame
-func (s *httpSender) getReader(b []byte) (io.Reader, bool, error) {
-	var err error
-	if len(b) > 1500 {
-		buf := new(bytes.Buffer)
-		w := s.zippers.Get().(*gzip.Writer)
-		defer s.zippers.Put(w)
-		w.Reset(buf)
-		_, err = w.Write(b)
-		if err == nil {
-			err = w.Close()
-			if err == nil {
-				return buf, true, nil
-			}
-		}
-	}
-	return bytes.NewReader(b), false, err
 }

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"sync"
 	"testing"
@@ -110,9 +111,12 @@ func TestConsumeMetricsData(t *testing.T) {
 			}))
 			defer server.Close()
 
+			serverURL, err := url.Parse(server.URL)
+			assert.NoError(t, err)
+
 			sender := &httpSender{
-				url:     server.URL,
-				headers: map[string]string{"test_header_": "test"},
+				ingestURL: serverURL,
+				headers:   map[string]string{"test_header_": "test"},
 				client: &http.Client{
 					Timeout: 1 * time.Second,
 				},

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -114,7 +114,7 @@ func TestConsumeMetricsData(t *testing.T) {
 			serverURL, err := url.Parse(server.URL)
 			assert.NoError(t, err)
 
-			sender := &httpSender{
+			sender := &sfxDPClient{
 				ingestURL: serverURL,
 				headers:   map[string]string{"test_header_": "test"},
 				client: &http.Client{

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -111,7 +111,7 @@ func TestFactory_CreateMetricsExporterFails(t *testing.T) {
 				Realm:       "lab",
 				Timeout:     -2 * time.Second,
 			},
-			errorMessage: "\"signalfx\" config cannot have a negative \"timeout\"",
+			errorMessage: "failed to process \"signalfx\" config: cannot have a negative \"timeout\"",
 		},
 		{
 			name: "empty_realm_and_url",
@@ -121,7 +121,7 @@ func TestFactory_CreateMetricsExporterFails(t *testing.T) {
 					NameVal: typeStr,
 				},
 			},
-			errorMessage: "\"signalfx\" config requires a non-empty \"realm\" or \"url\"",
+			errorMessage: "failed to process \"signalfx\" config: requires a non-empty \"realm\" or \"ingest_url\"",
 		},
 	}
 	for _, tt := range tests {

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -130,7 +130,7 @@ func Test_signalfxeceiver_EndToEnd(t *testing.T) {
 	}
 
 	expCfg := &signalfxexporter.Config{
-		URL: "http://" + addr + "/v2/datapoint",
+		IngestURL: "http://" + addr + "/v2/datapoint",
 	}
 	exp, err := signalfxexporter.New(expCfg, zap.NewNop())
 	require.NoError(t, err)

--- a/testbed/tests/receivers.go
+++ b/testbed/tests/receivers.go
@@ -121,7 +121,7 @@ func (sr *SFxMetricsDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   signalfx:
-    url: "http://localhost:%d/v2/datapoint"`, sr.Port)
+    ingest_url: "http://localhost:%d/v2/datapoint"`, sr.Port)
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.

--- a/testbed/tests/senders.go
+++ b/testbed/tests/senders.go
@@ -109,7 +109,7 @@ func NewSFxMetricDataSender(port int) *SFxMetricsDataSender {
 // Start the sender.
 func (sf *SFxMetricsDataSender) Start() error {
 	cfg := &signalfxexporter.Config{
-		URL: fmt.Sprintf("http://localhost:%d/v2/datapoint", sf.port),
+		IngestURL: fmt.Sprintf("http://localhost:%d/v2/datapoint", sf.port),
 	}
 
 	factory := signalfxexporter.Factory{}


### PR DESCRIPTION
**Description:** Refactor `sfxexporter` to prepare for addition of a dimension client. The `url` option in the config has been updated to `ingest_url` since in subsequent updates a config option for API URL will also be added

**Testing:** Updated unit tests
