### PR TITLE
k8sclusterreceiver: Rename metrics to start with "k8s/"

### DIFF
--- a/receiver/k8sclusterreceiver/collection/containers.go
+++ b/receiver/k8sclusterreceiver/collection/containers.go
@@ -35,7 +35,7 @@ const (
 )
 
 var containerRestartMetric = &metricspb.MetricDescriptor{
-	Name: "kubernetes/container/restarts",
+	Name: "k8s/container/restarts",
 	Description: "How many times the container has restarted in the recent past. " +
 		"This value is pulled directly from the K8s API and the value can go indefinitely high" +
 		" and be reset to 0 at any time depending on how your kubelet is configured to prune" +
@@ -48,7 +48,7 @@ var containerRestartMetric = &metricspb.MetricDescriptor{
 }
 
 var containerReadyMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/container/ready",
+	Name:        "k8s/container/ready",
 	Description: "Whether a container has passed its readiness probe (0 for no, 1 for yes)",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
@@ -81,14 +81,14 @@ func boolToInt64(b bool) int64 {
 }
 
 var containerRequestMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/container/request",
+	Name:        "k8s/container/request",
 	Description: "Resource requested for the container",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 	LabelKeys:   []*metricspb.LabelKey{{Key: "resource"}},
 }
 
 var containerLimitMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/container/limit",
+	Name:        "k8s/container/limit",
 	Description: "Maximum resource limit set for the container",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 	LabelKeys:   []*metricspb.LabelKey{{Key: "resource"}},

--- a/receiver/k8sclusterreceiver/collection/cronjobs.go
+++ b/receiver/k8sclusterreceiver/collection/cronjobs.go
@@ -30,7 +30,7 @@ const (
 )
 
 var activeJobs = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/cronjob/active_jobs",
+	Name:        "k8s/cronjob/active_jobs",
 	Description: "The number of actively running jobs for a cronjob",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/cronjobs_test.go
+++ b/receiver/k8sclusterreceiver/collection/cronjobs_test.go
@@ -44,7 +44,7 @@ func TestCronJobMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[0], "kubernetes/cronjob/active_jobs",
+	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[0], "k8s/cronjob/active_jobs",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 }
 

--- a/receiver/k8sclusterreceiver/collection/daemonsets.go
+++ b/receiver/k8sclusterreceiver/collection/daemonsets.go
@@ -24,28 +24,28 @@ import (
 )
 
 var daemonSetCurrentScheduledMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/daemon_set/current_scheduled_nodes",
+	Name:        "k8s/daemon_set/current_scheduled_nodes",
 	Description: "Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var daemonSetDesiredScheduledMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/daemon_set/desired_scheduled_nodes",
+	Name:        "k8s/daemon_set/desired_scheduled_nodes",
 	Description: "Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var daemonSetMisScheduledMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/daemon_set/misscheduled_nodes",
+	Name:        "k8s/daemon_set/misscheduled_nodes",
 	Description: "Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var daemonSetReadyMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/daemon_set/ready_nodes",
+	Name:        "k8s/daemon_set/ready_nodes",
 	Description: "Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/daemonsets_test.go
+++ b/receiver/k8sclusterreceiver/collection/daemonsets_test.go
@@ -44,16 +44,16 @@ func TestDaemonsetMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *rm.metrics[0], "kubernetes/daemon_set/current_scheduled_nodes",
+	testutils.AssertMetrics(t, *rm.metrics[0], "k8s/daemon_set/current_scheduled_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 
-	testutils.AssertMetrics(t, *rm.metrics[1], "kubernetes/daemon_set/desired_scheduled_nodes",
+	testutils.AssertMetrics(t, *rm.metrics[1], "k8s/daemon_set/desired_scheduled_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 5)
 
-	testutils.AssertMetrics(t, *rm.metrics[2], "kubernetes/daemon_set/misscheduled_nodes",
+	testutils.AssertMetrics(t, *rm.metrics[2], "k8s/daemon_set/misscheduled_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1)
 
-	testutils.AssertMetrics(t, *rm.metrics[3], "kubernetes/daemon_set/ready_nodes",
+	testutils.AssertMetrics(t, *rm.metrics[3], "k8s/daemon_set/ready_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 }
 

--- a/receiver/k8sclusterreceiver/collection/deployments_test.go
+++ b/receiver/k8sclusterreceiver/collection/deployments_test.go
@@ -44,10 +44,10 @@ func TestDeploymentMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *rm.metrics[0], "kubernetes/deployment/desired",
+	testutils.AssertMetrics(t, *rm.metrics[0], "k8s/deployment/desired",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetrics(t, *rm.metrics[1], "kubernetes/deployment/available",
+	testutils.AssertMetrics(t, *rm.metrics[1], "k8s/deployment/available",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 }
 

--- a/receiver/k8sclusterreceiver/collection/hpa.go
+++ b/receiver/k8sclusterreceiver/collection/hpa.go
@@ -24,28 +24,28 @@ import (
 )
 
 var hpaMaxReplicasMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/hpa/max_replicas",
+	Name:        "k8s/hpa/max_replicas",
 	Description: "Maximum number of replicas to which the autoscaler can scale up",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var hpaMinReplicasMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/hpa/min_replicas",
+	Name:        "k8s/hpa/min_replicas",
 	Description: "Minimum number of replicas to which the autoscaler can scale down",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var hpaCurrentReplicasMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/hpa/current_replicas",
+	Name:        "k8s/hpa/current_replicas",
 	Description: "Current number of pod replicas managed by this autoscaler",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var hpaDesiredReplicasMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/hpa/desired_replicas",
+	Name:        "k8s/hpa/desired_replicas",
 	Description: "Desired number of pod replicas managed by this autoscaler",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/hpa_test.go
+++ b/receiver/k8sclusterreceiver/collection/hpa_test.go
@@ -44,16 +44,16 @@ func TestHPAMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *rm.metrics[0], "kubernetes/hpa/max_replicas",
+	testutils.AssertMetrics(t, *rm.metrics[0], "k8s/hpa/max_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetrics(t, *rm.metrics[1], "kubernetes/hpa/min_replicas",
+	testutils.AssertMetrics(t, *rm.metrics[1], "k8s/hpa/min_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
-	testutils.AssertMetrics(t, *rm.metrics[2], "kubernetes/hpa/current_replicas",
+	testutils.AssertMetrics(t, *rm.metrics[2], "k8s/hpa/current_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 5)
 
-	testutils.AssertMetrics(t, *rm.metrics[3], "kubernetes/hpa/desired_replicas",
+	testutils.AssertMetrics(t, *rm.metrics[3], "k8s/hpa/desired_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 7)
 }
 

--- a/receiver/k8sclusterreceiver/collection/jobs.go
+++ b/receiver/k8sclusterreceiver/collection/jobs.go
@@ -24,35 +24,35 @@ import (
 )
 
 var podsActiveMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/job/active_pods",
+	Name:        "k8s/job/active_pods",
 	Description: "The number of actively running pods for a job",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var podsDesiredCompletedMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/job/desired_successful_pods",
+	Name:        "k8s/job/desired_successful_pods",
 	Description: "The desired number of successfully finished pods the job should be run with",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var podsFailedMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/job/failed_pods",
+	Name:        "k8s/job/failed_pods",
 	Description: "The number of pods which reached phase Failed for a job",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var podsMaxParallelMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/job/max_parallel_pods",
+	Name:        "k8s/job/max_parallel_pods",
 	Description: "The max desired number of pods the job should run at any given time",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var podsSuccessfulMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/job/successful_pods",
+	Name:        "k8s/job/successful_pods",
 	Description: "The number of pods which reached phase Succeeded for a job",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/jobs_test.go
+++ b/receiver/k8sclusterreceiver/collection/jobs_test.go
@@ -43,19 +43,19 @@ func TestJobMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[0], "kubernetes/job/active_pods",
+	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[0], "k8s/job/active_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
-	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[1], "kubernetes/job/desired_successful_pods",
+	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[1], "k8s/job/desired_successful_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[2], "kubernetes/job/failed_pods",
+	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[2], "k8s/job/failed_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 
-	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[3], "kubernetes/job/max_parallel_pods",
+	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[3], "k8s/job/max_parallel_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
-	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[4], "kubernetes/job/successful_pods",
+	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[4], "k8s/job/successful_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 }
 

--- a/receiver/k8sclusterreceiver/collection/namespaces.go
+++ b/receiver/k8sclusterreceiver/collection/namespaces.go
@@ -27,7 +27,7 @@ func getMetricsForNamespace(ns *corev1.Namespace) []*resourceMetrics {
 	metrics := []*metricspb.Metric{
 		{
 			MetricDescriptor: &metricspb.MetricDescriptor{
-				Name:        "kubernetes/namespace/phase",
+				Name:        "k8s/namespace/phase",
 				Description: "The current phase of namespaces (1 for active and 0 for terminating)",
 				Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 			},

--- a/receiver/k8sclusterreceiver/collection/namespaces_test.go
+++ b/receiver/k8sclusterreceiver/collection/namespaces_test.go
@@ -42,7 +42,7 @@ func TestNamespaceMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[0], "kubernetes/namespace/phase",
+	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[0], "k8s/namespace/phase",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 }
 

--- a/receiver/k8sclusterreceiver/collection/nodes.go
+++ b/receiver/k8sclusterreceiver/collection/nodes.go
@@ -61,7 +61,7 @@ func getMetricsForNode(node *corev1.Node, nodeConditionTypesToReport []string) [
 }
 
 func getNodeConditionMetric(nodeConditionTypeValue string) string {
-	return fmt.Sprintf("kubernetes/node/condition_%s", strcase.ToSnake(nodeConditionTypeValue))
+	return fmt.Sprintf("k8s/node/condition_%s", strcase.ToSnake(nodeConditionTypeValue))
 }
 
 func getResourceForNode(node *corev1.Node) *resourcepb.Resource {

--- a/receiver/k8sclusterreceiver/collection/nodes_test.go
+++ b/receiver/k8sclusterreceiver/collection/nodes_test.go
@@ -42,10 +42,10 @@ func TestNodeMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[0], "kubernetes/node/condition_ready",
+	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[0], "k8s/node/condition_ready",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1)
 
-	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[1], "kubernetes/node/condition_memory_pressure",
+	testutils.AssertMetrics(t, *actualResourceMetrics[0].metrics[1], "k8s/node/condition_memory_pressure",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 }
 
@@ -83,15 +83,15 @@ func TestGetNodeConditionMetric(t *testing.T) {
 	}{
 		{"Metric for Node condition Ready",
 			"Ready",
-			"kubernetes/node/condition_ready",
+			"k8s/node/condition_ready",
 		},
 		{"Metric for Node condition MemoryPressure",
 			"MemoryPressure",
-			"kubernetes/node/condition_memory_pressure",
+			"k8s/node/condition_memory_pressure",
 		},
 		{"Metric for Node condition DiskPressure",
 			"DiskPressure",
-			"kubernetes/node/condition_disk_pressure",
+			"k8s/node/condition_disk_pressure",
 		},
 	}
 

--- a/receiver/k8sclusterreceiver/collection/pods.go
+++ b/receiver/k8sclusterreceiver/collection/pods.go
@@ -37,7 +37,7 @@ const (
 )
 
 var podPhaseMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/pod/phase",
+	Name:        "k8s/pod/phase",
 	Description: "Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }

--- a/receiver/k8sclusterreceiver/collection/pods_test.go
+++ b/receiver/k8sclusterreceiver/collection/pods_test.go
@@ -48,7 +48,7 @@ func TestPodAndContainerMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *rm.metrics[0], "kubernetes/pod/phase",
+	testutils.AssertMetrics(t, *rm.metrics[0], "k8s/pod/phase",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 
 	rm = actualResourceMetrics[1]
@@ -67,16 +67,16 @@ func TestPodAndContainerMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *rm.metrics[0], "kubernetes/container/restarts",
+	testutils.AssertMetrics(t, *rm.metrics[0], "k8s/container/restarts",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 
-	testutils.AssertMetrics(t, *rm.metrics[1], "kubernetes/container/ready",
+	testutils.AssertMetrics(t, *rm.metrics[1], "k8s/container/ready",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1)
 
-	testutils.AssertMetricsWithLabels(t, *rm.metrics[2], "kubernetes/container/request",
+	testutils.AssertMetricsWithLabels(t, *rm.metrics[2], "k8s/container/request",
 		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "cpu"}, 10000)
 
-	testutils.AssertMetricsWithLabels(t, *rm.metrics[3], "kubernetes/container/limit",
+	testutils.AssertMetricsWithLabels(t, *rm.metrics[3], "k8s/container/limit",
 		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "cpu"}, 20000)
 }
 

--- a/receiver/k8sclusterreceiver/collection/replica.go
+++ b/receiver/k8sclusterreceiver/collection/replica.go
@@ -26,7 +26,7 @@ func getReplicaMetrics(resource string, desired, available int32) []*metricspb.M
 	return []*metricspb.Metric{
 		{
 			MetricDescriptor: &metricspb.MetricDescriptor{
-				Name:        fmt.Sprintf("kubernetes/%s/desired", resource),
+				Name:        fmt.Sprintf("k8s/%s/desired", resource),
 				Description: fmt.Sprintf("Number of desired pods in this %s", resource),
 				Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 				Unit:        "1",
@@ -35,7 +35,7 @@ func getReplicaMetrics(resource string, desired, available int32) []*metricspb.M
 		},
 		{
 			MetricDescriptor: &metricspb.MetricDescriptor{
-				Name:        fmt.Sprintf("kubernetes/%s/available", resource),
+				Name:        fmt.Sprintf("k8s/%s/available", resource),
 				Description: fmt.Sprintf("Total number of available pods (ready for at least minReadySeconds) targeted by this %s", resource),
 				Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 				Unit:        "1",

--- a/receiver/k8sclusterreceiver/collection/resourcequotas.go
+++ b/receiver/k8sclusterreceiver/collection/resourcequotas.go
@@ -26,7 +26,7 @@ import (
 )
 
 var resourceQuotaHardLimitMetric = &metricspb.MetricDescriptor{
-	Name: "kubernetes/resource_quota/hard_limt",
+	Name: "k8s/resource_quota/hard_limt",
 	Description: "The upper limit for a particular resource in a specific namespace." +
 		" Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores",
 	Type: metricspb.MetricDescriptor_GAUGE_INT64,
@@ -36,7 +36,7 @@ var resourceQuotaHardLimitMetric = &metricspb.MetricDescriptor{
 }
 
 var resourceQuotaUsedMetric = &metricspb.MetricDescriptor{
-	Name: "kubernetes/resource_quota/used",
+	Name: "k8s/resource_quota/used",
 	Description: "The usage for a particular resource in a specific namespace." +
 		" Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores",
 	Type: metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/resourcequotas_test.go
+++ b/receiver/k8sclusterreceiver/collection/resourcequotas_test.go
@@ -44,10 +44,10 @@ func TestRequestQuotaMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsWithLabels(t, *actualResourceMetrics[0].metrics[0], "kubernetes/resource_quota/hard_limt",
+	testutils.AssertMetricsWithLabels(t, *actualResourceMetrics[0].metrics[0], "k8s/resource_quota/hard_limt",
 		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "requests.cpu"}, 2000)
 
-	testutils.AssertMetricsWithLabels(t, *actualResourceMetrics[0].metrics[1], "kubernetes/resource_quota/used",
+	testutils.AssertMetricsWithLabels(t, *actualResourceMetrics[0].metrics[1], "k8s/resource_quota/used",
 		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "requests.cpu"}, 1000)
 }
 

--- a/receiver/k8sclusterreceiver/collection/statefulsets.go
+++ b/receiver/k8sclusterreceiver/collection/statefulsets.go
@@ -30,28 +30,28 @@ const (
 )
 
 var statefulSetReplicasDesiredMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/stateful_set/desired_pods",
+	Name:        "k8s/stateful_set/desired_pods",
 	Description: "Number of desired pods in the stateful set (the `spec.replicas` field)",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var statefulSetReplicasReadyMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/stateful_set/ready_pods",
+	Name:        "k8s/stateful_set/ready_pods",
 	Description: "Number of pods created by the stateful set that have the `Ready` condition",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var statefulSetReplicasCurrentMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/stateful_set/current_pods",
+	Name:        "k8s/stateful_set/current_pods",
 	Description: "The number of pods created by the StatefulSet controller from the StatefulSet version",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var statefulSetReplicasUpdatedMetric = &metricspb.MetricDescriptor{
-	Name:        "kubernetes/stateful_set/updated_pods",
+	Name:        "k8s/stateful_set/updated_pods",
 	Description: "Number of pods created by the StatefulSet controller from the StatefulSet version",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/statefulsets_test.go
+++ b/receiver/k8sclusterreceiver/collection/statefulsets_test.go
@@ -44,16 +44,16 @@ func TestStatefulsettMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, *rm.metrics[0], "kubernetes/stateful_set/desired_pods",
+	testutils.AssertMetrics(t, *rm.metrics[0], "k8s/stateful_set/desired_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetrics(t, *rm.metrics[1], "kubernetes/stateful_set/ready_pods",
+	testutils.AssertMetrics(t, *rm.metrics[1], "k8s/stateful_set/ready_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 7)
 
-	testutils.AssertMetrics(t, *rm.metrics[2], "kubernetes/stateful_set/current_pods",
+	testutils.AssertMetrics(t, *rm.metrics[2], "k8s/stateful_set/current_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 5)
 
-	testutils.AssertMetrics(t, *rm.metrics[3], "kubernetes/stateful_set/updated_pods",
+	testutils.AssertMetrics(t, *rm.metrics[3], "k8s/stateful_set/updated_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 }
 


### PR DESCRIPTION
**Description:** Rename metrics to be prefixed with `k8s/` rather than `kubernetes/`. This will make the metric names consistent with the semantic convention followed for collecting resource labels. This is a breaking change.

**Testing:** Updated tests.
