### PR TITLE
Add ability to optionally translate metrics in signalfx exporter

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -27,6 +27,11 @@ If `realm` is set, this option is derived and will be `https://api.{realm}.signa
 set, the value of `realm` will not be used in determining `api_url`. The explicit value will be used instead.
 - `log_dimension_updates` (default = `false`): Whether or not to log dimension updates.
 - `access_token_passthrough`: (default = `true`) Whether to use `"com.splunk.signalfx.access_token"` metric resource label, if any, as SFx access token.  In either case this label will be dropped during final translation.  Intended to be used in tandem with identical configuration option for [SignalFx receiver](../../receiver/signalfxreceiver/README.md) to preserve datapoint origin.
+- `send_compatible_metrics` (default = `false`): Whether metrics must be translated to a format 
+backward-compatible with SignalFx naming conventions.
+- `translation_rules`: Set of rules on how to translate metrics to a SignalFx compatible format
+If not provided explicitly, the rules defined in `translations/config/default.yaml` are used.
+Used only when `send_compatible_metrics` set to `true`.
 
 Note: Either `realm` or both `ingest_url` and `api_url` should be explicitly set.
 

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/dimensions"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/translation"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/collection"
 )
 
@@ -41,11 +42,12 @@ type signalfxExporter struct {
 }
 
 type exporterOptions struct {
-	ingestURL    *url.URL
-	apiURL       *url.URL
-	httpTimeout  time.Duration
-	token        string
-	logDimUpdate bool
+	ingestURL        *url.URL
+	apiURL           *url.URL
+	httpTimeout      time.Duration
+	token            string
+	logDimUpdate     bool
+	metricTranslator *translation.MetricTranslator
 }
 
 // New returns a new SignalFx exporter.
@@ -82,6 +84,7 @@ func New(
 			return gzip.NewWriter(nil)
 		}},
 		accessTokenPassthrough: config.AccessTokenPassthrough,
+		metricTranslator:       options.metricTranslator,
 	}
 
 	dimClient := dimensions.NewDimensionClient(
@@ -98,6 +101,7 @@ func New(
 			// buffer a fixed number of updates. Might also be a good candidate
 			// to make configurable.
 			PropertiesMaxBuffered: 10000,
+			MetricTranslator:      options.metricTranslator,
 		})
 	dimClient.Start()
 

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -15,13 +15,17 @@
 package signalfxexporter
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	otelconfig "go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/translation"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 )
 
@@ -52,6 +56,8 @@ func (f *Factory) CreateDefaultConfig() configmodels.Exporter {
 		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
 			AccessTokenPassthrough: true,
 		},
+		SendCompatibleMetrics: false,
+		TranslationRules:      nil,
 	}
 }
 
@@ -67,15 +73,35 @@ func (f *Factory) CreateTraceExporter(
 func (f *Factory) CreateMetricsExporter(
 	logger *zap.Logger,
 	config configmodels.Exporter,
-) (component.MetricsExporterOld, error) {
+) (exp component.MetricsExporterOld, err error) {
 
 	expCfg := config.(*Config)
+	if expCfg.SendCompatibleMetrics && expCfg.TranslationRules == nil {
+		expCfg.TranslationRules, err = loadDefaultTranslationRules()
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	exp, err := New(expCfg, logger)
+	exp, err = New(expCfg, logger)
 
 	if err != nil {
 		return nil, err
 	}
 
 	return exp, nil
+}
+
+func loadDefaultTranslationRules() ([]translation.Rule, error) {
+	config := Config{}
+
+	v := otelconfig.NewViper()
+	v.SetConfigType("yaml")
+	v.ReadConfig(strings.NewReader(translation.DefaultTranslationRulesYaml))
+	err := v.UnmarshalExact(&config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load default translation rules: %v", err)
+	}
+
+	return config.TranslationRules, nil
 }

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -25,6 +25,8 @@ import (
 	"go.opentelemetry.io/collector/config/configerror"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/translation"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -154,4 +156,58 @@ func TestFactory_CreateMetricsExporterFails(t *testing.T) {
 			assert.Nil(t, te)
 		})
 	}
+}
+
+func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
+	f := &Factory{}
+	config := &Config{
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: configmodels.Type(typeStr),
+			NameVal: typeStr,
+		},
+		AccessToken:           "testToken",
+		Realm:                 "us1",
+		SendCompatibleMetrics: true,
+	}
+
+	te, err := f.CreateMetricsExporter(zap.NewNop(), config)
+	assert.NoError(t, err)
+	assert.NotNil(t, te)
+
+	// Validate that default translation rules are loaded
+	// Expected values has to be updated once default config changed
+	assert.Equal(t, 1, len(config.TranslationRules))
+	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
+	assert.Equal(t, 6, len(config.TranslationRules[0].Mapping))
+}
+
+func TestCreateMetricsExporterWithSpecifiedTranslaitonRules(t *testing.T) {
+	f := &Factory{}
+	config := &Config{
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: configmodels.Type(typeStr),
+			NameVal: typeStr,
+		},
+		AccessToken:           "testToken",
+		Realm:                 "us1",
+		SendCompatibleMetrics: true,
+		TranslationRules: []translation.Rule{
+			{
+				Action: translation.ActionRenameDimensionKeys,
+				Mapping: map[string]string{
+					"old_dimension": "new_dimension",
+				},
+			},
+		},
+	}
+
+	te, err := f.CreateMetricsExporter(zap.NewNop(), config)
+	assert.NoError(t, err)
+	assert.NotNil(t, te)
+
+	// Validate that specified translation rules are loaded instead of default ones
+	assert.Equal(t, 1, len(config.TranslationRules))
+	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
+	assert.Equal(t, 1, len(config.TranslationRules[0].Mapping))
+	assert.Equal(t, "new_dimension", config.TranslationRules[0].Mapping["old_dimension"])
 }

--- a/exporter/signalfxexporter/testdata/config.yaml
+++ b/exporter/signalfxexporter/testdata/config.yaml
@@ -15,6 +15,11 @@ exporters:
       added-entry: "added value"
       dot.test: test
     access_token_passthrough: false
+    send_compatible_metrics: true
+    translation_rules:
+    - action: rename_dimension_keys
+      mapping: 
+        k8s.cluster.name: kubernetes_cluster
 
 service:
   pipelines:

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -1,0 +1,33 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translation
+
+const (
+	// DefaultTranslationRulesYaml defines default translation rules that will be applied to metrics if
+	// config.SendCompatibleMetrics set to true and config.TranslationRules not specified explicitly.
+	// Keep it in YAML format to be able to easily copy and paste it in config if modifications needed.
+	DefaultTranslationRulesYaml = `
+translation_rules:
+
+- action: rename_dimension_keys
+  mapping:
+    container.image.name: container_image
+    k8s.pod.name: kubernetes_pod_name
+    k8s.pod.uid: kubernetes_pod_uid
+    k8s.node.uid: kubernetes_node_uid
+    k8s.node.name: kubernetes_node
+    k8s.namespace.name: kubernetes_namespace
+`
+)

--- a/exporter/signalfxexporter/translation/metricdata_to_signalfxv2.go
+++ b/exporter/signalfxexporter/translation/metricdata_to_signalfxv2.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package signalfxexporter
+package translation
 
 import (
 	"fmt"
@@ -76,14 +76,29 @@ var (
 	infinityBoundSFxDimValue = float64ToDimValue(math.Inf(1))
 )
 
-func metricDataToSignalFxV2(
+func MetricDataToSignalFxV2(
+	logger *zap.Logger,
+	metricTranslator *MetricTranslator,
+	md consumerdata.MetricsData,
+) (sfxDataPoints []*sfxpb.DataPoint, numDroppedTimeSeries int) {
+	sfxDataPoints, numDroppedTimeSeries = metricDataToSfxDataPoints(logger, md)
+	if metricTranslator != nil {
+		metricTranslator.TranslateDataPoints(sfxDataPoints)
+	}
+	sanitizeDataPointDimensions(sfxDataPoints)
+	return
+}
+
+func metricDataToSfxDataPoints(
 	logger *zap.Logger,
 	md consumerdata.MetricsData,
-) (sfxDataPoints []*sfxpb.DataPoint, numDroppedTimeSeries int, err error) {
+) (sfxDataPoints []*sfxpb.DataPoint, numDroppedTimeSeries int) {
 
 	// The final number of data points is likely larger than len(md.Metrics)
 	// but at least that is expected.
 	sfxDataPoints = make([]*sfxpb.DataPoint, 0, len(md.Metrics))
+
+	var err error
 
 	// Labels from Node and Resource.
 	// TODO: Options to add lib, service name, etc as dimensions?
@@ -111,17 +126,13 @@ func metricDataToSignalFxV2(
 
 		metricType := fromOCMetricDescriptorToMetricType(descriptor.Type)
 		numLabels := len(descriptor.LabelKeys)
-		filteredLabelKeys := make([]string, numLabels)
-		for i := 0; i < numLabels; i++ {
-			filteredLabelKeys[i] = filterKeyChars(descriptor.LabelKeys[i].Key)
-		}
 
 		for _, series := range metric.Timeseries {
 			dimensions := make([]*sfxpb.Dimension, numLabels+numExtraDimensions)
 			copy(dimensions, extraDimensions)
 			for i := 0; i < numLabels; i++ {
 				dimension := &sfxpb.Dimension{
-					Key:   filteredLabelKeys[i],
+					Key:   descriptor.LabelKeys[i].Key,
 					Value: series.LabelValues[i].Value,
 				}
 				dimensions[numExtraDimensions+i] = dimension
@@ -187,7 +198,7 @@ func metricDataToSignalFxV2(
 		}
 	}
 
-	return sfxDataPoints, numDroppedTimeSeries, nil
+	return sfxDataPoints, numDroppedTimeSeries
 }
 
 func appendAttributesToDimensions(
@@ -197,7 +208,7 @@ func appendAttributesToDimensions(
 
 	for k, v := range attribs {
 		dim := &sfxpb.Dimension{
-			Key:   filterKeyChars(k),
+			Key:   k,
 			Value: v,
 		}
 		dimensions = append(dimensions, dim)
@@ -368,6 +379,16 @@ func buildSumDataPoint(
 	sumDP.Value = sfxpb.Datum{DoubleValue: sum}
 
 	return &sumDP
+}
+
+// sanitizeDataPointLabels replaces all characters unsupported by SignalFx backend
+// in metric label keys and with "_"
+func sanitizeDataPointDimensions(dps []*sfxpb.DataPoint) {
+	for _, dp := range dps {
+		for _, d := range dp.Dimensions {
+			d.Key = filterKeyChars(d.Key)
+		}
+	}
 }
 
 func filterKeyChars(str string) string {

--- a/exporter/signalfxexporter/translation/translator.go
+++ b/exporter/signalfxexporter/translation/translator.go
@@ -1,0 +1,110 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translation
+
+import (
+	"fmt"
+
+	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
+)
+
+// Action is the enum to capture actions to perform on metrics.
+type Action string
+
+const (
+	// ActionRenameDimensionKeys renames dimension keys using Rule.Mapping.
+	ActionRenameDimensionKeys Action = "rename_dimension_keys"
+)
+
+type Rule struct {
+	// Action specifies the translation action to be applied on metrics.
+	// This is a required field.
+	Action Action `mapstructure:"action"`
+
+	// Mapping specifies key/value mapping that is used by rename_dimension_keys action.
+	Mapping map[string]string `mapstructure:"mapping"`
+}
+
+type MetricTranslator struct {
+	rules []Rule
+
+	// Additional map to be used only for dimension renaming in metadata
+	dimensionsMap map[string]string
+}
+
+func NewMetricTranslator(rules []Rule) (*MetricTranslator, error) {
+	err := validateTranslationRules(rules)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MetricTranslator{
+		rules:         rules,
+		dimensionsMap: createDimensionsMap(rules),
+	}, nil
+}
+
+func validateTranslationRules(rules []Rule) error {
+	var renameDimentionKeysFound bool
+	for _, tr := range rules {
+		switch tr.Action {
+		case ActionRenameDimensionKeys:
+			if tr.Mapping == nil {
+				return fmt.Errorf("field \"mapping\" is required for %q translation rule", tr.Action)
+			}
+			if renameDimentionKeysFound {
+				return fmt.Errorf("only one %q translation rule can be specified", tr.Action)
+			}
+			renameDimentionKeysFound = true
+		default:
+			return fmt.Errorf("unknown \"action\" value: %q", tr.Action)
+		}
+	}
+	return nil
+}
+
+// createDimensionsMap creates an additional map for dimensions
+// from ActionRenameDimensionKeys actions in rules.
+func createDimensionsMap(rules []Rule) map[string]string {
+	for _, tr := range rules {
+		if tr.Action == ActionRenameDimensionKeys {
+			return tr.Mapping
+		}
+	}
+
+	return nil
+}
+
+func (mp *MetricTranslator) TranslateDataPoints(sfxDataPoints []*sfxpb.DataPoint) {
+	for _, tr := range mp.rules {
+		for _, dp := range sfxDataPoints {
+			switch tr.Action {
+			case ActionRenameDimensionKeys:
+				for _, d := range dp.Dimensions {
+					if newKey, ok := tr.Mapping[d.Key]; ok {
+						d.Key = newKey
+					}
+				}
+			}
+		}
+	}
+}
+
+func (mp *MetricTranslator) TranslateDimension(orig string) string {
+	if translated, ok := mp.dimensionsMap[orig]; ok {
+		return translated
+	}
+	return orig
+}

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -1,0 +1,222 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translation
+
+import (
+	"testing"
+	"time"
+
+	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMetricTranslator(t *testing.T) {
+	tests := []struct {
+		name              string
+		trs               []Rule
+		wantDimensionsMap map[string]string
+		wantError         string
+	}{
+		{
+			name: "invalid_rule",
+			trs: []Rule{
+				{
+					Action: "invalid_rule",
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "unknown \"action\" value: \"invalid_rule\"",
+		},
+		{
+			name: "rename_dimension_keys_valid",
+			trs: []Rule{
+				{
+					Action: ActionRenameDimensionKeys,
+					Mapping: map[string]string{
+						"k8s.cluster.name": "kubernetes_cluster",
+					},
+				},
+			},
+			wantDimensionsMap: map[string]string{
+				"k8s.cluster.name": "kubernetes_cluster",
+			},
+			wantError: "",
+		},
+		{
+			name: "rename_dimension_keys_no_mapping",
+			trs: []Rule{
+				{
+					Action: ActionRenameDimensionKeys,
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "field \"mapping\" is required for \"rename_dimension_keys\" translation rule",
+		},
+		{
+			name: "rename_dimension_keys_many_actions_invalid",
+			trs: []Rule{
+				{
+					Action: ActionRenameDimensionKeys,
+					Mapping: map[string]string{
+						"dimension1": "dimension2",
+						"dimension3": "dimension4",
+					},
+				},
+				{
+					Action: ActionRenameDimensionKeys,
+					Mapping: map[string]string{
+						"dimension4": "dimension5",
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "only one \"rename_dimension_keys\" translation rule can be specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mt, err := NewMetricTranslator(tt.trs)
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				require.NotNil(t, mt)
+				assert.Equal(t, tt.trs, mt.rules)
+				assert.Equal(t, tt.wantDimensionsMap, mt.dimensionsMap)
+			} else {
+				require.Error(t, err)
+				assert.Equal(t, err.Error(), tt.wantError)
+				require.Nil(t, mt)
+			}
+		})
+	}
+}
+
+func TestTranslateDataPoints(t *testing.T) {
+	msec := time.Now().Unix() * 1e3
+	gaugeType := sfxpb.MetricType_GAUGE
+
+	tests := []struct {
+		name string
+		trs  []Rule
+		dps  []*sfxpb.DataPoint
+		want []*sfxpb.DataPoint
+	}{
+		{
+			name: "rename_dimension_keys",
+			trs: []Rule{
+				{
+					Action: ActionRenameDimensionKeys,
+					Mapping: map[string]string{
+						"old_dimension": "new_dimension",
+						"old.dimension": "new.dimension",
+					},
+				},
+			},
+			dps: []*sfxpb.DataPoint{
+				{
+					Metric:    "single",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(13),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "old_dimension",
+							Value: "value1",
+						},
+						{
+							Key:   "old.dimension",
+							Value: "value2",
+						},
+						{
+							Key:   "dimension",
+							Value: "value3",
+						},
+					},
+				},
+			},
+			want: []*sfxpb.DataPoint{
+				{
+					Metric:    "single",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(13),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "new_dimension",
+							Value: "value1",
+						},
+						{
+							Key:   "new.dimension",
+							Value: "value2",
+						},
+						{
+							Key:   "dimension",
+							Value: "value3",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mt, err := NewMetricTranslator(tt.trs)
+			require.NoError(t, err)
+			assert.NotEqualValues(t, tt.want, tt.dps)
+			mt.TranslateDataPoints(tt.dps)
+
+			for i, dp := range tt.dps {
+				if dp.GetValue().DoubleValue != nil {
+					assert.InDelta(t, *tt.want[i].GetValue().DoubleValue, *dp.GetValue().DoubleValue, 0.00000001)
+					*dp.GetValue().DoubleValue = *tt.want[i].GetValue().DoubleValue
+				}
+			}
+
+			assert.EqualValues(t, tt.want, tt.dps)
+		})
+	}
+}
+
+func TestTestTranslateDimension(t *testing.T) {
+	mt, err := NewMetricTranslator([]Rule{
+		{
+			Action: ActionRenameDimensionKeys,
+			Mapping: map[string]string{
+				"old_dimension": "new_dimension",
+				"old.dimension": "new.dimension",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "new_dimension", mt.TranslateDimension("old_dimension"))
+	assert.Equal(t, "new.dimension", mt.TranslateDimension("old.dimension"))
+	assert.Equal(t, "another_dimension", mt.TranslateDimension("another_dimension"))
+
+	// Test no rename_dimension_keys translation rule
+	mt, err = NewMetricTranslator([]Rule{})
+	require.NoError(t, err)
+	assert.Equal(t, "old_dimension", mt.TranslateDimension("old_dimension"))
+}
+
+func generateIntPtr(i int) *int64 {
+	var iPtr int64 = int64(i)
+	return &iPtr
+}


### PR DESCRIPTION
**Description:**
This PR provides ability to translate metrics in siganlfx exporter. If an optional "send_compatible_metrics" configuration flag is enabled, signalfx exporter translates metrics before sending them out according to `translation_rules` configuration. If `translation_rules` field is not set, default translation rules are used that defined in exporter/signalfxexporter/translation/constants.go.

Only dimension renaming is added in this commit to validate the approach. Dimension translation applied to metric dimensions as well as to metadata properties update. Other translation rules will be added in the following PRs.
