### PR TITLE
elasticexporter: don't return error on invalid tags

### DIFF
--- a/exporter/elasticexporter/internal/translator/elastic/traces_test.go
+++ b/exporter/elasticexporter/internal/translator/elastic/traces_test.go
@@ -208,6 +208,17 @@ func TestTransactionHTTPRequestURL(t *testing.T) {
 	})
 }
 
+func TestTransactionHTTPRequestURLInvalid(t *testing.T) {
+	transaction := transactionWithAttributes(t, map[string]pdata.AttributeValue{
+		"http.url": pdata.NewAttributeValueString("0.0.0.0:8081"),
+	})
+	require.NotNil(t, transaction.Context)
+	assert.Nil(t, transaction.Context.Request)
+	assert.Equal(t, model.IfaceMap{
+		{Key: "http_url", Value: "0.0.0.0:8081"},
+	}, transaction.Context.Tags)
+}
+
 func TestTransactionHTTPRequestSocketRemoteAddr(t *testing.T) {
 	test := func(t *testing.T, expected string, attrs map[string]pdata.AttributeValue) {
 		transaction := transactionWithAttributes(t, attrs)
@@ -323,6 +334,17 @@ func TestSpanHTTPURL(t *testing.T) {
 			"http.target": pdata.NewAttributeValueString("/foo?bar"),
 		})
 	})
+}
+
+func TestSpanHTTPURLInvalid(t *testing.T) {
+	span := spanWithAttributes(t, map[string]pdata.AttributeValue{
+		"http.url": pdata.NewAttributeValueString("0.0.0.0:8081"),
+	})
+	require.NotNil(t, span.Context)
+	assert.Nil(t, span.Context.HTTP)
+	assert.Equal(t, model.IfaceMap{
+		{Key: "http_url", Value: "0.0.0.0:8081"},
+	}, span.Context.Tags)
 }
 
 func TestSpanHTTPStatusCode(t *testing.T) {

--- a/exporter/elasticexporter/internal/translator/elastic/utils.go
+++ b/exporter/elasticexporter/internal/translator/elastic/utils.go
@@ -17,7 +17,6 @@
 package elastic
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -28,15 +27,6 @@ var (
 	serviceNameInvalidRegexp = regexp.MustCompile("[^a-zA-Z0-9 _-]")
 	labelKeyReplacer         = strings.NewReplacer(`.`, `_`, `*`, `_`, `"`, `_`)
 )
-
-func combineErrors(errs []error) error {
-	if n := len(errs); n == 0 {
-		return nil
-	} else if n == 1 {
-		return errs[0]
-	}
-	return fmt.Errorf("%q", errs)
-}
 
 func ifaceAttributeValue(v pdata.AttributeValue) interface{} {
 	switch v.Type() {


### PR DESCRIPTION
**Description:**

If an `http.url` attribute is provided, and does not conform to the
opentelemetry conventions, do not return an error if URL parsing fails.
Instead, just record the value as-is in a label.

For example, the OpenTracing instrumentation for Go's net/http client sends host:port in some cases: https://github.com/opentracing-contrib/go-stdlib/blob/cf7a6c988dc994e945d2715565026f3cc8718689/nethttp/client.go#L255

**Testing:**

Tested manually with Jaeger HotR.O.D. -> OpenTelemetry Collector -> Elastic APM
(This is how we found the issue in the first place.)

Added unit tests.