### PR TITLE
Add timeout parameter for Stackdriver exporter

### DIFF
--- a/exporter/stackdriverexporter/README.md
+++ b/exporter/stackdriverexporter/README.md
@@ -9,6 +9,7 @@ The following configuration options are supported:
 - `metric_prefix` (optional): MetricPrefix overrides the prefix of a Stackdriver metric names.
 - `number_of_workers` (optional): NumberOfWorkers sets the number of go rountines that send requests. The minimum number of workers is 1.
 - `use_insecure` (optional): If true. use gRPC as their communication transport. Only has effect if Endpoint is not "".
+- `timeout` (optional): Timeout for all API calls. If not set, defaults to 12 seconds.
 - `skip_create_metric_descriptor` (optional): Whether to skip creating the metric descriptor.
 - `resource_mappings` (optional): ResourceMapping defines mapping of resources from source (OpenCensus) to target (Stackdriver).
 - `label_mappings`.`optional` (optional): Optional flag signals whether we can proceed with transformation if a label is missing in the resource.
@@ -24,6 +25,7 @@ exporters:
     number_of_workers: 3
     skip_create_metric_descriptor: true
     use_insecure: true
+    timeout: 12s
     resource_mappings:
       - source_type: source.resource1
         target_type: target-resource1

--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -15,6 +15,8 @@
 package stackdriverexporter
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
@@ -28,6 +30,8 @@ type Config struct {
 	SkipCreateMetricDescriptor    bool                     `mapstructure:"skip_create_metric_descriptor"`
 	// Only has effect if Endpoint is not ""
 	UseInsecure      bool              `mapstructure:"use_insecure"`
+	// Timeout for all API calls. If not set, defaults to 12 seconds.
+  Timeout          time.Duration     `mapstructure:"timeout"`
 	ResourceMappings []ResourceMapping `mapstructure:"resource_mappings"`
 }
 

--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -15,9 +15,8 @@
 package stackdriverexporter
 
 import (
-	"time"
-
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 // Config defines configuration for Stackdriver exporter.
@@ -31,8 +30,8 @@ type Config struct {
 	// Only has effect if Endpoint is not ""
 	UseInsecure bool `mapstructure:"use_insecure"`
 	// Timeout for all API calls. If not set, defaults to 12 seconds.
-	Timeout          time.Duration     `mapstructure:"timeout"`
-	ResourceMappings []ResourceMapping `mapstructure:"resource_mappings"`
+	exporterhelper.TimeoutSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	ResourceMappings               []ResourceMapping        `mapstructure:"resource_mappings"`
 }
 
 // ResourceMapping defines mapping of resources from source (OpenCensus) to target (Stackdriver).

--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -23,11 +23,11 @@ import (
 // Config defines configuration for Stackdriver exporter.
 type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	ProjectID                     string `mapstructure:"project"`
-	Prefix                        string `mapstructure:"metric_prefix"`
-	Endpoint                      string `mapstructure:"endpoint"`
-	NumOfWorkers                  int    `mapstructure:"number_of_workers"`
-	SkipCreateMetricDescriptor    bool   `mapstructure:"skip_create_metric_descriptor"`
+	ProjectID                     string                   `mapstructure:"project"`
+	Prefix                        string                   `mapstructure:"metric_prefix"`
+	Endpoint                      string                   `mapstructure:"endpoint"`
+	NumOfWorkers                  int                      `mapstructure:"number_of_workers"`
+	SkipCreateMetricDescriptor    bool                     `mapstructure:"skip_create_metric_descriptor"`
 	// Only has effect if Endpoint is not ""
 	UseInsecure bool `mapstructure:"use_insecure"`
 	// Timeout for all API calls. If not set, defaults to 12 seconds.

--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -23,15 +23,15 @@ import (
 // Config defines configuration for Stackdriver exporter.
 type Config struct {
 	configmodels.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	ProjectID                     string                   `mapstructure:"project"`
-	Prefix                        string                   `mapstructure:"metric_prefix"`
-	Endpoint                      string                   `mapstructure:"endpoint"`
-	NumOfWorkers                  int                      `mapstructure:"number_of_workers"`
-	SkipCreateMetricDescriptor    bool                     `mapstructure:"skip_create_metric_descriptor"`
+	ProjectID                     string `mapstructure:"project"`
+	Prefix                        string `mapstructure:"metric_prefix"`
+	Endpoint                      string `mapstructure:"endpoint"`
+	NumOfWorkers                  int    `mapstructure:"number_of_workers"`
+	SkipCreateMetricDescriptor    bool   `mapstructure:"skip_create_metric_descriptor"`
 	// Only has effect if Endpoint is not ""
-	UseInsecure      bool              `mapstructure:"use_insecure"`
+	UseInsecure bool `mapstructure:"use_insecure"`
 	// Timeout for all API calls. If not set, defaults to 12 seconds.
-  Timeout          time.Duration     `mapstructure:"timeout"`
+	Timeout          time.Duration     `mapstructure:"timeout"`
 	ResourceMappings []ResourceMapping `mapstructure:"resource_mappings"`
 }
 

--- a/exporter/stackdriverexporter/config_test.go
+++ b/exporter/stackdriverexporter/config_test.go
@@ -54,7 +54,7 @@ func TestLoadConfig(t *testing.T) {
 			NumOfWorkers:               3,
 			SkipCreateMetricDescriptor: true,
 			UseInsecure:                true,
-			Timeout: 20 * time.Second,
+			Timeout:                    20 * time.Second,
 			ResourceMappings: []ResourceMapping{
 				{
 					SourceType: "source.resource1",

--- a/exporter/stackdriverexporter/config_test.go
+++ b/exporter/stackdriverexporter/config_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -54,7 +55,9 @@ func TestLoadConfig(t *testing.T) {
 			NumOfWorkers:               3,
 			SkipCreateMetricDescriptor: true,
 			UseInsecure:                true,
-			Timeout:                    20 * time.Second,
+			TimeoutSettings: exporterhelper.TimeoutSettings{
+				Timeout: 20 * time.Second,
+			},
 			ResourceMappings: []ResourceMapping{
 				{
 					SourceType: "source.resource1",

--- a/exporter/stackdriverexporter/config_test.go
+++ b/exporter/stackdriverexporter/config_test.go
@@ -17,6 +17,7 @@ package stackdriverexporter
 import (
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,7 @@ func TestLoadConfig(t *testing.T) {
 			NumOfWorkers:               3,
 			SkipCreateMetricDescriptor: true,
 			UseInsecure:                true,
+			Timeout: 20 * time.Second,
 			ResourceMappings: []ResourceMapping{
 				{
 					SourceType: "source.resource1",

--- a/exporter/stackdriverexporter/factory.go
+++ b/exporter/stackdriverexporter/factory.go
@@ -61,18 +61,18 @@ func createDefaultConfig() configmodels.Exporter {
 
 // createTraceExporter creates a trace exporter based on this config.
 func createTraceExporter(
-		_ context.Context,
-		_ component.ExporterCreateParams,
-		cfg configmodels.Exporter) (component.TraceExporter, error) {
+	_ context.Context,
+	_ component.ExporterCreateParams,
+	cfg configmodels.Exporter) (component.TraceExporter, error) {
 	eCfg := cfg.(*Config)
 	return newStackdriverTraceExporter(eCfg)
 }
 
 // createMetricsExporter creates a metrics exporter based on this config.
 func createMetricsExporter(
-		_ context.Context,
-		_ component.ExporterCreateParams,
-		cfg configmodels.Exporter) (component.MetricsExporter, error) {
+	_ context.Context,
+	_ component.ExporterCreateParams,
+	cfg configmodels.Exporter) (component.MetricsExporter, error) {
 	eCfg := cfg.(*Config)
 	return newStackdriverMetricsExporter(eCfg)
 }

--- a/exporter/stackdriverexporter/factory.go
+++ b/exporter/stackdriverexporter/factory.go
@@ -17,6 +17,7 @@ package stackdriverexporter
 import (
 	"context"
 	"sync"
+	"time"
 
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
@@ -26,7 +27,8 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr = "stackdriver"
+	typeStr        = "stackdriver"
+	defaultTimeout = 12 * time.Second // Consistent with Cloud Monitoring's timeout
 )
 
 var once sync.Once
@@ -53,23 +55,24 @@ func createDefaultConfig() configmodels.Exporter {
 			TypeVal: configmodels.Type(typeStr),
 			NameVal: typeStr,
 		},
+		TimeoutSettings: exporterhelper.TimeoutSettings{Timeout: defaultTimeout},
 	}
 }
 
 // createTraceExporter creates a trace exporter based on this config.
 func createTraceExporter(
-	_ context.Context,
-	_ component.ExporterCreateParams,
-	cfg configmodels.Exporter) (component.TraceExporter, error) {
+		_ context.Context,
+		_ component.ExporterCreateParams,
+		cfg configmodels.Exporter) (component.TraceExporter, error) {
 	eCfg := cfg.(*Config)
 	return newStackdriverTraceExporter(eCfg)
 }
 
 // createMetricsExporter creates a metrics exporter based on this config.
 func createMetricsExporter(
-	_ context.Context,
-	_ component.ExporterCreateParams,
-	cfg configmodels.Exporter) (component.MetricsExporter, error) {
+		_ context.Context,
+		_ component.ExporterCreateParams,
+		cfg configmodels.Exporter) (component.MetricsExporter, error) {
 	eCfg := cfg.(*Config)
 	return newStackdriverMetricsExporter(eCfg)
 }

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	name = "stackdriver"
-  defaultTimeout = 12 * time.Second // Consistent with Cloud Monitoring's timeout
+	name           = "stackdriver"
+	defaultTimeout = 12 * time.Second // Consistent with Cloud Monitoring's timeout
 )
 
 // traceExporter is a wrapper struct of OT cloud trace exporter
@@ -128,11 +128,11 @@ func newStackdriverMetricsExporter(cfg *Config) (component.MetricsExporter, erro
 		options.TraceClientOptions = copts
 		options.MonitoringClientOptions = copts
 	}
-  if cfg.Timeout > 0 {
-    options.Timeout = cfg.Timeout
-  } else {
-    options.Timeout = defaultTimeout
-  }
+	if cfg.Timeout > 0 {
+		options.Timeout = cfg.Timeout
+	} else {
+		options.Timeout = defaultTimeout
+	}
 	if cfg.NumOfWorkers > 0 {
 		options.NumberOfWorkers = cfg.NumOfWorkers
 	}

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -19,6 +19,7 @@ package stackdriverexporter
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	cloudtrace "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
@@ -32,7 +33,10 @@ import (
 	"google.golang.org/grpc"
 )
 
-const name = "stackdriver"
+const (
+	name = "stackdriver"
+  defaultTimeout = 12 * time.Second // Consistent with Cloud Monitoring's timeout
+)
 
 // traceExporter is a wrapper struct of OT cloud trace exporter
 type traceExporter struct {
@@ -124,6 +128,11 @@ func newStackdriverMetricsExporter(cfg *Config) (component.MetricsExporter, erro
 		options.TraceClientOptions = copts
 		options.MonitoringClientOptions = copts
 	}
+  if cfg.Timeout > 0 {
+    options.Timeout = cfg.Timeout
+  } else {
+    options.Timeout = defaultTimeout
+  }
 	if cfg.NumOfWorkers > 0 {
 		options.NumberOfWorkers = cfg.NumOfWorkers
 	}

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -82,8 +82,14 @@ func generateClientOptions(cfg *Config) ([]option.ClientOption, error) {
 }
 
 func newStackdriverTraceExporter(cfg *Config) (component.TraceExporter, error) {
+	timeout := defaultTimeout
+	if cfg.Timeout > 0 {
+		timeout = cfg.Timeout
+	}
+
 	topts := []cloudtrace.Option{
 		cloudtrace.WithProjectID(cfg.ProjectID),
+		cloudtrace.WithTimeout(timeout),
 	}
 	if cfg.Endpoint != "" {
 		copts, err := generateClientOptions(cfg)

--- a/exporter/stackdriverexporter/testdata/config.yaml
+++ b/exporter/stackdriverexporter/testdata/config.yaml
@@ -13,6 +13,7 @@ exporters:
     number_of_workers: 3
     skip_create_metric_descriptor: true
     use_insecure: true
+    timeout: 20s
     resource_mappings:
       - source_type: source.resource1
         target_type: target-resource1


### PR DESCRIPTION
**Description:** Add timeout parameter to Stackdriver exporter for Cloud Monitoring and Cloud Trace API requests.
Also, change default timeout to 12 seconds (from 5 seconds).

**Link to tracking Issue:** Fixes #738

**Testing:** Unit tests

**Documentation:** Updated README