### PR TITLE
Don't crash when converting segments with no Status.

### DIFF
--- a/exporter/awsxrayexporter/translator/cause.go
+++ b/exporter/awsxrayexporter/translator/cause.go
@@ -47,7 +47,7 @@ type Stack struct {
 
 func makeCause(status *tracepb.Status, attributes map[string]string) (isError, isFault bool,
 	filtered map[string]string, cause *CauseData) {
-	if status.Code == 0 {
+	if status == nil || status.Code == 0 {
 		return false, false, attributes, nil
 	}
 	var (

--- a/exporter/awsxrayexporter/translator/http.go
+++ b/exporter/awsxrayexporter/translator/http.go
@@ -124,7 +124,7 @@ func makeHTTP(span *tracepb.Span) (map[string]string, *HTTPData) {
 		info.Request.URL = constructClientURL(urlParts)
 	}
 
-	if info.Response.Status == 0 {
+	if span.Status != nil && info.Response.Status == 0 {
 		info.Response.Status = int64(tracetranslator.HTTPStatusCodeFromOCStatus(span.Status.Code))
 	}
 
@@ -138,7 +138,7 @@ func extractResponseSizeFromEvents(span *tracepb.Span) int64 {
 	if span.TimeEvents != nil {
 		for _, te := range span.TimeEvents.TimeEvent {
 			anno := te.GetAnnotation()
-			if anno != nil {
+			if anno != nil && anno.Attributes != nil {
 				attrMap := anno.Attributes.AttributeMap
 				typeVal := attrMap[semconventions.AttributeMessageType]
 				if typeVal != nil {

--- a/exporter/awsxrayexporter/translator/segment.go
+++ b/exporter/awsxrayexporter/translator/segment.go
@@ -123,7 +123,7 @@ func MakeSegment(name string, span *tracepb.Span) Segment {
 		endTime                                = timestampToFloatSeconds(span.EndTime)
 		httpfiltered, http                     = makeHTTP(span)
 		isError, isFault, causefiltered, cause = makeCause(span.Status, httpfiltered)
-		isThrottled                            = span.Status.Code == tracetranslator.OCResourceExhausted
+		isThrottled                            = span.Status != nil && span.Status.Code == tracetranslator.OCResourceExhausted
 		origin                                 = determineAwsOrigin(span.Resource)
 		awsfiltered, aws                       = makeAws(causefiltered, span.Resource)
 		service                                = makeService(span.Resource)

--- a/exporter/awsxrayexporter/translator/segment_test.go
+++ b/exporter/awsxrayexporter/translator/segment_test.go
@@ -113,6 +113,20 @@ func TestServerSpanNoParentId(t *testing.T) {
 	assert.Empty(t, segment.ParentID)
 }
 
+func TestSpanWithNoStatus(t *testing.T) {
+	span := &tracepb.Span{
+		TraceId:      newTraceID(),
+		SpanId:       newSegmentID(),
+		ParentSpanId: newSegmentID(),
+		Name:         &tracepb.TruncatableString{Value: "nostatus"},
+		Kind:         tracepb.Span_SERVER,
+		StartTime:    convertTimeToTimestamp(time.Now()),
+		EndTime:      convertTimeToTimestamp(time.Now().Add(10)),
+	}
+	segment := MakeSegment("nostatus", span)
+	assert.NotNil(t, segment)
+}
+
 func TestClientSpanWithDbComponent(t *testing.T) {
 	spanName := "call update_user_preference( ?, ?, ? )"
 	parentSpanID := newSegmentID()


### PR DESCRIPTION
**Description:** <Describe what has changed. 
Currently, if a span doesn't have Status set, the X-Ray exporter crashes. While Status should always be set in a Span, due to bugs in other modules (it seems zipkin receiver has an issue), this could happen and we should avoid crashing here.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** < Describe what testing was performed and which tests were added.>

Added unit test with span without status, test doesn't crash
Verified can collect spans from zipkin reporter

**Documentation:** < Describe the documentation added.>