### PR TITLE
Add SAPM AccessTokenPassthrough

### DIFF
--- a/exporter/sapmexporter/README.md
+++ b/exporter/sapmexporter/README.md
@@ -15,6 +15,10 @@ idle HTTP connection the exporter can keep open.
 - `num_workers` (default = 8): NumWorkers is the number of workers that should be used to
 export traces. Exporter can make as many requests in parallel as the number of workers. Note
 that this will likely be removed in future in favour of processors handling parallel exporting.
+- `access_token_passthrough`: (default = `true`) Whether to use `"com.splunk.signalfx.access_token"`
+trace resource attribute, if any, as SFx access token.  In either case this attribute will be dropped
+during final translation.  Intended to be used in tandem with identical configuration option for
+[SAPM receiver](../../receiver/sapmreceiver/README.md) to preserve trace origin.
 
 Example:
 
@@ -22,6 +26,7 @@ Example:
 exporters:
   sapm:
     access_token: YOUR_ACCESS_TOKEN
+    access_token_passthrough: true
     endpoint: https://ingest.YOUR_SIGNALFX_REALM.signalfx.com/v2/trace
     max_connections: 100
     num_workers: 8

--- a/exporter/sapmexporter/README.md
+++ b/exporter/sapmexporter/README.md
@@ -16,7 +16,7 @@ idle HTTP connection the exporter can keep open.
 export traces. Exporter can make as many requests in parallel as the number of workers. Note
 that this will likely be removed in future in favour of processors handling parallel exporting.
 - `access_token_passthrough`: (default = `true`) Whether to use `"com.splunk.signalfx.access_token"`
-trace resource attribute, if any, as SFx access token.  In either case this attribute will be dropped
+trace resource attribute, if any, as SFx access token.  In either case this attribute will be deleted
 during final translation.  Intended to be used in tandem with identical configuration option for
 [SAPM receiver](../../receiver/sapmreceiver/README.md) to preserve trace origin.
 

--- a/exporter/sapmexporter/config.go
+++ b/exporter/sapmexporter/config.go
@@ -20,6 +20,8 @@ import (
 
 	sapmclient "github.com/signalfx/sapm-proto/client"
 	"go.opentelemetry.io/collector/config/configmodels"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 )
 
 const (
@@ -47,6 +49,8 @@ type Config struct {
 
 	// Disable GZip compression.
 	DisableCompression bool `mapstructure:"disable_compression"`
+
+	splunk.AccessTokenPassthroughConfig `mapstructure:",squash"`
 }
 
 func (c *Config) validate() error {

--- a/exporter/sapmexporter/config_test.go
+++ b/exporter/sapmexporter/config_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -50,5 +52,8 @@ func TestLoadConfig(t *testing.T) {
 			AccessToken:      "abcd1234",
 			NumWorkers:       3,
 			MaxConnections:   45,
+			AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
+				AccessTokenPassthrough: false,
+			},
 		})
 }

--- a/exporter/sapmexporter/config_test.go
+++ b/exporter/sapmexporter/config_test.go
@@ -57,3 +57,22 @@ func TestLoadConfig(t *testing.T) {
 			},
 		})
 }
+
+func TestInvalidConfig(t *testing.T) {
+	invalid := Config{
+		AccessToken:    "abcd1234",
+		NumWorkers:     3,
+		MaxConnections: 45,
+	}
+	noEndpointErr := invalid.validate()
+	require.Error(t, noEndpointErr)
+
+	invalid = Config{
+		Endpoint:       ":123:456",
+		AccessToken:    "abcd1234",
+		NumWorkers:     3,
+		MaxConnections: 45,
+	}
+	invalidURLErr := invalid.validate()
+	require.Error(t, invalidURLErr)
+}

--- a/exporter/sapmexporter/exporter.go
+++ b/exporter/sapmexporter/exporter.go
@@ -25,12 +25,15 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/translator/trace/jaeger"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 )
 
 // sapmExporter is a wrapper struct of SAPM exporter
 type sapmExporter struct {
 	client *sapmclient.Client
 	logger *zap.Logger
+	config *Config
 }
 
 func (se *sapmExporter) Shutdown(context.Context) error {
@@ -38,40 +41,99 @@ func (se *sapmExporter) Shutdown(context.Context) error {
 	return nil
 }
 
-func newSAPMTraceExporter(cfg *Config, params component.ExporterCreateParams) (component.TraceExporter, error) {
+func newSAPMExporter(cfg *Config, params component.ExporterCreateParams) (sapmExporter, error) {
 	err := cfg.validate()
 	if err != nil {
-		return nil, err
+		return sapmExporter{}, err
 	}
 
 	client, err := sapmclient.New(cfg.clientOptions()...)
 	if err != nil {
-		return nil, err
+		return sapmExporter{}, err
 	}
-	se := sapmExporter{
+	return sapmExporter{
 		client: client,
 		logger: params.Logger,
+		config: cfg,
+	}, err
+}
+
+func newSAPMTraceExporter(cfg *Config, params component.ExporterCreateParams) (component.TraceExporter, error) {
+	se, err := newSAPMExporter(cfg, params)
+	if err != nil {
+		return nil, err
 	}
+
 	return exporterhelper.NewTraceExporter(
 		cfg,
 		se.pushTraceData,
 		exporterhelper.WithShutdown(se.Shutdown))
 }
 
-// pushTraceData exports traces in SAPM proto and returns number of dropped spans and error if export failed
-func (se *sapmExporter) pushTraceData(ctx context.Context, td pdata.Traces) (droppedSpansCount int, err error) {
-	batches, err := jaeger.InternalTracesToJaegerProto(td)
-	if err != nil {
-		return td.SpanCount(), consumererror.Permanent(err)
-	}
-	err = se.client.Export(ctx, batches)
-	if err != nil {
-		if sendErr, ok := err.(*sapmclient.ErrSend); ok {
-			if sendErr.Permanent {
-				return 0, consumererror.Permanent(sendErr)
+// tracesByAccessToken takes a pdata.Traces struct and will iterate through its ResourceSpans' attributes,
+// regrouping by any SFx access token label value if Config.AccessTokenPassthrough is enabled.  It will drop any
+// set token label in any case to prevent serialization.
+// It returns a map of newly constructed pdata.Traces keyed by access token, defaulting to empty string.
+func (se *sapmExporter) tracesByAccessToken(td pdata.Traces) map[string]pdata.Traces {
+	tracesByToken := make(map[string]pdata.Traces, 1)
+	resourceSpans := td.ResourceSpans()
+	for i := 0; i < resourceSpans.Len(); i++ {
+		resourceSpan := resourceSpans.At(i)
+		if resourceSpan.IsNil() {
+			// Invalid trace so nothing to export
+			continue
+		}
+
+		accessToken := ""
+		if !resourceSpan.Resource().IsNil() {
+			attrs := resourceSpan.Resource().Attributes()
+			attributeValue, ok := attrs.Get(splunk.SFxAccessTokenLabel)
+			if ok {
+				attrs.Delete(splunk.SFxAccessTokenLabel)
+				if se.config.AccessTokenPassthrough {
+					accessToken = attributeValue.StringVal()
+				}
 			}
 		}
-		return td.SpanCount(), err
+
+		traceForToken, ok := tracesByToken[accessToken]
+		if !ok {
+			traceForToken = pdata.NewTraces()
+			tracesByToken[accessToken] = traceForToken
+		}
+
+		// Append ResourceSpan to trace for this access token
+		traceForTokenSize := traceForToken.ResourceSpans().Len()
+		traceForToken.ResourceSpans().Resize(traceForTokenSize + 1)
+		traceForToken.ResourceSpans().At(traceForTokenSize).InitEmpty()
+		resourceSpan.CopyTo(traceForToken.ResourceSpans().At(traceForTokenSize))
 	}
-	return 0, nil
+
+	return tracesByToken
+}
+
+// pushTraceData exports traces in SAPM proto by associated SFx access token and returns number of dropped spans
+// and the last experienced error if any translation or export failed
+func (se *sapmExporter) pushTraceData(ctx context.Context, td pdata.Traces) (droppedSpansCount int, err error) {
+	traces := se.tracesByAccessToken(td)
+	droppedSpansCount = 0
+	for accessToken, trace := range traces {
+		batches, translateErr := jaeger.InternalTracesToJaegerProto(trace)
+		if translateErr != nil {
+			droppedSpansCount += trace.SpanCount()
+			err = consumererror.Permanent(translateErr)
+			continue
+		}
+
+		exportErr := se.client.ExportWithAccessToken(ctx, batches, accessToken)
+		if exportErr != nil {
+			if sendErr, ok := exportErr.(*sapmclient.ErrSend); ok {
+				if sendErr.Permanent {
+					err = consumererror.Permanent(sendErr)
+				}
+			}
+			droppedSpansCount += trace.SpanCount()
+		}
+	}
+	return
 }

--- a/exporter/sapmexporter/exporter.go
+++ b/exporter/sapmexporter/exporter.go
@@ -71,7 +71,7 @@ func newSAPMTraceExporter(cfg *Config, params component.ExporterCreateParams) (c
 }
 
 // tracesByAccessToken takes a pdata.Traces struct and will iterate through its ResourceSpans' attributes,
-// regrouping by any SFx access token label value if Config.AccessTokenPassthrough is enabled.  It will drop any
+// regrouping by any SFx access token label value if Config.AccessTokenPassthrough is enabled.  It will delete any
 // set token label in any case to prevent serialization.
 // It returns a map of newly constructed pdata.Traces keyed by access token, defaulting to empty string.
 func (se *sapmExporter) tracesByAccessToken(td pdata.Traces) map[string]pdata.Traces {

--- a/exporter/sapmexporter/exporter_test.go
+++ b/exporter/sapmexporter/exporter_test.go
@@ -1,0 +1,158 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sapmexporter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
+)
+
+func TestCreateTraceExporter(t *testing.T) {
+	config := &Config{
+		ExporterSettings: configmodels.ExporterSettings{TypeVal: configmodels.Type(typeStr), NameVal: "sapm/customname"},
+		Endpoint:         "test-endpoint",
+		AccessToken:      "abcd1234",
+		NumWorkers:       3,
+		MaxConnections:   45,
+		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
+			AccessTokenPassthrough: true,
+		},
+	}
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+
+	te, err := newSAPMTraceExporter(config, params)
+	assert.Nil(t, err)
+	assert.NotNil(t, te, "failed to create trace exporter")
+}
+
+func buildTestTraces(setTokenLabel, accessTokenPassthrough bool) (traces pdata.Traces, expected map[string]pdata.Traces) {
+	traces = pdata.NewTraces()
+	expected = map[string]pdata.Traces{}
+	rss := traces.ResourceSpans()
+	rss.Resize(50)
+
+	for i := 0; i < 50; i++ {
+		span := rss.At(i)
+		span.InitEmpty()
+		resource := span.Resource()
+		resource.InitEmpty()
+		token := ""
+		if setTokenLabel && i%2 == 1 {
+			tokenLabel := fmt.Sprintf("MyToken%d", i/25)
+			resource.Attributes().InsertString("com.splunk.signalfx.access_token", tokenLabel)
+			if accessTokenPassthrough {
+				token = tokenLabel
+			}
+		}
+
+		resource.Attributes().InsertString("MyLabel", "MyLabelValue")
+		span.InstrumentationLibrarySpans().Resize(1)
+		span.InstrumentationLibrarySpans().At(0).Spans().Resize(1)
+		name := fmt.Sprintf("Span%d", i)
+		span.InstrumentationLibrarySpans().At(0).Spans().At(0).SetName(name)
+
+		trace, contains := expected[token]
+		if !contains {
+			trace = pdata.NewTraces()
+			expected[token] = trace
+		}
+		newSize := trace.ResourceSpans().Len() + 1
+		trace.ResourceSpans().Resize(newSize)
+		span.CopyTo(trace.ResourceSpans().At(newSize - 1))
+		trace.ResourceSpans().At(newSize - 1).Resource().Attributes().Delete("com.splunk.signalfx.access_token")
+	}
+
+	return traces, expected
+}
+
+func assertTracesEqual(t *testing.T, expected, actual map[string]pdata.Traces) {
+	for token, trace := range expected {
+		aTrace := actual[token]
+		eResourceSpans := trace.ResourceSpans()
+		aResourceSpans := aTrace.ResourceSpans()
+		assert.Equal(t, eResourceSpans.Len(), aResourceSpans.Len())
+		for i := 0; i < eResourceSpans.Len(); i++ {
+			eAttrs := eResourceSpans.At(i).Resource().Attributes()
+			aAttrs := aResourceSpans.At(i).Resource().Attributes()
+			assert.Equal(t, eAttrs.Len(), aAttrs.Len())
+			aAttrs.ForEach(func(k string, v pdata.AttributeValue) {
+				eVal, _ := eAttrs.Get(k)
+				assert.EqualValues(t, eVal, v)
+			})
+
+			eSpans := eResourceSpans.At(i).InstrumentationLibrarySpans()
+			aSpans := aResourceSpans.At(i).InstrumentationLibrarySpans()
+			assert.Equal(t, eSpans.Len(), aSpans.Len())
+		}
+	}
+}
+
+func TestAccessTokenPassthrough(t *testing.T) {
+	tests := []struct {
+		name                   string
+		accessTokenPassthrough bool
+		useToken               bool
+	}{
+		{
+			name:                   "no token without passthrough",
+			accessTokenPassthrough: false,
+			useToken:               false,
+		},
+		{
+			name:                   "no token with passthrough",
+			accessTokenPassthrough: true,
+			useToken:               false,
+		},
+		{
+			name:                   "token without passthrough",
+			accessTokenPassthrough: false,
+			useToken:               true,
+		},
+		{
+			name:                   "token with passthrough",
+			accessTokenPassthrough: true,
+			useToken:               true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				Endpoint: "localhost",
+				AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
+					AccessTokenPassthrough: tt.accessTokenPassthrough,
+				},
+			}
+			fmt.Printf("tt.useToken: %v", tt.useToken)
+			params := component.ExporterCreateParams{Logger: zap.NewNop()}
+
+			se, err := newSAPMExporter(config, params)
+			assert.Nil(t, err)
+			assert.NotNil(t, se, "failed to create trace exporter")
+
+			traces, expected := buildTestTraces(tt.useToken, tt.accessTokenPassthrough)
+
+			actual := se.tracesByAccessToken(traces)
+			assertTracesEqual(t, expected, actual)
+		})
+	}
+}

--- a/exporter/sapmexporter/factory.go
+++ b/exporter/sapmexporter/factory.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 )
 
 const (
@@ -44,6 +46,9 @@ func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
 			NameVal: typeStr,
 		},
 		NumWorkers: defaultNumWorkers,
+		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
+			AccessTokenPassthrough: true,
+		},
 	}
 }
 

--- a/exporter/sapmexporter/factory_test.go
+++ b/exporter/sapmexporter/factory_test.go
@@ -33,6 +33,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 func TestCreateExporter(t *testing.T) {
 	factory := Factory{}
+	assert.Equal(t, "sapm", string(factory.Type()))
+
 	cfg := factory.CreateDefaultConfig()
 	eCfg := cfg.(*Config)
 	eCfg.Endpoint = "http://local"

--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -4,10 +4,13 @@ go 1.14
 
 require (
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
-	github.com/signalfx/sapm-proto v0.5.1
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.4.0
+	github.com/signalfx/sapm-proto v0.5.3
 	github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac // indirect
 	github.com/stretchr/testify v1.5.1
 	go.opentelemetry.io/collector v0.4.0
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/exporter/sapmexporter/go.sum
+++ b/exporter/sapmexporter/go.sum
@@ -1000,6 +1000,8 @@ github.com/shurcooL/vfsgen v0.0.0-20180825020608-02ddb050ef6b/go.mod h1:TrYk7fJV
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/signalfx/sapm-proto v0.5.1 h1:Au3g2x4R1sW3i43RjKfd51VJsxXFkoQcwvErsqkGEw4=
 github.com/signalfx/sapm-proto v0.5.1/go.mod h1:irslr5i7XlHJTm1CpRy+llvf4COzF5K6Je05RkhetTE=
+github.com/signalfx/sapm-proto v0.5.3 h1:1+YNMTQBCS3XXuwfXARAyk2PbsbZdMwRVb6Y7WgfGio=
+github.com/signalfx/sapm-proto v0.5.3/go.mod h1:irslr5i7XlHJTm1CpRy+llvf4COzF5K6Je05RkhetTE=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.1.0/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=

--- a/exporter/sapmexporter/testdata/config.yaml
+++ b/exporter/sapmexporter/testdata/config.yaml
@@ -22,6 +22,8 @@ exporters:
     # MaxConnections is used to set a limit to the maximum idle HTTP connection the exporter can keep open.
     max_connections: 45
 
+    access_token_passthrough: false
+
 service:
   pipelines:
     traces:

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/golang/protobuf v1.3.5
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.0.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.4.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.0.0
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.0-20190530013331-054be550cb49
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1200,8 +1200,8 @@ github.com/signalfx/omnition-kinesis-producer v0.4.6 h1:rs18AQ+zz7+B0akJfzJtwdrz
 github.com/signalfx/omnition-kinesis-producer v0.4.6/go.mod h1:Qo5UjM14fq/eVKavLkovKbXWbNTTQwiyuADYnXoGx1I=
 github.com/signalfx/opencensus-go-exporter-kinesis v0.4.2 h1:euMCOJ9wQhaWQ/xehHWPsWeEHGibGn1vihg/15okcts=
 github.com/signalfx/opencensus-go-exporter-kinesis v0.4.2/go.mod h1:4YEoC8CxFYfcCj9c8QAlWgbNBeUMSyfUwe4wckBCAXQ=
-github.com/signalfx/sapm-proto v0.5.1 h1:Au3g2x4R1sW3i43RjKfd51VJsxXFkoQcwvErsqkGEw4=
-github.com/signalfx/sapm-proto v0.5.1/go.mod h1:irslr5i7XlHJTm1CpRy+llvf4COzF5K6Je05RkhetTE=
+github.com/signalfx/sapm-proto v0.5.3 h1:1+YNMTQBCS3XXuwfXARAyk2PbsbZdMwRVb6Y7WgfGio=
+github.com/signalfx/sapm-proto v0.5.3/go.mod h1:irslr5i7XlHJTm1CpRy+llvf4COzF5K6Je05RkhetTE=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.1.0/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=

--- a/receiver/sapmreceiver/README.md
+++ b/receiver/sapmreceiver/README.md
@@ -12,12 +12,14 @@ Example:
 receivers:
   sapm:
     endpoint: localhost:7276
+    access_token_passthrough: true
     tls:
       cert_file: /test.crt
       key_file: /test.key
 ```
 
 * `endpoint`: Address and port that the SAPM receiver should bind to. Note that this must be 0.0.0.0:<port> instead of localhost if you want to receive spans from sources exporting to IPs other than localhost on the same host. For example, when the collector is deployed as a k8s deployment and exposed using a service.
+* `access_token_passthrough`: (default = `false`) Whether to preserve incoming access token (`X-Sf-Token` header value) as `"com.splunk.signalfx.access_token"` trace resource attribute.  Can be used in tandem with identical configuration option for [SAPM exporter](../../exporter/sapmexporter/README.md) to preserve trace origin.
 * `tls`: This is an optional object used to specify if TLS should be used for incoming connections.
     * `cert_file`: Specifies the certificate file to use for TLS connection.  Note: Both `key_file` and `cert_file` are required for TLS connection. 
     * `key_file`: Specifies the key file to use for TLS connection. Note: Both `key_file` and `cert_file` are required for TLS connection. 

--- a/receiver/sapmreceiver/config.go
+++ b/receiver/sapmreceiver/config.go
@@ -17,6 +17,8 @@ package sapmreceiver
 import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtls"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 )
 
 // Config defines configuration for SAPM receiver.
@@ -26,4 +28,6 @@ type Config struct {
 	// Configures the receiver to use TLS.
 	// The default value is nil, which will cause the receiver to not use TLS.
 	TLSCredentials *configtls.TLSSetting `mapstructure:"tls, omitempty"`
+
+	splunk.AccessTokenPassthroughConfig `mapstructure:",squash"`
 }

--- a/receiver/sapmreceiver/config_test.go
+++ b/receiver/sapmreceiver/config_test.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtls"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -38,7 +40,7 @@ func TestLoadConfig(t *testing.T) {
 
 	// The receiver `sapm/disabled` doesn't count because disabled receivers
 	// are excluded from the final list.
-	assert.Equal(t, len(cfg.Receivers), 3)
+	assert.Equal(t, len(cfg.Receivers), 4)
 
 	r0 := cfg.Receivers["sapm"]
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
@@ -64,6 +66,19 @@ func TestLoadConfig(t *testing.T) {
 			TLSCredentials: &configtls.TLSSetting{
 				CertFile: "/test.crt",
 				KeyFile:  "/test.key",
+			},
+		})
+
+	r3 := cfg.Receivers["sapm/passthrough"].(*Config)
+	assert.Equal(t, r3,
+		&Config{
+			ReceiverSettings: configmodels.ReceiverSettings{
+				TypeVal:  typeStr,
+				NameVal:  "sapm/passthrough",
+				Endpoint: ":7276",
+			},
+			AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
+				AccessTokenPassthrough: true,
 			},
 		})
 }

--- a/receiver/sapmreceiver/go.mod
+++ b/receiver/sapmreceiver/go.mod
@@ -9,8 +9,9 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/jaegertracing/jaeger v1.17.0
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.4.0
 	github.com/open-telemetry/opentelemetry-proto v0.3.0
-	github.com/signalfx/sapm-proto v0.5.1
+	github.com/signalfx/sapm-proto v0.5.3
 	github.com/smartystreets/assertions v0.0.0-20190215210624-980c5ac6f3ac // indirect
 	github.com/stretchr/testify v1.5.1
 	go.opencensus.io v0.22.3
@@ -20,3 +21,5 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/sapmreceiver/go.sum
+++ b/receiver/sapmreceiver/go.sum
@@ -1005,6 +1005,8 @@ github.com/shurcooL/vfsgen v0.0.0-20180825020608-02ddb050ef6b/go.mod h1:TrYk7fJV
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/signalfx/sapm-proto v0.5.1 h1:Au3g2x4R1sW3i43RjKfd51VJsxXFkoQcwvErsqkGEw4=
 github.com/signalfx/sapm-proto v0.5.1/go.mod h1:irslr5i7XlHJTm1CpRy+llvf4COzF5K6Je05RkhetTE=
+github.com/signalfx/sapm-proto v0.5.3 h1:1+YNMTQBCS3XXuwfXARAyk2PbsbZdMwRVb6Y7WgfGio=
+github.com/signalfx/sapm-proto v0.5.3/go.mod h1:irslr5i7XlHJTm1CpRy+llvf4COzF5K6Je05RkhetTE=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.1.0/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=

--- a/receiver/sapmreceiver/testdata/config.yaml
+++ b/receiver/sapmreceiver/testdata/config.yaml
@@ -15,6 +15,9 @@ receivers:
       cert_file: /test.crt
       key_file: /test.key
 
+  sapm/passthrough:
+    access_token_passthrough: true
+
 
 processors:
   exampleprocessor:

--- a/receiver/sapmreceiver/trace_receiver_test.go
+++ b/receiver/sapmreceiver/trace_receiver_test.go
@@ -45,6 +45,8 @@ import (
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 )
 
 func expectedTraceData(t1, t2, t3 time.Time) pdata.Traces {
@@ -140,7 +142,7 @@ func grpcFixture(t1 time.Time, d1, d2 time.Duration) *model.Batch {
 }
 
 // sendSapm acts as a client for sending sapm to the receiver.  This could be replaced with a sapm exporter in the future.
-func sendSapm(endpoint string, sapm *splunksapm.PostSpansRequest, zipped bool, tlsEnabled bool) (*http.Response, error) {
+func sendSapm(endpoint string, sapm *splunksapm.PostSpansRequest, zipped bool, tlsEnabled bool, token string) (*http.Response, error) {
 	// marshal the sapm
 	reqBytes, err := proto.Marshal(sapm)
 	if err != nil {
@@ -182,6 +184,10 @@ func sendSapm(endpoint string, sapm *splunksapm.PostSpansRequest, zipped bool, t
 		req.Header.Set(sapmprotocol.AcceptEncodingHeaderName, sapmprotocol.GZipEncodingHeaderValue)
 	}
 
+	if token != "" {
+		req.Header.Set("x-sf-token", token)
+	}
+
 	// send the request
 	client := &http.Client{}
 
@@ -205,6 +211,25 @@ func sendSapm(endpoint string, sapm *splunksapm.PostSpansRequest, zipped bool, t
 	}
 
 	return resp, nil
+}
+
+func setupReceiver(t *testing.T, config *Config, sink *exportertest.SinkTraceExporter) component.TraceReceiver {
+	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
+	sr, err := New(context.Background(), params, config, sink)
+	assert.NoError(t, err, "should not have failed to create the SAPM receiver")
+	t.Log("Starting")
+
+	// NewNopHost swallows errors so using NewErrorWaitingHost to catch any potential errors starting the
+	// receiver.
+	mh := componenttest.NewErrorWaitingHost()
+	require.NoError(t, sr.Start(context.Background(), mh), "should not have failed to start trace reception")
+
+	// If there are errors reported through host.ReportFatalError() this will retrieve it.
+	receivedError, receivedErr := mh.WaitForFatalError(500 * time.Millisecond)
+	require.NoError(t, receivedErr, "should not have failed to start trace reception")
+	require.False(t, receivedError)
+	t.Log("Trace Reception Started")
+	return sr
 }
 
 func TestReception(t *testing.T) {
@@ -271,27 +296,12 @@ func TestReception(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			sink := new(exportertest.SinkTraceExporter)
-
-			params := component.ReceiverCreateParams{Logger: zap.NewNop()}
-			sr, err := New(context.Background(), params, tt.args.config, sink)
-			assert.NoError(t, err, "should not have failed to create the SAPM receiver")
-			t.Log("Starting")
+			sr := setupReceiver(t, tt.args.config, sink)
 			defer sr.Shutdown(context.Background())
-
-			// NewNopHost swallows errors so using NewErrorWaitingHost to catch any potential errors starting the
-			// receiver.
-			mh := componenttest.NewErrorWaitingHost()
-			require.NoError(t, sr.Start(context.Background(), mh), "should not have failed to start trace reception")
-
-			// If there are errors reported through host.ReportFatalError() this will retrieve it.
-			receivedError, receivedErr := mh.WaitForFatalError(500 * time.Millisecond)
-			require.NoError(t, receivedErr, "should not have failed to start trace reception")
-			require.False(t, receivedError)
-			t.Log("Trace Reception Started")
 
 			t.Log("Sending Sapm Request")
 			var resp *http.Response
-			resp, err = sendSapm(tt.args.config.Endpoint, tt.args.sapm, tt.args.zipped, tt.args.useTLS)
+			resp, err := sendSapm(tt.args.config.Endpoint, tt.args.sapm, tt.args.zipped, tt.args.useTLS, "")
 			require.NoErrorf(t, err, "should not have failed when sending sapm %v", err)
 			assert.Equal(t, 200, resp.StatusCode)
 			t.Log("SAPM Request Received")
@@ -303,6 +313,73 @@ func TestReception(t *testing.T) {
 			// compare what we got to what we wanted
 			t.Log("Comparing expected data to trace data")
 			assert.EqualValues(t, tt.want, got[0])
+		})
+	}
+}
+
+func TestAccessTokenPassthrough(t *testing.T) {
+	tests := []struct {
+		name                   string
+		accessTokenPassthrough bool
+		token                  string
+	}{
+		{
+			name:                   "no passthrough and no token",
+			accessTokenPassthrough: false,
+			token:                  "",
+		},
+		{
+			name:                   "no passthrough and token",
+			accessTokenPassthrough: false,
+			token:                  "MyAccessToken",
+		},
+		{
+			name:                   "passthrough and no token",
+			accessTokenPassthrough: true,
+			token:                  "",
+		},
+		{
+			name:                   "passthrough and token",
+			accessTokenPassthrough: true,
+			token:                  "MyAccessToken",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				ReceiverSettings: configmodels.ReceiverSettings{Endpoint: defaultEndpoint},
+				AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
+					AccessTokenPassthrough: tt.accessTokenPassthrough,
+				},
+			}
+
+			sapm := &splunksapm.PostSpansRequest{
+				Batches: []*model.Batch{grpcFixture(time.Now().UTC(), time.Minute*10, time.Second*2)},
+			}
+
+			sink := new(exportertest.SinkTraceExporter)
+			sr := setupReceiver(t, config, sink)
+			defer sr.Shutdown(context.Background())
+
+			var resp *http.Response
+			resp, err := sendSapm(config.Endpoint, sapm, true, false, tt.token)
+			require.NoErrorf(t, err, "should not have failed when sending sapm %v", err)
+			assert.Equal(t, 200, resp.StatusCode)
+
+			got := sink.AllTraces()
+			assert.Equal(t, 1, len(got))
+
+			received := got[0].ResourceSpans()
+			for i := 0; i < received.Len(); i++ {
+				rspan := received.At(i)
+				attrs := rspan.Resource().Attributes()
+				amap, contains := attrs.Get("com.splunk.signalfx.access_token")
+				if tt.accessTokenPassthrough && tt.token != "" {
+					assert.Equal(t, tt.token, amap.StringVal())
+				} else {
+					assert.False(t, contains)
+				}
+			}
 		})
 	}
 }

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.3.5
 	github.com/gorilla/mux v1.7.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.0.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.0.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.4.0
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.0-20190530013331-054be550cb49
 	github.com/stretchr/testify v1.5.1
 	go.opencensus.io v0.22.3

--- a/testbed/datareceivers/sapm.go
+++ b/testbed/datareceivers/sapm.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/testbed/testbed"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver"
 )
 
@@ -44,6 +45,7 @@ func (sr *SapmDataReceiver) Start(tc *testbed.MockTraceConsumer, mc *testbed.Moc
 		ReceiverSettings: configmodels.ReceiverSettings{
 			Endpoint: fmt.Sprintf("localhost:%d", sr.Port),
 		},
+		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{AccessTokenPassthrough: true},
 	}
 	var err error
 	params := component.ReceiverCreateParams{Logger: zap.L()}
@@ -70,7 +72,8 @@ func (sr *SapmDataReceiver) GenConfigYAMLStr() string {
 	return fmt.Sprintf(`
   sapm:
     endpoint: "http://localhost:%d/v2/trace"
-    disable_compression: true`, sr.Port)
+    disable_compression: true
+    access_token_passthrough: true`, sr.Port)
 }
 
 // ProtocolName returns protocol name as it is specified in Collector config.

--- a/testbed/datasenders/sapm.go
+++ b/testbed/datasenders/sapm.go
@@ -46,6 +46,7 @@ func (je *SapmDataSender) Start() error {
 	cfg := &sapmexporter.Config{
 		Endpoint:           fmt.Sprintf("http://localhost:%d/v2/trace", je.port),
 		DisableCompression: true,
+		AccessToken:        "MyToken",
 	}
 
 	var err error

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.0.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.4.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver v0.0.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver v0.0.0
+	github.com/signalfx/sapm-proto v0.5.3
 	go.opentelemetry.io/collector v0.4.1-0.20200622191610-a8db6271f90a
 	go.uber.org/zap v1.14.1
 )

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -1118,6 +1118,8 @@ github.com/signalfx/com_signalfx_metrics_protobuf v0.0.0-20190530013331-054be550
 github.com/signalfx/com_signalfx_metrics_protobuf v0.0.0-20190530013331-054be550cb49/go.mod h1:muYA2clvwCdj7nzAJ5vJIXYpJsUumhAl4Uu1wUNpWzA=
 github.com/signalfx/sapm-proto v0.5.1 h1:Au3g2x4R1sW3i43RjKfd51VJsxXFkoQcwvErsqkGEw4=
 github.com/signalfx/sapm-proto v0.5.1/go.mod h1:irslr5i7XlHJTm1CpRy+llvf4COzF5K6Je05RkhetTE=
+github.com/signalfx/sapm-proto v0.5.3 h1:1+YNMTQBCS3XXuwfXARAyk2PbsbZdMwRVb6Y7WgfGio=
+github.com/signalfx/sapm-proto v0.5.3/go.mod h1:irslr5i7XlHJTm1CpRy+llvf4COzF5K6Je05RkhetTE=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.1.0/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=


### PR DESCRIPTION
**Description:** Adding the `access_token_passthrough` config option and functionality to SAPM receiver and exporter similar to that of the SignalFx metric receiver and exporter from f361e4d8bd64cd4f4bd888899c7fcc739523e82f.  These changes add a `com.splunk.signalfx.access_token` attribute with a value taken from `X-Sf-Token` headers, if provided, that will be used for subsequent trace submissions in the SAPM exporter by its client.

**Testing:** Added and modified unit tests and e2e run configuration.

**Documentation:** Updated relevant readmes.