### PR TITLE
Add /pods endpoint support in kubeletstats receiver to add extra labels

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -978,6 +978,7 @@ github.com/santhosh-tekuri/jsonschema v1.2.4 h1:hNhW8e7t+H1vgY+1QeEQpveR6D4+OwKP
 github.com/santhosh-tekuri/jsonschema v1.2.4/go.mod h1:TEAUOeZSmIxTTuHatJzrvARHiuO9LYd+cIxzgEHCQI4=
 github.com/satori/go.uuid v0.0.0-20160603004225-b111a074d5ef h1:RoeI7K0oZIcUirMHsFpQjTVDrl1ouNh8T7v3eNsUxL0=
 github.com/satori/go.uuid v0.0.0-20160603004225-b111a074d5ef/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -83,3 +83,25 @@ service:
       receivers: [kubeletstats]
       exporters: [file]
 ```    
+
+### Extra metadata labels
+
+By default all produced metrics get resource labels based on what kubelet /stats/summary endpoint provides.
+For some use cases it might be not enough. So it's possible to leverage other endpoints to fetch
+additional metadata entities and set them as extra labels on metric resource.
+The only additional label supported at the moment is `container.id`. If you want to have that label
+added to your metrics, use `extra_metadata_labels` field to enable it, for example:
+
+```yaml
+receivers:
+  kubeletstats:
+    collection_interval: 10s
+    auth_type: "serviceAccount"
+    endpoint: "${K8S_NODE_NAME}:10250"
+    insecure_skip_verify: true
+    extra_metadata_labels:
+      - container.id
+```
+
+If `extra_metadata_labels` is not set, no additional API calls is done to fetch extra metadata.
+

--- a/receiver/kubeletstatsreceiver/config.go
+++ b/receiver/kubeletstatsreceiver/config.go
@@ -30,4 +30,10 @@ type Config struct {
 	kubelet.ClientConfig          `mapstructure:",squash"`
 	confignet.TCPAddr             `mapstructure:",squash"`
 	CollectionInterval            time.Duration `mapstructure:"collection_interval"`
+
+	// ExtraMetadataLabels contains list of extra metadata that should be taken from /pods endpoint
+	// and put as extra labels on metrics resource.
+	// No additional metadata is fetched by default, so there are no extra calls to /pods endpoint.
+	// Only container.id label is supported at the moment.
+	ExtraMetadataLabels []kubelet.MetadataLabel `mapstructure:"extra_metadata_labels"`
 }

--- a/receiver/kubeletstatsreceiver/config_test.go
+++ b/receiver/kubeletstatsreceiver/config_test.go
@@ -79,4 +79,19 @@ func TestLoadConfig(t *testing.T) {
 		},
 		CollectionInterval: duration,
 	}, saCfg)
+
+	metadataCfg := cfg.Receivers["kubeletstats/metadata"].(*Config)
+	require.Equal(t, &Config{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			TypeVal: "kubeletstats",
+			NameVal: "kubeletstats/metadata",
+		},
+		ClientConfig: kubelet.ClientConfig{
+			APIConfig: k8sconfig.APIConfig{
+				AuthType: "serviceAccount",
+			},
+		},
+		CollectionInterval:  duration,
+		ExtraMetadataLabels: []kubelet.MetadataLabel{kubelet.MetadataLabelContainerID},
+	}, metadataCfg)
 }

--- a/receiver/kubeletstatsreceiver/factory.go
+++ b/receiver/kubeletstatsreceiver/factory.go
@@ -69,9 +69,14 @@ func (f *Factory) CreateTraceReceiver(
 func (f *Factory) CreateMetricsReceiver(
 	ctx context.Context,
 	logger *zap.Logger,
-	cfg configmodels.Receiver,
+	baseCfg configmodels.Receiver,
 	consumer consumer.MetricsConsumerOld,
 ) (component.MetricsReceiver, error) {
+	cfg := baseCfg.(*Config)
+	err := kubelet.ValidateMetadataLabelsConfig(cfg.ExtraMetadataLabels)
+	if err != nil {
+		return nil, err
+	}
 	rest, err := f.restClient(logger, cfg)
 	if err != nil {
 		return nil, err
@@ -84,8 +89,7 @@ func (f *Factory) CreateMetricsReceiver(
 	}, nil
 }
 
-func (f *Factory) restClient(logger *zap.Logger, baseCfg configmodels.Receiver) (kubelet.RestClient, error) {
-	cfg := baseCfg.(*Config)
+func (f *Factory) restClient(logger *zap.Logger, cfg *Config) (kubelet.RestClient, error) {
 	clientProvider, err := kubelet.NewClientProvider(cfg.Endpoint, &cfg.ClientConfig, logger)
 	if err != nil {
 		return nil, err

--- a/receiver/kubeletstatsreceiver/factory_test.go
+++ b/receiver/kubeletstatsreceiver/factory_test.go
@@ -65,6 +65,22 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	require.NotNil(t, metricsReceiver)
 }
 
+func TestFactoryInvalidExtraMetadataLabels(t *testing.T) {
+	factory := &Factory{}
+	cfg := Config{
+		ExtraMetadataLabels: []kubelet.MetadataLabel{kubelet.MetadataLabel("invalid-label")},
+	}
+	metricsReceiver, err := factory.CreateMetricsReceiver(
+		context.Background(),
+		zap.NewNop(),
+		&cfg,
+		&testbed.MockMetricConsumer{},
+	)
+	require.Error(t, err)
+	require.Equal(t, "label \"invalid-label\" is not supported", err.Error())
+	require.Nil(t, metricsReceiver)
+}
+
 func TestFactoryBadAuthType(t *testing.T) {
 	factory := &Factory{}
 	cfg := &Config{

--- a/receiver/kubeletstatsreceiver/go.mod
+++ b/receiver/kubeletstatsreceiver/go.mod
@@ -12,6 +12,8 @@ require (
 	go.opentelemetry.io/collector v0.5.1-0.20200723232356-d4053cc823a0
 	go.uber.org/zap v1.15.0
 	google.golang.org/grpc/examples v0.0.0-20200723182653-9106c3fff523 // indirect
+	k8s.io/api v0.0.0-20190813020757-36bff7324fb7
+	k8s.io/apimachinery v0.0.0-20190809020650-423f5d784010
 	k8s.io/kubernetes v1.12.0
 )
 

--- a/receiver/kubeletstatsreceiver/go.sum
+++ b/receiver/kubeletstatsreceiver/go.sum
@@ -874,6 +874,7 @@ github.com/securego/gosec/v2 v2.3.0 h1:y/9mCF2WPDbSDpL3QDWZD3HHGrSYw0QSHnCqTfs4J
 github.com/securego/gosec/v2 v2.3.0/go.mod h1:UzeVyUXbxukhLeHKV3VVqo7HdoQR9MrRfFmZYotn8ME=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
+github.com/shirou/gopsutil v0.0.0-20200517204708-c89193f22d93 h1:+ZhxoIovCjs+mkd0pCBqczqvx/vl+emW8x04WM15Y7M=
 github.com/shirou/gopsutil v0.0.0-20200517204708-c89193f22d93/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e h1:MZM7FHLqUHYI0Y/mQAt3d2aYa0SiNms/hFqC9qJYolM=
@@ -1368,6 +1369,7 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
+google.golang.org/protobuf v1.24.0 h1:UhZDfRO8JRQru4/+LlLE0BRKGF8L+PICnvYZmx/fEGA=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/receiver/kubeletstatsreceiver/kubelet/accumulator_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator_test.go
@@ -1,0 +1,83 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubelet
+
+import (
+	"testing"
+
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+)
+
+// TestContainerStatsMetadataNotFound walks through the error cases of containerStats.
+// Happy paths are covered in metadata_test.go
+func TestContainerStatsMetadataNotFound(t *testing.T) {
+	now := metav1.Now()
+	podResource := &resourcepb.Resource{
+		Labels: map[string]string{
+			labelPodUID:        "pod-uid-123",
+			labelContainerName: "container1",
+		},
+	}
+	containerStats := stats.ContainerStats{
+		Name:      "container1",
+		StartTime: now,
+	}
+	metadata := NewMetadata(
+		[]MetadataLabel{MetadataLabelContainerID},
+		&v1.PodList{
+			Items: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: types.UID("pod-uid-123"),
+					},
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								// different container name
+								Name:        "container2",
+								ContainerID: "test-container",
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	observedLogger, logs := observer.New(zapcore.WarnLevel)
+	logger := zap.New(observedLogger)
+
+	mds := []*consumerdata.MetricsData{}
+	acc := metricDataAccumulator{
+		m:        mds,
+		metadata: metadata,
+		logger:   logger,
+	}
+
+	acc.containerStats(podResource, containerStats)
+
+	assert.Equal(t, 0, len(mds))
+	assert.Equal(t, 1, logs.Len())
+	assert.Equal(t, "failed to fetch container metrics", logs.All()[0].Message)
+}

--- a/receiver/kubeletstatsreceiver/kubelet/client.go
+++ b/receiver/kubeletstatsreceiver/kubelet/client.go
@@ -179,10 +179,17 @@ func (c *clientImpl) Get(path string) ([]byte, error) {
 			c.logger.Warn("failed to close response body", zap.Error(closeErr))
 		}
 	}()
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithMessage(err, "failed to read Kubelet response body")
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("kubelet request GET %s failed - %q, response: %q",
+			req.URL.String(), resp.Status, string(body))
+	}
+
 	return body, nil
 }
 

--- a/receiver/kubeletstatsreceiver/kubelet/conventions.go
+++ b/receiver/kubeletstatsreceiver/kubelet/conventions.go
@@ -1,0 +1,24 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubelet
+
+const (
+	labelContainerID   = "container.id"
+	labelContainerName = "container.name"
+	labelNamespaceName = "k8s.namespace.name"
+	labelNodeName      = "k8s.node.name"
+	labelPodName       = "k8s.pod.name"
+	labelPodUID        = "k8s.pod.uid"
+)

--- a/receiver/kubeletstatsreceiver/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata.go
@@ -1,0 +1,105 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubelet
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type MetadataLabel string
+
+const (
+	MetadataLabelContainerID MetadataLabel = labelContainerID
+)
+
+var supportedLabels = map[MetadataLabel]bool{
+	MetadataLabelContainerID: true,
+}
+
+// ValidateMetadataLabelsConfig validates that provided list of metadata labels is supported
+func ValidateMetadataLabelsConfig(labels []MetadataLabel) error {
+	labelsFound := map[MetadataLabel]bool{}
+	for _, label := range labels {
+		if _, supported := supportedLabels[label]; supported {
+			if _, duplicate := labelsFound[label]; duplicate {
+				return fmt.Errorf("duplicate metadata label: %q", label)
+			}
+			labelsFound[label] = true
+		} else {
+			return fmt.Errorf("label %q is not supported", label)
+		}
+	}
+	return nil
+}
+
+type Metadata struct {
+	Labels       []MetadataLabel
+	PodsMetadata *v1.PodList
+}
+
+func NewMetadata(labels []MetadataLabel, podsMetadata *v1.PodList) Metadata {
+	return Metadata{
+		Labels:       labels,
+		PodsMetadata: podsMetadata,
+	}
+}
+
+// setExtraLabels sets extra labels in `lables` map based on available metadata
+func (m *Metadata) setExtraLabels(labels map[string]string, podUID string, containerName string) error {
+	for _, label := range m.Labels {
+		switch label {
+		case MetadataLabelContainerID:
+			containerID, err := m.getContainerID(podUID, containerName)
+			if err != nil {
+				return err
+			}
+			labels[labelContainerID] = containerID
+			return nil
+		}
+	}
+	return nil
+}
+
+// getContainerID retrieves container id from metadata for given pod UID and container name,
+// returns an error if no container found in the metadata that matches the requirements.
+func (m *Metadata) getContainerID(podUID string, containerName string) (string, error) {
+	if m.PodsMetadata == nil {
+		return "", errors.New("pods metadata were not fetched")
+	}
+
+	for _, pod := range m.PodsMetadata.Items {
+		if pod.UID == types.UID(podUID) {
+			for _, containerStatus := range pod.Status.ContainerStatuses {
+				if containerName == containerStatus.Name {
+					return stripContainerID(containerStatus.ContainerID), nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("pod %q with container %q not found in the fetched metadata", podUID, containerName)
+}
+
+var containerSchemeRegexp = regexp.MustCompile(`^[\w_-]+://`)
+
+// stripContainerID returns a pure container id without the runtime scheme://
+func stripContainerID(id string) string {
+	return containerSchemeRegexp.ReplaceAllString(id, "")
+}

--- a/receiver/kubeletstatsreceiver/kubelet/metadata_provider.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata_provider.go
@@ -1,0 +1,45 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubelet
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// MetadataProvider wraps a RestClient, returning an unmarshaled metadata.
+type MetadataProvider struct {
+	rc RestClient
+}
+
+func NewMetadataProvider(rc RestClient) *MetadataProvider {
+	return &MetadataProvider{rc: rc}
+}
+
+// Pods calls the /pods endpoint and unmarshals the
+// results into a v1.PodList struct.
+func (p *MetadataProvider) Pods() (*v1.PodList, error) {
+	pods, err := p.rc.Pods()
+	if err != nil {
+		return nil, err
+	}
+	var out v1.PodList
+	err = json.Unmarshal(pods, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/receiver/kubeletstatsreceiver/kubelet/metadata_provider_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata_provider_test.go
@@ -1,0 +1,80 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubelet
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testRestClient struct {
+	fail        bool
+	invalidJSON bool
+}
+
+func (f testRestClient) StatsSummary() ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (f testRestClient) Pods() ([]byte, error) {
+	if f.fail {
+		return []byte{}, errors.New("failed")
+	}
+	if f.invalidJSON {
+		return []byte("wrong-json-body"), nil
+	}
+
+	return ioutil.ReadFile("../testdata/pods.json")
+}
+
+func TestPods(t *testing.T) {
+	tests := []struct {
+		name      string
+		client    RestClient
+		wantError string
+	}{
+		{
+			name:      "success",
+			client:    &testRestClient{},
+			wantError: "",
+		},
+		{
+			name:      "failure",
+			client:    &testRestClient{fail: true},
+			wantError: "failed",
+		},
+		{
+			name:      "invalid-json",
+			client:    &testRestClient{invalidJSON: true},
+			wantError: "invalid character 'w' looking for beginning of value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadataProvider := NewMetadataProvider(tt.client)
+			podsMetadata, err := metadataProvider.Pods()
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				require.Less(t, 0, len(podsMetadata.Items))
+			} else {
+				assert.Equal(t, tt.wantError, err.Error())
+			}
+		})
+	}
+}

--- a/receiver/kubeletstatsreceiver/kubelet/metadata_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata_test.go
@@ -1,0 +1,158 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubelet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestValidateMetadataLabelsConfig(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		labels    []MetadataLabel
+		wantError string
+	}{
+		{
+			name:      "no_labels",
+			labels:    []MetadataLabel{},
+			wantError: "",
+		},
+		{
+			name:      "container_id_valid",
+			labels:    []MetadataLabel{MetadataLabelContainerID},
+			wantError: "",
+		},
+		{
+			name:      "container_id_duplicate",
+			labels:    []MetadataLabel{MetadataLabelContainerID, MetadataLabelContainerID},
+			wantError: "duplicate metadata label: \"container.id\"",
+		},
+		{
+			name:      "unknown_label",
+			labels:    []MetadataLabel{MetadataLabel("wrong-label")},
+			wantError: "label \"wrong-label\" is not supported",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMetadataLabelsConfig(tt.labels)
+			if tt.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				assert.Equal(t, tt.wantError, err.Error())
+			}
+		})
+	}
+}
+
+func TestSetExtraLabels(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		metadata      Metadata
+		podUID        string
+		containerName string
+		wantError     string
+		want          map[string]string
+	}{
+		{
+			name:          "no_labels",
+			metadata:      NewMetadata([]MetadataLabel{}, nil),
+			podUID:        "uid",
+			containerName: "container",
+			want:          map[string]string{},
+		},
+		{
+			name: "set_container_id_valid",
+			metadata: NewMetadata(
+				[]MetadataLabel{MetadataLabelContainerID},
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: types.UID("uid-1234"),
+							},
+							Status: v1.PodStatus{
+								ContainerStatuses: []v1.ContainerStatus{
+									{
+										Name:        "container1",
+										ContainerID: "test-container",
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			podUID:        "uid-1234",
+			containerName: "container1",
+			want: map[string]string{
+				string(MetadataLabelContainerID): "test-container",
+			},
+		},
+		{
+			name:          "set_container_id_no_metadata",
+			metadata:      NewMetadata([]MetadataLabel{MetadataLabelContainerID}, nil),
+			podUID:        "uid-1234",
+			containerName: "container1",
+			wantError:     "pods metadata were not fetched",
+		},
+		{
+			name: "set_container_id_not_found",
+			metadata: NewMetadata(
+				[]MetadataLabel{MetadataLabelContainerID},
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: types.UID("uid-1234"),
+							},
+							Status: v1.PodStatus{
+								ContainerStatuses: []v1.ContainerStatus{
+									{
+										Name:        "container2",
+										ContainerID: "another-container",
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			podUID:        "uid-1234",
+			containerName: "container1",
+			wantError:     "pod \"uid-1234\" with container \"container1\" not found in the fetched metadata",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := map[string]string{}
+			err := tt.metadata.setExtraLabels(fields, tt.podUID, tt.containerName)
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				assert.EqualValues(t, tt.want, fields)
+			} else {
+				assert.Equal(t, tt.wantError, err.Error())
+			}
+		})
+	}
+}

--- a/receiver/kubeletstatsreceiver/kubelet/metrics.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metrics.go
@@ -16,11 +16,15 @@ package kubelet
 
 import (
 	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.uber.org/zap"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
-func MetricsData(summary *stats.Summary, typeStr string) []*consumerdata.MetricsData {
-	acc := &metricDataAccumulator{}
+func MetricsData(logger *zap.Logger, summary *stats.Summary, metadata Metadata, typeStr string) []*consumerdata.MetricsData {
+	acc := &metricDataAccumulator{
+		metadata: metadata,
+		logger:   logger,
+	}
 	acc.nodeStats(summary.Node)
 	for _, podStats := range summary.Pods {
 		// propagate the pod resource down to the container

--- a/receiver/kubeletstatsreceiver/receiver.go
+++ b/receiver/kubeletstatsreceiver/receiver.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer"
 	"go.uber.org/zap"
 
@@ -29,7 +28,7 @@ import (
 var _ component.MetricsReceiver = (*receiver)(nil)
 
 type receiver struct {
-	cfg      configmodels.Receiver
+	cfg      *Config
 	logger   *zap.Logger
 	consumer consumer.MetricsConsumerOld
 	runner   *interval.Runner
@@ -38,10 +37,8 @@ type receiver struct {
 
 // Creates and starts the kubelet stats runnable.
 func (r *receiver) Start(ctx context.Context, host component.Host) error {
-	runnable := newRunnable(ctx, r.cfg.Name(), r.consumer, r.rest, r.logger)
-
-	cfg := r.cfg.(*Config)
-	r.runner = interval.NewRunner(cfg.CollectionInterval, runnable)
+	runnable := newRunnable(ctx, r.cfg.Name(), r.consumer, r.rest, r.cfg.ExtraMetadataLabels, r.logger)
+	r.runner = interval.NewRunner(r.cfg.CollectionInterval, runnable)
 
 	go func() {
 		if err := r.runner.Start(); err != nil {

--- a/receiver/kubeletstatsreceiver/receiver_test.go
+++ b/receiver/kubeletstatsreceiver/receiver_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestMetricsReceiver(t *testing.T) {
 	factory := &Factory{}
-	cfg := factory.CreateDefaultConfig()
+	cfg := factory.CreateDefaultConfig().(*Config)
 	metricsReceiver := receiver{
 		cfg:      cfg,
 		logger:   zap.NewNop(),

--- a/receiver/kubeletstatsreceiver/testdata/config.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/config.yaml
@@ -11,6 +11,11 @@ receivers:
     collection_interval: 10s
     auth_type: "serviceAccount"
     insecure_skip_verify: true
+  kubeletstats/metadata:
+    collection_interval: 10s
+    auth_type: "serviceAccount"
+    extra_metadata_labels:
+    - container.id
 exporters:
   exampleexporter:
 service:

--- a/receiver/kubeletstatsreceiver/testdata/pods.json
+++ b/receiver/kubeletstatsreceiver/testdata/pods.json
@@ -1,0 +1,130 @@
+{
+  "items": [
+    {
+      "metadata": {
+        "name": "kube-scheduler-minikube",
+        "uid": "5795d0c442cb997ff93c49feeb9f6386"
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "kube-scheduler",
+            "containerID": "364bd8f13021f326"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "go-hello-world-5456b4b8cd-99vxc",
+        "uid": "42ad382b-ed0b-446d-9aab-3fdce8b4f9e2"
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "server",
+            "containerID": "c3d470faf18eba2b"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-apiserver-minikube",
+        "uid": "3bef16d65fa74d46458df57d8f6f59af"
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "kube-apiserver",
+            "containerID": "b798809239aad09b"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "coredns-66bff467f8-szddj",
+        "uid": "0adffe8e-9849-4e05-b4cd-92d2d1e1f1c3"
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "coredns",
+            "containerID": "bd76db53336d07eb"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "coredns-66bff467f8-58qvv",
+        "uid": "eb632b33-62c6-4a80-9575-a97ab363ad7f"
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "coredns",
+            "containerID": "765c28ca19767b2e"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-controller-manager-minikube",
+        "uid": "3016593d20758bbfe68aba26604a8e3d"
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "kube-controller-manager",
+            "containerID": "bddddc92226476d2"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-proxy-v48tf",
+        "uid": "0a6d6b05-0e8d-4920-8a38-926a33164d45"
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "kube-proxy",
+            "containerID": "3c340a1810969eb1"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "storage-provisioner",
+        "uid": "14bf95e0-9451-4192-b111-807b03163670"
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "storage-provisioner",
+            "containerID": "bcaf30860852fd24"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "etcd-minikube",
+        "uid": "5a5fbd34cfb43ee7bee976798370c910"
+      },
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "etcd",
+            "containerID": "baa7aaedeab79d38"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Description:**
This commits adds ability to optionally fetch extra metadata from /pods endpoint in kubeletstats receiver and use that data to set additional labels on metric resource. For now only container.id label is supported

**Testing:** Unit tests and manual testing

**Documentation:** Additional section in README.md