### PR TITLE
Add long-running stability tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
       - restore_workspace
       - run:
           name: Loadtest
-          command: make -C testbed runtests
+          command: make e2e-test
       - store_artifacts:
           path: testbed/tests/results
       - store_test_results:
@@ -309,12 +309,33 @@ jobs:
             git status
 
   run-stability-tests:
+    parameters:
+      # Number of runners must be always in sync with number of stability tests,
+      # so every node runs exactly one stability test.
+      runners-number:
+        type: integer 
+        default: 9
     executor: golang
+    resource_class: medium+
+    parallelism: << parameters.runners-number >>
     steps:
       - restore_workspace
       - run:
+          no_output_timeout: 70m
           name: Run stability tests
-          command: make stability-tests
+          command: |
+            export TESTS=$(make -C testbed -s list-stability-tests)
+            export TEST_NUM=$(echo ${TESTS} | wc -w | tr -d '[:space:]')
+            if [ "${TEST_NUM}" -ne "<< parameters.runners-number >>" ]; then \
+              echo "ERROR: Number of stability tests must match number of CircleCI runners. Update runners-number parameter"; exit 2; \
+            fi
+            export TEST_NAME=$(echo ${TESTS} | sed 's/ /\n/g' | circleci tests split --total=${TEST_NUM})
+            echo "Running ${TEST_NAME}..."
+            TEST_ARGS="-test.run=${TEST_NAME}" make stability-tests
+      - store_artifacts:
+          path: testbed/stabilitytests/results
+      - store_test_results:
+          path: testbed/stabilitytests/results/junit
       - run:
           name: Run on fail status
           command: |

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: common otelcontribcol
 
 .PHONY: e2e-test
 e2e-test: otelcontribcol
-	$(MAKE) -C testbed runtests
+	$(MAKE) -C testbed run-tests
 
 .PHONY: test-with-cover
 unit-tests-with-cover:
@@ -40,9 +40,10 @@ integration-tests-with-cover:
 	@echo $(INTEGRATION_TEST_MODULES)
 	@$(MAKE) for-all CMD="make do-integration-tests-with-cover" ALL_MODULES="$(INTEGRATION_TEST_MODULES)"
 
+# Long-running e2e tests
 .PHONY: stability-tests
-stability-tests:
-	@echo Stability tests have not been implemented yet
+stability-tests: otelcontribcol
+	$(MAKE) -C testbed run-stability-tests
 
 .PHONY: gotidy
 gotidy:

--- a/testbed/Makefile
+++ b/testbed/Makefile
@@ -1,8 +1,20 @@
 include ../Makefile.Common
 
-.PHONY: runtests
-runtests: test
+.PHONY: list-tests
+list-tests:
+	TESTBED_CONFIG=local.yaml $(GOTEST) -v ./tests --test.list '.*' | sed '$$d'
+
+.PHONY: run-tests
+run-tests:
 	./runtests.sh
+
+.PHONY: list-stability-tests
+list-stability-tests:
+	TESTBED_CONFIG=local.yaml $(GOTEST) -v ./stabilitytests --test.list '.*' | sed '$$d'
+
+.PHONY: run-stability-tests
+run-stability-tests:
+	TESTCASE_DURATION=1h TEST_ARGS="$${TEST_ARGS} -timeout 70m" TESTS_DIR=stabilitytests ./runtests.sh
 
 .PHONY: install-tools
 install-tools:

--- a/testbed/runtests.sh
+++ b/testbed/runtests.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-cd tests
+TESTS_DIR=${TESTS_DIR:-tests}
+
+cd ${TESTS_DIR}
 
 SED="sed"
 
@@ -10,11 +12,12 @@ PASS_COLOR=$(printf "\033[32mPASS\033[0m")
 FAIL_COLOR=$(printf "\033[31mFAIL\033[0m")
 TEST_COLORIZE="${SED} 's/PASS/${PASS_COLOR}/' | ${SED} 's/FAIL/${FAIL_COLOR}/'"
 
+mkdir -p results/junit
+
 TESTBED_CONFIG=local.yaml go test -v ${TEST_ARGS} 2>&1 | tee results/testoutput.log | bash -c "${TEST_COLORIZE}"
 
 testStatus=${PIPESTATUS[0]}
 
-mkdir -p results/junit
 go-junit-report < results/testoutput.log > results/junit/results.xml
 
 bash -c "cat results/TESTRESULTS.md | ${TEST_COLORIZE}"

--- a/testbed/stabilitytests/.gitignore
+++ b/testbed/stabilitytests/.gitignore
@@ -1,0 +1,1 @@
+results/*

--- a/testbed/stabilitytests/local.yaml
+++ b/testbed/stabilitytests/local.yaml
@@ -1,0 +1,1 @@
+agent: ../../bin/otelcontribcol_{{.GOOS}}_{{.GOARCH}}

--- a/testbed/stabilitytests/metric_test.go
+++ b/testbed/stabilitytests/metric_test.go
@@ -1,0 +1,81 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/testbed/testbed"
+	scenarios "go.opentelemetry.io/collector/testbed/tests"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
+)
+
+func TestStabilityMetricsOTLP(t *testing.T) {
+	scenarios.Scenario10kItemsPerSecond(
+		t,
+		testbed.NewOTLPMetricDataSender(testbed.GetAvailablePort(t)),
+		testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU:      50,
+			ExpectedMaxRAM:      80,
+			ResourceCheckPeriod: resourceCheckPeriod,
+		},
+		nil,
+	)
+}
+
+func TestStabilityMetricsOpenCensus(t *testing.T) {
+	scenarios.Scenario10kItemsPerSecond(
+		t,
+		testbed.NewOCMetricDataSender(testbed.GetAvailablePort(t)),
+		testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU:      45,
+			ExpectedMaxRAM:      86,
+			ResourceCheckPeriod: resourceCheckPeriod,
+		},
+		nil,
+	)
+}
+
+func TestStabilityMetricsCarbon(t *testing.T) {
+	scenarios.Scenario10kItemsPerSecond(
+		t,
+		datasenders.NewCarbonDataSender(testbed.GetAvailablePort(t)),
+		datareceivers.NewCarbonDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU:      237,
+			ExpectedMaxRAM:      100,
+			ResourceCheckPeriod: resourceCheckPeriod,
+		},
+		nil,
+	)
+}
+
+func TestStabilityMetricsSignalFx(t *testing.T) {
+	scenarios.Scenario10kItemsPerSecond(
+		t,
+		datasenders.NewSFxMetricDataSender(testbed.GetAvailablePort(t)),
+		datareceivers.NewSFxMetricsDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU:      83,
+			ExpectedMaxRAM:      95,
+			ResourceCheckPeriod: resourceCheckPeriod,
+		},
+		nil,
+	)
+}

--- a/testbed/stabilitytests/trace_test.go
+++ b/testbed/stabilitytests/trace_test.go
@@ -1,0 +1,117 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stabilitytests contains long-running test cases verifying that otel-collector can run
+// sustainably for long time, 1 hour by default.
+// Tests supposed to be run on CircleCI, each tests must be allocated to exactly one runner
+// to make sure that the whole test suit will not take longer than one hour.
+// Because of that, every time overall number of stability tests changed,
+// make sure to update CircleCI parameter: run-stability-tests.runners-number
+
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/testbed/testbed"
+	scenarios "go.opentelemetry.io/collector/testbed/tests"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
+)
+
+var (
+	resourceCheckPeriod, _ = time.ParseDuration("1m")
+	processorsConfig       = map[string]string{
+		"batch": `
+  batch:
+`,
+	}
+)
+
+// TestMain is used to initiate setup, execution and tear down of testbed.
+func TestMain(m *testing.M) {
+	testbed.DoTestMain(m)
+}
+
+func TestStabilityTracesOpenCensus(t *testing.T) {
+	scenarios.Scenario10kItemsPerSecond(
+		t,
+		testbed.NewOCTraceDataSender(testbed.GetAvailablePort(t)),
+		testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU:      30,
+			ExpectedMaxRAM:      90,
+			ResourceCheckPeriod: resourceCheckPeriod,
+		},
+		processorsConfig,
+	)
+}
+
+func TestStabilityTracesSAPM(t *testing.T) {
+	scenarios.Scenario10kItemsPerSecond(
+		t,
+		datasenders.NewSapmDataSender(testbed.GetAvailablePort(t)),
+		datareceivers.NewSapmDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU:      24,
+			ExpectedMaxRAM:      100,
+			ResourceCheckPeriod: resourceCheckPeriod,
+		},
+		processorsConfig,
+	)
+}
+
+func TestStabilityTracesOTLP(t *testing.T) {
+	scenarios.Scenario10kItemsPerSecond(
+		t,
+		testbed.NewOTLPTraceDataSender(testbed.GetAvailablePort(t)),
+		testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU:      20,
+			ExpectedMaxRAM:      80,
+			ResourceCheckPeriod: resourceCheckPeriod,
+		},
+		processorsConfig,
+	)
+}
+
+func TestStabilityTracesJaegerGRPC(t *testing.T) {
+	scenarios.Scenario10kItemsPerSecond(
+		t,
+		testbed.NewJaegerGRPCDataSender(testbed.GetAvailablePort(t)),
+		testbed.NewJaegerDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU:      40,
+			ExpectedMaxRAM:      90,
+			ResourceCheckPeriod: resourceCheckPeriod,
+		},
+		processorsConfig,
+	)
+}
+
+func TestStabilityTracesZipkin(t *testing.T) {
+	scenarios.Scenario10kItemsPerSecond(
+		t,
+		testbed.NewZipkinDataSender(testbed.GetAvailablePort(t)),
+		testbed.NewZipkinDataReceiver(testbed.GetAvailablePort(t)),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU:      60,
+			ExpectedMaxRAM:      95,
+			ResourceCheckPeriod: resourceCheckPeriod,
+		},
+		processorsConfig,
+	)
+}


### PR DESCRIPTION
**Description:** 
End-2-end tests running for an hour with fixed resource limits. If limits are reached tests fail. 

Current state of the collector shows a slow grow in memory usage, which may indicate a memory leak that needs to be investigated. Once this solved, this tests can be upgraded to not use a fixed limit, but check resources consumption at the beginning and making sure it doesn't grow more than in a specified small percentage after that.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/1022