### PR TITLE
kubeletstatsreceiver: Update to use convetions from core

### DIFF
--- a/receiver/kubeletstatsreceiver/kubelet/accumulator.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator.go
@@ -21,6 +21,7 @@ import (
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
@@ -94,8 +95,8 @@ func (a *metricDataAccumulator) containerStats(podResource *resourcepb.Resource,
 
 	resource, err := containerResource(podResource, s, a.metadata)
 	if err != nil {
-		a.logger.Warn("failed to fetch container metrics", zap.String("pod", podResource.Labels[labelPodName]),
-			zap.String("container", podResource.Labels[labelContainerName]), zap.Error(err))
+		a.logger.Warn("failed to fetch container metrics", zap.String("pod", podResource.Labels[conventions.AttributeK8sPod]),
+			zap.String("container", podResource.Labels[conventions.AttributeK8sContainer]), zap.Error(err))
 		return
 	}
 

--- a/receiver/kubeletstatsreceiver/kubelet/accumulator_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator_test.go
@@ -36,8 +36,8 @@ func TestContainerStatsMetadataNotFound(t *testing.T) {
 	now := metav1.Now()
 	podResource := &resourcepb.Resource{
 		Labels: map[string]string{
-			labelPodUID:        "pod-uid-123",
-			labelContainerName: "container1",
+			"k8s.pod.uid":        "pod-uid-123",
+			"k8s.container.name": "container1",
 		},
 	}
 	containerStats := stats.ContainerStats{

--- a/receiver/kubeletstatsreceiver/kubelet/conventions.go
+++ b/receiver/kubeletstatsreceiver/kubelet/conventions.go
@@ -15,10 +15,5 @@
 package kubelet
 
 const (
-	labelContainerID   = "container.id"
-	labelContainerName = "container.name"
-	labelNamespaceName = "k8s.namespace.name"
-	labelNodeName      = "k8s.node.name"
-	labelPodName       = "k8s.pod.name"
-	labelPodUID        = "k8s.pod.uid"
+	labelNodeName = "k8s.node.name"
 )

--- a/receiver/kubeletstatsreceiver/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/collector/translator/conventions"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -26,7 +27,7 @@ import (
 type MetadataLabel string
 
 const (
-	MetadataLabelContainerID MetadataLabel = labelContainerID
+	MetadataLabelContainerID MetadataLabel = conventions.AttributeContainerID
 )
 
 var supportedLabels = map[MetadataLabel]bool{
@@ -70,7 +71,7 @@ func (m *Metadata) setExtraLabels(labels map[string]string, podUID string, conta
 			if err != nil {
 				return err
 			}
-			labels[labelContainerID] = containerID
+			labels[conventions.AttributeContainerID] = containerID
 			return nil
 		}
 	}

--- a/receiver/kubeletstatsreceiver/kubelet/resource.go
+++ b/receiver/kubeletstatsreceiver/kubelet/resource.go
@@ -17,6 +17,7 @@ package kubelet
 import (
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/collector/translator/conventions"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
@@ -33,9 +34,9 @@ func podResource(s stats.PodStats) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: "k8s", // k8s/pod
 		Labels: map[string]string{
-			labelPodUID:        s.PodRef.UID,
-			labelPodName:       s.PodRef.Name,
-			labelNamespaceName: s.PodRef.Namespace,
+			conventions.AttributeK8sPodUID:    s.PodRef.UID,
+			conventions.AttributeK8sPod:       s.PodRef.Name,
+			conventions.AttributeK8sNamespace: s.PodRef.Namespace,
 		},
 	}
 }
@@ -46,8 +47,8 @@ func containerResource(pod *resourcepb.Resource, s stats.ContainerStats, metadat
 		labels[k] = v
 	}
 	// augment the container resource with pod labels
-	labels[labelContainerName] = s.Name
-	err := metadata.setExtraLabels(labels, labels[labelPodUID], labels[labelContainerName])
+	labels[conventions.AttributeK8sContainer] = s.Name
+	err := metadata.setExtraLabels(labels, labels[conventions.AttributeK8sPodUID], labels[conventions.AttributeK8sContainer])
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to set extra labels from metadata")
 


### PR DESCRIPTION
- Make use of constants defined in core
- change `container.name` label to `k8s.container.name` as per newly added convention (https://github.com/open-telemetry/opentelemetry-specification/pull/762)

Related to #188 