### PR TITLE
Improve kubeletstats receiver test coverage

### DIFF
--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -79,7 +79,7 @@ func components() (config.Factories, error) {
 		&wavefrontreceiver.Factory{},
 		&jaegerlegacyreceiver.Factory{},
 		&redisreceiver.Factory{},
-		kubeletstatsreceiver.NewFactory(),
+		&kubeletstatsreceiver.Factory{},
 		&simpleprometheusreceiver.Factory{},
 		&k8sclusterreceiver.Factory{},
 		&receivercreator.Factory{},

--- a/receiver/kubeletstatsreceiver/kubelet/client.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client.go
@@ -134,14 +134,9 @@ type clientImpl struct {
 }
 
 func (c *clientImpl) Get(path string) ([]byte, error) {
-	url := c.baseURL + path
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := c.buildReq(path)
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if c.tok != nil {
-		req.Header.Set("Authorization", fmt.Sprintf("bearer %s", c.tok))
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -158,4 +153,17 @@ func (c *clientImpl) Get(path string) ([]byte, error) {
 		return nil, err
 	}
 	return body, nil
+}
+
+func (c *clientImpl) buildReq(path string) (*http.Request, error) {
+	url := c.baseURL + path
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.tok != nil {
+		req.Header.Set("Authorization", fmt.Sprintf("bearer %s", c.tok))
+	}
+	return req, nil
 }

--- a/receiver/kubeletstatsreceiver/kubelet/client.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client.go
@@ -64,7 +64,7 @@ func newTLSClient(endpoint string, cfg *ClientConfig, logger *zap.Logger) (Clien
 	), nil
 }
 
-func newServiceAccountClient(endpoint string, caCertPath string, tokenPath string, logger *zap.Logger) (*tlsClient, error) {
+func newServiceAccountClient(endpoint string, caCertPath string, tokenPath string, logger *zap.Logger) (*clientImpl, error) {
 	rootCAs, err := systemCertPoolPlusPath(caCertPath)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func defaultTLSClient(
 	certificates []tls.Certificate,
 	tok []byte,
 	logger *zap.Logger,
-) *tlsClient {
+) *clientImpl {
 	tr := defaultTransport()
 	tr.TLSClientConfig = &tls.Config{
 		RootCAs:            rootCAs,
@@ -97,7 +97,7 @@ func defaultTLSClient(
 	if endpoint == "" {
 		endpoint = defaultEndpoint(logger)
 	}
-	return &tlsClient{
+	return &clientImpl{
 		baseURL:    "https://" + endpoint,
 		httpClient: http.Client{Transport: tr},
 		tok:        tok,
@@ -122,18 +122,18 @@ func defaultTransport() *http.Transport {
 	return http.DefaultTransport.(*http.Transport).Clone()
 }
 
-// tlsClient
+// clientImpl
 
-var _ Client = (*tlsClient)(nil)
+var _ Client = (*clientImpl)(nil)
 
-type tlsClient struct {
+type clientImpl struct {
 	baseURL    string
 	httpClient http.Client
 	logger     *zap.Logger
 	tok        []byte
 }
 
-func (c *tlsClient) Get(path string) ([]byte, error) {
+func (c *clientImpl) Get(path string) ([]byte, error) {
 	url := c.baseURL + path
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/receiver/kubeletstatsreceiver/kubelet/client.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client.go
@@ -34,9 +34,6 @@ type Client interface {
 	Get(path string) ([]byte, error)
 }
 
-// NewClient creates a new kubelet client. Pass in a fake readFile
-// implementation for testing, or pass in a nil readFile for the default
-// implementation.
 func NewClient(endpoint string, cfg *ClientConfig, logger *zap.Logger) (Client, error) {
 	switch cfg.APIConfig.AuthType {
 	case k8sconfig.AuthTypeTLS:

--- a/receiver/kubeletstatsreceiver/kubelet/client.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client.go
@@ -65,7 +65,12 @@ func newTLSClient(endpoint string, cfg *ClientConfig, logger *zap.Logger) (Clien
 	)
 }
 
-func newServiceAccountClient(endpoint string, caCertPath string, tokenPath string, logger *zap.Logger) (*clientImpl, error) {
+func newServiceAccountClient(
+	endpoint string,
+	caCertPath string,
+	tokenPath string,
+	logger *zap.Logger,
+) (*clientImpl, error) {
 	rootCAs, err := systemCertPoolPlusPath(caCertPath)
 	if err != nil {
 		return nil, err

--- a/receiver/kubeletstatsreceiver/kubelet/client_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client_test.go
@@ -16,27 +16,19 @@ package kubelet
 
 import (
 	"crypto/x509"
-	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/k8sconfig"
 )
-
-const certPath = "../testdata/testcert.crt"
-const keyFile = "../testdata/testkey.key"
-const tokenPath = "../testdata/token"
 
 func TestClient(t *testing.T) {
 	tr := &fakeRoundTripper{}
 	baseURL := "http://localhost:9876"
-	client := &clientImpl{
+	client := &tlsClient{
 		baseURL:    baseURL,
 		httpClient: http.Client{Transport: tr},
 	}
@@ -51,209 +43,52 @@ func TestClient(t *testing.T) {
 	require.Equal(t, "GET", tr.method)
 }
 
-func TestNewClient(t *testing.T) {
-	client, err := NewClient("localhost:9876", &ClientConfig{
-		APIConfig: k8sconfig.APIConfig{
-			AuthType: k8sconfig.AuthTypeTLS,
-		},
-		TLSSetting: configtls.TLSSetting{
-			CAFile:   certPath,
-			CertFile: certPath,
-			KeyFile:  keyFile,
-		},
-	}, zap.NewNop())
-	require.NoError(t, err)
-	require.NotNil(t, client)
-	c := client.(*clientImpl)
-	tcc := c.httpClient.Transport.(*http.Transport).TLSClientConfig
-	require.Equal(t, 1, len(tcc.Certificates))
-	require.NotNil(t, tcc.RootCAs)
-}
-
 func TestDefaultTLSClient(t *testing.T) {
 	endpoint := "localhost:9876"
-	client, err := defaultTLSClient(endpoint, true, &x509.CertPool{}, nil, nil, zap.NewNop())
-	require.NoError(t, err)
+	client := defaultTLSClient(endpoint, true, &x509.CertPool{}, nil, nil, zap.NewNop())
 	require.NotNil(t, client.httpClient.Transport)
 	require.Equal(t, "https://"+endpoint, client.baseURL)
 }
 
 func TestSvcAcctClient(t *testing.T) {
 	cl, err := newServiceAccountClient(
-		"localhost:9876", certPath, tokenPath, zap.NewNop(),
+		"localhost:9876", "../testdata/testcert.crt", "../testdata/token", zap.NewNop(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, "s3cr3t", string(cl.tok))
 }
 
-func TestDefaultEndpoint(t *testing.T) {
-	endpt, err := defaultEndpoint()
-	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(endpt, ":10250"))
-}
-
-func TestBadAuthType(t *testing.T) {
-	_, err := NewClient("foo", &ClientConfig{
-		APIConfig: k8sconfig.APIConfig{
-			AuthType: "bar",
-		},
-	}, zap.NewNop())
-	require.Error(t, err)
-}
-
-func TestTLSMissingCAFile(t *testing.T) {
-	_, err := newTLSClient("", &ClientConfig{}, zap.NewNop())
-	require.Error(t, err)
-}
-
-func TestTLSMissingCertFile(t *testing.T) {
-	_, err := newTLSClient("", &ClientConfig{
-		TLSSetting: configtls.TLSSetting{
-			CAFile: certPath,
-		},
-	}, zap.NewNop())
-	require.Error(t, err)
-}
-
-func TestSABadCertPath(t *testing.T) {
-	_, err := newServiceAccountClient("foo", "bar", "baz", zap.NewNop())
-	require.Error(t, err)
-}
-
-func TestSABadTokenPath(t *testing.T) {
-	_, err := newServiceAccountClient("foo", certPath, "bar", zap.NewNop())
-	require.Error(t, err)
-}
-
-func TestTLSDefaultEndpoint(t *testing.T) {
-	client, err := defaultTLSClient("", true, nil, nil, nil, zap.NewNop())
-	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(client.baseURL, "https://"))
-	require.True(t, strings.HasSuffix(client.baseURL, ":10250"))
-}
-
-func TestBuildReq(t *testing.T) {
-	cl, err := newServiceAccountClient(
-		"localhost:9876", certPath, tokenPath, zap.NewNop(),
-	)
-	require.NoError(t, err)
-	req, err := cl.buildReq("/foo")
-	require.NoError(t, err)
-	require.NotNil(t, req)
-	require.Equal(t, req.Header["Authorization"][0], "bearer s3cr3t")
-}
-
-func TestBuildBadReq(t *testing.T) {
-	cl, err := newServiceAccountClient(
-		"localhost:9876", certPath, tokenPath, zap.NewNop(),
-	)
-	require.NoError(t, err)
-	_, err = cl.buildReq(" ")
-	require.Error(t, err)
-}
-
-func TestFailedRT(t *testing.T) {
-	tr := &fakeRoundTripper{failOnRT: true}
-	baseURL := "http://localhost:9876"
-	client := &clientImpl{
-		baseURL:    baseURL,
-		httpClient: http.Client{Transport: tr},
-	}
-	_, err := client.Get("/foo")
-	require.Error(t, err)
-}
-
-func TestBadReq(t *testing.T) {
-	tr := &fakeRoundTripper{}
-	baseURL := "http://localhost:9876"
-	client := &clientImpl{
-		baseURL:    baseURL,
-		httpClient: http.Client{Transport: tr},
-	}
-	_, err := client.Get(" ")
-	require.Error(t, err)
-}
-
-func TestErrOnClose(t *testing.T) {
-	tr := &fakeRoundTripper{errOnClose: true}
-	baseURL := "http://localhost:9876"
-	client := &clientImpl{
-		baseURL:    baseURL,
-		httpClient: http.Client{Transport: tr},
-		logger:     zap.NewNop(),
-	}
-	resp, err := client.Get("/foo")
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-}
-
-func TestErrOnRead(t *testing.T) {
-	tr := &fakeRoundTripper{errOnRead: true}
-	baseURL := "http://localhost:9876"
-	client := &clientImpl{
-		baseURL:    baseURL,
-		httpClient: http.Client{Transport: tr},
-		logger:     zap.NewNop(),
-	}
-	resp, err := client.Get("/foo")
-	require.Error(t, err)
-	require.Nil(t, resp)
-}
-
 var _ http.RoundTripper = (*fakeRoundTripper)(nil)
 
 type fakeRoundTripper struct {
-	closed     bool
-	header     http.Header
-	method     string
-	url        string
-	failOnRT   bool
-	errOnClose bool
-	errOnRead  bool
+	closed bool
+	header http.Header
+	method string
+	url    string
 }
 
 func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if f.failOnRT {
-		return nil, errors.New("failOnRT == true")
-	}
 	f.header = req.Header
 	f.method = req.Method
 	f.url = req.URL.String()
-	var reader io.Reader
-	if f.errOnRead {
-		reader = &failingReader{}
-	} else {
-		reader = strings.NewReader("hello")
-	}
 	return &http.Response{
 		Body: &fakeReadCloser{
-			Reader: reader,
-			onClose: func() error {
+			Reader: strings.NewReader("hello"),
+			onClose: func() {
 				f.closed = true
-				if f.errOnClose {
-					return errors.New("")
-				}
-				return nil
 			},
 		},
 	}, nil
-}
-
-var _ io.Reader = (*failingReader)(nil)
-
-type failingReader struct{}
-
-func (f *failingReader) Read([]byte) (n int, err error) {
-	return 0, errors.New("")
 }
 
 var _ io.ReadCloser = (*fakeReadCloser)(nil)
 
 type fakeReadCloser struct {
 	io.Reader
-	onClose func() error
+	onClose func()
 }
 
 func (f *fakeReadCloser) Close() error {
-	return f.onClose()
+	f.onClose()
+	return nil
 }

--- a/receiver/kubeletstatsreceiver/kubelet/client_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client_test.go
@@ -72,7 +72,8 @@ func TestNewClient(t *testing.T) {
 
 func TestDefaultTLSClient(t *testing.T) {
 	endpoint := "localhost:9876"
-	client := defaultTLSClient(endpoint, true, &x509.CertPool{}, nil, nil, zap.NewNop())
+	client, err := defaultTLSClient(endpoint, true, &x509.CertPool{}, nil, nil, zap.NewNop())
+	require.NoError(t, err)
 	require.NotNil(t, client.httpClient.Transport)
 	require.Equal(t, "https://"+endpoint, client.baseURL)
 }
@@ -86,7 +87,8 @@ func TestSvcAcctClient(t *testing.T) {
 }
 
 func TestDefaultEndpoint(t *testing.T) {
-	endpt := defaultEndpoint(zap.NewNop())
+	endpt, err := defaultEndpoint()
+	require.NoError(t, err)
 	require.True(t, strings.HasSuffix(endpt, ":10250"))
 }
 
@@ -124,7 +126,8 @@ func TestSABadTokenPath(t *testing.T) {
 }
 
 func TestTLSDefaultEndpoint(t *testing.T) {
-	client := defaultTLSClient("", true, nil, nil, nil, zap.NewNop())
+	client, err := defaultTLSClient("", true, nil, nil, nil, zap.NewNop())
+	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(client.baseURL, "https://"))
 	require.True(t, strings.HasSuffix(client.baseURL, ":10250"))
 }

--- a/receiver/kubeletstatsreceiver/kubelet/client_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client_test.go
@@ -128,6 +128,17 @@ func TestTLSDefaultEndpoint(t *testing.T) {
 	require.True(t, strings.HasSuffix(client.baseURL, ":10250"))
 }
 
+func TestBuildReq(t *testing.T) {
+	cl, err := newServiceAccountClient(
+		"localhost:9876", certPath, tokenPath, zap.NewNop(),
+	)
+	require.NoError(t, err)
+	req, err := cl.buildReq("/foo")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, req.Header["Authorization"][0], "bearer s3cr3t")
+}
+
 var _ http.RoundTripper = (*fakeRoundTripper)(nil)
 
 type fakeRoundTripper struct {

--- a/receiver/kubeletstatsreceiver/kubelet/client_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client_test.go
@@ -118,7 +118,7 @@ func TestSABadCertPath(t *testing.T) {
 }
 
 func TestSABadTokenPath(t *testing.T) {
-	_, err := newServiceAccountClient("foo", certPath, "baz", zap.NewNop())
+	_, err := newServiceAccountClient("foo", certPath, "bar", zap.NewNop())
 	require.Error(t, err)
 }
 

--- a/receiver/kubeletstatsreceiver/kubelet/client_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client_test.go
@@ -239,7 +239,9 @@ func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	}, nil
 }
 
-type failingReader struct {}
+var _ io.Reader = (*failingReader)(nil)
+
+type failingReader struct{}
 
 func (f *failingReader) Read([]byte) (n int, err error) {
 	return 0, errors.New("")

--- a/receiver/kubeletstatsreceiver/kubelet/client_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client_test.go
@@ -80,6 +80,11 @@ func TestSvcAcctClient(t *testing.T) {
 	require.Equal(t, "s3cr3t", string(cl.tok))
 }
 
+func TestDefaultEndpoint(t *testing.T) {
+	endpt := defaultEndpoint(zap.NewNop())
+	require.True(t, strings.HasSuffix(endpt, ":10250"))
+}
+
 var _ http.RoundTripper = (*fakeRoundTripper)(nil)
 
 type fakeRoundTripper struct {


### PR DESCRIPTION
This change was created to improve test coverage but it was pushed after the PR it was addressing was merged. I believe this change to be worthwhile nonetheless, so I'd like for it to be considered for merging.

I have tested this change using TLS against minikube and using ServiceAccount auth against GKE.