### PR TITLE
Add checks for nil start timestamp to Metrics Transform processor

### DIFF
--- a/processor/metricstransformprocessor/metrics_testcase_builder_test.go
+++ b/processor/metricstransformprocessor/metrics_testcase_builder_test.go
@@ -52,7 +52,7 @@ func (b builder) setLabels(labels []string) builder {
 }
 
 // addTimeseries adds new timeseries with the labelValuesVal and startTimestamp
-func (b builder) addTimeseries(startTimestamp int64, labelValuesVal []string) builder {
+func (b builder) addTimeseries(startTimestampSeconds int64, labelValuesVal []string) builder {
 	labelValues := make([]*metricspb.LabelValue, len(labelValuesVal))
 	for i, v := range labelValuesVal {
 		labelValues[i] = &metricspb.LabelValue{
@@ -60,13 +60,16 @@ func (b builder) addTimeseries(startTimestamp int64, labelValuesVal []string) bu
 			HasValue: true,
 		}
 	}
+
+	var startTimestamp *timestamppb.Timestamp
+	if startTimestampSeconds != 0 {
+		startTimestamp = &timestamppb.Timestamp{Seconds: startTimestampSeconds}
+	}
+
 	timeseries := &metricspb.TimeSeries{
-		StartTimestamp: &timestamppb.Timestamp{
-			Seconds: startTimestamp,
-			Nanos:   0,
-		},
-		LabelValues: labelValues,
-		Points:      make([]*metricspb.Point, 0),
+		StartTimestamp: startTimestamp,
+		LabelValues:    labelValues,
+		Points:         make([]*metricspb.Point, 0),
 	}
 	b.metric.Timeseries = append(b.metric.Timeseries, timeseries)
 	return b

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -147,5 +147,9 @@ func (mtp *metricsTransformProcessor) minInt64(num1, num2 int64) int64 {
 
 // compareTimestamps returns if t1 is a smaller timestamp than t2
 func (mtp *metricsTransformProcessor) compareTimestamps(t1 *timestamppb.Timestamp, t2 *timestamppb.Timestamp) bool {
+	if t1 == nil || t2 == nil {
+		return t1 != nil
+	}
+
 	return t1.Seconds < t2.Seconds || (t1.Seconds == t2.Seconds && t1.Nanos < t2.Nanos)
 }

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -377,15 +377,17 @@ var (
 			},
 			in: []*metricspb.Metric{
 				metricBuilder().setName("metric1").setLabels([]string{"label1", "label2"}).setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
-					addTimeseries(1, []string{"label1-value1", "label2-value1"}).addTimeseries(1, []string{"label1-value1", "label2-value2"}).
-					addTimeseries(2, []string{"label1-value2", "label2-value2"}).
-					addDoublePoint(0, 1, 2).addDoublePoint(1, 3, 2).addDoublePoint(2, 3, 2).
+					addTimeseries(2, []string{"label1-value2", "label2-value2"}).addDoublePoint(0, 3, 2).
+					addTimeseries(0, []string{"label1-value0", "label2-value0"}).addDoublePoint(1, 4, 2).
+					addTimeseries(1, []string{"label1-value1", "label2-value1"}).addDoublePoint(2, 1, 2).
+					addTimeseries(1, []string{"label1-value1", "label2-value2"}).addDoublePoint(3, 3, 2).
 					build(),
 			},
 			out: []*metricspb.Metric{
 				metricBuilder().setName("metric1").setLabels([]string{"label1"}).setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
-					addTimeseries(1, []string{"label1-value1"}).addTimeseries(2, []string{"label1-value2"}).
-					addDoublePoint(0, 1, 2).addDoublePoint(1, 3, 2).
+					addTimeseries(1, []string{"label1-value1"}).addDoublePoint(0, 1, 2).
+					addTimeseries(2, []string{"label1-value2"}).addDoublePoint(1, 3, 2).
+					addTimeseries(0, []string{"label1-value0"}).addDoublePoint(2, 4, 2).
 					build(),
 			},
 		},
@@ -410,15 +412,17 @@ var (
 			},
 			in: []*metricspb.Metric{
 				metricBuilder().setName("metric1").setLabels([]string{"label1", "label2"}).setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
-					addTimeseries(3, []string{"label1-value1", "label2-value1"}).addTimeseries(3, []string{"label1-value1", "label2-value2"}).
-					addTimeseries(1, []string{"label1-value1", "label2-value3"}).
-					addInt64Point(0, 3, 2).addInt64Point(1, 1, 2).addInt64Point(1, 2, 3).addInt64Point(2, 1, 2).
+					addTimeseries(3, []string{"label1-value1", "label2-value1"}).addInt64Point(0, 3, 2).
+					addTimeseries(0, []string{"label1-value1", "label2-value4"}).
+					addTimeseries(3, []string{"label1-value1", "label2-value2"}).addInt64Point(2, 1, 2).addInt64Point(2, 2, 3).
+					addTimeseries(1, []string{"label1-value1", "label2-value3"}).addInt64Point(3, 1, 2).
 					build(),
 			},
 			out: []*metricspb.Metric{
 				metricBuilder().setName("metric1").setLabels([]string{"label1", "label2"}).setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
-					addTimeseries(1, []string{"label1-value1", "label2-value3"}).addTimeseries(3, []string{"label1-value1", "new/label2-value"}).
-					addInt64Point(0, 1, 2).addInt64Point(1, 4, 2).addInt64Point(1, 2, 3).
+					addTimeseries(1, []string{"label1-value1", "label2-value3"}).addInt64Point(0, 1, 2).
+					addTimeseries(3, []string{"label1-value1", "new/label2-value"}).addInt64Point(1, 4, 2).addInt64Point(1, 2, 3).
+					addTimeseries(0, []string{"label1-value1", "label2-value4"}).
 					build(),
 			},
 		},

--- a/processor/metricstransformprocessor/operation_aggregate_label_values.go
+++ b/processor/metricstransformprocessor/operation_aggregate_label_values.go
@@ -54,7 +54,9 @@ func (mtp *metricsTransformProcessor) groupTimeseriesByNewLabelValue(metric *met
 		}
 
 		key, newLabelValues := mtp.newLabelValuesAsKey(labelIdx, timeseries, newValue, aggregatedValuesSet)
-		key += strconv.FormatInt(timeseries.StartTimestamp.Seconds, 10)
+		if timeseries.StartTimestamp != nil {
+			key += strconv.FormatInt(timeseries.StartTimestamp.Seconds, 10)
+		}
 
 		timeseriesGroup, ok := groupedTimeseries[key]
 		if ok {

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -44,7 +44,9 @@ func (mtp *metricsTransformProcessor) groupTimeseriesByLabelSet(metric *metricsp
 	groupedTimeseries := make(map[string]*timeseriesAndLabelValues)
 	for _, timeseries := range metric.Timeseries {
 		key, newLabelValues := mtp.selectedLabelsAsKey(labelIdxs, timeseries)
-		key += strconv.FormatInt(timeseries.StartTimestamp.Seconds, 10)
+		if timeseries.StartTimestamp != nil {
+			key += strconv.FormatInt(timeseries.StartTimestamp.Seconds, 10)
+		}
 
 		timeseriesGroup, ok := groupedTimeseries[key]
 		if ok {


### PR DESCRIPTION
The metrics transform processor assumed start timestamp was never nil. This value can be nil for Gauge types. Added nil checks for this case and related tests.