### PR TITLE
Make zipkinscribe test repeatable by using random port

### DIFF
--- a/receiver/zipkinscribereceiver/receiver_test.go
+++ b/receiver/zipkinscribereceiver/receiver_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"net"
 	"reflect"
-	"strconv"
 	"sync"
 	"testing"
 
@@ -142,7 +141,7 @@ func TestScribeReceiverPortAlreadyInUse(t *testing.T) {
 }
 
 func TestScribeReceiverServer(t *testing.T) {
-	const endpoint = "localhost:9410"
+	const endpoint = "localhost:0"
 
 	messages := []*scribe.LogEntry{
 		{
@@ -164,7 +163,7 @@ func TestScribeReceiverServer(t *testing.T) {
 	}()
 
 	var trans thrift.TTransport
-	trans, err = thrift.NewTSocket(net.JoinHostPort("localhost", strconv.Itoa(9410)))
+	trans, err = thrift.NewTSocket(traceReceiver.(*scribeReceiver).server.ServerTransport().(*thrift.TServerSocket).Addr().String())
 	if err != nil {
 		t.Fatalf("error creating thrift socket: %v", err)
 	}


### PR DESCRIPTION
Tests in general should be able to be run with 'go test -count X' in order to flush out flaky tests.

I needed this to debug https://circleci.com/gh/open-telemetry/opentelemetry-collector-contrib/2543?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link.