### PR TITLE
k8sclusterreceiver: Fix container resource metrics

### DIFF
--- a/receiver/k8sclusterreceiver/collection/pods_test.go
+++ b/receiver/k8sclusterreceiver/collection/pods_test.go
@@ -73,11 +73,11 @@ func TestPodAndContainerMetrics(t *testing.T) {
 	testutils.AssertMetrics(t, *rm.metrics[1], "k8s/container/ready",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1)
 
-	testutils.AssertMetricsWithLabels(t, *rm.metrics[2], "k8s/container/request",
-		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "cpu"}, 10000)
+	testutils.AssertMetrics(t, *rm.metrics[2], "k8s/container/cpu/request",
+		metricspb.MetricDescriptor_GAUGE_INT64, 10000)
 
-	testutils.AssertMetricsWithLabels(t, *rm.metrics[3], "k8s/container/limit",
-		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "cpu"}, 20000)
+	testutils.AssertMetrics(t, *rm.metrics[3], "k8s/container/cpu/limit",
+		metricspb.MetricDescriptor_GAUGE_INT64, 20000)
 }
 
 func TestPodAndContainerMetadata(t *testing.T) {


### PR DESCRIPTION
**Description:** Split container resource metrics by resource type. Currently the `k8s_cluster` receiver dimensionalizes resource metrics with `resource` as label on the `k8s/container/limit` and `k8s/container/request`. This would result in measurements with different units being sent in as a single metric. Updated to have separate metrics per resource, i.e., now the receiver would emit `k8s/container/cpu/limit`, `k8s/container/cpu/request`, `k8s/container/memory/limit` and so on for each resource.

**Testing:** Updated unit tests.