### PR TITLE
Readd removed sapm receiver config field

### DIFF
--- a/receiver/sapmreceiver/README.md
+++ b/receiver/sapmreceiver/README.md
@@ -1,7 +1,7 @@
 # SAPM Receiver 
 
 The SAPM receiver builds on the Jaeger proto. This allows the collector to
-receiver traces from other collectors or the SignalFx Smart Agent. SAPM proto
+receive traces from other collectors or the SignalFx Smart Agent. SAPM proto
 and some useful related utilities can be found
 [here](https://github.com/signalfx/sapm-proto/).
 
@@ -14,6 +14,10 @@ The following settings are required:
 
 The following setting are optional:
 
+* `access_token_passthrough`: (default = `false`) Whether to preserve incoming
+  access token (`X-Sf-Token` header value) as `"com.splunk.signalfx.access_token"`
+  trace resource attribute.  Can be used in tandem with identical configuration option
+  for [SAPM exporter](../../exporter/sapmexporter/README.md) to preserve trace origin.
 * `tls_settings` (no default): This is an optional object used to specify if TLS should
   be used for incoming connections.
     * `cert_file`: Specifies the certificate file to use for TLS connection.


### PR DESCRIPTION
**Description:**

Add an accidentally removed config field for the SAPM receiver and fix typo.