### PR TITLE
Add AWSUniqueId and gcp_id generation in signalfxexporter

### DIFF
--- a/exporter/signalfxexporter/translation/converter.go
+++ b/exporter/signalfxexporter/translation/converter.go
@@ -24,6 +24,7 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
 )
 
@@ -113,13 +114,11 @@ func (c *MetricsConverter) metricDataToSfxDataPoints(md consumerdata.MetricsData
 	//  Q.: what about resource type?
 	nodeAttribs := md.Node.GetAttributes()
 	resourceAttribs := md.Resource.GetLabels()
-	numExtraDimensions := len(nodeAttribs) + len(resourceAttribs)
-	var extraDimensions []*sfxpb.Dimension
-	if numExtraDimensions > 0 {
-		extraDimensions = make([]*sfxpb.Dimension, 0, numExtraDimensions)
-		extraDimensions = appendAttributesToDimensions(extraDimensions, nodeAttribs)
-		extraDimensions = appendAttributesToDimensions(extraDimensions, resourceAttribs)
-	}
+
+	extraDimensions := make([]*sfxpb.Dimension, 0, len(nodeAttribs)+len(resourceAttribs))
+
+	extraDimensions = appendResourceAttributesToDimensions(extraDimensions, resourceAttribs)
+	extraDimensions = appendAttributesToDimensions(extraDimensions, nodeAttribs)
 
 	for _, metric := range md.Metrics {
 		if metric == nil || metric.MetricDescriptor == nil {
@@ -143,14 +142,14 @@ func (c *MetricsConverter) metricDataToSfxDataPoints(md consumerdata.MetricsData
 		numLabels := len(descriptor.LabelKeys)
 
 		for _, series := range metric.Timeseries {
-			dimensions := make([]*sfxpb.Dimension, numLabels+numExtraDimensions)
+			dimensions := make([]*sfxpb.Dimension, numLabels+len(extraDimensions))
 			copy(dimensions, extraDimensions)
 			for i := 0; i < numLabels; i++ {
 				dimension := &sfxpb.Dimension{
 					Key:   descriptor.LabelKeys[i].Key,
 					Value: series.LabelValues[i].Value,
 				}
-				dimensions[numExtraDimensions+i] = dimension
+				dimensions[len(extraDimensions)+i] = dimension
 			}
 
 			for _, dp := range series.Points {
@@ -431,4 +430,61 @@ func float64ToDimValue(f float64) string {
 	// The important issue here is consistency with the exporter, opting for the
 	// more common one used by Prometheus.
 	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// resourceAttributesToDimensions will return a set of dimension from the
+// resource attributes, including a cloud host id (AWSUniqueId, gcp_id, etc.)
+// if it can be constructed from the provided metadata.
+func appendResourceAttributesToDimensions(dims []*sfxpb.Dimension, resourceAttr map[string]string) []*sfxpb.Dimension {
+	accountID := resourceAttr[conventions.AttributeCloudAccount]
+	region := resourceAttr[conventions.AttributeCloudRegion]
+	instanceID := resourceAttr[conventions.AttributeHostID]
+	provider := resourceAttr[conventions.AttributeCloudProvider]
+
+	filter := func(k string) bool { return true }
+
+	switch provider {
+	// TODO: Should these be defined as constants in resourcedetector module that we import or somewhere else?
+	case "ec2":
+		if instanceID == "" || region == "" || accountID == "" {
+			break
+		}
+		filter = func(k string) bool {
+			return k != conventions.AttributeCloudAccount &&
+				k != conventions.AttributeCloudRegion &&
+				k != conventions.AttributeHostID &&
+				k != conventions.AttributeCloudProvider
+		}
+		dims = append(dims, &sfxpb.Dimension{
+			Key:   "AWSUniqueId",
+			Value: fmt.Sprintf("%s_%s_%s", instanceID, region, accountID),
+		})
+	case "gce":
+		if accountID == "" || instanceID == "" {
+			break
+		}
+		filter = func(k string) bool {
+			return k != conventions.AttributeCloudAccount &&
+				k != conventions.AttributeHostID &&
+				k != conventions.AttributeCloudProvider
+		}
+		dims = append(dims, &sfxpb.Dimension{
+			Key:   "gcp_id",
+			Value: fmt.Sprintf("%s_%s", accountID, instanceID),
+		})
+	default:
+	}
+
+	for k, v := range resourceAttr {
+		if !filter(k) {
+			continue
+		}
+
+		dims = append(dims, &sfxpb.Dimension{
+			Key:   k,
+			Value: v,
+		})
+	}
+
+	return dims
 }

--- a/exporter/signalfxexporter/translation/converter_test.go
+++ b/exporter/signalfxexporter/translation/converter_test.go
@@ -152,6 +152,118 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 			},
 		},
 		{
+			name: "with_resources_cloud_partial_aws_dim",
+			metricsDataFn: func() consumerdata.MetricsData {
+				return consumerdata.MetricsData{
+					Resource: &resourcepb.Resource{
+						Labels: map[string]string{
+							"k/r0":             "vr0",
+							"k/r1":             "vr1",
+							"cloud.provider":   "ec2",
+							"cloud.account.id": "efgh",
+							"cloud.region":     "us-east",
+						},
+					},
+					Metrics: []*metricspb.Metric{
+						metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
+					},
+				}
+			},
+			wantSfxDataPoints: []*sfxpb.DataPoint{
+				doubleSFxDataPoint(
+					"gauge_double_with_dims",
+					tsMSecs,
+					&sfxMetricTypeGauge,
+					append([]string{"cloud_account_id", "cloud_provider", "cloud_region", "k_r0", "k_r1"}, keys...),
+					append([]string{"efgh", "ec2", "us-east", "vr0", "vr1"}, values...),
+					doubleVal),
+			},
+		},
+		{
+			name: "with_resources_cloud_aws_dim",
+			metricsDataFn: func() consumerdata.MetricsData {
+				return consumerdata.MetricsData{
+					Resource: &resourcepb.Resource{
+						Labels: map[string]string{
+							"k/r0":             "vr0",
+							"k/r1":             "vr1",
+							"cloud.provider":   "ec2",
+							"cloud.account.id": "efgh",
+							"cloud.region":     "us-east",
+							"host.id":          "abcd",
+						},
+					},
+					Metrics: []*metricspb.Metric{
+						metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
+					},
+				}
+			},
+			wantSfxDataPoints: []*sfxpb.DataPoint{
+				doubleSFxDataPoint(
+					"gauge_double_with_dims",
+					tsMSecs,
+					&sfxMetricTypeGauge,
+					append([]string{"AWSUniqueId", "k_r0", "k_r1"}, keys...),
+					append([]string{"abcd_us-east_efgh", "vr0", "vr1"}, values...),
+					doubleVal),
+			},
+		},
+		{
+			name: "with_resources_cloud_gce_dim_partial",
+			metricsDataFn: func() consumerdata.MetricsData {
+				return consumerdata.MetricsData{
+					Resource: &resourcepb.Resource{
+						Labels: map[string]string{
+							"k/r0":           "vr0",
+							"k/r1":           "vr1",
+							"cloud.provider": "gce",
+							"host.id":        "abcd",
+						},
+					},
+					Metrics: []*metricspb.Metric{
+						metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
+					},
+				}
+			},
+			wantSfxDataPoints: []*sfxpb.DataPoint{
+				doubleSFxDataPoint(
+					"gauge_double_with_dims",
+					tsMSecs,
+					&sfxMetricTypeGauge,
+					append([]string{"cloud_provider", "host_id", "k_r0", "k_r1"}, keys...),
+					append([]string{"gce", "abcd", "vr0", "vr1"}, values...),
+					doubleVal),
+			},
+		},
+		{
+			name: "with_resources_cloud_gcp_dim",
+			metricsDataFn: func() consumerdata.MetricsData {
+				return consumerdata.MetricsData{
+					Resource: &resourcepb.Resource{
+						Labels: map[string]string{
+							"k/r0":             "vr0",
+							"k/r1":             "vr1",
+							"cloud.provider":   "gce",
+							"cloud.account.id": "efgh",
+							"host.id":          "abcd",
+						},
+					},
+					Metrics: []*metricspb.Metric{
+						metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
+					},
+				}
+			},
+			wantSfxDataPoints: []*sfxpb.DataPoint{
+				doubleSFxDataPoint(
+					"gauge_double_with_dims",
+					tsMSecs,
+					&sfxMetricTypeGauge,
+					append([]string{"gcp_id", "k_r0", "k_r1"}, keys...),
+					append([]string{"efgh_abcd", "vr0", "vr1"}, values...),
+					doubleVal),
+			},
+		},
+		{
 			name: "distributions",
 			metricsDataFn: func() consumerdata.MetricsData {
 				return consumerdata.MetricsData{


### PR DESCRIPTION
These dimensions will be derived from the relevant resource attributes, if present.

The resource attributes used to derive the values will be removed and thus
not sent as dimensions.