### PR TITLE
Resource Detection Processor: Logs Support 

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -1,6 +1,6 @@
 # Resource Detection Processor
 
-Supported pipeline types: metrics, traces
+Supported pipeline types: metrics, traces, logs
 
 The resource detection processor can be used to detect resource information from the host,
 in a format that conforms to the [OpenTelemetry resource semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/README.md), and append or

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -4,7 +4,7 @@ Supported pipeline types: metrics, traces, logs
 
 The resource detection processor can be used to detect resource information from the host,
 in a format that conforms to the [OpenTelemetry resource semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/README.md), and append or
-override the resource value in traces and metrics with this information.
+override the resource value in telemetry data with this information.
 
 Currently supported detectors include:
 

--- a/processor/resourcedetectionprocessor/factory_test.go
+++ b/processor/resourcedetectionprocessor/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/exporter/exportertest"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -33,11 +34,15 @@ func TestCreateProcessor(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, nil, cfg)
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, exportertest.NewNopTraceExporter(), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, tp)
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, nil, cfg)
+	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, exportertest.NewNopMetricsExporter(), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, mp)
+
+	lp, err := factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopLogsExporter())
+	assert.NoError(t, err)
+	assert.NotNil(t, lp)
 }

--- a/processor/resourcedetectionprocessor/factory_test.go
+++ b/processor/resourcedetectionprocessor/factory_test.go
@@ -46,3 +46,22 @@ func TestCreateProcessor(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, lp)
 }
+
+func TestInvalidConfig(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	oCfg := cfg.(*Config)
+	oCfg.Detectors = []string{"not-existing"}
+
+	tp, err := factory.CreateTraceProcessor(context.Background(), component.ProcessorCreateParams{}, exportertest.NewNopTraceExporter(), cfg)
+	assert.Error(t, err)
+	assert.Nil(t, tp)
+
+	mp, err := factory.CreateMetricsProcessor(context.Background(), component.ProcessorCreateParams{}, exportertest.NewNopMetricsExporter(), cfg)
+	assert.Error(t, err)
+	assert.Nil(t, mp)
+
+	lp, err := factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{}, cfg, exportertest.NewNopLogsExporter())
+	assert.Error(t, err)
+	assert.Nil(t, lp)
+}

--- a/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
+++ b/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
@@ -220,8 +220,8 @@ func TestResourceProcessor(t *testing.T) {
 
 			err = rmp.Start(context.Background(), componenttest.NewNopHost())
 
-			if tt.expectedNewError != "" {
-				assert.EqualError(t, err, tt.expectedNewError)
+			if tt.expectedStartError != "" {
+				assert.EqualError(t, err, tt.expectedStartError)
 				return
 			}
 
@@ -234,6 +234,40 @@ func TestResourceProcessor(t *testing.T) {
 			}))
 			require.NoError(t, err)
 			got = tmn.AllMetrics()[0].ResourceMetrics().At(0).Resource()
+
+			tt.expectedResource.Attributes().Sort()
+			got.Attributes().Sort()
+			assert.Equal(t, tt.expectedResource, got)
+
+			// Test logs consumer
+			tln := &exportertest.SinkLogsExporter{}
+			rlp, err := factory.createLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, tln)
+
+			if tt.expectedNewError != "" {
+				assert.EqualError(t, err, tt.expectedNewError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.True(t, rlp.GetCapabilities().MutatesConsumedData)
+
+			err = rlp.Start(context.Background(), componenttest.NewNopHost())
+
+			if tt.expectedStartError != "" {
+				assert.EqualError(t, err, tt.expectedStartError)
+				return
+			}
+
+			require.NoError(t, err)
+			defer func() { assert.NoError(t, rlp.Shutdown(context.Background())) }()
+
+			ld := pdata.NewLogs()
+			ld.ResourceLogs().Resize(1)
+			tt.sourceResource.CopyTo(ld.ResourceLogs().At(0).Resource())
+
+			err = rlp.ConsumeLogs(context.Background(), ld)
+			require.NoError(t, err)
+			got = tln.AllLogs()[0].ResourceLogs().At(0).Resource()
 
 			tt.expectedResource.Attributes().Sort()
 			got.Attributes().Sort()
@@ -297,4 +331,26 @@ func BenchmarkConsumeMetricsDefault(b *testing.B) {
 func BenchmarkConsumeMetricsAll(b *testing.B) {
 	cfg := &Config{Override: true, Detectors: []string{env.TypeStr, gce.TypeStr}}
 	benchmarkConsumeMetrics(b, cfg)
+}
+
+func benchmarkConsumeLogs(b *testing.B, cfg *Config) {
+	factory := NewFactory()
+	sink := &exportertest.SinkLogsExporter{}
+	processor, _ := factory.CreateLogsProcessor(context.Background(), component.ProcessorCreateParams{Logger: zap.NewNop()}, cfg, sink)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		// TODO use testbed.PerfTestDataProvider here once that includes resources
+		processor.ConsumeLogs(context.Background(), pdata.NewLogs())
+	}
+}
+
+func BenchmarkConsumeLogsDefault(b *testing.B) {
+	cfg := NewFactory().CreateDefaultConfig()
+	benchmarkConsumeLogs(b, cfg.(*Config))
+}
+
+func BenchmarkConsumeLogsAll(b *testing.B) {
+	cfg := &Config{Override: true, Detectors: []string{env.TypeStr, gce.TypeStr}}
+	benchmarkConsumeLogs(b, cfg)
 }


### PR DESCRIPTION
**Description:**

Add logs support to `resourcedetection` processor

This is a re-open of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/967 due to issues with CircleCI build triggering

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/1653

**Testing:** unit test for logs added. Tested manually with EC2 and ENV detectors

**Documentation:** Added a note on logs being supported by the processor