### PR TITLE
Fix flaky test in signalfx exporter

### DIFF
--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -1210,7 +1210,7 @@ func TestTranslateDataPoints(t *testing.T) {
 			}
 
 			// Sort metrics to handle not deterministic order from aggregation
-			if tt.name == "aggregate_metric" {
+			if tt.trs[0].Action == ActionAggregateMetric {
 				sort.Sort(byContent(tt.want))
 				sort.Sort(byContent(got))
 			}


### PR DESCRIPTION
Aggregation translation uses a map, as a result output datapoints are not consistently sorted. This commit fixes it.
