### PR TITLE
Use TraceData.Resource when Span.Resource not available.

### DIFF
--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/xray"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -55,7 +56,7 @@ func NewTraceExporter(config configmodels.Exporter, logger *zap.Logger, cn connA
 				if nextOffset > totalSpans {
 					nextOffset = totalSpans
 				}
-				droppedSpans, input := assembleRequest(td.Spans[offset:nextOffset], logger)
+				droppedSpans, input := assembleRequest(td.Spans[offset:nextOffset], td.Resource, logger)
 				totalDroppedSpans += droppedSpans
 				logger.Debug("request: " + input.String())
 				output, localErr := xrayClient.PutTraceSegments(input)
@@ -80,7 +81,7 @@ func NewTraceExporter(config configmodels.Exporter, logger *zap.Logger, cn connA
 	)
 }
 
-func assembleRequest(spans []*tracepb.Span, logger *zap.Logger) (int, *xray.PutTraceSegmentsInput) {
+func assembleRequest(spans []*tracepb.Span, resource *resourcepb.Resource, logger *zap.Logger) (int, *xray.PutTraceSegmentsInput) {
 	documents := make([]*string, len(spans))
 	droppedSpans := int(0)
 	for i, span := range spans {
@@ -89,6 +90,9 @@ func assembleRequest(spans []*tracepb.Span, logger *zap.Logger) (int, *xray.PutT
 			continue
 		}
 		spanName := span.Name.Value
+		if span.Resource == nil {
+			span.Resource = resource
+		}
 		jsonStr, err := translator.MakeSegmentDocumentString(spanName, span)
 		if err != nil {
 			droppedSpans++

--- a/exporter/awsxrayexporter/awsxray_test.go
+++ b/exporter/awsxrayexporter/awsxray_test.go
@@ -43,6 +43,32 @@ func TestTraceExport(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestTraceRequestResourceInSpan(t *testing.T) {
+	logger := zap.NewExample()
+	resource := constructResource()
+	spans := make([]*tracepb.Span, 2)
+	spans[0] = constructHTTPClientSpan()
+	spans[0].Resource = resource
+	spans[1] = constructHTTPServerSpan()
+	spans[1].Resource = resource
+	_, request := assembleRequest(spans, nil, logger)
+	for _, segment := range request.TraceSegmentDocuments {
+		assert.Contains(t, *segment, resource.Labels[semconventions.AttributeContainerName])
+	}
+}
+
+func TestTraceRequestResourceNotInSpan(t *testing.T) {
+	logger := zap.NewExample()
+	resource := constructResource()
+	spans := make([]*tracepb.Span, 2)
+	spans[0] = constructHTTPClientSpan()
+	spans[1] = constructHTTPServerSpan()
+	_, request := assembleRequest(spans, resource, logger)
+	for _, segment := range request.TraceSegmentDocuments {
+		assert.Contains(t, *segment, resource.Labels[semconventions.AttributeContainerName])
+	}
+}
+
 func initializeTraceExporter() component.TraceExporterOld {
 	os.Setenv("AWS_ACCESS_KEY_ID", "AKIASSWVJUY4PZXXXXXX")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "XYrudg2H87u+ADAAq19Wqx3D41a09RsTXXXXXXXX")


### PR DESCRIPTION
**Description:** <Describe what has changed. 

Currently, `TraceData.Resource` is ignored in xray exporter. This means OTLP ingestion doesn't have resource information available because `Span.Resource` is never set. This change falls back to `TraceData.Resource` when needed.

**Testing:** Unit tests