### PR TITLE
signalfxexporter: Group metrics by token

### DIFF
--- a/exporter/signalfxexporter/dpclient.go
+++ b/exporter/signalfxexporter/dpclient.go
@@ -67,7 +67,9 @@ func (s *sfxDPClient) pushMetricsData(
 		//    there are a lot of tokens.
 		droppedCount, err := s.pushMetricsDataForToken(metricsData, accessToken)
 		numDroppedTimeseries += droppedCount
-		errs = append(errs, err)
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return numDroppedTimeseries, componenterror.CombineErrors(errs)

--- a/exporter/signalfxexporter/dpclient.go
+++ b/exporter/signalfxexporter/dpclient.go
@@ -108,13 +108,13 @@ func (s *sfxDPClient) pushMetricsDataForToken(
 		return numTimeseries, consumererror.Permanent(err)
 	}
 
-	// Override access token in headers map if it's non empty.
-	if accessToken != "" {
-		s.headers[splunk.SFxAccessTokenHeader] = accessToken
-	}
-
 	for k, v := range s.headers {
 		req.Header.Set(k, v)
+	}
+
+	// Override access token in headers map if it's non empty.
+	if accessToken != "" {
+		req.Header.Set(splunk.SFxAccessTokenHeader, accessToken)
 	}
 
 	if compressed {

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -385,9 +385,6 @@ func TestConsumeMetricsWithAccessTokenPassthrough(t *testing.T) {
 
 				token := r.Header.Get("x-sf-token")
 				receivedTokens.tokens = append(receivedTokens.tokens, token)
-				if _, ok := receivedTokens.totalCalls[token]; !ok {
-					receivedTokens.totalCalls[token] = 0
-				}
 				receivedTokens.totalCalls[token]++
 
 				receivedTokens.Unlock()

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -270,7 +270,7 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.True(t, ok, "container_memory_major_page_faults not found")
 }
 
-func md() consumerdata.MetricsData {
+func md() []consumerdata.MetricsData {
 	md := consumerdata.MetricsData{
 		Metrics: []*metricspb.Metric{
 			{
@@ -614,7 +614,7 @@ func md() consumerdata.MetricsData {
 			},
 		},
 	}
-	return md
+	return []consumerdata.MetricsData{md}
 }
 
 func TestDefaultDiskTranslations(t *testing.T) {

--- a/exporter/signalfxexporter/go.sum
+++ b/exporter/signalfxexporter/go.sum
@@ -115,6 +115,7 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.31.9 h1:n+b34ydVfgC30j0Qm69yaapmjejQPW2BoDBX7Uy/tLI=
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -132,6 +133,7 @@ github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n
 github.com/cenkalti/backoff v0.0.0-20181003080854-62661b46c409/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/census-instrumentation/opencensus-proto v0.3.0 h1:t/LhUZLVitR1Ow2YOnduCsavhwFUklBMoGVYUCqmCqk=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
@@ -229,6 +231,7 @@ github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTD
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
@@ -374,6 +377,7 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -409,6 +413,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -495,6 +500,7 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -545,6 +551,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -1355,11 +1362,13 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20200724153422-f32512634ab7 h1:bYyloM4UeWug24euLZfEH7muFQoqvFj9h/pxAnOZLt4=
 k8s.io/utils v0.0.0-20200724153422-f32512634ab7/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 mvdan.cc/gofumpt v0.0.0-20200709182408-4fd085cb6d5f h1:gi7cb8HTDZ6q8VqsUpkdoFi3vxwHMneQ6+Q5Ap5hjPE=
 mvdan.cc/gofumpt v0.0.0-20200709182408-4fd085cb6d5f/go.mod h1:9VQ397fNXEnF84t90W4r4TRCQK+pg9f8ugVfyj+S26w=
@@ -1371,8 +1380,10 @@ rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
+sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=

--- a/exporter/signalfxexporter/translation/converter.go
+++ b/exporter/signalfxexporter/translation/converter.go
@@ -93,132 +93,134 @@ func NewMetricsConverter(logger *zap.Logger, t *MetricTranslator) *MetricsConver
 // MetricDataToSignalFxV2 converts the passed in MetricsData to SFx datapoints,
 // returning those datapoints and the number of time series that had to be
 // dropped because of errors or warnings.
-func (c *MetricsConverter) MetricDataToSignalFxV2(md []consumerdata.MetricsData) (
+func (c *MetricsConverter) MetricDataToSignalFxV2(mds []consumerdata.MetricsData) (
 	sfxDataPoints []*sfxpb.DataPoint,
 	numDroppedTimeSeries int,
 ) {
-	sfxDataPoints, numDroppedTimeSeries = c.metricDataToSfxDataPoints(md)
+	for _, md := range mds {
+		dps, droppedDPCount := c.metricDataToSfxDataPoints(md)
+		sfxDataPoints = append(sfxDataPoints, dps...)
+		numDroppedTimeSeries += droppedDPCount
+	}
 	sanitizeDataPointDimensions(sfxDataPoints)
 	return
 }
 
-func (c *MetricsConverter) metricDataToSfxDataPoints(mds []consumerdata.MetricsData) (
+func (c *MetricsConverter) metricDataToSfxDataPoints(md consumerdata.MetricsData) (
 	sfxDataPoints []*sfxpb.DataPoint,
 	numDroppedTimeSeries int,
 ) {
 	var err error
 
-	for _, md := range mds {
-		// Labels from Node and Resource.
-		// TODO: Options to add lib, service name, etc as dimensions?
-		//  Q.: what about resource type?
-		nodeAttribs := md.Node.GetAttributes()
-		resourceAttribs := md.Resource.GetLabels()
-		numExtraDimensions := len(nodeAttribs) + len(resourceAttribs)
-		var extraDimensions []*sfxpb.Dimension
-		if numExtraDimensions > 0 {
-			extraDimensions = make([]*sfxpb.Dimension, 0, numExtraDimensions)
-			extraDimensions = appendAttributesToDimensions(extraDimensions, nodeAttribs)
-			extraDimensions = appendAttributesToDimensions(extraDimensions, resourceAttribs)
+	// Labels from Node and Resource.
+	// TODO: Options to add lib, service name, etc as dimensions?
+	//  Q.: what about resource type?
+	nodeAttribs := md.Node.GetAttributes()
+	resourceAttribs := md.Resource.GetLabels()
+	numExtraDimensions := len(nodeAttribs) + len(resourceAttribs)
+	var extraDimensions []*sfxpb.Dimension
+	if numExtraDimensions > 0 {
+		extraDimensions = make([]*sfxpb.Dimension, 0, numExtraDimensions)
+		extraDimensions = appendAttributesToDimensions(extraDimensions, nodeAttribs)
+		extraDimensions = appendAttributesToDimensions(extraDimensions, resourceAttribs)
+	}
+
+	for _, metric := range md.Metrics {
+		if metric == nil || metric.MetricDescriptor == nil {
+			c.logger.Warn("Received nil metrics data or nil descriptor for metrics")
+			numDroppedTimeSeries += len(metric.GetTimeseries())
+			continue
 		}
 
-		for _, metric := range md.Metrics {
-			if metric == nil || metric.MetricDescriptor == nil {
-				c.logger.Warn("Received nil metrics data or nil descriptor for metrics")
-				numDroppedTimeSeries += len(metric.GetTimeseries())
-				continue
+		if sfxDataPoints == nil {
+			// Suppose all metrics has roughly similar number of timeseries
+			sfxDataPoints = make([]*sfxpb.DataPoint, 0, len(md.Metrics)*len(metric.Timeseries))
+		}
+
+		metricDataPoints := make([]*sfxpb.DataPoint, 0, len(metric.Timeseries))
+
+		// Build the fixed parts for this metrics from the descriptor.
+		descriptor := metric.MetricDescriptor
+		metricName := descriptor.Name
+
+		metricType := fromOCMetricDescriptorToMetricType(descriptor.Type)
+		numLabels := len(descriptor.LabelKeys)
+
+		for _, series := range metric.Timeseries {
+			dimensions := make([]*sfxpb.Dimension, numLabels+numExtraDimensions)
+			copy(dimensions, extraDimensions)
+			for i := 0; i < numLabels; i++ {
+				dimension := &sfxpb.Dimension{
+					Key:   descriptor.LabelKeys[i].Key,
+					Value: series.LabelValues[i].Value,
+				}
+				dimensions[numExtraDimensions+i] = dimension
 			}
 
-			if sfxDataPoints == nil {
-				// Suppose all metrics has roughly similar number of timeseries
-				sfxDataPoints = make([]*sfxpb.DataPoint, 0, len(md.Metrics)*len(metric.Timeseries))
-			}
+			for _, dp := range series.Points {
 
-			metricDataPoints := make([]*sfxpb.DataPoint, 0, len(metric.Timeseries))
-
-			// Build the fixed parts for this metrics from the descriptor.
-			descriptor := metric.MetricDescriptor
-			metricName := descriptor.Name
-
-			metricType := fromOCMetricDescriptorToMetricType(descriptor.Type)
-			numLabels := len(descriptor.LabelKeys)
-
-			for _, series := range metric.Timeseries {
-				dimensions := make([]*sfxpb.Dimension, numLabels+numExtraDimensions)
-				copy(dimensions, extraDimensions)
-				for i := 0; i < numLabels; i++ {
-					dimension := &sfxpb.Dimension{
-						Key:   descriptor.LabelKeys[i].Key,
-						Value: series.LabelValues[i].Value,
-					}
-					dimensions[numExtraDimensions+i] = dimension
+				var msec int64
+				if dp.Timestamp != nil {
+					msec = dp.Timestamp.Seconds*1e3 + int64(dp.Timestamp.Nanos)/1e6
 				}
 
-				for _, dp := range series.Points {
+				sfxDataPoint := &sfxpb.DataPoint{
+					// Source field is not set by code seen at
+					// github.com/signalfx/golib/sfxclient/httpsink.go
+					Metric:     metricName,
+					MetricType: metricType,
+					Timestamp:  msec,
+					Dimensions: dimensions,
+				}
 
-					var msec int64
-					if dp.Timestamp != nil {
-						msec = dp.Timestamp.Seconds*1e3 + int64(dp.Timestamp.Nanos)/1e6
-					}
+				switch pv := dp.Value.(type) {
+				case *metricspb.Point_Int64Value:
+					sfxDataPoint.Value = sfxpb.Datum{IntValue: &pv.Int64Value}
+					metricDataPoints = append(metricDataPoints, sfxDataPoint)
 
-					sfxDataPoint := &sfxpb.DataPoint{
-						// Source field is not set by code seen at
-						// github.com/signalfx/golib/sfxclient/httpsink.go
-						Metric:     metricName,
-						MetricType: metricType,
-						Timestamp:  msec,
-						Dimensions: dimensions,
-					}
+				case *metricspb.Point_DoubleValue:
+					sfxDataPoint.Value = sfxpb.Datum{DoubleValue: &pv.DoubleValue}
+					metricDataPoints = append(metricDataPoints, sfxDataPoint)
 
-					switch pv := dp.Value.(type) {
-					case *metricspb.Point_Int64Value:
-						sfxDataPoint.Value = sfxpb.Datum{IntValue: &pv.Int64Value}
-						metricDataPoints = append(metricDataPoints, sfxDataPoint)
-
-					case *metricspb.Point_DoubleValue:
-						sfxDataPoint.Value = sfxpb.Datum{DoubleValue: &pv.DoubleValue}
-						metricDataPoints = append(metricDataPoints, sfxDataPoint)
-
-					case *metricspb.Point_DistributionValue:
-						metricDataPoints, err = appendDistributionValues(
-							metricDataPoints,
-							sfxDataPoint,
-							pv.DistributionValue)
-						if err != nil {
-							numDroppedTimeSeries++
-							c.logger.Warn(
-								"Timeseries for distribution metric dropped",
-								zap.Error(err),
-								zap.String("metric", sfxDataPoint.Metric))
-						}
-					case *metricspb.Point_SummaryValue:
-						metricDataPoints, err = appendSummaryValues(
-							metricDataPoints,
-							sfxDataPoint,
-							pv.SummaryValue)
-						if err != nil {
-							numDroppedTimeSeries++
-							c.logger.Warn(
-								"Timeseries for summary metric dropped",
-								zap.Error(err),
-								zap.String("metric", sfxDataPoint.Metric))
-						}
-					default:
+				case *metricspb.Point_DistributionValue:
+					metricDataPoints, err = appendDistributionValues(
+						metricDataPoints,
+						sfxDataPoint,
+						pv.DistributionValue)
+					if err != nil {
 						numDroppedTimeSeries++
 						c.logger.Warn(
-							"Timeseries dropped to unexpected metric type",
+							"Timeseries for distribution metric dropped",
+							zap.Error(err),
 							zap.String("metric", sfxDataPoint.Metric))
 					}
-
+				case *metricspb.Point_SummaryValue:
+					metricDataPoints, err = appendSummaryValues(
+						metricDataPoints,
+						sfxDataPoint,
+						pv.SummaryValue)
+					if err != nil {
+						numDroppedTimeSeries++
+						c.logger.Warn(
+							"Timeseries for summary metric dropped",
+							zap.Error(err),
+							zap.String("metric", sfxDataPoint.Metric))
+					}
+				default:
+					numDroppedTimeSeries++
+					c.logger.Warn(
+						"Timeseries dropped to unexpected metric type",
+						zap.String("metric", sfxDataPoint.Metric))
 				}
-			}
 
-			if c.metricTranslator != nil {
-				metricDataPoints = c.metricTranslator.TranslateDataPoints(c.logger, metricDataPoints)
 			}
-
-			sfxDataPoints = append(sfxDataPoints, metricDataPoints...)
 		}
+
+		if c.metricTranslator != nil {
+			metricDataPoints = c.metricTranslator.TranslateDataPoints(c.logger, metricDataPoints)
+		}
+
+		sfxDataPoints = append(sfxDataPoints, metricDataPoints...)
 	}
 
 	return sfxDataPoints, numDroppedTimeSeries

--- a/exporter/signalfxexporter/translation/converter_test.go
+++ b/exporter/signalfxexporter/translation/converter_test.go
@@ -70,19 +70,21 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		metricsDataFn            func() consumerdata.MetricsData
+		metricsDataFn            func() []consumerdata.MetricsData
 		wantSfxDataPoints        []*sfxpb.DataPoint
 		wantNumDroppedTimeseries int
 	}{
 		{
 			name: "nil_node_nil_resources_no_dims",
-			metricsDataFn: func() consumerdata.MetricsData {
-				return consumerdata.MetricsData{
-					Metrics: []*metricspb.Metric{
-						metricstestutil.Gauge("gauge_double_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, doublePt)),
-						metricstestutil.GaugeInt("gauge_int_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, int64Pt)),
-						metricstestutil.Cumulative("cumulative_double_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, doublePt)),
-						metricstestutil.CumulativeInt("cumulative_int_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, int64Pt)),
+			metricsDataFn: func() []consumerdata.MetricsData {
+				return []consumerdata.MetricsData{
+					{
+						Metrics: []*metricspb.Metric{
+							metricstestutil.Gauge("gauge_double_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, doublePt)),
+							metricstestutil.GaugeInt("gauge_int_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, int64Pt)),
+							metricstestutil.Cumulative("cumulative_double_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, doublePt)),
+							metricstestutil.CumulativeInt("cumulative_int_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, int64Pt)),
+						},
 					},
 				}
 			},
@@ -95,13 +97,15 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 		},
 		{
 			name: "nil_node_and_resources_with_dims",
-			metricsDataFn: func() consumerdata.MetricsData {
-				return consumerdata.MetricsData{
-					Metrics: []*metricspb.Metric{
-						metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-						metricstestutil.GaugeInt("gauge_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
-						metricstestutil.Cumulative("cumulative_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-						metricstestutil.CumulativeInt("cumulative_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
+			metricsDataFn: func() []consumerdata.MetricsData {
+				return []consumerdata.MetricsData{
+					{
+						Metrics: []*metricspb.Metric{
+							metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
+							metricstestutil.GaugeInt("gauge_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
+							metricstestutil.Cumulative("cumulative_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
+							metricstestutil.CumulativeInt("cumulative_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
+						},
 					},
 				}
 			},
@@ -114,23 +118,25 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 		},
 		{
 			name: "with_node_resources_dims",
-			metricsDataFn: func() consumerdata.MetricsData {
-				return consumerdata.MetricsData{
-					Node: &commonpb.Node{
-						Attributes: map[string]string{
-							"k/n0": "vn0",
-							"k/n1": "vn1",
+			metricsDataFn: func() []consumerdata.MetricsData {
+				return []consumerdata.MetricsData{
+					{
+						Node: &commonpb.Node{
+							Attributes: map[string]string{
+								"k/n0": "vn0",
+								"k/n1": "vn1",
+							},
 						},
-					},
-					Resource: &resourcepb.Resource{
-						Labels: map[string]string{
-							"k/r0": "vr0",
-							"k/r1": "vr1",
+						Resource: &resourcepb.Resource{
+							Labels: map[string]string{
+								"k/r0": "vr0",
+								"k/r1": "vr1",
+							},
 						},
-					},
-					Metrics: []*metricspb.Metric{
-						metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-						metricstestutil.GaugeInt("gauge_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
+						Metrics: []*metricspb.Metric{
+							metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
+							metricstestutil.GaugeInt("gauge_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
+						},
 					},
 				}
 			},
@@ -153,11 +159,13 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 		},
 		{
 			name: "distributions",
-			metricsDataFn: func() consumerdata.MetricsData {
-				return consumerdata.MetricsData{
-					Metrics: []*metricspb.Metric{
-						metricstestutil.GaugeDist("gauge_distrib", keys, distributionTimeSeries),
-						metricstestutil.CumulativeDist("cumulative_distrib", keys, distributionTimeSeries),
+			metricsDataFn: func() []consumerdata.MetricsData {
+				return []consumerdata.MetricsData{
+					{
+						Metrics: []*metricspb.Metric{
+							metricstestutil.GaugeDist("gauge_distrib", keys, distributionTimeSeries),
+							metricstestutil.CumulativeDist("cumulative_distrib", keys, distributionTimeSeries),
+						},
 					},
 				}
 			},
@@ -167,10 +175,12 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 		},
 		{
 			name: "summary",
-			metricsDataFn: func() consumerdata.MetricsData {
-				return consumerdata.MetricsData{
-					Metrics: []*metricspb.Metric{
-						metricstestutil.Summary("summary", keys, summaryTimeSeries),
+			metricsDataFn: func() []consumerdata.MetricsData {
+				return []consumerdata.MetricsData{
+					{
+						Metrics: []*metricspb.Metric{
+							metricstestutil.Summary("summary", keys, summaryTimeSeries),
+						},
 					},
 				}
 			},
@@ -202,20 +212,22 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	md := consumerdata.MetricsData{
-		Node: &commonpb.Node{
-			Attributes: map[string]string{"old.dim": "val1"},
-		},
-		Metrics: []*metricspb.Metric{
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name: "metric1",
-					Type: metricspb.MetricDescriptor_GAUGE_INT64,
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						Points: []*metricspb.Point{
-							{Value: &metricspb.Point_Int64Value{Int64Value: 123}},
+	md := []consumerdata.MetricsData{
+		{
+			Node: &commonpb.Node{
+				Attributes: map[string]string{"old.dim": "val1"},
+			},
+			Metrics: []*metricspb.Metric{
+				{
+					MetricDescriptor: &metricspb.MetricDescriptor{
+						Name: "metric1",
+						Type: metricspb.MetricDescriptor_GAUGE_INT64,
+					},
+					Timeseries: []*metricspb.TimeSeries{
+						{
+							Points: []*metricspb.Point{
+								{Value: &metricspb.Point_Int64Value{Int64Value: 123}},
+							},
 						},
 					},
 				},
@@ -398,12 +410,14 @@ func Test_InvalidDistribution_NoExplicitBuckets(t *testing.T) {
 	}
 	point := &metricspb.Point{Timestamp: metricstestutil.Timestamp(tsUnix), Value: &metricspb.Point_DistributionValue{DistributionValue: distrValue}}
 	assert.Nil(t, point.GetDistributionValue().BucketOptions.GetExplicit())
-	metricData := consumerdata.MetricsData{
-		Metrics: []*metricspb.Metric{
-			metricstestutil.GaugeDist("gauge_distrib", keys, metricstestutil.Timeseries(
-				tsUnix,
-				values,
-				point)),
+	metricData := []consumerdata.MetricsData{
+		{
+			Metrics: []*metricspb.Metric{
+				metricstestutil.GaugeDist("gauge_distrib", keys, metricstestutil.Timeseries(
+					tsUnix,
+					values,
+					point)),
+			},
 		},
 	}
 	c := NewMetricsConverter(logger, nil)
@@ -426,12 +440,14 @@ func Test_InvalidSummary_NoPercentileValues(t *testing.T) {
 	}
 	point := &metricspb.Point{Timestamp: metricstestutil.Timestamp(tsUnix), Value: &metricspb.Point_SummaryValue{SummaryValue: summaryValue}}
 	assert.Nil(t, point.GetSummaryValue().GetSnapshot().GetPercentileValues())
-	metricData := consumerdata.MetricsData{
-		Metrics: []*metricspb.Metric{
-			metricstestutil.Summary("summary", keys, metricstestutil.Timeseries(
-				tsUnix,
-				values,
-				point)),
+	metricData := []consumerdata.MetricsData{
+		{
+			Metrics: []*metricspb.Metric{
+				metricstestutil.Summary("summary", keys, metricstestutil.Timeseries(
+					tsUnix,
+					values,
+					point)),
+			},
 		},
 	}
 	c := NewMetricsConverter(logger, nil)
@@ -448,12 +464,14 @@ func Test_InvalidPoint_NoValue(t *testing.T) {
 	values := []string{"v0", "v1"}
 
 	point := &metricspb.Point{Timestamp: metricstestutil.Timestamp(tsUnix), Value: nil}
-	metricData := consumerdata.MetricsData{
-		Metrics: []*metricspb.Metric{
-			metricstestutil.Gauge("gauge", keys, metricstestutil.Timeseries(
-				tsUnix,
-				values,
-				point)),
+	metricData := []consumerdata.MetricsData{
+		{
+			Metrics: []*metricspb.Metric{
+				metricstestutil.Gauge("gauge", keys, metricstestutil.Timeseries(
+					tsUnix,
+					values,
+					point)),
+			},
 		},
 	}
 	c := NewMetricsConverter(logger, nil)
@@ -463,12 +481,14 @@ func Test_InvalidPoint_NoValue(t *testing.T) {
 
 func Test_InvalidMetric(t *testing.T) {
 	logger := zap.NewNop()
-	metricData := consumerdata.MetricsData{
-		Metrics: []*metricspb.Metric{
-			nil,
-			{
-				MetricDescriptor: nil,
-				Timeseries:       []*metricspb.TimeSeries{nil},
+	metricData := []consumerdata.MetricsData{
+		{
+			Metrics: []*metricspb.Metric{
+				nil,
+				{
+					MetricDescriptor: nil,
+					Timeseries:       []*metricspb.TimeSeries{nil},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**Description:** Group metrics by token to reduce number of network calls made by the exporter. 

When the [Partial error](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.8.0/consumer/consumererror/partialerror.go) type extends support for metrics, the exporter should be updated to mark errors as partial wherever applicable so it can also leverage the queued retry mechanism available in new exporters.

**Testing:** Updated tests.