### PR TITLE
Tweak xray export to improve rendering of traces and improve parity a…

### DIFF
--- a/exporter/awsxrayexporter/translator/aws.go
+++ b/exporter/awsxrayexporter/translator/aws.go
@@ -32,6 +32,7 @@ const (
 	AWSRequestIDAttribute2 = "aws.requestId"
 	AWSQueueURLAttribute   = "aws.queue_url"
 	AWSQueueURLAttribute2  = "aws.queue.url"
+	AWSServiceAttribute    = "aws.service"
 	AWSTableNameAttribute  = "aws.table_name"
 	AWSTableNameAttribute2 = "aws.table.name"
 )
@@ -123,12 +124,15 @@ func makeAws(attributes map[string]string, resource *resourcepb.Resource) (map[s
 		case AWSRegionAttribute:
 			remoteRegion = value
 		case AWSRequestIDAttribute:
+			fallthrough
 		case AWSRequestIDAttribute2:
 			requestID = value
 		case AWSQueueURLAttribute:
+			fallthrough
 		case AWSQueueURLAttribute2:
 			queueURL = value
 		case AWSTableNameAttribute:
+			fallthrough
 		case AWSTableNameAttribute2:
 			tableName = value
 		default:

--- a/exporter/awsxrayexporter/translator/aws.go
+++ b/exporter/awsxrayexporter/translator/aws.go
@@ -27,8 +27,13 @@ const (
 	AWSAccountAttribute   = "aws.account_id"
 	AWSRegionAttribute    = "aws.region"
 	AWSRequestIDAttribute = "aws.request_id"
-	AWSQueueURLAttribute  = "aws.queue_url"
-	AWSTableNameAttribute = "aws.table_name"
+	// Currently different instrumentation uses different tag formats.
+	// TODO(anuraaga): Find current instrumentation and consolidate.
+	AWSRequestIDAttribute2 = "aws.requestId"
+	AWSQueueURLAttribute   = "aws.queue_url"
+	AWSQueueURLAttribute2  = "aws.queue.url"
+	AWSTableNameAttribute  = "aws.table_name"
+	AWSTableNameAttribute2 = "aws.table.name"
 )
 
 // AWSData provides the shape for unmarshalling AWS resource data.
@@ -72,7 +77,6 @@ func makeAws(attributes map[string]string, resource *resourcepb.Resource) (map[s
 		namespace    string
 		deployID     string
 		ver          string
-		origin       string
 		operation    string
 		remoteRegion string
 		requestID    string
@@ -82,30 +86,30 @@ func makeAws(attributes map[string]string, resource *resourcepb.Resource) (map[s
 		ecs          *ECSMetadata
 		ebs          *BeanstalkMetadata
 	)
-	if resource == nil {
-		return attributes, nil
-	}
+
 	filtered := make(map[string]string)
-	for key, value := range resource.Labels {
-		switch key {
-		case semconventions.AttributeCloudProvider:
-			cloud = value
-		case semconventions.AttributeCloudAccount:
-			account = value
-		case semconventions.AttributeCloudZone:
-			zone = value
-		case semconventions.AttributeHostID:
-			hostID = value
-		case semconventions.AttributeContainerName:
-			if container == "" {
+	if resource != nil {
+		for key, value := range resource.Labels {
+			switch key {
+			case semconventions.AttributeCloudProvider:
+				cloud = value
+			case semconventions.AttributeCloudAccount:
+				account = value
+			case semconventions.AttributeCloudZone:
+				zone = value
+			case semconventions.AttributeHostID:
+				hostID = value
+			case semconventions.AttributeContainerName:
+				if container == "" {
+					container = value
+				}
+			case semconventions.AttributeK8sPod:
 				container = value
+			case semconventions.AttributeServiceNamespace:
+				namespace = value
+			case semconventions.AttributeServiceInstance:
+				deployID = value
 			}
-		case semconventions.AttributeK8sPod:
-			container = value
-		case semconventions.AttributeServiceNamespace:
-			namespace = value
-		case semconventions.AttributeServiceInstance:
-			deployID = value
 		}
 	}
 	for key, value := range attributes {
@@ -119,10 +123,13 @@ func makeAws(attributes map[string]string, resource *resourcepb.Resource) (map[s
 		case AWSRegionAttribute:
 			remoteRegion = value
 		case AWSRequestIDAttribute:
+		case AWSRequestIDAttribute2:
 			requestID = value
 		case AWSQueueURLAttribute:
+		case AWSQueueURLAttribute2:
 			queueURL = value
 		case AWSTableNameAttribute:
+		case AWSTableNameAttribute2:
 			tableName = value
 		default:
 			filtered[key] = value
@@ -134,20 +141,17 @@ func makeAws(attributes map[string]string, resource *resourcepb.Resource) (map[s
 	// progress from least specific to most specific origin so most specific ends up as origin
 	// as per X-Ray docs
 	if hostID != "" {
-		origin = OriginEC2
 		ec2 = &EC2Metadata{
 			InstanceID:       hostID,
 			AvailabilityZone: zone,
 		}
 	}
 	if container != "" {
-		origin = OriginECS
 		ecs = &ECSMetadata{
 			ContainerName: container,
 		}
 	}
 	if deployID != "" {
-		origin = OriginEB
 		deployNum, err := strconv.ParseInt(deployID, 10, 64)
 		if err != nil {
 			deployNum = 0
@@ -157,9 +161,6 @@ func makeAws(attributes map[string]string, resource *resourcepb.Resource) (map[s
 			VersionLabel: ver,
 			DeploymentID: deployNum,
 		}
-	}
-	if origin == "" {
-		return filtered, nil
 	}
 	awsData := &AWSData{
 		AccountID:         account,

--- a/exporter/awsxrayexporter/translator/aws_test.go
+++ b/exporter/awsxrayexporter/translator/aws_test.go
@@ -166,6 +166,18 @@ func TestAwsWithAwsSqsResources(t *testing.T) {
 	assert.True(t, strings.Contains(jsonStr, queueURL))
 }
 
+func TestAwsWithSqsAlternateAttribute(t *testing.T) {
+	queueURL := "https://sqs.use1.amazonaws.com/Meltdown-Alerts"
+	attributes := make(map[string]string)
+	attributes[AWSQueueURLAttribute2] = queueURL
+
+	filtered, awsData := makeAws(attributes, nil)
+
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, queueURL, awsData.QueueURL)
+}
+
 func TestAwsWithAwsDynamoDbResources(t *testing.T) {
 	instanceID := "i-00f7c0bcb26da2a99"
 	containerID := "signup_aggregator-x82ufje83"
@@ -207,4 +219,28 @@ func TestAwsWithAwsDynamoDbResources(t *testing.T) {
 	testWriters.release(w)
 	assert.True(t, strings.Contains(jsonStr, containerID))
 	assert.True(t, strings.Contains(jsonStr, tableName))
+}
+
+func TestAwsWithDynamoDbAlternateAttribute(t *testing.T) {
+	tableName := "MyTable"
+	attributes := make(map[string]string)
+	attributes[AWSTableNameAttribute2] = tableName
+
+	filtered, awsData := makeAws(attributes, nil)
+
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, tableName, awsData.TableName)
+}
+
+func TestAwsWithRequestIdAlternateAttribute(t *testing.T) {
+	requestid := "12345-request"
+	attributes := make(map[string]string)
+	attributes[AWSRequestIDAttribute2] = requestid
+
+	filtered, awsData := makeAws(attributes, nil)
+
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, requestid, awsData.RequestID)
 }

--- a/exporter/awsxrayexporter/translator/http.go
+++ b/exporter/awsxrayexporter/translator/http.go
@@ -46,10 +46,9 @@ type ResponseData struct {
 
 func makeHTTP(span *tracepb.Span) (map[string]string, *HTTPData) {
 	var (
-		info           HTTPData
-		filtered       = make(map[string]string)
-		urlParts       = make(map[string]string)
-		componentValue string
+		info     HTTPData
+		filtered = make(map[string]string)
+		urlParts = make(map[string]string)
 	)
 
 	if span.Attributes == nil {
@@ -58,9 +57,6 @@ func makeHTTP(span *tracepb.Span) (map[string]string, *HTTPData) {
 
 	for key, value := range span.Attributes.AttributeMap {
 		switch key {
-		case semconventions.AttributeComponent:
-			componentValue = value.GetStringValue().GetValue()
-			filtered[key] = componentValue
 		case semconventions.AttributeHTTPMethod:
 			info.Request.Method = value.GetStringValue().GetValue()
 		case semconventions.AttributeHTTPClientIP:
@@ -95,21 +91,20 @@ func makeHTTP(span *tracepb.Span) (map[string]string, *HTTPData) {
 				urlParts[key] = strconv.FormatInt(value.GetIntValue(), 10)
 			}
 		case semconventions.AttributeNetPeerIP:
+			// Prefer HTTP forwarded information (AttributeHTTPClientIP) when present.
+			if info.Request.ClientIP == "" {
+				info.Request.ClientIP = value.GetStringValue().GetValue()
+			}
 			urlParts[key] = value.GetStringValue().GetValue()
 		default:
 			filtered[key] = value.GetStringValue().GetValue()
 		}
 	}
 
-	if (componentValue != semconventions.ComponentTypeHTTP && componentValue != semconventions.ComponentTypeGRPC) ||
-		info.Request.Method == "" {
-		return filtered, nil
-	}
-
 	if tracepb.Span_SERVER == span.Kind {
-		info.Request.URL = constructServerURL(componentValue, urlParts)
+		info.Request.URL = constructServerURL(urlParts)
 	} else {
-		info.Request.URL = constructClientURL(componentValue, urlParts)
+		info.Request.URL = constructClientURL(urlParts)
 	}
 
 	if info.Response.Status == 0 {
@@ -143,7 +138,7 @@ func extractResponseSizeFromEvents(span *tracepb.Span) int64 {
 	return size
 }
 
-func constructClientURL(component string, urlParts map[string]string) string {
+func constructClientURL(urlParts map[string]string) string {
 	// follows OpenTelemetry specification-defined combinations for client spans described in
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md
 	url, ok := urlParts[semconventions.AttributeHTTPURL]
@@ -154,11 +149,7 @@ func constructClientURL(component string, urlParts map[string]string) string {
 
 	scheme, ok := urlParts[semconventions.AttributeHTTPScheme]
 	if !ok {
-		if component == semconventions.ComponentTypeGRPC {
-			scheme = "dns"
-		} else {
-			scheme = "http"
-		}
+		scheme = "http"
 	}
 	port := ""
 	host, ok := urlParts[semconventions.AttributeHTTPHost]
@@ -185,7 +176,7 @@ func constructClientURL(component string, urlParts map[string]string) string {
 	return url
 }
 
-func constructServerURL(component string, urlParts map[string]string) string {
+func constructServerURL(urlParts map[string]string) string {
 	// follows OpenTelemetry specification-defined combinations for server spans described in
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md
 	url, ok := urlParts[semconventions.AttributeHTTPURL]
@@ -196,11 +187,7 @@ func constructServerURL(component string, urlParts map[string]string) string {
 
 	scheme, ok := urlParts[semconventions.AttributeHTTPScheme]
 	if !ok {
-		if component == semconventions.ComponentTypeGRPC {
-			scheme = "dns"
-		} else {
-			scheme = "http"
-		}
+		scheme = "http"
 	}
 	port := ""
 	host, ok := urlParts[semconventions.AttributeHTTPHost]

--- a/exporter/awsxrayexporter/translator/http.go
+++ b/exporter/awsxrayexporter/translator/http.go
@@ -55,41 +55,41 @@ func makeHTTP(span *tracepb.Span) (map[string]string, *HTTPData) {
 		return filtered, nil
 	}
 
-	hasHttp := false
+	hasHTTP := false
 
 	for key, value := range span.Attributes.AttributeMap {
 		switch key {
 		case semconventions.AttributeHTTPMethod:
 			info.Request.Method = value.GetStringValue().GetValue()
-			hasHttp = true
+			hasHTTP = true
 		case semconventions.AttributeHTTPClientIP:
 			info.Request.ClientIP = value.GetStringValue().GetValue()
 			info.Request.XForwardedFor = true
-			hasHttp = true
+			hasHTTP = true
 		case semconventions.AttributeHTTPUserAgent:
 			info.Request.UserAgent = value.GetStringValue().GetValue()
-			hasHttp = true
+			hasHTTP = true
 		case semconventions.AttributeHTTPStatusCode:
 			info.Response.Status = value.GetIntValue()
-			hasHttp = true
+			hasHTTP = true
 		case semconventions.AttributeHTTPURL:
 			urlParts[key] = value.GetStringValue().GetValue()
-			hasHttp = true
+			hasHTTP = true
 		case semconventions.AttributeHTTPScheme:
 			urlParts[key] = value.GetStringValue().GetValue()
-			hasHttp = true
+			hasHTTP = true
 		case semconventions.AttributeHTTPHost:
 			urlParts[key] = value.GetStringValue().GetValue()
-			hasHttp = true
+			hasHTTP = true
 		case semconventions.AttributeHTTPTarget:
 			urlParts[key] = value.GetStringValue().GetValue()
-			hasHttp = true
+			hasHTTP = true
 		case semconventions.AttributeHTTPServerName:
 			urlParts[key] = value.GetStringValue().GetValue()
-			hasHttp = true
+			hasHTTP = true
 		case semconventions.AttributeHTTPHostPort:
 			urlParts[key] = value.GetStringValue().GetValue()
-			hasHttp = true
+			hasHTTP = true
 			if len(urlParts[key]) == 0 {
 				urlParts[key] = strconv.FormatInt(value.GetIntValue(), 10)
 			}
@@ -113,7 +113,7 @@ func makeHTTP(span *tracepb.Span) (map[string]string, *HTTPData) {
 		}
 	}
 
-	if !hasHttp {
+	if !hasHTTP {
 		// Didn't have any HTTP-specific information so don't need to fill it in segment
 		return filtered, nil
 	}

--- a/exporter/awsxrayexporter/translator/http_test.go
+++ b/exporter/awsxrayexporter/translator/http_test.go
@@ -28,7 +28,6 @@ import (
 
 func TestClientSpanWithURLAttribute(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
 	attributes[semconventions.AttributeHTTPStatusCode] = 200
@@ -49,7 +48,6 @@ func TestClientSpanWithURLAttribute(t *testing.T) {
 
 func TestClientSpanWithSchemeHostTargetAttributes(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPScheme] = "https"
 	attributes[semconventions.AttributeHTTPHost] = "api.example.com"
@@ -73,7 +71,6 @@ func TestClientSpanWithSchemeHostTargetAttributes(t *testing.T) {
 
 func TestClientSpanWithPeerAttributes(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPScheme] = "http"
 	attributes[semconventions.AttributeNetPeerName] = "kb234.example.com"
@@ -87,6 +84,9 @@ func TestClientSpanWithPeerAttributes(t *testing.T) {
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
+
+	assert.Equal(t, "10.8.17.36", httpData.Request.ClientIP)
+
 	w := testWriters.borrow()
 	if err := w.Encode(httpData); err != nil {
 		assert.Fail(t, "invalid json")
@@ -96,9 +96,22 @@ func TestClientSpanWithPeerAttributes(t *testing.T) {
 	assert.True(t, strings.Contains(jsonStr, "http://kb234.example.com:8080/users/junit"))
 }
 
+func TestClientSpanWithHttpPeerAttributes(t *testing.T) {
+	attributes := make(map[string]interface{})
+	attributes[semconventions.AttributeHTTPClientIP] = "1.2.3.4"
+	attributes[semconventions.AttributeNetPeerIP] = "10.8.17.36"
+	span := constructHTTPClientSpan(attributes)
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.NotNil(t, httpData)
+	assert.NotNil(t, filtered)
+
+	assert.Equal(t, "1.2.3.4", httpData.Request.ClientIP)
+}
+
 func TestClientSpanWithPeerIp4Attributes(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPScheme] = "http"
 	attributes[semconventions.AttributeNetPeerIP] = "10.8.17.36"
@@ -120,7 +133,6 @@ func TestClientSpanWithPeerIp4Attributes(t *testing.T) {
 
 func TestClientSpanWithPeerIp6Attributes(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPScheme] = "https"
 	attributes[semconventions.AttributeNetPeerIP] = "2001:db8:85a3::8a2e:370:7334"
@@ -142,7 +154,6 @@ func TestClientSpanWithPeerIp6Attributes(t *testing.T) {
 
 func TestServerSpanWithURLAttribute(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
 	attributes[semconventions.AttributeHTTPClientIP] = "192.168.15.32"
@@ -165,7 +176,6 @@ func TestServerSpanWithURLAttribute(t *testing.T) {
 
 func TestServerSpanWithSchemeHostTargetAttributes(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPScheme] = "https"
 	attributes[semconventions.AttributeHTTPHost] = "api.example.com"
@@ -189,7 +199,6 @@ func TestServerSpanWithSchemeHostTargetAttributes(t *testing.T) {
 
 func TestServerSpanWithSchemeServernamePortTargetAttributes(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPScheme] = "https"
 	attributes[semconventions.AttributeHTTPServerName] = "api.example.com"
@@ -214,7 +223,6 @@ func TestServerSpanWithSchemeServernamePortTargetAttributes(t *testing.T) {
 
 func TestServerSpanWithSchemeNamePortTargetAttributes(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPScheme] = "http"
 	attributes[semconventions.AttributeHostName] = "kb234.example.com"
@@ -241,7 +249,6 @@ func TestServerSpanWithSchemeNamePortTargetAttributes(t *testing.T) {
 
 func TestHttpStatusFromSpanStatus(t *testing.T) {
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
 	attributes[semconventions.AttributeHTTPMethod] = "GET"
 	attributes[semconventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
 	span := constructHTTPClientSpan(attributes)

--- a/exporter/awsxrayexporter/translator/segment.go
+++ b/exporter/awsxrayexporter/translator/segment.go
@@ -266,7 +266,7 @@ func convertToAmazonTraceID(traceID []byte) string {
 // convertToAmazonSpanID generates an Amazon spanID from a trace.SpanID - a 64-bit identifier
 // for the Segment, unique among segments in the same trace, in 16 hexadecimal digits.
 func convertToAmazonSpanID(v []byte) string {
-	if v == nil || bytes.Compare(v, zeroSpanID) == 0 {
+	if v == nil || bytes.Equal(v, zeroSpanID) {
 		return ""
 	}
 	return hex.EncodeToString(v[0:8])

--- a/exporter/awsxrayexporter/translator/segment.go
+++ b/exporter/awsxrayexporter/translator/segment.go
@@ -135,7 +135,7 @@ func MakeSegment(name string, span *tracepb.Span) Segment {
 
 	if span.Attributes != nil {
 		attributes := span.Attributes.AttributeMap
-		if awsService, ok := attributes["aws.service"]; ok {
+		if awsService, ok := attributes[AWSServiceAttribute]; ok {
 			// Generally spans are named something like "Method" or "Service.Method" but for AWS spans, X-Ray expects spans
 			// to be named "Service"
 			name = awsService.GetStringValue().GetValue()

--- a/exporter/awsxrayexporter/translator/segment_test.go
+++ b/exporter/awsxrayexporter/translator/segment_test.go
@@ -33,27 +33,6 @@ var (
 	testWriters = newWriterPool(2048)
 )
 
-func TestClientSpanWithGrpcComponent(t *testing.T) {
-	spanName := "platformapi.widgets.searchWidgets"
-	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeGRPC
-	attributes[semconventions.AttributeHTTPMethod] = "GET"
-	attributes[semconventions.AttributeHTTPScheme] = "ipv6"
-	attributes[semconventions.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
-	attributes[semconventions.AttributeNetPeerPort] = "9443"
-	attributes[semconventions.AttributeHTTPTarget] = spanName
-	labels := constructDefaultResourceLabels()
-	span := constructClientSpan(nil, spanName, 0, "OK", attributes, labels)
-	timeEvents := constructTimedEventsWithSentMessageEvent(span.StartTime)
-	span.TimeEvents = &timeEvents
-
-	jsonStr, err := MakeSegmentDocumentString(spanName, span)
-
-	assert.NotNil(t, jsonStr)
-	assert.Nil(t, err)
-	assert.True(t, strings.Contains(jsonStr, spanName))
-}
-
 func TestClientSpanWithAwsSdkClient(t *testing.T) {
 	spanName := "AmazonDynamoDB.getItem"
 	parentSpanID := newSegmentID()
@@ -64,17 +43,23 @@ func TestClientSpanWithAwsSdkClient(t *testing.T) {
 	attributes[semconventions.AttributeHTTPScheme] = "https"
 	attributes[semconventions.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
 	attributes[semconventions.AttributeHTTPTarget] = "/"
+	attributes[AWSServiceAttribute] = "DynamoDB"
 	attributes[AWSOperationAttribute] = "GetItem"
 	attributes[AWSRequestIDAttribute] = "18BO1FEPJSSAOGNJEDPTPCMIU7VV4KQNSO5AEMVJF66Q9ASUAAJG"
 	attributes[AWSTableNameAttribute] = "otel-dev-Testing"
 	labels := constructDefaultResourceLabels()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes, labels)
 
+	segment := MakeSegment(spanName, span)
+	assert.Equal(t, "DynamoDB", segment.Name)
+	assert.Equal(t, "aws", segment.Namespace)
+	assert.Equal(t, "subsegment", segment.Type)
+
 	jsonStr, err := MakeSegmentDocumentString(spanName, span)
 
 	assert.NotNil(t, jsonStr)
 	assert.Nil(t, err)
-	assert.True(t, strings.Contains(jsonStr, spanName))
+	assert.True(t, strings.Contains(jsonStr, "DynamoDB"))
 	assert.False(t, strings.Contains(jsonStr, user))
 	assert.False(t, strings.Contains(jsonStr, semconventions.AttributeComponent))
 }
@@ -117,11 +102,22 @@ func TestServerSpanWithInternalServerError(t *testing.T) {
 	assert.True(t, strings.Contains(jsonStr, enduser))
 }
 
+func TestServerSpanNoParentId(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	labels := constructDefaultResourceLabels()
+	span := constructServerSpan(parentSpanID, spanName, 0, "OK", nil, labels)
+
+	segment := MakeSegment(spanName, span)
+
+	assert.Empty(t, segment.ParentID)
+}
+
 func TestClientSpanWithDbComponent(t *testing.T) {
 	spanName := "call update_user_preference( ?, ?, ? )"
+	parentSpanId := newSegmentID()
 	enterpriseAppID := "25F2E73B-4769-4C79-9DF3-7EBE85D571EA"
 	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeComponent] = "db"
 	attributes[semconventions.AttributeDBType] = "sql"
 	attributes[semconventions.AttributeDBInstance] = "customers"
 	attributes[semconventions.AttributeDBStatement] = spanName
@@ -131,7 +127,7 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	attributes[semconventions.AttributeNetPeerPort] = "3306"
 	attributes["enterprise.app.id"] = enterpriseAppID
 	labels := constructDefaultResourceLabels()
-	span := constructClientSpan(nil, spanName, 0, "OK", attributes, labels)
+	span := constructClientSpan(parentSpanId, spanName, 0, "OK", attributes, labels)
 
 	segment := MakeSegment(spanName, span)
 
@@ -145,6 +141,8 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	assert.Equal(t, spanName, segment.Name)
 	assert.False(t, segment.Fault)
 	assert.False(t, segment.Error)
+	assert.Equal(t, "remote", segment.Namespace)
+
 	w := testWriters.borrow()
 	if err := w.Encode(segment); err != nil {
 		assert.Fail(t, "invalid json")

--- a/exporter/awsxrayexporter/translator/segment_test.go
+++ b/exporter/awsxrayexporter/translator/segment_test.go
@@ -115,7 +115,7 @@ func TestServerSpanNoParentId(t *testing.T) {
 
 func TestClientSpanWithDbComponent(t *testing.T) {
 	spanName := "call update_user_preference( ?, ?, ? )"
-	parentSpanId := newSegmentID()
+	parentSpanID := newSegmentID()
 	enterpriseAppID := "25F2E73B-4769-4C79-9DF3-7EBE85D571EA"
 	attributes := make(map[string]interface{})
 	attributes[semconventions.AttributeDBType] = "sql"
@@ -127,7 +127,7 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	attributes[semconventions.AttributeNetPeerPort] = "3306"
 	attributes["enterprise.app.id"] = enterpriseAppID
 	labels := constructDefaultResourceLabels()
-	span := constructClientSpan(parentSpanId, spanName, 0, "OK", attributes, labels)
+	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes, labels)
 
 	segment := MakeSegment(spanName, span)
 

--- a/exporter/awsxrayexporter/translator/sql.go
+++ b/exporter/awsxrayexporter/translator/sql.go
@@ -41,30 +41,25 @@ func makeSQL(attributes map[string]string) (map[string]string, *SQLData) {
 		dbUser      string
 	)
 
-	hasSql := false
 	for key, value := range attributes {
 		switch key {
 		case semconventions.AttributeDBURL:
 			dbURL = value
-			hasSql = true
 		case semconventions.AttributeDBType:
 			dbType = value
-			hasSql = true
 		case semconventions.AttributeDBInstance:
 			dbInstance = value
-			hasSql = true
 		case semconventions.AttributeDBStatement:
 			dbStatement = value
-			hasSql = true
 		case semconventions.AttributeDBUser:
 			dbUser = value
-			hasSql = true
 		default:
 			filtered[key] = value
 		}
 	}
 
-	if !hasSql {
+	if len(filtered) == len(attributes) {
+		// Didn't filter any attributes meaning didn't have any SQL information.
 		return attributes, nil
 	}
 

--- a/exporter/awsxrayexporter/translator/sql.go
+++ b/exporter/awsxrayexporter/translator/sql.go
@@ -40,27 +40,34 @@ func makeSQL(attributes map[string]string) (map[string]string, *SQLData) {
 		dbStatement string
 		dbUser      string
 	)
-	componentType := attributes[semconventions.AttributeComponent]
-	if componentType == semconventions.ComponentTypeHTTP ||
-		componentType == semconventions.ComponentTypeGRPC {
-		return attributes, nil
-	}
+
+	hasSql := false
 	for key, value := range attributes {
 		switch key {
 		case semconventions.AttributeDBURL:
 			dbURL = value
+			hasSql = true
 		case semconventions.AttributeDBType:
 			dbType = value
+			hasSql = true
 		case semconventions.AttributeDBInstance:
 			dbInstance = value
+			hasSql = true
 		case semconventions.AttributeDBStatement:
 			dbStatement = value
+			hasSql = true
 		case semconventions.AttributeDBUser:
 			dbUser = value
+			hasSql = true
 		default:
 			filtered[key] = value
 		}
 	}
+
+	if !hasSql {
+		return attributes, nil
+	}
+
 	if dbURL == "" {
 		dbURL = "localhost"
 	}

--- a/exporter/awsxrayexporter/translator/sql_test.go
+++ b/exporter/awsxrayexporter/translator/sql_test.go
@@ -45,20 +45,3 @@ func TestClientSpanWithStatementAttribute(t *testing.T) {
 	testWriters.release(w)
 	assert.True(t, strings.Contains(jsonStr, "mysql://db.example.com:3306/customers"))
 }
-
-func TestClientSpanWithHttpComponent(t *testing.T) {
-	attributes := make(map[string]string)
-	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
-	attributes[semconventions.AttributeDBType] = "sql"
-	attributes[semconventions.AttributeDBInstance] = "customers"
-	attributes[semconventions.AttributeDBStatement] = "SELECT * FROM user WHERE user_id = ?"
-	attributes[semconventions.AttributeDBUser] = "readonly_user"
-	attributes[semconventions.AttributeDBURL] = "mysql://db.example.com:3306"
-	attributes[semconventions.AttributeNetPeerName] = "db.example.com"
-	attributes[semconventions.AttributeNetPeerPort] = "3306"
-
-	filtered, sqlData := makeSQL(attributes)
-
-	assert.NotNil(t, filtered)
-	assert.Nil(t, sqlData)
-}

--- a/go.sum
+++ b/go.sum
@@ -1649,14 +1649,10 @@ k8s.io/api v0.0.0-20190620084959-7cf5895f2711/go.mod h1:TBhBqb1AWbBQbW3XRusr7n7E
 k8s.io/api v0.0.0-20190813020757-36bff7324fb7/go.mod h1:3Iy+myeAORNCLgjd/Xu9ebwN7Vh59Bw0vh9jhoX+V58=
 k8s.io/api v0.17.0 h1:H9d/lw+VkZKEVIUc8F3wgiQ+FUXTTr21M87jXLU7yqM=
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
-k8s.io/api v0.17.4 h1:HbwOhDapkguO8lTAE8OX3hdF2qp8GtpC9CW/MQATXXo=
-k8s.io/api v0.17.4/go.mod h1:5qxx6vjmwUVG2nHQTKGlLts8Tbok8PzHl4vHtVFuZCA=
 k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719/go.mod h1:I4A+glKBHiTgiEjQiCCQfCAIcIMFGt291SmsvcrFzJA=
 k8s.io/apimachinery v0.0.0-20190809020650-423f5d784010/go.mod h1:Waf/xTS2FGRrgXCkO5FP3XxTOWh0qLf2QhL1qFZZ/R8=
 k8s.io/apimachinery v0.17.0 h1:xRBnuie9rXcPxUkDizUsGvPf1cnlZCFu210op7J7LJo=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
-k8s.io/apimachinery v0.17.4 h1:UzM+38cPUJnzqSQ+E1PY4YxMHIzQyCg29LOoGfo79Zw=
-k8s.io/apimachinery v0.17.4/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab h1:E8Fecph0qbNsAbijJJQryKu4Oi9QTp5cVpjTE+nqg6g=
 k8s.io/client-go v0.0.0-20190620085101-78d2af792bab/go.mod h1:E95RaSlHr79aHaX0aGSwcPNfygDiPKOVXdmivCIZT0k=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=


### PR DESCRIPTION
…gainst native instrumentation.

**Description:** 

Improve parity of xray exporter vs native xray instrumentation

- Don't require a resource to fill in AWS info because instrumentation doesn't always fill it in but it's worth doing a best effort
- Handle AWS attributes as set by java instrumentation
- Remove usage of component which was removed in OTel specification [0.3.0](https://github.com/open-telemetry/opentelemetry-specification/blob/master/CHANGELOG.md#v030-02-21-2020)
- Read net peer IP as client IP
- Set aws namespace for aws operations and span name to service instead of operation
- Don't set namespace to remote for internal spans (spans with parent but not Kind.Client)
- Fix 0 parent ID still set as hex
- Fill SQL info when available rather than filtering on deprecated HTTP component attribute

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Compared traces in X-Ray console for toy [app](https://github.com/anuraaga/aws-xray-sdk-with-opentelemetry-sample/tree/both-otel-and-xray)