### PR TITLE
Remove check for Jaeger source when extracting IP in k8s processor.

### DIFF
--- a/processor/k8sprocessor/processor.go
+++ b/processor/k8sprocessor/processor.go
@@ -95,14 +95,11 @@ func (kp *kubernetesprocessor) ConsumeTraceData(ctx context.Context, td consumer
 	if td.Resource != nil {
 		podIP = kp.k8sIPFromAttributes(td.Resource.Labels)
 	}
-
 	// Jaeger client libs tag the process with the process/resource IP and
 	// jaeger to OC translator maps jaeger process to OC node.
 	// TODO: Should jaeger translator map jaeger process to OC resource instead?
-	if podIP == "" && td.SourceFormat == sourceFormatJaeger {
-		if td.Node != nil {
-			podIP = kp.k8sIPFromAttributes(td.Node.Attributes)
-		}
+	if podIP == "" && td.Node != nil {
+		podIP = kp.k8sIPFromAttributes(td.Node.Attributes)
 	}
 
 	// Check if the receiver detected client IP.


### PR DESCRIPTION
K8S processor used to check if a batch was received by the Jaeger
receiver before trying to extract the IP tag from Node. We already try
to extract the IP from OC Resource which has quite a bit of overlap with
Jaeger Node so the check is not really neccesary.

Fixes #262

