### PR TITLE
kubeletstatsreceiver: Sync available volume metadata from /pods endpoint

### DIFF
--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -86,11 +86,16 @@ service:
 
 ### Extra metadata labels
 
-By default all produced metrics get resource labels based on what kubelet /stats/summary endpoint provides.
+By default, all produced metrics get resource labels based on what kubelet /stats/summary endpoint provides.
 For some use cases it might be not enough. So it's possible to leverage other endpoints to fetch
-additional metadata entities and set them as extra labels on metric resource.
-The only additional label supported at the moment is `container.id`. If you want to have that label
-added to your metrics, use `extra_metadata_labels` field to enable it, for example:
+additional metadata entities and set them as extra labels on metric resource. Currently supported metadata
+include the following - 
+
+- `container.id` - to augment metrics with Container ID label obtained from container statuses exposed via `/pods`.
+- `k8s.volume.type` - to collect volume type from the Pod spec exposed via `/pods` and have it as a label on volume metrics.
+
+If you want to have `container.id` label added to your metrics, use `extra_metadata_labels` field to enable
+it, for example:
 
 ```yaml
 receivers:

--- a/receiver/kubeletstatsreceiver/config.go
+++ b/receiver/kubeletstatsreceiver/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	// ExtraMetadataLabels contains list of extra metadata that should be taken from /pods endpoint
 	// and put as extra labels on metrics resource.
 	// No additional metadata is fetched by default, so there are no extra calls to /pods endpoint.
-	// Only container.id label is supported at the moment.
+	// Supported values include container.id and k8s.volume.type.
 	ExtraMetadataLabels []kubelet.MetadataLabel `mapstructure:"extra_metadata_labels"`
 
 	// MetricGroupsToCollect provides a list of metrics groups to collect metrics from.

--- a/receiver/kubeletstatsreceiver/config_test.go
+++ b/receiver/kubeletstatsreceiver/config_test.go
@@ -121,8 +121,11 @@ func TestLoadConfig(t *testing.T) {
 				AuthType: "serviceAccount",
 			},
 		},
-		CollectionInterval:  duration,
-		ExtraMetadataLabels: []kubelet.MetadataLabel{kubelet.MetadataLabelContainerID},
+		CollectionInterval: duration,
+		ExtraMetadataLabels: []kubelet.MetadataLabel{
+			kubelet.MetadataLabelContainerID,
+			kubelet.MetadataLabelVolumeType,
+		},
 		MetricGroupsToCollect: []kubelet.MetricGroup{
 			kubelet.ContainerMetricGroup,
 			kubelet.PodMetricGroup,

--- a/receiver/kubeletstatsreceiver/kubelet/accumulator.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator.go
@@ -119,7 +119,16 @@ func (a *metricDataAccumulator) volumeStats(podResource *resourcepb.Resource, s 
 		return
 	}
 
-	volume := volumeResource(podResource, s)
+	volume, err := volumeResource(podResource, s, a.metadata)
+	if err != nil {
+		a.logger.Warn(
+			"Failed to gather additional volume metadata. Skipping metric collection.",
+			zap.String("pod", podResource.Labels[conventions.AttributeK8sPod]),
+			zap.String("volume", podResource.Labels[labelVolumeName]),
+			zap.Error(err),
+		)
+		return
+	}
 
 	a.accumulate(
 		nil,

--- a/receiver/kubeletstatsreceiver/kubelet/accumulator_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator_test.go
@@ -30,58 +30,160 @@ import (
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
-// TestContainerStatsMetadataNotFound walks through the error cases of containerStats.
-// Happy paths are covered in metadata_test.go
-func TestContainerStatsMetadataNotFound(t *testing.T) {
-	now := metav1.Now()
-	podResource := &resourcepb.Resource{
-		Labels: map[string]string{
-			"k8s.pod.uid":        "pod-uid-123",
-			"k8s.container.name": "container1",
-		},
-	}
-	containerStats := stats.ContainerStats{
-		Name:      "container1",
-		StartTime: now,
-	}
-	metadata := NewMetadata(
-		[]MetadataLabel{MetadataLabelContainerID},
-		&v1.PodList{
-			Items: []v1.Pod{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						UID: types.UID("pod-uid-123"),
-					},
-					Status: v1.PodStatus{
-						ContainerStatuses: []v1.ContainerStatus{
-							{
-								// different container name
-								Name:        "container2",
-								ContainerID: "test-container",
+// TestMetadataErrorCases walks through the error cases of collecting
+// metadata. Happy paths are covered in metadata_test.go.
+func TestMetadataErrorCases(t *testing.T) {
+	tests := []struct {
+		name                  string
+		metricGroupsToCollect map[MetricGroup]bool
+		testScenario          func(acc metricDataAccumulator)
+		metadata              Metadata
+		numMDs                int
+		numLogs               int
+		logMessages           []string
+	}{
+		{
+			name: "Fails to get container metadata",
+			metricGroupsToCollect: map[MetricGroup]bool{
+				ContainerMetricGroup: true,
+			},
+			metadata: NewMetadata(
+				[]MetadataLabel{MetadataLabelContainerID},
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: types.UID("pod-uid-123"),
+							},
+							Status: v1.PodStatus{
+								ContainerStatuses: []v1.ContainerStatus{
+									{
+										// different container name
+										Name:        "container2",
+										ContainerID: "test-container",
+									},
+								},
 							},
 						},
 					},
 				},
+			),
+			testScenario: func(acc metricDataAccumulator) {
+				now := metav1.Now()
+				podResource := &resourcepb.Resource{
+					Labels: map[string]string{
+						"k8s.pod.uid":        "pod-uid-123",
+						"k8s.container.name": "container1",
+					},
+				}
+				containerStats := stats.ContainerStats{
+					Name:      "container1",
+					StartTime: now,
+				}
+
+				acc.containerStats(podResource, containerStats)
+			},
+			numMDs:  0,
+			numLogs: 1,
+			logMessages: []string{
+				"failed to fetch container metrics",
 			},
 		},
-	)
+		{
+			name: "Fails to get volume metadata - no pods data",
+			metricGroupsToCollect: map[MetricGroup]bool{
+				VolumeMetricGroup: true,
+			},
+			metadata: NewMetadata(
+				[]MetadataLabel{MetadataLabelVolumeType},
+				nil,
+			),
+			testScenario: func(acc metricDataAccumulator) {
+				podResource := &resourcepb.Resource{
+					Labels: map[string]string{
+						"k8s.pod.uid": "pod-uid-123",
+					},
+				}
+				volumeStats := stats.VolumeStats{
+					Name: "volume-1",
+				}
 
-	observedLogger, logs := observer.New(zapcore.WarnLevel)
-	logger := zap.New(observedLogger)
+				acc.volumeStats(podResource, volumeStats)
+			},
+			numMDs:  0,
+			numLogs: 1,
+			logMessages: []string{
+				"Failed to gather additional volume metadata. Skipping metric collection.",
+			},
+		},
 
-	mds := []*consumerdata.MetricsData{}
-	acc := metricDataAccumulator{
-		m:        mds,
-		metadata: metadata,
-		logger:   logger,
-		metricGroupsToCollect: map[MetricGroup]bool{
-			ContainerMetricGroup: true,
+		{
+			name: "Fails to get volume metadata - volume not found",
+			metricGroupsToCollect: map[MetricGroup]bool{
+				VolumeMetricGroup: true,
+			},
+			metadata: NewMetadata(
+				[]MetadataLabel{MetadataLabelVolumeType},
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: types.UID("pod-uid-123"),
+							},
+							Spec: v1.PodSpec{
+								Volumes: []v1.Volume{
+									{
+										Name: "volume-0",
+										VolumeSource: v1.VolumeSource{
+											HostPath: &v1.HostPathVolumeSource{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			testScenario: func(acc metricDataAccumulator) {
+				podResource := &resourcepb.Resource{
+					Labels: map[string]string{
+						"k8s.pod.uid": "pod-uid-123",
+					},
+				}
+				volumeStats := stats.VolumeStats{
+					Name: "volume-1",
+				}
+
+				acc.volumeStats(podResource, volumeStats)
+			},
+			numMDs:  0,
+			numLogs: 1,
+			logMessages: []string{
+				"Failed to gather additional volume metadata. Skipping metric collection.",
+			},
 		},
 	}
 
-	acc.containerStats(podResource, containerStats)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedLogger, logs := observer.New(zapcore.WarnLevel)
+			logger := zap.New(observedLogger)
 
-	assert.Equal(t, 0, len(mds))
-	require.Equal(t, 1, logs.Len())
-	assert.Equal(t, "failed to fetch container metrics", logs.All()[0].Message)
+			var mds []*consumerdata.MetricsData
+			acc := metricDataAccumulator{
+				m:                     mds,
+				metadata:              tt.metadata,
+				logger:                logger,
+				metricGroupsToCollect: tt.metricGroupsToCollect,
+			}
+
+			tt.testScenario(acc)
+
+			assert.Equal(t, tt.numMDs, len(mds))
+			require.Equal(t, tt.numLogs, logs.Len())
+			for i := 0; i < tt.numLogs; i++ {
+				assert.Equal(t, tt.logMessages[i], logs.All()[i].Message)
+			}
+		})
+	}
 }

--- a/receiver/kubeletstatsreceiver/kubelet/conventions.go
+++ b/receiver/kubeletstatsreceiver/kubelet/conventions.go
@@ -17,4 +17,5 @@ package kubelet
 const (
 	labelNodeName   = "k8s.node.name"
 	labelVolumeName = "k8s.volume.name"
+	labelVolumeType = "k8s.volume.type"
 )

--- a/receiver/kubeletstatsreceiver/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata.go
@@ -28,10 +28,12 @@ type MetadataLabel string
 
 const (
 	MetadataLabelContainerID MetadataLabel = conventions.AttributeContainerID
+	MetadataLabelVolumeType  MetadataLabel = labelVolumeType
 )
 
 var supportedLabels = map[MetadataLabel]bool{
 	MetadataLabelContainerID: true,
+	labelVolumeType:          true,
 }
 
 // ValidateMetadataLabelsConfig validates that provided list of metadata labels is supported
@@ -51,28 +53,54 @@ func ValidateMetadataLabelsConfig(labels []MetadataLabel) error {
 }
 
 type Metadata struct {
-	Labels       []MetadataLabel
+	Labels       map[MetadataLabel]bool
 	PodsMetadata *v1.PodList
 }
 
 func NewMetadata(labels []MetadataLabel, podsMetadata *v1.PodList) Metadata {
 	return Metadata{
-		Labels:       labels,
+		Labels:       getLabelsMap(labels),
 		PodsMetadata: podsMetadata,
 	}
 }
 
-// setExtraLabels sets extra labels in `lables` map based on available metadata
-func (m *Metadata) setExtraLabels(labels map[string]string, podUID string, containerName string) error {
-	for _, label := range m.Labels {
-		switch label {
-		case MetadataLabelContainerID:
-			containerID, err := m.getContainerID(podUID, containerName)
-			if err != nil {
-				return err
-			}
-			labels[conventions.AttributeContainerID] = containerID
-			return nil
+func getLabelsMap(metadataLabels []MetadataLabel) map[MetadataLabel]bool {
+	out := make(map[MetadataLabel]bool, len(metadataLabels))
+	for _, l := range metadataLabels {
+		out[l] = true
+	}
+	return out
+}
+
+// setExtraLabels sets extra labels in `lables` map based on provided metadata label.
+func (m *Metadata) setExtraLabels(
+	labels map[string]string, podUID string,
+	extraMetadataLabel MetadataLabel, extraMetadataFrom string) error {
+	// Ensure MetadataLabel exists before proceeding.
+	if !m.Labels[extraMetadataLabel] || len(m.Labels) == 0 {
+		return nil
+	}
+
+	// Cannot proceed, if metadata is unavailable.
+	if m.PodsMetadata == nil {
+		return errors.New("pods metadata were not fetched")
+	}
+
+	switch extraMetadataLabel {
+	case MetadataLabelContainerID:
+		containerID, err := m.getContainerID(podUID, extraMetadataFrom)
+		if err != nil {
+			return err
+		}
+		labels[conventions.AttributeContainerID] = containerID
+	case MetadataLabelVolumeType:
+		extraLabels, err := m.getExtraVolumeMetadata(podUID, extraMetadataFrom)
+		if err != nil {
+			return err
+		}
+
+		for k, v := range extraLabels {
+			labels[k] = v
 		}
 	}
 	return nil
@@ -81,12 +109,9 @@ func (m *Metadata) setExtraLabels(labels map[string]string, podUID string, conta
 // getContainerID retrieves container id from metadata for given pod UID and container name,
 // returns an error if no container found in the metadata that matches the requirements.
 func (m *Metadata) getContainerID(podUID string, containerName string) (string, error) {
-	if m.PodsMetadata == nil {
-		return "", errors.New("pods metadata were not fetched")
-	}
-
+	uid := types.UID(podUID)
 	for _, pod := range m.PodsMetadata.Items {
-		if pod.UID == types.UID(podUID) {
+		if pod.UID == uid {
 			for _, containerStatus := range pod.Status.ContainerStatuses {
 				if containerName == containerStatus.Name {
 					return stripContainerID(containerStatus.ContainerID), nil
@@ -103,4 +128,19 @@ var containerSchemeRegexp = regexp.MustCompile(`^[\w_-]+://`)
 // stripContainerID returns a pure container id without the runtime scheme://
 func stripContainerID(id string) string {
 	return containerSchemeRegexp.ReplaceAllString(id, "")
+}
+
+func (m *Metadata) getExtraVolumeMetadata(podUID string, volumeName string) (map[string]string, error) {
+	uid := types.UID(podUID)
+	for _, pod := range m.PodsMetadata.Items {
+		if pod.UID == uid {
+			for _, volume := range pod.Spec.Volumes {
+				if volumeName == volume.Name {
+					return getLabelsFromVolume(volume), nil
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("pod %q with volume %q not found in the fetched metadata", podUID, volumeName)
 }

--- a/receiver/kubeletstatsreceiver/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata.go
@@ -94,7 +94,7 @@ func (m *Metadata) setExtraLabels(
 		}
 		labels[conventions.AttributeContainerID] = containerID
 	case MetadataLabelVolumeType:
-		err := m.getExtraVolumeMetadata(podUID, extraMetadataFrom, labels)
+		err := m.setExtraVolumeMetadata(podUID, extraMetadataFrom, labels)
 		if err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ func stripContainerID(id string) string {
 	return containerSchemeRegexp.ReplaceAllString(id, "")
 }
 
-func (m *Metadata) getExtraVolumeMetadata(podUID string, volumeName string, labels map[string]string) error {
+func (m *Metadata) setExtraVolumeMetadata(podUID string, volumeName string, labels map[string]string) error {
 	uid := types.UID(podUID)
 	for _, pod := range m.PodsMetadata.Items {
 		if pod.UID == uid {

--- a/receiver/kubeletstatsreceiver/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata.go
@@ -72,7 +72,7 @@ func getLabelsMap(metadataLabels []MetadataLabel) map[MetadataLabel]bool {
 	return out
 }
 
-// setExtraLabels sets extra labels in `lables` map based on provided metadata label.
+// setExtraLabels sets extra labels in `labels` map based on provided metadata label.
 func (m *Metadata) setExtraLabels(
 	labels map[string]string, podUID string,
 	extraMetadataLabel MetadataLabel, extraMetadataFrom string) error {

--- a/receiver/kubeletstatsreceiver/kubelet/metadata_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestValidateMetadataLabelsConfig(t *testing.T) {
-
 	tests := []struct {
 		name      string
 		labels    []MetadataLabel
@@ -39,6 +38,11 @@ func TestValidateMetadataLabelsConfig(t *testing.T) {
 		{
 			name:      "container_id_valid",
 			labels:    []MetadataLabel{MetadataLabelContainerID},
+			wantError: "",
+		},
+		{
+			name:      "volume_type_valid",
+			labels:    []MetadataLabel{MetadataLabelVolumeType},
 			wantError: "",
 		},
 		{
@@ -65,21 +69,18 @@ func TestValidateMetadataLabelsConfig(t *testing.T) {
 }
 
 func TestSetExtraLabels(t *testing.T) {
-
 	tests := []struct {
-		name          string
-		metadata      Metadata
-		podUID        string
-		containerName string
-		wantError     string
-		want          map[string]string
+		name      string
+		metadata  Metadata
+		args      []string
+		wantError string
+		want      map[string]string
 	}{
 		{
-			name:          "no_labels",
-			metadata:      NewMetadata([]MetadataLabel{}, nil),
-			podUID:        "uid",
-			containerName: "container",
-			want:          map[string]string{},
+			name:     "no_labels",
+			metadata: NewMetadata([]MetadataLabel{}, nil),
+			args:     []string{"uid", "container.id", "container"},
+			want:     map[string]string{},
 		},
 		{
 			name: "set_container_id_valid",
@@ -103,18 +104,16 @@ func TestSetExtraLabels(t *testing.T) {
 					},
 				},
 			),
-			podUID:        "uid-1234",
-			containerName: "container1",
+			args: []string{"uid-1234", "container.id", "container1"},
 			want: map[string]string{
 				string(MetadataLabelContainerID): "test-container",
 			},
 		},
 		{
-			name:          "set_container_id_no_metadata",
-			metadata:      NewMetadata([]MetadataLabel{MetadataLabelContainerID}, nil),
-			podUID:        "uid-1234",
-			containerName: "container1",
-			wantError:     "pods metadata were not fetched",
+			name:      "set_container_id_no_metadata",
+			metadata:  NewMetadata([]MetadataLabel{MetadataLabelContainerID}, nil),
+			args:      []string{"uid-1234", "container.id", "container1"},
+			wantError: "pods metadata were not fetched",
 		},
 		{
 			name: "set_container_id_not_found",
@@ -138,21 +137,156 @@ func TestSetExtraLabels(t *testing.T) {
 					},
 				},
 			),
-			podUID:        "uid-1234",
-			containerName: "container1",
-			wantError:     "pod \"uid-1234\" with container \"container1\" not found in the fetched metadata",
+			args:      []string{"uid-1234", "container.id", "container1"},
+			wantError: "pod \"uid-1234\" with container \"container1\" not found in the fetched metadata",
+		},
+		{
+			name:      "set_volume_type_no_metadata",
+			metadata:  NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, nil),
+			args:      []string{"uid-1234", "k8s.volume.type", "volume0"},
+			wantError: "pods metadata were not fetched",
+		},
+		{
+			name: "set_volume_type_not_found",
+			metadata: NewMetadata(
+				[]MetadataLabel{MetadataLabelVolumeType},
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: types.UID("uid-1234"),
+							},
+							Spec: v1.PodSpec{
+								Volumes: []v1.Volume{
+									{
+										Name:         "volume0",
+										VolumeSource: v1.VolumeSource{},
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			args:      []string{"uid-1234", "k8s.volume.type", "volume1"},
+			wantError: "pod \"uid-1234\" with volume \"volume1\" not found in the fetched metadata",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fields := map[string]string{}
-			err := tt.metadata.setExtraLabels(fields, tt.podUID, tt.containerName)
+			err := tt.metadata.setExtraLabels(fields, tt.args[0], MetadataLabel(tt.args[1]), tt.args[2])
 			if tt.wantError == "" {
 				require.NoError(t, err)
 				assert.EqualValues(t, tt.want, fields)
 			} else {
 				assert.Equal(t, tt.wantError, err.Error())
 			}
+		})
+	}
+}
+
+// Test happy paths for volume type metadata.
+func TestSetExtraLabelsForVolumeTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		vs   v1.VolumeSource
+		args []string
+		want map[string]string
+	}{
+		{
+			name: "hostPath",
+			vs: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{},
+			},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{
+				"k8s.volume.type": "hostPath",
+			},
+		},
+		{
+			name: "configMap",
+			vs: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{},
+			},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{
+				"k8s.volume.type": "configMap",
+			},
+		},
+		{
+			name: "emptyDir",
+			vs: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{},
+			},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{
+				"k8s.volume.type": "emptyDir",
+			},
+		},
+		{
+			name: "secret",
+			vs: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{},
+			},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{
+				"k8s.volume.type": "secret",
+			},
+		},
+		{
+			name: "downwardAPI",
+			vs: v1.VolumeSource{
+				DownwardAPI: &v1.DownwardAPIVolumeSource{},
+			},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{
+				"k8s.volume.type": "downwardAPI",
+			},
+		},
+		{
+			name: "persistentVolumeClaim",
+			vs: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
+			},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{
+				"k8s.volume.type": "persistentVolumeClaim",
+			},
+		},
+		{
+			name: "unsupported type",
+			vs:   v1.VolumeSource{},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := map[string]string{}
+			volName := "volume0"
+			metadata := NewMetadata(
+				[]MetadataLabel{MetadataLabelVolumeType},
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID: types.UID("uid-1234"),
+							},
+							Spec: v1.PodSpec{
+								Volumes: []v1.Volume{
+									{
+										Name:         volName,
+										VolumeSource: tt.vs,
+									},
+								},
+							},
+						},
+					},
+				},
+			)
+			metadata.setExtraLabels(fields, tt.args[0], MetadataLabel(tt.args[1]), volName)
+			assert.Equal(t, tt.want, fields)
 		})
 	}
 }

--- a/receiver/kubeletstatsreceiver/kubelet/resource.go
+++ b/receiver/kubeletstatsreceiver/kubelet/resource.go
@@ -48,7 +48,10 @@ func containerResource(pod *resourcepb.Resource, s stats.ContainerStats, metadat
 	}
 	// augment the container resource with pod labels
 	labels[conventions.AttributeK8sContainer] = s.Name
-	err := metadata.setExtraLabels(labels, labels[conventions.AttributeK8sPodUID], labels[conventions.AttributeK8sContainer])
+	err := metadata.setExtraLabels(
+		labels, labels[conventions.AttributeK8sPodUID],
+		MetadataLabelContainerID, labels[conventions.AttributeK8sContainer],
+	)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to set extra labels from metadata")
 
@@ -59,9 +62,15 @@ func containerResource(pod *resourcepb.Resource, s stats.ContainerStats, metadat
 	}, nil
 }
 
-func volumeResource(pod *resourcepb.Resource, vs stats.VolumeStats) *resourcepb.Resource {
+func volumeResource(pod *resourcepb.Resource, vs stats.VolumeStats, metadata Metadata) (*resourcepb.Resource, error) {
 	labels := map[string]string{
 		labelVolumeName: vs.Name,
+	}
+
+	err := metadata.setExtraLabels(labels, pod.Labels[conventions.AttributeK8sPodUID], MetadataLabelVolumeType, labels[labelVolumeName])
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to set extra labels from metadata")
+
 	}
 
 	// Collect relevant Pod labels to be able to associate the volume to it.
@@ -69,11 +78,10 @@ func volumeResource(pod *resourcepb.Resource, vs stats.VolumeStats) *resourcepb.
 	labels[conventions.AttributeK8sPod] = pod.Labels[conventions.AttributeK8sPod]
 	labels[conventions.AttributeK8sNamespace] = pod.Labels[conventions.AttributeK8sNamespace]
 
-	//TODO: Optionally add more labels through the /pods endpoint and
-	// the Kubernetes API. Will make PRs for those enhancements separately.
+	//TODO: Optionally add more labels through the Kubernetes API when dealing with PVCs.
 
 	return &resourcepb.Resource{
 		Type:   "k8s",
 		Labels: labels,
-	}
+	}, nil
 }

--- a/receiver/kubeletstatsreceiver/kubelet/volume.go
+++ b/receiver/kubeletstatsreceiver/kubelet/volume.go
@@ -16,6 +16,7 @@ package kubelet
 
 import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	v1 "k8s.io/api/core/v1"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
@@ -83,4 +84,23 @@ func volumeInodesUsedMetric(prefix string, s stats.VolumeStats) *metricspb.Metri
 			" free because filesystem may share inodes with other filesystems.",
 		s.InodesUsed,
 	)
+}
+
+func getLabelsFromVolume(volume v1.Volume) map[string]string {
+	switch {
+	// TODO: Support more types
+	case volume.ConfigMap != nil:
+		return map[string]string{labelVolumeType: "configMap"}
+	case volume.DownwardAPI != nil:
+		return map[string]string{labelVolumeType: "downwardAPI"}
+	case volume.EmptyDir != nil:
+		return map[string]string{labelVolumeType: "emptyDir"}
+	case volume.Secret != nil:
+		return map[string]string{labelVolumeType: "secret"}
+	case volume.PersistentVolumeClaim != nil:
+		return map[string]string{labelVolumeType: "persistentVolumeClaim"}
+	case volume.HostPath != nil:
+		return map[string]string{labelVolumeType: "hostPath"}
+	}
+	return nil
 }

--- a/receiver/kubeletstatsreceiver/kubelet/volume.go
+++ b/receiver/kubeletstatsreceiver/kubelet/volume.go
@@ -86,21 +86,20 @@ func volumeInodesUsedMetric(prefix string, s stats.VolumeStats) *metricspb.Metri
 	)
 }
 
-func getLabelsFromVolume(volume v1.Volume) map[string]string {
+func getLabelsFromVolume(volume v1.Volume, labels map[string]string) {
 	switch {
 	// TODO: Support more types
 	case volume.ConfigMap != nil:
-		return map[string]string{labelVolumeType: "configMap"}
+		labels[labelVolumeType] = "configMap"
 	case volume.DownwardAPI != nil:
-		return map[string]string{labelVolumeType: "downwardAPI"}
+		labels[labelVolumeType] = "downwardAPI"
 	case volume.EmptyDir != nil:
-		return map[string]string{labelVolumeType: "emptyDir"}
+		labels[labelVolumeType] = "emptyDir"
 	case volume.Secret != nil:
-		return map[string]string{labelVolumeType: "secret"}
+		labels[labelVolumeType] = "secret"
 	case volume.PersistentVolumeClaim != nil:
-		return map[string]string{labelVolumeType: "persistentVolumeClaim"}
+		labels[labelVolumeType] = "persistentVolumeClaim"
 	case volume.HostPath != nil:
-		return map[string]string{labelVolumeType: "hostPath"}
+		labels[labelVolumeType] = "hostPath"
 	}
-	return nil
 }

--- a/receiver/kubeletstatsreceiver/testdata/config.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/config.yaml
@@ -17,6 +17,7 @@ receivers:
     auth_type: "serviceAccount"
     extra_metadata_labels:
     - container.id
+    - k8s.volume.type
   kubeletstats/metric_groups:
     collection_interval: 20s
     auth_type: "serviceAccount"

--- a/receiver/kubeletstatsreceiver/testdata/pods.json
+++ b/receiver/kubeletstatsreceiver/testdata/pods.json
@@ -19,6 +19,21 @@
         "name": "go-hello-world-5456b4b8cd-99vxc",
         "uid": "42ad382b-ed0b-446d-9aab-3fdce8b4f9e2"
       },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-wgfsl",
+            "secret": {
+              "secretName": "default-token-ndwz2",
+              "defaultMode": 420
+            }
+          },
+          {
+            "name": "test-missing-metrics",
+            "secret": {}
+          }
+        ]
+      },
       "status": {
         "containerStatuses": [
           {
@@ -47,6 +62,30 @@
         "name": "coredns-66bff467f8-szddj",
         "uid": "0adffe8e-9849-4e05-b4cd-92d2d1e1f1c3"
       },
+      "spec": {
+        "volumes": [
+          {
+            "name": "config-volume",
+            "configMap": {
+              "name": "coredns",
+              "items": [
+                {
+                  "key": "Corefile",
+                  "path": "Corefile"
+                }
+              ],
+              "defaultMode": 420
+            }
+          },
+          {
+            "name": "coredns-token-dzc5t",
+            "secret": {
+              "secretName": "coredns-token-hwxlx",
+              "defaultMode": 420
+            }
+          }
+        ]
+      },
       "status": {
         "containerStatuses": [
           {
@@ -60,6 +99,30 @@
       "metadata": {
         "name": "coredns-66bff467f8-58qvv",
         "uid": "eb632b33-62c6-4a80-9575-a97ab363ad7f"
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "config-volume",
+            "configMap": {
+              "name": "coredns",
+              "items": [
+                {
+                  "key": "Corefile",
+                  "path": "Corefile"
+                }
+              ],
+              "defaultMode": 420
+            }
+          },
+          {
+            "name": "coredns-token-dzc5t",
+            "secret": {
+              "secretName": "coredns-token-dzc5t",
+              "defaultMode": 420
+            }
+          }
+        ]
       },
       "status": {
         "containerStatuses": [
@@ -89,6 +152,24 @@
         "name": "kube-proxy-v48tf",
         "uid": "0a6d6b05-0e8d-4920-8a38-926a33164d45"
       },
+      "spec": {
+        "volumes": [
+          {
+            "name": "kube-proxy",
+            "configMap": {
+              "name": "kube-proxy",
+              "defaultMode": 420
+            }
+          },
+          {
+            "name": "kube-proxy-token-2z27z",
+            "secret": {
+              "secretName": "kube-proxy-token-2z27z",
+              "defaultMode": 420
+            }
+          }
+        ]
+      },
       "status": {
         "containerStatuses": [
           {
@@ -102,6 +183,24 @@
       "metadata": {
         "name": "storage-provisioner",
         "uid": "14bf95e0-9451-4192-b111-807b03163670"
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "tmp",
+            "hostPath": {
+              "path": "/tmp",
+              "type": "Directory"
+            }
+          },
+          {
+            "name": "storage-provisioner-token-qzlx6",
+            "secret": {
+              "secretName": "storage-provisioner-token-qzlx6",
+              "defaultMode": 420
+            }
+          }
+        ]
       },
       "status": {
         "containerStatuses": [


### PR DESCRIPTION
**Description:** Optionally sync `k8s.volume.type` label with volume metric. This information is collected from the Pod spec exposed via `/pods` endpoint only if the receiver is configured to do so (using `extra_metadata_labels` option). 

Currently, Persistent Volume Claim is synced as its own type. This will be updated in a subsequent PR so that metadata from the actual storage backing the claim is synced instead using the Kubernetes API.

**Testing:** Added tests.

**Documentation:** Updated README.