### PR TITLE
Add working-set and page-fault metrics

### DIFF
--- a/receiver/kubeletstatsreceiver/kubelet/mem.go
+++ b/receiver/kubeletstatsreceiver/kubelet/mem.go
@@ -24,6 +24,9 @@ func memMetrics(prefix string, s *stats.MemoryStats) []*metricspb.Metric {
 		memAvailableMetric(prefix, s),
 		memUsageMetric(prefix, s),
 		memRssMetric(prefix, s),
+		memWorkingSetMetric(prefix, s),
+		memPageFaultsMetric(prefix, s),
+		memMajorPageFaultsMetric(prefix, s),
 	}
 }
 
@@ -37,4 +40,16 @@ func memUsageMetric(prefix string, s *stats.MemoryStats) *metricspb.Metric {
 
 func memRssMetric(prefix string, s *stats.MemoryStats) *metricspb.Metric {
 	return intGauge(prefix+"memory.rss", "By", s.RSSBytes)
+}
+
+func memWorkingSetMetric(prefix string, s *stats.MemoryStats) *metricspb.Metric {
+	return intGauge(prefix+"memory.working_set", "By", s.WorkingSetBytes)
+}
+
+func memPageFaultsMetric(prefix string, s *stats.MemoryStats) *metricspb.Metric {
+	return intGauge(prefix+"memory.page_faults", "1", s.PageFaults)
+}
+
+func memMajorPageFaultsMetric(prefix string, s *stats.MemoryStats) *metricspb.Metric {
+	return intGauge(prefix+"memory.major_page_faults", "1", s.MajorPageFaults)
 }

--- a/receiver/kubeletstatsreceiver/kubelet/metrics.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metrics.go
@@ -27,7 +27,8 @@ func MetricsData(
 	summary *stats.Summary,
 	metadata Metadata,
 	typeStr string,
-	metricGroupsToCollect map[MetricGroup]bool) []*consumerdata.MetricsData {
+	metricGroupsToCollect map[MetricGroup]bool,
+) []*consumerdata.MetricsData {
 	acc := &metricDataAccumulator{
 		metadata:              metadata,
 		logger:                logger,

--- a/receiver/kubeletstatsreceiver/testdata/stats-summary.json
+++ b/receiver/kubeletstatsreceiver/testdata/stats-summary.json
@@ -65,10 +65,10 @@
       "time": "2020-04-20T22:52:27Z",
       "availableBytes": 2620624896,
       "usageBytes": 3608727552,
-      "workingSetBytes": 1410809856,
+      "workingSetBytes": 1234567890,
       "rssBytes": 607125504,
-      "pageFaults": 24915,
-      "majorPageFaults": 0
+      "pageFaults": 12345,
+      "majorPageFaults": 12
     },
     "network": {
       "time": "2020-04-20T22:52:27Z",


### PR DESCRIPTION
**Description:** Adds memory working set, page faults, and major page faults metrics to kubeletstats receiver.

**Testing:** Unit tests added using test fixtures recorded from minikube.
