### PR TITLE
gcp detector

### DIFF
--- a/detector/aws/aws.go
+++ b/detector/aws/aws.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws

--- a/detector/gcp/gcp.go
+++ b/detector/gcp/gcp.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
-
 	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/standard"
 	"go.opentelemetry.io/otel/sdk/resource"

--- a/detector/gcp/gcp.go
+++ b/detector/gcp/gcp.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"cloud.google.com/go/compute/metadata"
+	"github.com/open-telemetry/opentelemetry-go/blob/master/api/standard/resource.go"
+
+	"go.opentelemetry.io/otel/api/kv"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+// GCP is a detector that implements Detect() function
+type GCP struct{}
+
+// Detect detects associated resources when running on GCE hosts.
+func (gcp *GCP) Detect(ctx context.Context) (*resource.Resource, error) {
+	if !metadata.OnGCE() {
+		return nil, nil
+	}
+
+	labels := []kv.KeyValue{}
+
+	labels = append(labels, kv.String(CloudKeyProvider, CloudProviderGCP))
+
+	projectID, err := metadata.ProjectID()
+	logError(err)
+	if projectID != "" {
+		labels = append(labels, kv.String(CloudKeyAccountID, projectID))
+	}
+
+	zone, err := metadata.Zone()
+	logError(err)
+	if zone != "" {
+		labels = append(labels, kv.String(CloudZoneKey, zone))
+	}
+
+	labels = append(labels, kv.String(CloudRegionKey, ""))
+
+	instanceID, err := metadata.InstanceID()
+	logError(err)
+	if instanceID != "" {
+		labels = append(labels, kv.String(HostIDKey, instanceID))
+	}
+
+	name, err := metadata.InstanceName()
+	logError(err)
+	if instanceID != "" {
+		labels = append(labels, kv.String(HostNameKey, name))
+	}
+
+	hostname, err := metadata.Hostname()
+	logError(err)
+	if instanceID != "" {
+		labels = append(labels, kv.String(HostHostNameKey, hostname))
+	}
+
+	hostType, err := metadata.Get("instance/machine-type")
+	logError(err)
+	if instanceID != "" {
+		labels = append(labels, kv.String(HostTypeKey, hostType))
+	}
+
+	return resource.New(labels...), nil
+
+}
+
+//logError logs error only if the error is present and it is not 'not defined'
+func logError(err error) {
+	if err != nil {
+		if !strings.Contains(err.Error(), "not defined") {
+			log.Printf("Error retrieving gcp metadata: %v", err)
+		}
+	}
+}

--- a/detector/gcp/gcp.go
+++ b/detector/gcp/gcp.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 
 	"cloud.google.com/go/compute/metadata"
-	"github.com/open-telemetry/opentelemetry-go/blob/master/api/standard/resource.go"
 
 	"go.opentelemetry.io/otel/api/kv"
+	"go.opentelemetry.io/otel/api/standard"
 	"go.opentelemetry.io/otel/sdk/resource"
 )
 
@@ -37,44 +37,44 @@ func (gcp *GCP) Detect(ctx context.Context) (*resource.Resource, error) {
 
 	labels := []kv.KeyValue{}
 
-	labels = append(labels, kv.String(CloudKeyProvider, CloudProviderGCP))
+	labels = append(labels, standard.CloudProviderGCP)
 
 	projectID, err := metadata.ProjectID()
 	logError(err)
 	if projectID != "" {
-		labels = append(labels, kv.String(CloudKeyAccountID, projectID))
+		labels = append(labels, standard.CloudAccountIDKey.String(projectID))
 	}
 
 	zone, err := metadata.Zone()
 	logError(err)
 	if zone != "" {
-		labels = append(labels, kv.String(CloudZoneKey, zone))
+		labels = append(labels, standard.CloudZoneKey.String(zone))
 	}
 
-	labels = append(labels, kv.String(CloudRegionKey, ""))
+	labels = append(labels, standard.CloudRegionKey.String(""))
 
 	instanceID, err := metadata.InstanceID()
 	logError(err)
 	if instanceID != "" {
-		labels = append(labels, kv.String(HostIDKey, instanceID))
+		labels = append(labels, standard.HostIDKey.String(instanceID))
 	}
 
 	name, err := metadata.InstanceName()
 	logError(err)
 	if instanceID != "" {
-		labels = append(labels, kv.String(HostNameKey, name))
+		labels = append(labels, standard.HostNameKey.String(name))
 	}
 
 	hostname, err := metadata.Hostname()
 	logError(err)
 	if instanceID != "" {
-		labels = append(labels, kv.String(HostHostNameKey, hostname))
+		labels = append(labels, standard.HostHostNameKey.String(hostname))
 	}
 
 	hostType, err := metadata.Get("instance/machine-type")
 	logError(err)
 	if instanceID != "" {
-		labels = append(labels, kv.String(HostTypeKey, hostType))
+		labels = append(labels, standard.HostTypeKey.String(hostType))
 	}
 
 	return resource.New(labels...), nil

--- a/detector/gke/gke.go
+++ b/detector/gke/gke.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gke

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib
 go 1.14
 
 require (
+	cloud.google.com/go v0.49.0
 	github.com/client9/misspell v0.3.4
 	github.com/golangci/golangci-lint v1.28.1
 	github.com/google/addlicense v0.0.0-20200622132530-df58acafd6d5
@@ -39,6 +40,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tcnksm/ghr v0.13.0
 	go.opentelemetry.io/collector v0.5.1-0.20200708194928-7d7e0083f30b
+	go.opentelemetry.io/otel v0.6.0
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980
 	honnef.co/go/tools v0.0.1-2020.1.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1070,6 +1070,7 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/open-telemetry/opentelemetry-go v0.7.0 h1:kEVp5i6DT6MD4B8BtqUYWbJZa6es25C2mpDlCi0wiHw=
 github.com/open-telemetry/opentelemetry-proto v0.4.0 h1:7EGs7QkdnR039zcQv71/wPLeeUUzqpH855VEWN4IHTE=
 github.com/open-telemetry/opentelemetry-proto v0.4.0/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
In progress, but open to comment
This PR is the implementation of https://github.com/open-telemetry/opentelemetry-go/pull/924
aws.go and gke.go would work similarly as gcp.go.