### PR TITLE
[newrelicexporter] Fix panic on missing span status

### DIFF
--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -91,7 +91,7 @@ func (t *transformer) SpanAttributes(span *tracepb.Span) map[string]interface{} 
 
 	length := 2
 
-	isErr := t.isError(span.Status.Code)
+	isErr := span.Status != nil && span.Status.Code != 0
 	if isErr {
 		length++
 	}
@@ -149,10 +149,6 @@ func (t *transformer) Timestamp(ts *timestamp.Timestamp) time.Time {
 		return time.Time{}
 	}
 	return time.Unix(ts.Seconds, int64(ts.Nanos))
-}
-
-func (t *transformer) isError(code int32) bool {
-	return code != 0
 }
 
 func (t *transformer) Metric(metric *metricspb.Metric) ([]telemetry.Metric, error) {

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -43,6 +43,21 @@ func TestTransformSpan(t *testing.T) {
 	}{
 		{
 			in: &tracepb.Span{
+				// No status means no error.
+			},
+			want: telemetry.Span{
+				ID:          "0000000000000000",
+				TraceID:     "00000000000000000000000000000000",
+				ServiceName: "test-service",
+				Attributes: map[string]interface{}{
+					"collector.name":    name,
+					"collector.version": version,
+					"resource":          "R1",
+				},
+			},
+		},
+		{
+			in: &tracepb.Span{
 				Status: &tracepb.Status{},
 			},
 			want: telemetry.Span{


### PR DESCRIPTION
**Description:** Fixing a bug in the newrelicexporter exporter. The span status is optional and a missing status means no error, updates the newrelicexporter to handle this and adds tests to prevent regression.

**Link to tracking Issue:** Resolves #348