### PR TITLE
Add aggregation capability to signalfx exporter translations

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -176,7 +176,7 @@ func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
 
 	// Validate that default translation rules are loaded
 	// Expected values has to be updated once default config changed
-	assert.Equal(t, 7, len(config.TranslationRules))
+	assert.Equal(t, 9, len(config.TranslationRules))
 	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
 	assert.Equal(t, 15, len(config.TranslationRules[0].Mapping))
 }

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -116,5 +116,17 @@ translation_rules:
     cpu.wait: int
     cpu.softirq: int
     cpu.nice: int
+
+- action: copy_metrics
+  mapping:
+    cpu.idle: machine_cpu_cores
+
+- action: aggregate_metric
+  metric_name: machine_cpu_cores
+  aggregation_method: count
+  dimensions:
+  - host
+  - kubernetes_node
+  - kubernetes_cluster
 `
 )


### PR DESCRIPTION
**Description:**
We need simple aggregation capability to get machine_cpu_cores metric. For now only "count" aggregation method is needed. Later this might be moved to metrics transform processor.