### PR TITLE
Fixed add-tag make target & publish CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,9 +234,6 @@ jobs:
       - run:
           name: Build collector for all archs
           command: grep ^otelcontribcol-all-sys Makefile|fmt -w 1|tail -n +2|circleci tests split|xargs make
-      - persist_to_workspace:
-          root: ~/
-          paths: project/bin
 
   unit-tests:
     executor: golang

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ for-all:
 add-tag:
 	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
 	@echo "Adding tag ${TAG}"
+	@git tag -a ${TAG} -s -m "Version ${TAG}"
 	@set -e; for dir in $(ALL_MODULES); do \
 	  (echo Adding tag "$${dir:2}/$${TAG}" && \
 	 	git tag -a "$${dir:2}/$${TAG}" -s -m "Version ${dir:2}/${TAG}" ); \


### PR DESCRIPTION
Fixes add-tag target and CI publish workflow

* add-tag did not tag the root module. This fixes the issue.
* publish workflow could possibly fail if build and cross-compile both saves the binaries to the workspace concurently but publish only needs the binary from the build step. So we are disabling persisting to workspace from the cross-compile step.