### PR TITLE
Bump memory limit for TestStabilityMetricsCarbon

### DIFF
--- a/testbed/stabilitytests/metric_test.go
+++ b/testbed/stabilitytests/metric_test.go
@@ -61,7 +61,7 @@ func TestStabilityMetricsCarbon(t *testing.T) {
 		datareceivers.NewCarbonDataReceiver(testbed.GetAvailablePort(t)),
 		testbed.ResourceSpec{
 			ExpectedMaxCPU:      237,
-			ExpectedMaxRAM:      100,
+			ExpectedMaxRAM:      120,
 			ResourceCheckPeriod: resourceCheckPeriod,
 		},
 		contribPerfResultsSummary,


### PR DESCRIPTION
To avoid randomly failing stability tests