### PR TITLE
keeping timeseries and points in order after aggregation in metrics transform processor

### DIFF
--- a/processor/metricstransformprocessor/datapoint_aggregation.go
+++ b/processor/metricstransformprocessor/datapoint_aggregation.go
@@ -102,7 +102,9 @@ func (mtp *metricsTransformProcessor) mergePoints(timestampToPoints map[int64][]
 
 		}
 	}
-	sort.Sort(pointsByTimestamp(newPoints))
+	sort.SliceStable(newPoints, func(i, j int) bool {
+		return mtp.compareTimestamps(newPoints[i].Timestamp, newPoints[j].Timestamp)
+	})
 	return newPoints
 }
 

--- a/processor/metricstransformprocessor/datapoint_aggregation.go
+++ b/processor/metricstransformprocessor/datapoint_aggregation.go
@@ -102,7 +102,7 @@ func (mtp *metricsTransformProcessor) mergePoints(timestampToPoints map[int64][]
 
 		}
 	}
-	sort.SliceStable(newPoints, func(i, j int) bool {
+	sort.Slice(newPoints, func(i, j int) bool {
 		return mtp.compareTimestamps(newPoints[i].Timestamp, newPoints[j].Timestamp)
 	})
 	return newPoints

--- a/processor/metricstransformprocessor/datapoint_aggregation.go
+++ b/processor/metricstransformprocessor/datapoint_aggregation.go
@@ -17,6 +17,7 @@ package metricstransformprocessor
 import (
 	"math"
 	"math/rand"
+	"sort"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -101,6 +102,7 @@ func (mtp *metricsTransformProcessor) mergePoints(timestampToPoints map[int64][]
 
 		}
 	}
+	sort.Sort(pointsByTimestamp(newPoints))
 	return newPoints
 }
 

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -166,33 +166,7 @@ func (mtp *metricsTransformProcessor) minInt64(num1, num2 int64) int64 {
 	return num2
 }
 
-// timeseriesByStartTimestamp implements sort.Interface based on the start timestamp field of the Timeseries
-type timeseriesByStartTimestamp []*metricspb.TimeSeries
-
-func (t timeseriesByStartTimestamp) Len() int {
-	return len(t)
-}
-func (t timeseriesByStartTimestamp) Less(i, j int) bool {
-	return compareTimestamps(t[i].StartTimestamp, t[j].StartTimestamp)
-}
-func (t timeseriesByStartTimestamp) Swap(i, j int) {
-	t[i], t[j] = t[j], t[i]
-}
-
-// pointsByTimestamp implements sort.Interface based on the timestamp field of the Points
-type pointsByTimestamp []*metricspb.Point
-
-func (p pointsByTimestamp) Len() int {
-	return len(p)
-}
-func (p pointsByTimestamp) Less(i, j int) bool {
-	return compareTimestamps(p[i].Timestamp, p[j].Timestamp)
-}
-func (p pointsByTimestamp) Swap(i, j int) {
-	p[i], p[j] = p[j], p[i]
-}
-
 // compareTimestamps returns if t1 is a smaller timestamp than t2
-func compareTimestamps(t1 *timestamp.Timestamp, t2 *timestamp.Timestamp) bool {
+func (mtp *metricsTransformProcessor) compareTimestamps(t1 *timestamp.Timestamp, t2 *timestamp.Timestamp) bool {
 	return t1.Seconds < t2.Seconds || (t1.Seconds == t2.Seconds && t1.Nanos < t2.Nanos)
 }

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -409,15 +409,15 @@ var (
 			},
 			in: []*metricspb.Metric{
 				metricBuilder().setName("metric1").setLabels([]string{"label1", "label2"}).setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
-					addTimeseries(1, []string{"label1-value1", "label2-value1"}).addTimeseries(1, []string{"label1-value1", "label2-value2"}).
+					addTimeseries(3, []string{"label1-value1", "label2-value1"}).addTimeseries(3, []string{"label1-value1", "label2-value2"}).
 					addTimeseries(1, []string{"label1-value1", "label2-value3"}).
-					addInt64Point(0, 3, 2).addInt64Point(1, 1, 2).addInt64Point(2, 1, 2).
+					addInt64Point(0, 3, 2).addInt64Point(1, 1, 2).addInt64Point(1, 2, 3).addInt64Point(2, 1, 2).
 					build(),
 			},
 			out: []*metricspb.Metric{
 				metricBuilder().setName("metric1").setLabels([]string{"label1", "label2"}).setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
-					addTimeseries(1, []string{"label1-value1", "new/label2-value"}).addTimeseries(1, []string{"label1-value1", "label2-value3"}).
-					addInt64Point(0, 4, 2).addInt64Point(1, 1, 2).
+					addTimeseries(1, []string{"label1-value1", "label2-value3"}).addTimeseries(3, []string{"label1-value1", "new/label2-value"}).
+					addInt64Point(0, 1, 2).addInt64Point(1, 4, 2).addInt64Point(1, 2, 3).
 					build(),
 			},
 		},

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -378,13 +378,14 @@ var (
 			in: []*metricspb.Metric{
 				metricBuilder().setName("metric1").setLabels([]string{"label1", "label2"}).setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
 					addTimeseries(1, []string{"label1-value1", "label2-value1"}).addTimeseries(1, []string{"label1-value1", "label2-value2"}).
-					addDoublePoint(0, 1, 2).addDoublePoint(1, 3, 2).
+					addTimeseries(2, []string{"label1-value2", "label2-value2"}).
+					addDoublePoint(0, 1, 2).addDoublePoint(1, 3, 2).addDoublePoint(2, 3, 2).
 					build(),
 			},
 			out: []*metricspb.Metric{
 				metricBuilder().setName("metric1").setLabels([]string{"label1"}).setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
-					addTimeseries(1, []string{"label1-value1"}).
-					addDoublePoint(0, 1, 2).
+					addTimeseries(1, []string{"label1-value1"}).addTimeseries(2, []string{"label1-value2"}).
+					addDoublePoint(0, 1, 2).addDoublePoint(1, 3, 2).
 					build(),
 			},
 		},

--- a/processor/metricstransformprocessor/operation_aggregate_label_values.go
+++ b/processor/metricstransformprocessor/operation_aggregate_label_values.go
@@ -16,6 +16,7 @@ package metricstransformprocessor
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
@@ -34,6 +35,7 @@ func (mtp *metricsTransformProcessor) aggregateLabelValuesOp(metric *metricspb.M
 	groupedTimeseries, unchangedTimeseries := mtp.groupTimeseriesByNewLabelValue(metric, operationLabelIdx, op.NewValue, mtpOp.aggregatedValuesSet)
 	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, op.AggregationType, metric.MetricDescriptor.Type)
 	aggregatedTimeseries = append(aggregatedTimeseries, unchangedTimeseries...)
+	sort.Sort(timeseriesByStartTimestamp(aggregatedTimeseries))
 	metric.Timeseries = aggregatedTimeseries
 }
 

--- a/processor/metricstransformprocessor/operation_aggregate_label_values.go
+++ b/processor/metricstransformprocessor/operation_aggregate_label_values.go
@@ -35,7 +35,9 @@ func (mtp *metricsTransformProcessor) aggregateLabelValuesOp(metric *metricspb.M
 	groupedTimeseries, unchangedTimeseries := mtp.groupTimeseriesByNewLabelValue(metric, operationLabelIdx, op.NewValue, mtpOp.aggregatedValuesSet)
 	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, op.AggregationType, metric.MetricDescriptor.Type)
 	aggregatedTimeseries = append(aggregatedTimeseries, unchangedTimeseries...)
-	sort.Sort(timeseriesByStartTimestamp(aggregatedTimeseries))
+	sort.SliceStable(aggregatedTimeseries, func(i, j int) bool {
+		return mtp.compareTimestamps(aggregatedTimeseries[i].StartTimestamp, aggregatedTimeseries[j].StartTimestamp)
+	})
 	metric.Timeseries = aggregatedTimeseries
 }
 

--- a/processor/metricstransformprocessor/operation_aggregate_label_values.go
+++ b/processor/metricstransformprocessor/operation_aggregate_label_values.go
@@ -35,7 +35,7 @@ func (mtp *metricsTransformProcessor) aggregateLabelValuesOp(metric *metricspb.M
 	groupedTimeseries, unchangedTimeseries := mtp.groupTimeseriesByNewLabelValue(metric, operationLabelIdx, op.NewValue, mtpOp.aggregatedValuesSet)
 	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, op.AggregationType, metric.MetricDescriptor.Type)
 	aggregatedTimeseries = append(aggregatedTimeseries, unchangedTimeseries...)
-	sort.SliceStable(aggregatedTimeseries, func(i, j int) bool {
+	sort.Slice(aggregatedTimeseries, func(i, j int) bool {
 		return mtp.compareTimestamps(aggregatedTimeseries[i].StartTimestamp, aggregatedTimeseries[j].StartTimestamp)
 	})
 	metric.Timeseries = aggregatedTimeseries

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -30,7 +30,9 @@ func (mtp *metricsTransformProcessor) aggregateLabelsOp(metric *metricspb.Metric
 	groupedTimeseries := mtp.groupTimeseriesByLabelSet(metric, labelIdxs)
 
 	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, op.AggregationType, metric.MetricDescriptor.Type)
-	sort.Sort(timeseriesByStartTimestamp(aggregatedTimeseries))
+	sort.SliceStable(aggregatedTimeseries, func(i, j int) bool {
+		return mtp.compareTimestamps(aggregatedTimeseries[i].StartTimestamp, aggregatedTimeseries[j].StartTimestamp)
+	})
 	metric.Timeseries = aggregatedTimeseries
 	metric.MetricDescriptor.LabelKeys = labels
 }

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -30,7 +30,7 @@ func (mtp *metricsTransformProcessor) aggregateLabelsOp(metric *metricspb.Metric
 	groupedTimeseries := mtp.groupTimeseriesByLabelSet(metric, labelIdxs)
 
 	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, op.AggregationType, metric.MetricDescriptor.Type)
-	sort.SliceStable(aggregatedTimeseries, func(i, j int) bool {
+	sort.Slice(aggregatedTimeseries, func(i, j int) bool {
 		return mtp.compareTimestamps(aggregatedTimeseries[i].StartTimestamp, aggregatedTimeseries[j].StartTimestamp)
 	})
 	metric.Timeseries = aggregatedTimeseries

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -16,6 +16,7 @@ package metricstransformprocessor
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
@@ -29,6 +30,7 @@ func (mtp *metricsTransformProcessor) aggregateLabelsOp(metric *metricspb.Metric
 	groupedTimeseries := mtp.groupTimeseriesByLabelSet(metric, labelIdxs)
 
 	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, op.AggregationType, metric.MetricDescriptor.Type)
+	sort.Sort(timeseriesByStartTimestamp(aggregatedTimeseries))
 	metric.Timeseries = aggregatedTimeseries
 	metric.MetricDescriptor.LabelKeys = labels
 }


### PR DESCRIPTION
**Description:** This update to the metrics transform processor would keep the timeseries and points ordered by timestamp

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/332