### PR TITLE
Fix nil pointer exception in kubeletstats receiver

### DIFF
--- a/receiver/kubeletstatsreceiver/kubelet/utils.go
+++ b/receiver/kubeletstatsreceiver/kubelet/utils.go
@@ -59,5 +59,7 @@ func labels(labels map[string]string, descriptions map[string]string) (
 }
 
 func applyLabels(metric *metricspb.Metric, attrs map[string]string) {
-	metric.MetricDescriptor.LabelKeys, metric.Timeseries[0].LabelValues = labels(attrs, nil)
+	if metric != nil {
+		metric.MetricDescriptor.LabelKeys, metric.Timeseries[0].LabelValues = labels(attrs, nil)
+	}
 }


### PR DESCRIPTION
**Description:**
Looks like some stats can be absent for the pods that are just created. And it causes crashing the otel agent with nil pointer exception.

Stacktrace:
```
goroutine 93 [running]:
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/kubelet.applyLabels(...)
	/home/circleci/project/receiver/kubeletstatsreceiver/kubelet/utils.go:62
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/kubelet.rxBytesMetric(0x2b05180, 0x8, 0xc00f0caae0, 0xc00064edb8)
	/home/circleci/project/receiver/kubeletstatsreceiver/kubelet/network.go:34 +0x1d7
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/kubelet.networkMetrics(0x2b05180, 0x8, 0xc00f0caae0, 0xc00edcff00, 0x3, 0x3)
	/home/circleci/project/receiver/kubeletstatsreceiver/kubelet/network.go:25 +0x43
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/kubelet.(*metricDataAccumulator).podStats(0xc00d999ac0, 0xc00f1a7d80, 0xc00eff3380, 0x27, 0xc00edd5120, 0x11, 0xc00eff33b0, 0x24, 0x0, 0xed695ea54, ...)
	/home/circleci/project/receiver/kubeletstatsreceiver/kubelet/accumulator.go:57 +0x156
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/kubelet.MetricsData(0xc00e3493b0, 0x2b0c3e3, 0xc, 0x0, 0x2afeeb0, 0x4)
	/home/circleci/project/receiver/kubeletstatsreceiver/kubelet/metrics.go:28 +0x392
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver.(*runnable).Run(0xc00e177140, 0xc00e1f4f50, 0xc00e1f4f01)
	/home/circleci/project/receiver/kubeletstatsreceiver/runnable.go:68 +0x101
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver/interval.(*Runner).run(0xc00e1c5420, 0x0, 0x0)
	/home/circleci/project/receiver/redisreceiver/interval/interval_runner.go:74 +0xba
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver/interval.(*Runner).Start(0xc00e1c5420, 0x0, 0x0)
	/home/circleci/project/receiver/redisreceiver/interval/interval_runner.go:54 +0x4c
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver.(*receiver).Start.func1(0xc00e176d40, 0x303bd20, 0xc0001bef00)
	/home/circleci/project/receiver/kubeletstatsreceiver/receiver.go:47 +0x2f
created by github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver.(*receiver).Start
	/home/circleci/project/receiver/kubeletstatsreceiver/receiver.go:46 +0x1d7
```