### PR TITLE
k8sclusterreceiver: Update to use conventions from core

### DIFF
--- a/receiver/k8sclusterreceiver/collection/collector.go
+++ b/receiver/k8sclusterreceiver/collection/collector.go
@@ -40,34 +40,17 @@ const (
 	containerType = "container"
 
 	// Resource labels keys for UID.
-	k8sKeyPodUID                   = "k8s.pod.uid"
 	k8sKeyNodeUID                  = "k8s.node.uid"
-	k8sKeyCronJobUID               = "k8s.cronjob.uid"
-	k8sKeyDeploymentUID            = "k8s.deployment.uid"
-	k8sKeyJobUID                   = "k8s.job.uid"
 	k8sKeyNamespaceUID             = "k8s.namespace.uid"
-	k8sKeyReplicaSetUID            = "k8s.replicaset.uid"
 	k8sKeyReplicationControllerUID = "k8s.replicationcontroller.uid"
-	k8sKeyStatefulSetUID           = "k8s.statefulset.uid"
-	k8sKeyDaemonSetUID             = "k8s.daemonset.uid"
 	k8sKeyHPAUID                   = "k8s.hpa.uid"
 	k8sKeyResourceQuotaUID         = "k8s.resourcequota.uid"
 
 	// Resource labels keys for Name.
-	k8sKeyCronJobName               = "k8s.cronjob.name"
 	k8sKeyNodeName                  = "k8s.node.name"
-	k8sKeyDeploymentName            = "k8s.deployment.name"
-	k8sKeyJobName                   = "k8s.job.name"
-	k8sKeyReplicaSetName            = "k8s.replicaset.name"
 	k8sKeyReplicationControllerName = "k8s.replicationcontroller.name"
-	k8sKeyStatefulSetName           = "k8s.statefulset.name"
-	k8sKeyDaemonSetName             = "k8s.daemonset.name"
 	k8sKeyHPAName                   = "k8s.hpa.name"
 	k8sKeyResourceQuotaName         = "k8s.resourcequota.name"
-
-	// Resource labels for container.
-	containerKeyID       = "container.id"
-	containerKeySpecName = "container.spec.name"
 
 	// Kubernetes resource kinds
 	k8sKindCronJob               = "CronJob"

--- a/receiver/k8sclusterreceiver/collection/containers.go
+++ b/receiver/k8sclusterreceiver/collection/containers.go
@@ -144,8 +144,8 @@ func getAllContainerLabels(cs corev1.ContainerStatus,
 
 	out := utils.CloneStringMap(dims)
 
-	out[containerKeyID] = utils.StripContainerID(cs.ContainerID)
-	out[containerKeySpecName] = cs.Name
+	out[conventions.AttributeContainerID] = utils.StripContainerID(cs.ContainerID)
+	out[conventions.AttributeK8sContainer] = cs.Name
 	out[conventions.AttributeContainerImage] = cs.Image
 
 	return out
@@ -169,7 +169,7 @@ func getMetadataForContainer(cs corev1.ContainerStatus) *KubernetesMetadata {
 	}
 
 	return &KubernetesMetadata{
-		resourceIDKey: containerKeyID,
+		resourceIDKey: conventions.AttributeContainerID,
 		resourceID:    ResourceID(utils.StripContainerID(cs.ContainerID)),
 		metadata:      metadata,
 	}

--- a/receiver/k8sclusterreceiver/collection/cronjobs.go
+++ b/receiver/k8sclusterreceiver/collection/cronjobs.go
@@ -58,10 +58,10 @@ func getResourceForCronJob(cj *batchv1beta1.CronJob) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: k8sType,
 		Labels: map[string]string{
-			k8sKeyCronJobUID:                  string(cj.UID),
-			k8sKeyCronJobName:                 cj.Name,
-			conventions.AttributeK8sNamespace: cj.Namespace,
-			conventions.AttributeK8sCluster:   cj.ClusterName,
+			conventions.AttributeK8sCronJobUID: string(cj.UID),
+			conventions.AttributeK8sCronJob:    cj.Name,
+			conventions.AttributeK8sNamespace:  cj.Namespace,
+			conventions.AttributeK8sCluster:    cj.ClusterName,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/collection/daemonsets.go
+++ b/receiver/k8sclusterreceiver/collection/daemonsets.go
@@ -91,10 +91,10 @@ func getResourceForDaemonSet(ds *appsv1.DaemonSet) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: k8sType,
 		Labels: map[string]string{
-			k8sKeyDaemonSetUID:                string(ds.UID),
-			k8sKeyDaemonSetName:               ds.Name,
-			conventions.AttributeK8sNamespace: ds.Namespace,
-			conventions.AttributeK8sCluster:   ds.ClusterName,
+			conventions.AttributeK8sDaemonSetUID: string(ds.UID),
+			conventions.AttributeK8sDaemonSet:    ds.Name,
+			conventions.AttributeK8sNamespace:    ds.Namespace,
+			conventions.AttributeK8sCluster:      ds.ClusterName,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/collection/deployments.go
+++ b/receiver/k8sclusterreceiver/collection/deployments.go
@@ -41,16 +41,16 @@ func getResourceForDeployment(dep *appsv1.Deployment) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: k8sType,
 		Labels: map[string]string{
-			k8sKeyDeploymentUID:               string(dep.UID),
-			k8sKeyDeploymentName:              dep.Name,
-			conventions.AttributeK8sNamespace: dep.Namespace,
-			conventions.AttributeK8sCluster:   dep.ClusterName,
+			conventions.AttributeK8sDeploymentUID: string(dep.UID),
+			conventions.AttributeK8sDeployment:    dep.Name,
+			conventions.AttributeK8sNamespace:     dep.Namespace,
+			conventions.AttributeK8sCluster:       dep.ClusterName,
 		},
 	}
 }
 
 func getMetadataForDeployment(dep *appsv1.Deployment) map[ResourceID]*KubernetesMetadata {
 	rm := getGenericMetadata(&dep.ObjectMeta, k8sKindDeployment)
-	rm.metadata[k8sKeyDeploymentName] = dep.Name
+	rm.metadata[conventions.AttributeK8sDeployment] = dep.Name
 	return map[ResourceID]*KubernetesMetadata{ResourceID(dep.UID): rm}
 }

--- a/receiver/k8sclusterreceiver/collection/jobs.go
+++ b/receiver/k8sclusterreceiver/collection/jobs.go
@@ -104,8 +104,8 @@ func getResourceForJob(j *batchv1.Job) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: k8sType,
 		Labels: map[string]string{
-			k8sKeyJobUID:                      string(j.UID),
-			k8sKeyJobName:                     j.Name,
+			conventions.AttributeK8sJobUID:    string(j.UID),
+			conventions.AttributeK8sJob:       j.Name,
 			conventions.AttributeK8sNamespace: j.Namespace,
 			conventions.AttributeK8sCluster:   j.ClusterName,
 		},

--- a/receiver/k8sclusterreceiver/collection/pods.go
+++ b/receiver/k8sclusterreceiver/collection/pods.go
@@ -109,7 +109,7 @@ func getResourceForPod(pod *corev1.Pod) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: k8sType,
 		Labels: map[string]string{
-			k8sKeyPodUID:                      string(pod.UID),
+			conventions.AttributeK8sPodUID:    string(pod.UID),
 			conventions.AttributeK8sPod:       pod.Name,
 			k8sKeyNodeName:                    pod.Spec.NodeName,
 			conventions.AttributeK8sNamespace: pod.Namespace,
@@ -174,7 +174,7 @@ func getMetadataForPod(pod *corev1.Pod, mc *metadataStore) map[ResourceID]*Kuber
 	podID := ResourceID(pod.UID)
 	return mergeKubernetesMetadataMaps(map[ResourceID]*KubernetesMetadata{
 		podID: {
-			resourceIDKey: k8sKeyPodUID,
+			resourceIDKey: conventions.AttributeK8sPodUID,
 			resourceID:    podID,
 			metadata:      metadata,
 		},
@@ -190,9 +190,9 @@ func collectPodJobProperties(pod *corev1.Pod, JobStore cache.Store) map[string]s
 		if ok {
 			jobObj := job.(*batchv1.Job)
 			if cronJobRef := utils.FindOwnerWithKind(jobObj.OwnerReferences, k8sKindCronJob); cronJobRef != nil {
-				return getWorkloadProperties(cronJobRef, k8sKeyCronJobName)
+				return getWorkloadProperties(cronJobRef, conventions.AttributeK8sCronJob)
 			}
-			return getWorkloadProperties(jobRef, k8sKeyJobName)
+			return getWorkloadProperties(jobRef, conventions.AttributeK8sJob)
 
 		}
 	}
@@ -208,9 +208,9 @@ func collectPodReplicaSetProperties(pod *corev1.Pod, replicaSetstore cache.Store
 		if ok {
 			replicaSetObj := replicaSet.(*appsv1.ReplicaSet)
 			if deployRef := utils.FindOwnerWithKind(replicaSetObj.OwnerReferences, k8sKindDeployment); deployRef != nil {
-				return getWorkloadProperties(deployRef, k8sKeyDeploymentName)
+				return getWorkloadProperties(deployRef, conventions.AttributeK8sDeployment)
 			}
-			return getWorkloadProperties(rsRef, k8sKeyReplicaSetName)
+			return getWorkloadProperties(rsRef, conventions.AttributeK8sReplicaSet)
 		}
 	}
 	return nil

--- a/receiver/k8sclusterreceiver/collection/pods_test.go
+++ b/receiver/k8sclusterreceiver/collection/pods_test.go
@@ -57,7 +57,7 @@ func TestPodAndContainerMetrics(t *testing.T) {
 	testutils.AssertResource(t, rm.resource, "container",
 		map[string]string{
 			"container.id":         "container-id",
-			"container.spec.name":  "container-name",
+			"k8s.container.name":   "container-name",
 			"container.image.name": "container-image-name",
 			"k8s.pod.uid":          "test-pod-1-uid",
 			"k8s.pod.name":         "test-pod-1",

--- a/receiver/k8sclusterreceiver/collection/replicasets.go
+++ b/receiver/k8sclusterreceiver/collection/replicasets.go
@@ -42,10 +42,10 @@ func getResourceForReplicaSet(rs *appsv1.ReplicaSet) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: k8sType,
 		Labels: map[string]string{
-			k8sKeyReplicaSetUID:               string(rs.UID),
-			k8sKeyReplicaSetName:              rs.Name,
-			conventions.AttributeK8sNamespace: rs.Namespace,
-			conventions.AttributeK8sCluster:   rs.ClusterName,
+			conventions.AttributeK8sReplicaSetUID: string(rs.UID),
+			conventions.AttributeK8sReplicaSet:    rs.Name,
+			conventions.AttributeK8sNamespace:     rs.Namespace,
+			conventions.AttributeK8sCluster:       rs.ClusterName,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/collection/statefulsets.go
+++ b/receiver/k8sclusterreceiver/collection/statefulsets.go
@@ -101,10 +101,10 @@ func getResourceForStatefulSet(ss *appsv1.StatefulSet) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: k8sType,
 		Labels: map[string]string{
-			k8sKeyStatefulSetUID:              string(ss.UID),
-			k8sKeyStatefulSetName:             ss.Name,
-			conventions.AttributeK8sNamespace: ss.Namespace,
-			conventions.AttributeK8sCluster:   ss.ClusterName,
+			conventions.AttributeK8sStatefulSetUID: string(ss.UID),
+			conventions.AttributeK8sStatefulSet:    ss.Name,
+			conventions.AttributeK8sNamespace:      ss.Namespace,
+			conventions.AttributeK8sCluster:        ss.ClusterName,
 		},
 	}
 }


### PR DESCRIPTION
- Make use of constants defined in core
- change `container.spec.name` label to `k8s.container.name` as per newly added convention (https://github.com/open-telemetry/opentelemetry-specification/pull/762)

Relates to #188 