### PR TITLE
signalfxexporter: Update config handling

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -17,8 +17,10 @@ The following configuration options can also be configured:
 - `headers` (no default): Headers to pass in the payload.
 - `timeout` (default = 5s): Amount of time to wait for a send operation to complete.
 - `ingest_url` (no default): Destination
-where SignalFx metrics are sent. If this option is specified, `realm` is ignored.
-If path is not specified, `/v2/datapoint` is used.
+where SignalFx metrics are sent. If `realm` is set, this option is derived and will be
+`https://ingest.{realm}.signalfx.com/v2/datapoint`.  If a value is explicitly set, the
+value of `realm` will not be used in determining `ingest_url`. The explicit value will
+be used instead. If path is not specified, `/v2/datapoint` is used.
 - `api_url` (no default): Destination to which SignalFx
 [properties and tags](https://docs.signalfx.com/en/latest/metrics-metadata/metrics-metadata.html#metrics-metadata) are sent.
 If `realm` is set, this option is derived and will be `https://api.{realm}.signalfx.com/`. If a value is explicitly

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -10,18 +10,22 @@ The following configuration options are required:
 
 - `access_token` (no default): AccessToken is the authentication token provided
 by SignalFx.
-- `realm` (default = us0): SignalFx realm where the data will be received.
+- `realm` (no default): SignalFx realm where the data will be received.
 
 The following configuration options can also be configured:
 
 - `headers` (no default): Headers to pass in the payload.
 - `timeout` (default = 5s): Amount of time to wait for a send operation to complete.
-- `ingest_url` (default = https://ingest.`realm`.signalfx.com/v2/datapoint): Destination
+- `ingest_url` (no default): Destination
 where SignalFx metrics are sent. If this option is specified, `realm` is ignored.
 If path is not specified, `/v2/datapoint` is used.
-- `api_url` (default = https://api.`realm`.signalfx.com/): Destination to which SignalFx
+- `api_url` (no default): Destination to which SignalFx
 [properties and tags](https://docs.signalfx.com/en/latest/metrics-metadata/metrics-metadata.html#metrics-metadata) are sent.
+If `realm` is set, this option is derived and will be `https://api.{realm}.signalfx.com/`. If a value is explicitly
+set, the value of `realm` will not be used in determining `api_url`. The explicit value will be used instead.
 - `log_dimension_updates` (default = `false`): Whether or not to log dimension updates.
+
+Note: Either `realm` or both `ingest_url` and `api_url` should be explicitly set.
 
 Example:
 

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -131,6 +131,26 @@ func TestConfig_getOptionsFromConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Test empty realm and API URL",
+			fields: fields{
+				AccessToken: "access_token",
+				Timeout:     10 * time.Second,
+				IngestURL:   "https://ingest.us1.signalfx.com/",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Test empty realm and Ingest URL",
+			fields: fields{
+				AccessToken: "access_token",
+				Timeout:     10 * time.Second,
+				APIURL:      "https://api.us1.signalfx.com/",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name:    "Test empty config",
 			want:    nil,
 			wantErr: true,

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -151,6 +151,17 @@ func TestConfig_getOptionsFromConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Test invalid URLs",
+			fields: fields{
+				AccessToken: "access_token",
+				Timeout:     10 * time.Second,
+				APIURL:      "https://api us1 signalfx com/",
+				IngestURL:   "https://api us1 signalfx com/",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name:    "Test empty config",
 			want:    nil,
 			wantErr: true,

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -64,9 +64,6 @@ func New(
 			fmt.Errorf("failed to process %q config: %v", config.Name(), err)
 	}
 
-	logger.Info("SignalFx Config", zap.String("ingest_url", options.ingestURL.String()))
-	logger.Info("SignalFx Config", zap.String("api_url", options.apiURL.String()))
-
 	if config.Name() == "" {
 		config.SetType(typeStr)
 		config.SetName(typeStr)

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -65,6 +65,7 @@ func New(
 	}
 
 	logger.Info("SignalFx Config", zap.String("ingest_url", options.ingestURL.String()))
+	logger.Info("SignalFx Config", zap.String("api_url", options.apiURL.String()))
 
 	if config.Name() == "" {
 		config.SetType(typeStr)

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -27,7 +27,6 @@ const (
 	// The value of "type" key in configuration.
 	typeStr = "signalfx"
 
-	defaultSFxRealm    = "us0"
 	defaultHTTPTimeout = time.Second * 5
 )
 
@@ -47,7 +46,6 @@ func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
 			TypeVal: configmodels.Type(typeStr),
 			NameVal: typeStr,
 		},
-		Realm:   defaultSFxRealm,
 		Timeout: defaultHTTPTimeout,
 	}
 }

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -39,6 +39,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	c := cfg.(*Config)
 	c.AccessToken = "access_token"
+	c.Realm = "us0"
 
 	assert.Equal(t, configmodels.Type(typeStr), factory.Type())
 	_, err := factory.CreateMetricsExporter(zap.NewNop(), cfg)
@@ -58,6 +59,7 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	c := cfg.(*Config)
 	c.AccessToken = "access_token"
+	c.Realm = "us0"
 
 	exp, err := factory.CreateMetricsExporter(
 		zap.NewNop(),
@@ -119,13 +121,26 @@ func TestFactory_CreateMetricsExporterFails(t *testing.T) {
 			errorMessage: "failed to process \"signalfx\" config: cannot have a negative \"timeout\"",
 		},
 		{
-			name: "empty_realm_and_url",
+			name: "empty_realm_and_urls",
 			config: &Config{
 				ExporterSettings: configmodels.ExporterSettings{
 					TypeVal: configmodels.Type(typeStr),
 					NameVal: typeStr,
 				},
 				AccessToken: "testToken",
+			},
+			errorMessage: "failed to process \"signalfx\" config: requires a non-empty \"realm\"," +
+				" or \"ingest_url\" and \"api_url\" should be explicitly set",
+		},
+		{
+			name: "empty_realm_and_api_url",
+			config: &Config{
+				ExporterSettings: configmodels.ExporterSettings{
+					TypeVal: configmodels.Type(typeStr),
+					NameVal: typeStr,
+				},
+				AccessToken: "testToken",
+				IngestURL:   "http://localhost:123",
 			},
 			errorMessage: "failed to process \"signalfx\" config: requires a non-empty \"realm\"," +
 				" or \"ingest_url\" and \"api_url\" should be explicitly set",


### PR DESCRIPTION
**Description:** Update config handling in SignalFx exporter. Make either `realm` or both `ingest_url` and `api_url` required config options. If either of the URL options are set apart from `realm`, the explicitly set URL will take precedence.

**Testing:** Updated tests.

**Documentation:** Updated README.md