### PR TITLE
Stackdriver exporter: Allow overriding client options via config

### DIFF
--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -17,6 +17,7 @@ package stackdriverexporter
 import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"google.golang.org/api/option"
 )
 
 // Config defines configuration for Stackdriver exporter.
@@ -33,6 +34,11 @@ type Config struct {
 	// Timeout for all API calls. If not set, defaults to 12 seconds.
 	exporterhelper.TimeoutSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	ResourceMappings               []ResourceMapping        `mapstructure:"resource_mappings"`
+	// ClientOptions are additional options to be passed
+	// to the underlying Cloud Monitoring API client.
+	// Must be set programmatically (no support via declarative config).
+	// Optional.
+	ClientOptions []option.ClientOption
 }
 
 // ResourceMapping defines mapping of resources from source (OpenCensus) to target (Stackdriver).

--- a/exporter/stackdriverexporter/config.go
+++ b/exporter/stackdriverexporter/config.go
@@ -34,11 +34,11 @@ type Config struct {
 	// Timeout for all API calls. If not set, defaults to 12 seconds.
 	exporterhelper.TimeoutSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	ResourceMappings               []ResourceMapping        `mapstructure:"resource_mappings"`
-	// ClientOptions are additional options to be passed
-	// to the underlying Cloud Monitoring API client.
+	// GetClientOptions returns additional options to be passed
+	// to the underlying Google Cloud API client.
 	// Must be set programmatically (no support via declarative config).
 	// Optional.
-	ClientOptions []option.ClientOption
+	GetClientOptions func() []option.ClientOption
 }
 
 // ResourceMapping defines mapping of resources from source (OpenCensus) to target (Stackdriver).

--- a/exporter/stackdriverexporter/factory.go
+++ b/exporter/stackdriverexporter/factory.go
@@ -63,10 +63,10 @@ func createDefaultConfig() configmodels.Exporter {
 // createTraceExporter creates a trace exporter based on this config.
 func createTraceExporter(
 	_ context.Context,
-	_ component.ExporterCreateParams,
+	params component.ExporterCreateParams,
 	cfg configmodels.Exporter) (component.TraceExporter, error) {
 	eCfg := cfg.(*Config)
-	return newStackdriverTraceExporter(eCfg)
+	return newStackdriverTraceExporter(eCfg, params.ApplicationStartInfo.Version)
 }
 
 // createMetricsExporter creates a metrics exporter based on this config.

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -76,10 +76,8 @@ func generateClientOptions(cfg *Config, dialOpts ...grpc.DialOption) ([]option.C
 	} else {
 		copts = append(copts, option.WithEndpoint(cfg.Endpoint))
 	}
-	if len(cfg.ClientOptions) > 0 {
-		for _, opt := range cfg.ClientOptions {
-			copts = append(copts, opt)
-		}
+	if cfg.GetClientOptions != nil {
+		copts = append(copts, cfg.GetClientOptions()...)
 	}
 	return copts, nil
 }

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -65,7 +65,8 @@ func (me *metricsExporter) Shutdown(context.Context) error {
 	return nil
 }
 
-func generateClientOptions(cfg *Config, userAgent string) ([]option.ClientOption, error) {
+func generateClientOptions(cfg *Config, version string) ([]option.ClientOption, error) {
+	userAgent := strings.ReplaceAll(cfg.UserAgent, "{{version}}", version)
 	var copts []option.ClientOption
 	if userAgent != "" {
 		copts = append(copts, option.WithUserAgent(userAgent))
@@ -92,12 +93,12 @@ func generateClientOptions(cfg *Config, userAgent string) ([]option.ClientOption
 	return copts, nil
 }
 
-func newStackdriverTraceExporter(cfg *Config) (component.TraceExporter, error) {
+func newStackdriverTraceExporter(cfg *Config, version string) (component.TraceExporter, error) {
 	topts := []cloudtrace.Option{
 		cloudtrace.WithProjectID(cfg.ProjectID),
 		cloudtrace.WithTimeout(cfg.Timeout),
 	}
-	copts, err := generateClientOptions(cfg, "")
+	copts, err := generateClientOptions(cfg, version)
 	if err != nil {
 		return nil, err
 	}
@@ -136,8 +137,7 @@ func newStackdriverMetricsExporter(cfg *Config, version string) (component.Metri
 		Timeout: cfg.Timeout,
 	}
 
-	userAgent := strings.ReplaceAll(cfg.UserAgent, "{{version}}", version)
-	copts, err := generateClientOptions(cfg, userAgent)
+	copts, err := generateClientOptions(cfg, version)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -76,6 +76,11 @@ func generateClientOptions(cfg *Config, dialOpts ...grpc.DialOption) ([]option.C
 	} else {
 		copts = append(copts, option.WithEndpoint(cfg.Endpoint))
 	}
+	if len(cfg.ClientOptions) > 0 {
+		for _, opt := range cfg.ClientOptions {
+			copts = append(copts, opt)
+		}
+	}
 	return copts, nil
 }
 

--- a/exporter/stackdriverexporter/stackdriver_test.go
+++ b/exporter/stackdriverexporter/stackdriver_test.go
@@ -156,7 +156,9 @@ func TestStackdriverMetricExport(t *testing.T) {
 		Endpoint: "127.0.0.1:8080",
 		UserAgent: "MyAgent {{version}}",
 		UseInsecure: true,
-		ClientOptions: clientOptions,
+		GetClientOptions: func() []option.ClientOption {
+			 return clientOptions
+		},
 	}, "v0.0.1")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, sde.Shutdown(context.Background())) }()

--- a/exporter/stackdriverexporter/stackdriver_test.go
+++ b/exporter/stackdriverexporter/stackdriver_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/testutil/metricstestutil"
 	"go.opentelemetry.io/collector/translator/internaldata"
+	"google.golang.org/api/option"
 	cloudmetricpb "google.golang.org/genproto/googleapis/api/metric"
 	cloudtracepb "google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
 	cloudmonitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
@@ -144,7 +145,19 @@ func TestStackdriverMetricExport(t *testing.T) {
 
 	go srv.Serve(lis)
 
-	sde, err := newStackdriverMetricsExporter(&Config{ProjectID: "idk", Endpoint: "127.0.0.1:8080", UserAgent: "MyAgent {{version}}", UseInsecure: true}, "v0.0.1")
+	// Example with overridden client options
+	clientOptions := []option.ClientOption{
+		option.WithoutAuthentication(),
+		option.WithTelemetryDisabled(),
+	}
+
+	sde, err := newStackdriverMetricsExporter(&Config{
+		ProjectID: "idk",
+		Endpoint: "127.0.0.1:8080",
+		UserAgent: "MyAgent {{version}}",
+		UseInsecure: true,
+		ClientOptions: clientOptions,
+	}, "v0.0.1")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, sde.Shutdown(context.Background())) }()
 

--- a/exporter/stackdriverexporter/stackdriver_test.go
+++ b/exporter/stackdriverexporter/stackdriver_test.go
@@ -66,7 +66,10 @@ func TestStackdriverTraceExport(t *testing.T) {
 
 	go srv.Serve(lis)
 
-	sde, err := newStackdriverTraceExporter(&Config{ProjectID: "idk", Endpoint: "127.0.0.1:8080", UseInsecure: true})
+	sde, err := newStackdriverTraceExporter(
+		&Config{ProjectID: "idk", Endpoint: "127.0.0.1:8080", UseInsecure: true},
+		"v0.0.1",
+	)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, sde.Shutdown(context.Background())) }()
 
@@ -152,12 +155,12 @@ func TestStackdriverMetricExport(t *testing.T) {
 	}
 
 	sde, err := newStackdriverMetricsExporter(&Config{
-		ProjectID: "idk",
-		Endpoint: "127.0.0.1:8080",
-		UserAgent: "MyAgent {{version}}",
+		ProjectID:   "idk",
+		Endpoint:    "127.0.0.1:8080",
+		UserAgent:   "MyAgent {{version}}",
 		UseInsecure: true,
 		GetClientOptions: func() []option.ClientOption {
-			 return clientOptions
+			return clientOptions
 		},
 	}, "v0.0.1")
 	require.NoError(t, err)


### PR DESCRIPTION
**Description:** Currently we have to use a forked Stackdriver exporter for custom authorization (#688).
Adding ability to override client options will only require to make a "wrapper" factory without having a complete fork of the code.

**Link to tracking Issue:** #688

**Testing:** Added a basic unit test overriding client options

**Documentation:** Given that a new config parameter is meant to be overridden programmatically by developers, there is no need for user documentation.