### PR TITLE
Adopt dynamic docker stats functionality

### DIFF
--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -42,6 +42,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver"
@@ -91,6 +92,7 @@ func components() (component.Factories, error) {
 		statsdreceiver.NewFactory(),
 		awsxrayreceiver.NewFactory(),
 		splunkhecreceiver.NewFactory(),
+		dockerstatsreceiver.NewFactory(),
 	}
 	for _, rcv := range factories.Receivers {
 		receivers = append(receivers, rcv)

--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -42,7 +42,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver"
@@ -92,7 +91,6 @@ func components() (component.Factories, error) {
 		statsdreceiver.NewFactory(),
 		awsxrayreceiver.NewFactory(),
 		splunkhecreceiver.NewFactory(),
-		dockerstatsreceiver.NewFactory(),
 	}
 	for _, rcv := range factories.Receivers {
 		receivers = append(receivers, rcv)

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver v0.0.0-00010101000000-000000000000
@@ -119,6 +120,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpl
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver => ./receiver/prometheusexecreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver => ./receiver/wavefrontreceiver
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver => ./receiver/dockerstatsreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor => ./processor/k8sprocessor/
 

--- a/internal/common/testing/container/container_integration_test.go
+++ b/internal/common/testing/container/container_integration_test.go
@@ -64,6 +64,7 @@ func TestContainerIntegration(t *testing.T) {
 func TestRemoveContainerIntegration(t *testing.T) {
 	con := New(t)
 	nginx := con.StartImage("docker.io/library/nginx:1.17", WithPortReady(80))
+	require.Equal(t, 1, len(con.runningContainers))
 
 	err := con.RemoveContainer(nginx)
 	require.NoError(t, err)

--- a/internal/common/testing/container/container_integration_test.go
+++ b/internal/common/testing/container/container_integration_test.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -53,9 +54,22 @@ func TestContainerIntegration(t *testing.T) {
 
 	con.Cleanup()
 
-	assert.Nil(t, con.runningContainers, "started containers should be empty after cleanup")
+	assert.Zero(t, len(con.runningContainers), "started containers should be empty after cleanup")
 
 	_, err = cli.ContainerInspect(context.Background(), string(started.ID))
 	require.Error(t, err, "inspect should have returned an error")
 	require.True(t, client.IsErrNotFound(err), "inspect error should have been of type not found")
+}
+
+func TestRemoveContainerIntegration(t *testing.T) {
+	con := New(t)
+	nginx := con.StartImage("docker.io/library/nginx:1.17", WithPortReady(80))
+
+	err := con.RemoveContainer(nginx)
+	require.NoError(t, err)
+	require.Zero(t, len(con.runningContainers))
+
+	err = con.RemoveContainer(nginx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("failed removing container %v", nginx.ID))
 }

--- a/receiver/dockerstatsreceiver/docker.go
+++ b/receiver/dockerstatsreceiver/docker.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	dtypes "github.com/docker/docker/api/types"
 	dfilters "github.com/docker/docker/api/types/filters"
@@ -154,7 +155,7 @@ func (dc *dockerClient) FetchContainerStatsAndConvertToMetrics(
 	}
 
 	statsJSON, err := dc.toStatsJSON(containerStats, &container)
-	if err != nil { // results have been sent in converter
+	if err != nil {
 		return nil, err
 	}
 
@@ -167,7 +168,6 @@ func (dc *dockerClient) FetchContainerStatsAndConvertToMetrics(
 		)
 		return nil, err
 	}
-
 	return md, nil
 }
 
@@ -194,6 +194,61 @@ func (dc *dockerClient) toStatsJSON(
 	return &statsJSON, nil
 }
 
+func (dc *dockerClient) ContainerEventLoop(ctx context.Context) {
+	filters := dfilters.NewArgs([]dfilters.KeyValuePair{
+		{Key: "type", Value: "container"},
+		{Key: "event", Value: "destroy"},
+		{Key: "event", Value: "die"},
+		{Key: "event", Value: "pause"},
+		{Key: "event", Value: "stop"},
+		{Key: "event", Value: "start"},
+		{Key: "event", Value: "unpause"},
+		{Key: "event", Value: "update"},
+	}...)
+	lastTime := time.Now()
+
+EVENT_LOOP:
+	for {
+		options := dtypes.EventsOptions{
+			Filters: filters,
+			Since:   lastTime.Format(time.RFC3339Nano),
+		}
+		eventCh, errCh := dc.client.Events(ctx, options)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventCh:
+				switch event.Action {
+				case "destroy":
+					dc.logger.Debug("Docker container was destroyed:", zap.String("id", event.ID))
+					dc.removeContainer(event.ID)
+				default:
+					dc.logger.Debug(
+						"Docker container update:",
+						zap.String("id", event.ID),
+						zap.String("action", event.Action),
+					)
+
+					if container, ok := dc.inspectedContainerIsOfInterest(ctx, event.ID); ok {
+						dc.persistContainer(container)
+					}
+				}
+
+				lastTime = time.Unix(0, event.TimeNano)
+			case err := <-errCh:
+				// We are only interested when the context hasn't been canceled
+				if ctx.Err() == nil {
+					dc.logger.Error("Error watching docker container events", zap.Error(err))
+					time.Sleep(3 * time.Second)
+					continue EVENT_LOOP
+				}
+			}
+		}
+	}
+}
+
 // Queries inspect api and returns *ContainerJSON and true when container should be queried for stats,
 // nil and false otherwise.
 func (dc *dockerClient) inspectedContainerIsOfInterest(ctx context.Context, cid string) (*dtypes.ContainerJSON, bool) {
@@ -216,8 +271,17 @@ func (dc *dockerClient) persistContainer(containerJSON *dtypes.ContainerJSON) {
 	if containerJSON == nil {
 		return
 	}
+
 	cid := containerJSON.ID
+	if !containerJSON.State.Running || containerJSON.State.Paused {
+		dc.logger.Debug("Docker container not running.  Will not persist.", zap.String("id", cid))
+		dc.removeContainer(cid)
+		return
+	}
+
 	dc.logger.Debug("Monitoring Docker container", zap.String("id", cid))
+	dc.containersLock.Lock()
+	defer dc.containersLock.Unlock()
 	dc.containers[cid] = DockerContainer{
 		ContainerJSON: containerJSON,
 		EnvMap:        containerEnvToMap(containerJSON.Config.Env),

--- a/receiver/dockerstatsreceiver/docker.go
+++ b/receiver/dockerstatsreceiver/docker.go
@@ -236,7 +236,10 @@ EVENT_LOOP:
 					}
 				}
 
-				lastTime = time.Unix(0, event.TimeNano)
+				if event.TimeNano > lastTime.UnixNano() {
+					lastTime = time.Unix(0, event.TimeNano)
+				}
+
 			case err := <-errCh:
 				// We are only interested when the context hasn't been canceled
 				if ctx.Err() == nil {

--- a/receiver/dockerstatsreceiver/go.mod
+++ b/receiver/dockerstatsreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/protobuf v1.4.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.0.0-00010101000000-000000000000
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.0.0-20200518175917-05cf2ea24e6c
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.9.1-0.20200911183545-c0b3c61876d7
 	go.uber.org/zap v1.16.0

--- a/receiver/dockerstatsreceiver/receiver.go
+++ b/receiver/dockerstatsreceiver/receiver.go
@@ -101,10 +101,13 @@ func (r *Receiver) Shutdown(ctx context.Context) error {
 
 func (r *Receiver) Setup() error {
 	err := r.client.LoadContainerList(r.runnerCtx)
-	if err == nil {
-		r.successfullySetup = true
+	if err != nil {
+		return err
 	}
-	return err
+
+	go r.client.ContainerEventLoop(r.runnerCtx)
+	r.successfullySetup = true
+	return nil
 }
 
 type result struct {

--- a/receiver/dockerstatsreceiver/receiver.go
+++ b/receiver/dockerstatsreceiver/receiver.go
@@ -81,7 +81,7 @@ func (r *Receiver) Start(ctx context.Context, host component.Host) error {
 
 	r.obsCtx = obsreport.ReceiverContext(ctx, typeStr, r.transport, r.config.Name())
 
-	r.runnerCtx, r.runnerCancel = context.WithCancel(ctx)
+	r.runnerCtx, r.runnerCancel = context.WithCancel(context.Background())
 	r.runner = interval.NewRunner(r.config.CollectionInterval, r)
 
 	go func() {


### PR DESCRIPTION
**Description:**
Adding a feature - Adds a core docker event loop to allow the collector to monitor docker stats for containers that were not running during the initialization of the receiver.  ~~Also sources the docker stats receiver as a top level component.~~

**Link to tracking Issue:** ~~resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/957~~

**Testing:** Includes additional unit and integration tests.  Also adds a remove container feature to the test container helpers to assist in verifying dynamic container monitoring.

**Documentation:** will add to changelog