### PR TITLE
Separate out "not found pod ip" condition in k8s processor for metrics

### DIFF
--- a/processor/k8sprocessor/processor.go
+++ b/processor/k8sprocessor/processor.go
@@ -215,9 +215,14 @@ func (kp *kubernetesprocessor) ConsumeMetrics(ctx context.Context, metrics pdata
 			md.Resource.Labels[k8sIPLabelName] = podIP
 		}
 
+		// Ignore metrics if cannot infer IP address of the origin pod.
+		if podIP == "" {
+			continue
+		}
+
 		// Don't invoke any k8s client functionality in passthrough mode.
 		// Just tag the IP and forward the batch.
-		if kp.passthroughMode || podIP == "" {
+		if kp.passthroughMode {
 			continue
 		}
 


### PR DESCRIPTION
**Description:**
It addresses comment https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/358#discussion_r445118419