### PR TITLE
Add option to configurably set UserAgent string in Stackdriver exporter

### DIFF
--- a/exporter/stackdriverexporter/README.md
+++ b/exporter/stackdriverexporter/README.md
@@ -13,6 +13,8 @@ The following configuration options are supported:
 - `skip_create_metric_descriptor` (optional): Whether to skip creating the metric descriptor.
 - `resource_mappings` (optional): ResourceMapping defines mapping of resources from source (OpenCensus) to target (Stackdriver).
 - `label_mappings`.`optional` (optional): Optional flag signals whether we can proceed with transformation if a label is missing in the resource.
+- `user_agent` (optional): Override the user agent string sent on requests to Cloud Monitoring (currently only applies to metrics). Specify `{{version}}` to include the application version number. Defaults to `opentelemetry-collector-contrib {{version}}`.
+
 Example:
 
 ```yaml
@@ -22,6 +24,7 @@ exporters:
     project: my-project
     metric_prefix: prefix
     endpoint: test-endpoint
+    user_agent: my-collector {{version}}
     number_of_workers: 3
     skip_create_metric_descriptor: true
     use_insecure: true

--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	ProjectID                     string                   `mapstructure:"project"`
 	Prefix                        string                   `mapstructure:"metric_prefix"`
+	UserAgent                     string                   `mapstructure:"user_agent"`
 	Endpoint                      string                   `mapstructure:"endpoint"`
 	NumOfWorkers                  int                      `mapstructure:"number_of_workers"`
 	SkipCreateMetricDescriptor    bool                     `mapstructure:"skip_create_metric_descriptor"`

--- a/exporter/stackdriverexporter/config_test.go
+++ b/exporter/stackdriverexporter/config_test.go
@@ -51,6 +51,7 @@ func TestLoadConfig(t *testing.T) {
 			ExporterSettings:           configmodels.ExporterSettings{TypeVal: configmodels.Type(typeStr), NameVal: "stackdriver/customname"},
 			ProjectID:                  "my-project",
 			Prefix:                     "prefix",
+			UserAgent:                  "opentelemetry-collector-contrib {{version}}",
 			Endpoint:                   "test-endpoint",
 			NumOfWorkers:               3,
 			SkipCreateMetricDescriptor: true,

--- a/exporter/stackdriverexporter/factory.go
+++ b/exporter/stackdriverexporter/factory.go
@@ -56,6 +56,7 @@ func createDefaultConfig() configmodels.Exporter {
 			NameVal: typeStr,
 		},
 		TimeoutSettings: exporterhelper.TimeoutSettings{Timeout: defaultTimeout},
+		UserAgent:       "opentelemetry-collector-contrib {{version}}",
 	}
 }
 
@@ -71,8 +72,8 @@ func createTraceExporter(
 // createMetricsExporter creates a metrics exporter based on this config.
 func createMetricsExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	cfg configmodels.Exporter) (component.MetricsExporter, error) {
 	eCfg := cfg.(*Config)
-	return newStackdriverMetricsExporter(eCfg)
+	return newStackdriverMetricsExporter(eCfg, params.ApplicationStartInfo.Version)
 }

--- a/exporter/stackdriverexporter/observability.go
+++ b/exporter/stackdriverexporter/observability.go
@@ -44,7 +44,7 @@ func recordPointCount(ctx context.Context, success, dropped int, grpcErr error) 
 	}
 
 	if dropped > 0 {
-		var st string
+		st := "UNKNOWN"
 		s, ok := status.FromError(grpcErr)
 		if ok {
 			st = statusCodeToString(s)

--- a/exporter/stackdriverexporter/testdata/config.yaml
+++ b/exporter/stackdriverexporter/testdata/config.yaml
@@ -9,6 +9,7 @@ exporters:
   stackdriver/customname:
     project: my-project
     metric_prefix: prefix
+    user_agent: opentelemetry-collector-contrib {{version}}
     endpoint: test-endpoint
     number_of_workers: 3
     skip_create_metric_descriptor: true


### PR DESCRIPTION
Add option to configurably set UserAgent string in Stackdriver exporter. Also allow the user to specify `{{version}}` in this field and replace it with the app version.