### PR TITLE
Dockerfile default config location

### DIFF
--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -4,5 +4,6 @@ RUN apk --update add ca-certificates
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY otelcontribcol /
-ENTRYPOINT ["/otelcontribcol"]
 EXPOSE 55680 55679
+ENTRYPOINT ["/otelcontribcol"]
+CMD ["--config", "/etc/otel/config.yaml"]


### PR DESCRIPTION
**Description:** 
Update docker file to have a default config location.

 We specify an entrypoint in the Dockerfile but expect the users to
 supply the arguments (mainly the --config) parameter. This change adds a
 default value for the `--config` parameter so users don't have to
specify it.

 Before this change users would have to issue the following command to
 run the collector with docker:

        docker run -v $(pwd):/etc/otel otel/opentelemetry-collector-contrib:0.3.0 --config /etc/otel/config.yaml

 This change reduces it to the following:

        docker run -v $(pwd):/etc/otel otel/opentelemetry-collector-contrib:0.3.0
 
Users can still specify the --config flag to use a different file.

This also makes the Dockerfile a bit more self-documenting.

-----------------

Once this is merged, I'll update the core repo and docs as well. With this change we can also ship a default config but I'm not sure what that should look like so didn't want to hold this PR because of that. 
