### PR TITLE
Add & delete tags command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ endif
 BUILD_X3=-X github.com/open-telemetry/opentelemetry-collector/internal/version.BuildType=$(BUILD_TYPE)
 BUILD_INFO=-ldflags "${BUILD_X1} ${BUILD_X2} ${BUILD_X3}"
 STATIC_CHECK=staticcheck
+OTEL_VERSION=master
 
 .DEFAULT_GOAL := all
 
@@ -58,6 +59,25 @@ for-all:
 	  (cd "$${dir}" && \
 	  	echo "running $${CMD} in $${dir}" && \
 	 	$${CMD} ); \
+	done
+
+.PHONY: add-tag
+add-tag:
+	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
+	@echo "Adding tag ${TAG}"
+	@set -e; for dir in $(ALL_MODULES); do \
+	  (echo Adding tag "$${dir:2}/$${TAG}" && \
+	 	git tag -a "$${dir:2}/$${TAG}" -s -m "Version ${dir:2}/${TAG}" ); \
+	done
+
+.PHONY: delete-tag
+delete-tag:
+	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
+	@echo "Deleting tag ${TAG}"
+	@git tag -d ${TAG}
+	@set -e; for dir in $(ALL_MODULES); do \
+	  (echo Deleting tag "$${dir:2}/$${TAG}" && \
+	 	git tag -d "$${dir:2}/$${TAG}" ); \
 	done
 
 GOMODULES = $(ALL_MODULES) $(PWD)
@@ -130,7 +150,7 @@ update-dep:
 
 .PHONY: update-otel
 update-otel:
-	$(MAKE) update-dep MODULE=go.opentelemetry.io/collector VERSION=master
+	$(MAKE) update-dep MODULE=go.opentelemetry.io/collector VERSION=$(OTEL_VERSION)
 
 .PHONY: otel-from-tree
 otel-from-tree:


### PR DESCRIPTION
Added add-tag and delete-tag make targets

Added new add-tag and delete-tag make targets. These targets allow to
tag all Go modules in the repository with the given tag as is needed to
be done before every release.

The commit also add a VERSION parameter to the update-otel target so
that we can update to a specific version.

Fixes #294 