### PR TITLE
Remove k8s processor log line

### DIFF
--- a/processor/k8sprocessor/processor.go
+++ b/processor/k8sprocessor/processor.go
@@ -124,7 +124,6 @@ func (kp *kubernetesprocessor) Shutdown(context.Context) error {
 
 func (kp *kubernetesprocessor) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
 	rss := td.ResourceSpans()
-	kp.logger.Info("received rss len: ", zap.Int("size", rss.Len()))
 	for i := 0; i < rss.Len(); i++ {
 		rs := rss.At(i)
 		if rs.IsNil() {


### PR DESCRIPTION
Does not appear to be necessary even at debug level.

Addresses #472

