### PR TITLE
Update kubeletstats metrics according to semantic conventions

### DIFF
--- a/receiver/kubeletstatsreceiver/kubelet/accumulator.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator.go
@@ -27,10 +27,10 @@ type metricDataAccumulator struct {
 }
 
 const (
-	k8sPrefix       = "k8s/"
-	nodePrefix      = k8sPrefix + "node/"
-	podPrefix       = k8sPrefix + "pod/"
-	containerPrefix = k8sPrefix + "container/"
+	k8sPrefix       = "k8s."
+	nodePrefix      = k8sPrefix + "node."
+	podPrefix       = k8sPrefix + "pod."
+	containerPrefix = "container."
 )
 
 func (a *metricDataAccumulator) nodeStats(s stats.NodeStats) {

--- a/receiver/kubeletstatsreceiver/kubelet/cpu.go
+++ b/receiver/kubeletstatsreceiver/kubelet/cpu.go
@@ -31,10 +31,11 @@ func cpuUsageMetric(prefix string, s *stats.CPUStats) *metricspb.Metric {
 	if nanoCores == nil {
 		return nil
 	}
-	value := float64(*nanoCores) / 1_000_000
-	return doubleGauge(prefix+"cpu/usage", "%", &value)
+	value := float64(*nanoCores) / 1_000_000_000
+	return doubleGauge(prefix+"cpu.utilization", "1", &value)
 }
 
 func cpuCumulativeUsageMetric(prefix string, s *stats.CPUStats) *metricspb.Metric {
-	return cumulativeInt(prefix+"cpu/cumulative", "ns", s.UsageCoreNanoSeconds)
+	value := float64(*s.UsageCoreNanoSeconds) / 1_000_000_000
+	return cumulativeDouble(prefix+"cpu.time", "s", &value)
 }

--- a/receiver/kubeletstatsreceiver/kubelet/fs.go
+++ b/receiver/kubeletstatsreceiver/kubelet/fs.go
@@ -23,13 +23,18 @@ func fsMetrics(prefix string, s *stats.FsStats) []*metricspb.Metric {
 	return applyCurrentTime([]*metricspb.Metric{
 		fsAvailableMetric(prefix, s),
 		fsCapacityMetric(prefix, s),
+		fsUsedMetric(prefix, s),
 	}, s.Time.Time)
 }
 
 func fsAvailableMetric(prefix string, s *stats.FsStats) *metricspb.Metric {
-	return intGauge(prefix+"fs/available", "By", s.AvailableBytes)
+	return intGauge(prefix+"filesystem.available", "By", s.AvailableBytes)
 }
 
 func fsCapacityMetric(prefix string, s *stats.FsStats) *metricspb.Metric {
-	return intGauge(prefix+"fs/capacity", "By", s.CapacityBytes)
+	return intGauge(prefix+"filesystem.capacity", "By", s.CapacityBytes)
+}
+
+func fsUsedMetric(prefix string, s *stats.FsStats) *metricspb.Metric {
+	return intGauge(prefix+"filesystem.usage", "By", s.UsedBytes)
 }

--- a/receiver/kubeletstatsreceiver/kubelet/mem.go
+++ b/receiver/kubeletstatsreceiver/kubelet/mem.go
@@ -28,13 +28,13 @@ func memMetrics(prefix string, s *stats.MemoryStats) []*metricspb.Metric {
 }
 
 func memAvailableMetric(prefix string, s *stats.MemoryStats) *metricspb.Metric {
-	return intGauge(prefix+"mem/available", "By", s.AvailableBytes)
+	return intGauge(prefix+"memory.available", "By", s.AvailableBytes)
 }
 
 func memUsageMetric(prefix string, s *stats.MemoryStats) *metricspb.Metric {
-	return intGauge(prefix+"mem/usage", "By", s.UsageBytes)
+	return intGauge(prefix+"memory.usage", "By", s.UsageBytes)
 }
 
 func memRssMetric(prefix string, s *stats.MemoryStats) *metricspb.Metric {
-	return intGauge(prefix+"mem/rss", "By", s.RSSBytes)
+	return intGauge(prefix+"memory.rss", "By", s.RSSBytes)
 }

--- a/receiver/kubeletstatsreceiver/kubelet/network.go
+++ b/receiver/kubeletstatsreceiver/kubelet/network.go
@@ -24,19 +24,33 @@ func networkMetrics(prefix string, s *stats.NetworkStats) []*metricspb.Metric {
 	return applyCurrentTime([]*metricspb.Metric{
 		rxBytesMetric(prefix, s),
 		txBytesMetric(prefix, s),
+		rxErrorsMetric(prefix, s),
+		txErrorsMetric(prefix, s),
 	}, s.Time.Time)
 }
 
 const directionLabel = "direction"
 
 func rxBytesMetric(prefix string, s *stats.NetworkStats) *metricspb.Metric {
-	metric := cumulativeInt(prefix+"network", "By", s.RxBytes)
-	applyLabels(metric, map[string]string{"interface": s.Name, directionLabel: "received"})
+	metric := cumulativeInt(prefix+"network.io", "By", s.RxBytes)
+	applyLabels(metric, map[string]string{"interface": s.Name, directionLabel: "receive"})
 	return metric
 }
 
 func txBytesMetric(prefix string, s *stats.NetworkStats) *metricspb.Metric {
-	metric := cumulativeInt(prefix+"network", "By", s.TxBytes)
-	applyLabels(metric, map[string]string{"interface": s.Name, directionLabel: "transmitted"})
+	metric := cumulativeInt(prefix+"network.io", "By", s.TxBytes)
+	applyLabels(metric, map[string]string{"interface": s.Name, directionLabel: "transmit"})
+	return metric
+}
+
+func rxErrorsMetric(prefix string, s *stats.NetworkStats) *metricspb.Metric {
+	metric := cumulativeInt(prefix+"network.errors", "By", s.RxErrors)
+	applyLabels(metric, map[string]string{"interface": s.Name, directionLabel: "receive"})
+	return metric
+}
+
+func txErrorsMetric(prefix string, s *stats.NetworkStats) *metricspb.Metric {
+	metric := cumulativeInt(prefix+"network.errors", "By", s.TxErrors)
+	applyLabels(metric, map[string]string{"interface": s.Name, directionLabel: "transmit"})
 	return metric
 }

--- a/receiver/kubeletstatsreceiver/kubelet/pb.go
+++ b/receiver/kubeletstatsreceiver/kubelet/pb.go
@@ -36,6 +36,26 @@ func cumulativeInt(metricName string, units string, value *uint64) *metricspb.Me
 	}
 }
 
+func cumulativeDouble(metricName string, units string, value *float64) *metricspb.Metric {
+	if value == nil {
+		return nil
+	}
+	return &metricspb.Metric{
+		MetricDescriptor: &metricspb.MetricDescriptor{
+			Name: metricName,
+			Unit: units,
+			Type: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
+		},
+		Timeseries: []*metricspb.TimeSeries{{
+			Points: []*metricspb.Point{{
+				Value: &metricspb.Point_DoubleValue{
+					DoubleValue: *value,
+				},
+			}},
+		}},
+	}
+}
+
 func intGauge(metricName string, units string, value *uint64) *metricspb.Metric {
 	if value == nil {
 		return nil


### PR DESCRIPTION
**Description:**
Update kubeletstats receiver metrics according to https://github.com/open-telemetry/oteps/pull/119 :
- Remove "k8s." from container metrics
- Change "/" metric delimiter to "."
- Change ...network -> ...network.io
- Avoid short forms in metrics: "mem" -> "memory", "fs" -> "filesystem"
- Use "cpu.usage" in [0,1] scale instead of "cpu.utilization" in percents
- Use "cpu.time" in seconds instead of "cpu/cumulative" in nanoseconds