### PR TITLE
Fix comments in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
-**Description:** <Describe what has changed. 
-Ex. Fixing a bug - Describe the bug and how this fixes the issue.
-Ex. Adding a feature - Explain what this achieves.>
+**Description:** <Describe what has changed.>
+<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
+Ex. Adding a feature - Explain what this achieves.-->
 
 **Link to tracking Issue:** <Issue number if applicable>
 
-**Testing:** < Describe what testing was performed and which tests were added.>
+**Testing:** <Describe what testing was performed and which tests were added.>
 
-**Documentation:** < Describe the documentation added.>
+**Documentation:** <Describe the documentation added.>


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fix the comments in the PR template file. I'm assuming we want the section descriptions and examples hidden once the PR is opened, so if that assumption is incorrect we can just close this.

**Link to tracking Issue:** <Issue number if applicable>
N/A

**Testing:** <Describe what testing was performed and which tests were added.>
## Before
![ot-pr-template-before](https://user-images.githubusercontent.com/6614021/91073794-67867c00-e5f0-11ea-8861-bed327eb5324.png)

## After
![ot-pr-template-after](https://user-images.githubusercontent.com/6614021/91073804-6e14f380-e5f0-11ea-9401-44906f5f48b8.png)

**Documentation:** <Describe the documentation added.>
N/A