### PR TITLE
Azure Monitor Exporter: treat UNSPECIFIED span kind as INTERNAL

### DIFF
--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -43,7 +43,6 @@ const (
 )
 
 var (
-	errUnspecifiedSpanKind          = errors.New("SpanKind is unspecified")
 	errUnexpectedAttributeValueType = errors.New("attribute value type is unexpected")
 	errUnsupportedSpanType          = errors.New("unsupported Span type")
 )
@@ -61,9 +60,10 @@ func spanToEnvelope(
 
 	spanKind := span.Kind()
 
-	// unspecified, drop it
+	// According to the SpanKind documentation, we can assume it to be INTERNAL
+	// when we get UNSPECIFIED.
 	if spanKind == pdata.SpanKindUNSPECIFIED {
-		return nil, errUnspecifiedSpanKind
+		spanKind = pdata.SpanKindINTERNAL
 	}
 
 	attributeMap := span.Attributes()

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -524,6 +524,17 @@ func TestUnknownInternalSpanToRemoteDependencyData(t *testing.T) {
 	defaultInternalRemoteDependencyDataValidations(t, span, data)
 }
 
+// Tests that spans with unspecified kind are treated similar to internal spans
+func TestUnspecifiedSpanToInProcRemoteDependencyData(t *testing.T) {
+	span := getDefaultInternalSpan()
+	span.SetKind(pdata.SpanKindUNSPECIFIED)
+
+	envelope, _ := spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	commonEnvelopeValidations(t, span, envelope, defaultRemoteDependencyDataEnvelopeName)
+	data := envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+	defaultInternalRemoteDependencyDataValidations(t, span, data)
+}
+
 func TestSanitize(t *testing.T) {
 	sanitizeFunc := func() []string {
 		warnings := [4]string{

--- a/exporter/azuremonitorexporter/traceexporter_test.go
+++ b/exporter/azuremonitorexporter/traceexporter_test.go
@@ -21,6 +21,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
@@ -80,10 +81,11 @@ func TestExporterTraceDataCallbackSingleSpanNoEnvelope(t *testing.T) {
 	// re-use some test generation method(s) from trace_to_envelope_test
 	resource := getResource()
 	instrumentationLibrary := getInstrumentationLibrary()
-	span := getDefaultHTTPServerSpan()
+	span := getDefaultInternalSpan()
 
-	// rest the SpanKind to unspecified
-	span.SetKind(pdata.SpanKindUNSPECIFIED)
+	// Make this a FaaS span, which will trigger an error, because conversion
+	// of them is currently not supported.
+	span.Attributes().InsertString(conventions.AttributeFaaSTrigger, "http")
 
 	traces := pdata.NewTraces()
 	traces.ResourceSpans().Resize(1)


### PR DESCRIPTION
**Description:**

The Azure Monitor exporter translates spans to different objects depending on the span kind. It currently returns an error if the span kind is set to UNSPECIFIED. This makes sense, because we don't know how to translate those spans.

However this can cause problems when trying to get 3rd party applications to participate in the distributed tracing. One example is NGINX, which supports OpenTracing through the nginx-opentracing plugin. However it does not report a span kind, which means spans reported by NGINX are not exported to Azure Monitor.

This changes the Azure Monitor exporter to treat unspecified span kinds as INTERNAL. While this is not perfect, it does at least report some data for these spans.

@pcwiese Does this change make sense for you? What was the original reason to return an error for unspecified span kind?

**Testing:**

Added unit test to check that spans with unspecified span kind are treated like internal spans.