### PR TITLE
support aws plugins EC2/ECS/Beanstalk

### DIFF
--- a/exporter/awsxrayexporter/translator/aws.go
+++ b/exporter/awsxrayexporter/translator/aws.go
@@ -54,6 +54,8 @@ type AWSData struct {
 type EC2Metadata struct {
 	InstanceID       string `json:"instance_id"`
 	AvailabilityZone string `json:"availability_zone"`
+	InstanceSize     string `json:"instance_size"`
+	AmiId            string `json:"ami_id"`
 }
 
 // ECSMetadata provides the shape for unmarshalling ECS metadata.
@@ -74,9 +76,12 @@ func makeAws(attributes map[string]string, resource pdata.Resource) (map[string]
 		account      string
 		zone         string
 		hostID       string
+		hostType     string
+		amiId        string
 		container    string
 		namespace    string
 		deployID     string
+		versionLabel string
 		operation    string
 		remoteRegion string
 		requestID    string
@@ -99,6 +104,10 @@ func makeAws(attributes map[string]string, resource pdata.Resource) (map[string]
 				zone = value.StringVal()
 			case semconventions.AttributeHostID:
 				hostID = value.StringVal()
+			case semconventions.AttributeHostType:
+				hostType = value.StringVal()
+			case semconventions.AttributeHostImageID:
+				amiId = value.StringVal()
 			case semconventions.AttributeContainerName:
 				if container == "" {
 					container = value.StringVal()
@@ -109,6 +118,8 @@ func makeAws(attributes map[string]string, resource pdata.Resource) (map[string]
 				namespace = value.StringVal()
 			case semconventions.AttributeServiceInstance:
 				deployID = value.StringVal()
+			case semconventions.AttributeServiceVersion:
+				versionLabel = value.StringVal()
 			}
 		})
 	}
@@ -148,6 +159,8 @@ func makeAws(attributes map[string]string, resource pdata.Resource) (map[string]
 		ec2 = &EC2Metadata{
 			InstanceID:       hostID,
 			AvailabilityZone: zone,
+			InstanceSize:     hostType,
+			AmiId:            amiId,
 		}
 	}
 	if container != "" {
@@ -163,6 +176,7 @@ func makeAws(attributes map[string]string, resource pdata.Resource) (map[string]
 		ebs = &BeanstalkMetadata{
 			Environment:  namespace,
 			DeploymentID: deployNum,
+			VersionLabel: versionLabel,
 		}
 	}
 	awsData := &AWSData{

--- a/exporter/awsxrayexporter/translator/aws.go
+++ b/exporter/awsxrayexporter/translator/aws.go
@@ -55,7 +55,7 @@ type EC2Metadata struct {
 	InstanceID       string `json:"instance_id"`
 	AvailabilityZone string `json:"availability_zone"`
 	InstanceSize     string `json:"instance_size"`
-	AmiId            string `json:"ami_id"`
+	AmiID            string `json:"ami_id"`
 }
 
 // ECSMetadata provides the shape for unmarshalling ECS metadata.
@@ -77,7 +77,7 @@ func makeAws(attributes map[string]string, resource pdata.Resource) (map[string]
 		zone         string
 		hostID       string
 		hostType     string
-		amiId        string
+		amiID        string
 		container    string
 		namespace    string
 		deployID     string
@@ -107,7 +107,7 @@ func makeAws(attributes map[string]string, resource pdata.Resource) (map[string]
 			case semconventions.AttributeHostType:
 				hostType = value.StringVal()
 			case semconventions.AttributeHostImageID:
-				amiId = value.StringVal()
+				amiID = value.StringVal()
 			case semconventions.AttributeContainerName:
 				if container == "" {
 					container = value.StringVal()
@@ -160,7 +160,7 @@ func makeAws(attributes map[string]string, resource pdata.Resource) (map[string]
 			InstanceID:       hostID,
 			AvailabilityZone: zone,
 			InstanceSize:     hostType,
-			AmiId:            amiId,
+			AmiID:            amiID,
 		}
 	}
 	if container != "" {

--- a/exporter/awsxrayexporter/translator/aws_test.go
+++ b/exporter/awsxrayexporter/translator/aws_test.go
@@ -24,6 +24,8 @@ import (
 
 func TestAwsFromEc2Resource(t *testing.T) {
 	instanceID := "i-00f7c0bcb26da2a99"
+	hostType := "m5.xlarge"
+	imageId := "ami-0123456789"
 	resource := pdata.NewResource()
 	resource.InitEmpty()
 	attrs := pdata.NewAttributeMap()
@@ -31,7 +33,8 @@ func TestAwsFromEc2Resource(t *testing.T) {
 	attrs.InsertString(semconventions.AttributeCloudAccount, "123456789")
 	attrs.InsertString(semconventions.AttributeCloudZone, "us-east-1c")
 	attrs.InsertString(semconventions.AttributeHostID, instanceID)
-	attrs.InsertString(semconventions.AttributeHostType, "m5.xlarge")
+	attrs.InsertString(semconventions.AttributeHostType, hostType)
+	attrs.InsertString(semconventions.AttributeHostImageID, imageId)
 	attrs.CopyTo(resource.Attributes())
 
 	attributes := make(map[string]string)
@@ -47,6 +50,8 @@ func TestAwsFromEc2Resource(t *testing.T) {
 	assert.Equal(t, &EC2Metadata{
 		InstanceID:       instanceID,
 		AvailabilityZone: "us-east-1c",
+		InstanceSize:     hostType,
+		AmiId:            imageId,
 	}, awsData.EC2Metadata)
 }
 
@@ -86,6 +91,7 @@ func TestAwsFromEcsResource(t *testing.T) {
 
 func TestAwsFromBeanstalkResource(t *testing.T) {
 	deployID := "232"
+	versionLabel := "4"
 	resource := pdata.NewResource()
 	resource.InitEmpty()
 	attrs := pdata.NewAttributeMap()
@@ -94,6 +100,7 @@ func TestAwsFromBeanstalkResource(t *testing.T) {
 	attrs.InsertString(semconventions.AttributeCloudZone, "us-east-1c")
 	attrs.InsertString(semconventions.AttributeServiceNamespace, "production")
 	attrs.InsertString(semconventions.AttributeServiceInstance, deployID)
+	attrs.InsertString(semconventions.AttributeServiceVersion, versionLabel)
 	attrs.CopyTo(resource.Attributes())
 
 	attributes := make(map[string]string)
@@ -107,7 +114,7 @@ func TestAwsFromBeanstalkResource(t *testing.T) {
 	assert.NotNil(t, awsData.BeanstalkMetadata)
 	assert.Equal(t, &BeanstalkMetadata{
 		Environment:  "production",
-		VersionLabel: "",
+		VersionLabel: versionLabel,
 		DeploymentID: 232,
 	}, awsData.BeanstalkMetadata)
 }

--- a/exporter/awsxrayexporter/translator/aws_test.go
+++ b/exporter/awsxrayexporter/translator/aws_test.go
@@ -25,7 +25,7 @@ import (
 func TestAwsFromEc2Resource(t *testing.T) {
 	instanceID := "i-00f7c0bcb26da2a99"
 	hostType := "m5.xlarge"
-	imageId := "ami-0123456789"
+	imageID := "ami-0123456789"
 	resource := pdata.NewResource()
 	resource.InitEmpty()
 	attrs := pdata.NewAttributeMap()
@@ -34,7 +34,7 @@ func TestAwsFromEc2Resource(t *testing.T) {
 	attrs.InsertString(semconventions.AttributeCloudZone, "us-east-1c")
 	attrs.InsertString(semconventions.AttributeHostID, instanceID)
 	attrs.InsertString(semconventions.AttributeHostType, hostType)
-	attrs.InsertString(semconventions.AttributeHostImageID, imageId)
+	attrs.InsertString(semconventions.AttributeHostImageID, imageID)
 	attrs.CopyTo(resource.Attributes())
 
 	attributes := make(map[string]string)
@@ -51,7 +51,7 @@ func TestAwsFromEc2Resource(t *testing.T) {
 		InstanceID:       instanceID,
 		AvailabilityZone: "us-east-1c",
 		InstanceSize:     hostType,
-		AmiId:            imageId,
+		AmiID:            imageID,
 	}, awsData.EC2Metadata)
 }
 

--- a/exporter/awsxrayexporter/translator/segment.go
+++ b/exporter/awsxrayexporter/translator/segment.go
@@ -241,15 +241,19 @@ func newSegmentID() pdata.SpanID {
 }
 
 func determineAwsOrigin(resource pdata.Resource) string {
-	origin := OriginEC2
+	// EB > ECS > EC2
 	if resource.IsNil() {
-		return origin
+		return OriginEC2
 	}
-	_, ok := resource.Attributes().Get(semconventions.AttributeContainerName)
-	if ok {
-		origin = OriginECS
+	_, eb := resource.Attributes().Get(semconventions.AttributeServiceInstance)
+	if eb {
+		return OriginEB
 	}
-	return origin
+	_, ecs := resource.Attributes().Get(semconventions.AttributeContainerName)
+	if ecs {
+		return OriginECS
+	}
+	return OriginEC2
 }
 
 // convertToAmazonTraceID converts a trace ID to the Amazon format.


### PR DESCRIPTION
**Description:** Add AWS EC2/ECS/Beanstack resources support

**Link to tracking Issue:** 

**Testing:** Verified in https://github.com/aws-samples/aws-xray-sdk-with-opentelemetry-sample/tree/both-otel-and-xray
Can get AWS service resources in Span.

**Documentation:** https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-java-configuration.html#xray-sdk-java-configuration-plugins