### PR TITLE
exporter/elasticexporter: translate semantic conventions to Elastic destination fields

### DIFF
--- a/exporter/elasticexporter/internal/translator/elastic/metadata.go
+++ b/exporter/elasticexporter/internal/translator/elastic/metadata.go
@@ -56,9 +56,15 @@ func EncodeResourceMetadata(resource pdata.Resource, w *fastjson.Writer) {
 
 			case conventions.AttributeK8sNamespace:
 				k8s.Namespace = truncate(v.StringVal())
+				system.Kubernetes = &k8s
 			case conventions.AttributeK8sPod:
 				k8sPod.Name = truncate(v.StringVal())
 				k8s.Pod = &k8sPod
+				system.Kubernetes = &k8s
+			case conventions.AttributeK8sPodUID:
+				k8sPod.UID = truncate(v.StringVal())
+				k8s.Pod = &k8sPod
+				system.Kubernetes = &k8s
 
 			case conventions.AttributeHostHostname:
 				system.Hostname = truncate(v.StringVal())

--- a/exporter/elasticexporter/internal/translator/elastic/metadata_test.go
+++ b/exporter/elasticexporter/internal/translator/elastic/metadata_test.go
@@ -56,6 +56,16 @@ func TestMetadataServiceVersion(t *testing.T) {
 	assert.Equal(t, "1.2.3", out.service.Version)
 }
 
+func TestMetadataServiceInstance(t *testing.T) {
+	resource := resourceFromAttributesMap(map[string]pdata.AttributeValue{
+		"service.instance.id": pdata.NewAttributeValueString("foo-1"),
+	})
+	out := metadataWithResource(t, resource)
+	assert.Equal(t, &model.ServiceNode{
+		ConfiguredName: "foo-1",
+	}, out.service.Node)
+}
+
 func TestMetadataSystemHostname(t *testing.T) {
 	resource := resourceFromAttributesMap(map[string]pdata.AttributeValue{
 		"host.hostname": pdata.NewAttributeValueString("foo"),
@@ -101,6 +111,22 @@ func TestMetadataLabels(t *testing.T) {
 		{Key: "int", Value: 123.0},
 		{Key: "string", Value: "abc"},
 	}, out.labels)
+}
+
+func TestMetadataKubernetes(t *testing.T) {
+	resource := resourceFromAttributesMap(map[string]pdata.AttributeValue{
+		"k8s.namespace.name": pdata.NewAttributeValueString("namespace_name"),
+		"k8s.pod.name":       pdata.NewAttributeValueString("pod_name"),
+		"k8s.pod.uid":        pdata.NewAttributeValueString("pod_uid"),
+	})
+	out := metadataWithResource(t, resource)
+	assert.Equal(t, &model.Kubernetes{
+		Namespace: "namespace_name",
+		Pod: &model.KubernetesPod{
+			Name: "pod_name",
+			UID:  "pod_uid",
+		},
+	}, out.system.Kubernetes)
 }
 
 func resourceFromAttributesMap(attrs map[string]pdata.AttributeValue) pdata.Resource {

--- a/exporter/elasticexporter/internal/translator/elastic/traces_test.go
+++ b/exporter/elasticexporter/internal/translator/elastic/traces_test.go
@@ -310,18 +310,19 @@ func TestSpanHTTPURL(t *testing.T) {
 			"http.target": pdata.NewAttributeValueString("/foo?bar"),
 		})
 	})
-	t.Run("scheme_netpeername_nethostport_target", func(t *testing.T) {
+	t.Run("scheme_netpeername_netpeerport_target", func(t *testing.T) {
 		test(t, "https://testing.invalid:80/foo?bar", map[string]pdata.AttributeValue{
 			"http.scheme":   pdata.NewAttributeValueString("https"),
 			"net.peer.name": pdata.NewAttributeValueString("testing.invalid"),
+			"net.peer.ip":   pdata.NewAttributeValueString("::1"), // net.peer.name preferred
 			"net.peer.port": pdata.NewAttributeValueInt(80),
 			"http.target":   pdata.NewAttributeValueString("/foo?bar"),
 		})
 	})
-	t.Run("scheme_nethostname_nethostport_target", func(t *testing.T) {
+	t.Run("scheme_netpeerip_netpeerport_target", func(t *testing.T) {
 		test(t, "https://[::1]:80/foo?bar", map[string]pdata.AttributeValue{
 			"http.scheme":   pdata.NewAttributeValueString("https"),
-			"net.peer.name": pdata.NewAttributeValueString("::1"),
+			"net.peer.ip":   pdata.NewAttributeValueString("::1"),
 			"net.peer.port": pdata.NewAttributeValueInt(80),
 			"http.target":   pdata.NewAttributeValueString("/foo?bar"),
 		})
@@ -332,6 +333,51 @@ func TestSpanHTTPURL(t *testing.T) {
 		test(t, "http://testing.invalid:80/foo?bar", map[string]pdata.AttributeValue{
 			"http.host":   pdata.NewAttributeValueString("testing.invalid:80"),
 			"http.target": pdata.NewAttributeValueString("/foo?bar"),
+		})
+	})
+}
+
+func TestSpanHTTPDestination(t *testing.T) {
+	test := func(t *testing.T, expectedAddr string, expectedPort int, expectedName string, expectedResource string, attrs map[string]pdata.AttributeValue) {
+		span := spanWithAttributes(t, attrs)
+		assert.Equal(t, &model.DestinationSpanContext{
+			Address: expectedAddr,
+			Port:    expectedPort,
+			Service: &model.DestinationServiceSpanContext{
+				Type:     "external",
+				Name:     expectedName,
+				Resource: expectedResource,
+			},
+		}, span.Context.Destination)
+	}
+	t.Run("url_default_port_specified", func(t *testing.T) {
+		test(t, "testing.invalid", 443, "https://testing.invalid", "testing.invalid:443", map[string]pdata.AttributeValue{
+			"http.url": pdata.NewAttributeValueString("https://testing.invalid:443/foo?bar"),
+		})
+	})
+	t.Run("url_port_scheme", func(t *testing.T) {
+		test(t, "testing.invalid", 443, "https://testing.invalid", "testing.invalid:443", map[string]pdata.AttributeValue{
+			"http.url": pdata.NewAttributeValueString("https://testing.invalid/foo?bar"),
+		})
+	})
+	t.Run("url_non_default_port", func(t *testing.T) {
+		test(t, "testing.invalid", 444, "https://testing.invalid:444", "testing.invalid:444", map[string]pdata.AttributeValue{
+			"http.url": pdata.NewAttributeValueString("https://testing.invalid:444/foo?bar"),
+		})
+	})
+	t.Run("scheme_host_target", func(t *testing.T) {
+		test(t, "testing.invalid", 444, "https://testing.invalid:444", "testing.invalid:444", map[string]pdata.AttributeValue{
+			"http.scheme": pdata.NewAttributeValueString("https"),
+			"http.host":   pdata.NewAttributeValueString("testing.invalid:444"),
+			"http.target": pdata.NewAttributeValueString("/foo?bar"),
+		})
+	})
+	t.Run("scheme_netpeername_nethostport_target", func(t *testing.T) {
+		test(t, "::1", 444, "https://[::1]:444", "[::1]:444", map[string]pdata.AttributeValue{
+			"http.scheme":   pdata.NewAttributeValueString("https"),
+			"net.peer.ip":   pdata.NewAttributeValueString("::1"),
+			"net.peer.port": pdata.NewAttributeValueInt(444),
+			"http.target":   pdata.NewAttributeValueString("/foo?bar"),
 		})
 	})
 }
@@ -355,28 +401,45 @@ func TestSpanHTTPStatusCode(t *testing.T) {
 }
 
 func TestSpanDatabaseContext(t *testing.T) {
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md#mysql
+	connectionString := "Server=shopdb.example.com;Database=ShopDb;Uid=billing_user;TableCache=true;UseCompression=True;MinimumPoolSize=10;MaximumPoolSize=50;"
 	span := spanWithAttributes(t, map[string]pdata.AttributeValue{
-		"db.system":            pdata.NewAttributeValueString("sql"),
-		"db.name":              pdata.NewAttributeValueString("customers"),
-		"db.statement":         pdata.NewAttributeValueString("SELECT * FROM wuser_table"),
-		"db.user":              pdata.NewAttributeValueString("readonly_user"),
-		"db.connection_string": pdata.NewAttributeValueString("mysql://db.example.com:3306"),
+		"db.system":            pdata.NewAttributeValueString("mysql"),
+		"db.connection_string": pdata.NewAttributeValueString(connectionString),
+		"db.user":              pdata.NewAttributeValueString("billing_user"),
+		"db.name":              pdata.NewAttributeValueString("ShopDb"),
+		"db.statement":         pdata.NewAttributeValueString("SELECT * FROM orders WHERE order_id = 'o4711'"),
+		"net.peer.name":        pdata.NewAttributeValueString("shopdb.example.com"),
+		"net.peer.ip":          pdata.NewAttributeValueString("192.0.2.12"),
+		"net.peer.port":        pdata.NewAttributeValueInt(3306),
+		"net.transport":        pdata.NewAttributeValueString("IP.TCP"),
 	})
 
 	assert.Equal(t, "db", span.Type)
-	assert.Equal(t, "sql", span.Subtype)
+	assert.Equal(t, "mysql", span.Subtype)
 	assert.Equal(t, "", span.Action)
 
 	assert.Equal(t, &model.DatabaseSpanContext{
-		Type:      "sql",
-		Instance:  "customers",
-		Statement: "SELECT * FROM wuser_table",
-		User:      "readonly_user",
+		Type:      "mysql",
+		Instance:  "ShopDb",
+		Statement: "SELECT * FROM orders WHERE order_id = 'o4711'",
+		User:      "billing_user",
 	}, span.Context.Database)
 
 	assert.Equal(t, model.IfaceMap{
-		{Key: "db_connection_string", Value: "mysql://db.example.com:3306"},
+		{Key: "db_connection_string", Value: connectionString},
+		{Key: "net_transport", Value: "IP.TCP"},
 	}, span.Context.Tags)
+
+	assert.Equal(t, &model.DestinationSpanContext{
+		Address: "shopdb.example.com",
+		Port:    3306,
+		Service: &model.DestinationServiceSpanContext{
+			Type:     "db",
+			Name:     "mysql",
+			Resource: "mysql",
+		},
+	}, span.Context.Destination)
 }
 
 func transactionWithAttributes(t *testing.T, attrs map[string]pdata.AttributeValue) model.Transaction {


### PR DESCRIPTION
**Description:**

Translate `http.*`, `net.peer.*`, and `db.*` semantic conventions to Elastic's equivalent `destination.*` fields. This is necessary to add external (non-instrumented) destination services to the service map.

**Testing:**

I've added unit tests, and performed manual testing with a Jaeger-instrumented test application:

<details><summary>Test code</summary>

```go
package main

import (
	"context"
	"fmt"
	"io"
	"log"
	"net/http"
	"time"

	"github.com/opentracing/opentracing-go"
	"github.com/opentracing/opentracing-go/ext"
	"github.com/uber/jaeger-client-go/config"
	"golang.org/x/sync/errgroup"
)

const (
	addrServiceA = "localhost:1234"
	addrServiceB = "localhost:4321"
)

func newTracer(name string) (opentracing.Tracer, io.Closer, error) {
	cfg, err := config.FromEnv()
	if err != nil {
		return nil, nil, err
	}
	cfg.ServiceName = name
	cfg.Sampler.Type = "const"
	cfg.Sampler.Param = 1
	return cfg.NewTracer()
}

func runServiceA(ctx context.Context) error {
	tracer, closer, err := newTracer("jaeger-service-a")
	if err != nil {
		return err
	}
	defer closer.Close()

	return http.ListenAndServe(addrServiceA, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		spanCtx, _ := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
		serverSpan := tracer.StartSpan("server", ext.RPCServerOption(spanCtx))
		defer serverSpan.Finish()

		clientSpan := tracer.StartSpan("client", opentracing.ChildOf(serverSpan.Context()))
		defer clientSpan.Finish()
		ext.SpanKindRPCClient.Set(clientSpan)

		req, _ := http.NewRequest("GET", fmt.Sprintf("http://%s/", addrServiceB), nil)
		ext.HTTPUrl.Set(clientSpan, req.URL.String())
		ext.HTTPMethod.Set(clientSpan, req.Method)

		// Inject the client span context into the headers
		tracer.Inject(clientSpan.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
		resp, err := http.DefaultClient.Do(req)
		if err != nil {
			w.WriteHeader(http.StatusInternalServerError)
			return
		}
		defer resp.Body.Close()
		ext.HTTPStatusCode.Set(clientSpan, uint16(resp.StatusCode))

		w.WriteHeader(resp.StatusCode)
		io.Copy(w, resp.Body)
	}))
}

func runServiceB(ctx context.Context) error {
	tracer, closer, err := newTracer("jaeger-service-b")
	if err != nil {
		return err
	}
	defer closer.Close()

	return http.ListenAndServe(addrServiceB, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		spanCtx, _ := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
		serverSpan := tracer.StartSpan("server", ext.RPCServerOption(spanCtx))
		defer serverSpan.Finish()

		dbSpan := tracer.StartSpan("querying database", opentracing.ChildOf(serverSpan.Context()))
		ext.DBStatement.Set(dbSpan, "SELECT * FROM table")
		ext.StringTagName("db.system").Set(dbSpan, "mysql")
		ext.StringTagName("net.peer.host").Set(dbSpan, "mysql-host")
		ext.Uint16TagName("net.peer.port").Set(dbSpan, 3306)
		time.Sleep(time.Millisecond)
		dbSpan.Finish()

		clientSpan := tracer.StartSpan("client", opentracing.ChildOf(serverSpan.Context()))
		defer clientSpan.Finish()
		ext.SpanKindRPCClient.Set(clientSpan)

		req, _ := http.NewRequest("GET", "https://testing.invalid/", nil)
		ext.HTTPUrl.Set(clientSpan, req.URL.String())
		ext.HTTPMethod.Set(clientSpan, req.Method)
		resp, err := http.DefaultClient.Do(req)
		if err != nil {
			w.WriteHeader(http.StatusInternalServerError)
			return
		}
		defer resp.Body.Close()
		ext.HTTPStatusCode.Set(clientSpan, uint16(resp.StatusCode))
	}))
}

func main() {
	g, ctx := errgroup.WithContext(context.Background())
	g.Go(func() error { return runServiceA(ctx) })
	g.Go(func() error { return runServiceB(ctx) })
	if err := g.Wait(); err != nil {
		log.Fatal(err)
	}
}
```

</details>

![image](https://user-images.githubusercontent.com/843579/89750866-5756a300-db00-11ea-8d7d-70d0670d2638.png)