### PR TITLE
OpenTelemetry Collector Ecosystem Integration

### DIFF
--- a/receiver/prometheusexec/README.md
+++ b/receiver/prometheusexec/README.md
@@ -29,7 +29,7 @@ receivers:
 ```
 
 - ### exec (required)
-Under each `prometheus_exec/custom_name` there needs to be an `exec` key. The value of this key is a string of the command to be run, with any flags needed (this will probably be the binary to run, in the correct relative directory). The format should be: `directory/binary_to_run --flag1 --flag2` (the binary as well as all flasg should be separated by spaces). Environment variables can be set in a later configuration setting. Example:
+Under each `prometheus_exec/custom_name` there needs to be an `exec` key. The value of this key is a string of the command to be run, with any flags needed (this will probably be the binary to run, in the correct relative directory). The format should be: `directory/binary_to_run flag1 flag2` (the binary should be separated from the flags by a space - as well as the flags separated from themselves by a space). Environment variables can be set in a later configuration setting. Example:
 
 ```yaml
 receivers:

--- a/receiver/prometheusexec/README.md
+++ b/receiver/prometheusexec/README.md
@@ -9,7 +9,7 @@ This receiver makes it easy for a user to collect metrics from third-party servi
 ### How?
 Through the configuration file, you can indicate which binaries to run (usually [Prometheus exporters](https://prometheus.io/docs/instrumenting/exporters/), which are custom binaries that expose the third-party services' metrics using the Prometheus protocol) and `prometheus_exec` will take care of starting the specified binaries with their equivalent Prometheus receiver. This receiver also supports starting binaries with flags and environment variables, retrying them with exponentional backoff if they crash, string templating, and random port assignments.
 
-*Note*: If you do not need to spawn the binaries locally, please condider using the [core Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver/prometheusreceiver) or the [Simple Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/simpleprometheusreceiver).
+*Note*: If you do not need to spawn the binaries locally, please consider using the [core Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver/prometheusreceiver) or the [Simple Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/simpleprometheusreceiver).
 
 ## Config
 For each `prometheus_exec` defined in the configuration file, the specified command will be run. The command *should* start a binary that exposes Prometheus metrics and an equivalent Prometheus receiver will be instantiated to scrape its metrics, if configured correctly.

--- a/receiver/prometheusexec/README.md
+++ b/receiver/prometheusexec/README.md
@@ -1,44 +1,18 @@
 # This receiver is currently under development, do not use.
 // TODO: Remove above message when done
 
-# Prometheus_exec Receiver
+# prometheus_exec Receiver
 
-This receiver makes it easy for a user to collect metrics with the Collector from third-party services such as MySQL, Apache, Redis, etc. It's meant for people who want a plug-and-play solution to getting metrics from those third-party services that don't natively export metrics or speak any instrumentation protocols. Through the configuration file, you can indicate which binaries to run (usually [Prometheus exporters](https://prometheus.io/docs/instrumenting/exporters/), which are custom binaries that will expose the services' metrics to the Prometheus protocol). It supports starting binaries with flags and environment variables, retrying them with exponentional backoff if they crash, string templating, and random port assignments. If you do not need to spawn the binaries locally, please condider using the [core Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver/prometheusreceiver) or the [Simple Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/simpleprometheusreceiver).
+### Why?
+This receiver makes it easy for a user to collect metrics from third-party services **via Prometheus exporters**. It's meant for people who want a plug-and-play solution to getting metrics from those third-party services that sometimes simply don't natively export metrics or speak any instrumentation protocols (MySQL, Apache, Nginx, etc.) while taking advantage of the large [Prometheus exporters]((https://prometheus.io/docs/instrumenting/exporters/)) ecosystem. 
 
-## Overview
-Here's an example Collector configuration file that starts two `prometheus_exec` receivers and two exporters.
+### How?
+Through the configuration file, you can indicate which binaries to run (usually [Prometheus exporters](https://prometheus.io/docs/instrumenting/exporters/), which are custom binaries that expose the third-party services' metrics using the Prometheus protocol) and `prometheus_exec` will take care of starting the specified binaries with their equivalent Prometheus receiver. This receiver also supports starting binaries with flags and environment variables, retrying them with exponentional backoff if they crash, string templating, and random port assignments.
 
-```yaml
-receivers:
-    prometheus_exec/mysqld:
-        exec: ./mysqld_exporter --port {{port}}
-        scrape_interval: 10s
-        port: 9104
-        env:
-          - name: DATA_SOURCE_NAME
-            value: user:password@(url:port)/
-
-    prometheus_exec/postgresql:
-        exec: ./postgres_exporter
-        env:
-          - name: DATA_SOURCE_NAME
-            value: postgresql://user:password@url:port/
-
-exporters:
-    stackdriver:
-        project: "project_name"
-    file:
-        path: ./file_name.json
-
-service:
-    pipelines:
-        metrics:
-            receivers: [prometheus_exec/mysqld, prometheus_exec/postgresql]
-            exporters: [stackdriver, file]
-```
+*Note*: If you do not need to spawn the binaries locally, please condider using the [core Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver/prometheusreceiver) or the [Simple Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/simpleprometheusreceiver).
 
 ## Config
-For every `prometheus_exec` defined in the configuration file, a command will be run (you *should* start a binary for this receiver to serve its purpose) and an equivalent Prometheus receiver will be instantiated to scrape its metrics.
+For each `prometheus_exec` defined in the configuration file, the specified command will be run. The command *should* start a binary that exposes Prometheus metrics and an equivalent Prometheus receiver will be instantiated to scrape its metrics, if configured correctly.
 
 - ### prometheus_exec (required)
 `prometheus_exec` receivers should hierarchically be placed under the `receivers` key. You can define as many of these as you want, and they should be named as follows: `prometheus_exec/custom_name`. The `custom_name` should be unique per receiver you define, and is important for logging and error tracing. If no `custom_name` is given (i.e. simply having `prometheus_exec`), one will be generated for you by using the first word in the command to be executed (doing this limits the amount of receivers to 1 though since you can't define multiple receivers with duplicate names, so it's not recommended). Example:
@@ -46,11 +20,12 @@ For every `prometheus_exec` defined in the configuration file, a command will be
 ```yaml
 receivers:
     prometheus_exec/mysql: 
-        # custom_name here is mysql
+        exec: ./mysqld_exporter
+        # custom_name here is "mysql"
 
     prometheus_exec:
-        exec: ./postgresql_exporter --port 1234 --config conf.xml 
-        # custom_name here is ./postgresql_exporter
+        exec: ./postgres_exporter
+        # custom_name here is "./postgres_exporter"
 ```
 
 - ### exec (required)
@@ -59,10 +34,10 @@ Under each `prometheus_exec/custom_name` there needs to be an `exec` key. The va
 ```yaml
 receivers:
     prometheus_exec/apache:
-        exec: ./apache_exporter --retry=false
+        exec: ./apache_exporter --log.level="info"
 
     prometheus_exec/postgresql:
-        exec: ./postgresql_exporter --port 1234 --config conf.xml
+        exec: ./postgres_exporter --web.telemetry-path="/metrics"
 ```
 
 - ### port
@@ -76,17 +51,17 @@ Example:
 ```yaml
 receivers:
     prometheus_exec/apache:
-        exec: ./apache_exporter --retry=false
-        port: 1234 
-    # this receiver will listen on port 1234
+        exec: ./apache_exporter
+        port: 9117 
+    # this receiver will listen on port 9117
 
     prometheus_exec/postgresql:
-        exec: ./postgresql_exporter --port {{port}} --config conf.xml
-        port: 9876
-    # this receiver will listen on port 9876 and {{port}} inside the command will become 9876
+        exec: ./postgres_exporter --web.listen-address=":{{port}}"
+        port: 9187
+    # this receiver will listen on port 9187 and {{port}} inside the command will become 9187
 
     prometheus_exec/mysql:
-        exec: ./mysqld_exporter --port={{port}}
+        exec: ./mysqld_exporter --web.listen-address=":{{port}}"
     # this receiver will listen on a random port and that port will be substituting the {{port}} inside the command
 ```
 
@@ -96,14 +71,14 @@ receivers:
 ```yaml
 receivers:
     prometheus_exec/apache:
-        exec: ./apache_exporter --retry=false
-        port: 1234 
+        exec: ./apache_exporter
+        port: 9117 
         scrape_interval: 60s
     # this receiver will scrape every 60 seconds
 
     prometheus_exec/postgresql:
-        exec: ./postgresql_exporter --port {{port}} --config conf.xml
-        port: 9876
+        exec: ./postgres_exporter --web.listen-address=":{{port}}"
+        port: 9187
     # this receiver will scrape every 10 seconds, by default
 ```
 
@@ -113,12 +88,12 @@ receivers:
 ```yaml
 receivers:
     prometheus_exec/mysql:
-        exec: ./mysql_exporter --retry=false
-        port: 1234 
+        exec: ./mysqld_exporter 
+        port: 9104 
         scrape_interval: 60s
         env:
           - name: DATA_SOURCE_NAME
-            value: user:password@url:port/dbname
+            value: user:password@(hostname:port)/dbname
           - name: SECONDARY_PORT
             value: {{port}}
     # this binary will start with the two above defined environment variables, notice how string templating also works in env

--- a/receiver/prometheusexec/README.md
+++ b/receiver/prometheusexec/README.md
@@ -29,7 +29,7 @@ receivers:
 ```
 
 - ### exec (required)
-Under each `prometheus_exec/custom_name` there needs to be an `exec` key. The value of this key is a string of the command to be run, with any flags needed (this will probably be the binary to run, in the correct relative directory). Environment variables can be set in a later configuration setting. Example:
+Under each `prometheus_exec/custom_name` there needs to be an `exec` key. The value of this key is a string of the command to be run, with any flags needed (this will probably be the binary to run, in the correct relative directory). The format should be: `directory/binary_to_run --flag1 --flag2` (the binary as well as all flasg should be separated by spaces). Environment variables can be set in a later configuration setting. Example:
 
 ```yaml
 receivers:

--- a/receiver/prometheusexec/README.md
+++ b/receiver/prometheusexec/README.md
@@ -112,8 +112,8 @@ receivers:
 
 ```yaml
 receivers:
-    prometheus_exec/apache:
-        exec: ./apache_exporter --retry=false
+    prometheus_exec/mysql:
+        exec: ./mysql_exporter --retry=false
         port: 1234 
         scrape_interval: 60s
         env:

--- a/receiver/prometheusexec/README.md
+++ b/receiver/prometheusexec/README.md
@@ -1,0 +1,126 @@
+# This receiver is currently under development, do not use.
+// TODO: Remove above message when done
+
+# Prometheus_exec Receiver
+
+This receiver makes it easy for a user to collect metrics with the Collector from third-party services such as MySQL, Apache, Redis, etc. It's meant for people who want a plug-and-play solution to getting metrics from those third-party services that don't natively export metrics or speak any instrumentation protocols. Through the configuration file, you can indicate which binaries to run (usually [Prometheus exporters](https://prometheus.io/docs/instrumenting/exporters/), which are custom binaries that will expose the services' metrics to the Prometheus protocol). It supports starting binaries with all flags and environment variables, retrying them with exponentional backoff, string templating, and random port assigning. If you do not need to spawn the binaries locally, please condider using the [core Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver/prometheusreceiver) or the [Simple Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver/simpleprometheusreceiver).
+
+## Overview
+Here's an example Collector configuration file that starts two `prometheus_exec` receivers and two exporters.
+
+```yaml
+receivers:
+    prometheus_exec/mysqld:
+        exec: ./mysqld_exporter --port {{port}}
+        scrape_interval: 10s
+        port: 9104
+        env:
+          - name: DATA_SOURCE_NAME
+            value: user:password@(url:port)/
+
+    prometheus_exec/postgresql:
+        exec: ./postgres_exporter
+        env:
+          - name: DATA_SOURCE_NAME
+            value: postgresql://user:password@url:port/
+
+exporters:
+    stackdriver:
+        project: "project_name"
+    file:
+        path: ./file_name.json
+
+service:
+    pipelines:
+        metrics:
+            receivers: [prometheus_exec/mysqld, prometheus_exec/postgresql]
+            exporters: [stackdriver, file]
+```
+
+## Config
+For every `prometheus_exec` defined in the configuration file, a command will be run (the user *should* want to start a binary) and an equivalent Prometheus receiver will be spawned to scrape its metrics.
+
+- ### prometheus_exec (required)
+`prometheus_exec` receivers should hierarchically be placed under the `receivers` key. As many of these receivers can be defined, and should be named as follows: `prometheus_exec/custom_name`. The `custom_name` should be unique per receiver you define, and is important for logging and error tracing. If no `custom_name` is given (i.e. `prometheus_exec`), one will try to be generated using the first word in the command to be executed. Example:
+
+```yaml
+receivers:
+    prometheus_exec/mysql: # custom_name here is mysql
+
+    prometheus_exec:
+        exec: ./postgresql_exporter --port 1234 --config conf.xml # custome_name here is ./postgresql_exporter
+
+```
+
+- ### exec (required)
+Under each `prometheus_exec/custom_name` there needs to be an `exec` key. The value of this key is a string of the command to be run, with any flags needed (this will probably be the binary to run, in the correct relative directory). Environment variables can be set in a later configuration setting. Example:
+
+```yaml
+receivers:
+    prometheus_exec/apache:
+        exec: ./apache_exporter --retry=false
+
+    prometheus_exec/postgresql:
+        exec: ./postgresql_exporter --port 1234 --config conf.xml
+
+```
+
+- ### port
+`port` is an optional entry. Its value is a number indicating the port the receiver should be scraping the binary's metrics from. Two important notes about `port`:
+1. If it is omitted, we will try to randomly generate a port for you, and retry until we find one that is free. Beware when using this, since you also need to indicate your binary to listen on that port with the use of a flag and templating inside the command, which is covered in 2.
+
+2. **All** instances of `{{port}}` in any string of any key for the enclosing `prometheus_exec` will be replaced with either the port value indicated or the randomly generated one if no port value is set with the `port` key.
+
+Example:
+
+```yaml
+receivers:
+    prometheus_exec/apache:
+        exec: ./apache_exporter --retry=false
+        port: 1234 
+    # this receiver will listen on port 1234
+
+    prometheus_exec/postgresql:
+        exec: ./postgresql_exporter --port {{port}} --config conf.xml
+        port: 9876
+    # this receiver will listen on port 9876 and {{port}} inside the command will become 9876
+
+    prometheus_exec/mysql:
+        exec: ./mysqld_exporter --port={{port}}
+    # this receiver will listen on a random port and that port will be substituting the {{port}} inside the command
+```
+
+- ### scrape_interval
+`scrape_interval` is an optional entry. Its value is a duration, in seconds (`s`), indicating how long the delay between scrapes done by the receiver is. The default is `10s` (10 seconds). Example:
+
+```yaml
+receivers:
+    prometheus_exec/apache:
+        exec: ./apache_exporter --retry=false
+        port: 1234 
+        scrape_interval: 60s
+    # this receiver will scrape every 60 seconds
+
+    prometheus_exec/postgresql:
+        exec: ./postgresql_exporter --port {{port}} --config conf.xml
+        port: 9876
+    # this receiver will scrape every 10 seconds
+```
+
+- ### env
+`env` is an optional entry to indicate which environment variables the command needs to run properly. Under it there should be a list of key (`name`) - value (`value`) pairs, separate by dashes (`-`). They are case-sensitive. These environment variables are added to the pre-existing environment variables the Collector is running with (the entire environment is replicated, including the directory). Example:
+
+```yaml
+receivers:
+    prometheus_exec/apache:
+        exec: ./apache_exporter --retry=false
+        port: 1234 
+        scrape_interval: 60s
+        env:
+          - name: DATA_SOURCE_NAME
+            value: user:password@url:port/dbname
+          - name: RETRY_TIMEOUT
+            value: 10
+    # this binary will start with the two above defined environment variables, 
+```
+

--- a/receiver/prometheusexec/README.md
+++ b/receiver/prometheusexec/README.md
@@ -34,10 +34,10 @@ Under each `prometheus_exec/custom_name` there needs to be an `exec` key. The va
 ```yaml
 receivers:
     prometheus_exec/apache:
-        exec: ./apache_exporter --log.level="info"
+        exec: ./apache_exporter --log.level=info
 
     prometheus_exec/postgresql:
-        exec: ./postgres_exporter --web.telemetry-path="/metrics"
+        exec: ./postgres_exporter --web.telemetry-path=/metrics
 ```
 
 - ### port
@@ -56,12 +56,12 @@ receivers:
     # this receiver will listen on port 9117
 
     prometheus_exec/postgresql:
-        exec: ./postgres_exporter --web.listen-address=":{{port}}"
+        exec: ./postgres_exporter --web.listen-address=:{{port}}
         port: 9187
     # this receiver will listen on port 9187 and {{port}} inside the command will become 9187
 
     prometheus_exec/mysql:
-        exec: ./mysqld_exporter --web.listen-address=":{{port}}"
+        exec: ./mysqld_exporter --web.listen-address=:{{port}}
     # this receiver will listen on a random port and that port will be substituting the {{port}} inside the command
 ```
 
@@ -77,7 +77,7 @@ receivers:
     # this receiver will scrape every 60 seconds
 
     prometheus_exec/postgresql:
-        exec: ./postgres_exporter --web.listen-address=":{{port}}"
+        exec: ./postgres_exporter --web.listen-address=:{{port}}
         port: 9187
     # this receiver will scrape every 10 seconds, by default
 ```


### PR DESCRIPTION
This PR is meant to define the folder and introduce the community to the receiver I've been working on, and get feedback on it. It includes a `README` with the current state of the config which is also a really good in-depth config explanation.

Hi! I'm Nic, an intern @ Google. 

`prometheus_exec` is a receiver meant to make it easy for users to get up-and-running quickly, collecting metrics from their favorite third-party services (that don't normally support instrumentation). This frictionless experience should help with adoption and be an attractive solution for those holding out on using the Collector because their systems/services were not compatible. In a nutshell, it runs binaries of [Prometheus exporters](https://prometheus.io/docs/instrumenting/exporters/) (custom-built code that make third-party services, such as MySQL, Redis, etc. communicate the Prometheus protocol) and spawns the equivalent Prometheus receiver to collect the metrics. It handles crashing binaries by applying exponential backoff, can assign a random port and supports string templating. Please read the `README` (it really has a lot of useful info) or ask me for more details :) !

README link with markdown applied (**much** nicer read): [link](https://github.com/Nicolas-MacBeth/opentelemetry-collector-contrib/blob/readme_and_structure/receiver/prometheusexec/README.md)

For example, a user wants to quickly get metrics from their MySQL and Apache servers running on a VM. Simply, they indicate a couple of things in the configuration file, download the exporter binaries and run the Collector. It will handle starting the exporters, starting the equivalent receivers and making everything work like magic (hopefully).

Example configuration:
```yaml
receivers:
    prometheus_exec/apache:
        exec: ./apache_exporter --retry=false
        port: 1234 
        scrape_interval: 60s

    prometheus_exec/postgresql:
        exec: ./postgresql_exporter --port {{port}} --config conf.xml
        port: 9876
        env:
          - name: DATA_SOURCE_NAME
            value: user:password@url:port/dbname
```