### PR TITLE
Bump CPU limit for TestStabilityMetricsSignalFx

### DIFF
--- a/testbed/stabilitytests/metric_test.go
+++ b/testbed/stabilitytests/metric_test.go
@@ -78,7 +78,7 @@ func TestStabilityMetricsSignalFx(t *testing.T) {
 		datasenders.NewSFxMetricDataSender(testbed.GetAvailablePort(t)),
 		datareceivers.NewSFxMetricsDataReceiver(testbed.GetAvailablePort(t)),
 		testbed.ResourceSpec{
-			ExpectedMaxCPU:      83,
+			ExpectedMaxCPU:      120,
 			ExpectedMaxRAM:      95,
 			ResourceCheckPeriod: resourceCheckPeriod,
 		},


### PR DESCRIPTION
This change reflects current loadtest limits for SignalFx pipeline
