### PR TITLE
Use X-Ray convention of segment name == service name.

### DIFF
--- a/exporter/awsxrayexporter/translator/segment.go
+++ b/exporter/awsxrayexporter/translator/segment.go
@@ -147,8 +147,8 @@ func MakeSegment(span pdata.Span, resource pdata.Resource) Segment {
 		if dbInstance, ok := attributes.Get(semconventions.AttributeDBInstance); ok {
 			// For database queries, the segment name convention is <db name>@<db host>
 			name = dbInstance.StringVal()
-			if dbUrl, ok := attributes.Get(semconventions.AttributeDBURL); ok {
-				if parsed, _ := url.Parse(dbUrl.StringVal()); parsed != nil {
+			if dbURL, ok := attributes.Get(semconventions.AttributeDBURL); ok {
+				if parsed, _ := url.Parse(dbURL.StringVal()); parsed != nil {
 					if parsed.Hostname() != "" {
 						name += "@" + parsed.Hostname()
 					}

--- a/exporter/awsxrayexporter/translator/segment.go
+++ b/exporter/awsxrayexporter/translator/segment.go
@@ -165,6 +165,12 @@ func MakeSegment(span pdata.Span, resource pdata.Resource) Segment {
 	}
 
 	if name == "" {
+		if rpcservice, ok := attributes.Get(semconventions.AttributeRPCService); ok {
+			name = rpcservice.StringVal()
+		}
+	}
+
+	if name == "" {
 		if host, ok := attributes.Get(semconventions.AttributeHTTPHost); ok {
 			name = host.StringVal()
 		}

--- a/exporter/awsxrayexporter/translator/segment_test.go
+++ b/exporter/awsxrayexporter/translator/segment_test.go
@@ -85,7 +85,7 @@ func TestServerSpanWithInternalServerError(t *testing.T) {
 
 	assert.NotNil(t, segment)
 	assert.NotNil(t, segment.Cause)
-	assert.Equal(t, spanName, segment.Name)
+	assert.Equal(t, "signup_aggregator", segment.Name)
 	assert.True(t, segment.Fault)
 	w := testWriters.borrow()
 	if err := w.Encode(segment); err != nil {
@@ -149,8 +149,7 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	assert.NotNil(t, segment.Annotations)
 	assert.Nil(t, segment.Cause)
 	assert.Nil(t, segment.HTTP)
-	// Restricted characters removed from span name.
-	assert.Equal(t, "call update_user_preference , ,  ", segment.Name)
+	assert.Equal(t, "customers@db.dev.example.com", segment.Name)
 	assert.False(t, segment.Fault)
 	assert.False(t, segment.Error)
 	assert.Equal(t, "remote", segment.Namespace)
@@ -163,6 +162,44 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	testWriters.release(w)
 	assert.True(t, strings.Contains(jsonStr, spanName))
 	assert.True(t, strings.Contains(jsonStr, enterpriseAppID))
+}
+
+func TestClientSpanWithHttpHost(t *testing.T) {
+	spanName := "GET /"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes[semconventions.AttributeHTTPMethod] = "GET"
+	attributes[semconventions.AttributeHTTPScheme] = "https"
+	attributes[semconventions.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
+	attributes[semconventions.AttributeNetPeerPort] = "9443"
+	attributes[semconventions.AttributeHTTPTarget] = "/"
+	attributes[semconventions.AttributeHTTPHost] = "foo.com"
+	attributes[semconventions.AttributeNetPeerName] = "bar.com"
+	resource := constructDefaultResource()
+	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
+
+	segment := MakeSegment(span, resource)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, "foo.com", segment.Name)
+}
+func TestClientSpanWithoutHttpHost(t *testing.T) {
+	spanName := "GET /"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes[semconventions.AttributeHTTPMethod] = "GET"
+	attributes[semconventions.AttributeHTTPScheme] = "https"
+	attributes[semconventions.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
+	attributes[semconventions.AttributeNetPeerPort] = "9443"
+	attributes[semconventions.AttributeHTTPTarget] = "/"
+	attributes[semconventions.AttributeNetPeerName] = "bar.com"
+	resource := constructDefaultResource()
+	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
+
+	segment := MakeSegment(span, resource)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, "bar.com", segment.Name)
 }
 
 func TestSpanWithInvalidTraceId(t *testing.T) {
@@ -225,15 +262,8 @@ func TestServerSpanWithNilAttributes(t *testing.T) {
 
 	assert.NotNil(t, segment)
 	assert.NotNil(t, segment.Cause)
-	assert.Equal(t, spanName, segment.Name)
+	assert.Equal(t, "signup_aggregator", segment.Name)
 	assert.True(t, segment.Fault)
-	w := testWriters.borrow()
-	if err := w.Encode(segment); err != nil {
-		assert.Fail(t, "invalid json")
-	}
-	jsonStr := w.String()
-	testWriters.release(w)
-	assert.True(t, strings.Contains(jsonStr, spanName))
 }
 
 func constructClientSpan(parentSpanID []byte, name string, code int32, message string, attributes map[string]interface{}) pdata.Span {

--- a/exporter/awsxrayexporter/translator/segment_test.go
+++ b/exporter/awsxrayexporter/translator/segment_test.go
@@ -183,6 +183,7 @@ func TestClientSpanWithHttpHost(t *testing.T) {
 	assert.NotNil(t, segment)
 	assert.Equal(t, "foo.com", segment.Name)
 }
+
 func TestClientSpanWithoutHttpHost(t *testing.T) {
 	spanName := "GET /"
 	parentSpanID := newSegmentID()
@@ -200,6 +201,26 @@ func TestClientSpanWithoutHttpHost(t *testing.T) {
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "bar.com", segment.Name)
+}
+
+func TestClientSpanWithRpcHost(t *testing.T) {
+	spanName := "GET /com.foo.AnimalService/GetCats"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes[semconventions.AttributeHTTPMethod] = "GET"
+	attributes[semconventions.AttributeHTTPScheme] = "https"
+	attributes[semconventions.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
+	attributes[semconventions.AttributeNetPeerPort] = "9443"
+	attributes[semconventions.AttributeHTTPTarget] = "/com.foo.AnimalService/GetCats"
+	attributes[semconventions.AttributeRPCService] = "com.foo.AnimalService"
+	attributes[semconventions.AttributeNetPeerName] = "bar.com"
+	resource := constructDefaultResource()
+	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
+
+	segment := MakeSegment(span, resource)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, "com.foo.AnimalService", segment.Name)
 }
 
 func TestSpanWithInvalidTraceId(t *testing.T) {


### PR DESCRIPTION
**Description:** 

X-Ray expects segment names to correspond to services, not methods. 

https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html

This uses a service name to set the segment name where possible.  The convention for DB spans is taken from the existing X-Ray instrumentation

https://github.com/aws/aws-xray-sdk-java/blob/master/aws-xray-recorder-sdk-sql/src/main/java/com/amazonaws/xray/sql/TracingStatement.java#L165

**Testing:** 
Checked traces from playground app in console