### PR TITLE
sfx exporter: group new metric translations by dimensions

### DIFF
--- a/exporter/signalfxexporter/translation/translator.go
+++ b/exporter/signalfxexporter/translation/translator.go
@@ -16,7 +16,6 @@ package translation
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/gogo/protobuf/proto"
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
@@ -422,13 +421,36 @@ func calcNewMetricInputPairs(processedDataPoints []*sfxpb.DataPoint, tr Rule) []
 	var out [][2]*sfxpb.DataPoint
 	for _, o1 := range operand1Pts {
 		for _, o2 := range operand2Pts {
-			if reflect.DeepEqual(o1.Dimensions, o2.Dimensions) {
+			if dimensionsEqual(o1.Dimensions, o2.Dimensions) {
 				pair := [2]*sfxpb.DataPoint{o1, o2}
 				out = append(out, pair)
 			}
 		}
 	}
 	return out
+}
+
+func dimensionsEqual(d1 []*sfxpb.Dimension, d2 []*sfxpb.Dimension) bool {
+	if d1 == nil && d2 == nil {
+		return true
+	}
+	if len(d1) != len(d2) {
+		return false
+	}
+	// avoid allocating a map
+	for _, dim1 := range d1 {
+		matched := false
+		for _, dim2 := range d2 {
+			if dim1.Key == dim2.Key && dim1.Value == dim2.Value {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
 }
 
 func calculateNewMetric(

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -1480,79 +1480,6 @@ func TestTranslateDataPoints(t *testing.T) {
 					},
 				},
 			},
-		}, {
-			name: "calculate_new_metric",
-			trs: []Rule{{
-				Action:         ActionCalculateNewMetric,
-				MetricName:     "new_metric",
-				Operand1Metric: "metric0",
-				Operand2Metric: "metric1",
-				Operator:       MetricOperatorDivision,
-			}},
-			dps: []*sfxpb.DataPoint{
-				{
-					Metric:     "metric0",
-					Timestamp:  msec,
-					MetricType: &gaugeType,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(42),
-					},
-					Dimensions: []*sfxpb.Dimension{{
-						Key:   "dim1",
-						Value: "val1",
-					}},
-				},
-				{
-					Metric:     "metric1",
-					Timestamp:  msec,
-					MetricType: &gaugeType,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(84),
-					},
-					Dimensions: []*sfxpb.Dimension{{
-						Key:   "dim2",
-						Value: "val2",
-					}},
-				},
-			},
-			want: []*sfxpb.DataPoint{
-				{
-					Metric:     "metric0",
-					Timestamp:  msec,
-					MetricType: &gaugeType,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(42),
-					},
-					Dimensions: []*sfxpb.Dimension{{
-						Key:   "dim1",
-						Value: "val1",
-					}},
-				},
-				{
-					Metric:     "metric1",
-					Timestamp:  msec,
-					MetricType: &gaugeType,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(84),
-					},
-					Dimensions: []*sfxpb.Dimension{{
-						Key:   "dim2",
-						Value: "val2",
-					}},
-				},
-				{
-					Metric:     "new_metric",
-					Timestamp:  msec,
-					MetricType: &gaugeType,
-					Value: sfxpb.Datum{
-						DoubleValue: generateFloatPtr(0.5),
-					},
-					Dimensions: []*sfxpb.Dimension{{
-						Key:   "dim1",
-						Value: "val1",
-					}},
-				},
-			},
 		},
 	}
 	for _, tt := range tests {
@@ -1561,24 +1488,27 @@ func TestTranslateDataPoints(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotEqualValues(t, tt.want, tt.dps)
 			got := mt.TranslateDataPoints(zap.NewNop(), tt.dps)
-
-			// Handle float values separately
-			for i, dp := range got {
-				if dp.GetValue().DoubleValue != nil {
-					assert.InDelta(t, *tt.want[i].GetValue().DoubleValue, *dp.GetValue().DoubleValue, 0.00000001)
-					*dp.GetValue().DoubleValue = *tt.want[i].GetValue().DoubleValue
-				}
-			}
-
-			// Sort metrics to handle not deterministic order from aggregation
-			if tt.trs[0].Action == ActionAggregateMetric {
-				sort.Sort(byContent(tt.want))
-				sort.Sort(byContent(got))
-			}
-
-			assert.EqualValues(t, tt.want, got)
+			assertEqualPoints(t, got, tt.want, tt.trs[0].Action)
 		})
 	}
+}
+
+func assertEqualPoints(t *testing.T, got []*sfxpb.DataPoint, want []*sfxpb.DataPoint, action Action) {
+	// Handle float values separately
+	for i, dp := range got {
+		if dp.GetValue().DoubleValue != nil {
+			assert.InDelta(t, *want[i].GetValue().DoubleValue, *dp.GetValue().DoubleValue, 0.00000001)
+			*dp.GetValue().DoubleValue = *want[i].GetValue().DoubleValue
+		}
+	}
+
+	// Sort metrics to handle not deterministic order from aggregation
+	if action == ActionAggregateMetric {
+		sort.Sort(byContent(want))
+		sort.Sort(byContent(got))
+	}
+
+	assert.EqualValues(t, want, got)
 }
 
 func TestTestTranslateDimension(t *testing.T) {
@@ -1678,8 +1608,8 @@ func TestNewCalculateNewMetricErrors(t *testing.T) {
 						IntValue: test.val2,
 					},
 					Dimensions: []*sfxpb.Dimension{{
-						Key:   "dim2",
-						Value: "val2",
+						Key:   "dim1",
+						Value: "val1",
 					}},
 				},
 			}
@@ -1696,8 +1626,8 @@ func TestNewCalculateNewMetricErrors(t *testing.T) {
 			if test.wantErr == "" {
 				require.Equal(t, 0, observedLogs.Len())
 			} else {
+				require.Equal(t, test.wantErr, observedLogs.All()[0].Message, "expected error: "+test.wantErr)
 				require.Equal(t, 1, observedLogs.Len())
-				require.Equal(t, test.wantErr, observedLogs.All()[0].Message)
 			}
 		})
 	}
@@ -1716,6 +1646,285 @@ func TestNewMetricTranslator_InvalidOperator(t *testing.T) {
 		err,
 		`invalid operator "*" for "calculate_new_metric" translation rule`,
 	)
+}
+
+func TestCalcNewMetricInputPairs_SameDims(t *testing.T) {
+	rule := Rule{
+		Operand1Metric: "m1",
+		Operand2Metric: "m2",
+		Operator:       "/",
+	}
+	pts := []*sfxpb.DataPoint{
+		{
+			Metric:     "m1",
+			Timestamp:  msec,
+			MetricType: &gaugeType,
+			Value: sfxpb.Datum{
+				IntValue: generateIntPtr(84),
+			},
+			Dimensions: []*sfxpb.Dimension{{
+				Key:   "dim1",
+				Value: "val1",
+			}},
+		},
+		{
+			Metric:     "m2",
+			Timestamp:  msec,
+			MetricType: &gaugeType,
+			Value: sfxpb.Datum{
+				IntValue: generateIntPtr(48),
+			},
+			Dimensions: []*sfxpb.Dimension{{
+				Key:   "dim1",
+				Value: "val1",
+			}},
+		},
+	}
+	pairs := calcNewMetricInputPairs(pts, rule)
+	require.Equal(t, 1, len(pairs))
+	pair := pairs[0]
+	require.Equal(t, "m1", pair[0].Metric)
+	require.Equal(t, "m2", pair[1].Metric)
+}
+
+func TestNewMetricInputPairs_MultiPairs(t *testing.T) {
+	rule := Rule{
+		Operand1Metric: "m1",
+		Operand2Metric: "m2",
+		Operator:       "/",
+	}
+	pts := []*sfxpb.DataPoint{
+		{
+			Metric:     "m1",
+			Timestamp:  msec,
+			MetricType: &gaugeType,
+			Value: sfxpb.Datum{
+				IntValue: generateIntPtr(1),
+			},
+			Dimensions: []*sfxpb.Dimension{{
+				Key:   "dim1",
+				Value: "val1",
+			}},
+		},
+		{
+			Metric:     "m2",
+			Timestamp:  msec,
+			MetricType: &gaugeType,
+			Value: sfxpb.Datum{
+				IntValue: generateIntPtr(2),
+			},
+			Dimensions: []*sfxpb.Dimension{{
+				Key:   "dim1",
+				Value: "val1",
+			}},
+		},
+		{
+			Metric:     "m1",
+			Timestamp:  msec,
+			MetricType: &gaugeType,
+			Value: sfxpb.Datum{
+				IntValue: generateIntPtr(3),
+			},
+			Dimensions: []*sfxpb.Dimension{{
+				Key:   "dim1",
+				Value: "val2",
+			}},
+		},
+		{
+			Metric:     "m2",
+			Timestamp:  msec,
+			MetricType: &gaugeType,
+			Value: sfxpb.Datum{
+				IntValue: generateIntPtr(4),
+			},
+			Dimensions: []*sfxpb.Dimension{{
+				Key:   "dim1",
+				Value: "val2",
+			}},
+		},
+	}
+	pairs := calcNewMetricInputPairs(pts, rule)
+	require.Equal(t, 2, len(pairs))
+	pair1 := pairs[0]
+	require.EqualValues(t, 1, *pair1[0].Value.IntValue)
+	require.EqualValues(t, 2, *pair1[1].Value.IntValue)
+	pair2 := pairs[1]
+	require.EqualValues(t, 3, *pair2[0].Value.IntValue)
+	require.EqualValues(t, 4, *pair2[1].Value.IntValue)
+}
+
+func TestCalcNewMetricInputPairs_DiffDims(t *testing.T) {
+	rule := Rule{
+		Operand1Metric: "m1",
+		Operand2Metric: "m2",
+		Operator:       "/",
+	}
+	pts := []*sfxpb.DataPoint{
+		{
+			Metric:     "m1",
+			Timestamp:  msec,
+			MetricType: &gaugeType,
+			Value: sfxpb.Datum{
+				IntValue: generateIntPtr(84),
+			},
+			Dimensions: []*sfxpb.Dimension{{
+				Key:   "dim1",
+				Value: "val1",
+			}},
+		},
+		{
+			Metric:     "m2",
+			Timestamp:  msec,
+			MetricType: &gaugeType,
+			Value: sfxpb.Datum{
+				IntValue: generateIntPtr(84),
+			},
+			Dimensions: []*sfxpb.Dimension{{
+				Key:   "dim1",
+				Value: "val2",
+			}},
+		},
+	}
+	pairs := calcNewMetricInputPairs(pts, rule)
+	require.Nil(t, pairs)
+}
+
+func TestCalculateNewMetric_MatchingDims_Single(t *testing.T) {
+	mt, err := NewMetricTranslator([]Rule{{
+		Action:         ActionCalculateNewMetric,
+		MetricName:     "metric3",
+		Operand1Metric: "metric1",
+		Operand2Metric: "metric2",
+		Operator:       "/",
+	}})
+	require.NoError(t, err)
+	m1 := &sfxpb.DataPoint{
+		Metric:     "metric1",
+		Timestamp:  msec,
+		MetricType: &gaugeType,
+		Value: sfxpb.Datum{
+			IntValue: generateIntPtr(1),
+		},
+		Dimensions: []*sfxpb.Dimension{{
+			Key:   "dim1",
+			Value: "val1",
+		}},
+	}
+	m2 := &sfxpb.DataPoint{
+		Metric:     "metric2",
+		Timestamp:  msec,
+		MetricType: &gaugeType,
+		Value: sfxpb.Datum{
+			IntValue: generateIntPtr(2),
+		},
+		Dimensions: []*sfxpb.Dimension{{
+			Key:   "dim1",
+			Value: "val1",
+		}},
+	}
+	dps := []*sfxpb.DataPoint{m1, m2}
+	translated := mt.TranslateDataPoints(zap.NewNop(), dps)
+	m3 := &sfxpb.DataPoint{
+		Metric:     "metric3",
+		Timestamp:  msec,
+		MetricType: &gaugeType,
+		Value: sfxpb.Datum{
+			DoubleValue: generateFloatPtr(0.5),
+		},
+		Dimensions: []*sfxpb.Dimension{{
+			Key:   "dim1",
+			Value: "val1",
+		}},
+	}
+	want := []*sfxpb.DataPoint{m1, m2, m3}
+	assertEqualPoints(t, translated, want, ActionCalculateNewMetric)
+}
+
+func TestCalculateNewMetric_MatchingDims_Multi(t *testing.T) {
+	mt, err := NewMetricTranslator([]Rule{{
+		Action:         ActionCalculateNewMetric,
+		MetricName:     "metric3",
+		Operand1Metric: "metric1",
+		Operand2Metric: "metric2",
+		Operator:       "/",
+	}})
+	require.NoError(t, err)
+	m1 := &sfxpb.DataPoint{
+		Metric:     "metric1",
+		Timestamp:  msec,
+		MetricType: &gaugeType,
+		Value: sfxpb.Datum{
+			IntValue: generateIntPtr(1),
+		},
+		Dimensions: []*sfxpb.Dimension{{
+			Key:   "dim1",
+			Value: "val1",
+		}},
+	}
+	m2 := &sfxpb.DataPoint{
+		Metric:     "metric2",
+		Timestamp:  msec,
+		MetricType: &gaugeType,
+		Value: sfxpb.Datum{
+			IntValue: generateIntPtr(2),
+		},
+		Dimensions: []*sfxpb.Dimension{{
+			Key:   "dim1",
+			Value: "val1",
+		}},
+	}
+	m1v2 := &sfxpb.DataPoint{
+		Metric:     "metric1",
+		Timestamp:  msec,
+		MetricType: &gaugeType,
+		Value: sfxpb.Datum{
+			IntValue: generateIntPtr(1),
+		},
+		Dimensions: []*sfxpb.Dimension{{
+			Key:   "dim1",
+			Value: "val2",
+		}},
+	}
+	m2v2 := &sfxpb.DataPoint{
+		Metric:     "metric2",
+		Timestamp:  msec,
+		MetricType: &gaugeType,
+		Value: sfxpb.Datum{
+			IntValue: generateIntPtr(2),
+		},
+		Dimensions: []*sfxpb.Dimension{{
+			Key:   "dim1",
+			Value: "val2",
+		}},
+	}
+	dps := []*sfxpb.DataPoint{m1, m2, m1v2, m2v2}
+	translated := mt.TranslateDataPoints(zap.NewNop(), dps)
+	m3 := &sfxpb.DataPoint{
+		Metric:     "metric3",
+		Timestamp:  msec,
+		MetricType: &gaugeType,
+		Value: sfxpb.Datum{
+			DoubleValue: generateFloatPtr(0.5),
+		},
+		Dimensions: []*sfxpb.Dimension{{
+			Key:   "dim1",
+			Value: "val1",
+		}},
+	}
+	m3v2 := &sfxpb.DataPoint{
+		Metric:     "metric3",
+		Timestamp:  msec,
+		MetricType: &gaugeType,
+		Value: sfxpb.Datum{
+			DoubleValue: generateFloatPtr(0.5),
+		},
+		Dimensions: []*sfxpb.Dimension{{
+			Key:   "dim1",
+			Value: "val2",
+		}},
+	}
+	want := []*sfxpb.DataPoint{m1, m2, m1v2, m2v2, m3, m3v2}
+	assertEqualPoints(t, translated, want, ActionCalculateNewMetric)
 }
 
 func generateIntPtr(i int) *int64 {

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -1936,3 +1936,78 @@ func generateFloatPtr(i float64) *float64 {
 	var iPtr = i
 	return &iPtr
 }
+
+func TestDimensionsEqual(t *testing.T) {
+	tests := []struct {
+		name   string
+		d1, d2 []*sfxpb.Dimension
+		want   bool
+	}{
+		{
+			name: "eq_both_nil",
+			d1:   nil,
+			d2:   nil,
+			want: true,
+		},
+		{
+			name: "ne_one_nil",
+			d1:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}},
+			d2:   nil,
+			want: false,
+		},
+		{
+			name: "eq_one_dim",
+			d1:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}},
+			d2:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}},
+			want: true,
+		},
+		{
+			name: "ne_one_dim_val_mismatch",
+			d1:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}},
+			d2:   []*sfxpb.Dimension{{Key: "k0", Value: "x"}},
+			want: false,
+		},
+		{
+			name: "ne_one_dim_key_mismatch",
+			d1:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}},
+			d2:   []*sfxpb.Dimension{{Key: "x", Value: "v0"}},
+			want: false,
+		},
+		{
+			name: "eq_two_dims",
+			d1:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}, {Key: "k1", Value: "v1"}},
+			d2:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}, {Key: "k1", Value: "v1"}},
+			want: true,
+		},
+		{
+			name: "eq_two_dims_different_order",
+			d1:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}, {Key: "k1", Value: "v1"}},
+			d2:   []*sfxpb.Dimension{{Key: "k1", Value: "v1"}, {Key: "k0", Value: "v0"}},
+			want: true,
+		},
+		{
+			name: "eq_three_dims_different_order",
+			d1:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}, {Key: "k1", Value: "v1"}, {Key: "k2", Value: "v2"}},
+			d2:   []*sfxpb.Dimension{{Key: "k2", Value: "v2"}, {Key: "k0", Value: "v0"}, {Key: "k1", Value: "v1"}},
+			want: true,
+		},
+		{
+			name: "ne_first_two_dims_match",
+			d1:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}, {Key: "k1", Value: "v1"}},
+			d2:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}, {Key: "k1", Value: "v1"}, {Key: "k2", Value: "v2"}},
+			want: false,
+		},
+		{
+			name: "ne_first_two_dims_match_reversed",
+			d1:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}, {Key: "k1", Value: "v1"}, {Key: "k2", Value: "v2"}},
+			d2:   []*sfxpb.Dimension{{Key: "k0", Value: "v0"}, {Key: "k1", Value: "v1"}},
+			want: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b := dimensionsEqual(test.d1, test.d2)
+			require.Equal(t, test.want, b)
+		})
+	}
+}


### PR DESCRIPTION
**Description:**
The first implementation of the new metric translator grabbed one match
of each of the first and second operands without regard to whether
their dimensions matched.

This update groups operand pairs by matching dimensions. An operand pair
will be considered only if their dimensions match. As a result, multiple
pairs are also now supported.

**Testing:** Unit tests added.