### PR TITLE
observer extension: Add generic endpoint watcher

### DIFF
--- a/extension/observer/endpoints.go
+++ b/extension/observer/endpoints.go
@@ -16,10 +16,12 @@ package observer
 
 import "fmt"
 
+type EndpointID string
+
 // Endpoint is a service that can be contacted remotely.
 type Endpoint struct {
 	// ID uniquely identifies this endpoint.
-	ID string
+	ID EndpointID
 	// Target is an IP address or hostname of the endpoint.
 	Target string
 	// Details contains additional context about the endpoint such as a Pod or Port.
@@ -75,8 +77,9 @@ func EndpointToEnv(endpoint Endpoint) (EndpointEnv, error) {
 			"name":     o.Name,
 			"port":     o.Port,
 			"pod": map[string]interface{}{
-				"name":   o.Pod.Name,
-				"labels": o.Pod.Labels,
+				"name":        o.Pod.Name,
+				"labels":      o.Pod.Labels,
+				"annotations": o.Pod.Annotations,
 			},
 			"protocol": o.Protocol,
 		}, nil

--- a/extension/observer/endpoints.go
+++ b/extension/observer/endpoints.go
@@ -1,0 +1,87 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observer
+
+import "fmt"
+
+// Endpoint is a service that can be contacted remotely.
+type Endpoint struct {
+	// ID uniquely identifies this endpoint.
+	ID string
+	// Target is an IP address or hostname of the endpoint.
+	Target string
+	// Details contains additional context about the endpoint such as a Pod or Port.
+	Details interface{}
+}
+
+func (e *Endpoint) String() string {
+	return fmt.Sprintf("Endpoint{ID: %v, Target: %v, Details: %T%+v}", e.ID, e.Target, e.Details, e.Details)
+}
+
+// Pod is a discovered k8s pod.
+type Pod struct {
+	// Name of the pod.
+	Name string
+	// Labels is a map of user-specified metadata.
+	Labels map[string]string
+	// Annotations is a map of user-specified metadata.
+	Annotations map[string]string
+}
+
+// Port is an endpoint that has a target as well as a port.
+type Port struct {
+	Name     string
+	Pod      Pod
+	Port     uint16
+	Protocol Protocol
+}
+
+type EndpointEnv map[string]interface{}
+
+// EndpointToEnv converts an endpoint into a map suitable for expr evaluation.
+func EndpointToEnv(endpoint Endpoint) (EndpointEnv, error) {
+	ruleTypes := map[string]interface{}{
+		"port": false,
+		"pod":  false,
+	}
+
+	switch o := endpoint.Details.(type) {
+	case Pod:
+		ruleTypes["pod"] = true
+		return map[string]interface{}{
+			"type":        ruleTypes,
+			"endpoint":    endpoint.Target,
+			"name":        o.Name,
+			"labels":      o.Labels,
+			"annotations": o.Annotations,
+		}, nil
+	case Port:
+		ruleTypes["port"] = true
+		return map[string]interface{}{
+			"type":     ruleTypes,
+			"endpoint": endpoint.Target,
+			"name":     o.Name,
+			"port":     o.Port,
+			"pod": map[string]interface{}{
+				"name":   o.Pod.Name,
+				"labels": o.Pod.Labels,
+			},
+			"protocol": o.Protocol,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown endpoint details type %T", endpoint.Details)
+	}
+}

--- a/extension/observer/endpoints_test.go
+++ b/extension/observer/endpoints_test.go
@@ -1,0 +1,121 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEndpointToEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint Endpoint
+		want     EndpointEnv
+		wantErr  bool
+	}{
+		{
+			name: "Pod",
+			endpoint: Endpoint{
+				ID:     "pod_id",
+				Target: "192.68.73.2",
+				Details: Pod{
+					Name: "pod_name",
+					Labels: map[string]string{
+						"label_key": "label_val",
+					},
+					Annotations: map[string]string{
+						"annotation_1": "value_1",
+					},
+				},
+			},
+			want: EndpointEnv{
+				"type": map[string]interface{}{
+					"port": false,
+					"pod":  true,
+				},
+				"endpoint": "192.68.73.2",
+				"name":     "pod_name",
+				"labels": map[string]string{
+					"label_key": "label_val",
+				},
+				"annotations": map[string]string{
+					"annotation_1": "value_1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "K8s port",
+			endpoint: Endpoint{
+				ID:     "port_id",
+				Target: "192.68.73.2",
+				Details: Port{
+					Name: "port_name",
+					Pod: Pod{
+						Name: "pod_name",
+						Labels: map[string]string{
+							"label_key": "label_val",
+						},
+						Annotations: map[string]string{
+							"annotation_1": "value_1",
+						},
+					},
+					Port:     2379,
+					Protocol: ProtocolTCP,
+				},
+			},
+			want: EndpointEnv{
+				"type": map[string]interface{}{
+					"port": true,
+					"pod":  false,
+				},
+				"endpoint": "192.68.73.2",
+				"name":     "port_name",
+				"port":     uint16(2379),
+				"pod": map[string]interface{}{
+					"name": "pod_name",
+					"labels": map[string]string{
+						"label_key": "label_val",
+					},
+				},
+				"protocol": ProtocolTCP,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Unsupported endpoint",
+			endpoint: Endpoint{
+				ID:      "port_id",
+				Target:  "127.0.0.1:2379",
+				Details: map[string]interface{}{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EndpointToEnv(tt.endpoint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EndpointToEnv() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("EndpointToEnv() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/extension/observer/endpoints_test.go
+++ b/extension/observer/endpoints_test.go
@@ -29,7 +29,7 @@ func TestEndpointToEnv(t *testing.T) {
 		{
 			name: "Pod",
 			endpoint: Endpoint{
-				ID:     "pod_id",
+				ID:     EndpointID("pod_id"),
 				Target: "192.68.73.2",
 				Details: Pod{
 					Name: "pod_name",
@@ -60,7 +60,7 @@ func TestEndpointToEnv(t *testing.T) {
 		{
 			name: "K8s port",
 			endpoint: Endpoint{
-				ID:     "port_id",
+				ID:     EndpointID("port_id"),
 				Target: "192.68.73.2",
 				Details: Port{
 					Name: "port_name",
@@ -90,6 +90,9 @@ func TestEndpointToEnv(t *testing.T) {
 					"labels": map[string]string{
 						"label_key": "label_val",
 					},
+					"annotations": map[string]string{
+						"annotation_1": "value_1",
+					},
 				},
 				"protocol": ProtocolTCP,
 			},
@@ -98,7 +101,7 @@ func TestEndpointToEnv(t *testing.T) {
 		{
 			name: "Unsupported endpoint",
 			endpoint: Endpoint{
-				ID:      "port_id",
+				ID:      EndpointID("port_id"),
 				Target:  "127.0.0.1:2379",
 				Details: map[string]interface{}{},
 			},

--- a/extension/observer/endpointswatcher.go
+++ b/extension/observer/endpointswatcher.go
@@ -1,0 +1,98 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observer
+
+import (
+	"time"
+)
+
+// EndpointsWatcher provides a generic mechanism to run ListEndpoints every
+// RefreshInterval and report any new or removed endpoints using Notify
+// passed into ListAndWatch. Any observer that lists endpoints can make
+// use of EndpointsWatcher to poll for endpoints by embedding this struct
+// in the observer struct.
+type EndpointsWatcher struct {
+	ListEndpoints     func() []Endpoint
+	RefreshInterval   time.Duration
+	existingEndpoints map[string]Endpoint
+	stop              chan struct{}
+}
+
+// ListAndWatch runs ListEndpoints on a regular interval and keeps the list.
+func (ew *EndpointsWatcher) ListAndWatch(listener Notify) {
+	ew.existingEndpoints = make(map[string]Endpoint)
+	ew.stop = make(chan struct{})
+
+	ticker := time.NewTicker(ew.RefreshInterval)
+
+	// Do the initial listing immediately so that services can be monitored ASAP.
+	ew.refreshEndpoints(listener)
+
+	go func() {
+		for {
+			select {
+			case <-ew.stop:
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				ew.refreshEndpoints(listener)
+			}
+		}
+	}()
+}
+
+// refreshEndpoints updates the listener with the latest list
+// of active endpoints.
+func (ew *EndpointsWatcher) refreshEndpoints(listener Notify) {
+	latestEndpoints := ew.ListEndpoints()
+
+	// Create map from ID to endpoint for lookup.
+	latestEndpointsMap := make(map[string]Endpoint, len(latestEndpoints))
+	for _, e := range latestEndpoints {
+		latestEndpointsMap[e.ID] = e
+	}
+
+	var removedEndpoints, addedEndpoints []Endpoint
+	// Iterate over the latest endpoints obtained. An endpoint needs
+	// to be added in case it is not already available in existingEndpoints.
+	for _, e := range latestEndpoints {
+		if _, ok := ew.existingEndpoints[e.ID]; !ok {
+			ew.existingEndpoints[e.ID] = e
+			addedEndpoints = append(addedEndpoints, e)
+		}
+	}
+
+	// If endpoint present in existingEndpoints does not exist in the latest
+	// list, it needs to be removed.
+	for id, e := range ew.existingEndpoints {
+		if _, ok := latestEndpointsMap[e.ID]; !ok {
+			delete(ew.existingEndpoints, id)
+			removedEndpoints = append(removedEndpoints, e)
+		}
+	}
+
+	if len(removedEndpoints) > 0 {
+		listener.OnRemove(removedEndpoints)
+	}
+
+	if len(addedEndpoints) > 0 {
+		listener.OnAdd(addedEndpoints)
+	}
+}
+
+// StopListAndWatch polling the ListEndpoints.
+func (ew *EndpointsWatcher) StopListAndWatch() {
+	close(ew.stop)
+}

--- a/extension/observer/endpointswatcher.go
+++ b/extension/observer/endpointswatcher.go
@@ -84,7 +84,7 @@ func (ew *EndpointsWatcher) refreshEndpoints(listener Notify) {
 	// If endpoint present in existingEndpoints does not exist in the latest
 	// list, it needs to be removed.
 	for id, e := range ew.existingEndpoints {
-		if _, ok := latestEndpointsMap[e.ID]; !ok {
+		if !latestEndpointsMap[e.ID] {
 			delete(ew.existingEndpoints, id)
 			removedEndpoints = append(removedEndpoints, e)
 		}

--- a/extension/observer/endpointswatcher_test.go
+++ b/extension/observer/endpointswatcher_test.go
@@ -1,0 +1,89 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observer
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefreshEndpoints(t *testing.T) {
+	endpointsMap = map[string]Endpoint{}
+
+	ew := EndpointsWatcher{
+		ListEndpoints:     listEndpoints,
+		RefreshInterval:   2,
+		existingEndpoints: map[string]Endpoint{},
+	}
+
+	mn := mockNotifier{}
+
+	addEndpoint(0)
+	ew.ListAndWatch(mn)
+
+	// Endpoints available before the ListAndWatch call should be
+	// readily discovered.
+	expected := map[string]Endpoint{"0": {ID: "0"}}
+	require.Equal(t, expected, ew.existingEndpoints)
+
+	addEndpoint(1)
+	addEndpoint(2)
+	removeEndpoint(0)
+
+	expected["1"] = Endpoint{ID: "1"}
+	expected["2"] = Endpoint{ID: "2"}
+	delete(expected, "0")
+
+	time.Sleep(1 * time.Second)
+
+	require.Equal(t, expected, ew.existingEndpoints)
+	ew.StopListAndWatch()
+}
+
+var endpointsMap map[string]Endpoint
+
+func addEndpoint(n int) {
+	e := Endpoint{ID: strconv.Itoa(n)}
+	endpointsMap[e.ID] = e
+}
+
+func removeEndpoint(n int) {
+	delete(endpointsMap, strconv.Itoa(n))
+}
+
+func listEndpoints() []Endpoint {
+	endpoints := make([]Endpoint, 0)
+	for _, e := range endpointsMap {
+		endpoints = append(endpoints, e)
+	}
+	return endpoints
+}
+
+type mockNotifier struct {
+}
+
+var _ Notify = (*mockNotifier)(nil)
+
+func (m mockNotifier) OnAdd([]Endpoint) {
+}
+
+func (m mockNotifier) OnRemove([]Endpoint) {
+}
+
+func (m mockNotifier) OnChange([]Endpoint) {
+}

--- a/extension/observer/endpointswatcher_test.go
+++ b/extension/observer/endpointswatcher_test.go
@@ -45,14 +45,13 @@ func TestRefreshEndpoints(t *testing.T) {
 	addEndpoint(2)
 	removeEndpoint(0)
 
+	time.Sleep(1 * time.Second)
+	ew.StopListAndWatch()
+
 	expected["1"] = Endpoint{ID: "1"}
 	expected["2"] = Endpoint{ID: "2"}
 	delete(expected, "0")
-
-	time.Sleep(1 * time.Second)
-
 	require.Equal(t, expected, ew.existingEndpoints)
-	ew.StopListAndWatch()
 }
 
 var endpointsMap map[string]Endpoint

--- a/extension/observer/go.mod
+++ b/extension/observer/go.mod
@@ -1,3 +1,5 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer
 
 go 1.14
+
+require github.com/stretchr/testify v1.6.1

--- a/extension/observer/go.sum
+++ b/extension/observer/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/extension/observer/k8sobserver/handler.go
+++ b/extension/observer/k8sobserver/handler.go
@@ -45,7 +45,7 @@ func (h *handler) OnAdd(obj interface{}) {
 // include the pod itself as well as an endpoint for each container port that is mapped
 // to a container that is in a running state.
 func (h *handler) convertPodToEndpoints(pod *v1.Pod) []observer.Endpoint {
-	podID := fmt.Sprintf("%s/%s", h.idNamespace, pod.UID)
+	podID := observer.EndpointID(fmt.Sprintf("%s/%s", h.idNamespace, pod.UID))
 	podIP := pod.Status.PodIP
 
 	podDetails := observer.Pod{
@@ -76,8 +76,13 @@ func (h *handler) convertPodToEndpoints(pod *v1.Pod) []observer.Endpoint {
 		}
 
 		for _, port := range container.Ports {
+			endpointID := observer.EndpointID(
+				fmt.Sprintf(
+					"%s/%s(%d)", podID, port.Name, port.ContainerPort,
+				),
+			)
 			endpoints = append(endpoints, observer.Endpoint{
-				ID:     fmt.Sprintf("%s/%s(%d)", podID, port.Name, port.ContainerPort),
+				ID:     endpointID,
 				Target: fmt.Sprintf("%s:%d", podIP, port.ContainerPort),
 				Details: observer.Port{
 					Pod:      podDetails,
@@ -113,8 +118,8 @@ func (h *handler) OnUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	oldEndpoints := map[string]observer.Endpoint{}
-	newEndpoints := map[string]observer.Endpoint{}
+	oldEndpoints := map[observer.EndpointID]observer.Endpoint{}
+	newEndpoints := map[observer.EndpointID]observer.Endpoint{}
 
 	// Convert pods to endpoints and map by ID for easier lookup.
 	for _, e := range h.convertPodToEndpoints(oldPod) {

--- a/extension/observer/k8sobserver/handler_test.go
+++ b/extension/observer/k8sobserver/handler_test.go
@@ -106,8 +106,8 @@ func TestEndpointsChanged(t *testing.T) {
 	assert.Nil(t, sink.added)
 	assert.Nil(t, sink.removed)
 	assert.ElementsMatch(t,
-		[]string{"test-1/pod-2-UID", "test-1/pod-2-UID/https(443)"},
-		[]string{sink.changed[0].ID, sink.changed[1].ID})
+		[]observer.EndpointID{"test-1/pod-2-UID", "test-1/pod-2-UID/https(443)"},
+		[]observer.EndpointID{sink.changed[0].ID, sink.changed[1].ID})
 
 	// Running state changed, one added and one removed.
 	sink = endpointSink{}

--- a/extension/observer/observer.go
+++ b/extension/observer/observer.go
@@ -14,10 +14,6 @@
 
 package observer
 
-import (
-	"fmt"
-)
-
 // Protocol defines network protocol for container ports.
 type Protocol string
 
@@ -29,38 +25,6 @@ const (
 	// ProtocolUnknown is some other protocol or it is unknown.
 	ProtocolUnknown Protocol = "Unknown"
 )
-
-// Endpoint is a service that can be contacted remotely.
-type Endpoint struct {
-	// ID uniquely identifies this endpoint.
-	ID string
-	// Target is an IP address or hostname of the endpoint.
-	Target string
-	// Details contains additional context about the endpoint such as a Pod or Port.
-	Details interface{}
-}
-
-func (e *Endpoint) String() string {
-	return fmt.Sprintf("Endpoint{ID: %v, Target: %v, Details: %T%+v}", e.ID, e.Target, e.Details, e.Details)
-}
-
-// Pod is a discovered k8s pod.
-type Pod struct {
-	// Name of the pod.
-	Name string
-	// Labels is a map of user-specified metadata.
-	Labels map[string]string
-	// Annotations is a map of user-specified metadata.
-	Annotations map[string]string
-}
-
-// Port is an endpoint that has a target as well as a port.
-type Port struct {
-	Name     string
-	Pod      Pod
-	Port     uint16
-	Protocol Protocol
-}
 
 // Observable is an interface that provides notification of endpoint changes.
 type Observable interface {

--- a/receiver/receivercreator/config_expansion.go
+++ b/receiver/receivercreator/config_expansion.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"github.com/antonmedv/expr"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
 
 // evalBackticksInConfigValue expands any expressions within backticks inside configValue
@@ -34,7 +36,7 @@ import (
 // of the expression. For instance:
 //
 //   `"secure" in pod.labels` -> true (boolean)
-func evalBackticksInConfigValue(configValue string, env endpointEnv) (interface{}, error) {
+func evalBackticksInConfigValue(configValue string, env observer.EndpointEnv) (interface{}, error) {
 	// Tracks index into configValue where an expression (backtick) begins. -1 is unset.
 	exprStartIndex := -1
 	// Accumulate expanded string.
@@ -99,7 +101,7 @@ func evalBackticksInConfigValue(configValue string, env endpointEnv) (interface{
 
 // expandMap recursively expands any expressions in backticks inside values of cfg using
 // env as variables available within the expression, returning a copy of the map.
-func expandMap(cfg map[string]interface{}, env endpointEnv) (map[string]interface{}, error) {
+func expandMap(cfg map[string]interface{}, env observer.EndpointEnv) (map[string]interface{}, error) {
 	resolved := map[string]interface{}{}
 	for k, v := range cfg {
 		if v == nil {

--- a/receiver/receivercreator/config_expansion_test.go
+++ b/receiver/receivercreator/config_expansion_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
 
 func Test_expandConfigValue(t *testing.T) {
@@ -54,12 +56,12 @@ func Test_expandConfigValue(t *testing.T) {
 		{"extra whitespace should not impact returned type", args{nil, "`       true ==           true`"}, true, false},
 
 		// Error cases.
-		{"only backticks", args{endpointEnv{}, "``"}, nil, true},
-		{"whitespace between backticks", args{endpointEnv{}, "`   `"}, nil, true},
+		{"only backticks", args{observer.EndpointEnv{}, "``"}, nil, true},
+		{"whitespace between backticks", args{observer.EndpointEnv{}, "`   `"}, nil, true},
 		{"unbalanced backticks", args{nil, "foo ` bar"}, nil, true},
-		{"invalid expression", args{endpointEnv{}, "`(`"}, nil, true},
+		{"invalid expression", args{observer.EndpointEnv{}, "`(`"}, nil, true},
 		{"escape at end without value", args{localhostEnv, "foo \\"}, nil, true},
-		{"missing variables", args{endpointEnv{}, "`missing + vars`"}, nil, true},
+		{"missing variables", args{observer.EndpointEnv{}, "`missing + vars`"}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -75,7 +77,7 @@ func Test_expandConfigValue(t *testing.T) {
 
 func Test_userConfigMap_resolve(t *testing.T) {
 	type args struct {
-		env endpointEnv
+		env observer.EndpointEnv
 	}
 	tests := []struct {
 		name    string
@@ -89,7 +91,7 @@ func Test_userConfigMap_resolve(t *testing.T) {
 			"one": map[string]interface{}{
 				"two": "`endpoint`",
 			},
-		}, args{endpointEnv{"endpoint": "localhost"}}, map[string]interface{}{
+		}, args{observer.EndpointEnv{"endpoint": "localhost"}}, map[string]interface{}{
 			"one": map[string]interface{}{
 				"two": "localhost",
 			},
@@ -97,7 +99,7 @@ func Test_userConfigMap_resolve(t *testing.T) {
 		{
 			"single level map", userConfigMap{
 				"endpoint": "`endpoint`:6379",
-			}, args{endpointEnv{"endpoint": "localhost"}}, map[string]interface{}{
+			}, args{observer.EndpointEnv{"endpoint": "localhost"}}, map[string]interface{}{
 				"endpoint": "localhost:6379",
 			}, false,
 		},

--- a/receiver/receivercreator/fixtures_test.go
+++ b/receiver/receivercreator/fixtures_test.go
@@ -45,3 +45,9 @@ var portEndpoint = observer.Endpoint{
 		Protocol: observer.ProtocolTCP,
 	},
 }
+
+var unsupportedEndpoint = observer.Endpoint{
+	ID:      "endpoint-1",
+	Target:  "localhost:1234",
+	Details: map[string]interface{}{},
+}

--- a/receiver/receivercreator/observerhandler.go
+++ b/receiver/receivercreator/observerhandler.go
@@ -68,7 +68,7 @@ func (obs *observerHandler) OnAdd(added []observer.Endpoint) {
 	for _, e := range added {
 		env, err := observer.EndpointToEnv(e)
 		if err != nil {
-			obs.logger.Error("unable to convert endpoint to environment map", zap.String("endpoint", e.ID), zap.Error(err))
+			obs.logger.Error("unable to convert endpoint to environment map", zap.String("endpoint", string(e.ID)), zap.Error(err))
 			continue
 		}
 
@@ -84,7 +84,7 @@ func (obs *observerHandler) OnAdd(added []observer.Endpoint) {
 				zap.String("name", template.fullName),
 				zap.String("type", string(template.typeStr)),
 				zap.String("endpoint", e.Target),
-				zap.String("endpoint_id", e.ID))
+				zap.String("endpoint_id", string(e.ID)))
 
 			resolvedConfig, err := expandMap(template.config, env)
 			if err != nil {
@@ -129,7 +129,7 @@ func (obs *observerHandler) OnRemove(removed []observer.Endpoint) {
 
 	for _, e := range removed {
 		for _, rcvr := range obs.receiversByEndpointID.Get(e.ID) {
-			obs.logger.Info("stopping receiver", zap.Reflect("receiver", rcvr), zap.String("endpoint_id", e.ID))
+			obs.logger.Info("stopping receiver", zap.Reflect("receiver", rcvr), zap.String("endpoint_id", string(e.ID)))
 
 			if err := obs.runner.shutdown(rcvr); err != nil {
 				obs.logger.Error("failed to stop receiver", zap.Reflect("receiver", rcvr))

--- a/receiver/receivercreator/observerhandler.go
+++ b/receiver/receivercreator/observerhandler.go
@@ -66,7 +66,7 @@ func (obs *observerHandler) OnAdd(added []observer.Endpoint) {
 	defer obs.Unlock()
 
 	for _, e := range added {
-		env, err := endpointToEnv(e)
+		env, err := observer.EndpointToEnv(e)
 		if err != nil {
 			obs.logger.Error("unable to convert endpoint to environment map", zap.String("endpoint", e.ID), zap.Error(err))
 			continue

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -59,6 +59,7 @@ func TestOnAdd(t *testing.T) {
 
 	handler.OnAdd([]observer.Endpoint{
 		portEndpoint,
+		unsupportedEndpoint,
 	})
 
 	runner.AssertExpectations(t)

--- a/receiver/receivercreator/receivermap.go
+++ b/receiver/receivercreator/receivermap.go
@@ -16,24 +16,26 @@ package receivercreator
 
 import (
 	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
 
 // receiverMap is a multimap for mapping one id to many receivers. It does
 // not deduplicate the same value being associated with the same key.
-type receiverMap map[string][]component.Receiver
+type receiverMap map[observer.EndpointID][]component.Receiver
 
 // Put rcvr into key id. If rcvr is a duplicate it will still be added.
-func (rm receiverMap) Put(id string, rcvr component.Receiver) {
+func (rm receiverMap) Put(id observer.EndpointID, rcvr component.Receiver) {
 	rm[id] = append(rm[id], rcvr)
 }
 
 // Get receivers by id.
-func (rm receiverMap) Get(id string) []component.Receiver {
+func (rm receiverMap) Get(id observer.EndpointID) []component.Receiver {
 	return rm[id]
 }
 
 // Remove all receivers by id.
-func (rm receiverMap) RemoveAll(id string) {
+func (rm receiverMap) RemoveAll(id observer.EndpointID) {
 	delete(rm, id)
 }
 

--- a/receiver/receivercreator/rules_test.go
+++ b/receiver/receivercreator/rules_test.go
@@ -54,7 +54,7 @@ func Test_ruleEval(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, got)
 
-			env, err := endpointToEnv(tt.args.endpoint)
+			env, err := observer.EndpointToEnv(tt.args.endpoint)
 			require.NoError(t, err)
 
 			match, err := got.eval(env)


### PR DESCRIPTION
**Description:** Add `EndpointsWatcher`,  a struct with utilities required to poll and track endpoints in a generic manner. It is an implementation of `observer.Observable` and will help in abstracting some logic that's required by poll based observers. This struct is meant to be embedded by observers that list `observer.Endpoint`. Will also open a separate PR with changes that make use of this update.

The diff also has some minor refactoring.

**Testing:** Added unit tests.

**Documentation:** Added inline comments.