### PR TITLE
kubeletstatsreceiver: Set datapoint timestamp in receiver

### DIFF
--- a/receiver/kubeletstatsreceiver/kubelet/accumulator.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator.go
@@ -15,6 +15,8 @@
 package kubelet
 
 import (
+	"time"
+
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -42,6 +44,7 @@ type metricDataAccumulator struct {
 	metadata              Metadata
 	logger                *zap.Logger
 	metricGroupsToCollect map[MetricGroup]bool
+	time                  time.Time
 }
 
 const (
@@ -114,7 +117,7 @@ func (a *metricDataAccumulator) accumulate(
 ) {
 	var resourceMetrics []*metricspb.Metric
 	for _, metrics := range m {
-		for _, metric := range metrics {
+		for _, metric := range applyCurrentTime(metrics, a.time) {
 			if metric != nil {
 				metric.Timeseries[0].StartTimestamp = startTime
 				resourceMetrics = append(resourceMetrics, metric)

--- a/receiver/kubeletstatsreceiver/kubelet/cpu.go
+++ b/receiver/kubeletstatsreceiver/kubelet/cpu.go
@@ -20,10 +20,10 @@ import (
 )
 
 func cpuMetrics(prefix string, s *stats.CPUStats) []*metricspb.Metric {
-	return applyCurrentTime([]*metricspb.Metric{
+	return []*metricspb.Metric{
 		cpuUsageMetric(prefix, s),
 		cpuCumulativeUsageMetric(prefix, s),
-	}, s.Time.Time)
+	}
 }
 
 func cpuUsageMetric(prefix string, s *stats.CPUStats) *metricspb.Metric {

--- a/receiver/kubeletstatsreceiver/kubelet/fs.go
+++ b/receiver/kubeletstatsreceiver/kubelet/fs.go
@@ -20,11 +20,11 @@ import (
 )
 
 func fsMetrics(prefix string, s *stats.FsStats) []*metricspb.Metric {
-	return applyCurrentTime([]*metricspb.Metric{
+	return []*metricspb.Metric{
 		fsAvailableMetric(prefix, s),
 		fsCapacityMetric(prefix, s),
 		fsUsedMetric(prefix, s),
-	}, s.Time.Time)
+	}
 }
 
 func fsAvailableMetric(prefix string, s *stats.FsStats) *metricspb.Metric {

--- a/receiver/kubeletstatsreceiver/kubelet/mem.go
+++ b/receiver/kubeletstatsreceiver/kubelet/mem.go
@@ -20,11 +20,11 @@ import (
 )
 
 func memMetrics(prefix string, s *stats.MemoryStats) []*metricspb.Metric {
-	return applyCurrentTime([]*metricspb.Metric{
+	return []*metricspb.Metric{
 		memAvailableMetric(prefix, s),
 		memUsageMetric(prefix, s),
 		memRssMetric(prefix, s),
-	}, s.Time.Time)
+	}
 }
 
 func memAvailableMetric(prefix string, s *stats.MemoryStats) *metricspb.Metric {

--- a/receiver/kubeletstatsreceiver/kubelet/metrics.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metrics.go
@@ -15,6 +15,8 @@
 package kubelet
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.uber.org/zap"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
@@ -30,6 +32,7 @@ func MetricsData(
 		metadata:              metadata,
 		logger:                logger,
 		metricGroupsToCollect: metricGroupsToCollect,
+		time:                  time.Now(),
 	}
 
 	acc.nodeStats(summary.Node)

--- a/receiver/kubeletstatsreceiver/kubelet/network.go
+++ b/receiver/kubeletstatsreceiver/kubelet/network.go
@@ -21,12 +21,12 @@ import (
 
 func networkMetrics(prefix string, s *stats.NetworkStats) []*metricspb.Metric {
 	// todo s.RxErrors s.TxErrors?
-	return applyCurrentTime([]*metricspb.Metric{
+	return []*metricspb.Metric{
 		rxBytesMetric(prefix, s),
 		txBytesMetric(prefix, s),
 		rxErrorsMetric(prefix, s),
 		txErrorsMetric(prefix, s),
-	}, s.Time.Time)
+	}
 }
 
 const directionLabel = "direction"


### PR DESCRIPTION
Currently, the receiver sets the timestamp of a datapoint to be the time the stat was last updated. One of the cases where this is problematic is this timestamp could be the same between collection cycles of the receiver. That will result in multiple datapoints with the same timestamp for a timeseries. Set this timestamp to be the time of actual collection by the receiver.