### PR TITLE
Fix panic in newrelicexporter if service name is empty

### DIFF
--- a/exporter/newrelicexporter/newrelic.go
+++ b/exporter/newrelicexporter/newrelic.go
@@ -84,8 +84,14 @@ func (e exporter) pushTraceData(ctx context.Context, td pdata.Traces) (int, erro
 
 	octds := internaldata.TraceDataToOC(td)
 	for _, octd := range octds {
+
+		var srv string
+		if octd.Node != nil && octd.Node.ServiceInfo != nil {
+			srv = octd.Node.ServiceInfo.Name
+		}
+
 		transform := &transformer{
-			ServiceName: octd.Node.ServiceInfo.Name,
+			ServiceName: srv,
 			Resource:    octd.Resource,
 		}
 
@@ -115,9 +121,14 @@ func (e exporter) pushMetricData(ctx context.Context, md pdata.Metrics) (int, er
 
 	ocmds := internaldata.MetricsToOC(md)
 	for _, ocmd := range ocmds {
+		var srv string
+		if ocmd.Node != nil && ocmd.Node.ServiceInfo != nil {
+			srv = ocmd.Node.ServiceInfo.Name
+		}
+
 		transform := &transformer{
 			DeltaCalculator: e.deltaCalculator,
-			ServiceName:     ocmd.Node.ServiceInfo.Name,
+			ServiceName:     srv,
 			Resource:        ocmd.Resource,
 		}
 

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -228,7 +228,9 @@ func (t *transformer) MetricAttributes(metric *metricspb.Metric) map[string]inte
 
 	attrs[collectorNameKey] = name
 	attrs[collectorVersionKey] = version
-	attrs[serviceNameKey] = t.ServiceName
+	if t.ServiceName != "" {
+		attrs[serviceNameKey] = t.ServiceName
+	}
 
 	return attrs
 }


### PR DESCRIPTION
Resolves #964

Validate the Node and ServiceInfo are not nil pointers before dereferencing them. Additionally, add tests to prevent regression of this bug.