### PR TITLE
Fix kubeletstats logging and self reported metrics

### DIFF
--- a/receiver/kubeletstatsreceiver/receiver.go
+++ b/receiver/kubeletstatsreceiver/receiver.go
@@ -38,7 +38,7 @@ type receiver struct {
 
 // Creates and starts the kubelet stats runnable.
 func (r *receiver) Start(ctx context.Context, host component.Host) error {
-	runnable := newRunnable(ctx, r.consumer, r.rest, r.logger)
+	runnable := newRunnable(ctx, r.cfg.Name(), r.consumer, r.rest, r.logger)
 
 	cfg := r.cfg.(*Config)
 	r.runner = interval.NewRunner(cfg.CollectionInterval, runnable)

--- a/receiver/kubeletstatsreceiver/runnable.go
+++ b/receiver/kubeletstatsreceiver/runnable.go
@@ -62,12 +62,16 @@ func (r *runnable) Run() error {
 	ctx := obsreport.StartMetricsReceiveOp(r.ctx, dataformat, transport)
 	summary, err := r.provider.StatsSummary()
 	if err != nil {
+		r.logger.Error("StatsSummary failed", zap.Error(err))
 		obsreport.EndMetricsReceiveOp(ctx, dataformat, 0, 0, err)
 		return nil
 	}
 	mds := kubelet.MetricsData(summary, typeStr)
 	for _, md := range mds {
 		err = r.consumer.ConsumeMetricsData(r.ctx, *md)
+		if err != nil {
+			r.logger.Error("ConsumeMetricsData failed", zap.Error(err))
+		}
 		numTimeSeries, numPoints := obsreport.CountMetricPoints(*md)
 		obsreport.EndMetricsReceiveOp(ctx, dataformat, numTimeSeries, numPoints, err)
 	}

--- a/receiver/kubeletstatsreceiver/runnable_test.go
+++ b/receiver/kubeletstatsreceiver/runnable_test.go
@@ -34,6 +34,7 @@ func TestRunnable(t *testing.T) {
 	consumer := &fakeConsumer{}
 	r := newRunnable(
 		context.Background(),
+		"",
 		consumer,
 		&fakeRestClient{},
 		zap.NewNop(),
@@ -59,6 +60,7 @@ func TestClientErrors(t *testing.T) {
 			core, observedLogs := observer.New(zap.ErrorLevel)
 			r := newRunnable(
 				context.Background(),
+				"",
 				&fakeConsumer{},
 				&fakeRestClient{fail: test.fail},
 				zap.New(core),
@@ -86,6 +88,7 @@ func TestConsumerErrors(t *testing.T) {
 			core, observedLogs := observer.New(zap.ErrorLevel)
 			r := newRunnable(
 				context.Background(),
+				"",
 				&fakeConsumer{fail: test.fail},
 				&fakeRestClient{},
 				zap.New(core),

--- a/receiver/kubeletstatsreceiver/runnable_test.go
+++ b/receiver/kubeletstatsreceiver/runnable_test.go
@@ -16,15 +16,19 @@ package kubeletstatsreceiver
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/kubelet"
 )
+
+const dataLen = 19
 
 func TestRunnable(t *testing.T) {
 	consumer := &fakeConsumer{}
@@ -38,29 +42,95 @@ func TestRunnable(t *testing.T) {
 	require.NoError(t, err)
 	err = r.Run()
 	require.NoError(t, err)
-	require.Equal(t, 19, len(consumer.mds))
+	require.Equal(t, dataLen, len(consumer.mds))
+}
+
+func TestClientErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		fail    bool
+		numLogs int
+	}{
+		{"no error", false, 0},
+		{"rest error", true, 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			core, observedLogs := observer.New(zap.ErrorLevel)
+			r := newRunnable(
+				context.Background(),
+				&fakeConsumer{},
+				&fakeRestClient{fail: test.fail},
+				zap.New(core),
+			)
+			err := r.Setup()
+			require.NoError(t, err)
+			err = r.Run()
+			require.NoError(t, err)
+			require.Equal(t, test.numLogs, observedLogs.Len())
+		})
+	}
+}
+
+func TestConsumerErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		fail    bool
+		numLogs int
+	}{
+		{"no error", false, 0},
+		{"consume error", true, dataLen},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			core, observedLogs := observer.New(zap.ErrorLevel)
+			r := newRunnable(
+				context.Background(),
+				&fakeConsumer{fail: test.fail},
+				&fakeRestClient{},
+				zap.New(core),
+			)
+			err := r.Setup()
+			require.NoError(t, err)
+			err = r.Run()
+			require.NoError(t, err)
+			require.Equal(t, test.numLogs, observedLogs.Len())
+		})
+	}
 }
 
 type fakeConsumer struct {
-	mds []consumerdata.MetricsData
+	fail bool
+	mds  []consumerdata.MetricsData
 }
 
 func (c *fakeConsumer) ConsumeMetricsData(
 	ctx context.Context,
 	md consumerdata.MetricsData,
 ) error {
+	if c.fail {
+		return errors.New("")
+	}
 	c.mds = append(c.mds, md)
 	return nil
 }
 
 var _ kubelet.RestClient = (*fakeRestClient)(nil)
 
-type fakeRestClient struct{}
+type fakeRestClient struct {
+	fail bool
+}
 
 func (f *fakeRestClient) StatsSummary() ([]byte, error) {
+	if f.fail {
+		return nil, errors.New("")
+	}
 	return ioutil.ReadFile("testdata/stats-summary.json")
 }
 
 func (f *fakeRestClient) Pods() ([]byte, error) {
+	if f.fail {
+		return nil, errors.New("")
+	}
 	return ioutil.ReadFile("testdata/pods.json")
 }


### PR DESCRIPTION
Kubeletstats receiver was missing log statements on important errors and self-reported metrics was not working in lab.

Tested self-reported metrics by looking at prometheus endpoint at 8888.