### PR TITLE
k8sprocessor: wrap metrics before sending further down the pipeline

### DIFF
--- a/processor/k8sprocessor/processor.go
+++ b/processor/k8sprocessor/processor.go
@@ -236,7 +236,7 @@ func (kp *kubernetesprocessor) ConsumeMetrics(ctx context.Context, metrics pdata
 		}
 	}
 
-	return kp.nextMetricsConsumer.ConsumeMetrics(ctx, metrics)
+	return kp.nextMetricsConsumer.ConsumeMetrics(ctx, pdatautil.MetricsFromMetricsData(mds))
 }
 
 func (kp *kubernetesprocessor) getAttributesForPodIP(ip string) map[string]string {


### PR DESCRIPTION
**Description:**
The wrapping was missed in k8sprocessor, so any new-style component down the pipeline would drop all the k8s tags added to metrics.