### PR TITLE
honeycomb: Use SendPresampled 

### DIFF
--- a/exporter/honeycombexporter/honeycomb.go
+++ b/exporter/honeycombexporter/honeycomb.go
@@ -214,7 +214,7 @@ func (e *honeycombExporter) sendSpanLinks(span *tracepb.Span) {
 		for k, v := range attrs {
 			ev.AddField(k, v)
 		}
-		if err := ev.Send(); err != nil {
+		if err := ev.SendPresampled(); err != nil {
 			e.onError(err)
 		}
 	}
@@ -270,7 +270,7 @@ func (e *honeycombExporter) sendMessageEvents(td consumerdata.TraceData, span *t
 			ParentName: truncatableStringAsString(span.GetName()),
 			SpanType:   "span_event",
 		})
-		if err := ev.Send(); err != nil {
+		if err := ev.SendPresampled(); err != nil {
 			e.onError(err)
 		}
 	}


### PR DESCRIPTION
The honeycomb exporter isn't trace aware and relies on processors like probabilistic_sampler or tail_sampling to make sampling decisions. libhoney provides two methods for sending events `ev.send()` and `ev.sendpresampled()`. `sendpresampled` always sends events, `send` performs random sampling (if enabled)

The SendPresampled method is currently in use for traces https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/2c59911e2b4f557d220fc1199a609fbc124462c5/exporter/honeycombexporter/honeycomb.go#L184 but not for spanLinks or messageEvents. This has the effect of randomly sampling (inside lib honey) events that should always be sent to honeycomb.

@paulosman 
