### PR TITLE
Add info about receiver reviewers to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,17 +161,17 @@ Learn more about roles in the [community repository](https://github.com/open-tel
 
 | Receiver | Reviewer(s) |
 | -------- | ----------- |
-| awsecscontainermetricsreceiver/ | @kbrockhoff @anuraaga |
-| awsxrayreceiver/ | @kbrockhoff @anuraaga |
-| carbonreceiver/ | @pjanotti |
-| collectdreceiver/ | @owais |
-| k8sclusterreceiver/ | @asuresh4 |
-| kubeletstatsreceiver/ | @pmcollins @asuresh4 |
-| prometheusexecreceiver/ | @keitwb @james-bebbington |
-| receivercreator/ | @jrcamp |
-| redisreceiver/ | @pmcollins @jrcamp |
-| sapmreceiver/ | @owais |
-| signalfxreceiver/ | @pjanotti @asuresh4 |
-| simpleprometheusreceiver/ | @asuresh4 |
-| statsdreceiver/ | @keitwb @jmacd |
-| wavefrontreceiver/ | @pjanotti |
+| awsecscontainermetricsreceiver | @kbrockhoff @anuraaga |
+| awsxrayreceiver | @kbrockhoff @anuraaga |
+| carbonreceiver | @pjanotti |
+| collectdreceiver | @owais |
+| k8sclusterreceiver | @asuresh4 |
+| kubeletstatsreceiver | @pmcollins @asuresh4 |
+| prometheusexecreceiver | @keitwb @james-bebbington |
+| receivercreator | @jrcamp |
+| redisreceiver | @pmcollins @jrcamp |
+| sapmreceiver | @owais |
+| signalfxreceiver | @pjanotti @asuresh4 |
+| simpleprometheusreceiver | @asuresh4 |
+| statsdreceiver | @keitwb @jmacd |
+| wavefrontreceiver | @pjanotti |

--- a/README.md
+++ b/README.md
@@ -156,3 +156,22 @@ Learn more about roles in the [community repository](https://github.com/open-tel
 | signalfxexporter | @pmcollins @asuresh4 |
 | splunkhecexporter | @atoulme |
 | stackdriverexporter | @nilebox @james-bebbington |
+
+#### Receivers
+
+| Receiver | Reviewer(s) |
+| -------- | ----------- |
+| awsecscontainermetricsreceiver/ | @kbrockhoff @anuraaga |
+| awsxrayreceiver/ | @kbrockhoff @anuraaga |
+| carbonreceiver/ | @pjanotti |
+| collectdreceiver/ | @owais |
+| k8sclusterreceiver/ | @asuresh4 |
+| kubeletstatsreceiver/ | @pmcollins @asuresh4 |
+| prometheusexecreceiver/ | @keitwb @james-bebbington |
+| receivercreator/ | @jrcamp |
+| redisreceiver/ | @pmcollins @jrcamp |
+| sapmreceiver/ | @owais |
+| signalfxreceiver/ | @pjanotti @asuresh4 |
+| simpleprometheusreceiver/ | @asuresh4 |
+| statsdreceiver/ | @keitwb @jmacd |
+| wavefrontreceiver/ | @pjanotti |


### PR DESCRIPTION
Helping finding reviewers for receiver changes.

/receiver/awsecscontainermetricsreceiver/ @kbrockhoff @anuraaga
/receiver/awsxrayreceiver/ @kbrockhoff @anuraaga
/receiver/carbonreceiver/ @pjanotti
/receiver/collectdreceiver/ @owais
/receiver/k8sclusterreceiver/ @asuresh4
/receiver/kubeletstatsreceiver/ @pmcollins @asuresh4
/receiver/prometheusexecreceiver/ @keitwb @james-bebbington
/receiver/receivercreator/ @jrcamp
/receiver/redisreceiver/ @pmcollins @jrcamp
/receiver/sapmreceiver/ @owais
/receiver/signalfxreceiver/ @pjanotti @asuresh4
/receiver/simpleprometheusreceiver/ @asuresh4
/receiver/statsdreceiver/ @keitwb @jmacd
/receiver/wavefrontreceiver/ @pjanotti
