### PR TITLE
Signalfx exporter: reduce memory allocations for big batches processing

### DIFF
--- a/exporter/signalfxexporter/dpclient.go
+++ b/exporter/signalfxexporter/dpclient.go
@@ -96,7 +96,8 @@ func (s *sfxDPClient) pushMetricsData(
 func (s *sfxDPClient) pushMetricsDataForToken(
 	metricsData []consumerdata.MetricsData, accessToken string) (int, error) {
 	numTimeseries := timeseriesCount(metricsData)
-	sfxDataPoints, numDroppedTimeseries := s.converter.MetricDataToSignalFxV2(metricsData)
+	sfxDataPoints := make([]*sfxpb.DataPoint, 0, numTimeseries)
+	sfxDataPoints, numDroppedTimeseries := s.converter.MetricDataToSignalFxV2(metricsData, sfxDataPoints)
 
 	body, compressed, err := s.encodeBody(sfxDataPoints)
 	if err != nil {

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -213,10 +213,10 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.NotNil(t, rules, "rules are nil")
 	tr, err := translation.NewMetricTranslator(rules)
 	require.NoError(t, err)
-	data := md()
+	data := testMetricsData()
 
 	c := translation.NewMetricsConverter(zap.NewNop(), tr)
-	translated, _ := c.MetricDataToSignalFxV2(data)
+	translated, _ := c.MetricDataToSignalFxV2(data, nil)
 	require.NotNil(t, translated)
 
 	metrics := make(map[string][]*sfxpb.DataPoint)
@@ -270,7 +270,7 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.True(t, ok, "container_memory_major_page_faults not found")
 }
 
-func md() []consumerdata.MetricsData {
+func testMetricsData() []consumerdata.MetricsData {
 	md := consumerdata.MetricsData{
 		Metrics: []*metricspb.Metric{
 			{

--- a/exporter/signalfxexporter/translation/converter_test.go
+++ b/exporter/signalfxexporter/translation/converter_test.go
@@ -242,7 +242,7 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 	c := NewMetricsConverter(logger, nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSfxDataPoints, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(tt.metricsDataFn())
+			gotSfxDataPoints, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(tt.metricsDataFn(), nil)
 			assert.Equal(t, tt.wantNumDroppedTimeseries, gotNumDroppedTimeSeries)
 			// Sort SFx dimensions since they are built from maps and the order
 			// of those is not deterministic.
@@ -304,7 +304,7 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 		},
 	}
 	c := NewMetricsConverter(zap.NewNop(), translator)
-	got, dropped := c.MetricDataToSignalFxV2(md)
+	got, dropped := c.MetricDataToSignalFxV2(md, nil)
 
 	assert.EqualValues(t, 0, dropped)
 	assert.EqualValues(t, expected, got)
@@ -462,7 +462,7 @@ func Test_InvalidPoint_NoValue(t *testing.T) {
 		},
 	}
 	c := NewMetricsConverter(logger, nil)
-	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData)
+	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData, nil)
 	assert.Equal(t, 1, gotNumDroppedTimeSeries)
 }
 
@@ -480,7 +480,7 @@ func Test_InvalidMetric(t *testing.T) {
 		},
 	}
 	c := NewMetricsConverter(logger, nil)
-	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData)
+	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData, nil)
 	// Only 1 timeseries is dropped because the nil metric does not have any timeseries.
 	assert.Equal(t, 1, gotNumDroppedTimeSeries)
 }


### PR DESCRIPTION
**Description:**
Enabling batching causes many extra allocations in signalfx exporter. This change reduces allocations of []*sfxpb.DataPoint slices by pre-initializing []*sfxpb.DataPoint slice for the whole batch.

**Testing:**
Benchmark test on a 1000 metrics batch:

BEFORE:
```
Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^(BenchmarkExporterConsumeData)$
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
BenchmarkExporterConsumeData-12           78      14264799 ns/op     6911068 B/op      70208 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter 1.896s
```

AFTER:
```
Running tool: /usr/local/bin/go test -benchmem -run=^$ -bench ^(BenchmarkExporterConsumeData)$
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
BenchmarkExporterConsumeData-12    	      93	  12466935 ns/op	 6429209 B/op	   68854 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter	1.897s
```