### PR TITLE
Resolve race condition with resource detection parallel test

### DIFF
--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -167,10 +167,8 @@ func TestDetectResource_Parallel(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		go func() {
 			defer wg.Done()
-			got, err := p.Get(context.Background())
+			_, err := p.Get(context.Background())
 			require.NoError(t, err)
-			got.Attributes().Sort()
-			assert.Equal(t, expectedResource, got)
 		}()
 	}
 


### PR DESCRIPTION
**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/386

This was performing a `Sort` of the attributes of the same "cached" resource across goroutines. Removed this sort and the associated assertions related to the returned object. We are validating the returned data in other tests, so can just ignore it in this test which is for validating the number of calls to "Detect".

**Testing:** Ran the test for 5 mins with no race conditions detected