### PR TITLE
sfxexporter: add disk usage translations

### DIFF
--- a/exporter/signalfxexporter/testdata/json/system.filesystem.usage.json
+++ b/exporter/signalfxexporter/testdata/json/system.filesystem.usage.json
@@ -1,0 +1,374 @@
+[
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 2
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s5"
+      },
+      {
+        "key": "state",
+        "value": "used"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 3
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s5"
+      },
+      {
+        "key": "state",
+        "value": "free"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 5
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s5"
+      },
+      {
+        "key": "state",
+        "value": "reserved"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 7
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s1"
+      },
+      {
+        "key": "state",
+        "value": "used"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 11
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s1"
+      },
+      {
+        "key": "state",
+        "value": "free"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 13
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s1"
+      },
+      {
+        "key": "state",
+        "value": "reserved"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 17
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s4"
+      },
+      {
+        "key": "state",
+        "value": "used"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 19
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s4"
+      },
+      {
+        "key": "state",
+        "value": "free"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 23
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s4"
+      },
+      {
+        "key": "state",
+        "value": "reserved"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 29
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s3"
+      },
+      {
+        "key": "state",
+        "value": "used"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 31
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s3"
+      },
+      {
+        "key": "state",
+        "value": "free"
+      }
+    ]
+  },
+  {
+    "source": "",
+    "metric": "system.filesystem.usage",
+    "timestamp": 1597439222904,
+    "value": {
+      "intValue": 37
+    },
+    "metricType": 0,
+    "dimensions": [
+      {
+        "key": "host",
+        "value": "test-node"
+      },
+      {
+        "key": "kubernetes_cluster",
+        "value": "test-cluster"
+      },
+      {
+        "key": "kubernetes_node",
+        "value": "test-node"
+      },
+      {
+        "key": "device",
+        "value": "/dev/disk1s3"
+      },
+      {
+        "key": "state",
+        "value": "reserved"
+      }
+    ]
+  }
+]

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -212,6 +212,27 @@ translation_rules:
     slab_unreclaimable: memory.slab_unrecl
     used: memory.used
 
+# calculate disk.total
+- action: copy_metrics
+  mapping:
+    system.filesystem.usage: disk.total
+- action: aggregate_metric
+  metric_name: disk.total
+  aggregation_method: sum
+  without_dimensions:
+    - state
+
+# calculate disk.summary_total
+- action: copy_metrics
+  mapping:
+    system.filesystem.usage: disk.summary_total
+- action: aggregate_metric
+  metric_name: disk.summary_total
+  aggregation_method: sum
+  without_dimensions:
+    - state
+    - device
+
 # convert filesystem metrics
 - action: split_metric
   metric_name: system.filesystem.usage
@@ -226,6 +247,16 @@ translation_rules:
   mapping:
     free: df_inodes.free
     used: df_inodes.used
+
+# df_complex.used_total
+- action: copy_metrics
+  mapping:
+    df_complex.used: df_complex.used_total 
+- action: aggregate_metric
+  metric_name: df_complex.used_total
+  aggregation_method: sum
+  without_dimensions:
+  - device
 
 # convert disk I/O metrics
 - action: rename_dimension_keys


### PR DESCRIPTION
**Description:** Adds translations to produce `disk.total`, `disk.summary_total`, and `df_complex.used_total` metrics needed by the SFx backend.

**Testing:** Test data from local k8s env added to testdata dir and used in unit test.