### PR TITLE
Modify performance test resource limits

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -34,7 +34,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 40,
-				ExpectedMaxRAM: 70,
+				ExpectedMaxRAM: 86,
 			},
 		},
 		{
@@ -42,8 +42,8 @@ func TestMetric10kDPS(t *testing.T) {
 			NewCarbonDataSender(testbed.GetAvailablePort(t)),
 			NewCarbonDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 200,
-				ExpectedMaxRAM: 65,
+				ExpectedMaxCPU: 237,
+				ExpectedMaxRAM: 90,
 			},
 		},
 		{
@@ -51,8 +51,8 @@ func TestMetric10kDPS(t *testing.T) {
 			NewSFxMetricDataSender(testbed.GetAvailablePort(t)),
 			NewSFxMetricsDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 80,
-				ExpectedMaxRAM: 80,
+				ExpectedMaxCPU: 83,
+				ExpectedMaxRAM: 91,
 			},
 		},
 	}

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -41,8 +41,8 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOCTraceDataSender(testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 50,
-				ExpectedMaxRAM: 80,
+				ExpectedMaxCPU: 26,
+				ExpectedMaxRAM: 90,
 			},
 		},
 		{
@@ -50,8 +50,8 @@ func TestTrace10kSPS(t *testing.T) {
 			NewSapmDataSender(testbed.GetAvailablePort(t)),
 			NewSapmDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 90,
-				ExpectedMaxRAM: 120,
+				ExpectedMaxCPU: 24,
+				ExpectedMaxRAM: 100,
 			},
 		},
 	}


### PR DESCRIPTION
This gives more room to performance tests which currently run on
unstable CI environment where performance is not guaranteed.
