### PR TITLE
Azure Monitor Exporter: Mark spanToEnvelope errors as permanent

### DIFF
--- a/exporter/azuremonitorexporter/traceexporter.go
+++ b/exporter/azuremonitorexporter/traceexporter.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
@@ -43,7 +44,7 @@ func (v *traceVisitor) visit(
 	envelope, err := spanToEnvelope(resource, instrumentationLibrary, span, v.exporter.logger)
 	if err != nil {
 		// record the error and short-circuit
-		v.err = err
+		v.err = consumererror.Permanent(err)
 		return false
 	}
 

--- a/exporter/azuremonitorexporter/traceexporter_test.go
+++ b/exporter/azuremonitorexporter/traceexporter_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
@@ -99,6 +100,7 @@ func TestExporterTraceDataCallbackSingleSpanNoEnvelope(t *testing.T) {
 
 	droppedSpans, err := exporter.onTraceData(context.Background(), traces)
 	assert.NotNil(t, err)
+	assert.True(t, consumererror.IsPermanent(err), "error should be permanent")
 	assert.Equal(t, 1, droppedSpans)
 
 	mockTransportChannel.AssertNumberOfCalls(t, "Send", 0)


### PR DESCRIPTION
**Description:**

Fixing a bug - Mark span to envelope conversion errors in Azure Monitor Exporter as permanent.

The conversion from span to envelope is deterministic. It will always result in the same error for the same input span. If I understand that correctly, these types of errors should be marked as permanent, so that processors don't attempt to retry it.

I noticed the error when one of my applications didn't report a SpanKind. Because I had a queued retry processor, it attempted to send the same spans again and again. This resulted in the same spans being reported multiple times to Azure Application Insights:

<img src="https://user-images.githubusercontent.com/3579251/88333844-c8d4da00-cd28-11ea-9efa-74b64a4df196.png" alt="Azure Application Insights UI, showing the same spans multiple times" width="400">

**Testing:**

Assertion added to existing unit test.