### PR TITLE
zipkin as splunk event for traces

### DIFF
--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -76,7 +76,8 @@ func createTraceData(numberOfTraces int) consumerdata.TraceData {
 			SpanId:    []byte{0, 0, 0, 0, 0, 0, 0, 1},
 			Name:      &tracepb.TruncatableString{Value: "root"},
 			Status:    &tracepb.Status{},
-			StartTime: &timestamp.Timestamp{Seconds: int64(i)},
+			StartTime: &timestamp.Timestamp{Seconds: int64(i + 6)},
+			EndTime:   &timestamp.Timestamp{Seconds: int64(i + 10)},
 		}
 
 		traces = append(traces, span)
@@ -191,11 +192,11 @@ func runTraceExport(disableCompression bool, numberOfTraces int, t *testing.T) (
 func TestReceiveTraces(t *testing.T) {
 	actual, err := runTraceExport(true, 3, t)
 	assert.NoError(t, err)
-	expected := `{"time":0,"host":"unknown","event":{"trace_id":"AQEBAQEBAQEBAQEBAQEBAQ==","span_id":"AAAAAAAAAAE=","name":{"value":"root"},"start_time":{},"status":{}}}`
+	expected := `{"time":6,"host":"unknown","event":{"timestamp":6000000,"duration":4000000,"traceId":"01010101010101010101010101010101","id":"0100000000000000","parentId":"0000000000000000","name":"root","tags":{"ot.status_code":"\u0000"}}}`
 	expected += "\n\r\n\r\n"
-	expected += `{"time":1,"host":"unknown","event":{"trace_id":"AQEBAQEBAQEBAQEBAQEBAQ==","span_id":"AAAAAAAAAAE=","name":{"value":"root"},"start_time":{"seconds":1},"status":{}}}`
+	expected += `{"time":7,"host":"unknown","event":{"timestamp":7000000,"duration":4000000,"traceId":"01010101010101010101010101010101","id":"0100000000000000","parentId":"0000000000000000","name":"root","tags":{"ot.status_code":"\u0000"}}}`
 	expected += "\n\r\n\r\n"
-	expected += `{"time":2,"host":"unknown","event":{"trace_id":"AQEBAQEBAQEBAQEBAQEBAQ==","span_id":"AAAAAAAAAAE=","name":{"value":"root"},"start_time":{"seconds":2},"status":{}}}`
+	expected += `{"time":8,"host":"unknown","event":{"timestamp":8000000,"duration":4000000,"traceId":"01010101010101010101010101010101","id":"0100000000000000","parentId":"0000000000000000","name":"root","tags":{"ot.status_code":"\u0000"}}}`
 	expected += "\n\r\n\r\n"
 	assert.Equal(t, expected, actual)
 }
@@ -203,11 +204,11 @@ func TestReceiveTraces(t *testing.T) {
 func TestReceiveMetrics(t *testing.T) {
 	actual, err := runTraceExport(true, 3, t)
 	assert.NoError(t, err)
-	expected := `{"time":0,"host":"unknown","event":{"trace_id":"AQEBAQEBAQEBAQEBAQEBAQ==","span_id":"AAAAAAAAAAE=","name":{"value":"root"},"start_time":{},"status":{}}}`
+	expected := `{"time":6,"host":"unknown","event":{"timestamp":6000000,"duration":4000000,"traceId":"01010101010101010101010101010101","id":"0100000000000000","parentId":"0000000000000000","name":"root","tags":{"ot.status_code":"\u0000"}}}`
 	expected += "\n\r\n\r\n"
-	expected += `{"time":1,"host":"unknown","event":{"trace_id":"AQEBAQEBAQEBAQEBAQEBAQ==","span_id":"AAAAAAAAAAE=","name":{"value":"root"},"start_time":{"seconds":1},"status":{}}}`
+	expected += `{"time":7,"host":"unknown","event":{"timestamp":7000000,"duration":4000000,"traceId":"01010101010101010101010101010101","id":"0100000000000000","parentId":"0000000000000000","name":"root","tags":{"ot.status_code":"\u0000"}}}`
 	expected += "\n\r\n\r\n"
-	expected += `{"time":2,"host":"unknown","event":{"trace_id":"AQEBAQEBAQEBAQEBAQEBAQ==","span_id":"AAAAAAAAAAE=","name":{"value":"root"},"start_time":{"seconds":2},"status":{}}}`
+	expected += `{"time":8,"host":"unknown","event":{"timestamp":8000000,"duration":4000000,"traceId":"01010101010101010101010101010101","id":"0100000000000000","parentId":"0000000000000000","name":"root","tags":{"ot.status_code":"\u0000"}}}`
 	expected += "\n\r\n\r\n"
 	assert.Equal(t, expected, actual)
 }

--- a/exporter/splunkhecexporter/tracedata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/tracedata_to_splunk_test.go
@@ -16,9 +16,11 @@ package splunkhecexporter
 
 import (
 	"testing"
+	"time"
 
 	v1 "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/openzipkin/zipkin-go/model"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.uber.org/zap"
@@ -62,6 +64,26 @@ func Test_traceDataToSplunk(t *testing.T) {
 			wantSplunkEvents:    []*splunkEvent{},
 			wantNumDroppedSpans: 1,
 		},
+		{
+			name: "bad_tag_value",
+			traceDataFn: func() consumerdata.TraceData {
+				span := makeSpan("myspan", ts)
+				span.Attributes = &v1.Span_Attributes{
+					AttributeMap: map[string]*v1.AttributeValue{
+						"foo": {
+							Value: nil,
+						},
+					},
+				}
+				return consumerdata.TraceData{
+					Spans: []*v1.Span{
+						span,
+					},
+				}
+			},
+			wantSplunkEvents:    []*splunkEvent{},
+			wantNumDroppedSpans: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -81,8 +103,12 @@ func makeSpan(name string, ts *timestamp.Timestamp) *v1.Span {
 		Value: name,
 	}
 	return &v1.Span{
-		Name:      trunceableName,
-		StartTime: ts,
+		TraceId:      []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 8, 7, 6, 5, 4, 3, 2},
+		SpanId:       []byte{1, 2, 3, 4, 5, 6, 7, 8},
+		ParentSpanId: []byte{2, 1, 3, 4, 5, 6, 7, 8},
+		Name:         trunceableName,
+		StartTime:    ts,
+		Status:       &v1.Status{Code: 1, Message: "all good"},
 	}
 }
 
@@ -90,13 +116,113 @@ func commonSplunkEvent(
 	name string,
 	ts *timestamp.Timestamp,
 ) *splunkEvent {
-	trunceableName := &v1.TruncatableString{
-		Value: name,
+	id := model.ID(578437695752307201)
+	parentID := model.ID(578437695752306946)
+	span := model.SpanModel{
+		SpanContext: model.SpanContext{
+			TraceID: model.TraceID{
+				High: uint64(578437695752307201),
+				Low:  uint64(144964032628459529),
+			},
+			ID:       id,
+			ParentID: &parentID,
+			Debug:    false,
+			Sampled:  nil,
+			Err:      nil,
+		},
+		Name:           name,
+		Kind:           model.Undetermined,
+		Timestamp:      time.Unix(ts.GetSeconds(), int64(ts.GetNanos())),
+		Duration:       0,
+		Shared:         false,
+		LocalEndpoint:  nil,
+		RemoteEndpoint: nil,
+		Annotations:    nil,
+		Tags:           map[string]string{"ot.status_code": "\x01", "ot.status_description": "all good"},
 	}
-	span := v1.Span{Name: trunceableName, StartTime: ts}
 	return &splunkEvent{
 		Time:  timestampToEpochMilliseconds(ts),
 		Host:  "unknown",
-		Event: &span,
+		Event: span,
 	}
+}
+
+func Test_convertKind(t *testing.T) {
+	assert.Equal(t, model.Undetermined, convertKind(56))
+	assert.Equal(t, model.Undetermined, convertKind(v1.Span_SPAN_KIND_UNSPECIFIED))
+	assert.Equal(t, model.Client, convertKind(v1.Span_CLIENT))
+	assert.Equal(t, model.Server, convertKind(v1.Span_SERVER))
+}
+
+func Test_convertAnnotations(t *testing.T) {
+	ts := &timestamp.Timestamp{
+		Nanos: 0,
+	}
+	assert.Equal(t,
+		[]model.Annotation{{Timestamp: time.Unix(0, 0), Value: "foo"}, {Timestamp: time.Unix(0, 0), Value: "42"}},
+		convertAnnotations(&v1.Span_TimeEvents{
+			TimeEvent: []*v1.Span_TimeEvent{
+				{
+					Time: ts,
+					Value: &v1.Span_TimeEvent_Annotation_{Annotation: &v1.Span_TimeEvent_Annotation{
+						Description: &v1.TruncatableString{
+							Value: "foo",
+						},
+						Attributes: &v1.Span_Attributes{
+							AttributeMap: map[string]*v1.AttributeValue{
+								"foobar": {
+									Value: &v1.AttributeValue_StringValue{StringValue: &v1.TruncatableString{
+										Value: "foo",
+									}},
+								},
+							},
+						},
+					}},
+				},
+				{
+					Time: ts,
+					Value: &v1.Span_TimeEvent_MessageEvent_{MessageEvent: &v1.Span_TimeEvent_MessageEvent{
+						Type: 1,
+						Id:   42,
+					}},
+				},
+			},
+		}))
+}
+
+func Test_convertTags(t *testing.T) {
+	result, err := convertTags(&v1.Span_Attributes{
+		AttributeMap: map[string]*v1.AttributeValue{
+			"foo": {
+				Value: &v1.AttributeValue_StringValue{StringValue: &v1.TruncatableString{
+					Value: "bar",
+				}},
+			},
+			"foo1": {
+				Value: &v1.AttributeValue_IntValue{IntValue: 13},
+			},
+			"foo2": {
+				Value: &v1.AttributeValue_DoubleValue{DoubleValue: 13.33},
+			},
+			"foo3": {
+				Value: &v1.AttributeValue_BoolValue{BoolValue: false},
+			},
+			"foo4": {
+				Value: &v1.AttributeValue_BoolValue{BoolValue: true},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"foo": "bar", "foo1": "13", "foo2": "13.330000", "foo3": "false", "foo4": "true"}, result)
+}
+
+func Test_convertBadTag(t *testing.T) {
+	_, err := convertTags(&v1.Span_Attributes{
+		AttributeMap: map[string]*v1.AttributeValue{
+			"foo": {
+				Value: nil,
+			},
+		},
+	})
+	assert.EqualError(t, err, "cannot convert tag value")
 }


### PR DESCRIPTION
**Description:** 
Instead of sending the current full event with Splunk HEC, which may be redundant or malformed, use Zipkin as a model to send data.