### PR TITLE
Signalfx exporter: update k8s translations

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -178,7 +178,7 @@ func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
 	// Expected values has to be updated once default config changed
 	assert.Equal(t, 14, len(config.TranslationRules))
 	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
-	assert.Equal(t, 20, len(config.TranslationRules[0].Mapping))
+	assert.Equal(t, 28, len(config.TranslationRules[0].Mapping))
 }
 
 func TestCreateMetricsExporterWithSpecifiedTranslaitonRules(t *testing.T) {

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -27,26 +27,34 @@ translation_rules:
     # dimensions
     container.image.name: container_image
     container.name: container_spec_name
+    k8s.cluster.name: kubernetes_cluster
+    k8s.daemonset.name: kubernetes_name
+    k8s.daemonset.uid: kubernetes_uid
+    k8s.deployment.name: kubernetes_name
+    k8s.deployment.uid: kubernetes_uid
+    k8s.hpa.name: kubernetes_name
+    k8s.hpa.uid: kubernetes_uid
+    k8s.namespace.name: kubernetes_namespace
+    k8s.node.name: kubernetes_node
+    k8s.node.uid: kubernetes_node_uid
     k8s.pod.name: kubernetes_pod_name
     k8s.pod.uid: kubernetes_pod_uid
-    k8s.node.uid: kubernetes_node_uid
-    k8s.node.name: kubernetes_node
-    k8s.namespace.name: kubernetes_namespace
-    k8s.cluster.name: kubernetes_cluster
+    k8s.replicaset.name: kubernetes_name
+    k8s.replicaset.uid: kubernetes_uid
+    k8s.replicationcontroller.name: kubernetes_name
+    k8s.replicationcontroller.uid: kubernetes_uid
+    k8s.resourcequota.name: quota_name
+    k8s.resourcequota.uid: kubernetes_uid
 
     # properties
+    cronjob_uid: cronJob_uid
+    cronjob: cronJob
+    daemonset_uid: daemonSet_uid
+    daemonset: daemonSet
     k8s.workload.kind: kubernetes_workload
     k8s.workload.name: kubernetes_workload_name
-    k8s.deployment.uid: kubernetes_uid
-    k8s.deployment.name: kubernetes_name
-    k8s.replica_set.uid: kubernetes_uid
-    k8s.replica_set.name: kubernetes_name    
-    daemonset: daemonSet
-    daemonset_uid: daemonSet_uid
-    replicaset: replicaSet
     replicaset_uid: replicaSet_uid
-    cronjob: cronJob
-    cronjob_uid: cronJob_uid
+    replicaset: replicaSet
 
 - action: rename_metrics
   mapping:
@@ -56,6 +64,8 @@ translation_rules:
     container.filesystem.available: container_fs_available_bytes
     container.filesystem.capacity: container_fs_capacity_bytes
     container.filesystem.usage: container_fs_usage_bytes
+    container.memory.available: container_memory_available_bytes
+    container.memory.rss: container_memory_rss_bytes
     container.memory.usage: container_memory_usage_bytes
     k8s.node.cpu.utilization: cpu.utilization
 
@@ -78,6 +88,10 @@ translation_rules:
     k8s/job/failed_pods: kubernetes.job.failed
     k8s/job/max_parallel_pods: kubernetes.job.parallelism
     k8s/job/successful_pods: kubernetes.job.succeeded
+    k8s/hpa/current_replicas: kubernetes.hpa.status.current_replicas
+    k8s/hpa/desired_replicas: kubernetes.hpa.status.desired_replicas
+    k8s/hpa/max_replicas: kubernetes.hpa.spec.max_replicas
+    k8s/hpa/min_replicas: kubernetes.hpa.spec.min_replicas
     k8s/namespace/phase: kubernetes.namespace_phase
     k8s/node/condition_memory_pressure: kubernetes.node_memory_pressure
     k8s/node/condition_network_unavailable: kubernetes.node_network_unavailable
@@ -87,6 +101,10 @@ translation_rules:
     k8s/pod/phase: kubernetes.pod_phase
     k8s/replica_set/available: kubernetes.replica_set.available
     k8s/replica_set/desired: kubernetes.replica_set.desired
+    k8s/replication_controller/available: kubernetes.replication_controller.available
+    k8s/replication_controller/desired: kubernetes.replication_controller.desired
+    k8s/resource_quota/hard_limt: kubernetes.resource_quota_hard
+    k8s/resource_quota/used: kubernetes.resource_quota_used
     k8s/stateful_set/current_pods: kubernetes.stateful_set.current
     k8s/stateful_set/desired_pods: kubernetes.stateful_set.desired
     k8s/stateful_set/ready_pods: kubernetes.stateful_set.ready


### PR DESCRIPTION
- Add metric name and dimension translations k8s cluster receiver metrics: hpa, replication_controller, and resource_quota.
- Add missed metric name translation for kubelet metrics container.memory.available and container_memory_rss_bytes
- Add missed dimension translations for k8s cluster receiver daemonset metrics
