### PR TITLE
Add component doc verificaion script

### DIFF
--- a/cmd/otelcontribcol/components_docs_test.go
+++ b/cmd/otelcontribcol/components_docs_test.go
@@ -1,0 +1,49 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componentdocs"
+)
+
+const (
+	relativeDefaultComponentsPath = "cmd/otelcontribcol/components.go"
+	projectGoModule               = "github.com/open-telemetry/opentelemetry-collector-contrib"
+)
+
+// TestComponentDocs verifies existence of READMEs for components specified as
+// default components in the collector. Looking for default components being enabled
+// in the collector gives a reasonable measure of the components that need to be
+// documented. Note, that for this test to work, the underlying assumption is
+// the imports in cmd/otelcontribcol/components.go" are indicative
+// of components that require documentation.
+func TestComponentDocs(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err, "failed to get working directory: %v")
+
+	// Absolute path to the project root directory
+	projectPath := filepath.Join(wd, "../../")
+
+	err = componentdocs.VerifyComponentDocumentation(
+		projectPath,
+		relativeDefaultComponentsPath,
+		projectGoModule,
+	)
+	require.NoError(t, err)
+}

--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -1,0 +1,3 @@
+# Azure Monitor Exporter
+
+To be added.

--- a/exporter/carbonexporter/README.md
+++ b/exporter/carbonexporter/README.md
@@ -1,0 +1,3 @@
+# Carbon Exporter
+
+To be added.

--- a/exporter/kinesisexporter/README.md
+++ b/exporter/kinesisexporter/README.md
@@ -1,0 +1,3 @@
+# Kinesis Exporter
+
+To be added.

--- a/exporter/stackdriverexporter/README.md
+++ b/exporter/stackdriverexporter/README.md
@@ -1,0 +1,3 @@
+# Stackdriver Exporter
+
+To be added.

--- a/receiver/carbonreceiver/README.md
+++ b/receiver/carbonreceiver/README.md
@@ -1,0 +1,3 @@
+# Carbon Receiver
+
+To be added.

--- a/receiver/jaegerlegacyreceiver/README.md
+++ b/receiver/jaegerlegacyreceiver/README.md
@@ -1,0 +1,3 @@
+# Jaeger Receiver
+
+To be added.

--- a/receiver/wavefrontreceiver/README.md
+++ b/receiver/wavefrontreceiver/README.md
@@ -1,0 +1,3 @@
+# Wavefront Receiver
+
+To be added.

--- a/receiver/zipkinscribereceiver/README.md
+++ b/receiver/zipkinscribereceiver/README.md
@@ -1,0 +1,3 @@
+# Zipkin Receiver
+
+To be added.


### PR DESCRIPTION
Depends on https://github.com/open-telemetry/opentelemetry-collector/pull/1090

**Description:** Add script to verify component documentation exists.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/1025

Will open issues for missing READMEs (This PR adds empty README.md files so the test will pass).