### PR TITLE
Split job to run stability tests in a separate build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,14 @@
 version: 2.1
+parameters:
+  run-build-publish:
+    type: boolean 
+    default: true 
+  run-stability-tests:
+    type: boolean 
+    default: false
+  collector-sha:
+    type: string
+    default: ""
 
 executors:
   golang:
@@ -54,21 +64,45 @@ commands:
 
 workflows:
   version: 2
-  build-publish:
+  stability-tests:
+    when: << pipeline.parameters.run-stability-tests >>
     jobs:
-      - setup-and-lint:
+      - checkout-commit
+      - setup:
+          requires:
+            - checkout-commit
+      - build:
+          requires:
+            - setup
+      - run-stability-tests:
+          requires:
+            - build
+      - publish-dev:
+          requires:
+            - run-stability-tests 
+
+  build-publish:
+    when: << pipeline.parameters.run-build-publish >>
+    jobs:
+      - setup:
+          filters:
+            tags:
+              only: /.*/
+      - lint:
+          requires:
+            - setup 
           filters:
             tags:
               only: /.*/
       - build:
           requires:
-            - setup-and-lint
+            - setup
           filters:
             tags:
               only: /.*/
       - build-examples-tracing:
           requires:
-            - setup-and-lint
+            - setup
           filters:
             tags:
               only: /.*/
@@ -84,9 +118,9 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - coverage:
+      - test:
           requires:
-            - setup-and-lint
+            - setup
           filters:
             tags:
               only: /.*/
@@ -98,17 +132,19 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9].[0-9].[0-9]+.*/
-      - publish-dev:
+      - spawn-stability-tests-job:
           requires:
+            - lint
+            - test
             - build
           filters:
             branches:
-              only: master
+              only: /master/
             tags:
               ignore: /.*/
 
 jobs:
-  setup-and-lint:
+  setup:
     executor: golang
     steps:
       - checkout
@@ -116,9 +152,6 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths: project
-      - run:
-          name: Install bazzar
-          command: sudo apt update && sudo apt-get install bzr -y
       - run:
           name: Install tools
           command: make install-tools
@@ -128,6 +161,10 @@ jobs:
       - persist_to_workspace:
           root: ~/
           paths: go/bin
+  lint:
+    executor: golang
+    steps:
+      - attach_to_workspace
       - run:
           name: Lint
           command: CMD="make lint" make -j4 for-all
@@ -168,7 +205,7 @@ jobs:
           root: ~/
           paths: project/bin
 
-  coverage:
+  test:
     executor: golang
     steps:
       - attach_to_workspace
@@ -209,11 +246,50 @@ jobs:
           command: ghr -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME --replace $CIRCLE_TAG bin/
 
   publish-dev:
-    docker:
-      - image: cimg/go:1.14
+    executor: golang
     steps:
       - attach_to_workspace
       - setup_remote_docker
       - publish_docker_images:
           repo: opentelemetry-collector-contrib-dev
           tag: ${CIRCLE_SHA1}
+
+  spawn-stability-tests-job:
+    executor: golang
+    steps:
+      - run:
+          name: Trigger stability tests job
+          command: |
+            curl -f -X POST "https://circleci.com/api/v2/project/github/open-telemetry/${CIRCLE_PROJECT_REPONAME}/pipeline?circle-token=${CIRCLE_API_TOKEN}" \
+                -H 'Content-Type: application/json' \
+                -H 'Accept: application/json' \
+                -d '{"parameters": {"run-build-publish": false, "run-stability-tests": true, "collector-sha": "'"${CIRCLE_SHA1}"'"}, "branch": "'"${CIRCLE_BRANCH}"'"}'
+
+  checkout-commit:
+    executor: golang
+    steps:
+      - checkout
+      - run:
+          name: Checkout pipeline parameter commit
+          command: |
+            git checkout << pipeline.parameters.collector-sha >>
+            git status
+
+  run-stability-tests:
+    executor: golang
+    steps:
+      - run:
+          name: Run stability tests
+          command: make stability-tests
+      - run:
+          name: Run on fail status
+          command: |
+              curl --request POST \
+              --url https://api.github.com/repos/open-telemetry/opentelemetry-collector-contrib/issues \
+              --header "authorization: Bearer ${GITHUB_TOKEN}" \
+              --header "content-type: application/json" \
+              --data '{
+                "title": "Stability tests failed in branch '"${CIRCLE_BRANCH}"' for commit << pipeline.parameters.collector-sha >>",
+                "body": "Link to failed job: '"${CIRCLE_BUILD_URL}"'."
+                }'
+          when: on_fail

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ test-with-cover:
 	 	go tool cover -html=coverage.txt -o coverage.html ); \
 	done
 
+.PHONY: stability-tests
+stability-tests:
+	@echo Stability tests have not been implemented yet 
+
 .PHONY: gotidy
 gotidy:
 	$(MAKE) for-all CMD="go mod tidy"


### PR DESCRIPTION
Split upcoming stability tests into it's own CI job

We'll soon have long running stability tests that'll run on every commit in the master branch. Since the tests can take a long time to complete, we want to run them in a separate build without holding up the main master commit builds. This PR splits up the CI pipeline into two workflows. Each commit to master runs the default workflow which uses CircleCI API to trigger the stability tests workflow for the same commit.

Other changes:

- Stability tests workflow now publishes images to docker hub. We do this as we want to publish verified images only. Alternatively, we could publish dev images from the main workflow and then add a "verified" tag to the same image after stability tests pass.
- Splits the setup-and-lint job into separate setup and lint jobs. This allows build and test jobs to start much earlier as they don't really need to wait for lint. This along with removing bazaar vcs installation cuts down the build time in half. 
- Stability tests automatically create Github issues on failure. Right now the issues just link back to the failed build but we can add a lot more information to it. We can also categorize or auto-assign it to users (for example the commit author). 

Possible issues:

- As the stability tests will run for a long time, they might consume all available container for the project and block PR builds from running where there is a lot of activity on the repo.
- The CI system is configured to auto-cancel redundant builds meaning issuing a new build for a branch will cancel any in-progress builds for the same branch. This could result in a lot of stability test builds getting auto-cancelled. We can avoid this by running every stability build in it's own branch or tag but that would mean giving CI write access to the repo which we are trying to avoid as it opens up a new attack vector.

Both of these problems can be mitigated if we create a new github repository and use that to run stability tests in CI. In this scenario, the new repository will host only CI config. The CI pipeline will be parameterized and called by master builds using the Circle API. Builds in this new repo should not hold up PR builds for the collector repo. We can also configure it differently to not auto-cancel builds. The dedicated stability tests CI pipeline can run tests for both core and contrib repos.