### PR TITLE
Increase CPU limits for some stability tests

### DIFF
--- a/testbed/stabilitytests/metric_test.go
+++ b/testbed/stabilitytests/metric_test.go
@@ -45,7 +45,7 @@ func TestStabilityMetricsOpenCensus(t *testing.T) {
 		testbed.NewOCMetricDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 		testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 		testbed.ResourceSpec{
-			ExpectedMaxCPU:      45,
+			ExpectedMaxCPU:      50,
 			ExpectedMaxRAM:      86,
 			ResourceCheckPeriod: resourceCheckPeriod,
 		},

--- a/testbed/stabilitytests/trace_test.go
+++ b/testbed/stabilitytests/trace_test.go
@@ -68,7 +68,7 @@ func TestStabilityTracesSAPM(t *testing.T) {
 		datasenders.NewSapmDataSender(testbed.GetAvailablePort(t)),
 		datareceivers.NewSapmDataReceiver(testbed.GetAvailablePort(t)),
 		testbed.ResourceSpec{
-			ExpectedMaxCPU:      24,
+			ExpectedMaxCPU:      28,
 			ExpectedMaxRAM:      100,
 			ResourceCheckPeriod: resourceCheckPeriod,
 		},


### PR DESCRIPTION
**Description:**:
Bump CPU limits for SAPM traces and OC metrics stability tests to align with the unstable CircleCI environment and avoid sporadic stability tests failures like these: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/369 , https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/354