### PR TITLE
Separate annotations from labels in discovered pods

### DIFF
--- a/extension/observer/k8sobserver/handler.go
+++ b/extension/observer/k8sobserver/handler.go
@@ -47,18 +47,11 @@ func (h *handler) OnAdd(obj interface{}) {
 func (h *handler) convertPodToEndpoints(pod *v1.Pod) []observer.Endpoint {
 	podID := fmt.Sprintf("%s/%s", h.idNamespace, pod.UID)
 	podIP := pod.Status.PodIP
-	labels := map[string]string{}
-
-	for k, v := range pod.Labels {
-		labels[k] = v
-	}
-	for k, v := range pod.Annotations {
-		labels[k] = v
-	}
 
 	podDetails := observer.Pod{
-		Labels: labels,
-		Name:   pod.Name,
+		Annotations: pod.Annotations,
+		Labels:      pod.Labels,
+		Name:        pod.Name,
 	}
 
 	endpoints := []observer.Endpoint{{

--- a/extension/observer/observer.go
+++ b/extension/observer/observer.go
@@ -50,6 +50,8 @@ type Pod struct {
 	Name string
 	// Labels is a map of user-specified metadata.
 	Labels map[string]string
+	// Annotations is a map of user-specified metadata.
+	Annotations map[string]string
 }
 
 // Port is an endpoint that has a target as well as a port.

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -69,17 +69,17 @@ extensions:
   k8s_observer:
 
 receivers:
-  prometheus_simple:
-    # Configure prometheus scraping if standard prometheus annotations are set on the pod.
-    rule: type.pod && annotations["prometheus.io/scrape"] == "true"
-    config:
-      metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
-      endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
-
   receiver_creator/1:
     # Name of the extensions to watch for endpoints to start and stop.
     watch_observers: [k8s_observer]
     receivers:
+      prometheus_simple:
+        # Configure prometheus scraping if standard prometheus annotations are set on the pod.
+        rule: type.pod && annotations["prometheus.io/scrape"] == "true"
+        config:
+          metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
+          endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+
       redis/1:
         # If this rule matches an instance of this receiver will be started.
         rule: type.port && port == 6379

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -38,26 +38,28 @@ config:
 
 ## Rule Expressions
 
-Each rule must start with `type.(pod|port) &&` such that the rule matches only one endpoint type. Depending on the type of endpoint the rule is targeting it will have different variables available. 
+Each rule must start with `type.(pod|port) &&` such that the rule matches only one endpoint type. Depending on the type of endpoint the rule is targeting it will have different variables available.
 
 ### Pod
 
-| Variable  | Description                  |
-|-----------|------------------------------|
-| type.pod  | `true`                       |
-| name      | name of the pod              |
-| labels    | map of labels set on the pod |
+| Variable    | Description                       |
+|-------------|-----------------------------------|
+| type.pod    | `true`                            |
+| name        | name of the pod                   |
+| labels      | map of labels set on the pod      |
+| annotations | map of annotations set on the pod |
 
 ### Port
 
-| Variable   | Description                     |
-|------------|---------------------------------|
-| type.port  | `true`                          |
-| name       | container port name             |
-| port       | port number                     |
-| pod.name   | name of the owning pod          |
-| pod.labels | map of labels of the owning pod |
-| protocol   | "TCP" or "UDP"                  |
+| Variable        | Description                          |
+|-----------------|--------------------------------------|
+| type.port       | `true`                               |
+| name            | container port name                  |
+| port            | port number                          |
+| pod.name        | name of the owning pod               |
+| pod.labels      | map of labels of the owning pod      |
+| pod.annotations | map of annotations of the owning pod |
+| protocol        | "TCP" or "UDP"                       |
 
 ## Example
 
@@ -67,18 +69,25 @@ extensions:
   k8s_observer:
 
 receivers:
+  prometheus_simple:
+    # Configure prometheus scraping if standard prometheus annotations are set on the pod.
+    rule: type.pod && annotations["prometheus.io/scrape"] == "true"
+    config:
+      metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
+      endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+
   receiver_creator/1:
     # Name of the extensions to watch for endpoints to start and stop.
     watch_observers: [k8s_observer]
     receivers:
-        redis/1:
-          # If this rule matches an instance of this receiver will be started.
-          rule: type.port && port == 6379
-          config:
-            # Static receiver-specific config.
-            password: secret
-            # Dynamic configuration value.
-            service_name: `pod.labels["service_name"]`
+      redis/1:
+        # If this rule matches an instance of this receiver will be started.
+        rule: type.port && port == 6379
+        config:
+          # Static receiver-specific config.
+          password: secret
+          # Dynamic configuration value.
+          service_name: `pod.labels["service_name"]`
 
 processors:
   exampleprocessor:

--- a/receiver/receivercreator/fixtures_test.go
+++ b/receiver/receivercreator/fixtures_test.go
@@ -24,6 +24,9 @@ var pod = observer.Pod{
 		"app":    "redis",
 		"region": "west-1",
 	},
+	Annotations: map[string]string{
+		"scrape": "true",
+	},
 }
 
 var podEndpoint = observer.Endpoint{

--- a/receiver/receivercreator/rules.go
+++ b/receiver/receivercreator/rules.go
@@ -46,10 +46,11 @@ func endpointToEnv(endpoint observer.Endpoint) (endpointEnv, error) {
 	case observer.Pod:
 		ruleTypes["pod"] = true
 		return map[string]interface{}{
-			"type":     ruleTypes,
-			"endpoint": endpoint.Target,
-			"name":     o.Name,
-			"labels":   o.Labels,
+			"type":        ruleTypes,
+			"endpoint":    endpoint.Target,
+			"name":        o.Name,
+			"labels":      o.Labels,
+			"annotations": o.Annotations,
 		}, nil
 	case observer.Port:
 		ruleTypes["port"] = true

--- a/receiver/receivercreator/rules_test.go
+++ b/receiver/receivercreator/rules_test.go
@@ -46,6 +46,7 @@ func Test_ruleEval(t *testing.T) {
 		// {"unknown variable", args{`type == "port" && unknown_var == 1`, portEndpoint}, false, true},
 		{"basic port", args{`type.port && name == "http" && pod.labels["app"] == "redis"`, portEndpoint}, true, false},
 		{"basic pod", args{`type.pod && labels["region"] == "west-1"`, podEndpoint}, true, false},
+		{"annotations", args{`type.pod && annotations["scrape"] == "true"`, podEndpoint}, true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Before annotations were merged into labels which could be confusing. Separate
them out. Also document how to use these annotations in receiver creator.