### PR TITLE
Fix jaeger legacy and kubeletstats metric receivers

### DIFF
--- a/receiver/jaegerlegacyreceiver/factory.go
+++ b/receiver/jaegerlegacyreceiver/factory.go
@@ -135,6 +135,7 @@ func (f *Factory) CreateTraceReceiver(
 
 // CreateMetricsReceiver creates a metrics receiver based on provided config.
 func (f *Factory) CreateMetricsReceiver(
+	ctx context.Context,
 	logger *zap.Logger,
 	cfg configmodels.Receiver,
 	consumer consumer.MetricsConsumer,

--- a/receiver/jaegerlegacyreceiver/factory_test.go
+++ b/receiver/jaegerlegacyreceiver/factory_test.go
@@ -50,7 +50,7 @@ func TestCreateReceiver(t *testing.T) {
 	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
-	mReceiver, err := factory.CreateMetricsReceiver(zap.NewNop(), cfg, nil)
+	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), zap.NewNop(), cfg, nil)
 	assert.Equal(t, err, configerror.ErrDataTypeIsNotSupported)
 	assert.Nil(t, mReceiver)
 }

--- a/receiver/kubeletstatsreceiver/factory.go
+++ b/receiver/kubeletstatsreceiver/factory.go
@@ -67,6 +67,7 @@ func (f *Factory) CreateTraceReceiver(
 }
 
 func (f *Factory) CreateMetricsReceiver(
+	ctx context.Context,
 	logger *zap.Logger,
 	cfg configmodels.Receiver,
 	consumer consumer.MetricsConsumerOld,

--- a/receiver/kubeletstatsreceiver/factory_test.go
+++ b/receiver/kubeletstatsreceiver/factory_test.go
@@ -56,6 +56,7 @@ func TestCreateTraceReceiver(t *testing.T) {
 func TestCreateMetricsReceiver(t *testing.T) {
 	factory := &Factory{}
 	metricsReceiver, err := factory.CreateMetricsReceiver(
+		context.Background(),
 		zap.NewNop(),
 		tlsConfig(),
 		&testbed.MockMetricConsumer{},
@@ -73,7 +74,7 @@ func TestFactoryBadAuthType(t *testing.T) {
 			},
 		},
 	}
-	_, err := factory.CreateMetricsReceiver(zap.NewNop(), cfg, &testbed.MockMetricConsumer{})
+	_, err := factory.CreateMetricsReceiver(context.Background(), zap.NewNop(), cfg, &testbed.MockMetricConsumer{})
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
**Description:**
The jaeger legacy and kubeletstats receivers were not updated to the latest change in the ReceiverFactoryOld interface https://github.com/open-telemetry/opentelemetry-collector/commit/2f6d6039d2d5ac7b9bd6ed77f017766a0efa1c64