### PR TITLE
sfx exporter: wrap MetricTranslator and logger in MetricsConverter

### DIFF
--- a/exporter/signalfxexporter/dpclient.go
+++ b/exporter/signalfxexporter/dpclient.go
@@ -43,7 +43,7 @@ type sfxDPClient struct {
 	logger                 *zap.Logger
 	zippers                sync.Pool
 	accessTokenPassthrough bool
-	metricTranslator       *translation.MetricTranslator
+	converter              *translation.MetricsConverter
 }
 
 func (s *sfxDPClient) pushMetricsData(
@@ -51,7 +51,8 @@ func (s *sfxDPClient) pushMetricsData(
 	md consumerdata.MetricsData,
 ) (droppedTimeSeries int, err error) {
 	accessToken := s.retrieveAccessToken(md)
-	sfxDataPoints, numDroppedTimeseries := translation.MetricDataToSignalFxV2(s.logger, s.metricTranslator, md)
+
+	sfxDataPoints, numDroppedTimeseries := s.converter.MetricDataToSignalFxV2(md)
 
 	body, compressed, err := s.encodeBody(sfxDataPoints)
 	if err != nil {

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -85,7 +85,7 @@ func newSignalFxExporter(
 			return gzip.NewWriter(nil)
 		}},
 		accessTokenPassthrough: config.AccessTokenPassthrough,
-		metricTranslator:       options.metricTranslator,
+		converter:              translation.NewMetricsConverter(logger, options.metricTranslator),
 	}
 
 	dimClient := dimensions.NewDimensionClient(

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -38,6 +38,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/dimensions"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/translation"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/collection"
 )
 
@@ -130,6 +131,7 @@ func TestConsumeMetricsData(t *testing.T) {
 				zippers: sync.Pool{New: func() interface{} {
 					return gzip.NewWriter(nil)
 				}},
+				converter: translation.NewMetricsConverter(zap.NewNop(), nil),
 			}
 
 			numDroppedTimeSeries, err := dpClient.pushMetricsData(context.Background(), *tt.md)
@@ -233,6 +235,7 @@ func TestConsumeMetricsDataWithAccessTokenPassthrough(t *testing.T) {
 					return gzip.NewWriter(nil)
 				}},
 				accessTokenPassthrough: tt.accessTokenPassthrough,
+				converter:              translation.NewMetricsConverter(zap.NewNop(), nil),
 			}
 
 			numDroppedTimeSeries, err := dpClient.pushMetricsData(context.Background(), newMetricData(tt.includedInMetricData))

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -215,7 +215,8 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.NoError(t, err)
 	data := md()
 
-	translated, _ := translation.MetricDataToSignalFxV2(zap.NewNop(), tr, data)
+	c := translation.NewMetricsConverter(zap.NewNop(), tr)
+	translated, _ := c.MetricDataToSignalFxV2(data)
 	require.NotNil(t, translated)
 
 	metrics := make(map[string][]*sfxpb.DataPoint)

--- a/exporter/signalfxexporter/translation/converter_test.go
+++ b/exporter/signalfxexporter/translation/converter_test.go
@@ -177,9 +177,10 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 			wantSfxDataPoints: expectedFromSummary("summary", tsMSecs, keys, values, summaryTimeSeries),
 		},
 	}
+	c := NewMetricsConverter(logger, nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSfxDataPoints, gotNumDroppedTimeSeries := MetricDataToSignalFxV2(logger, nil, tt.metricsDataFn())
+			gotSfxDataPoints, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(tt.metricsDataFn())
 			assert.Equal(t, tt.wantNumDroppedTimeseries, gotNumDroppedTimeSeries)
 			// Sort SFx dimensions since they are built from maps and the order
 			// of those is not deterministic.
@@ -238,7 +239,8 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 			},
 		},
 	}
-	got, dropped := MetricDataToSignalFxV2(zap.NewNop(), translator, md)
+	c := NewMetricsConverter(zap.NewNop(), translator)
+	got, dropped := c.MetricDataToSignalFxV2(md)
 
 	assert.EqualValues(t, 0, dropped)
 	assert.EqualValues(t, expected, got)
@@ -404,7 +406,8 @@ func Test_InvalidDistribution_NoExplicitBuckets(t *testing.T) {
 				point)),
 		},
 	}
-	_, gotNumDroppedTimeSeries := MetricDataToSignalFxV2(logger, nil, metricData)
+	c := NewMetricsConverter(logger, nil)
+	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData)
 	assert.Equal(t, 1, gotNumDroppedTimeSeries)
 }
 
@@ -431,7 +434,8 @@ func Test_InvalidSummary_NoPercentileValues(t *testing.T) {
 				point)),
 		},
 	}
-	_, gotNumDroppedTimeSeries := MetricDataToSignalFxV2(logger, nil, metricData)
+	c := NewMetricsConverter(logger, nil)
+	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData)
 	assert.Equal(t, 1, gotNumDroppedTimeSeries)
 }
 
@@ -452,7 +456,8 @@ func Test_InvalidPoint_NoValue(t *testing.T) {
 				point)),
 		},
 	}
-	_, gotNumDroppedTimeSeries := MetricDataToSignalFxV2(logger, nil, metricData)
+	c := NewMetricsConverter(logger, nil)
+	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData)
 	assert.Equal(t, 1, gotNumDroppedTimeSeries)
 }
 
@@ -467,7 +472,8 @@ func Test_InvalidMetric(t *testing.T) {
 			},
 		},
 	}
-	_, gotNumDroppedTimeSeries := MetricDataToSignalFxV2(logger, nil, metricData)
+	c := NewMetricsConverter(logger, nil)
+	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData)
 	// Only 1 timeseries is dropped because the nil metric does not have any timeseries.
 	assert.Equal(t, 1, gotNumDroppedTimeSeries)
 }


### PR DESCRIPTION
**Description:** This change adds a type, MetricsConverter, which wraps a
MetricTranslator and logger. MetricsConverter has the same lifecycle as
signalfxExporter, and will be able to maintain state if desired, which
may be needed to calculate deltas.

**Testing:** Unit tests pass.

**Documentation:** Docs added to exported types/functions.