### PR TITLE
Align load test limits with the limits set in core

### DIFF
--- a/testbed/stabilitytests/metric_test.go
+++ b/testbed/stabilitytests/metric_test.go
@@ -45,7 +45,7 @@ func TestStabilityMetricsOpenCensus(t *testing.T) {
 		testbed.NewOCMetricDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 		testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 		testbed.ResourceSpec{
-			ExpectedMaxCPU:      50,
+			ExpectedMaxCPU:      70,
 			ExpectedMaxRAM:      86,
 			ResourceCheckPeriod: resourceCheckPeriod,
 		},

--- a/testbed/stabilitytests/trace_test.go
+++ b/testbed/stabilitytests/trace_test.go
@@ -53,7 +53,7 @@ func TestStabilityTracesOpenCensus(t *testing.T) {
 		testbed.NewOCTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 		testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 		testbed.ResourceSpec{
-			ExpectedMaxCPU:      30,
+			ExpectedMaxCPU:      39,
 			ExpectedMaxRAM:      90,
 			ResourceCheckPeriod: resourceCheckPeriod,
 		},
@@ -68,7 +68,7 @@ func TestStabilityTracesSAPM(t *testing.T) {
 		datasenders.NewSapmDataSender(testbed.GetAvailablePort(t)),
 		datareceivers.NewSapmDataReceiver(testbed.GetAvailablePort(t)),
 		testbed.ResourceSpec{
-			ExpectedMaxCPU:      28,
+			ExpectedMaxCPU:      40,
 			ExpectedMaxRAM:      100,
 			ResourceCheckPeriod: resourceCheckPeriod,
 		},

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -36,8 +36,8 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOCMetricDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 45,
-				ExpectedMaxRAM: 86,
+				ExpectedMaxCPU: 70,
+				ExpectedMaxRAM: 60,
 			},
 		},
 		{

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -46,8 +46,8 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOCTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 90,
+				ExpectedMaxCPU: 39,
+				ExpectedMaxRAM: 70,
 			},
 		},
 		{
@@ -56,7 +56,7 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 20,
-				ExpectedMaxRAM: 90,
+				ExpectedMaxRAM: 70,
 			},
 		},
 		{
@@ -64,8 +64,8 @@ func TestTrace10kSPS(t *testing.T) {
 			datasenders.NewSapmDataSender(testbed.GetAvailablePort(t)),
 			datareceivers.NewSapmDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 100,
+				ExpectedMaxCPU: 40,
+				ExpectedMaxRAM: 80,
 			},
 		},
 	}


### PR DESCRIPTION
**Description:**
Same load test scenarios have lower CPU limits in contrib repo than set in core. This commit adjusts the limits to be close to what's defined in core.

Resolves: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/407 https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/413 https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/421 https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/423 https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/424