### PR TITLE
Bump memory limits for TestStabilityTracesZipkin

### DIFF
--- a/testbed/stabilitytests/trace_test.go
+++ b/testbed/stabilitytests/trace_test.go
@@ -118,7 +118,7 @@ func TestStabilityTracesZipkin(t *testing.T) {
 		testbed.NewZipkinDataReceiver(testbed.GetAvailablePort(t)),
 		testbed.ResourceSpec{
 			ExpectedMaxCPU:      80,
-			ExpectedMaxRAM:      95,
+			ExpectedMaxRAM:      110,
 			ResourceCheckPeriod: resourceCheckPeriod,
 		},
 		contribPerfResultsSummary,


### PR DESCRIPTION
To avoid randomly failing tests until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/400 is taken care of
