### PR TITLE
Signalfx exporter: Change aggregation to use "without" clause

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -452,6 +452,7 @@ func md() consumerdata.MetricsData {
 					Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 					LabelKeys: []*metricspb.LabelKey{
 						{Key: "direction"},
+						{Key: "interface"},
 						{Key: "host"},
 						{Key: "kubernetes_node"},
 						{Key: "kubernetes_cluster"},
@@ -462,6 +463,9 @@ func md() consumerdata.MetricsData {
 						StartTimestamp: &timestamp.Timestamp{},
 						LabelValues: []*metricspb.LabelValue{{
 							Value:    "receive",
+							HasValue: true,
+						}, {
+							Value:    "eth0",
 							HasValue: true,
 						}, {
 							Value:    "host0",
@@ -486,6 +490,9 @@ func md() consumerdata.MetricsData {
 						StartTimestamp: &timestamp.Timestamp{},
 						LabelValues: []*metricspb.LabelValue{{
 							Value:    "transmit",
+							HasValue: true,
+						}, {
+							Value:    "eth0",
 							HasValue: true,
 						}, {
 							Value:    "host0",

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -181,10 +181,8 @@ translation_rules:
 - action: aggregate_metric
   metric_name: cpu.num_processors
   aggregation_method: count
-  dimensions:
-  - host
-  - kubernetes_node
-  - kubernetes_cluster
+  without_dimensions: 
+  - cpu
 
 # compute memory.total
 - action: copy_metrics
@@ -199,10 +197,8 @@ translation_rules:
 - action: aggregate_metric
   metric_name: memory.total
   aggregation_method: sum
-  dimensions:
-  - host
-  - kubernetes_node
-  - kubernetes_cluster
+  without_dimensions: 
+  - state
 
 # convert memory metrics
 - action: split_metric
@@ -276,10 +272,9 @@ translation_rules:
 - action: aggregate_metric
   metric_name: network.total
   aggregation_method: sum
-  dimensions:
-  - host
-  - kubernetes_node
-  - kubernetes_cluster
+  without_dimensions: 
+  - direction
+  - interface
 - action: split_metric
   metric_name: system.network.dropped_packets
   dimension_key: direction

--- a/exporter/signalfxexporter/translation/translator.go
+++ b/exporter/signalfxexporter/translation/translator.go
@@ -16,6 +16,8 @@ package translation
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/gogo/protobuf/proto"
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
@@ -71,17 +73,18 @@ const (
 	// k8s.pod.network.io{direction="transmit"} -> pod_network_transmit_bytes_total{}
 	ActionSplitMetric Action = "split_metric"
 
-	// ActionAggregateMetric aggregates metrics by dimensions provided in tr.Dimensions.
+	// ActionAggregateMetric aggregates metrics excluding dimensions set in tr.WithoutDimensions.
+	// This method is equivalent of "without" clause in Prometheus aggregation:
+	// https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
 	// It takes datapoints with name tr.MetricName and aggregates them to a smaller set keeping the same name.
-	// It drops all other dimensions other then those that match tr.Dimensions.
-	// If a datapoint doesn't have a dimension matchin tr.Dimensions, the datapoint will be dropped.
+	// It drops the dimensions provided in tr.WithoutDimensions and keeps others as is.
 	// tr.AggregationMethod is used to specify a method to aggregate the values.
 	// For example, having the following translation rule:
 	// - action: aggregate_metric
 	//   metric_name: machine_cpu_cores
 	//   aggregation_method: count
-	//   dimensions:
-	// 	 - host
+	//   without_dimensions:
+	//   - cpu
 	// The following translations will be performed:
 	// Original datapoints:
 	//   machine_cpu_cores{cpu="cpu1",host="host1"} 0.22
@@ -170,10 +173,9 @@ type Rule struct {
 	// AggregationMethod specifies method used by "aggregate_metric" translation rule
 	AggregationMethod AggregationMethod `mapstructure:"aggregation_method"`
 
-	// Dimensions is used by "aggregate_metric" translation rule to specify dimension keys
-	// that will be used to aggregate the metric across.
-	// Datapoints that don't have all the dimensions will be dropped.
-	Dimensions []string `mapstructure:"dimensions"`
+	// WithoutDimensions used by "aggregate_metric" translation rule to specify dimensions to be
+	// excluded by aggregation.
+	WithoutDimensions []string `mapstructure:"without_dimensions"`
 
 	// MetricName is used by "split_metric" translation rule to specify a name
 	// of a metric that will be split.
@@ -263,8 +265,8 @@ func validateTranslationRules(rules []Rule) error {
 				}
 			}
 		case ActionAggregateMetric:
-			if tr.MetricName == "" || tr.AggregationMethod == "" || len(tr.Dimensions) == 0 {
-				return fmt.Errorf("fields \"metric_name\", \"dimensions\", and \"aggregation_method\" "+
+			if tr.MetricName == "" || tr.AggregationMethod == "" || len(tr.WithoutDimensions) == 0 {
+				return fmt.Errorf("fields \"metric_name\", \"without_dimensions\", and \"aggregation_method\" "+
 					"are required for %q translation rule", tr.Action)
 			}
 			if tr.AggregationMethod != "count" && tr.AggregationMethod != "sum" {
@@ -401,7 +403,7 @@ func (mp *MetricTranslator) TranslateDataPoints(logger *zap.Logger, sfxDataPoint
 					otherDps = append(otherDps, dp)
 				}
 			}
-			aggregatedDps := aggregateDatapoints(logger, dpsToAggregate, tr.Dimensions, tr.AggregationMethod)
+			aggregatedDps := aggregateDatapoints(dpsToAggregate, tr.WithoutDimensions, tr.AggregationMethod)
 			processedDataPoints = append(otherDps, aggregatedDps...)
 		}
 	}
@@ -512,9 +514,8 @@ func (mp *MetricTranslator) TranslateDimension(orig string) string {
 // aggregateDatapoints aggregates datapoints assuming that they have
 // the same Timestamp, MetricType, Metric and Source fields.
 func aggregateDatapoints(
-	logger *zap.Logger,
 	dps []*sfxpb.DataPoint,
-	dimensionsKeys []string,
+	withoutDimensions []string,
 	aggregation AggregationMethod,
 ) []*sfxpb.DataPoint {
 	if len(dps) == 0 {
@@ -524,11 +525,7 @@ func aggregateDatapoints(
 	// group datapoints by dimension values
 	dimValuesToDps := make(map[string][]*sfxpb.DataPoint, len(dps))
 	for i, dp := range dps {
-		aggregationKey, err := getAggregationKey(dp.Dimensions, dimensionsKeys)
-		if err != nil {
-			logger.Debug("datapoint is dropped", zap.String("metric", dp.Metric), zap.Error(err))
-			continue
-		}
+		aggregationKey := getAggregationKey(dp.Dimensions, withoutDimensions)
 		if _, ok := dimValuesToDps[aggregationKey]; !ok {
 			// set slice capacity to the possible maximum = len(dps)-i to avoid reallocations
 			dimValuesToDps[aggregationKey] = make([]*sfxpb.DataPoint, 0, len(dps)-i)
@@ -540,7 +537,7 @@ func aggregateDatapoints(
 	result := make([]*sfxpb.DataPoint, 0, len(dimValuesToDps))
 	for _, dps := range dimValuesToDps {
 		dp := proto.Clone(dps[0]).(*sfxpb.DataPoint)
-		dp.Dimensions = filterDimensions(dp.Dimensions, dimensionsKeys)
+		dp.Dimensions = filterDimensions(dp.Dimensions, withoutDimensions)
 		switch aggregation {
 		case AggregationMethodCount:
 			gauge := sfxpb.MetricType_GAUGE
@@ -571,44 +568,42 @@ func aggregateDatapoints(
 	return result
 }
 
-// getAggregationKey composes an aggregation key based on provided dimensions.
-// If all the dimensions found, the function returns an aggregationkey.
-// If any dimension os not found the function returns an error.
-func getAggregationKey(dimensions []*sfxpb.Dimension, dimensionsKeys []string) (string, error) {
+// getAggregationKey composes an aggregation key based on dimensions that left after excluding withoutDimensions.
+// The key composed from dimensions has the following form: dim1:val1//dim2:val2
+func getAggregationKey(dimensions []*sfxpb.Dimension, withoutDimensions []string) string {
 	const aggregationKeyDelimiter = "//"
-	var aggregationKey string
-	for _, dk := range dimensionsKeys {
-		var dimensionFound bool
-		for _, d := range dimensions {
-			if d.Key == dk {
-				// compose an aggregation key with "//" as delimiter
-				aggregationKey += d.Value + aggregationKeyDelimiter
-				dimensionFound = true
-				continue
-			}
-		}
-		if !dimensionFound {
-			return "", fmt.Errorf("dimension to aggregate by is not found: %q", dk)
+	var aggregationKeyParts = make([]string, 0, len(dimensions))
+	for _, d := range dimensions {
+		if !dimensionIn(d, withoutDimensions) {
+			aggregationKeyParts = append(aggregationKeyParts, fmt.Sprintf("%s:%s", d.Key, d.Value))
 		}
 	}
-	return aggregationKey, nil
+	sort.Strings(aggregationKeyParts)
+	return strings.Join(aggregationKeyParts, aggregationKeyDelimiter)
 }
 
-// filterDimensions returns list of dimension filtered by dimensionsKeys
-func filterDimensions(dimensions []*sfxpb.Dimension, dimensionsKeys []string) []*sfxpb.Dimension {
-	if len(dimensions) == 0 || len(dimensionsKeys) == 0 {
+// filterDimensions returns list of dimension excluding withoutDimensions
+func filterDimensions(dimensions []*sfxpb.Dimension, withoutDimensions []string) []*sfxpb.Dimension {
+	if len(dimensions) == 0 || len(dimensions)-len(withoutDimensions) <= 0 {
 		return nil
 	}
-	result := make([]*sfxpb.Dimension, 0, len(dimensionsKeys))
-	for _, dk := range dimensionsKeys {
-		for _, d := range dimensions {
-			if d.Key == dk {
-				result = append(result, d)
-				continue
-			}
+	result := make([]*sfxpb.Dimension, 0, len(dimensions)-len(withoutDimensions))
+	for _, d := range dimensions {
+		if !dimensionIn(d, withoutDimensions) {
+			result = append(result, d)
 		}
 	}
 	return result
+}
+
+// dimensionIn checks if the dimension found in the dimensionsKeysFilter
+func dimensionIn(dimension *sfxpb.Dimension, dimensionsKeysFilter []string) bool {
+	for _, dk := range dimensionsKeysFilter {
+		if dimension.Key == dk {
+			return true
+		}
+	}
+	return false
 }
 
 // splitMetric renames a metric with "dimension key" == dimensionKey to mapping["dimension value"],

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -336,7 +336,7 @@ func TestNewMetricTranslator(t *testing.T) {
 				{
 					Action:            ActionAggregateMetric,
 					MetricName:        "metric",
-					Dimensions:        []string{"dim"},
+					WithoutDimensions: []string{"dim"},
 					AggregationMethod: AggregationMethodCount,
 				},
 			},
@@ -344,7 +344,7 @@ func TestNewMetricTranslator(t *testing.T) {
 			wantError:         "",
 		},
 		{
-			name: "aggregate_metric_invalid_no_dimensions",
+			name: "aggregate_metric_invalid_no_dimension_key",
 			trs: []Rule{
 				{
 					Action:            ActionAggregateMetric,
@@ -353,7 +353,7 @@ func TestNewMetricTranslator(t *testing.T) {
 				},
 			},
 			wantDimensionsMap: nil,
-			wantError: "fields \"metric_name\", \"dimensions\", and \"aggregation_method\" " +
+			wantError: "fields \"metric_name\", \"without_dimensions\", and \"aggregation_method\" " +
 				"are required for \"aggregate_metric\" translation rule",
 		},
 		{
@@ -362,7 +362,7 @@ func TestNewMetricTranslator(t *testing.T) {
 				{
 					Action:            ActionAggregateMetric,
 					MetricName:        "metric",
-					Dimensions:        []string{"dim"},
+					WithoutDimensions: []string{"dim"},
 					AggregationMethod: AggregationMethod("invalid"),
 				},
 			},
@@ -1178,7 +1178,7 @@ func TestTranslateDataPoints(t *testing.T) {
 				{
 					Action:            ActionAggregateMetric,
 					MetricName:        "metric1",
-					Dimensions:        []string{"dim1", "dim2"},
+					WithoutDimensions: []string{"dim3"},
 					AggregationMethod: "count",
 				},
 			},
@@ -1201,10 +1201,6 @@ func TestTranslateDataPoints(t *testing.T) {
 						{
 							Key:   "dim3",
 							Value: "different",
-						},
-						{
-							Key:   "dim4",
-							Value: "just-one",
 						},
 					},
 				},
@@ -1244,6 +1240,10 @@ func TestTranslateDataPoints(t *testing.T) {
 							Key:   "dim2",
 							Value: "val2",
 						},
+						{
+							Key:   "dim3",
+							Value: "another",
+						},
 					},
 				},
 				{
@@ -1256,21 +1256,6 @@ func TestTranslateDataPoints(t *testing.T) {
 						{
 							Key:   "dim1",
 							Value: "val1",
-						},
-					},
-				},
-
-				// invalid datapoint without required dimension, must be dropped
-				{
-					Metric:    "metric1",
-					Timestamp: msec,
-					Value: sfxpb.Datum{
-						IntValue: generateIntPtr(2),
-					},
-					Dimensions: []*sfxpb.Dimension{
-						{
-							Key:   "dim2",
-							Value: "val2",
 						},
 					},
 				},
@@ -1333,7 +1318,7 @@ func TestTranslateDataPoints(t *testing.T) {
 				{
 					Action:            ActionAggregateMetric,
 					MetricName:        "metric1",
-					Dimensions:        []string{"dim1"},
+					WithoutDimensions: []string{"dim2"},
 					AggregationMethod: "sum",
 				},
 			},
@@ -1431,7 +1416,7 @@ func TestTranslateDataPoints(t *testing.T) {
 					Action:            ActionAggregateMetric,
 					MetricName:        "metric1",
 					AggregationMethod: "sum",
-					Dimensions:        []string{"dim1"},
+					WithoutDimensions: []string{"dim2"},
 				},
 			},
 			dps: []*sfxpb.DataPoint{
@@ -1447,6 +1432,10 @@ func TestTranslateDataPoints(t *testing.T) {
 							Key:   "dim1",
 							Value: "val1",
 						},
+						{
+							Key:   "dim2",
+							Value: "val1",
+						},
 					},
 				},
 				{
@@ -1459,6 +1448,10 @@ func TestTranslateDataPoints(t *testing.T) {
 					Dimensions: []*sfxpb.Dimension{
 						{
 							Key:   "dim1",
+							Value: "val1",
+						},
+						{
+							Key:   "dim2",
 							Value: "val1",
 						},
 					},


### PR DESCRIPTION
**Description:** 
Sometimes we don't know exact set of dimensions set on metrics to be translated, user can add some custom dimensions. Thats why we cannot aggregate using predefined set of dimensions in signalfx translations. But we always know which dimensions we want to exclude in an aggregation. This commit changes "aggregate_metric" translation rule to use equivalent of "without" Prometheus clause instead of "by" clause: https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
