### PR TITLE
AWS X-Ray exporter: Only convert SQL information for SQL databases.

### DIFF
--- a/exporter/awsxrayexporter/translator/sql.go
+++ b/exporter/awsxrayexporter/translator/sql.go
@@ -58,8 +58,8 @@ func makeSQL(attributes map[string]string) (map[string]string, *SQLData) {
 		}
 	}
 
-	if len(filtered) == len(attributes) {
-		// Didn't filter any attributes meaning didn't have any SQL information.
+	if dbType != "sql" {
+		// Either no DB attributes or this is not an SQL DB.
 		return attributes, nil
 	}
 

--- a/exporter/awsxrayexporter/translator/sql_test.go
+++ b/exporter/awsxrayexporter/translator/sql_test.go
@@ -45,3 +45,19 @@ func TestClientSpanWithStatementAttribute(t *testing.T) {
 	testWriters.release(w)
 	assert.True(t, strings.Contains(jsonStr, "mysql://db.example.com:3306/customers"))
 }
+
+func TestClientSpanWithNonSQLDatabase(t *testing.T) {
+	attributes := make(map[string]string)
+	attributes[semconventions.AttributeComponent] = "db"
+	attributes[semconventions.AttributeDBType] = "redis"
+	attributes[semconventions.AttributeDBInstance] = "0"
+	attributes[semconventions.AttributeDBStatement] = "SET key value"
+	attributes[semconventions.AttributeDBUser] = "readonly_user"
+	attributes[semconventions.AttributeDBURL] = "redis://db.example.com:3306"
+	attributes[semconventions.AttributeNetPeerName] = "db.example.com"
+	attributes[semconventions.AttributeNetPeerPort] = "3306"
+
+	filtered, sqlData := makeSQL(attributes)
+	assert.Nil(t, sqlData)
+	assert.NotNil(t, filtered)
+}


### PR DESCRIPTION
**Description:** 
Currently, we fill in the X-Ray `sql` field for any database. However, it's only meant for SQL databases - notably, if it's filled for a redis database, X-Ray displays it incorrectly as a `Database::SQL`.