### PR TITLE
AWS X-Ray exporter: Use peer.service as segment name when set.

### DIFF
--- a/exporter/awsxrayexporter/translator/segment.go
+++ b/exporter/awsxrayexporter/translator/segment.go
@@ -135,12 +135,20 @@ func MakeSegment(span pdata.Span, resource pdata.Resource) Segment {
 	// X-Ray segment names are service names, unlike span names which are methods. Try to find a service name.
 
 	attributes := span.Attributes()
-	if awsService, ok := attributes.Get(AWSServiceAttribute); ok {
-		// Generally spans are named something like "Method" or "Service.Method" but for AWS spans, X-Ray expects spans
-		// to be named "Service"
-		name = awsService.StringVal()
 
-		namespace = "aws"
+	// peer.service should always be prioritized for segment names when set because it is what the user decided.
+	if peerService, ok := attributes.Get(semconventions.AttributePeerService); ok {
+		name = peerService.StringVal()
+	}
+
+	if name == "" {
+		if awsService, ok := attributes.Get(AWSServiceAttribute); ok {
+			// Generally spans are named something like "Method" or "Service.Method" but for AWS spans, X-Ray expects spans
+			// to be named "Service"
+			name = awsService.StringVal()
+
+			namespace = "aws"
+		}
 	}
 
 	if name == "" {

--- a/exporter/awsxrayexporter/translator/segment_test.go
+++ b/exporter/awsxrayexporter/translator/segment_test.go
@@ -61,6 +61,27 @@ func TestClientSpanWithAwsSdkClient(t *testing.T) {
 	assert.False(t, strings.Contains(jsonStr, semconventions.AttributeComponent))
 }
 
+func TestClientSpanWithPeerService(t *testing.T) {
+	spanName := "AmazonDynamoDB.getItem"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes[semconventions.AttributeComponent] = semconventions.ComponentTypeHTTP
+	attributes[semconventions.AttributeHTTPMethod] = "POST"
+	attributes[semconventions.AttributeHTTPScheme] = "https"
+	attributes[semconventions.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
+	attributes[semconventions.AttributeHTTPTarget] = "/"
+	attributes[semconventions.AttributePeerService] = "cats-table"
+	attributes[AWSServiceAttribute] = "DynamoDB"
+	attributes[AWSOperationAttribute] = "GetItem"
+	attributes[AWSRequestIDAttribute] = "18BO1FEPJSSAOGNJEDPTPCMIU7VV4KQNSO5AEMVJF66Q9ASUAAJG"
+	attributes[AWSTableNameAttribute] = "otel-dev-Testing"
+	resource := constructDefaultResource()
+	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
+
+	segment := MakeSegment(span, resource)
+	assert.Equal(t, "cats-table", segment.Name)
+}
+
 func TestServerSpanWithInternalServerError(t *testing.T) {
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()


### PR DESCRIPTION
**Description:** 

`peer.service` is a user-defined name for a service, which is conceptually the same as a segment name. We should use it when defined.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Unit tests
