### PR TITLE
honeycomb exporter: don't emit default proc id + starttime

### DIFF
--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -314,3 +314,121 @@ func TestEmptyNode(t *testing.T) {
 		t.Errorf("otel span: (-want +got):\n%s", diff)
 	}
 }
+
+type testNodeCase struct {
+	name       string
+	identifier *commonpb.ProcessIdentifier
+	expected   map[string]interface{}
+}
+
+func TestNode(t *testing.T) {
+
+	testcases := []testNodeCase{
+		{
+			name: "all_information",
+			identifier: &commonpb.ProcessIdentifier{
+				HostName: "my-host",
+				Pid:      123,
+				StartTimestamp: &timestamppb.Timestamp{
+					Seconds: 1599596112,
+					Nanos:   0,
+				},
+			},
+			expected: map[string]interface{}{
+				"B":                                      "C",
+				"duration_ms":                            float64(0),
+				"has_remote_parent":                      false,
+				"name":                                   "root",
+				"source_format":                          "otlp_trace",
+				"status.code":                            float64(0),
+				"status.message":                         "OK",
+				"trace.span_id":                          "02",
+				"trace.trace_id":                         "01",
+				"opencensus.resourcetype":                "container",
+				"opencensus.same_process_as_parent_span": true,
+				"opencensus.start_timestamp":             "2020-09-08T16:15:12-04:00",
+				"process.hostname":                       "my-host",
+				"process.pid":                            float64(123),
+				"service_name":                           "test_service",
+			},
+		},
+		{
+			name: "missing_pid_and_time",
+			identifier: &commonpb.ProcessIdentifier{
+				HostName: "my-host",
+			},
+			expected: map[string]interface{}{
+				"B":                                      "C",
+				"duration_ms":                            float64(0),
+				"has_remote_parent":                      false,
+				"name":                                   "root",
+				"source_format":                          "otlp_trace",
+				"status.code":                            float64(0),
+				"status.message":                         "OK",
+				"trace.span_id":                          "02",
+				"trace.trace_id":                         "01",
+				"opencensus.resourcetype":                "container",
+				"opencensus.same_process_as_parent_span": true,
+				"process.hostname":                       "my-host",
+				"service_name":                           "test_service",
+			},
+		},
+		{
+			name:       "nil_identifier",
+			identifier: nil,
+			expected: map[string]interface{}{
+				"B":                                      "C",
+				"duration_ms":                            float64(0),
+				"has_remote_parent":                      false,
+				"name":                                   "root",
+				"source_format":                          "otlp_trace",
+				"status.code":                            float64(0),
+				"status.message":                         "OK",
+				"trace.span_id":                          "02",
+				"trace.trace_id":                         "01",
+				"opencensus.resourcetype":                "container",
+				"opencensus.same_process_as_parent_span": true,
+				"service_name":                           "test_service",
+			},
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			td := consumerdata.TraceData{
+				Node: &commonpb.Node{
+					ServiceInfo: &commonpb.ServiceInfo{Name: "test_service"},
+					Identifier:  test.identifier,
+				},
+				Resource: &resourcepb.Resource{
+					Type: "container",
+					Labels: map[string]string{
+						"B": "C",
+					},
+				},
+				Spans: []*tracepb.Span{
+					{
+						TraceId:                 []byte{0x01},
+						SpanId:                  []byte{0x02},
+						Name:                    &tracepb.TruncatableString{Value: "root"},
+						Kind:                    tracepb.Span_SERVER,
+						SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: true},
+					},
+				},
+			}
+
+			got := testTraceExporter(internaldata.OCToTraceData(td), t)
+
+			want := []honeycombData{
+				{
+					Data: test.expected,
+				},
+			}
+
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("otel span: (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -346,7 +346,7 @@ func TestNode(t *testing.T) {
 				"trace.trace_id":                         "01",
 				"opencensus.resourcetype":                "container",
 				"opencensus.same_process_as_parent_span": true,
-				"opencensus.start_timestamp":             "2020-09-08T16:15:12-04:00",
+				"opencensus.start_timestamp":             "2020-09-08T20:15:12Z",
 				"process.hostname":                       "my-host",
 				"process.pid":                            float64(123),
 				"service_name":                           "test_service",

--- a/exporter/honeycombexporter/translator.go
+++ b/exporter/honeycombexporter/translator.go
@@ -109,8 +109,14 @@ func getTraceLevelFields(node *commonpb.Node, resource *resourcepb.Resource, sou
 			if len(process.HostName) != 0 {
 				fields["process.hostname"] = process.HostName
 			}
-			fields["process.pid"] = process.Pid
-			fields["opencensus.start_timestamp"] = timestampToTime(process.StartTimestamp)
+			if process.Pid != 0 {
+				fields["process.pid"] = process.Pid
+			}
+
+			startTime := timestampToTime(process.StartTimestamp)
+			if startTime != (time.Time{}) {
+				fields["opencensus.start_timestamp"] = startTime
+			}
 		}
 	}
 


### PR DESCRIPTION
**Description:** 
Fixes a bug where the honeycomb exporter would emit default values for the process id and process start time

**Testing:** 
Added tests

@lizthegrey @paulosman 