### PR TITLE
hostobserver: Bug fix and refactor to simplify testing

### DIFF
--- a/extension/observer/hostobserver/extension.go
+++ b/extension/observer/hostobserver/extension.go
@@ -38,7 +38,7 @@ type endpointsLister struct {
 
 	// For testing
 	getConnections        func() ([]net.ConnectionStat, error)
-	newProcess            func(pid int32) (*process.Process, error)
+	getProcess            func(pid int32) (*process.Process, error)
 	collectProcessDetails func(proc *process.Process) (*processDetails, error)
 }
 
@@ -52,7 +52,7 @@ func newObserver(logger *zap.Logger, config *Config) (component.ServiceExtension
 				logger:                logger,
 				observerName:          config.Name(),
 				getConnections:        getConnections,
-				newProcess:            process.NewProcess,
+				getProcess:            process.NewProcess,
 				collectProcessDetails: collectProcessDetails,
 			},
 		},
@@ -139,7 +139,7 @@ func (e endpointsLister) collectEndpoints(conns []net.ConnectionStat) []observer
 	}
 
 	for pid, conns := range connsByPID {
-		proc, err := e.newProcess(pid)
+		proc, err := e.getProcess(pid)
 		if err != nil {
 			e.logger.Warn("Could not examine process (it might have terminated already)")
 			continue

--- a/extension/observer/hostobserver/extension.go
+++ b/extension/observer/hostobserver/extension.go
@@ -35,6 +35,11 @@ type hostObserver struct {
 type endpointsLister struct {
 	logger       *zap.Logger
 	observerName string
+
+	// For testing
+	getConnections        func() ([]net.ConnectionStat, error)
+	newProcess            func(pid int32) (*process.Process, error)
+	collectProcessDetails func(proc *process.Process) (*processDetails, error)
 }
 
 var _ component.ServiceExtension = (*hostObserver)(nil)
@@ -44,8 +49,11 @@ func newObserver(logger *zap.Logger, config *Config) (component.ServiceExtension
 		EndpointsWatcher: observer.EndpointsWatcher{
 			RefreshInterval: config.RefreshInterval,
 			Endpointslister: endpointsLister{
-				logger:       logger,
-				observerName: config.Name(),
+				logger:                logger,
+				observerName:          config.Name(),
+				getConnections:        getConnections,
+				newProcess:            process.NewProcess,
+				collectProcessDetails: collectProcessDetails,
 			},
 		},
 	}
@@ -63,7 +71,7 @@ func (h *hostObserver) Shutdown(context.Context) error {
 }
 
 func (e endpointsLister) ListEndpoints() []observer.Endpoint {
-	conns, err := getConnections()
+	conns, err := e.getConnections()
 	if err != nil {
 		e.logger.Error("Could not get local network listeners", zap.Error(err))
 		return nil
@@ -72,7 +80,7 @@ func (e endpointsLister) ListEndpoints() []observer.Endpoint {
 	return e.collectEndpoints(conns)
 }
 
-var getConnections = func() (conns []net.ConnectionStat, err error) {
+func getConnections() (conns []net.ConnectionStat, err error) {
 	// Skip UID lookup since it's not used by the observer, the method
 	// is available only on linux. See https://github.com/shirou/gopsutil/pull/783
 	// for details.
@@ -109,7 +117,7 @@ func (e endpointsLister) collectEndpoints(conns []net.ConnectionStat) []observer
 			cd := collectConnectionDetails(&c)
 			id := observer.EndpointID(
 				fmt.Sprintf(
-					"(%s)%s-%d-%s", e.observerName, c.Laddr.IP, cd.port, cd.transport,
+					"(%s)%s-%d-%s", e.observerName, cd.ip, cd.port, cd.transport,
 				),
 			)
 
@@ -131,15 +139,15 @@ func (e endpointsLister) collectEndpoints(conns []net.ConnectionStat) []observer
 	}
 
 	for pid, conns := range connsByPID {
-		proc, err := process.NewProcess(pid)
+		proc, err := e.newProcess(pid)
 		if err != nil {
 			e.logger.Warn("Could not examine process (it might have terminated already)")
 			continue
 		}
 
-		pd, err := collectProcessDetails(proc)
+		pd, err := e.collectProcessDetails(proc)
 		if err != nil {
-			e.logger.Error("failed collecting process details (skipping)",
+			e.logger.Error("Failed collecting process details (skipping)",
 				zap.Int32("pid", pid), zap.Error(err),
 			)
 			continue
@@ -151,7 +159,7 @@ func (e endpointsLister) collectEndpoints(conns []net.ConnectionStat) []observer
 			id := observer.EndpointID(
 				fmt.Sprintf(
 					"(%s)%s-%d-%s-%d",
-					e.observerName, c.Laddr.IP, cd.port, cd.transport, pid,
+					e.observerName, cd.ip, cd.port, cd.transport, pid,
 				),
 			)
 
@@ -185,9 +193,10 @@ type connectionDetails struct {
 
 func collectConnectionDetails(c *net.ConnectionStat) connectionDetails {
 	ip := c.Laddr.IP
-	// An IP addr of 0.0.0.0 means it listens on all interfaces, including
-	// localhost, so use that since we can't actually connect to 0.0.0.0.
-	if ip == "0.0.0.0" {
+	// An IP addr of 0.0.0.0 (or "*" on darwin) means it listens on all
+	// interfaces, including localhost, so use that since we can't
+	// actually connect to 0.0.0.0.
+	if ip == "0.0.0.0" || ip == "*" {
 		ip = "127.0.0.1"
 	}
 
@@ -217,12 +226,12 @@ type processDetails struct {
 }
 
 func collectProcessDetails(proc *process.Process) (*processDetails, error) {
-	name, err := getProcessName(proc)
+	name, err := proc.Name()
 	if err != nil {
 		return nil, fmt.Errorf("could not get process name: %v", err)
 	}
 
-	args, err := getProcessArgs(proc)
+	args, err := proc.Cmdline()
 	if err != nil {
 		return nil, fmt.Errorf("could not get process args: %v", err)
 	}
@@ -231,14 +240,6 @@ func collectProcessDetails(proc *process.Process) (*processDetails, error) {
 		name: name,
 		args: args,
 	}, nil
-}
-
-var getProcessName = func(proc *process.Process) (string, error) {
-	return proc.Name()
-}
-
-var getProcessArgs = func(proc *process.Process) (string, error) {
-	return proc.Cmdline()
 }
 
 func portTypeToProtocol(t uint32) observer.Transport {

--- a/extension/observer/hostobserver/extension_test.go
+++ b/extension/observer/hostobserver/extension_test.go
@@ -12,22 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !darwin
-
 package hostobserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"syscall"
 	"testing"
 	"time"
 
 	psnet "github.com/shirou/gopsutil/net"
+	"github.com/shirou/gopsutil/process"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -36,71 +37,147 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
 
+// Tests observer with real connections on system.
 func TestHostObserver(t *testing.T) {
-	tcpConns := openTestTCPPorts(t)
-	udpConns := openTestUDPPorts(t)
-
-	mn := startAndStopObserver(t)
-
-	assert.True(t, len(mn.endpointsMap) >= len(tcpConns)+len(udpConns))
-
-	t.Run("TCP Ports", func(t *testing.T) {
-		for _, conn := range tcpConns {
-			host, port, err := net.SplitHostPort(conn.Addr().String())
-			assert.NoError(t, err, "Failed to et host and port")
-
-			expectedID := observer.EndpointID(
-				fmt.Sprintf(
-					"(host_observer/1)%s-%s-%s-%d", host, port, observer.ProtocolTCP, selfPid),
-			)
-			actualEndpoint := mn.endpointsMap[expectedID]
-			assert.NotEmpty(t, actualEndpoint, "expected endpoint ID not found")
-			assert.Equal(t, expectedID, actualEndpoint.ID, "unexpected endpoint ID found")
-
-			details, ok := actualEndpoint.Details.(observer.HostPort)
-			assert.True(t, ok, "failed to get Endpoint.Details")
-			assert.Equal(t, filepath.Base(exe), details.Name)
-			assert.Equal(t, observer.ProtocolTCP, details.Transport)
-			if host[0] == ':' {
-				assert.Equal(t, true, details.IsIPv6)
-			} else {
-				assert.Equal(t, false, details.IsIPv6)
+	tests := []struct {
+		name                    string
+		protocol                observer.Transport
+		setup                   func() ([]hostPort, mockNotifier)
+		errorListingConnections bool
+	}{
+		{
+			name:     "TCP ports",
+			protocol: observer.ProtocolTCP,
+			setup: func() ([]hostPort, mockNotifier) {
+				tcpConns := openTestTCPPorts(t)
+				mn := startAndStopObserver(t, nil)
+				out := make([]hostPort, len(tcpConns))
+				for i, conn := range tcpConns {
+					out[i] = getHostAndPort(conn)
+				}
+				return out, mn
+			},
+		},
+		{
+			name:     "UDP ports",
+			protocol: observer.ProtocolUDP,
+			setup: func() ([]hostPort, mockNotifier) {
+				udpConns := openTestUDPPorts(t)
+				mn := startAndStopObserver(t, nil)
+				out := make([]hostPort, len(udpConns))
+				for i, conn := range udpConns {
+					out[i] = getHostAndPort(conn)
+				}
+				return out, mn
+			},
+		},
+		{
+			name: "Fails to get connections",
+			setup: func() ([]hostPort, mockNotifier) {
+				mn := startAndStopObserver(t, func() (conns []psnet.ConnectionStat, err error) {
+					return nil, errors.New("fails to list connections")
+				})
+				return nil, mn
+			},
+			errorListingConnections: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostPorts, notifier := tt.setup()
+			if tt.errorListingConnections {
+				require.Equal(t, len(notifier.endpointsMap), 0)
+				return
 			}
-		}
-	})
 
-	t.Run("UDP Ports", func(t *testing.T) {
-		for _, conn := range udpConns {
-			host, port, err := net.SplitHostPort(conn.LocalAddr().String())
-			assert.NoError(t, err, "Failed to et host and port")
+			require.True(t, len(notifier.endpointsMap) >= len(hostPorts))
 
-			expectedID := observer.EndpointID(
-				fmt.Sprintf(
-					"(host_observer/1)%s-%s-%s-%d", host, port, observer.ProtocolUDP, selfPid),
-			)
+			for _, hp := range hostPorts {
+				require.NoError(t, hp.err, "Failed to et host and port")
 
-			actualEndpoint := mn.endpointsMap[expectedID]
-			assert.NotEmpty(t, actualEndpoint, "expected endpoint ID not found")
-			assert.Equal(t, expectedID, actualEndpoint.ID, "unexpected endpoint ID found")
+				host := hp.host
+				port := hp.port
+				isIPv6 := false
+				if host[0] == ':' {
+					isIPv6 = true
+				}
 
-			details, ok := actualEndpoint.Details.(observer.HostPort)
-			assert.True(t, ok, "failed to get Endpoint.Details")
-			assert.Equal(t, filepath.Base(exe), details.Name)
-			assert.Equal(t, observer.ProtocolUDP, details.Transport)
-			if host[0] == ':' {
-				assert.Equal(t, true, details.IsIPv6)
-			} else {
-				assert.Equal(t, false, details.IsIPv6)
+				host = getExpectedHost(host, isIPv6)
+				expectedID := observer.EndpointID(
+					fmt.Sprintf(
+						"(host_observer/1)%s-%s-%s-%d", host, port, tt.protocol, selfPid),
+				)
+
+				actualEndpoint := notifier.endpointsMap[expectedID]
+				require.NotEmpty(t, actualEndpoint, "expected endpoint ID not found. ID: %v", expectedID)
+				assert.Equal(t, expectedID, actualEndpoint.ID, "unexpected endpoint ID found")
+
+				details, ok := actualEndpoint.Details.(observer.HostPort)
+				assert.True(t, ok, "failed to get Endpoint.Details")
+				assert.Equal(t, filepath.Base(exe), details.Name)
+				assert.Equal(t, tt.protocol, details.Transport)
+				assert.Equal(t, isIPv6, details.IsIPv6)
+
 			}
-		}
-	})
+		})
+	}
 }
 
-func startAndStopObserver(t *testing.T) mockNotifier {
-	ml := endpointsLister{
-		logger:       zap.NewNop(),
-		observerName: "host_observer/1",
+type hostPort struct {
+	host string
+	port string
+	err  error
+}
+
+func getHostAndPort(i interface{}) hostPort {
+	var host, port string
+	var err error
+	switch conn := i.(type) {
+	case *net.TCPListener:
+		host, port, err = net.SplitHostPort(conn.Addr().String())
+	case *net.UDPConn:
+		host, port, err = net.SplitHostPort(conn.LocalAddr().String())
+	default:
+		err = errors.New("failed to get host and port")
 	}
+	return hostPort{
+		host: host,
+		port: port,
+		err:  err,
+	}
+}
+
+func getExpectedHost(host string, isIPv6 bool) string {
+	out := host
+
+	if runtime.GOOS == "darwin" && host == "::" {
+		out = "127.0.0.1"
+	}
+
+	if isIPv6 {
+		out = "[" + out + "]"
+	}
+	return out
+}
+
+func startAndStopObserver(
+	t *testing.T,
+	getConnectionsOverride func() (conns []psnet.ConnectionStat, err error)) mockNotifier {
+	ml := endpointsLister{
+		logger:                zap.NewNop(),
+		observerName:          "host_observer/1",
+		getConnections:        getConnections,
+		newProcess:            process.NewProcess,
+		collectProcessDetails: collectProcessDetails,
+	}
+
+	if getConnectionsOverride != nil {
+		ml.getConnections = getConnectionsOverride
+	}
+
+	require.NotNil(t, ml.getConnections)
+	require.NotNil(t, ml.newProcess)
+	require.NotNil(t, ml.collectProcessDetails)
 
 	h := &hostObserver{
 		EndpointsWatcher: observer.EndpointsWatcher{
@@ -339,10 +416,11 @@ func TestCollectConnectionDetails(t *testing.T) {
 
 func TestCollectEndpoints(t *testing.T) {
 	tests := []struct {
-		name                       string
-		conns                      []psnet.ConnectionStat
-		overrideProcessInfoMethods func()
-		want                       []observer.Endpoint
+		name        string
+		conns       []psnet.ConnectionStat
+		newProc     func(pid int32) (*process.Process, error)
+		procDetails func(proc *process.Process) (*processDetails, error)
+		want        []observer.Endpoint
 	}{
 		{
 			name: "Listening TCP socket without process info",
@@ -388,6 +466,25 @@ func TestCollectEndpoints(t *testing.T) {
 			want: []observer.Endpoint{},
 		},
 		{
+			name: "Fails to get process that no longer exists",
+			conns: []psnet.ConnectionStat{
+				{
+					Family: syscall.AF_INET,
+					Type:   syscall.SOCK_STREAM,
+					Laddr: psnet.Addr{
+						IP:   "123.345.567.789",
+						Port: 80,
+					},
+					Status: "LISTEN",
+					Pid:    9999,
+				},
+			},
+			newProc: func(int32) (*process.Process, error) {
+				return nil, errors.New("always fail")
+			},
+			want: []observer.Endpoint{},
+		},
+		{
 			name: "Fails to get process info",
 			conns: []psnet.ConnectionStat{
 				{
@@ -401,14 +498,34 @@ func TestCollectEndpoints(t *testing.T) {
 					Pid:    9999,
 				},
 			},
+			newProc: func(pid int32) (*process.Process, error) {
+				return &process.Process{Pid: pid}, nil
+			},
+			procDetails: func(proc *process.Process) (*processDetails, error) {
+				return nil, errors.New("always fail")
+			},
 			want: []observer.Endpoint{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := endpointsLister{
-				logger: zap.NewNop(),
+				logger:                zap.NewNop(),
+				newProcess:            process.NewProcess,
+				collectProcessDetails: collectProcessDetails,
 			}
+
+			if tt.procDetails != nil {
+				e.collectProcessDetails = tt.procDetails
+			}
+
+			if tt.newProc != nil {
+				e.newProcess = tt.newProc
+			}
+
+			require.NotNil(t, e.collectProcessDetails)
+			require.NotNil(t, e.newProcess)
+
 			if got := e.collectEndpoints(tt.conns); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("collectEndpoints() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
- Bug fix for issue on darwin where ports listening on all interfaces are not correctly accounted for
- Minor refactoring to simplify testing 