### PR TITLE
Add metrics support to k8s processor

### DIFF
--- a/processor/k8sprocessor/config.go
+++ b/processor/k8sprocessor/config.go
@@ -51,7 +51,7 @@ type ExtractConfig struct {
 	//   namespace, podName, podUID, deployment, cluster, node and startTime
 	//
 	// Specifying anything other than these values will result in an error.
-	// By default all of the fields are extracted and added to spans.
+	// By default all of the fields are extracted and added to spans and metrics.
 	Metadata []string `mapstructure:"metadata"`
 
 	// Annotations allows extracting data from pod annotations and record it
@@ -99,7 +99,7 @@ type ExtractConfig struct {
 //	         key: kubernetes.io/change-cause
 //           regex: JENKINS=(?P<value>[\w]+)
 //
-//   this will add the `git.sha` and `ci.build` tags to the spans.
+//   this will add the `git.sha` and `ci.build` tags to the spans or metrics.
 type FieldExtractConfig struct {
 	TagName string `mapstructure:"tag_name"`
 	Key     string `mapstructure:"key"`

--- a/processor/k8sprocessor/doc.go
+++ b/processor/k8sprocessor/doc.go
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package k8sprocessor allow automatic tagging of spans with k8s metadata.
+// Package k8sprocessor allow automatic tagging of spans and metrics with k8s metadata.
 //
 // The processor automatically discovers k8s resources (pods), extracts metadata from them and adds the
-// extracted metadata to the relevant spans. The processor use the kubernetes API to discover all pods
+// extracted metadata to the relevant spans and metrics. The processor use the kubernetes API to discover all pods
 // running in a cluster, keeps a record of their IP addresses and interesting metadata. Upon receiving spans,
 // the processor tries to identify the source IP address of the service that sent the spans and matches
-// it with the in memory data. If a match is found, the cached metadata is added to the spans as attributes.
+// it with the in memory data. To find a k8s pod producing metrics, the processor looks at "host.hostname"
+// resource attribute which is set by prometheus receiver and some metrics instrumentation libraries.
+// If a match is found, the cached metadata is added to the spans and metrics as resource attributes.
 //
 // RBAC
 //
@@ -34,8 +36,8 @@
 //
 // As an agent
 //
-// When running as an agent, the processor detects IP addresses of pods sending spans to the agent and uses this
-// information to extract metadata from pods and add to spans. When running as an agent, it is important to apply
+// When running as an agent, the processor detects IP addresses of pods sending spans or metrics to the agent and uses
+// this information to extract metadata from pods. When running as an agent, it is important to apply
 // a discovery filter so that the processor only discovers pods from the same host that it is running on. Not using
 // such a filter can result in unnecessary resource usage especially on very large clusters. Once the filter is applied,
 // each processor will only query the k8s API for pods running on it's own node.
@@ -93,6 +95,9 @@
 // No special configuration changes are needed to be made on the collector. It'll automatically detect
 // the IP address of spans sent by the agents as well as directly by other services/pods.
 //
+// This approach is also relevant for metrics data since it's not guaranteed that all the metric formats
+// that used to send data from agent to collector preserve "host.hostname" attribute. We need to rely on an additional
+// attribute keeping a k8s pod IP value in the passthrough mode.
 //
 // Caveats
 //

--- a/processor/k8sprocessor/factory.go
+++ b/processor/k8sprocessor/factory.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer"
 
@@ -57,9 +56,25 @@ func (f *Factory) CreateDefaultConfig() configmodels.Processor {
 func (f *Factory) CreateTraceProcessor(
 	ctx context.Context,
 	params component.ProcessorCreateParams,
-	nextConsumer consumer.TraceConsumer,
+	nextTraceConsumer consumer.TraceConsumer,
 	cfg configmodels.Processor,
 ) (component.TraceProcessor, error) {
+	opts := createProcessorOpts(cfg)
+	return NewTraceProcessor(params.Logger, nextTraceConsumer, f.KubeClient, opts...)
+}
+
+// CreateMetricsProcessor creates a metrics processor based on this config.
+func (f *Factory) CreateMetricsProcessor(
+	ctx context.Context,
+	params component.ProcessorCreateParams,
+	nextMetricsConsumer consumer.MetricsConsumer,
+	cfg configmodels.Processor,
+) (component.MetricsProcessor, error) {
+	opts := createProcessorOpts(cfg)
+	return NewMetricsProcessor(params.Logger, nextMetricsConsumer, f.KubeClient, opts...)
+}
+
+func createProcessorOpts(cfg configmodels.Processor) []Option {
 	oCfg := cfg.(*Config)
 	opts := []Option{}
 	if oCfg.Passthrough {
@@ -77,15 +92,6 @@ func (f *Factory) CreateTraceProcessor(
 	opts = append(opts, WithFilterLabels(oCfg.Filter.Labels...))
 	opts = append(opts, WithFilterFields(oCfg.Filter.Fields...))
 	opts = append(opts, WithAPIConfig(oCfg.APIConfig))
-	return NewTraceProcessor(params.Logger, nextConsumer, f.KubeClient, opts...)
-}
 
-// CreateMetricsProcessor creates a metrics processor based on this config.
-func (f *Factory) CreateMetricsProcessor(
-	ctx context.Context,
-	params component.ProcessorCreateParams,
-	nextConsumer consumer.MetricsConsumer,
-	cfg configmodels.Processor,
-) (component.MetricsProcessor, error) {
-	return nil, configerror.ErrDataTypeIsNotSupported
+	return opts
 }

--- a/processor/k8sprocessor/factory_test.go
+++ b/processor/k8sprocessor/factory_test.go
@@ -46,13 +46,18 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NotNil(t, tp)
 	assert.NoError(t, err, "cannot create trace processor")
 
+	mp, err := factory.CreateMetricsProcessor(context.Background(), params, nil, cfg)
+	assert.NotNil(t, mp)
+	assert.NoError(t, err, "cannot create metrics processor")
+
 	oCfg := cfg.(*Config)
 	oCfg.Passthrough = true
+
 	tp, err = factory.CreateTraceProcessor(context.Background(), params, nil, cfg)
 	assert.NotNil(t, tp)
 	assert.NoError(t, err, "cannot create trace processor")
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), params, nil, cfg)
-	assert.Nil(t, mp)
-	assert.Error(t, err, "should not be able to create metric processor")
+	mp, err = factory.CreateMetricsProcessor(context.Background(), params, nil, cfg)
+	assert.NotNil(t, mp)
+	assert.NoError(t, err, "cannot create metrics processor")
 }

--- a/processor/k8sprocessor/go.mod
+++ b/processor/k8sprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8spr
 go 1.14
 
 require (
+	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.4.0
 	github.com/stretchr/testify v1.5.1
 	go.opencensus.io v0.22.3

--- a/processor/k8sprocessor/processor.go
+++ b/processor/k8sprocessor/processor.go
@@ -16,11 +16,14 @@ package k8sprocessor
 
 import (
 	"context"
+	"net"
 
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/consumer/pdatautil"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/k8sconfig"
@@ -33,43 +36,72 @@ const (
 )
 
 type kubernetesprocessor struct {
-	logger          *zap.Logger
-	apiConfig       k8sconfig.APIConfig
-	nextConsumer    consumer.TraceConsumer
-	kc              kube.Client
-	passthroughMode bool
-	rules           kube.ExtractionRules
-	filters         kube.Filters
+	logger              *zap.Logger
+	apiConfig           k8sconfig.APIConfig
+	kc                  kube.Client
+	passthroughMode     bool
+	rules               kube.ExtractionRules
+	filters             kube.Filters
+	nextTraceConsumer   consumer.TraceConsumer
+	nextMetricsConsumer consumer.MetricsConsumer
 }
 
 var _ (component.TraceProcessor) = (*kubernetesprocessor)(nil)
+var _ (component.MetricsProcessor) = (*kubernetesprocessor)(nil)
 
-// NewTraceProcessor returns a component.TraceProcessorOld that adds the WithAttributeMap(attributes) to all spans
+// NewTraceProcessor returns a component.TraceProcessor that adds the WithAttributeMap(attributes) to all spans
 // passed to it.
 func NewTraceProcessor(
 	logger *zap.Logger,
-	nextConsumer consumer.TraceConsumer,
+	nextTraceConsumer consumer.TraceConsumer,
 	kubeClient kube.ClientProvider,
 	options ...Option,
 ) (component.TraceProcessor, error) {
-	kp := &kubernetesprocessor{logger: logger, nextConsumer: nextConsumer}
+	kp := &kubernetesprocessor{logger: logger, nextTraceConsumer: nextTraceConsumer}
 	for _, opt := range options {
 		if err := opt(kp); err != nil {
 			return nil, err
 		}
 	}
+	err := kp.initKubeClient(logger, kubeClient)
+	if err != nil {
+		return nil, err
+	}
+	return kp, nil
+}
 
+// NewMetricsProcessor returns a component.MetricProcessor that adds the k8s attributes to metrics passed to it.
+func NewMetricsProcessor(
+	logger *zap.Logger,
+	nextMetricsConsumer consumer.MetricsConsumer,
+	kubeClient kube.ClientProvider,
+	options ...Option,
+) (component.MetricsProcessor, error) {
+	kp := &kubernetesprocessor{logger: logger, nextMetricsConsumer: nextMetricsConsumer}
+	for _, opt := range options {
+		if err := opt(kp); err != nil {
+			return nil, err
+		}
+	}
+	err := kp.initKubeClient(logger, kubeClient)
+	if err != nil {
+		return nil, err
+	}
+	return kp, nil
+}
+
+func (kp *kubernetesprocessor) initKubeClient(logger *zap.Logger, kubeClient kube.ClientProvider) error {
 	if kubeClient == nil {
 		kubeClient = kube.New
 	}
 	if !kp.passthroughMode {
 		kc, err := kubeClient(logger, kp.apiConfig, kp.rules, kp.filters, nil, nil)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		kp.kc = kc
 	}
-	return kp, nil
+	return nil
 }
 
 func (kp *kubernetesprocessor) GetCapabilities() component.ProcessorCapabilities {
@@ -144,7 +176,63 @@ func (kp *kubernetesprocessor) ConsumeTraces(ctx context.Context, td pdata.Trace
 		}
 	}
 
-	return kp.nextConsumer.ConsumeTraces(ctx, td)
+	return kp.nextTraceConsumer.ConsumeTraces(ctx, td)
+}
+
+// ConsumeMetrics process metrics and add k8s metadata using resource hostname as pod origin.
+// TODO: Move to internal data model once it's available in contrib.
+func (kp *kubernetesprocessor) ConsumeMetrics(ctx context.Context, metrics pdata.Metrics) error {
+	mds := pdatautil.MetricsToMetricsData(metrics)
+
+	for i := range mds {
+		md := &mds[i]
+		var presetPodIP string
+		var podIP string
+
+		// Check if a collector/agent or a prior processor has already annotated the metrics with IP.
+		if md.Resource.GetLabels() != nil {
+			presetPodIP = md.Resource.Labels[k8sIPLabelName]
+		}
+
+		// Most of the metric receivers uses "host.hostname" resource label (which is represented as
+		// Node.Identifier.HostName in OpenCensus format) to identify metrics origin.
+		// In k8s environment, it's set to a pod IP address. If the value doesn't represent
+		// an IP address, we skip it.
+		if podIP == "" && md.Node.GetIdentifier().GetHostName() != "" {
+			hostname := md.Node.Identifier.HostName
+			if net.ParseIP(hostname) != nil {
+				podIP = hostname
+			}
+		}
+
+		if presetPodIP == "" && podIP != "" {
+			if md.Resource == nil {
+				md.Resource = &resourcepb.Resource{}
+			}
+			if md.Resource.Labels == nil {
+				md.Resource.Labels = map[string]string{}
+			}
+			md.Resource.Labels[k8sIPLabelName] = podIP
+		}
+
+		// Don't invoke any k8s client functionality in passthrough mode.
+		// Just tag the IP and forward the batch.
+		if kp.passthroughMode || podIP == "" {
+			continue
+		}
+
+		// Add k8s tags to resource.
+		attrsToAdd := kp.getAttributesForPodIP(podIP)
+		if len(attrsToAdd) == 0 {
+			continue
+		}
+
+		for k, v := range attrsToAdd {
+			md.Resource.Labels[k] = v
+		}
+	}
+
+	return kp.nextMetricsConsumer.ConsumeMetrics(ctx, metrics)
 }
 
 func (kp *kubernetesprocessor) getAttributesForPodIP(ip string) map[string]string {

--- a/processor/k8sprocessor/processor_test.go
+++ b/processor/k8sprocessor/processor_test.go
@@ -20,12 +20,15 @@ import (
 	"testing"
 	"time"
 
+	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/client"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/consumer/pdatautil"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.uber.org/zap"
 
@@ -85,7 +88,7 @@ func generateTraces() pdata.Traces {
 }
 
 func TestIPDetection(t *testing.T) {
-	next := &testConsumer{}
+	next := &testTraceConsumer{}
 	kp, err := NewTraceProcessor(
 		zap.NewNop(),
 		next,
@@ -107,7 +110,7 @@ func TestIPDetection(t *testing.T) {
 }
 
 func TestNilBatch(t *testing.T) {
-	next := &testConsumer{}
+	next := &testTraceConsumer{}
 	kp, err := NewTraceProcessor(
 		zap.NewNop(),
 		next,
@@ -120,8 +123,8 @@ func TestNilBatch(t *testing.T) {
 	require.Len(t, next.data, 1)
 }
 
-func TestNoAttrs(t *testing.T) {
-	next := &testConsumer{}
+func TestTraceProcessorNoAttrs(t *testing.T) {
+	next := &testTraceConsumer{}
 	p, err := NewTraceProcessor(
 		zap.NewNop(),
 		next,
@@ -173,7 +176,7 @@ func TestNoAttrs(t *testing.T) {
 }
 
 func TestNoIP(t *testing.T) {
-	next := &testConsumer{}
+	next := &testTraceConsumer{}
 	kp, err := NewTraceProcessor(
 		zap.NewNop(),
 		next,
@@ -192,7 +195,7 @@ func TestNoIP(t *testing.T) {
 }
 
 func TestIPSource(t *testing.T) {
-	next := &testConsumer{}
+	next := &testTraceConsumer{}
 	kp, err := NewTraceProcessor(
 		zap.NewNop(),
 		next,
@@ -252,8 +255,8 @@ func TestIPSource(t *testing.T) {
 	}
 }
 
-func TestAddLabels(t *testing.T) {
-	next := &testConsumer{}
+func TestTraceProcessorAddLabels(t *testing.T) {
+	next := &testTraceConsumer{}
 	p, err := NewTraceProcessor(
 		zap.NewNop(),
 		next,
@@ -261,7 +264,10 @@ func TestAddLabels(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	kc := fakeClientFromProcessor(t, p)
+	kp, ok := p.(*kubernetesprocessor)
+	assert.True(t, ok)
+	kc, ok := kp.kc.(*fakeClient)
+	assert.True(t, ok)
 
 	tests := map[string]map[string]string{
 		"1": {
@@ -296,7 +302,7 @@ func TestAddLabels(t *testing.T) {
 }
 
 func TestPassthroughStart(t *testing.T) {
-	next := &testConsumer{}
+	next := &testTraceConsumer{}
 	opts := []Option{WithPassthrough()}
 
 	p, err := NewTraceProcessor(
@@ -315,7 +321,7 @@ func TestPassthroughStart(t *testing.T) {
 func TestRealClient(t *testing.T) {
 	p, err := NewTraceProcessor(
 		zap.NewNop(),
-		&testConsumer{},
+		&testTraceConsumer{},
 		nil,
 		WithAPIConfig(k8sconfig.APIConfig{AuthType: "none"}),
 	)
@@ -325,14 +331,14 @@ func TestRealClient(t *testing.T) {
 }
 
 func TestCapabilities(t *testing.T) {
-	p, err := NewTraceProcessor(zap.NewNop(), &testConsumer{}, newFakeClient)
+	p, err := NewTraceProcessor(zap.NewNop(), &testTraceConsumer{}, newFakeClient)
 	assert.NoError(t, err)
 	caps := p.GetCapabilities()
 	assert.True(t, caps.MutatesConsumedData)
 }
 
 func TestStartStop(t *testing.T) {
-	next := &testConsumer{}
+	next := &testTraceConsumer{}
 	p, err := NewTraceProcessor(
 		zap.NewNop(),
 		next,
@@ -353,28 +359,204 @@ func TestStartStop(t *testing.T) {
 	assert.True(t, controller.HasStopped())
 }
 
-func fakeClientFromProcessor(t *testing.T, p component.TraceProcessor) *fakeClient {
-	kp, ok := p.(*kubernetesprocessor)
-	if !ok {
-		assert.FailNow(t, "could not assert processor %s to kubernetesprocessor", p)
-		return nil
-	}
-	kc, ok := kp.kc.(*fakeClient)
-	if !ok {
-		assert.FailNow(t, "could not assert kube client %s to kube.FakeClient", p)
-		return nil
-
-	}
-	return kc
+func TestNewMetricsProcessor(t *testing.T) {
+	_, err := NewMetricsProcessor(
+		zap.NewNop(),
+		exportertest.NewNopMetricsExporter(),
+		newFakeClient,
+	)
+	require.NoError(t, err)
 }
 
-type testConsumer struct {
+func TestMetricsProcessorNoAttrs(t *testing.T) {
+	next := &testMetricsConsumer{}
+	p, err := NewMetricsProcessor(
+		zap.NewNop(),
+		next,
+		newFakeClient,
+		WithExtractMetadata(metadataPodName),
+	)
+	require.NoError(t, err)
+	kp := p.(*kubernetesprocessor)
+	kc := kp.kc.(*fakeClient)
+
+	// pod doesn't have attrs to add
+	kc.Pods["1.1.1.1"] = &kube.Pod{Name: "PodA"}
+	metrics := generateMetrics()
+
+	p.ConsumeMetrics(context.Background(), metrics)
+	require.Len(t, next.data, 1)
+	mds := pdatautil.MetricsToMetricsData(next.data[0])
+	require.Equal(t, len(mds), 1)
+	md := mds[0]
+	require.Equal(t, 1, len(md.Resource.Labels))
+	gotIP, ok := md.Resource.Labels["k8s.pod.ip"]
+	assert.True(t, ok)
+	assert.Equal(t, "1.1.1.1", gotIP)
+
+	// attrs should be added now
+	kc.Pods["1.1.1.1"] = &kube.Pod{
+		Name: "PodA",
+		Attributes: map[string]string{
+			"k":  "v",
+			"1":  "2",
+			"aa": "b",
+		},
+	}
+
+	p.ConsumeMetrics(context.Background(), metrics)
+	require.Len(t, next.data, 2)
+	mds = pdatautil.MetricsToMetricsData(next.data[1])
+	require.Equal(t, len(mds), 1)
+	md = mds[0]
+	require.Equal(t, 4, len(md.Resource.Labels))
+	gotIP, ok = md.Resource.Labels["k8s.pod.ip"]
+	assert.True(t, ok)
+	assert.Equal(t, "1.1.1.1", gotIP)
+	gotAttr, ok := md.Resource.Labels["aa"]
+	assert.True(t, ok)
+	assert.Equal(t, "b", gotAttr)
+
+	// passthrough doesn't add attrs
+	metrics = generateMetrics()
+	kp.passthroughMode = true
+	p.ConsumeMetrics(context.Background(), metrics)
+	require.Len(t, next.data, 3)
+	mds = pdatautil.MetricsToMetricsData(next.data[2])
+	require.Equal(t, len(mds), 1)
+	md = mds[0]
+	require.Equal(t, 1, len(md.Resource.Labels))
+}
+
+func TestMetricsProcessoInvalidIP(t *testing.T) {
+	next := &testMetricsConsumer{}
+	p, err := NewMetricsProcessor(
+		zap.NewNop(),
+		next,
+		newFakeClient,
+		WithExtractMetadata(metadataPodName),
+	)
+	require.NoError(t, err)
+	kp := p.(*kubernetesprocessor)
+	kc := kp.kc.(*fakeClient)
+
+	// invalid ip should not be used to lookup k8s pod
+	kc.Pods["invalid-ip"] = &kube.Pod{
+		Name: "PodA",
+		Attributes: map[string]string{
+			"k":  "v",
+			"1":  "2",
+			"aa": "b",
+		},
+	}
+	metrics := generateMetrics()
+	md := pdatautil.MetricsToMetricsData(metrics)[0]
+	md.Node.Identifier.HostName = "invalid-ip"
+
+	p.ConsumeMetrics(context.Background(), metrics)
+	require.Len(t, next.data, 1)
+	mds := pdatautil.MetricsToMetricsData(next.data[0])
+	require.Equal(t, len(mds), 1)
+	md = mds[0]
+	require.Nil(t, md.Resource)
+}
+
+func TestMetricsProcessorAddLabels(t *testing.T) {
+	next := &testMetricsConsumer{}
+	p, err := NewMetricsProcessor(
+		zap.NewNop(),
+		next,
+		newFakeClient,
+	)
+	require.NoError(t, err)
+
+	kp, ok := p.(*kubernetesprocessor)
+	assert.True(t, ok)
+	kc, ok := kp.kc.(*fakeClient)
+	assert.True(t, ok)
+
+	tests := map[string]map[string]string{
+		"1.2.3.4": {
+			"pod":         "test-2323",
+			"ns":          "default",
+			"another tag": "value",
+		},
+		"2.3.4.5": {
+			"pod": "test-12",
+		},
+	}
+	for ip, attrs := range tests {
+		kc.Pods[ip] = &kube.Pod{Attributes: attrs}
+	}
+
+	var i int
+	for ip, attrs := range tests {
+		metrics := generateMetrics()
+		md := pdatautil.MetricsToMetricsData(metrics)[0]
+		md.Node.Identifier.HostName = ip
+
+		err = p.ConsumeMetrics(context.Background(), metrics)
+		require.NoError(t, err)
+
+		require.Len(t, next.data, i+1)
+		mds := pdatautil.MetricsToMetricsData(next.data[i])
+		require.Equal(t, len(mds), 1)
+		md = mds[0]
+		require.Equal(t, len(attrs)+1, len(md.Resource.Labels))
+		gotIP, ok := md.Resource.Labels["k8s.pod.ip"]
+		assert.True(t, ok)
+		assert.Equal(t, ip, gotIP)
+		for k, v := range attrs {
+			got, ok := attrs[k]
+			assert.True(t, ok)
+			assert.Equal(t, v, got)
+		}
+		i++
+	}
+}
+
+type testTraceConsumer struct {
 	data []pdata.Traces
 }
 
-func (ts *testConsumer) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
-	ts.data = append(ts.data, td)
+func (tc *testTraceConsumer) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
+	tc.data = append(tc.data, td)
 	return nil
+}
+
+type testMetricsConsumer struct {
+	data []pdata.Metrics
+}
+
+func (mc *testMetricsConsumer) ConsumeMetrics(ctx context.Context, td pdata.Metrics) error {
+	mc.data = append(mc.data, td)
+	return nil
+}
+
+func generateMetrics() pdata.Metrics {
+	md := consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			Identifier: &commonpb.ProcessIdentifier{
+				HostName: "1.1.1.1",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name: "my-metric",
+					Type: metricspb.MetricDescriptor_GAUGE_INT64,
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						Points: []*metricspb.Point{
+							{Value: &metricspb.Point_Int64Value{Int64Value: 123}},
+						},
+					},
+				},
+			},
+		},
+	}
+	return pdatautil.MetricsFromMetricsData([]consumerdata.MetricsData{md})
 }
 
 func assertResourceHasStringAttribute(t *testing.T, r pdata.Resource, k, v string) {


### PR DESCRIPTION
**Description:** 
Kubernetes processor can be used to enrich not only spans but metrics with k8s metadata. In order to find a source of the metrics we take a different approach then for spans. The processor looks at "host.hostname" resource attribute which is set by prometheus receiver and some metrics instrumentation libraries to an originated IP address. That IP address is used by k8s processor to lookup for a k8s pod and fetch its metadata.

The processor uses the old-style metrics data model since the new metric model is not available in contrib yet. But it must be easy to switch over later once we wave it the new metrics model support.

**Testing:**
- Added unit tests
- Tested on a local k8s cluster

**Documentation:** 
Added details about metrics to existing docs.