### PR TITLE
Port ocprot to spandata from core, stackdriver exporter still uses this

### DIFF
--- a/exporter/stackdriverexporter/spandata.go
+++ b/exporter/stackdriverexporter/spandata.go
@@ -1,0 +1,309 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package spandata defines translators from Trace proto spans to OpenCensus Go spanData.
+package stackdriverexporter
+
+import (
+	"errors"
+
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/tracestate"
+)
+
+var errNilSpan = errors.New("expected a non-nil span")
+
+// ProtoSpanToOCSpanData transforms a protobuf span into the equivalent trace.SpanData one.
+// When resource is not nil, then its labels are attached to span attributes
+func protoSpanToOCSpanData(span *tracepb.Span, resource *resourcepb.Resource) (*trace.SpanData, error) {
+	if span == nil {
+		return nil, errNilSpan
+	}
+
+	sTracestate, err := protoTracestateToOCTracestate(span.Tracestate)
+	if err != nil {
+		return nil, err
+	}
+
+	sc := trace.SpanContext{Tracestate: sTracestate}
+	copy(sc.TraceID[:], span.TraceId)
+	copy(sc.SpanID[:], span.SpanId)
+	var parentSpanID trace.SpanID
+	copy(parentSpanID[:], span.ParentSpanId)
+	startTime, _ := ptypes.Timestamp(span.StartTime)
+	endTime, _ := ptypes.Timestamp(span.EndTime)
+	sd := &trace.SpanData{
+		SpanContext:     sc,
+		ParentSpanID:    parentSpanID,
+		StartTime:       startTime,
+		EndTime:         endTime,
+		Name:            derefTruncatableString(span.Name),
+		Attributes:      protoAttributesToOCAttributes(span.Attributes, resource),
+		Links:           protoLinksToOCLinks(span.Links),
+		Status:          protoStatusToOCStatus(span.Status),
+		SpanKind:        protoSpanKindToOCSpanKind(span.Kind),
+		MessageEvents:   protoTimeEventsToOCMessageEvents(span.TimeEvents),
+		Annotations:     protoTimeEventsToOCAnnotations(span.TimeEvents),
+		HasRemoteParent: protoSameProcessAsParentToOCHasRemoteParent(span.SameProcessAsParentSpan),
+	}
+
+	return sd, nil
+}
+
+func derefTruncatableString(ts *tracepb.TruncatableString) string {
+	if ts == nil {
+		return ""
+	}
+	return ts.Value
+}
+
+func protoStatusToOCStatus(s *tracepb.Status) (ts trace.Status) {
+	if s == nil {
+		return
+	}
+	return trace.Status{
+		Code:    s.Code,
+		Message: s.Message,
+	}
+}
+
+func protoTracestateToOCTracestate(ts *tracepb.Span_Tracestate) (*tracestate.Tracestate, error) {
+	if ts == nil {
+		return nil, nil
+	}
+	return tracestate.New(nil, protoEntriesToOCEntries(ts.Entries)...)
+}
+
+func protoEntriesToOCEntries(protoEntries []*tracepb.Span_Tracestate_Entry) []tracestate.Entry {
+	ocEntries := make([]tracestate.Entry, 0, len(protoEntries))
+	for _, protoEntry := range protoEntries {
+		var entry tracestate.Entry
+		if protoEntry != nil {
+			entry.Key = protoEntry.Key
+			entry.Value = protoEntry.Value
+		}
+		ocEntries = append(ocEntries, entry)
+	}
+	return ocEntries
+}
+
+func protoLinksToOCLinks(sls *tracepb.Span_Links) []trace.Link {
+	if sls == nil || len(sls.Link) == 0 {
+		return nil
+	}
+	links := make([]trace.Link, 0, len(sls.Link))
+	for _, sl := range sls.Link {
+		var traceID trace.TraceID
+		var spanID trace.SpanID
+		copy(traceID[:], sl.TraceId)
+		copy(spanID[:], sl.SpanId)
+		links = append(links, trace.Link{
+			TraceID: traceID,
+			SpanID:  spanID,
+			Type:    protoLinkTypeToOCLinkType(sl.Type),
+		})
+	}
+	return links
+}
+
+func protoLinkTypeToOCLinkType(lt tracepb.Span_Link_Type) trace.LinkType {
+	switch lt {
+	case tracepb.Span_Link_CHILD_LINKED_SPAN:
+		return trace.LinkTypeChild
+	case tracepb.Span_Link_PARENT_LINKED_SPAN:
+		return trace.LinkTypeParent
+	default:
+		return trace.LinkTypeUnspecified
+	}
+}
+
+func protoAttributesToOCAttributes(attrs *tracepb.Span_Attributes, resource *resourcepb.Resource) map[string]interface{} {
+	if attrs == nil && resource == nil {
+		return nil
+	}
+
+	ocAttrsMap := make(map[string]interface{})
+
+	if resource != nil {
+		for key, value := range resource.Labels {
+			ocAttrsMap[key] = value
+		}
+	}
+
+	if attrs == nil || len(attrs.AttributeMap) == 0 {
+		return ocAttrsMap
+	}
+	for key, attr := range attrs.AttributeMap {
+		if attr == nil || attr.Value == nil {
+			continue
+		}
+		switch value := attr.Value.(type) {
+		case *tracepb.AttributeValue_BoolValue:
+			ocAttrsMap[key] = value.BoolValue
+
+		case *tracepb.AttributeValue_IntValue:
+			ocAttrsMap[key] = value.IntValue
+
+		case *tracepb.AttributeValue_StringValue:
+			ocAttrsMap[key] = derefTruncatableString(value.StringValue)
+		}
+	}
+
+	return ocAttrsMap
+}
+
+func protoTimeEventsToOCMessageEvents(tes *tracepb.Span_TimeEvents) []trace.MessageEvent {
+	// TODO: (@odeke-em) file a bug with OpenCensus-Go and ask them why
+	// only MessageEvents are implemented.
+	if tes == nil || len(tes.TimeEvent) == 0 {
+		return nil
+	}
+
+	ocmes := make([]trace.MessageEvent, 0, len(tes.TimeEvent))
+	for _, te := range tes.TimeEvent {
+		if te == nil || te.Value == nil {
+			continue
+		}
+		tme, ok := te.Value.(*tracepb.Span_TimeEvent_MessageEvent_)
+		if !ok || tme == nil {
+			continue
+		}
+		me := tme.MessageEvent
+		var ocme trace.MessageEvent
+		// TODO: (@odeke-em) file an issue with OpenCensus-Go to ask why
+		// they have these attributes as int64 yet the proto definitions
+		// are uint64, this could be a potential loss of precision particularly
+		// in very high traffic systems.
+		ocme.MessageID = int64(me.Id)
+		ocme.UncompressedByteSize = int64(me.UncompressedSize)
+		ocme.CompressedByteSize = int64(me.CompressedSize)
+		ocme.EventType = protoMessageEventTypeToOCEventType(me.Type)
+		teTime, _ := ptypes.Timestamp(te.Time)
+		ocme.Time = teTime
+		ocmes = append(ocmes, ocme)
+	}
+
+	// For the purposes of rigorous equality during comparisons and tests,
+	// the absence of message events should return nil instead of []
+	if len(ocmes) == 0 {
+		return nil
+	}
+	return ocmes
+}
+
+func protoTimeEventsToOCAnnotations(tes *tracepb.Span_TimeEvents) []trace.Annotation {
+	if tes == nil || len(tes.TimeEvent) == 0 {
+		return nil
+	}
+
+	ocanns := make([]trace.Annotation, 0, len(tes.TimeEvent))
+	for _, te := range tes.TimeEvent {
+		if te == nil || te.Value == nil {
+			continue
+		}
+		tann, ok := te.Value.(*tracepb.Span_TimeEvent_Annotation_)
+		if !ok || tann == nil {
+			continue
+		}
+		me := tann.Annotation
+		var ocann trace.Annotation
+		// TODO: (@odeke-em) file an issue with OpenCensus-Go to ask why
+		// they have these attributes as int64 yet the proto definitions
+		// are uint64, this could be a potential loss of precision particularly
+		// in very high traffic systems.
+		teTime, _ := ptypes.Timestamp(te.Time)
+		ocann.Time = teTime
+		ocann.Message = me.Description.GetValue()
+		ocann.Attributes = protoSpanAttributesToOCAttributes(me.Attributes)
+		ocanns = append(ocanns, ocann)
+	}
+
+	// For the purposes of rigorous equality during comparisons and tests,
+	// the absence of annotations should return nil instead of []
+	if len(ocanns) == 0 {
+		return nil
+	}
+	return ocanns
+}
+
+func protoSpanAttributesToOCAttributes(sa *tracepb.Span_Attributes) map[string]interface{} {
+	if sa == nil || len(sa.AttributeMap) == 0 {
+		return nil
+	}
+
+	amap := make(map[string]interface{})
+	for pkey, pattr := range sa.AttributeMap {
+		var value interface{}
+
+		if pattr != nil && pattr.Value != nil {
+			switch typ := pattr.Value.(type) {
+			case *tracepb.AttributeValue_BoolValue:
+				value = typ.BoolValue
+
+			case *tracepb.AttributeValue_DoubleValue:
+				value = typ.DoubleValue
+
+			case *tracepb.AttributeValue_IntValue:
+				value = typ.IntValue
+
+			case *tracepb.AttributeValue_StringValue:
+				value = typ.StringValue.GetValue()
+			}
+		}
+
+		amap[pkey] = value
+	}
+
+	// For the purposes of rigorous equality during comparisons and
+	// tests, the absence of attributes should return nil instead of []
+	if len(amap) == 0 {
+		return nil
+	}
+	return amap
+}
+
+func protoMessageEventTypeToOCEventType(st tracepb.Span_TimeEvent_MessageEvent_Type) trace.MessageEventType {
+	switch st {
+	case tracepb.Span_TimeEvent_MessageEvent_SENT:
+		return trace.MessageEventTypeSent
+	case tracepb.Span_TimeEvent_MessageEvent_RECEIVED:
+		return trace.MessageEventTypeRecv
+	default:
+		return trace.MessageEventTypeUnspecified
+	}
+}
+
+func protoSpanKindToOCSpanKind(kind tracepb.Span_SpanKind) int {
+	switch kind {
+	case tracepb.Span_CLIENT:
+		return trace.SpanKindClient
+	case tracepb.Span_SERVER:
+		return trace.SpanKindServer
+	default:
+		return trace.SpanKindUnspecified
+	}
+}
+
+// Translating a variable that states if the parent and the current span are in the same process
+// to a variable that indicates whether the current span and parent are in different process.
+func protoSameProcessAsParentToOCHasRemoteParent(sameProcessAsParent *wrappers.BoolValue) bool {
+	if sameProcessAsParent == nil {
+		return false
+	}
+	return !sameProcessAsParent.Value
+}

--- a/exporter/stackdriverexporter/spandata_test.go
+++ b/exporter/stackdriverexporter/spandata_test.go
@@ -1,0 +1,174 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stackdriverexporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/tracestate"
+)
+
+func TestProtoSpanToOCSpanData_endToEnd(t *testing.T) {
+	// The goal of this test is to ensure that each
+	// tracepb.Span is transformed to its *trace.SpanData correctly!
+
+	endTime := time.Now().Round(time.Second)
+	endTimeProto, _ := ptypes.TimestampProto(endTime)
+	startTime := endTime.Add(-90 * time.Second)
+	startTimeProto, _ := ptypes.TimestampProto(startTime)
+
+	protoSpan := &tracepb.Span{
+		TraceId:      []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+		SpanId:       []byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8},
+		ParentSpanId: []byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8},
+		Name:         &tracepb.TruncatableString{Value: "End-To-End Here"},
+		Kind:         tracepb.Span_SERVER,
+		StartTime:    startTimeProto,
+		EndTime:      endTimeProto,
+		Status: &tracepb.Status{
+			Code:    13,
+			Message: "This is not a drill!",
+		},
+		SameProcessAsParentSpan: &wrappers.BoolValue{Value: false},
+		TimeEvents: &tracepb.Span_TimeEvents{
+			TimeEvent: []*tracepb.Span_TimeEvent{
+				{
+					Time: startTimeProto,
+					Value: &tracepb.Span_TimeEvent_MessageEvent_{
+						MessageEvent: &tracepb.Span_TimeEvent_MessageEvent{
+							Type: tracepb.Span_TimeEvent_MessageEvent_SENT, UncompressedSize: 1024, CompressedSize: 512,
+						},
+					},
+				},
+				{
+					Time: endTimeProto,
+					Value: &tracepb.Span_TimeEvent_MessageEvent_{
+						MessageEvent: &tracepb.Span_TimeEvent_MessageEvent{
+							Type: tracepb.Span_TimeEvent_MessageEvent_RECEIVED, UncompressedSize: 1024, CompressedSize: 1000,
+						},
+					},
+				},
+			},
+		},
+		Links: &tracepb.Span_Links{
+			Link: []*tracepb.Span_Link{
+				{
+					TraceId: []byte{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF},
+					SpanId:  []byte{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7},
+					Type:    tracepb.Span_Link_PARENT_LINKED_SPAN,
+				},
+				{
+					TraceId: []byte{0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF},
+					SpanId:  []byte{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7},
+					Type:    tracepb.Span_Link_CHILD_LINKED_SPAN,
+				},
+			},
+		},
+		Tracestate: &tracepb.Span_Tracestate{
+			Entries: []*tracepb.Span_Tracestate_Entry{
+				{Key: "foo", Value: "bar"},
+				{Key: "a", Value: "b"},
+			},
+		},
+		Attributes: &tracepb.Span_Attributes{
+			AttributeMap: map[string]*tracepb.AttributeValue{
+				"cache_hit":  {Value: &tracepb.AttributeValue_BoolValue{BoolValue: true}},
+				"timeout_ns": {Value: &tracepb.AttributeValue_IntValue{IntValue: 12e9}},
+				"ping_count": {Value: &tracepb.AttributeValue_IntValue{IntValue: 25}},
+				"agent": {Value: &tracepb.AttributeValue_StringValue{
+					StringValue: &tracepb.TruncatableString{Value: "ocagent"},
+				}},
+			},
+		},
+	}
+
+	resource := &resourcepb.Resource{
+		Type: "k8s",
+		Labels: map[string]string{
+			"namespace": "kube-system",
+		},
+	}
+
+	gotOCSpanData, err := protoSpanToOCSpanData(protoSpan, resource)
+	if err != nil {
+		t.Fatalf("Failed to convert from ProtoSpan to OCSpanData: %v", err)
+	}
+
+	ocTracestate, err := tracestate.New(new(tracestate.Tracestate), tracestate.Entry{Key: "foo", Value: "bar"},
+		tracestate.Entry{Key: "a", Value: "b"})
+	if err != nil || ocTracestate == nil {
+		t.Fatalf("Failed to create ocTracestate: %v", err)
+	}
+
+	wantOCSpanData := &trace.SpanData{
+		SpanContext: trace.SpanContext{
+			TraceID:    trace.TraceID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+			SpanID:     trace.SpanID{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8},
+			Tracestate: ocTracestate,
+		},
+		SpanKind:     trace.SpanKindServer,
+		ParentSpanID: trace.SpanID{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8},
+		Name:         "End-To-End Here",
+		StartTime:    startTime,
+		EndTime:      endTime,
+		MessageEvents: []trace.MessageEvent{
+			{Time: startTime, EventType: trace.MessageEventTypeSent, UncompressedByteSize: 1024, CompressedByteSize: 512},
+			{Time: endTime, EventType: trace.MessageEventTypeRecv, UncompressedByteSize: 1024, CompressedByteSize: 1000},
+		},
+		Links: []trace.Link{
+			{
+				TraceID: trace.TraceID{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF},
+				SpanID:  trace.SpanID{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7},
+				Type:    trace.LinkTypeParent,
+			},
+			{
+				TraceID: trace.TraceID{0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF},
+				SpanID:  trace.SpanID{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7},
+				Type:    trace.LinkTypeChild,
+			},
+		},
+		Status: trace.Status{
+			Code:    trace.StatusCodeInternal,
+			Message: "This is not a drill!",
+		},
+		HasRemoteParent: true,
+		Attributes: map[string]interface{}{
+			"namespace":  "kube-system",
+			"timeout_ns": int64(12e9),
+			"agent":      "ocagent",
+			"cache_hit":  true,
+			"ping_count": int(25), // Should be transformed into int64
+		},
+	}
+
+	if g, w := gotOCSpanData, wantOCSpanData; !reflect.DeepEqual(g, w) {
+		// As a last resort now compare by bytes here since reflect.DeepEqual might have been
+		// tripped out perhaps due to pointer differences(although this shouldn't hinder it).
+		gBlob, _ := json.MarshalIndent(g, "", "  ")
+		wBlob, _ := json.MarshalIndent(w, "", "  ")
+		if !bytes.Equal(wBlob, gBlob) {
+			t.Fatalf("End-to-end transformed span\n\tGot  %+v\n\tWant %+v", g, w)
+		}
+	}
+}

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -25,7 +25,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector/component/componenterror"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/exporter/exporterhelper"
-	spandatatranslator "github.com/open-telemetry/opentelemetry-collector/translator/trace/spandata"
 	"go.opencensus.io/trace"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -125,7 +124,7 @@ func (se *stackdriverExporter) pushTraceData(ctx context.Context, td consumerdat
 	spans := make([]*trace.SpanData, 0, len(td.Spans))
 
 	for _, span := range td.Spans {
-		sd, err := spandatatranslator.ProtoSpanToOCSpanData(span, td.Resource)
+		sd, err := protoSpanToOCSpanData(span, td.Resource)
 		if err == nil {
 			spans = append(spans, sd)
 			goodSpans++


### PR DESCRIPTION
This is a copy of the removed code from the core repository.