### PR TITLE
Add more translation rules to signalfx exporter

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -176,9 +176,9 @@ func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
 
 	// Validate that default translation rules are loaded
 	// Expected values has to be updated once default config changed
-	assert.Equal(t, 1, len(config.TranslationRules))
+	assert.Equal(t, 7, len(config.TranslationRules))
 	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
-	assert.Equal(t, 6, len(config.TranslationRules[0].Mapping))
+	assert.Equal(t, 15, len(config.TranslationRules[0].Mapping))
 }
 
 func TestCreateMetricsExporterWithSpecifiedTranslaitonRules(t *testing.T) {

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
+	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.3.5
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.4.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.0.0-00010101000000-000000000000

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -23,11 +23,98 @@ translation_rules:
 
 - action: rename_dimension_keys
   mapping:
+
+    # dimensions
     container.image.name: container_image
     k8s.pod.name: kubernetes_pod_name
     k8s.pod.uid: kubernetes_pod_uid
     k8s.node.uid: kubernetes_node_uid
     k8s.node.name: kubernetes_node
     k8s.namespace.name: kubernetes_namespace
+    k8s.cluster.name: kubernetes_cluster
+
+    # properties
+    k8s.workload.kind: kubernetes_workload
+    k8s.workload.name: kubernetes_workload_name
+    daemonset: daemonSet
+    daemonset_uid: daemonSet_uid
+    replicaset: replicaSet
+    replicaset_uid: replicaSet_uid
+    cronjob: cronJob
+    cronjob_uid: cronJob_uid
+
+- action: rename_metrics
+  mapping:
+
+    # kubeletstats receiver metrics
+    container.cpu.time: container_cpu_utilization
+    container.memory.usage: container_memory_usage_bytes
+    container.filesystem.usage: container_fs_usage_bytes
+    container.filesystem.available: container_fs_available_bytes
+    container.filesystem.capacity: container_fs_capacity_bytes
+
+    # k8s cluster receiver metrics
+    k8s/pod/phase: kubernetes.pod_phase
+    k8s/deployment/available: kubernetes.deployment.available
+    k8s/deployment/desired: kubernetes.deployment.desired
+    k8s/container/cpu/limit: kubernetes.container_cpu_limit
+    k8s/container/cpu/request: kubernetes.container_cpu_request
+    k8s/container/memory/limit: kubernetes.container_memory_limit
+    k8s/container/memory/request: kubernetes.container_memory_request
+    k8s/container/ready: kubernetes.container_ready
+    k8s/node/condition_out_of_disk: kubernetes.node_out_of_disk
+    k8s/node/condition_ready: kubernetes.node_ready
+    k8s/node/condition_p_i_d_pressure: kubernetes.node_p_i_d_pressure
+    k8s/node/condition_memory_pressure: kubernetes.node_memory_pressure
+    k8s/node/condition_network_unavailable: kubernetes.node_network_unavailable
+
+# container network metrics
+- action: split_metric
+  metric_name: k8s.pod.network.io
+  dimension_key: direction
+  mapping: 
+    receive: pod_network_receive_bytes_total
+    transmit: pod_network_transmit_bytes_total
+- action: split_metric
+  metric_name: k8s.pod.network.errors
+  dimension_key: direction
+  mapping: 
+    receive: pod_network_receive_errors_total
+    transmit: pod_network_transmit_errors_total
+
+- action: split_metric
+  metric_name: system.cpu.time
+  dimension_key: state
+  mapping:
+    idle: cpu.idle
+    interrupt: cpu.interrupt
+    system: cpu.system
+    user: cpu.user
+    steal: cpu.steal
+    wait: cpu.wait
+    softirq: cpu.softirq
+    nice: cpu.nice
+- action: multiply_float
+  scale_factors_float:
+    container_cpu_utilization: 100
+    cpu.idle: 100
+    cpu.interrupt: 100
+    cpu.system: 100
+    cpu.user: 100
+    cpu.steal: 100
+    cpu.wait: 100
+    cpu.softirq: 100
+    cpu.nice: 100
+- action: convert_values
+  types_mapping:
+    container_cpu_utilization: int
+    cpu.idle: int
+    cpu.interrupt: int
+    cpu.system: int
+    cpu.user: int
+    cpu.steal: int
+    cpu.wait: int
+    cpu.softirq: int
+    cpu.nice: int
 `
 )

--- a/exporter/signalfxexporter/translation/metricdata_to_signalfxv2.go
+++ b/exporter/signalfxexporter/translation/metricdata_to_signalfxv2.go
@@ -83,7 +83,7 @@ func MetricDataToSignalFxV2(
 ) (sfxDataPoints []*sfxpb.DataPoint, numDroppedTimeSeries int) {
 	sfxDataPoints, numDroppedTimeSeries = metricDataToSfxDataPoints(logger, md)
 	if metricTranslator != nil {
-		metricTranslator.TranslateDataPoints(sfxDataPoints)
+		sfxDataPoints = metricTranslator.TranslateDataPoints(logger, sfxDataPoints)
 	}
 	sanitizeDataPointDimensions(sfxDataPoints)
 	return

--- a/exporter/signalfxexporter/translation/translator.go
+++ b/exporter/signalfxexporter/translation/translator.go
@@ -17,7 +17,9 @@ package translation
 import (
 	"fmt"
 
+	"github.com/gogo/protobuf/proto"
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
+	"go.uber.org/zap"
 )
 
 // Action is the enum to capture actions to perform on metrics.
@@ -26,6 +28,53 @@ type Action string
 const (
 	// ActionRenameDimensionKeys renames dimension keys using Rule.Mapping.
 	ActionRenameDimensionKeys Action = "rename_dimension_keys"
+
+	// ActionRenameMetrics renames metrics using Rule.Mapping.
+	ActionRenameMetrics Action = "rename_metrics"
+
+	// ActionMultiplyInt scales integer metrics by multiplying their values using
+	// Rule.ScaleFactorsInt key/values as metric_name/multiplying_factor
+	ActionMultiplyInt Action = "multiply_int"
+
+	// ActionDivideInt scales integer metric by dividing their values using
+	// Rule.ScaleFactorsInt key/values as metric_name/divisor
+	ActionDivideInt Action = "divide_int"
+
+	// ActionMultiplyFloat scales integer metric by dividing their values using
+	// Rule.ScaleFactorsFloat key/values as metric_name/multiplying_factor
+	ActionMultiplyFloat Action = "multiply_float"
+
+	// ActionConvertValues converts float metrics values to integer values using
+	// Rule.TypesMapping key/values as metric_name/new_type.
+	ActionConvertValues Action = "convert_values"
+
+	// ActionCopyMetrics copies metrics using Rule.Mapping
+	ActionCopyMetrics Action = "copy_metrics"
+
+	// ActionSplitMetric splits a metric with Rule.MetricName into multiple metrics
+	// based on a dimension specified in Rule.DimensionKey.
+	// Rule.Mapping represents "dimension value" -> "new metric name" for the translation.
+	// For example, having the following translation rule:
+	//   - action: split_metric
+	// 	   metric_name: k8s.pod.network.io
+	//     dimension_key: direction
+	//     mapping:
+	//       receive: pod_network_receive_bytes_total
+	//       transmit: pod_network_transmit_bytes_total
+	// The following translations will be performed:
+	// k8s.pod.network.io{direction="receive"} -> pod_network_receive_bytes_total{}
+	// k8s.pod.network.io{direction="transmit"} -> pod_network_transmit_bytes_total{}
+	ActionSplitMetric Action = "split_metric"
+)
+
+// MetricValueType is the enum to capture valid metric value types that can be converted
+type MetricValueType string
+
+const (
+	// MetricValueTypeInt represents integer metric value type
+	MetricValueTypeInt MetricValueType = "int"
+	// MetricValueTypeDouble represents double metric value type
+	MetricValueTypeDouble MetricValueType = "double"
 )
 
 type Rule struct {
@@ -33,8 +82,29 @@ type Rule struct {
 	// This is a required field.
 	Action Action `mapstructure:"action"`
 
-	// Mapping specifies key/value mapping that is used by rename_dimension_keys action.
+	// Mapping specifies key/value mapping that is used by rename_dimension_keys,
+	// rename_metrics, copy_metrics, and split_metric actions.
 	Mapping map[string]string `mapstructure:"mapping"`
+
+	// ScaleFactorsInt is used by multiply_int and divide_int action to scale
+	// integer metric values, key/value format: metric_name/scale_factor
+	ScaleFactorsInt map[string]int64 `mapstructure:"scale_factors_int"`
+
+	// ScaleFactorsInt is used by multiply_float action to scale
+	// float metric values, key/value format: metric_name/scale_factor
+	ScaleFactorsFloat map[string]float64 `mapstructure:"scale_factors_float"`
+
+	// MetricName is used by "split_metric" translation rule to specify a name
+	// of a metric that will be split.
+	MetricName string `mapstructure:"metric_name"`
+	// DimensionKey is used by "split_metric" translation rule action to specify dimension key
+	// that will be used to translate the metric datapoints. Datapoints that don't have
+	// the specified dimension key will not be translated.
+	DimensionKey string `mapstructure:"dimension_key"`
+
+	// TypesMapping is represents metric_name/metric_type key/value pairs,
+	// used by ActionConvertValues.
+	TypesMapping map[string]MetricValueType `mapstructure:"types_mapping"`
 }
 
 type MetricTranslator struct {
@@ -68,6 +138,46 @@ func validateTranslationRules(rules []Rule) error {
 				return fmt.Errorf("only one %q translation rule can be specified", tr.Action)
 			}
 			renameDimentionKeysFound = true
+		case ActionRenameMetrics:
+			if tr.Mapping == nil {
+				return fmt.Errorf("field \"mapping\" is required for %q translation rule", tr.Action)
+			}
+		case ActionMultiplyInt:
+			if tr.ScaleFactorsInt == nil {
+				return fmt.Errorf("field \"scale_factors_int\" is required for %q translation rule", tr.Action)
+			}
+		case ActionDivideInt:
+			if tr.ScaleFactorsInt == nil {
+				return fmt.Errorf("field \"scale_factors_int\" is required for %q translation rule", tr.Action)
+			}
+			for k, v := range tr.ScaleFactorsInt {
+				if v == 0 {
+					return fmt.Errorf("\"scale_factors_int\" for %q translation rule has 0 value for %q metric", tr.Action, k)
+				}
+			}
+		case ActionMultiplyFloat:
+			if tr.ScaleFactorsFloat == nil {
+				return fmt.Errorf("field \"scale_factors_float\" is required for %q translation rule", tr.Action)
+			}
+		case ActionCopyMetrics:
+			if tr.Mapping == nil {
+				return fmt.Errorf("field \"mapping\" is required for %q translation rule", tr.Action)
+			}
+		case ActionSplitMetric:
+			if tr.MetricName == "" || tr.DimensionKey == "" || tr.Mapping == nil {
+				return fmt.Errorf(
+					"fields \"metric_name\", \"dimension_key\", and \"mapping\" are required for %q translation rule",
+					tr.Action)
+			}
+		case ActionConvertValues:
+			if tr.TypesMapping == nil {
+				return fmt.Errorf("field \"types_mapping\" are required for %q translation rule", tr.Action)
+			}
+			for k, v := range tr.TypesMapping {
+				if v != MetricValueTypeInt && v != MetricValueTypeDouble {
+					return fmt.Errorf("invalid value type %q set for metric %q in \"types_mapping\"", v, k)
+				}
+			}
 		default:
 			return fmt.Errorf("unknown \"action\" value: %q", tr.Action)
 		}
@@ -87,9 +197,13 @@ func createDimensionsMap(rules []Rule) map[string]string {
 	return nil
 }
 
-func (mp *MetricTranslator) TranslateDataPoints(sfxDataPoints []*sfxpb.DataPoint) {
+func (mp *MetricTranslator) TranslateDataPoints(logger *zap.Logger, sfxDataPoints []*sfxpb.DataPoint) []*sfxpb.DataPoint {
+	processedDataPoints := sfxDataPoints
+
 	for _, tr := range mp.rules {
-		for _, dp := range sfxDataPoints {
+		newDataPoints := []*sfxpb.DataPoint{}
+
+		for _, dp := range processedDataPoints {
 			switch tr.Action {
 			case ActionRenameDimensionKeys:
 				for _, d := range dp.Dimensions {
@@ -97,9 +211,52 @@ func (mp *MetricTranslator) TranslateDataPoints(sfxDataPoints []*sfxpb.DataPoint
 						d.Key = newKey
 					}
 				}
+			case ActionRenameMetrics:
+				if newKey, ok := tr.Mapping[dp.Metric]; ok {
+					dp.Metric = newKey
+				}
+			case ActionMultiplyInt:
+				if multiplier, ok := tr.ScaleFactorsInt[dp.Metric]; ok {
+					v := dp.GetValue().IntValue
+					if v != nil {
+						*v = *v * multiplier
+					}
+				}
+			case ActionDivideInt:
+				if divisor, ok := tr.ScaleFactorsInt[dp.Metric]; ok {
+					v := dp.GetValue().IntValue
+					if v != nil {
+						*v = *v / divisor
+					}
+				}
+			case ActionMultiplyFloat:
+				if multiplier, ok := tr.ScaleFactorsFloat[dp.Metric]; ok {
+					v := dp.GetValue().DoubleValue
+					if v != nil {
+						*v = *v * multiplier
+					}
+				}
+			case ActionCopyMetrics:
+				if newMetric, ok := tr.Mapping[dp.Metric]; ok {
+					newDataPoint := proto.Clone(dp).(*sfxpb.DataPoint)
+					newDataPoint.Metric = newMetric
+					newDataPoints = append(newDataPoints, newDataPoint)
+				}
+			case ActionSplitMetric:
+				if tr.MetricName == dp.Metric {
+					splitMetric(dp, tr.DimensionKey, tr.Mapping)
+				}
+			case ActionConvertValues:
+				if newType, ok := tr.TypesMapping[dp.Metric]; ok {
+					convertMetricValue(logger, dp, newType)
+				}
 			}
 		}
+
+		processedDataPoints = append(processedDataPoints, newDataPoints...)
 	}
+
+	return processedDataPoints
 }
 
 func (mp *MetricTranslator) TranslateDimension(orig string) string {
@@ -107,4 +264,59 @@ func (mp *MetricTranslator) TranslateDimension(orig string) string {
 		return translated
 	}
 	return orig
+}
+
+// splitMetric renames a metric with "dimension key" == dimensionKey to mapping["dimension value"],
+// datapoint not changed if not dimension found equal to dimensionKey:mapping->key.
+func splitMetric(dp *sfxpb.DataPoint, dimensionKey string, mapping map[string]string) {
+	if len(dp.Dimensions) == 0 {
+		return
+	}
+
+	dimensions := make([]*sfxpb.Dimension, 0, len(dp.Dimensions)-1)
+	var match bool
+	for i, d := range dp.Dimensions {
+		if dimensionKey == d.Key {
+			if newName, ok := mapping[d.Value]; ok {
+				// The dimension value matches the mapping, proceeding
+				dp.Metric = newName
+				match = true
+				continue
+			}
+			// The dimension value doesn't match the mapping, keep the datapoint as is
+			return
+		}
+
+		// No dimension key found for the specified dimensionKey, keep the datapoint as is
+		if i == len(dp.Dimensions)-1 && !match {
+			return
+		}
+
+		dimensions = append(dimensions, d)
+	}
+
+	dp.Dimensions = dimensions
+}
+
+func convertMetricValue(logger *zap.Logger, dp *sfxpb.DataPoint, newType MetricValueType) {
+	switch newType {
+	case MetricValueTypeInt:
+		val := dp.GetValue().DoubleValue
+		if val == nil {
+			logger.Debug("only datapoint of \"double\" type can be converted to int",
+				zap.String("metric", dp.Metric))
+			return
+		}
+		var intVal = int64(*val)
+		dp.Value = sfxpb.Datum{IntValue: &intVal}
+	case MetricValueTypeDouble:
+		val := dp.GetValue().IntValue
+		if val == nil {
+			logger.Debug("only datapoint of \"int\" type can be converted to double",
+				zap.String("metric", dp.Metric))
+			return
+		}
+		var floatVal = float64(*val)
+		dp.Value = sfxpb.Datum{DoubleValue: &floatVal}
+	}
 }

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -21,6 +21,7 @@ import (
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestNewMetricTranslator(t *testing.T) {
@@ -84,6 +85,222 @@ func TestNewMetricTranslator(t *testing.T) {
 			},
 			wantDimensionsMap: nil,
 			wantError:         "only one \"rename_dimension_keys\" translation rule can be specified",
+		},
+		{
+			name: "rename_metric_valid",
+			trs: []Rule{
+				{
+					Action: ActionRenameMetrics,
+					Mapping: map[string]string{
+						"metric1": "metric2",
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "",
+		},
+		{
+			name: "rename_metric_invalid",
+			trs: []Rule{
+				{
+					Action: ActionRenameMetrics,
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "field \"mapping\" is required for \"rename_metrics\" translation rule",
+		},
+		{
+			name: "rename_dimensions_and_metrics_valid",
+			trs: []Rule{
+				{
+					Action: ActionRenameDimensionKeys,
+					Mapping: map[string]string{
+						"dimension1": "dimension2",
+						"dimension3": "dimension4",
+					},
+				},
+				{
+					Action: ActionRenameMetrics,
+					Mapping: map[string]string{
+						"metric1": "metric2",
+					},
+				},
+			},
+			wantDimensionsMap: map[string]string{
+				"dimension1": "dimension2",
+				"dimension3": "dimension4",
+			},
+			wantError: "",
+		},
+		{
+			name: "multiply_int_valid",
+			trs: []Rule{
+				{
+					Action: ActionMultiplyInt,
+					ScaleFactorsInt: map[string]int64{
+						"metric1": 10,
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "",
+		},
+		{
+			name: "multiply_int_invalid",
+			trs: []Rule{
+				{
+					Action: ActionMultiplyInt,
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "field \"scale_factors_int\" is required for \"multiply_int\" translation rule",
+		},
+		{
+			name: "divide_int_valid",
+			trs: []Rule{
+				{
+					Action: ActionDivideInt,
+					ScaleFactorsInt: map[string]int64{
+						"metric1": 10,
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "",
+		},
+		{
+			name: "divide_int_invalid_no_scale_factors",
+			trs: []Rule{
+				{
+					Action: ActionDivideInt,
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "field \"scale_factors_int\" is required for \"divide_int\" translation rule",
+		},
+		{
+			name: "divide_int_invalid_zero",
+			trs: []Rule{
+				{
+					Action: ActionDivideInt,
+					ScaleFactorsInt: map[string]int64{
+						"metric1": 10,
+						"metric2": 0,
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "\"scale_factors_int\" for \"divide_int\" translation rule has 0 value for \"metric2\" metric",
+		},
+		{
+			name: "multiply_float_valid",
+			trs: []Rule{
+				{
+					Action: ActionMultiplyFloat,
+					ScaleFactorsFloat: map[string]float64{
+						"metric1": 0.1,
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "",
+		},
+		{
+			name: "multiply_float_invalid",
+			trs: []Rule{
+				{
+					Action: ActionMultiplyFloat,
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "field \"scale_factors_float\" is required for \"multiply_float\" translation rule",
+		},
+		{
+			name: "copy_metric_valid",
+			trs: []Rule{
+				{
+					Action: ActionCopyMetrics,
+					Mapping: map[string]string{
+						"from_metric": "to_metric",
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "",
+		},
+		{
+			name: "copy_metric_invalid",
+			trs: []Rule{
+				{
+					Action: ActionCopyMetrics,
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "field \"mapping\" is required for \"copy_metrics\" translation rule",
+		},
+		{
+			name: "split_metric_valid",
+			trs: []Rule{
+				{
+					Action:       ActionSplitMetric,
+					MetricName:   "metric1",
+					DimensionKey: "dim1",
+					Mapping: map[string]string{
+						"val1": "metric1.val1",
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "",
+		},
+		{
+			name: "split_metric_invalid",
+			trs: []Rule{
+				{
+					Action:       ActionSplitMetric,
+					MetricName:   "metric1",
+					DimensionKey: "dim1",
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError: "fields \"metric_name\", \"dimension_key\", and \"mapping\" are required " +
+				"for \"split_metric\" translation rule",
+		},
+		{
+			name: "convert_values_valid",
+			trs: []Rule{
+				{
+					Action: ActionConvertValues,
+					TypesMapping: map[string]MetricValueType{
+						"val1": MetricValueTypeInt,
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "",
+		},
+		{
+			name: "convert_values_invalid_no_mapping",
+			trs: []Rule{
+				{
+					Action: ActionConvertValues,
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "field \"types_mapping\" are required for \"convert_values\" translation rule",
+		},
+		{
+			name: "convert_values_invalid_type",
+			trs: []Rule{
+				{
+					Action: ActionConvertValues,
+					TypesMapping: map[string]MetricValueType{
+						"metric1": MetricValueType("invalid-type"),
+					},
+				},
+			},
+			wantDimensionsMap: nil,
+			wantError:         "invalid value type \"invalid-type\" set for metric \"metric1\" in \"types_mapping\"",
 		},
 	}
 
@@ -174,13 +391,455 @@ func TestTranslateDataPoints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "rename_metric",
+			trs: []Rule{
+				{
+					Action: ActionRenameMetrics,
+					Mapping: map[string]string{
+						"k8s/container/mem/usage": "container_memory_usage_bytes",
+					},
+				},
+			},
+			dps: []*sfxpb.DataPoint{
+				{
+					Metric:    "k8s/container/mem/usage",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(13),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+			want: []*sfxpb.DataPoint{
+				{
+					Metric:    "container_memory_usage_bytes",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(13),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+		},
+		{
+			name: "multiply_int",
+			trs: []Rule{
+				{
+					Action: ActionMultiplyInt,
+					ScaleFactorsInt: map[string]int64{
+						"metric1": 100,
+					},
+				},
+			},
+			dps: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(13),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+			want: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(1300),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+		},
+		{
+			name: "divide_int",
+			trs: []Rule{
+				{
+					Action: ActionDivideInt,
+					ScaleFactorsInt: map[string]int64{
+						"metric1": 100,
+					},
+				},
+			},
+			dps: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(1300),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+			want: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(13),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+		},
+		{
+			name: "multiply_float",
+			trs: []Rule{
+				{
+					Action: ActionMultiplyFloat,
+					ScaleFactorsFloat: map[string]float64{
+						"metric1": 0.1,
+					},
+				},
+			},
+			dps: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						DoubleValue: generateFloatPtr(0.9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+			want: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						DoubleValue: generateFloatPtr(0.09),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+		},
+		{
+			name: "copy_metric",
+			trs: []Rule{
+				{
+					Action: ActionCopyMetrics,
+					Mapping: map[string]string{
+						"metric1": "metric2",
+					},
+				},
+			},
+			dps: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+			want: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+				{
+					Metric:    "metric2",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+		},
+		{
+			name: "copy_and_rename",
+			trs: []Rule{
+				{
+					Action: ActionCopyMetrics,
+					Mapping: map[string]string{
+						"metric1": "metric2",
+					},
+				},
+				{
+					Action: ActionRenameMetrics,
+					Mapping: map[string]string{
+						"metric2": "metric3",
+					},
+				},
+			},
+			dps: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+				},
+			},
+			want: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+				},
+				{
+					Metric:    "metric3",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+				},
+			},
+		},
+		{
+			name: "split_metric",
+			trs: []Rule{
+				{
+					Action:       ActionSplitMetric,
+					MetricName:   "metric1",
+					DimensionKey: "dim1",
+					Mapping: map[string]string{
+						"val1": "metric1.dim1-val1",
+						"val2": "metric1.dim1-val2",
+					},
+				},
+			},
+			dps: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "dim1",
+							Value: "val1",
+						},
+						{
+							Key:   "dim2",
+							Value: "val2",
+						},
+					},
+				},
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "dim1",
+							Value: "val2",
+						},
+						{
+							Key:   "dim2",
+							Value: "val2-aleternate",
+						},
+					},
+				},
+				// datapoint with no dimensions, should not be changed
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+				// datapoint with another dimension key, should not be changed
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "dim2",
+							Value: "val2",
+						},
+					},
+				},
+				// datapoint with dimension value not matching the mapping, should not be changed
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "dim1",
+							Value: "val3",
+						},
+					},
+				},
+			},
+			want: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1.dim1-val1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "dim2",
+							Value: "val2",
+						},
+					},
+				},
+				{
+					Metric:    "metric1.dim1-val2",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "dim2",
+							Value: "val2-aleternate",
+						},
+					},
+				},
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "dim2",
+							Value: "val2",
+						},
+					},
+				},
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{
+						{
+							Key:   "dim1",
+							Value: "val3",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "convert_values",
+			trs: []Rule{
+				{
+					Action: ActionConvertValues,
+					TypesMapping: map[string]MetricValueType{
+						"metric1": MetricValueTypeInt,
+						"metric2": MetricValueTypeDouble,
+						"metric3": MetricValueTypeInt,
+					},
+				},
+			},
+			dps: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						DoubleValue: generateFloatPtr(9.1),
+					},
+					MetricType: &gaugeType,
+				},
+				{
+					Metric:    "metric2",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(0),
+					},
+					MetricType: &gaugeType,
+				},
+				{
+					Metric:    "metric3",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(12),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+			want: []*sfxpb.DataPoint{
+				{
+					Metric:    "metric1",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(9),
+					},
+					MetricType: &gaugeType,
+				},
+				{
+					Metric:    "metric2",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						DoubleValue: generateFloatPtr(0),
+					},
+					MetricType: &gaugeType,
+				},
+				{
+					Metric:    "metric3",
+					Timestamp: msec,
+					Value: sfxpb.Datum{
+						IntValue: generateIntPtr(12),
+					},
+					MetricType: &gaugeType,
+					Dimensions: []*sfxpb.Dimension{},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mt, err := NewMetricTranslator(tt.trs)
 			require.NoError(t, err)
 			assert.NotEqualValues(t, tt.want, tt.dps)
-			mt.TranslateDataPoints(tt.dps)
+			got := mt.TranslateDataPoints(zap.NewNop(), tt.dps)
 
 			for i, dp := range tt.dps {
 				if dp.GetValue().DoubleValue != nil {
@@ -189,7 +848,7 @@ func TestTranslateDataPoints(t *testing.T) {
 				}
 			}
 
-			assert.EqualValues(t, tt.want, tt.dps)
+			assert.EqualValues(t, tt.want, got)
 		})
 	}
 }
@@ -218,5 +877,10 @@ func TestTestTranslateDimension(t *testing.T) {
 
 func generateIntPtr(i int) *int64 {
 	var iPtr int64 = int64(i)
+	return &iPtr
+}
+
+func generateFloatPtr(i float64) *float64 {
+	var iPtr float64 = float64(i)
 	return &iPtr
 }


### PR DESCRIPTION
**Description:**
This PR adds the following translation rules to produce metrics backward compatible with SignalFx conventions:
- Rename metrics
- Copy metrics
- Scale metric values
- Split metric by dimension
- Convert metrics values int<->double
