### PR TITLE
Added loadtest job as a dependency for publish and stability test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,7 @@ workflows:
             - unit-tests
             - integration-tests
             - cross-compile
+            - loadtest
             - windows-msi
             - deb-package
             - rpm-package
@@ -202,6 +203,7 @@ workflows:
             - unit-tests
             - integration-tests
             - cross-compile
+            - loadtest
             - windows-msi
             - deb-package
             - rpm-package
@@ -214,6 +216,7 @@ workflows:
           requires:
             - lint
             - unit-tests
+            - loadtest
             - integration-tests
             - cross-compile
           filters:


### PR DESCRIPTION
If a pipeline triggers stability tests pipeline for a branch other than master before
all jobs in the pipeline are finished, the pipeline is cancelled by
Circle CI as it appears to be redundant. This change makes the spawn
stability tests job wait for other jobs (loadtest) to finish before spawning the
stability tests pipeline.

Also enabled loadtest as a requirement for the publish jobs. Not sure why they 
this was not the case already. May be we'll find out after merging :)