### PR TITLE
Update signalfx exporter translations

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -176,9 +176,9 @@ func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
 
 	// Validate that default translation rules are loaded
 	// Expected values has to be updated once default config changed
-	assert.Equal(t, 9, len(config.TranslationRules))
+	assert.Equal(t, 12, len(config.TranslationRules))
 	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
-	assert.Equal(t, 15, len(config.TranslationRules[0].Mapping))
+	assert.Equal(t, 20, len(config.TranslationRules[0].Mapping))
 }
 
 func TestCreateMetricsExporterWithSpecifiedTranslaitonRules(t *testing.T) {

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -26,6 +26,7 @@ translation_rules:
 
     # dimensions
     container.image.name: container_image
+    container.name: container_spec_name
     k8s.pod.name: kubernetes_pod_name
     k8s.pod.uid: kubernetes_pod_uid
     k8s.node.uid: kubernetes_node_uid
@@ -36,6 +37,10 @@ translation_rules:
     # properties
     k8s.workload.kind: kubernetes_workload
     k8s.workload.name: kubernetes_workload_name
+    k8s.deployment.uid: kubernetes_uid
+    k8s.deployment.name: kubernetes_name
+    k8s.replica_set.uid: kubernetes_uid
+    k8s.replica_set.name: kubernetes_name    
     daemonset: daemonSet
     daemonset_uid: daemonSet_uid
     replicaset: replicaSet
@@ -48,25 +53,44 @@ translation_rules:
 
     # kubeletstats receiver metrics
     container.cpu.time: container_cpu_utilization
-    container.memory.usage: container_memory_usage_bytes
-    container.filesystem.usage: container_fs_usage_bytes
     container.filesystem.available: container_fs_available_bytes
     container.filesystem.capacity: container_fs_capacity_bytes
+    container.filesystem.usage: container_fs_usage_bytes
+    container.memory.usage: container_memory_usage_bytes
+    k8s.node.cpu.utilization: cpu.utilization
 
     # k8s cluster receiver metrics
-    k8s/pod/phase: kubernetes.pod_phase
-    k8s/deployment/available: kubernetes.deployment.available
-    k8s/deployment/desired: kubernetes.deployment.desired
     k8s/container/cpu/limit: kubernetes.container_cpu_limit
     k8s/container/cpu/request: kubernetes.container_cpu_request
     k8s/container/memory/limit: kubernetes.container_memory_limit
     k8s/container/memory/request: kubernetes.container_memory_request
     k8s/container/ready: kubernetes.container_ready
-    k8s/node/condition_out_of_disk: kubernetes.node_out_of_disk
-    k8s/node/condition_ready: kubernetes.node_ready
-    k8s/node/condition_p_i_d_pressure: kubernetes.node_p_i_d_pressure
+    k8s/container/restarts: kubernetes.container_restart_count
+    k8s/cronjob/active_jobs: kubernetes.cronjob.active
+    k8s/daemon_set/current_scheduled_nodes: kubernetes.daemon_set.current_scheduled
+    k8s/daemon_set/desired_scheduled_nodes: kubernetes.daemon_set.desired_scheduled
+    k8s/daemon_set/misscheduled_nodes: kubernetes.daemon_set.misscheduled
+    k8s/daemon_set/ready_nodes: kubernetes.daemon_set.ready
+    k8s/deployment/available: kubernetes.deployment.available
+    k8s/deployment/desired: kubernetes.deployment.desired
+    k8s/job/active_pods: kubernetes.job.active
+    k8s/job/desired_successful_pods: kubernetes.job.completions
+    k8s/job/failed_pods: kubernetes.job.failed
+    k8s/job/max_parallel_pods: kubernetes.job.parallelism
+    k8s/job/successful_pods: kubernetes.job.succeeded
+    k8s/namespace/phase: kubernetes.namespace_phase
     k8s/node/condition_memory_pressure: kubernetes.node_memory_pressure
     k8s/node/condition_network_unavailable: kubernetes.node_network_unavailable
+    k8s/node/condition_out_of_disk: kubernetes.node_out_of_disk
+    k8s/node/condition_p_i_d_pressure: kubernetes.node_p_i_d_pressure
+    k8s/node/condition_ready: kubernetes.node_ready
+    k8s/pod/phase: kubernetes.pod_phase
+    k8s/replica_set/available: kubernetes.replica_set.available
+    k8s/replica_set/desired: kubernetes.replica_set.desired
+    k8s/stateful_set/current_pods: kubernetes.stateful_set.current
+    k8s/stateful_set/desired_pods: kubernetes.stateful_set.desired
+    k8s/stateful_set/ready_pods: kubernetes.stateful_set.ready
+    k8s/stateful_set/updated_pods: kubernetes.stateful_set.updated
 
 # container network metrics
 - action: split_metric
@@ -82,6 +106,7 @@ translation_rules:
     receive: pod_network_receive_errors_total
     transmit: pod_network_transmit_errors_total
 
+# convert cpu metrics
 - action: split_metric
   metric_name: system.cpu.time
   dimension_key: state
@@ -117,16 +142,46 @@ translation_rules:
     cpu.softirq: int
     cpu.nice: int
 
+# compute cpu.num_processors
 - action: copy_metrics
   mapping:
-    cpu.idle: machine_cpu_cores
-
+    cpu.idle: cpu.num_processors
 - action: aggregate_metric
-  metric_name: machine_cpu_cores
+  metric_name: cpu.num_processors
   aggregation_method: count
   dimensions:
   - host
   - kubernetes_node
   - kubernetes_cluster
+
+# compute memory.total
+- action: copy_metrics
+  mapping:
+    system.memory.usage: memory.total
+  dimension_key: state
+  dimension_values:
+    buffered: true
+    cached: true
+    free: true
+    used: true
+- action: aggregate_metric
+  metric_name: memory.total
+  aggregation_method: sum
+  dimensions:
+  - host
+  - kubernetes_node
+  - kubernetes_cluster
+
+# convert memory metrics
+- action: split_metric
+  metric_name: system.memory.usage
+  dimension_key: state
+  mapping:
+    buffered: memory.buffered
+    cached: memory.cached
+    free: memory.free
+    slab_reclaimable: memory.slab_recl
+    slab_unreclaimable: memory.slab_unrecl
+    used: memory.used    
 `
 )


### PR DESCRIPTION
- Rename more k8s specific dimensions and metrics
- Use cpu.num_processors instead of machine_cpu_cores
- Compute memory.total
- Split system.memory.usage
