### PR TITLE
Infer resource type based on conventions for export to Google Cloud Monitoring (Stackdriver)

### DIFF
--- a/exporter/stackdriverexporter/resource_mapper.go
+++ b/exporter/stackdriverexporter/resource_mapper.go
@@ -45,6 +45,14 @@ func (mr *resourceMapper) mapResource(res *resource.Resource) *monitoredrespb.Mo
 		return result
 	}
 
+	// If resource type is missing, try to infer it
+	// based on the presence of resource labels (semantic conventions)
+	if res.Type == "" {
+		if resType, ok := inferResourceType(res.Labels); ok {
+			res.Type = resType
+		}
+	}
+
 	// Keep original behavior by default
 	return stackdriver.DefaultMapResource(res)
 }

--- a/exporter/stackdriverexporter/resource_type_mapper.go
+++ b/exporter/stackdriverexporter/resource_type_mapper.go
@@ -1,3 +1,17 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package stackdriverexporter
 
 import (

--- a/exporter/stackdriverexporter/resource_type_mapper.go
+++ b/exporter/stackdriverexporter/resource_type_mapper.go
@@ -1,0 +1,52 @@
+package stackdriverexporter
+
+import (
+	"go.opencensus.io/resource/resourcekeys"
+)
+
+type resourceTypeDetector struct {
+	// label presence to check against
+	labelKey string
+	// matching resource type
+	resourceType string
+}
+
+// mapping of label presence to inferred resource type
+// NOTE: defined in the priority order (first match wins)
+var attributeToResourceType = []resourceTypeDetector{
+	{
+		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/container.md
+		labelKey:     resourcekeys.ContainerKeyName,
+		resourceType: resourcekeys.ContainerType,
+	},
+	{
+		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/k8s.md#pod
+		labelKey: resourcekeys.K8SKeyPodName,
+		// NOTE: OpenCensus is using "k8s" rather than "k8s.pod" for Pod
+		resourceType: resourcekeys.K8SType,
+	},
+	{
+		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/host.md
+		labelKey:     resourcekeys.HostKeyName,
+		resourceType: resourcekeys.HostType,
+	},
+	{
+		// See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/cloud.md
+		labelKey:     resourcekeys.CloudKeyProvider,
+		resourceType: resourcekeys.CloudType,
+	},
+}
+
+func inferResourceType(labels map[string]string) (string, bool) {
+	if labels == nil {
+		return "", false
+	}
+
+	for _, detector := range attributeToResourceType {
+		if _, ok := labels[detector.labelKey]; ok {
+			return detector.resourceType, true
+		}
+	}
+
+	return "", false
+}

--- a/exporter/stackdriverexporter/resource_type_mapper_test.go
+++ b/exporter/stackdriverexporter/resource_type_mapper_test.go
@@ -1,0 +1,80 @@
+package stackdriverexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/resource/resourcekeys"
+)
+
+func TestInferResourceType(t *testing.T) {
+	tests := []struct {
+		name             string
+		labels           map[string]string
+		wantResourceType string
+		wantOk           bool
+	}{
+		{
+			name:   "empty labels",
+			labels: nil,
+			wantOk: false,
+		},
+		{
+			name: "container",
+			labels: map[string]string{
+				resourcekeys.K8SKeyClusterName:   "cluster1",
+				resourcekeys.K8SKeyPodName:       "pod1",
+				resourcekeys.K8SKeyNamespaceName: "namespace1",
+				resourcekeys.ContainerKeyName:    "container-name1",
+				resourcekeys.CloudKeyAccountID:   "proj1",
+				resourcekeys.CloudKeyZone:        "zone1",
+			},
+			wantResourceType: resourcekeys.ContainerType,
+			wantOk:           true,
+		},
+		{
+			name: "pod",
+			labels: map[string]string{
+				resourcekeys.K8SKeyClusterName:   "cluster1",
+				resourcekeys.K8SKeyPodName:       "pod1",
+				resourcekeys.K8SKeyNamespaceName: "namespace1",
+				resourcekeys.CloudKeyZone:        "zone1",
+			},
+			wantResourceType: resourcekeys.K8SType,
+			wantOk:           true,
+		},
+		{
+			name: "host",
+			labels: map[string]string{
+				resourcekeys.K8SKeyClusterName: "cluster1",
+				resourcekeys.CloudKeyZone:      "zone1",
+				resourcekeys.HostKeyName:       "node1",
+			},
+			wantResourceType: resourcekeys.HostType,
+			wantOk:           true,
+		},
+		{
+			name: "gce",
+			labels: map[string]string{
+				resourcekeys.CloudKeyProvider: resourcekeys.CloudProviderGCP,
+				resourcekeys.HostKeyID:        "inst1",
+				resourcekeys.CloudKeyZone:     "zone1",
+			},
+			wantResourceType: resourcekeys.CloudType,
+			wantOk:           true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceType, ok := inferResourceType(tc.labels)
+			if tc.wantOk {
+				assert.True(t, ok)
+				assert.Equal(t, tc.wantResourceType, resourceType)
+			} else {
+				assert.False(t, ok)
+				assert.Equal(t, "", resourceType)
+			}
+		})
+	}
+}

--- a/exporter/stackdriverexporter/resource_type_mapper_test.go
+++ b/exporter/stackdriverexporter/resource_type_mapper_test.go
@@ -1,3 +1,17 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package stackdriverexporter
 
 import (


### PR DESCRIPTION
**Description:**
Reverse mapping from [OpenTelemetry's semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions) to OpenCensus resource type.

Since OpenTelemetry has switched to using semantic conventions over explicit resource types, the resource type may now be missing when converted to OpenCensus resource.
In that case we will try to infer the resource type based on documented conventions.

**Link to tracking Issue:**
The issue has been originally discussed in https://github.com/open-telemetry/opentelemetry-python/issues/951#issuecomment-666095032, pointing to inconsistency between OpenCensus and OpenTelemetry which needs to be addressed.

**Testing:** Unit tests added for new functionality

**Documentation:** No documentation needed, we may just refer to the already documented semantic conventions.

/cc @james-bebbington @aabmass 