### PR TITLE
Support namespace attribute tagging for K8S Processor

### DIFF
--- a/processor/k8sprocessor/client_test.go
+++ b/processor/k8sprocessor/client_test.go
@@ -28,12 +28,12 @@ import (
 
 // fakeClient is used as a replacement for WatchClient in test cases.
 type fakeClient struct {
-	Pods     map[string]*kube.Pod
-	Namespaces     map[string]*kube.Namespace
-	Rules    kube.ExtractionRules
-	Filters  kube.Filters
-	Informer cache.SharedInformer
-	StopCh   chan struct{}
+	Pods       map[string]*kube.Pod
+	Namespaces map[string]*kube.Namespace
+	Rules      kube.ExtractionRules
+	Filters    kube.Filters
+	Informer   cache.SharedInformer
+	StopCh     chan struct{}
 }
 
 func (f *fakeClient) GetNamespace(name string) (*kube.Namespace, bool) {
@@ -59,12 +59,12 @@ func newFakeClient(_ *zap.Logger, apiCfg k8sconfig.APIConfig, rules kube.Extract
 
 	ls, fs := selectors()
 	return &fakeClient{
-		Pods:     map[string]*kube.Pod{},
+		Pods:       map[string]*kube.Pod{},
 		Namespaces: map[string]*kube.Namespace{},
-		Rules:    rules,
-		Filters:  filters,
-		Informer: kube.NewFakeInformer(cs, "", ls, fs),
-		StopCh:   make(chan struct{}),
+		Rules:      rules,
+		Filters:    filters,
+		Informer:   kube.NewFakeInformer(cs, "", ls, fs),
+		StopCh:     make(chan struct{}),
 	}, nil
 }
 

--- a/processor/k8sprocessor/client_test.go
+++ b/processor/k8sprocessor/client_test.go
@@ -29,10 +29,20 @@ import (
 // fakeClient is used as a replacement for WatchClient in test cases.
 type fakeClient struct {
 	Pods     map[string]*kube.Pod
+	Namespaces     map[string]*kube.Namespace
 	Rules    kube.ExtractionRules
 	Filters  kube.Filters
 	Informer cache.SharedInformer
 	StopCh   chan struct{}
+}
+
+func (f *fakeClient) GetNamespace(name string) (*kube.Namespace, bool) {
+	namespace := f.Namespaces[name]
+	if namespace != nil {
+		return namespace, true
+	} else {
+		return nil, false
+	}
 }
 
 func selectors() (labels.Selector, fields.Selector) {
@@ -50,6 +60,7 @@ func newFakeClient(_ *zap.Logger, apiCfg k8sconfig.APIConfig, rules kube.Extract
 	ls, fs := selectors()
 	return &fakeClient{
 		Pods:     map[string]*kube.Pod{},
+		Namespaces: map[string]*kube.Namespace{},
 		Rules:    rules,
 		Filters:  filters,
 		Informer: kube.NewFakeInformer(cs, "", ls, fs),

--- a/processor/k8sprocessor/config.go
+++ b/processor/k8sprocessor/config.go
@@ -42,6 +42,22 @@ type Config struct {
 }
 
 // ExtractConfig section allows specifying extraction rules to extract
+// data from k8s namespace specs.
+type NamespaceExtractConfig struct {
+	// Annotations allows extracting data from namespace annotations and record it
+	// as resource attributes.
+	// It is a list of FieldExtractConfig type. See FieldExtractConfig
+	// documentation for more details.
+	Annotations []FieldExtractConfig `mapstructure:"annotations"`
+
+	// Annotations allows extracting data from namespace labels and record it
+	// as resource attributes.
+	// It is a list of FieldExtractConfig type. See FieldExtractConfig
+	// documentation for more details.
+	Labels []FieldExtractConfig `mapstructure:"labels"`
+}
+
+// ExtractConfig section allows specifying extraction rules to extract
 // data from k8s pod specs.
 type ExtractConfig struct {
 	// Metadata allows to extract pod metadata from a list of metadata fields.
@@ -65,6 +81,9 @@ type ExtractConfig struct {
 	// It is a list of FieldExtractConfig type. See FieldExtractConfig
 	// documentation for more details.
 	Labels []FieldExtractConfig `mapstructure:"labels"`
+
+	// Namespace allows extracting data from namespace labels and annotations.
+	Namespace NamespaceExtractConfig `mapstructure:"namespace"`
 }
 
 // FieldExtractConfig allows specifying an extraction rule to extract a value from exactly one field.

--- a/processor/k8sprocessor/config.go
+++ b/processor/k8sprocessor/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	Filter FilterConfig `mapstructure:"filter"`
 }
 
-// ExtractConfig section allows specifying extraction rules to extract
+// NamespaceExtractConfig section allows specifying extraction rules to extract
 // data from k8s namespace specs.
 type NamespaceExtractConfig struct {
 	// Annotations allows extracting data from namespace annotations and record it

--- a/processor/k8sprocessor/config.go
+++ b/processor/k8sprocessor/config.go
@@ -50,7 +50,7 @@ type NamespaceExtractConfig struct {
 	// documentation for more details.
 	Annotations []FieldExtractConfig `mapstructure:"annotations"`
 
-	// Annotations allows extracting data from namespace labels and record it
+	// Labels allows extracting data from namespace labels and record it
 	// as resource attributes.
 	// It is a list of FieldExtractConfig type. See FieldExtractConfig
 	// documentation for more details.

--- a/processor/k8sprocessor/config_test.go
+++ b/processor/k8sprocessor/config_test.go
@@ -74,9 +74,9 @@ func TestLoadConfig(t *testing.T) {
 					{TagName: "l1", Key: "label1"},
 					{TagName: "l2", Key: "label2", Regex: "field=(?P<value>.+)"},
 				},
-				Namespace:NamespaceExtractConfig{
+				Namespace: NamespaceExtractConfig{
 					Annotations: nil,
-					Labels:      []FieldExtractConfig{
+					Labels: []FieldExtractConfig{
 						{TagName: "testing.asset_id", Key: "test.asset_id"},
 					},
 				},

--- a/processor/k8sprocessor/config_test.go
+++ b/processor/k8sprocessor/config_test.go
@@ -77,7 +77,7 @@ func TestLoadConfig(t *testing.T) {
 				Namespace:NamespaceExtractConfig{
 					Annotations: nil,
 					Labels:      []FieldExtractConfig{
-						{TagName: "intuit.asset_id", Key: "intuit.asset_id"},
+						{TagName: "testing.asset_id", Key: "test.asset_id"},
 					},
 				},
 			},

--- a/processor/k8sprocessor/config_test.go
+++ b/processor/k8sprocessor/config_test.go
@@ -74,6 +74,12 @@ func TestLoadConfig(t *testing.T) {
 					{TagName: "l1", Key: "label1"},
 					{TagName: "l2", Key: "label2", Regex: "field=(?P<value>.+)"},
 				},
+				Namespace:NamespaceExtractConfig{
+					Annotations: nil,
+					Labels:      []FieldExtractConfig{
+						{TagName: "intuit.asset_id", Key: "intuit.asset_id"},
+					},
+				},
 			},
 			Filter: FilterConfig{
 				Namespace:      "ns2",

--- a/processor/k8sprocessor/factory.go
+++ b/processor/k8sprocessor/factory.go
@@ -85,6 +85,8 @@ func createProcessorOpts(cfg configmodels.Processor) []Option {
 	opts = append(opts, WithExtractMetadata(oCfg.Extract.Metadata...))
 	opts = append(opts, WithExtractLabels(oCfg.Extract.Labels...))
 	opts = append(opts, WithExtractAnnotations(oCfg.Extract.Annotations...))
+	opts = append(opts, WithExtractNamespace(oCfg.Extract.Namespace))
+
 
 	// filters
 	opts = append(opts, WithFilterNode(oCfg.Filter.Node, oCfg.Filter.NodeFromEnvVar))

--- a/processor/k8sprocessor/factory.go
+++ b/processor/k8sprocessor/factory.go
@@ -87,7 +87,6 @@ func createProcessorOpts(cfg configmodels.Processor) []Option {
 	opts = append(opts, WithExtractAnnotations(oCfg.Extract.Annotations...))
 	opts = append(opts, WithExtractNamespace(oCfg.Extract.Namespace))
 
-
 	// filters
 	opts = append(opts, WithFilterNode(oCfg.Filter.Node, oCfg.Filter.NodeFromEnvVar))
 	opts = append(opts, WithFilterNamespace(oCfg.Filter.Namespace))

--- a/processor/k8sprocessor/kube/client.go
+++ b/processor/k8sprocessor/kube/client.go
@@ -107,26 +107,29 @@ func (c *WatchClient) Start() {
 }
 
 func (c *WatchClient) handleNamespaceAdd(obj interface{}) {
+	observability.RecordNamespaceAdded()
 	if namespace, ok := obj.(*api_v1.Namespace); ok {
 		c.addOrUpdateNamespace(namespace)
 	} else {
-
+		c.logger.Error("object received was not of type api_v1.Namespace", zap.Any("received", obj))
 	}
 }
 
 func (c *WatchClient) handleNamespaceUpdate(old, obj interface{}) {
+	observability.RecordNamespaceUpdated()
 	if namespace, ok := obj.(*api_v1.Namespace); ok {
 		c.addOrUpdateNamespace(namespace)
 	} else {
-
+		c.logger.Error("object received was not of type api_v1.Namespace", zap.Any("received", obj))
 	}
 }
 
 func (c *WatchClient) handleNamespaceDelete(obj interface{}) {
+	observability.RecordNamespaceDeleted()
 	if namespace, ok := obj.(*api_v1.Namespace); ok {
 		delete(c.Namespaces, namespace.Name)
 	} else {
-
+		c.logger.Error("object received was not of type api_v1.Namespace", zap.Any("received", obj))
 	}
 }
 

--- a/processor/k8sprocessor/kube/client.go
+++ b/processor/k8sprocessor/kube/client.go
@@ -35,20 +35,20 @@ import (
 
 // WatchClient is the main interface provided by this package to a kubernetes cluster.
 type WatchClient struct {
-	m               sync.RWMutex
-	deleteMut       sync.Mutex
-	logger          *zap.Logger
-	kc              kubernetes.Interface
-	informer        cache.SharedInformer
+	m                 sync.RWMutex
+	deleteMut         sync.Mutex
+	logger            *zap.Logger
+	kc                kubernetes.Interface
+	informer          cache.SharedInformer
 	namespaceInformer cache.SharedInformer
-	deploymentRegex *regexp.Regexp
-	deleteQueue     []deleteRequest
-	stopCh          chan struct{}
+	deploymentRegex   *regexp.Regexp
+	deleteQueue       []deleteRequest
+	stopCh            chan struct{}
 
-	Pods    map[string]*Pod
+	Pods       map[string]*Pod
 	Namespaces map[string]*Namespace
-	Rules   ExtractionRules
-	Filters Filters
+	Rules      ExtractionRules
+	Filters    Filters
 }
 
 // Extract deployment name from the pod name. Pod name is created using
@@ -61,7 +61,7 @@ func New(logger *zap.Logger, apiCfg k8sconfig.APIConfig, rules ExtractionRules, 
 	go c.deleteLoop(time.Second*30, defaultPodDeleteGracePeriod)
 
 	c.Pods = map[string]*Pod{}
-	c.Namespaces= map[string]*Namespace{}
+	c.Namespaces = map[string]*Namespace{}
 	if newClientSet == nil {
 		newClientSet = k8sconfig.MakeClient
 	}
@@ -133,7 +133,6 @@ func (c *WatchClient) handleNamespaceDelete(obj interface{}) {
 		c.logger.Error("object received was not of type api_v1.Namespace", zap.Any("received", obj))
 	}
 }
-
 
 // Stop signals the the k8s watcher/informer to stop watching for new events.
 func (c *WatchClient) Stop() {
@@ -349,7 +348,7 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 
 func (c *WatchClient) addOrUpdateNamespace(namespace *api_v1.Namespace) {
 	newNamespace := &Namespace{
-		Name:      namespace.Name,
+		Name:       namespace.Name,
 		Attributes: c.extractNamespaceAttributes(namespace),
 	}
 	c.Namespaces[namespace.Name] = newNamespace

--- a/processor/k8sprocessor/kube/client.go
+++ b/processor/k8sprocessor/kube/client.go
@@ -61,6 +61,7 @@ func New(logger *zap.Logger, apiCfg k8sconfig.APIConfig, rules ExtractionRules, 
 	go c.deleteLoop(time.Second*30, defaultPodDeleteGracePeriod)
 
 	c.Pods = map[string]*Pod{}
+	c.Namespaces= map[string]*Namespace{}
 	if newClientSet == nil {
 		newClientSet = k8sconfig.MakeClient
 	}

--- a/processor/k8sprocessor/kube/client_test.go
+++ b/processor/k8sprocessor/kube/client_test.go
@@ -107,7 +107,7 @@ func TestBadFilters(t *testing.T) {
 
 func TestClientStartStop(t *testing.T) {
 	c, _ := newTestClient(t)
-	ctr := c.informer.GetController()
+	ctr := c.podInformer.GetController()
 	require.IsType(t, &FakeController{}, ctr)
 	fctr := ctr.(*FakeController)
 	require.NotNil(t, fctr)
@@ -474,7 +474,7 @@ func TestFilters(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c, _ := newTestClientWithRulesAndFilters(t, ExtractionRules{}, tc.filters)
-			inf := c.informer.(*FakeInformer)
+			inf := c.podInformer.(*FakeInformer)
 			assert.Equal(t, tc.filters.Namespace, inf.namespace)
 			assert.Equal(t, tc.labels, inf.labelSelector.String())
 			assert.Equal(t, tc.fields, inf.fieldSelector.String())

--- a/processor/k8sprocessor/kube/client_test.go
+++ b/processor/k8sprocessor/kube/client_test.go
@@ -570,11 +570,14 @@ func TestNamespaceUpdate(t *testing.T) {
 
 func TestNamespaceDelete(t *testing.T) {
 	c, _ := newTestClient(t)
+	ns := &api_v1.Namespace{}
 	namespaceAddAndUpdateTest(t, c, func(obj interface{}) {
-		assert.Equal(t, len(c.Namespaces), 1)
-		c.handleNamespaceDelete(obj)
-		assert.Equal(t, len(c.Namespaces), 0)
+		c.handleNamespaceAdd(obj)
+		ns = obj.(*api_v1.Namespace)
 	})
+	assert.Equal(t, len(c.Namespaces), 1)
+	c.handleNamespaceDelete(ns)
+	assert.Equal(t, len(c.Namespaces), 0)
 }
 
 func Test_extractField(t *testing.T) {

--- a/processor/k8sprocessor/kube/informer.go
+++ b/processor/k8sprocessor/kube/informer.go
@@ -101,4 +101,3 @@ func namespaceInformerWatchFuncWithSelectors(client kubernetes.Interface, namesp
 		return client.CoreV1().Namespaces().Watch(opts)
 	}
 }
-

--- a/processor/k8sprocessor/kube/kube.go
+++ b/processor/k8sprocessor/kube/kube.go
@@ -52,6 +52,7 @@ var (
 // Client defines the main interface that allows querying pods by metadata.
 type Client interface {
 	GetPodByIP(string) (*Pod, bool)
+	GetNamespace(string) (*Namespace, bool)
 	Start()
 	Stop()
 }
@@ -68,10 +69,16 @@ type Pod struct {
 	Name       string
 	Address    string
 	Attributes map[string]string
+	Namespace  string
 	StartTime  *metav1.Time
 	Ignore     bool
 
 	DeletedAt time.Time
+}
+
+type Namespace struct {
+	Name       string
+	Attributes map[string]string
 }
 
 type deleteRequest struct {
@@ -104,6 +111,11 @@ type FieldFilter struct {
 	Op selection.Operator
 }
 
+type NamespaceRules struct {
+	Annotations []FieldExtractionRule
+	Labels      []FieldExtractionRule
+}
+
 // ExtractionRules is used to specify the information that needs to be extracted
 // from pods and added to the spans as tags.
 type ExtractionRules struct {
@@ -117,6 +129,8 @@ type ExtractionRules struct {
 
 	Annotations []FieldExtractionRule
 	Labels      []FieldExtractionRule
+
+	NamespaceRules NamespaceRules
 }
 
 // FieldExtractionRule is used to specify which fields to extract from pod fields

--- a/processor/k8sprocessor/observability/observability.go
+++ b/processor/k8sprocessor/observability/observability.go
@@ -38,6 +38,11 @@ var (
 	mPodsAdded   = stats.Int64("otelsvc/k8s/pod_added", "Number of pod add events received", "1")
 	mPodsDeleted = stats.Int64("otelsvc/k8s/pod_deleted", "Number of pod delete events received", "1")
 
+	mNamespacesAdded = stats.Int64("otelsvc/k8s/namespace_added", "Number of namespace add events received", "1")
+	mNamespacesUpdated = stats.Int64("otelsvc/k8s/namespace_updated", "Number of namespace update events received", "1")
+	mNamespacesDeleted = stats.Int64("otelsvc/k8s/namespace_deleted", "Number of namespace delete events received", "1")
+
+
 	mIPLookupMiss = stats.Int64("otelsvc/k8s/ip_lookup_miss", "Number of times pod by IP lookup failed.", "1")
 )
 
@@ -74,7 +79,7 @@ func RecordPodUpdated() {
 	stats.Record(context.Background(), mPodsUpdated.M(int64(1)))
 }
 
-// RecordPodAdded increments the metric that records pod add events receiver.
+// RecordPodAdded increments the metric that records pod add events received.
 func RecordPodAdded() {
 	stats.Record(context.Background(), mPodsAdded.M(int64(1)))
 }
@@ -83,6 +88,22 @@ func RecordPodAdded() {
 func RecordPodDeleted() {
 	stats.Record(context.Background(), mPodsDeleted.M(int64(1)))
 }
+
+// RecordNamespaceAdded increments the metric that records namespace add events received.
+func RecordNamespaceAdded() {
+	stats.Record(context.Background(), mNamespacesAdded.M(int64(1)))
+}
+
+// RecordNamespaceUpdated increments the metric that records namespace update events received.
+func RecordNamespaceUpdated() {
+	stats.Record(context.Background(), mNamespacesUpdated.M(int64(1)))
+}
+
+// RecordNamespaceDeleted increments the metric that records namespace delete events received.
+func RecordNamespaceDeleted() {
+	stats.Record(context.Background(), mNamespacesDeleted.M(int64(1)))
+}
+
 
 // RecordIPLookupMiss increments the metric that records Pod lookup by IP misses.
 func RecordIPLookupMiss() {

--- a/processor/k8sprocessor/observability/observability.go
+++ b/processor/k8sprocessor/observability/observability.go
@@ -38,10 +38,9 @@ var (
 	mPodsAdded   = stats.Int64("otelsvc/k8s/pod_added", "Number of pod add events received", "1")
 	mPodsDeleted = stats.Int64("otelsvc/k8s/pod_deleted", "Number of pod delete events received", "1")
 
-	mNamespacesAdded = stats.Int64("otelsvc/k8s/namespace_added", "Number of namespace add events received", "1")
+	mNamespacesAdded   = stats.Int64("otelsvc/k8s/namespace_added", "Number of namespace add events received", "1")
 	mNamespacesUpdated = stats.Int64("otelsvc/k8s/namespace_updated", "Number of namespace update events received", "1")
 	mNamespacesDeleted = stats.Int64("otelsvc/k8s/namespace_deleted", "Number of namespace delete events received", "1")
-
 
 	mIPLookupMiss = stats.Int64("otelsvc/k8s/ip_lookup_miss", "Number of times pod by IP lookup failed.", "1")
 )
@@ -103,7 +102,6 @@ func RecordNamespaceUpdated() {
 func RecordNamespaceDeleted() {
 	stats.Record(context.Background(), mNamespacesDeleted.M(int64(1)))
 }
-
 
 // RecordIPLookupMiss increments the metric that records Pod lookup by IP misses.
 func RecordIPLookupMiss() {

--- a/processor/k8sprocessor/observability/observability_test.go
+++ b/processor/k8sprocessor/observability/observability_test.go
@@ -75,6 +75,18 @@ func TestMetrics(t *testing.T) {
 			RecordPodUpdated,
 		},
 		{
+			"otelsvc/k8s/namespace_added",
+			RecordNamespaceAdded,
+		},
+		{
+			"otelsvc/k8s/namespace_deleted",
+			RecordNamespaceDeleted,
+		},
+		{
+			"otelsvc/k8s/namespace_updated",
+			RecordNamespaceUpdated,
+		},
+		{
 			"otelsvc/k8s/ip_lookup_miss",
 			RecordIPLookupMiss,
 		},

--- a/processor/k8sprocessor/options.go
+++ b/processor/k8sprocessor/options.go
@@ -108,7 +108,7 @@ func WithExtractNamespace(config NamespaceExtractConfig) Option {
 			return err
 		}
 
-		annotations, err := extractFieldRules("annotation", config.Labels...)
+		annotations, err := extractFieldRules("annotation", config.Annotations...)
 		if err != nil {
 			return err
 		}

--- a/processor/k8sprocessor/options.go
+++ b/processor/k8sprocessor/options.go
@@ -101,6 +101,25 @@ func WithExtractMetadata(fields ...string) Option {
 	}
 }
 
+func WithExtractNamespace(config NamespaceExtractConfig) Option {
+	return func(p *kubernetesprocessor) error {
+		labels, err := extractFieldRules("label", config.Labels...)
+		if err != nil {
+			return err
+		}
+
+		annotations, err := extractFieldRules("annotation", config.Labels...)
+		if err != nil {
+			return err
+		}
+		p.rules.NamespaceRules = kube.NamespaceRules{
+			Annotations: annotations,
+			Labels:      labels,
+		}
+		return nil
+	}
+}
+
 // WithExtractLabels allows specifying options to control extraction of pod labels.
 func WithExtractLabels(labels ...FieldExtractConfig) Option {
 	return func(p *kubernetesprocessor) error {

--- a/processor/k8sprocessor/options_test.go
+++ b/processor/k8sprocessor/options_test.go
@@ -576,7 +576,7 @@ func TestWithExtractNamespace(t *testing.T) {
 			"empty",
 			NamespaceExtractConfig{},
 			kube.NamespaceRules{
-				Labels: []kube.FieldExtractionRule{},
+				Labels:      []kube.FieldExtractionRule{},
 				Annotations: []kube.FieldExtractionRule{},
 			},
 			"",
@@ -595,7 +595,7 @@ func TestWithExtractNamespace(t *testing.T) {
 				Labels: []kube.FieldExtractionRule{
 					{
 						Name: "test",
-						Key: "foo",
+						Key:  "foo",
 					},
 				},
 				Annotations: []kube.FieldExtractionRule{},
@@ -616,7 +616,7 @@ func TestWithExtractNamespace(t *testing.T) {
 				Annotations: []kube.FieldExtractionRule{
 					{
 						Name: "test",
-						Key: "foo",
+						Key:  "foo",
 					},
 				},
 				Labels: []kube.FieldExtractionRule{},

--- a/processor/k8sprocessor/options_test.go
+++ b/processor/k8sprocessor/options_test.go
@@ -564,3 +564,82 @@ func Test_extractFieldRules(t *testing.T) {
 		})
 	}
 }
+
+func TestWithExtractNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      NamespaceExtractConfig
+		want      kube.NamespaceRules
+		wantError string
+	}{
+		{
+			"empty",
+			NamespaceExtractConfig{},
+			kube.NamespaceRules{
+				Labels: []kube.FieldExtractionRule{},
+				Annotations: []kube.FieldExtractionRule{},
+			},
+			"",
+		},
+		{
+			"single label",
+			NamespaceExtractConfig{
+				Labels: []FieldExtractConfig{
+					{
+						TagName: "test",
+						Key:     "foo",
+					},
+				},
+			},
+			kube.NamespaceRules{
+				Labels: []kube.FieldExtractionRule{
+					{
+						Name: "test",
+						Key: "foo",
+					},
+				},
+				Annotations: []kube.FieldExtractionRule{},
+			},
+			"",
+		},
+		{
+			"single annotation",
+			NamespaceExtractConfig{
+				Annotations: []FieldExtractConfig{
+					{
+						TagName: "test",
+						Key:     "foo",
+					},
+				},
+			},
+			kube.NamespaceRules{
+				Annotations: []kube.FieldExtractionRule{
+					{
+						Name: "test",
+						Key: "foo",
+					},
+				},
+				Labels: []kube.FieldExtractionRule{},
+			},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &kubernetesprocessor{}
+			option := WithExtractNamespace(tt.args)
+			err := option(p)
+			if tt.wantError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.Equal(t, err.Error(), tt.wantError)
+				return
+			}
+			got := p.rules.NamespaceRules
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WithExtractLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/processor/k8sprocessor/processor_test.go
+++ b/processor/k8sprocessor/processor_test.go
@@ -323,8 +323,8 @@ func TestTraceProcessorAddNamespaceLabels(t *testing.T) {
 		},
 		"2": {},
 	}
-	kc.Namespaces = map[string]*kube.Namespace {
-		"default": &kube.Namespace{Name:"default", Attributes:map[string]string{"ns-test": "foo"}},
+	kc.Namespaces = map[string]*kube.Namespace{
+		"default": {Name: "default", Attributes: map[string]string{"ns-test": "foo"}},
 	}
 	for ip, attrs := range tests {
 		kc.Pods[ip] = &kube.Pod{Attributes: attrs, Namespace: "default"}

--- a/processor/k8sprocessor/testdata/config.yaml
+++ b/processor/k8sprocessor/testdata/config.yaml
@@ -29,6 +29,10 @@ processors:
         - tag_name: l2 # extracts value of label with key `label1` with regexp and inserts it as a tag with key `l2`
           key: label2
           regex: field=(?P<value>.+)
+      namespace:
+        labels:
+          - tag_name: intuit.asset_id
+            key: intuit.asset_id
 
     filter:
       namespace: ns2 # only look for pods running in ns2 namespace

--- a/processor/k8sprocessor/testdata/config.yaml
+++ b/processor/k8sprocessor/testdata/config.yaml
@@ -34,6 +34,7 @@ processors:
           - tag_name: testing.asset_id
             key: test.asset_id
 
+
     filter:
       namespace: ns2 # only look for pods running in ns2 namespace
       node: ip-111.us-west-2.compute.internal # only look for pods running on this node/host

--- a/processor/k8sprocessor/testdata/config.yaml
+++ b/processor/k8sprocessor/testdata/config.yaml
@@ -31,8 +31,8 @@ processors:
           regex: field=(?P<value>.+)
       namespace:
         labels:
-          - tag_name: intuit.asset_id
-            key: intuit.asset_id
+          - tag_name: testing.asset_id
+            key: test.asset_id
 
     filter:
       namespace: ns2 # only look for pods running in ns2 namespace


### PR DESCRIPTION
**Description:**
Adds support to the K8S processor for tagging attributes that are on the Namespace of Pods that send spans. 
**Link to tracking Issue:** #378 

**Testing:**
- Unit tests added for options/config/processor
**Documentation:**
- Comments added to new structs / methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-telemetry/opentelemetry-collector-contrib/389)
<!-- Reviewable:end -->
