### PR TITLE
kubeletstatsreceiver: Add ability to collect detailed data from PVC

### DIFF
--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -93,6 +93,9 @@ include the following -
 
 - `container.id` - to augment metrics with Container ID label obtained from container statuses exposed via `/pods`.
 - `k8s.volume.type` - to collect volume type from the Pod spec exposed via `/pods` and have it as a label on volume metrics.
+If there's more information available from the endpoint than just volume type, those are sycned as well depending on
+the available fields and the type of volume. For example, `aws.volume.id` would be synced from `awsElasticBlockStore`
+and `gcp.pd.name` is synced for `gcePersistentDisk`.
 
 If you want to have `container.id` label added to your metrics, use `extra_metadata_labels` field to enable
 it, for example:

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -110,6 +110,29 @@ receivers:
 
 If `extra_metadata_labels` is not set, no additional API calls is done to fetch extra metadata.
 
+#### Collecting Additional Volume Metadata
+
+When dealing with Persistent Volume Claims, it is possible to optionally sync metdadata from the underlying
+storage resource rather than just the volume claim. This is achieved by talking to the Kubernetes API. Below
+is an example, configuration to achieve this.
+
+```yaml
+receivers:
+  kubeletstats:
+    collection_interval: 10s
+    auth_type: "serviceAccount"
+    endpoint: "${K8S_NODE_NAME}:10250"
+    insecure_skip_verify: true
+    extra_metadata_labels:
+      - k8s.volume.type
+    k8s_api_config:
+      auth_type: serviceAccount
+```
+
+If `k8s_api_config` set, the receiver will attempt to collect metadata from underlying storage resources for
+Persistent Volume Claims. For example, if a Pod is using a PVC backed by an EBS instance on AWS, the receiver
+would set the `k8s.volume.type` label to be `awsElasticBlockStore` rather than `persistentVolumeClaim`.
+
 ### Metric Groups
 
 A list of metric groups from which metrics should be collected. By default, metrics from containers,

--- a/receiver/kubeletstatsreceiver/go.mod
+++ b/receiver/kubeletstatsreceiver/go.mod
@@ -16,6 +16,7 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8
+	k8s.io/client-go v0.18.8
 	k8s.io/kubernetes v1.12.0
 )
 

--- a/receiver/kubeletstatsreceiver/go.sum
+++ b/receiver/kubeletstatsreceiver/go.sum
@@ -1361,7 +1361,6 @@ k8s.io/kubernetes v1.12.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20200724153422-f32512634ab7/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-mvdan.cc/gofumpt v0.0.0-20200709182408-4fd085cb6d5f h1:gi7cb8HTDZ6q8VqsUpkdoFi3vxwHMneQ6+Q5Ap5hjPE=
 mvdan.cc/gofumpt v0.0.0-20200709182408-4fd085cb6d5f/go.mod h1:9VQ397fNXEnF84t90W4r4TRCQK+pg9f8ugVfyj+S26w=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=

--- a/receiver/kubeletstatsreceiver/kubelet/accumulator.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator.go
@@ -43,11 +43,12 @@ var ValidMetricGroups = map[MetricGroup]bool{
 }
 
 type metricDataAccumulator struct {
-	m                     []consumerdata.MetricsData
-	metadata              Metadata
-	logger                *zap.Logger
-	metricGroupsToCollect map[MetricGroup]bool
-	time                  time.Time
+	m                       []consumerdata.MetricsData
+	metadata                Metadata
+	logger                  *zap.Logger
+	metricGroupsToCollect   map[MetricGroup]bool
+	time                    time.Time
+	volumeClaimLabelsSetter func(volumeClaim, namespace string, labels map[string]string) error
 }
 
 const (
@@ -119,7 +120,7 @@ func (a *metricDataAccumulator) volumeStats(podResource *resourcepb.Resource, s 
 		return
 	}
 
-	volume, err := volumeResource(podResource, s, a.metadata)
+	volume, err := volumeResource(podResource, s, a.metadata, a.volumeClaimLabelsSetter)
 	if err != nil {
 		a.logger.Warn(
 			"Failed to gather additional volume metadata. Skipping metric collection.",

--- a/receiver/kubeletstatsreceiver/kubelet/accumulator.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator.go
@@ -43,12 +43,11 @@ var ValidMetricGroups = map[MetricGroup]bool{
 }
 
 type metricDataAccumulator struct {
-	m                       []consumerdata.MetricsData
-	metadata                Metadata
-	logger                  *zap.Logger
-	metricGroupsToCollect   map[MetricGroup]bool
-	time                    time.Time
-	volumeClaimLabelsSetter func(volumeClaim, namespace string, labels map[string]string) error
+	m                     []consumerdata.MetricsData
+	metadata              Metadata
+	logger                *zap.Logger
+	metricGroupsToCollect map[MetricGroup]bool
+	time                  time.Time
 }
 
 const (
@@ -120,7 +119,7 @@ func (a *metricDataAccumulator) volumeStats(podResource *resourcepb.Resource, s 
 		return
 	}
 
-	volume, err := volumeResource(podResource, s, a.metadata, a.volumeClaimLabelsSetter)
+	volume, err := volumeResource(podResource, s, a.metadata)
 	if err != nil {
 		a.logger.Warn(
 			"Failed to gather additional volume metadata. Skipping metric collection.",

--- a/receiver/kubeletstatsreceiver/kubelet/accumulator_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/accumulator_test.go
@@ -35,41 +35,38 @@ import (
 // metadata. Happy paths are covered in metadata_test.go and volume_test.go.
 func TestMetadataErrorCases(t *testing.T) {
 	tests := []struct {
-		name                    string
-		metricGroupsToCollect   map[MetricGroup]bool
-		testScenario            func(acc metricDataAccumulator)
-		metadata                Metadata
-		numMDs                  int
-		numLogs                 int
-		logMessages             []string
-		volumeClaimLabelsSetter func(volumeClaim, namespace string, labels map[string]string) error
+		name                            string
+		metricGroupsToCollect           map[MetricGroup]bool
+		testScenario                    func(acc metricDataAccumulator)
+		metadata                        Metadata
+		numMDs                          int
+		numLogs                         int
+		logMessages                     []string
+		detailedPVCLabelsSetterOverride func(volumeClaim, namespace string, labels map[string]string) error
 	}{
 		{
 			name: "Fails to get container metadata",
 			metricGroupsToCollect: map[MetricGroup]bool{
 				ContainerMetricGroup: true,
 			},
-			metadata: NewMetadata(
-				[]MetadataLabel{MetadataLabelContainerID},
-				&v1.PodList{
-					Items: []v1.Pod{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								UID: types.UID("pod-uid-123"),
-							},
-							Status: v1.PodStatus{
-								ContainerStatuses: []v1.ContainerStatus{
-									{
-										// different container name
-										Name:        "container2",
-										ContainerID: "test-container",
-									},
+			metadata: NewMetadata([]MetadataLabel{MetadataLabelContainerID}, &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							UID: types.UID("pod-uid-123"),
+						},
+						Status: v1.PodStatus{
+							ContainerStatuses: []v1.ContainerStatus{
+								{
+									// different container name
+									Name:        "container2",
+									ContainerID: "test-container",
 								},
 							},
 						},
 					},
 				},
-			),
+			}, nil),
 			testScenario: func(acc metricDataAccumulator) {
 				now := metav1.Now()
 				podResource := &resourcepb.Resource{
@@ -96,10 +93,7 @@ func TestMetadataErrorCases(t *testing.T) {
 			metricGroupsToCollect: map[MetricGroup]bool{
 				VolumeMetricGroup: true,
 			},
-			metadata: NewMetadata(
-				[]MetadataLabel{MetadataLabelVolumeType},
-				nil,
-			),
+			metadata: NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, nil, nil),
 			testScenario: func(acc metricDataAccumulator) {
 				podResource := &resourcepb.Resource{
 					Labels: map[string]string{
@@ -123,28 +117,25 @@ func TestMetadataErrorCases(t *testing.T) {
 			metricGroupsToCollect: map[MetricGroup]bool{
 				VolumeMetricGroup: true,
 			},
-			metadata: NewMetadata(
-				[]MetadataLabel{MetadataLabelVolumeType},
-				&v1.PodList{
-					Items: []v1.Pod{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								UID: types.UID("pod-uid-123"),
-							},
-							Spec: v1.PodSpec{
-								Volumes: []v1.Volume{
-									{
-										Name: "volume-0",
-										VolumeSource: v1.VolumeSource{
-											HostPath: &v1.HostPathVolumeSource{},
-										},
+			metadata: NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							UID: types.UID("pod-uid-123"),
+						},
+						Spec: v1.PodSpec{
+							Volumes: []v1.Volume{
+								{
+									Name: "volume-0",
+									VolumeSource: v1.VolumeSource{
+										HostPath: &v1.HostPathVolumeSource{},
 									},
 								},
 							},
 						},
 					},
 				},
-			),
+			}, nil),
 			testScenario: func(acc metricDataAccumulator) {
 				podResource := &resourcepb.Resource{
 					Labels: map[string]string{
@@ -168,22 +159,19 @@ func TestMetadataErrorCases(t *testing.T) {
 			metricGroupsToCollect: map[MetricGroup]bool{
 				VolumeMetricGroup: true,
 			},
-			metadata: NewMetadata(
-				[]MetadataLabel{MetadataLabelVolumeType},
-				&v1.PodList{
-					Items: []v1.Pod{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								UID: types.UID("pod-uid-123"),
-							},
-							Spec: v1.PodSpec{
-								Volumes: []v1.Volume{
-									{
-										Name: "volume-0",
-										VolumeSource: v1.VolumeSource{
-											PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-												ClaimName: "claim",
-											},
+			metadata: NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							UID: types.UID("pod-uid-123"),
+						},
+						Spec: v1.PodSpec{
+							Volumes: []v1.Volume{
+								{
+									Name: "volume-0",
+									VolumeSource: v1.VolumeSource{
+										PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+											ClaimName: "claim",
 										},
 									},
 								},
@@ -191,8 +179,8 @@ func TestMetadataErrorCases(t *testing.T) {
 						},
 					},
 				},
-			),
-			volumeClaimLabelsSetter: func(volumeClaim, namespace string, labels map[string]string) error {
+			}, nil),
+			detailedPVCLabelsSetterOverride: func(volumeClaim, namespace string, labels map[string]string) error {
 				// Mock failure cases.
 				return errors.New("")
 			},
@@ -222,12 +210,12 @@ func TestMetadataErrorCases(t *testing.T) {
 			logger := zap.New(observedLogger)
 
 			var mds []consumerdata.MetricsData
+			tt.metadata.DetailedPVCLabelsSetter = tt.detailedPVCLabelsSetterOverride
 			acc := metricDataAccumulator{
-				m:                       mds,
-				metadata:                tt.metadata,
-				logger:                  logger,
-				metricGroupsToCollect:   tt.metricGroupsToCollect,
-				volumeClaimLabelsSetter: tt.volumeClaimLabelsSetter,
+				m:                     mds,
+				metadata:              tt.metadata,
+				logger:                logger,
+				metricGroupsToCollect: tt.metricGroupsToCollect,
 			}
 
 			tt.testScenario(acc)

--- a/receiver/kubeletstatsreceiver/kubelet/conventions.go
+++ b/receiver/kubeletstatsreceiver/kubelet/conventions.go
@@ -15,7 +15,20 @@
 package kubelet
 
 const (
-	labelNodeName   = "k8s.node.name"
-	labelVolumeName = "k8s.volume.name"
-	labelVolumeType = "k8s.volume.type"
+	labelNodeName                  = "k8s.node.name"
+	labelPersistentVolumeClaimName = "k8s.persistentvolumeclaim.name"
+	labelVolumeName                = "k8s.volume.name"
+	labelVolumeType                = "k8s.volume.type"
+
+	// Volume types.
+	labelValuePersistentVolumeClaim = "persistentVolumeClaim"
+	labelValueConfigMapVolume       = "configMap"
+	labelValueDownwardAPIVolume     = "downwardAPI"
+	labelValueEmptyDirVolume        = "emptyDir"
+	labelValueSecretVolume          = "secret"
+	labelValueHostPathVolume        = "hostPath"
+	labelValueLocalVolume           = "local"
+	labelValueAWSEBSVolume          = "awsElasticBlockStore"
+	labelValueGCEPDVolume           = "gcePersistentDisk"
+	labelValueGlusterFSVolume       = "glusterfs"
 )

--- a/receiver/kubeletstatsreceiver/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata.go
@@ -53,14 +53,18 @@ func ValidateMetadataLabelsConfig(labels []MetadataLabel) error {
 }
 
 type Metadata struct {
-	Labels       map[MetadataLabel]bool
-	PodsMetadata *v1.PodList
+	Labels                  map[MetadataLabel]bool
+	PodsMetadata            *v1.PodList
+	DetailedPVCLabelsSetter func(volumeClaim, namespace string, labels map[string]string) error
 }
 
-func NewMetadata(labels []MetadataLabel, podsMetadata *v1.PodList) Metadata {
+func NewMetadata(
+	labels []MetadataLabel, podsMetadata *v1.PodList,
+	detailedPVCLabelsSetter func(volumeClaim, namespace string, labels map[string]string) error) Metadata {
 	return Metadata{
-		Labels:       getLabelsMap(labels),
-		PodsMetadata: podsMetadata,
+		Labels:                  getLabelsMap(labels),
+		PodsMetadata:            podsMetadata,
+		DetailedPVCLabelsSetter: detailedPVCLabelsSetter,
 	}
 }
 

--- a/receiver/kubeletstatsreceiver/kubelet/metadata_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata_test.go
@@ -247,11 +247,63 @@ func TestSetExtraLabelsForVolumeTypes(t *testing.T) {
 		{
 			name: "persistentVolumeClaim",
 			vs: v1.VolumeSource{
-				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "claim-name",
+				},
 			},
 			args: []string{"uid-1234", "k8s.volume.type"},
 			want: map[string]string{
-				"k8s.volume.type": "persistentVolumeClaim",
+				"k8s.volume.type":                "persistentVolumeClaim",
+				"k8s.persistentvolumeclaim.name": "claim-name",
+			},
+		},
+		{
+			name: "awsElasticBlockStore",
+			vs: v1.VolumeSource{
+				AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+					VolumeID:  "volume_id",
+					FSType:    "fs_type",
+					Partition: 10,
+				},
+			},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{
+				"k8s.volume.type": "awsElasticBlockStore",
+				"aws.volume.id":   "volume_id",
+				"fs.type":         "fs_type",
+				"partition":       "10",
+			},
+		},
+		{
+			name: "gcePersistentDisk",
+			vs: v1.VolumeSource{
+				GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+					PDName:    "pd_name",
+					FSType:    "fs_type",
+					Partition: 10,
+				},
+			},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{
+				"k8s.volume.type": "gcePersistentDisk",
+				"gce.pd.name":     "pd_name",
+				"fs.type":         "fs_type",
+				"partition":       "10",
+			},
+		},
+		{
+			name: "glusterfs",
+			vs: v1.VolumeSource{
+				Glusterfs: &v1.GlusterfsVolumeSource{
+					EndpointsName: "endspoints_name",
+					Path:          "path",
+				},
+			},
+			args: []string{"uid-1234", "k8s.volume.type"},
+			want: map[string]string{
+				"k8s.volume.type":          "glusterfs",
+				"glusterfs.endpoints.name": "endspoints_name",
+				"glusterfs.path":           "path",
 			},
 		},
 		{

--- a/receiver/kubeletstatsreceiver/kubelet/metadata_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metadata_test.go
@@ -78,32 +78,29 @@ func TestSetExtraLabels(t *testing.T) {
 	}{
 		{
 			name:     "no_labels",
-			metadata: NewMetadata([]MetadataLabel{}, nil),
+			metadata: NewMetadata([]MetadataLabel{}, nil, nil),
 			args:     []string{"uid", "container.id", "container"},
 			want:     map[string]string{},
 		},
 		{
 			name: "set_container_id_valid",
-			metadata: NewMetadata(
-				[]MetadataLabel{MetadataLabelContainerID},
-				&v1.PodList{
-					Items: []v1.Pod{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								UID: types.UID("uid-1234"),
-							},
-							Status: v1.PodStatus{
-								ContainerStatuses: []v1.ContainerStatus{
-									{
-										Name:        "container1",
-										ContainerID: "test-container",
-									},
+			metadata: NewMetadata([]MetadataLabel{MetadataLabelContainerID}, &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							UID: types.UID("uid-1234"),
+						},
+						Status: v1.PodStatus{
+							ContainerStatuses: []v1.ContainerStatus{
+								{
+									Name:        "container1",
+									ContainerID: "test-container",
 								},
 							},
 						},
 					},
 				},
-			),
+			}, nil),
 			args: []string{"uid-1234", "container.id", "container1"},
 			want: map[string]string{
 				string(MetadataLabelContainerID): "test-container",
@@ -111,63 +108,57 @@ func TestSetExtraLabels(t *testing.T) {
 		},
 		{
 			name:      "set_container_id_no_metadata",
-			metadata:  NewMetadata([]MetadataLabel{MetadataLabelContainerID}, nil),
+			metadata:  NewMetadata([]MetadataLabel{MetadataLabelContainerID}, nil, nil),
 			args:      []string{"uid-1234", "container.id", "container1"},
 			wantError: "pods metadata were not fetched",
 		},
 		{
 			name: "set_container_id_not_found",
-			metadata: NewMetadata(
-				[]MetadataLabel{MetadataLabelContainerID},
-				&v1.PodList{
-					Items: []v1.Pod{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								UID: types.UID("uid-1234"),
-							},
-							Status: v1.PodStatus{
-								ContainerStatuses: []v1.ContainerStatus{
-									{
-										Name:        "container2",
-										ContainerID: "another-container",
-									},
+			metadata: NewMetadata([]MetadataLabel{MetadataLabelContainerID}, &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							UID: types.UID("uid-1234"),
+						},
+						Status: v1.PodStatus{
+							ContainerStatuses: []v1.ContainerStatus{
+								{
+									Name:        "container2",
+									ContainerID: "another-container",
 								},
 							},
 						},
 					},
 				},
-			),
+			}, nil),
 			args:      []string{"uid-1234", "container.id", "container1"},
 			wantError: "pod \"uid-1234\" with container \"container1\" not found in the fetched metadata",
 		},
 		{
 			name:      "set_volume_type_no_metadata",
-			metadata:  NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, nil),
+			metadata:  NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, nil, nil),
 			args:      []string{"uid-1234", "k8s.volume.type", "volume0"},
 			wantError: "pods metadata were not fetched",
 		},
 		{
 			name: "set_volume_type_not_found",
-			metadata: NewMetadata(
-				[]MetadataLabel{MetadataLabelVolumeType},
-				&v1.PodList{
-					Items: []v1.Pod{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								UID: types.UID("uid-1234"),
-							},
-							Spec: v1.PodSpec{
-								Volumes: []v1.Volume{
-									{
-										Name:         "volume0",
-										VolumeSource: v1.VolumeSource{},
-									},
+			metadata: NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							UID: types.UID("uid-1234"),
+						},
+						Spec: v1.PodSpec{
+							Volumes: []v1.Volume{
+								{
+									Name:         "volume0",
+									VolumeSource: v1.VolumeSource{},
 								},
 							},
 						},
 					},
 				},
-			),
+			}, nil),
 			args:      []string{"uid-1234", "k8s.volume.type", "volume1"},
 			wantError: "pod \"uid-1234\" with volume \"volume1\" not found in the fetched metadata",
 		},
@@ -317,26 +308,23 @@ func TestSetExtraLabelsForVolumeTypes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fields := map[string]string{}
 			volName := "volume0"
-			metadata := NewMetadata(
-				[]MetadataLabel{MetadataLabelVolumeType},
-				&v1.PodList{
-					Items: []v1.Pod{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								UID: types.UID("uid-1234"),
-							},
-							Spec: v1.PodSpec{
-								Volumes: []v1.Volume{
-									{
-										Name:         volName,
-										VolumeSource: tt.vs,
-									},
+			metadata := NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, &v1.PodList{
+				Items: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							UID: types.UID("uid-1234"),
+						},
+						Spec: v1.PodSpec{
+							Volumes: []v1.Volume{
+								{
+									Name:         volName,
+									VolumeSource: tt.vs,
 								},
 							},
 						},
 					},
 				},
-			)
+			}, nil)
 			metadata.setExtraLabels(fields, tt.args[0], MetadataLabel(tt.args[1]), volName)
 			assert.Equal(t, tt.want, fields)
 		})

--- a/receiver/kubeletstatsreceiver/kubelet/metrics.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metrics.go
@@ -23,15 +23,14 @@ import (
 )
 
 func MetricsData(
-	logger *zap.Logger, summary *stats.Summary, metadata Metadata,
-	typeStr string, metricGroupsToCollect map[MetricGroup]bool,
-	volumeClaimLabelsSetter func(volumeClaim, namespace string, labels map[string]string) error) []consumerdata.MetricsData {
+	logger *zap.Logger, summary *stats.Summary,
+	metadata Metadata, typeStr string,
+	metricGroupsToCollect map[MetricGroup]bool) []consumerdata.MetricsData {
 	acc := &metricDataAccumulator{
-		metadata:                metadata,
-		logger:                  logger,
-		metricGroupsToCollect:   metricGroupsToCollect,
-		time:                    time.Now(),
-		volumeClaimLabelsSetter: volumeClaimLabelsSetter,
+		metadata:              metadata,
+		logger:                logger,
+		metricGroupsToCollect: metricGroupsToCollect,
+		time:                  time.Now(),
 	}
 
 	acc.nodeStats(summary.Node)

--- a/receiver/kubeletstatsreceiver/kubelet/metrics.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metrics.go
@@ -23,17 +23,15 @@ import (
 )
 
 func MetricsData(
-	logger *zap.Logger,
-	summary *stats.Summary,
-	metadata Metadata,
-	typeStr string,
-	metricGroupsToCollect map[MetricGroup]bool,
-) []consumerdata.MetricsData {
+	logger *zap.Logger, summary *stats.Summary, metadata Metadata,
+	typeStr string, metricGroupsToCollect map[MetricGroup]bool,
+	volumeClaimLabelsSetter func(volumeClaim, namespace string, labels map[string]string) error) []consumerdata.MetricsData {
 	acc := &metricDataAccumulator{
-		metadata:              metadata,
-		logger:                logger,
-		metricGroupsToCollect: metricGroupsToCollect,
-		time:                  time.Now(),
+		metadata:                metadata,
+		logger:                  logger,
+		metricGroupsToCollect:   metricGroupsToCollect,
+		time:                    time.Now(),
+		volumeClaimLabelsSetter: volumeClaimLabelsSetter,
 	}
 
 	acc.nodeStats(summary.Node)

--- a/receiver/kubeletstatsreceiver/kubelet/metrics_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metrics_test.go
@@ -43,10 +43,10 @@ func TestMetricAccumulator(t *testing.T) {
 	metadataProvider := NewMetadataProvider(rc)
 	podsMetadata, _ := metadataProvider.Pods()
 	metadata := NewMetadata([]MetadataLabel{MetadataLabelContainerID}, podsMetadata)
-	requireMetricsDataOk(t, MetricsData(zap.NewNop(), summary, metadata, "", ValidMetricGroups))
+	requireMetricsDataOk(t, MetricsData(zap.NewNop(), summary, metadata, "", ValidMetricGroups, nil))
 
 	// Disable all groups
-	require.Equal(t, 0, len(MetricsData(zap.NewNop(), summary, metadata, "", map[MetricGroup]bool{})))
+	require.Equal(t, 0, len(MetricsData(zap.NewNop(), summary, metadata, "", map[MetricGroup]bool{}, nil)))
 }
 
 func requireMetricsDataOk(t *testing.T, mds []consumerdata.MetricsData) {
@@ -170,5 +170,5 @@ func fakeMetrics() []consumerdata.MetricsData {
 		PodMetricGroup:       true,
 		NodeMetricGroup:      true,
 	}
-	return MetricsData(zap.NewNop(), summary, Metadata{}, "foo", mgs)
+	return MetricsData(zap.NewNop(), summary, Metadata{}, "foo", mgs, nil)
 }

--- a/receiver/kubeletstatsreceiver/kubelet/metrics_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/metrics_test.go
@@ -42,11 +42,11 @@ func TestMetricAccumulator(t *testing.T) {
 	summary, _ := statsProvider.StatsSummary()
 	metadataProvider := NewMetadataProvider(rc)
 	podsMetadata, _ := metadataProvider.Pods()
-	metadata := NewMetadata([]MetadataLabel{MetadataLabelContainerID}, podsMetadata)
-	requireMetricsDataOk(t, MetricsData(zap.NewNop(), summary, metadata, "", ValidMetricGroups, nil))
+	metadata := NewMetadata([]MetadataLabel{MetadataLabelContainerID}, podsMetadata, nil)
+	requireMetricsDataOk(t, MetricsData(zap.NewNop(), summary, metadata, "", ValidMetricGroups))
 
 	// Disable all groups
-	require.Equal(t, 0, len(MetricsData(zap.NewNop(), summary, metadata, "", map[MetricGroup]bool{}, nil)))
+	require.Equal(t, 0, len(MetricsData(zap.NewNop(), summary, metadata, "", map[MetricGroup]bool{})))
 }
 
 func requireMetricsDataOk(t *testing.T, mds []consumerdata.MetricsData) {
@@ -170,5 +170,5 @@ func fakeMetrics() []consumerdata.MetricsData {
 		PodMetricGroup:       true,
 		NodeMetricGroup:      true,
 	}
-	return MetricsData(zap.NewNop(), summary, Metadata{}, "foo", mgs, nil)
+	return MetricsData(zap.NewNop(), summary, Metadata{}, "foo", mgs)
 }

--- a/receiver/kubeletstatsreceiver/kubelet/volume.go
+++ b/receiver/kubeletstatsreceiver/kubelet/volume.go
@@ -15,6 +15,8 @@
 package kubelet
 
 import (
+	"strconv"
+
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	v1 "k8s.io/api/core/v1"
 	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
@@ -90,16 +92,68 @@ func getLabelsFromVolume(volume v1.Volume, labels map[string]string) {
 	switch {
 	// TODO: Support more types
 	case volume.ConfigMap != nil:
-		labels[labelVolumeType] = "configMap"
+		labels[labelVolumeType] = labelValueConfigMapVolume
 	case volume.DownwardAPI != nil:
-		labels[labelVolumeType] = "downwardAPI"
+		labels[labelVolumeType] = labelValueDownwardAPIVolume
 	case volume.EmptyDir != nil:
-		labels[labelVolumeType] = "emptyDir"
+		labels[labelVolumeType] = labelValueEmptyDirVolume
 	case volume.Secret != nil:
-		labels[labelVolumeType] = "secret"
+		labels[labelVolumeType] = labelValueSecretVolume
 	case volume.PersistentVolumeClaim != nil:
-		labels[labelVolumeType] = "persistentVolumeClaim"
+		labels[labelVolumeType] = labelValuePersistentVolumeClaim
+		labels[labelPersistentVolumeClaimName] = volume.PersistentVolumeClaim.ClaimName
 	case volume.HostPath != nil:
-		labels[labelVolumeType] = "hostPath"
+		labels[labelVolumeType] = labelValueHostPathVolume
+	case volume.AWSElasticBlockStore != nil:
+		awsElasticBlockStoreDims(*volume.AWSElasticBlockStore, labels)
+	case volume.GCEPersistentDisk != nil:
+		gcePersistentDiskDims(*volume.GCEPersistentDisk, labels)
+	case volume.Glusterfs != nil:
+		glusterfsDims(*volume.Glusterfs, labels)
 	}
+}
+
+func GetPersistentVolumeLabels(pv v1.PersistentVolumeSource, labels map[string]string) {
+	// TODO: Support more types
+	switch {
+	case pv.Local != nil:
+		labels[labelVolumeType] = labelValueLocalVolume
+	case pv.AWSElasticBlockStore != nil:
+		awsElasticBlockStoreDims(*pv.AWSElasticBlockStore, labels)
+	case pv.GCEPersistentDisk != nil:
+		gcePersistentDiskDims(*pv.GCEPersistentDisk, labels)
+	case pv.Glusterfs != nil:
+		// pv.Glusterfs is a GlusterfsPersistentVolumeSource instead of GlusterfsVolumeSource,
+		// convert to GlusterfsVolumeSource so a single method can handle both structs. This
+		// can be broken out into separate methods if one is interested in different sets
+		// of labels from the two structs in the future.
+		glusterfsDims(v1.GlusterfsVolumeSource{
+			EndpointsName: pv.Glusterfs.EndpointsName,
+			Path:          pv.Glusterfs.Path,
+			ReadOnly:      pv.Glusterfs.ReadOnly,
+		}, labels)
+	}
+}
+
+func awsElasticBlockStoreDims(vs v1.AWSElasticBlockStoreVolumeSource, labels map[string]string) {
+	labels[labelVolumeType] = labelValueAWSEBSVolume
+	// AWS specific labels.
+	labels["aws.volume.id"] = vs.VolumeID
+	labels["fs.type"] = vs.FSType
+	labels["partition"] = strconv.Itoa(int(vs.Partition))
+}
+
+func gcePersistentDiskDims(vs v1.GCEPersistentDiskVolumeSource, labels map[string]string) {
+	labels[labelVolumeType] = labelValueGCEPDVolume
+	// GCP specific labels.
+	labels["gce.pd.name"] = vs.PDName
+	labels["fs.type"] = vs.FSType
+	labels["partition"] = strconv.Itoa(int(vs.Partition))
+}
+
+func glusterfsDims(vs v1.GlusterfsVolumeSource, labels map[string]string) {
+	labels[labelVolumeType] = labelValueGlusterFSVolume
+	// GlusterFS specific labels.
+	labels["glusterfs.endpoints.name"] = vs.EndpointsName
+	labels["glusterfs.path"] = vs.Path
 }

--- a/receiver/kubeletstatsreceiver/kubelet/volume_test.go
+++ b/receiver/kubeletstatsreceiver/kubelet/volume_test.go
@@ -1,0 +1,200 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubelet
+
+import (
+	"testing"
+
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	stats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+)
+
+type pod struct {
+	uid       string
+	name      string
+	namespace string
+}
+
+// Tests for correctness of additional labels collected from PVCs.
+func TestDetailedPVCLabels(t *testing.T) {
+	tests := []struct {
+		name                    string
+		volumeName              string
+		volumeSource            v1.VolumeSource
+		pod                     pod
+		pvcDetailedLabelsSetter func(volumeClaim, namespace string, labels map[string]string) error
+		want                    map[string]string
+	}{
+		{
+			name:       "persistentVolumeClaim - with detailed PVC labels (AWS)",
+			volumeName: "volume0",
+			volumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "claim-name",
+				},
+			},
+			pod: pod{uid: "uid-1234", name: "pod-name", namespace: "pod-namespace"},
+			pvcDetailedLabelsSetter: func(volumeClaim, namespace string, labels map[string]string) error {
+				GetPersistentVolumeLabels(v1.PersistentVolumeSource{
+					AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+						VolumeID:  "volume_id",
+						FSType:    "fs_type",
+						Partition: 10,
+					},
+				}, labels)
+				return nil
+			},
+			want: map[string]string{
+				"k8s.volume.name":                "volume0",
+				"k8s.volume.type":                "awsElasticBlockStore",
+				"aws.volume.id":                  "volume_id",
+				"fs.type":                        "fs_type",
+				"partition":                      "10",
+				"k8s.persistentvolumeclaim.name": "claim-name",
+				"k8s.pod.uid":                    "uid-1234",
+				"k8s.pod.name":                   "pod-name",
+				"k8s.namespace.name":             "pod-namespace",
+			},
+		},
+		{
+			name:       "persistentVolumeClaim - with detailed PVC labels (GCP)",
+			volumeName: "volume0",
+			volumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "claim-name",
+				},
+			},
+			pod: pod{uid: "uid-1234", name: "pod-name", namespace: "pod-namespace"},
+			pvcDetailedLabelsSetter: func(volumeClaim, namespace string, labels map[string]string) error {
+				GetPersistentVolumeLabels(v1.PersistentVolumeSource{
+					GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+						PDName:    "pd_name",
+						FSType:    "fs_type",
+						Partition: 10,
+					},
+				}, labels)
+				return nil
+			},
+			want: map[string]string{
+				"k8s.volume.name":                "volume0",
+				"k8s.volume.type":                "gcePersistentDisk",
+				"gce.pd.name":                    "pd_name",
+				"fs.type":                        "fs_type",
+				"partition":                      "10",
+				"k8s.persistentvolumeclaim.name": "claim-name",
+				"k8s.pod.uid":                    "uid-1234",
+				"k8s.pod.name":                   "pod-name",
+				"k8s.namespace.name":             "pod-namespace",
+			},
+		},
+		{
+			name:       "persistentVolumeClaim - with detailed PVC labels (GlusterFS)",
+			volumeName: "volume0",
+			volumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "claim-name",
+				},
+			},
+			pod: pod{uid: "uid-1234", name: "pod-name", namespace: "pod-namespace"},
+			pvcDetailedLabelsSetter: func(volumeClaim, namespace string, labels map[string]string) error {
+				GetPersistentVolumeLabels(v1.PersistentVolumeSource{
+					Glusterfs: &v1.GlusterfsPersistentVolumeSource{
+						EndpointsName: "endpoints_name",
+						Path:          "path",
+					},
+				}, labels)
+				return nil
+			},
+			want: map[string]string{
+				"k8s.volume.name":                "volume0",
+				"k8s.volume.type":                "glusterfs",
+				"glusterfs.endpoints.name":       "endpoints_name",
+				"glusterfs.path":                 "path",
+				"k8s.persistentvolumeclaim.name": "claim-name",
+				"k8s.pod.uid":                    "uid-1234",
+				"k8s.pod.name":                   "pod-name",
+				"k8s.namespace.name":             "pod-namespace",
+			},
+		},
+		{
+			name:       "persistentVolumeClaim - with detailed PVC labels (local)",
+			volumeName: "volume0",
+			volumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "claim-name",
+				},
+			},
+			pod: pod{uid: "uid-1234", name: "pod-name", namespace: "pod-namespace"},
+			pvcDetailedLabelsSetter: func(volumeClaim, namespace string, labels map[string]string) error {
+				GetPersistentVolumeLabels(v1.PersistentVolumeSource{
+					Local: &v1.LocalVolumeSource{
+						Path: "path",
+					},
+				}, labels)
+				return nil
+			},
+			want: map[string]string{
+				"k8s.volume.name":                "volume0",
+				"k8s.volume.type":                "local",
+				"k8s.persistentvolumeclaim.name": "claim-name",
+				"k8s.pod.uid":                    "uid-1234",
+				"k8s.pod.name":                   "pod-name",
+				"k8s.namespace.name":             "pod-namespace",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podResource := &resourcepb.Resource{
+				Labels: map[string]string{
+					"k8s.pod.uid":        tt.pod.uid,
+					"k8s.pod.name":       tt.pod.name,
+					"k8s.namespace.name": tt.pod.namespace,
+				},
+			}
+			metadata := NewMetadata(
+				[]MetadataLabel{MetadataLabelVolumeType},
+				&v1.PodList{
+					Items: []v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								UID:       types.UID(tt.pod.uid),
+								Name:      tt.pod.name,
+								Namespace: tt.pod.namespace,
+							},
+							Spec: v1.PodSpec{
+								Volumes: []v1.Volume{
+									{
+										Name:         tt.volumeName,
+										VolumeSource: tt.volumeSource,
+									},
+								},
+							},
+						},
+					},
+				},
+			)
+
+			volume, err := volumeResource(podResource, stats.VolumeStats{Name: tt.volumeName}, metadata, tt.pvcDetailedLabelsSetter)
+			require.NoError(t, err)
+			require.NotNil(t, volume)
+			require.Equal(t, tt.want, volume.Labels)
+		})
+	}
+}

--- a/receiver/kubeletstatsreceiver/mocked_objects_test.go
+++ b/receiver/kubeletstatsreceiver/mocked_objects_test.go
@@ -1,0 +1,140 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeletstatsreceiver
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// getValidMockedObjects returns a list of volume claims and persistent
+// volume objects based on values present in testdata/pods.json. These
+// values will be used to mock objects returned by the Kuberentes API.
+func getValidMockedObjects() []runtime.Object {
+	return []runtime.Object{
+		volumeClaim1,
+		awsPersistentVolume,
+		volumeClaim2,
+		gcePersistentVolume,
+		volumeClaim3,
+		glusterFSPersistentVolume,
+	}
+}
+
+var volumeClaim1 = getPVC("volume_claim_1", "kube-system", "storage-provisioner-token-qzlx6")
+var volumeClaim2 = getPVC("volume_claim_2", "kube-system", "kube-proxy")
+var volumeClaim3 = getPVC("volume_claim_3", "kube-system", "coredns-token-dzc5t")
+
+func getPVC(claimName, namespace, volumeName string) *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: namespace,
+			UID:       types.UID(claimName),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: volumeName,
+		},
+	}
+}
+
+var awsPersistentVolume = func() *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "storage-provisioner-token-qzlx6",
+			UID:  "volume_name_1",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+					VolumeID:  "volume_id",
+					FSType:    "fs_type",
+					Partition: 10,
+				},
+			},
+		},
+	}
+}()
+
+var gcePersistentVolume = func() *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-proxy",
+			UID:  "volume_name_2",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+					PDName:    "pd_name",
+					FSType:    "fs_type",
+					Partition: 10,
+				},
+			},
+		},
+	}
+}()
+
+var glusterFSPersistentVolume = func() *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "coredns-token-dzc5t",
+			UID:  "volume_name_3",
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				Glusterfs: &v1.GlusterfsPersistentVolumeSource{
+					EndpointsName: "endpoints_name",
+					Path:          "path",
+				},
+			},
+		},
+	}
+}()
+
+func getMockedObjectsWithEmptyVolumeName() []runtime.Object {
+	return []runtime.Object{
+		volumeClaim1,
+		awsPersistentVolume,
+		volumeClaim2,
+		gcePersistentVolume,
+		volumeClaimWithEmptyVolumeName,
+	}
+}
+
+var volumeClaimWithEmptyVolumeName = func() *v1.PersistentVolumeClaim {
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         "volume_claim_3",
+			GenerateName: "volume_claim_3",
+			Namespace:    "kube-system",
+			UID:          "volume_claim_3",
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			VolumeName: "",
+		},
+	}
+}()
+
+func getMockedObjectsWithNonExistentVolumeName() []runtime.Object {
+	return []runtime.Object{
+		volumeClaim1,
+		awsPersistentVolume,
+		volumeClaim2,
+		gcePersistentVolume,
+		volumeClaim3,
+	}
+}

--- a/receiver/kubeletstatsreceiver/receiver.go
+++ b/receiver/kubeletstatsreceiver/receiver.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/kubelet"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver/interval"
@@ -41,6 +42,7 @@ type receiverOptions struct {
 	collectionInterval    time.Duration
 	extraMetadataLabels   []kubelet.MetadataLabel
 	metricGroupsToCollect map[kubelet.MetricGroup]bool
+	k8sAPIClient          kubernetes.Interface
 }
 
 func newReceiver(rOptions *receiverOptions,

--- a/receiver/kubeletstatsreceiver/runnable.go
+++ b/receiver/kubeletstatsreceiver/runnable.go
@@ -16,12 +16,15 @@ package kubeletstatsreceiver
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdatautil"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/kubelet"
 	// todo replace with scraping lib when it's ready
@@ -40,6 +43,7 @@ type runnable struct {
 	restClient            kubelet.RestClient
 	extraMetadataLabels   []kubelet.MetadataLabel
 	metricGroupsToCollect map[kubelet.MetricGroup]bool
+	k8sAPIClient          kubernetes.Interface
 }
 
 func newRunnable(
@@ -57,6 +61,7 @@ func newRunnable(
 		logger:                logger,
 		extraMetadataLabels:   rOptions.extraMetadataLabels,
 		metricGroupsToCollect: rOptions.metricGroupsToCollect,
+		k8sAPIClient:          rOptions.k8sAPIClient,
 	}
 }
 
@@ -86,7 +91,7 @@ func (r *runnable) Run() error {
 	}
 
 	metadata := kubelet.NewMetadata(r.extraMetadataLabels, podsMetadata)
-	mds := kubelet.MetricsData(r.logger, summary, metadata, typeStr, r.metricGroupsToCollect)
+	mds := kubelet.MetricsData(r.logger, summary, metadata, typeStr, r.metricGroupsToCollect, r.getPersistentVolumeLabelsFromClaim)
 	metrics := pdatautil.MetricsFromMetricsData(mds)
 
 	var numTimeSeries, numPoints int
@@ -100,5 +105,31 @@ func (r *runnable) Run() error {
 	}
 	obsreport.EndMetricsReceiveOp(ctx, typeStr, numTimeSeries, numPoints, err)
 
+	return nil
+}
+
+func (r *runnable) getPersistentVolumeLabelsFromClaim(
+	volumeClaim, namespace string,
+	labels map[string]string) error {
+	if r.k8sAPIClient == nil {
+		return nil
+	}
+
+	pvc, err := r.k8sAPIClient.CoreV1().PersistentVolumeClaims(namespace).Get(r.ctx, volumeClaim, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	volName := pvc.Spec.VolumeName
+	if volName == "" {
+		return fmt.Errorf("PersistentVolumeClaim %s does not have a volume name", pvc.Name)
+	}
+
+	pv, err := r.k8sAPIClient.CoreV1().PersistentVolumes().Get(r.ctx, volName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	kubelet.GetPersistentVolumeLabels(pv.Spec.PersistentVolumeSource, labels)
 	return nil
 }

--- a/receiver/kubeletstatsreceiver/testdata/config.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/config.yaml
@@ -18,6 +18,13 @@ receivers:
     extra_metadata_labels:
     - container.id
     - k8s.volume.type
+  kubeletstats/metadata_with_k8s_api:
+    collection_interval: 10s
+    auth_type: "serviceAccount"
+    extra_metadata_labels:
+      - k8s.volume.type
+    k8s_api_config:
+      auth_type: kubeConfig
   kubeletstats/metric_groups:
     collection_interval: 20s
     auth_type: "serviceAccount"

--- a/receiver/kubeletstatsreceiver/testdata/pods.json
+++ b/receiver/kubeletstatsreceiver/testdata/pods.json
@@ -117,9 +117,8 @@
           },
           {
             "name": "coredns-token-dzc5t",
-            "secret": {
-              "secretName": "coredns-token-dzc5t",
-              "defaultMode": 420
+            "persistentVolumeClaim": {
+              "claimName": "volume_claim_3"
             }
           }
         ]
@@ -156,9 +155,8 @@
         "volumes": [
           {
             "name": "kube-proxy",
-            "configMap": {
-              "name": "kube-proxy",
-              "defaultMode": 420
+            "persistentVolumeClaim": {
+              "claimName": "volume_claim_2"
             }
           },
           {
@@ -195,9 +193,8 @@
           },
           {
             "name": "storage-provisioner-token-qzlx6",
-            "secret": {
-              "secretName": "storage-provisioner-token-qzlx6",
-              "defaultMode": 420
+            "persistentVolumeClaim": {
+              "claimName": "volume_claim_1"
             }
           }
         ]


### PR DESCRIPTION
**Description:** For pods using a Persistent Volume Claim, the Kubelet API only provides information about the claim and not the actual underlying physical resource. Add ability to optionally look up the underlying physical volume and collect labels accordingly.

**Testing:** Added tests.

**Documentation:** Updated README.