### PR TITLE
Reduce logging for calculate_new_metric

### DIFF
--- a/exporter/signalfxexporter/translation/translator.go
+++ b/exporter/signalfxexporter/translation/translator.go
@@ -410,7 +410,7 @@ func calculateNewMetric(
 	tr Rule,
 ) *sfxpb.DataPoint {
 	if operand1 == nil {
-		logger.Warn(
+		logger.Debug(
 			"calculate_new_metric: no matching datapoint found for operand1 to calculate new metric",
 			zap.String("tr.Operand1Metric", tr.Operand1Metric),
 			zap.String("tr.MetricName", tr.MetricName),
@@ -427,7 +427,7 @@ func calculateNewMetric(
 	}
 
 	if operand2 == nil {
-		logger.Warn(
+		logger.Debug(
 			"calculate_new_metric: no matching datapoint found for operand2 to calculate new metric",
 			zap.String("tr.Operand2Metric", tr.Operand2Metric),
 			zap.String("tr.MetricName", tr.MetricName),

--- a/exporter/signalfxexporter/translation/translator.go
+++ b/exporter/signalfxexporter/translation/translator.go
@@ -369,6 +369,9 @@ func (mp *MetricTranslator) TranslateDataPoints(logger *zap.Logger, sfxDataPoint
 					operand2 = dp
 				}
 			}
+			if operand1 == nil || operand2 == nil {
+				continue
+			}
 			newPt := calculateNewMetric(logger, operand1, operand2, tr)
 			if newPt == nil {
 				continue
@@ -409,14 +412,6 @@ func calculateNewMetric(
 	operand2 *sfxpb.DataPoint,
 	tr Rule,
 ) *sfxpb.DataPoint {
-	if operand1 == nil {
-		logger.Debug(
-			"calculate_new_metric: no matching datapoint found for operand1 to calculate new metric",
-			zap.String("tr.Operand1Metric", tr.Operand1Metric),
-			zap.String("tr.MetricName", tr.MetricName),
-		)
-		return nil
-	}
 	if operand1.Value.IntValue == nil {
 		logger.Warn(
 			"calculate_new_metric: operand1 has no IntValue",
@@ -426,14 +421,6 @@ func calculateNewMetric(
 		return nil
 	}
 
-	if operand2 == nil {
-		logger.Debug(
-			"calculate_new_metric: no matching datapoint found for operand2 to calculate new metric",
-			zap.String("tr.Operand2Metric", tr.Operand2Metric),
-			zap.String("tr.MetricName", tr.MetricName),
-		)
-		return nil
-	}
 	if operand2.Value.IntValue == nil {
 		logger.Warn(
 			"calculate_new_metric: operand2 has no IntValue",

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -1580,7 +1580,7 @@ func TestNewCalculateNewMetricErrors(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			core, observedLogs := observer.New(zap.WarnLevel)
+			core, observedLogs := observer.New(zap.DebugLevel)
 			logger := zap.New(core)
 			dps := []*sfxpb.DataPoint{
 				{

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -1543,7 +1543,7 @@ func TestNewCalculateNewMetricErrors(t *testing.T) {
 			val1:    generateIntPtr(1),
 			metric2: "metric2",
 			val2:    generateIntPtr(1),
-			wantErr: "calculate_new_metric: no matching datapoint found for operand1 to calculate new metric",
+			wantErr: "",
 		},
 		{
 			name:    "operand1_value_nil",
@@ -1559,7 +1559,7 @@ func TestNewCalculateNewMetricErrors(t *testing.T) {
 			val1:    generateIntPtr(1),
 			metric2: "foo",
 			val2:    generateIntPtr(1),
-			wantErr: "calculate_new_metric: no matching datapoint found for operand2 to calculate new metric",
+			wantErr: "",
 		},
 		{
 			name:    "operand2_value_nil",
@@ -1618,8 +1618,12 @@ func TestNewCalculateNewMetricErrors(t *testing.T) {
 			require.NoError(t, err)
 			tr := mt.TranslateDataPoints(logger, dps)
 			require.Equal(t, 2, len(tr))
-			require.Equal(t, 1, observedLogs.Len())
-			require.Equal(t, test.wantErr, observedLogs.All()[0].Message)
+			if test.wantErr == "" {
+				require.Equal(t, 0, observedLogs.Len())
+			} else {
+				require.Equal(t, 1, observedLogs.Len())
+				require.Equal(t, test.wantErr, observedLogs.All()[0].Message)
+			}
 		})
 	}
 }


### PR DESCRIPTION
It's expected that some groups of metrics will not have operand metrics so there's no need to log a warning.