### PR TITLE
Add span attributes as honeycomb event fields.

### DIFF
--- a/exporter/honeycombexporter/honeycomb.go
+++ b/exporter/honeycombexporter/honeycomb.go
@@ -154,6 +154,12 @@ func (e *honeycombExporter) pushTraceData(ctx context.Context, td consumerdata.T
 			}
 		}
 
+		if attrs := spanAttributesToMap(span.GetAttributes()); attrs != nil {
+			for k, v := range attrs {
+				ev.AddField(k, v)
+			}
+		}
+
 		ev.Timestamp = timestampToTime(span.GetStartTime())
 		startTime := timestampToTime(span.GetStartTime())
 		endTime := timestampToTime(span.GetEndTime())

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -111,6 +111,15 @@ func TestExporter(t *testing.T) {
 				Name:                    &tracepb.TruncatableString{Value: "root"},
 				Kind:                    tracepb.Span_SERVER,
 				SameProcessAsParentSpan: &wrappers.BoolValue{Value: true},
+				Attributes: &tracepb.Span_Attributes{
+					AttributeMap: map[string]*tracepb.AttributeValue{
+						"span_attr_name": {
+							Value: &tracepb.AttributeValue_StringValue{
+								StringValue: &tracepb.TruncatableString{Value: "Span Attribute"},
+							},
+						},
+					},
+				},
 				Resource: &resourcepb.Resource{
 					Type: "override",
 					Labels: map[string]string{
@@ -203,6 +212,7 @@ func TestExporter(t *testing.T) {
 				"name":                    "root",
 				"resource_type":           "override",
 				"service_name":            "test_service",
+				"span_attr_name":          "Span Attribute",
 				"status.code":             float64(0),
 				"status.message":          "OK",
 				"trace.span_id":           "02",


### PR DESCRIPTION
Fixing a regression introduced in the recent refactoring of the honeycomb exporter. Attributes were supported on span links and message events, but not on the span itself.