### PR TITLE
Extend Metrics Transform to be able to add a label to an existing metric

### DIFF
--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -15,6 +15,7 @@ The metrics transform processor can be used to rename metrics, labels, or label 
   - Aggregation_type: sum, average, max
 - Aggregate across label values (e.g. want `memory{slab}`, but don’t care about `memory{slab_reclaimable}` & `memory{slab_unreclaimable}`)
   - Aggregation_type: sum, average, max
+- Add label to an existing metric
 
 ## Configuration
 ```yaml
@@ -96,4 +97,17 @@ operations:
    aggregated_values: [ slab_reclaimable, slab_unreclaimable ]
    new_value: slab 
    aggregation_type: sum
+```
+
+### Add a label to an existing metric
+```yaml
+transforms:
+...
+# The following will append label {Key: `mylabel`, Description: `myvalue`} to the metric `some_name`.
+  - metric_name: some_name
+      action: update
+      operation:
+        - action: add_label
+          new_label: mylabel
+          new_value: myvalue
 ```

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -83,8 +83,7 @@ type Operation struct {
 	// AggregatedValues is a list of label values to aggregate away.
 	AggregatedValues []string `mapstructure:"aggregated_values"`
 
-	// NewValue indicates what is the value called when the AggregatedValues
-	// are aggregated into one or a new label is added to an existing metric.
+	// NewValue is used to set a new label value either when the operation is `AggregatedValues` or `AddLabel`.
 	NewValue string `mapstructure:"new_value"`
 
 	// ValueActions is a list of renaming actions for label values.

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -31,6 +31,9 @@ const (
 
 	// NewLabelFieldName is the mapstructure field name for NewLabel field
 	NewLabelFieldName = "new_label"
+
+	// NewValueFieldName is the mapstructure field name for NewValue field
+	NewValueFieldName = "new_value"
 )
 
 // Config defines configuration for Resource processor.
@@ -80,7 +83,8 @@ type Operation struct {
 	// AggregatedValues is a list of label values to aggregate away.
 	AggregatedValues []string `mapstructure:"aggregated_values"`
 
-	// NewValue indicates what is the value called when the AggregatedValues are aggregated into one.
+	// NewValue indicates what is the value called when the AggregatedValues
+	// are aggregated into one or a new label is added to an existing metric.
 	NewValue string `mapstructure:"new_value"`
 
 	// ValueActions is a list of renaming actions for label values.
@@ -114,6 +118,9 @@ const (
 
 	// ToggleScalarDataType changes the data type from int64 to double, or vice-versa
 	ToggleScalarDataType OperationAction = "toggle_scalar_data_type"
+
+	// AddLabel adds a new label to an existing metric.
+	AddLabel OperationAction = "add_label"
 
 	// UpdateLabel applies name changes to label and/or label values.
 	UpdateLabel OperationAction = "update_label"

--- a/processor/metricstransformprocessor/config_test.go
+++ b/processor/metricstransformprocessor/config_test.go
@@ -78,6 +78,28 @@ var (
 				},
 			},
 		},
+		{
+			filterName: "metricstransform/addlabel",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "metricstransform/addlabel",
+					TypeVal: typeStr,
+				},
+				Transforms: []Transform{
+					{
+						MetricName: "some_name",
+						Action:     Update,
+						Operations: []Operation{
+							{
+								Action:   AddLabel,
+								NewLabel: "mylabel",
+								NewValue: "myvalue",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 )
 

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -94,6 +94,12 @@ func validateConfiguration(config *Config) error {
 			if op.Action == UpdateLabel && op.Label == "" {
 				return fmt.Errorf("missing required field %q while %q is %v in the %vth operation", LabelFieldName, ActionFieldName, UpdateLabel, i)
 			}
+			if op.Action == AddLabel && op.NewLabel == "" {
+				return fmt.Errorf("missing required field %q while %q is %v in the %vth operation", NewLabelFieldName, ActionFieldName, AddLabel, i)
+			}
+			if op.Action == AddLabel && op.NewValue == "" {
+				return fmt.Errorf("missing required field %q while %q is %v in the %vth operation", NewValueFieldName, ActionFieldName, AddLabel, i)
+			}
 		}
 	}
 

--- a/processor/metricstransformprocessor/factory_test.go
+++ b/processor/metricstransformprocessor/factory_test.go
@@ -111,3 +111,41 @@ func TestCreateProcessors(t *testing.T) {
 		}
 	}
 }
+
+func TestFactory_validateConfiguration(t *testing.T) {
+	v1 := Config{
+		Transforms: []Transform{
+			{
+				MetricName: "mymetric",
+				Action:     Update,
+				Operations: []Operation{
+					{
+						Action:   AddLabel,
+						NewValue: "bar",
+					},
+				},
+			},
+		},
+	}
+	err := validateConfiguration(&v1)
+	assert.Equal(t, "missing required field \"new_label\" while \"action\" is add_label in the 0th operation", err.Error())
+
+	v2 := Config{
+		Transforms: []Transform{
+			{
+				MetricName: "mymetric",
+				Action:     Update,
+				Operations: []Operation{
+					{
+						Action:   AddLabel,
+						NewLabel: "foo",
+					},
+				},
+			},
+		},
+	}
+
+	err = validateConfiguration(&v2)
+	assert.Equal(t, "missing required field \"new_value\" while \"action\" is add_label in the 0th operation", err.Error())
+
+}

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -118,10 +118,16 @@ func (mtp *metricsTransformProcessor) update(metric *metricspb.Metric, transform
 
 func (mtp *metricsTransformProcessor) addLabelOp(metric *metricspb.Metric, op Operation) {
 	var lb = metricspb.LabelKey{
-		Key:         op.NewLabel,
-		Description: op.NewValue,
+		Key: op.NewLabel,
 	}
 	metric.MetricDescriptor.LabelKeys = append(metric.MetricDescriptor.LabelKeys, &lb)
+	for _, ts := range metric.Timeseries {
+		lv := &metricspb.LabelValue{
+			Value:    op.NewValue,
+			HasValue: true,
+		}
+		ts.LabelValues = append(ts.LabelValues, lv)
+	}
 }
 
 func (mtp *metricsTransformProcessor) updateLabelOp(metric *metricspb.Metric, op Operation) {

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -110,8 +110,18 @@ func (mtp *metricsTransformProcessor) update(metric *metricspb.Metric, transform
 			mtp.updateLabelOp(metric, op)
 		} else if op.Action == ToggleScalarDataType {
 			mtp.ToggleScalarDataType(metric)
+		} else if op.Action == AddLabel {
+			mtp.addLabelOp(metric, op)
 		}
 	}
+}
+
+func (mtp *metricsTransformProcessor) addLabelOp(metric *metricspb.Metric, op Operation) {
+	var lb = metricspb.LabelKey{
+		Key:         op.NewLabel,
+		Description: op.NewValue,
+	}
+	metric.MetricDescriptor.LabelKeys = append(metric.MetricDescriptor.LabelKeys, &lb)
 }
 
 func (mtp *metricsTransformProcessor) updateLabelOp(metric *metricspb.Metric, op Operation) {

--- a/processor/metricstransformprocessor/testdata/config_full.yaml
+++ b/processor/metricstransformprocessor/testdata/config_full.yaml
@@ -22,6 +22,14 @@ processors:
                   aggregated_values: [value1,  value2]
                   new_value: new_value
                   aggregation_type: sum
+    metricstransform/addlabel:
+      transforms:
+        - metric_name: some_name
+          action: update
+          operations:
+            - action: add_label
+              new_label: mylabel
+              new_value: myvalue
             
 
 exporters:


### PR DESCRIPTION
**Description:** The current metrics transformation processor is extended to support adding a label to an existing metric.
The configuration is. 
```
 - metric_name: some_name
      action: update
      operation:
        - action: add_label
          new_label: mylabel
          new_value: myvalue
```

**Link to tracking Issue:** N/A

**Testing:** Added tests to cover configuration requirements and the logic around adding a label.

**Documentation:** Readme has been updated. 