### PR TITLE
kubeletstatsreceiver: Add basic support for volume metrics

### DIFF
--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -109,8 +109,8 @@ If `extra_metadata_labels` is not set, no additional API calls is done to fetch 
 
 A list of metric groups from which metrics should be collected. By default, metrics from containers,
 pods and nodes will be collected. If `metric_groups` is set, only metrics from the listed groups
-will be collected. Valid groups are `container`, `pod` and `node`. For example, if you're looking to
-collect only `node` and `pod` metrics from the receiver use the following configuration.
+will be collected. Valid groups are `container`, `pod`, `node` and `volume`. For example, if you're
+looking to collect only `node` and `pod` metrics from the receiver use the following configuration.
 
 ```yaml
 receivers:

--- a/receiver/kubeletstatsreceiver/config.go
+++ b/receiver/kubeletstatsreceiver/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	ExtraMetadataLabels []kubelet.MetadataLabel `mapstructure:"extra_metadata_labels"`
 
 	// MetricGroupsToCollect provides a list of metrics groups to collect metrics from.
-	// "container", "pod" and "node" are the only valid groups.
+	// "container", "pod", "node" and "volume" are the only valid groups.
 	MetricGroupsToCollect []kubelet.MetricGroup `mapstructure:"metric_groups"`
 }
 

--- a/receiver/kubeletstatsreceiver/config_test.go
+++ b/receiver/kubeletstatsreceiver/config_test.go
@@ -145,6 +145,7 @@ func TestLoadConfig(t *testing.T) {
 		MetricGroupsToCollect: []kubelet.MetricGroup{
 			kubelet.PodMetricGroup,
 			kubelet.NodeMetricGroup,
+			kubelet.VolumeMetricGroup,
 		},
 	}, metricGroupsCfg)
 }

--- a/receiver/kubeletstatsreceiver/kubelet/accumulator.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator.go
@@ -32,12 +32,14 @@ const (
 	ContainerMetricGroup = MetricGroup("container")
 	PodMetricGroup       = MetricGroup("pod")
 	NodeMetricGroup      = MetricGroup("node")
+	VolumeMetricGroup    = MetricGroup("volume")
 )
 
 var ValidMetricGroups = map[MetricGroup]bool{
 	ContainerMetricGroup: true,
 	PodMetricGroup:       true,
 	NodeMetricGroup:      true,
+	VolumeMetricGroup:    true,
 }
 
 type metricDataAccumulator struct {
@@ -53,6 +55,7 @@ const (
 	nodePrefix      = k8sPrefix + "node."
 	podPrefix       = k8sPrefix + "pod."
 	containerPrefix = "container."
+	volumePrefix    = k8sPrefix + "volume."
 )
 
 func (a *metricDataAccumulator) nodeStats(s stats.NodeStats) {
@@ -108,6 +111,20 @@ func (a *metricDataAccumulator) containerStats(podResource *resourcepb.Resource,
 		cpuMetrics(containerPrefix, s.CPU),
 		memMetrics(containerPrefix, s.Memory),
 		fsMetrics(containerPrefix, s.Rootfs),
+	)
+}
+
+func (a *metricDataAccumulator) volumeStats(podResource *resourcepb.Resource, s stats.VolumeStats) {
+	if !a.metricGroupsToCollect[VolumeMetricGroup] {
+		return
+	}
+
+	volume := volumeResource(podResource, s)
+
+	a.accumulate(
+		nil,
+		volume,
+		volumeMetrics(volumePrefix, s),
 	)
 }
 

--- a/receiver/kubeletstatsreceiver/kubelet/conventions.go
+++ b/receiver/kubeletstatsreceiver/kubelet/conventions.go
@@ -15,5 +15,6 @@
 package kubelet
 
 const (
-	labelNodeName = "k8s.node.name"
+	labelNodeName   = "k8s.node.name"
+	labelVolumeName = "k8s.volume.name"
 )

--- a/receiver/kubeletstatsreceiver/kubelet/metrics.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metrics.go
@@ -44,6 +44,10 @@ func MetricsData(
 		for _, containerStats := range podStats.Containers {
 			acc.containerStats(podResource, containerStats)
 		}
+
+		for _, volumeStats := range podStats.VolumeStats {
+			acc.volumeStats(podResource, volumeStats)
+		}
 	}
 	for _, md := range acc.m {
 		// TODO this should prob go in core

--- a/receiver/kubeletstatsreceiver/kubelet/pb.go
+++ b/receiver/kubeletstatsreceiver/kubelet/pb.go
@@ -60,11 +60,16 @@ func intGauge(metricName string, units string, value *uint64) *metricspb.Metric 
 	if value == nil {
 		return nil
 	}
+	return intGaugeWithDescription(metricName, units, "", value)
+}
+
+func intGaugeWithDescription(metricName string, units string, description string, value *uint64) *metricspb.Metric {
 	return &metricspb.Metric{
 		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name: metricName,
-			Unit: units,
-			Type: metricspb.MetricDescriptor_GAUGE_INT64,
+			Name:        metricName,
+			Unit:        units,
+			Description: description,
+			Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 		},
 		Timeseries: []*metricspb.TimeSeries{{
 			Points: []*metricspb.Point{{

--- a/receiver/kubeletstatsreceiver/kubelet/resource.go
+++ b/receiver/kubeletstatsreceiver/kubelet/resource.go
@@ -58,3 +58,22 @@ func containerResource(pod *resourcepb.Resource, s stats.ContainerStats, metadat
 		Labels: labels,
 	}, nil
 }
+
+func volumeResource(pod *resourcepb.Resource, vs stats.VolumeStats) *resourcepb.Resource {
+	labels := map[string]string{
+		labelVolumeName: vs.Name,
+	}
+
+	// Collect relevant Pod labels to be able to associate the volume to it.
+	labels[conventions.AttributeK8sPodUID] = pod.Labels[conventions.AttributeK8sPodUID]
+	labels[conventions.AttributeK8sPod] = pod.Labels[conventions.AttributeK8sPod]
+	labels[conventions.AttributeK8sNamespace] = pod.Labels[conventions.AttributeK8sNamespace]
+
+	//TODO: Optionally add more labels through the /pods endpoint and
+	// the Kubernetes API. Will make PRs for those enhancements separately.
+
+	return &resourcepb.Resource{
+		Type:   "k8s",
+		Labels: labels,
+	}
+}

--- a/receiver/kubeletstatsreceiver/kubelet/volume.go
+++ b/receiver/kubeletstatsreceiver/kubelet/volume.go
@@ -1,0 +1,86 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubelet
+
+import (
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+)
+
+func volumeMetrics(metricPrefix string, volumeStats stats.VolumeStats) []*metricspb.Metric {
+	return []*metricspb.Metric{
+		volumeAvailableMetric(metricPrefix, volumeStats),
+		volumeCapacityMetric(metricPrefix, volumeStats),
+		volumeInodesMetric(metricPrefix, volumeStats),
+		volumeInodesFreeMetric(metricPrefix, volumeStats),
+		volumeInodesUsedMetric(metricPrefix, volumeStats),
+	}
+}
+
+func volumeAvailableMetric(prefix string, s stats.VolumeStats) *metricspb.Metric {
+	if s.AvailableBytes == nil {
+		return nil
+	}
+	return intGaugeWithDescription(
+		prefix+"available", "By",
+		"The number of available bytes in the volume.",
+		s.AvailableBytes,
+	)
+}
+
+func volumeCapacityMetric(prefix string, s stats.VolumeStats) *metricspb.Metric {
+	if s.CapacityBytes == nil {
+		return nil
+	}
+	return intGaugeWithDescription(
+		prefix+"capacity", "By",
+		"The total capacity in bytes of the volume.",
+		s.CapacityBytes,
+	)
+}
+
+func volumeInodesMetric(prefix string, s stats.VolumeStats) *metricspb.Metric {
+	if s.Inodes == nil {
+		return nil
+	}
+	return intGaugeWithDescription(
+		prefix+"inodes", "1",
+		"The total inodes in the filesystem.",
+		s.Inodes,
+	)
+}
+
+func volumeInodesFreeMetric(prefix string, s stats.VolumeStats) *metricspb.Metric {
+	if s.InodesFree == nil {
+		return nil
+	}
+	return intGaugeWithDescription(
+		prefix+"inodes.free", "1",
+		"The free inodes in the filesystem.",
+		s.InodesFree,
+	)
+}
+
+func volumeInodesUsedMetric(prefix string, s stats.VolumeStats) *metricspb.Metric {
+	if s.InodesUsed == nil {
+		return nil
+	}
+	return intGaugeWithDescription(
+		prefix+"inodes.used", "1",
+		"The inodes used by the filesystem. This may not equal inodes -"+
+			" free because filesystem may share inodes with other filesystems.",
+		s.InodesUsed,
+	)
+}

--- a/receiver/kubeletstatsreceiver/runnable_test.go
+++ b/receiver/kubeletstatsreceiver/runnable_test.go
@@ -30,18 +30,20 @@ import (
 )
 
 const (
-	dataLen = 19
+	dataLen = numContainers + numPods + numNodes + numVolumes
 
 	// Number of resources by type in testdata/stats-summary.json
 	numContainers = 9
 	numPods       = 9
 	numNodes      = 1
+	numVolumes    = 9
 )
 
 var allMetricGroups = map[kubelet.MetricGroup]bool{
 	kubelet.ContainerMetricGroup: true,
 	kubelet.PodMetricGroup:       true,
 	kubelet.NodeMetricGroup:      true,
+	kubelet.VolumeMetricGroup:    true,
 }
 
 func TestRunnable(t *testing.T) {
@@ -125,6 +127,13 @@ func TestRunnableWithMetricGroups(t *testing.T) {
 				kubelet.NodeMetricGroup: true,
 			},
 			dataLen: numNodes,
+		},
+		{
+			name: "only volume group",
+			metricGroups: map[kubelet.MetricGroup]bool{
+				kubelet.VolumeMetricGroup: true,
+			},
+			dataLen: numVolumes,
 		},
 		{
 			name: "pod and node groups",

--- a/receiver/kubeletstatsreceiver/testdata/config.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/config.yaml
@@ -20,7 +20,7 @@ receivers:
   kubeletstats/metric_groups:
     collection_interval: 20s
     auth_type: "serviceAccount"
-    metric_groups: [pod, node]
+    metric_groups: [pod, node, volume]
 exporters:
   exampleexporter:
 service:

--- a/receiver/kubeletstatsreceiver/testdata/stats-summary.json
+++ b/receiver/kubeletstatsreceiver/testdata/stats-summary.json
@@ -303,6 +303,10 @@
           "inodes": 492118,
           "inodesUsed": 9,
           "name": "default-token-wgfsl"
+        },
+        {
+          "time": "2020-04-20T22:51:40Z",
+          "name": "test-missing-metrics"
         }
       ],
       "ephemeral-storage": {


### PR DESCRIPTION
**Description:** Add ability to collect metrics from volumes. This PR adds a new metric group called `volume` and add basic metric collection from volumes. 

The idea is to be able to optionally enrich the metrics collected in this PR with labels from `/pods` endpoint and data from Kubernetes API in case the Pod is using a Persistent Volume Claim. These enhancements will be made in subsequent PRs. For anyone curious, a draft of these enhancements can be found here: https://github.com/asuresh4/opentelemetry-collector-contrib/tree/kubelet-volumes.

**Testing:** Added tests.
**Documentation:** Updated README.