### PR TITLE
AWS X-Ray exporter: Support and default to convert span attributes to X-Ray metadata

### DIFF
--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -69,7 +69,8 @@ func NewTraceExporter(config configmodels.Exporter, logger *zap.Logger, cn connA
 							continue
 						}
 
-						document, localErr := translator.MakeSegmentDocumentString(span, resource)
+						document, localErr := translator.MakeSegmentDocumentString(span, resource,
+							config.(*Config).IndexedAttributes, config.(*Config).IndexAllAttributes)
 						if localErr != nil {
 							totalDroppedSpans++
 							continue

--- a/exporter/awsxrayexporter/config.go
+++ b/exporter/awsxrayexporter/config.go
@@ -39,4 +39,11 @@ type Config struct {
 	ResourceARN string `mapstructure:"resource_arn"`
 	// IAM role to upload segments to a different account.
 	RoleARN string `mapstructure:"role_arn"`
+	// By default, OpenTelemetry attributes are converted to X-Ray metadata, which are not indexed.
+	// Specify a list of attribute names to be converted to X-Ray annotations instead, which will be indexed.
+	// See annotation vs. metadata: https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-annotations
+	IndexedAttributes []string `mapstructure:"indexed_attributes"`
+	// Set to true to convert all OpenTelemetry attributes to X-Ray annotation (indexed) ignoring the IndexedAttributes option.
+	// Default value: false
+	IndexAllAttributes bool `mapstructure:"index_all_attributes"`
 }

--- a/exporter/awsxrayexporter/config_test.go
+++ b/exporter/awsxrayexporter/config_test.go
@@ -57,5 +57,7 @@ func TestLoadConfig(t *testing.T) {
 			LocalMode:             false,
 			ResourceARN:           "arn:aws:ec2:us-east1:123456789:instance/i-293hiuhe0u",
 			RoleARN:               "arn:aws:iam::123456789:role/monitoring-EKS-NodeInstanceRole",
+			IndexedAttributes:     []string{"indexed_attr_0", "indexed_attr_1"},
+			IndexAllAttributes:    false,
 		})
 }

--- a/exporter/awsxrayexporter/testdata/config.yaml
+++ b/exporter/awsxrayexporter/testdata/config.yaml
@@ -10,6 +10,7 @@ exporters:
     region: eu-west-1
     resource_arn: "arn:aws:ec2:us-east1:123456789:instance/i-293hiuhe0u"
     role_arn: "arn:aws:iam::123456789:role/monitoring-EKS-NodeInstanceRole"
+    indexed_attributes: ["indexed_attr_0", "indexed_attr_1"]
 
 service:
   pipelines:

--- a/exporter/awsxrayexporter/translator/segment.go
+++ b/exporter/awsxrayexporter/translator/segment.go
@@ -293,9 +293,9 @@ func timestampToFloatSeconds(ts pdata.TimestampUnixNano) float64 {
 func makeXRayAttributes(attributes map[string]string, indexedAttrs []string, indexAllAttrs bool) (
 	string, map[string]interface{}, map[string]map[string]interface{}) {
 	var (
-		annotations     = map[string]interface{}{}
-		metadata        = map[string]map[string]interface{}{}
-		user            string
+		annotations = map[string]interface{}{}
+		metadata    = map[string]map[string]interface{}{}
+		user        string
 	)
 	delete(attributes, semconventions.AttributeComponent)
 	userid, ok := attributes[semconventions.AttributeEnduserID]

--- a/exporter/awsxrayexporter/translator/segment.go
+++ b/exporter/awsxrayexporter/translator/segment.go
@@ -65,9 +65,9 @@ var (
 	writers = newWriterPool(2048)
 )
 
-// MakeSegmentDocumentString converts an OpenCensus Span to an X-Ray Segment and then serialzies to JSON
-func MakeSegmentDocumentString(span pdata.Span, resource pdata.Resource) (string, error) {
-	segment := MakeSegment(span, resource)
+// MakeSegmentDocumentString converts an OpenTelemetry Span to an X-Ray Segment and then serialzies to JSON
+func MakeSegmentDocumentString(span pdata.Span, resource pdata.Resource, indexedAttrs []string, indexAllAttrs bool) (string, error) {
+	segment := MakeSegment(span, resource, indexedAttrs, indexAllAttrs)
 	w := writers.borrow()
 	if err := w.Encode(segment); err != nil {
 		return "", err
@@ -77,8 +77,8 @@ func MakeSegmentDocumentString(span pdata.Span, resource pdata.Resource) (string
 	return jsonStr, nil
 }
 
-// MakeSegment converts an OpenCensus Span to an X-Ray Segment
-func MakeSegment(span pdata.Span, resource pdata.Resource) awsxray.Segment {
+// MakeSegment converts an OpenTelemetry Span to an X-Ray Segment
+func MakeSegment(span pdata.Span, resource pdata.Resource, indexedAttrs []string, indexAllAttrs bool) awsxray.Segment {
 	var (
 		traceID                                = convertToAmazonTraceID(span.TraceID())
 		startTime                              = timestampToFloatSeconds(span.StartTime())
@@ -90,7 +90,7 @@ func MakeSegment(span pdata.Span, resource pdata.Resource) awsxray.Segment {
 		awsfiltered, aws                       = makeAws(causefiltered, resource)
 		service                                = makeService(resource)
 		sqlfiltered, sql                       = makeSQL(awsfiltered)
-		user, annotations                      = makeAnnotations(sqlfiltered)
+		user, annotations, metadata            = makeXRayAttributes(sqlfiltered, indexedAttrs, indexAllAttrs)
 		name                                   string
 		namespace                              string
 		segmentType                            string
@@ -185,7 +185,7 @@ func MakeSegment(span pdata.Span, resource pdata.Resource) awsxray.Segment {
 		Service:     service,
 		SQL:         sql,
 		Annotations: annotations,
-		Metadata:    nil,
+		Metadata:    metadata,
 		Type:        awsP.String(segmentType),
 	}
 }
@@ -290,17 +290,12 @@ func timestampToFloatSeconds(ts pdata.TimestampUnixNano) float64 {
 	return float64(ts) / float64(time.Second)
 }
 
-func sanitizeAndTransferAnnotations(dest map[string]interface{}, src map[string]string) {
-	for key, value := range src {
-		key = fixAnnotationKey(key)
-		dest[key] = value
-	}
-}
-
-func makeAnnotations(attributes map[string]string) (string, map[string]interface{}) {
+func makeXRayAttributes(attributes map[string]string, indexedAttrs []string, indexAllAttrs bool) (
+	string, map[string]interface{}, map[string]map[string]interface{}) {
 	var (
-		result = map[string]interface{}{}
-		user   string
+		annotations     = map[string]interface{}{}
+		metadata        = map[string]map[string]interface{}{}
+		user            string
 	)
 	delete(attributes, semconventions.AttributeComponent)
 	userid, ok := attributes[semconventions.AttributeEnduserID]
@@ -308,12 +303,37 @@ func makeAnnotations(attributes map[string]string) (string, map[string]interface
 		user = userid
 		delete(attributes, semconventions.AttributeEnduserID)
 	}
-	sanitizeAndTransferAnnotations(result, attributes)
 
-	if len(result) == 0 {
-		return user, nil
+	if len(attributes) == 0 {
+		return user, nil, nil
 	}
-	return user, result
+
+	if indexAllAttrs {
+		for key, value := range attributes {
+			key = fixAnnotationKey(key)
+			annotations[key] = value
+		}
+	} else {
+		defaultMetadata := map[string]interface{}{}
+		indexedKeys := map[string]interface{}{}
+		for _, name := range indexedAttrs {
+			indexedKeys[name] = true
+		}
+
+		for key, value := range attributes {
+			if _, ok := indexedKeys[key]; ok {
+				key = fixAnnotationKey(key)
+				annotations[key] = value
+			} else {
+				defaultMetadata[key] = value
+			}
+		}
+		if len(defaultMetadata) > 0 {
+			metadata["default"] = defaultMetadata
+		}
+	}
+
+	return user, annotations, metadata
 }
 
 // fixSegmentName removes any invalid characters from the span name.  AWS X-Ray defines

--- a/exporter/awsxrayexporter/translator/segment_test.go
+++ b/exporter/awsxrayexporter/translator/segment_test.go
@@ -51,12 +51,12 @@ func TestClientSpanWithAwsSdkClient(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
 
-	segment := MakeSegment(span, resource)
+	segment := MakeSegment(span, resource, nil, false)
 	assert.Equal(t, "DynamoDB", *segment.Name)
 	assert.Equal(t, "aws", *segment.Namespace)
 	assert.Equal(t, "subsegment", *segment.Type)
 
-	jsonStr, err := MakeSegmentDocumentString(span, resource)
+	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false)
 
 	assert.NotNil(t, jsonStr)
 	assert.Nil(t, err)
@@ -82,7 +82,7 @@ func TestClientSpanWithPeerService(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
 
-	segment := MakeSegment(span, resource)
+	segment := MakeSegment(span, resource, nil, false)
 	assert.Equal(t, "cats-table", *segment.Name)
 }
 
@@ -106,7 +106,7 @@ func TestServerSpanWithInternalServerError(t *testing.T) {
 	timeEvents := constructTimedEventsWithSentMessageEvent(span.StartTime())
 	timeEvents.CopyTo(span.Events())
 
-	segment := MakeSegment(span, resource)
+	segment := MakeSegment(span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.NotNil(t, segment.Cause)
@@ -130,7 +130,7 @@ func TestServerSpanNoParentId(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, 0, "OK", nil)
 
-	segment := MakeSegment(span, resource)
+	segment := MakeSegment(span, resource, nil, false)
 
 	assert.Empty(t, segment.ParentID)
 }
@@ -145,7 +145,7 @@ func TestSpanWithNoStatus(t *testing.T) {
 	span.SetStartTime(pdata.TimestampUnixNano(time.Now().UnixNano()))
 	span.SetEndTime(pdata.TimestampUnixNano(time.Now().Add(10).UnixNano()))
 
-	segment := MakeSegment(span, pdata.NewResource())
+	segment := MakeSegment(span, pdata.NewResource(), nil, false)
 	assert.NotNil(t, segment)
 }
 
@@ -165,13 +165,15 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
 
-	segment := MakeSegment(span, resource)
+	segment := MakeSegment(span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.NotNil(t, segment.SQL)
 	assert.NotNil(t, segment.Service)
 	assert.NotNil(t, segment.AWS)
-	assert.NotNil(t, segment.Annotations)
+	assert.NotNil(t, segment.Metadata)
+	assert.Equal(t, 0, len(segment.Annotations))
+	assert.Equal(t, enterpriseAppID, segment.Metadata["default"]["enterprise.app.id"])
 	assert.Nil(t, segment.Cause)
 	assert.Nil(t, segment.HTTP)
 	assert.Equal(t, "customers@db.dev.example.com", *segment.Name)
@@ -185,6 +187,7 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	}
 	jsonStr := w.String()
 	testWriters.release(w)
+	fmt.Println(jsonStr)
 	assert.True(t, strings.Contains(jsonStr, spanName))
 	assert.True(t, strings.Contains(jsonStr, enterpriseAppID))
 }
@@ -203,7 +206,7 @@ func TestClientSpanWithHttpHost(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
 
-	segment := MakeSegment(span, resource)
+	segment := MakeSegment(span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "foo.com", *segment.Name)
@@ -222,7 +225,7 @@ func TestClientSpanWithoutHttpHost(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
 
-	segment := MakeSegment(span, resource)
+	segment := MakeSegment(span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "bar.com", *segment.Name)
@@ -242,7 +245,7 @@ func TestClientSpanWithRpcHost(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
 
-	segment := MakeSegment(span, resource)
+	segment := MakeSegment(span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "com.foo.AnimalService", *segment.Name)
@@ -265,7 +268,7 @@ func TestSpanWithInvalidTraceId(t *testing.T) {
 	traceID[0] = 0x11
 	span.SetTraceID(traceID)
 
-	jsonStr, err := MakeSegmentDocumentString(span, resource)
+	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false)
 
 	assert.NotNil(t, jsonStr)
 	assert.Nil(t, err)
@@ -324,12 +327,66 @@ func TestServerSpanWithNilAttributes(t *testing.T) {
 	timeEvents.CopyTo(span.Events())
 	pdata.NewAttributeMap().CopyTo(span.Attributes())
 
-	segment := MakeSegment(span, resource)
+	segment := MakeSegment(span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.NotNil(t, segment.Cause)
 	assert.Equal(t, "signup_aggregator", *segment.Name)
 	assert.True(t, *segment.Fault)
+}
+
+func TestSpanWithAttributesDefaultNotIndexed(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes["attr1@1"] = "val1"
+	attributes["attr2@2"] = "val2"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, tracetranslator.OCInternal, "OK", attributes)
+
+	segment := MakeSegment(span, resource, nil, false)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, 0, len(segment.Annotations))
+	assert.Equal(t, 2, len(segment.Metadata["default"]))
+	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
+	assert.Equal(t, "val2", segment.Metadata["default"]["attr2@2"])
+}
+
+func TestSpanWithAttributesPartlyIndexed(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes["attr1@1"] = "val1"
+	attributes["attr2@2"] = "val2"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, tracetranslator.OCInternal, "OK", attributes)
+
+	segment := MakeSegment(span, resource, []string{"attr1@1", "not_exist"}, false)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, 1, len(segment.Annotations))
+	assert.Equal(t, "val1", segment.Annotations["attr1_1"])
+	assert.Equal(t, 1, len(segment.Metadata["default"]))
+	assert.Equal(t, "val2", segment.Metadata["default"]["attr2@2"])
+}
+
+func TestSpanWithAttributesAllIndexed(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes["attr1@1"] = "val1"
+	attributes["attr2@2"] = "val2"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, tracetranslator.OCInternal, "OK", attributes)
+
+	segment := MakeSegment(span, resource, []string{"attr1@1", "not_exist"}, true)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, 2, len(segment.Annotations))
+	assert.Equal(t, "val1", segment.Annotations["attr1_1"])
+	assert.Equal(t, "val2", segment.Annotations["attr2_2"])
+	assert.Equal(t, 0, len(segment.Metadata["default"]))
 }
 
 func constructClientSpan(parentSpanID []byte, name string, code int32, message string, attributes map[string]interface{}) pdata.Span {

--- a/exporter/awsxrayexporter/translator/writer_pool_test.go
+++ b/exporter/awsxrayexporter/translator/writer_pool_test.go
@@ -35,7 +35,7 @@ func TestWriterPoolBasic(t *testing.T) {
 	assert.NotNil(t, w.encoder)
 	assert.Equal(t, size, w.buffer.Cap())
 	assert.Equal(t, 0, w.buffer.Len())
-	if err := w.Encode(MakeSegment(span, pdata.NewResource())); err != nil {
+	if err := w.Encode(MakeSegment(span, pdata.NewResource(), nil, false)); err != nil {
 		assert.Fail(t, "invalid json")
 	}
 	jsonStr := w.String()
@@ -51,7 +51,7 @@ func BenchmarkWithoutPool(b *testing.B) {
 		b.StartTimer()
 		buffer := bytes.NewBuffer(make([]byte, 0, 2048))
 		encoder := json.NewEncoder(buffer)
-		encoder.Encode(MakeSegment(span, pdata.NewResource()))
+		encoder.Encode(MakeSegment(span, pdata.NewResource(), nil, false))
 		logger.Info(buffer.String())
 	}
 }
@@ -64,7 +64,7 @@ func BenchmarkWithPool(b *testing.B) {
 		span := constructWriterPoolSpan()
 		b.StartTimer()
 		w := wp.borrow()
-		w.Encode(MakeSegment(span, pdata.NewResource()))
+		w.Encode(MakeSegment(span, pdata.NewResource(), nil, false))
 		logger.Info(w.String())
 	}
 }


### PR DESCRIPTION
**Description:** 
* Changed the X-Ray segment translator to convert the span attributes to X-Ray metadata by default. 
* Provided options to specify indexed attributes to convert to annotation instead..

**Link to tracking Issue:** #807 

**Testing:** Existing unit tests updated. New ones added. End-to-end tested in local
