### PR TITLE
Add info about exporter reviewers to README.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,21 +13,3 @@
 #
 
 * @open-telemetry/collector-contrib-approvers
-
-# Exporters Reviewers
-
-/exporter/alibabacloudlogserviceexporter/ @shabicheng
-/exporter/awsxrayexporter/ @kbrockhoff @anuraaga
-/exporter/azuremonitorexporter/ @pcwiese
-/exporter/carbonexporter/ @pjanotti
-/exporter/elasticexporter/ @axw
-/exporter/honeycombexporter/ @paulosman @lizthegrey
-/exporter/jaegerthrifthttpexporter/ @jpkrohling @pavolloffay
-/exporter/kinesisexporter/ @owais
-/exporter/lightstepexporter/ @austinlparker @jmacd
-/exporter/newrelicexporter/ @MrAlias
-/exporter/sapmexporter/ @owais @dmitryax
-/exporter/sentryexporter/ @AbhiPrasad
-/exporter/signalfxexporter/ @pmcollins @asuresh4
-/exporter/splunkhecexporter/ @atoulme
-/exporter/stackdriverexporter/ @nilebox @james-bebbington

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,21 @@
 #
 
 * @open-telemetry/collector-contrib-approvers
+
+# Exporters Reviewers
+
+/exporter/alibabacloudlogserviceexporter/ @shabicheng
+/exporter/awsxrayexporter/ @kbrockhoff @anuraaga
+/exporter/azuremonitorexporter/ @pcwiese
+/exporter/carbonexporter/ @pjanotti
+/exporter/elasticexporter/ @axw
+/exporter/honeycombexporter/ @paulosman @lizthegrey
+/exporter/jaegerthrifthttpexporter/ @jpkrohling @pavolloffay
+/exporter/kinesisexporter/ @owais
+/exporter/lightstepexporter/ @austinlparker @jmacd
+/exporter/newrelicexporter/ @MrAlias
+/exporter/sapmexporter/ @owais @dmitryax
+/exporter/sentryexporter/ @AbhiPrasad
+/exporter/signalfxexporter/ @pmcollins @asuresh4
+/exporter/splunkhecexporter/ @atoulme
+/exporter/stackdriverexporter/ @nilebox @james-bebbington

--- a/README.md
+++ b/README.md
@@ -113,3 +113,46 @@ rigid rules and there are exceptions but in general try to follow them.
 Reach the Collector community on
 [gitter](https://gitter.im/open-telemetry/opentelemetry-service) if you have
 further questions.
+
+### Community Roles
+
+Triagers ([@open-telemetry/collector-contrib-triagers](https://github.com/orgs/open-telemetry/teams/collector-contrib-triagers))
+- [Steve Flanders](https://github.com/flands), Splunk
+
+Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs/open-telemetry/teams/collector-contrib-approvers)):
+
+- [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
+- [James Bebbington](https://github.com/james-bebbington), Google
+- [Jay Camp](https://github.com/jrcamp), Splunk
+- [Nail Islamov](https://github.com/nilebox), Google
+- [Owais Lone](https://github.com/owais), Splunk
+
+Maintainers ([@open-telemetry/collector-contrib-maintainer](https://github.com/orgs/open-telemetry/teams/collector-contrib-maintainer)):
+
+- [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk
+- [Paulo Janotti](https://github.com/pjanotti), Splunk
+- [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
+
+Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md).
+
+### Component Reviewers
+
+#### Exporters
+
+| Exporter | Reviewer(s) |
+| -------- | ----------- |
+| alibabacloudlogserviceexporter | @shabicheng |
+| awsxrayexporter | @kbrockhoff @anuraaga |
+| azuremonitorexporter | @pcwiese |
+| carbonexporter | @pjanotti |
+| elasticexporter | @axw |
+| honeycombexporter | @paulosman @lizthegrey |
+| jaegerthrifthttpexporter | @jpkrohling @pavolloffay |
+| kinesisexporter | @owais |
+| lightstepexporter | @austinlparker @jmacd |
+| newrelicexporter | @MrAlias |
+| sapmexporter | @owais @dmitryax |
+| sentryexporter | @AbhiPrasad |
+| signalfxexporter | @pmcollins @asuresh4 |
+| splunkhecexporter | @atoulme |
+| stackdriverexporter | @nilebox @james-bebbington |


### PR DESCRIPTION
Helping finding reviewers for exporter changes.

/exporter/alibabacloudlogserviceexporter/ @shabicheng
/exporter/awsxrayexporter/ @kbrockhoff @anuraaga
/exporter/azuremonitorexporter/ @pcwiese
/exporter/carbonexporter/ @pjanotti
/exporter/elasticexporter/ @axw
/exporter/honeycombexporter/ @paulosman @lizthegrey
/exporter/jaegerthrifthttpexporter/ @jpkrohling @pavolloffay
/exporter/kinesisexporter/ @owais
/exporter/lightstepexporter/ @austinlparker @jmacd
/exporter/newrelicexporter/ @MrAlias
/exporter/sapmexporter/ @owais @dmitryax
/exporter/sentryexporter/ @AbhiPrasad
/exporter/signalfxexporter/ @pmcollins @asuresh4
/exporter/splunkhecexporter/ @atoulme
/exporter/stackdriverexporter/ @nilebox @james-bebbington
