### PR TITLE
Do not show warnings in list-stability-tests output

### DIFF
--- a/testbed/Makefile
+++ b/testbed/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.Common
 
 .PHONY: list-tests
 list-tests:
-	TESTBED_CONFIG=local.yaml $(GOTEST) -v ./tests --test.list '.*' | sed '$$d'
+	TESTBED_CONFIG=local.yaml $(GOTEST) -v ./tests --test.list '.*' | grep "^Test" | sed '$$d'
 
 .PHONY: run-tests
 run-tests:
@@ -10,7 +10,7 @@ run-tests:
 
 .PHONY: list-stability-tests
 list-stability-tests:
-	TESTBED_CONFIG=local.yaml $(GOTEST) -v ./stabilitytests --test.list '.*' | sed '$$d'
+	TESTBED_CONFIG=local.yaml $(GOTEST) -v ./stabilitytests --test.list '.*' | grep "^Test" | sed '$$d'
 
 .PHONY: run-stability-tests
 run-stability-tests:


### PR DESCRIPTION
**Description:**
"Run stability tests" circle CI job relies on this make target to count stability tests. This commit cleans up output of list-stability-tests target to make sure it's not polluted with extra messages.

It resolves the failing stability tests: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/522 ...