### PR TITLE
K8s Processor: Logs Support

### DIFF
--- a/processor/k8sprocessor/doc.go
+++ b/processor/k8sprocessor/doc.go
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package k8sprocessor allow automatic tagging of spans and metrics with k8s metadata.
+// Package k8sprocessor allow automatic tagging of spans, metrics and logs with k8s metadata.
 //
 // The processor automatically discovers k8s resources (pods), extracts metadata from them and adds the
-// extracted metadata to the relevant spans and metrics. The processor use the kubernetes API to discover all pods
-// running in a cluster, keeps a record of their IP addresses and interesting metadata. Upon receiving spans,
+// extracted metadata to the relevant telemetry data. The processor use the kubernetes API to discover all pods
+// running in a cluster, keeps a record of their IP addresses and interesting metadata. Upon receiving data,
 // the processor tries to identify the source IP address of the service that sent the spans and matches
 // it with the in memory data. To find a k8s pod producing metrics, the processor looks at "host.hostname"
 // resource attribute which is set by prometheus receiver and some metrics instrumentation libraries.
@@ -36,8 +36,8 @@
 //
 // As an agent
 //
-// When running as an agent, the processor detects IP addresses of pods sending spans or metrics to the agent and uses
-// this information to extract metadata from pods. When running as an agent, it is important to apply
+// When running as an agent, the processor detects IP addresses of pods sending spans, metrics or logs to the agent
+// and uses this information to extract metadata from pods. When running as an agent, it is important to apply
 // a discovery filter so that the processor only discovers pods from the same host that it is running on. Not using
 // such a filter can result in unnecessary resource usage especially on very large clusters. Once the filter is applied,
 // each processor will only query the k8s API for pods running on it's own node.

--- a/processor/k8sprocessor/factory.go
+++ b/processor/k8sprocessor/factory.go
@@ -32,6 +32,7 @@ const (
 )
 
 var kubeClientProvider = kube.ClientProvider(nil)
+var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData: true}
 
 // NewFactory returns a new factory for the k8s processor.
 func NewFactory() component.ProcessorFactory {
@@ -39,7 +40,8 @@ func NewFactory() component.ProcessorFactory {
 		typeStr,
 		createDefaultConfig,
 		processorhelper.WithTraces(createTraceProcessor),
-		processorhelper.WithMetrics(createMetricsProcessor))
+		processorhelper.WithMetrics(createMetricsProcessor),
+		processorhelper.WithLogs(createLogsProcessor))
 }
 
 func createDefaultConfig() configmodels.Processor {
@@ -53,21 +55,119 @@ func createDefaultConfig() configmodels.Processor {
 }
 
 func createTraceProcessor(
-	_ context.Context,
+	ctx context.Context,
 	params component.ProcessorCreateParams,
 	cfg configmodels.Processor,
 	nextTraceConsumer consumer.TraceConsumer,
 ) (component.TraceProcessor, error) {
-	return newTraceProcessor(params.Logger, nextTraceConsumer, kubeClientProvider, createProcessorOpts(cfg)...)
+	return createTraceProcessorWithOptions(ctx, params, cfg, nextTraceConsumer)
 }
 
 func createMetricsProcessor(
-	_ context.Context,
+	ctx context.Context,
 	params component.ProcessorCreateParams,
 	cfg configmodels.Processor,
 	nextMetricsConsumer consumer.MetricsConsumer,
 ) (component.MetricsProcessor, error) {
-	return newMetricsProcessor(params.Logger, nextMetricsConsumer, kubeClientProvider, createProcessorOpts(cfg)...)
+	return createMetricsProcessorWithOptions(ctx, params, cfg, nextMetricsConsumer)
+}
+
+func createLogsProcessor(
+	ctx context.Context,
+	params component.ProcessorCreateParams,
+	cfg configmodels.Processor,
+	nextLogsConsumer consumer.LogsConsumer,
+) (component.LogsProcessor, error) {
+	return createLogsProcessorWithOptions(ctx, params, cfg, nextLogsConsumer)
+}
+
+func createTraceProcessorWithOptions(
+	_ context.Context,
+	params component.ProcessorCreateParams,
+	cfg configmodels.Processor,
+	nextTraceConsumer consumer.TraceConsumer,
+	options ...Option,
+) (component.TraceProcessor, error) {
+	kp, err := createKubernetesProcessor(params, cfg, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return processorhelper.NewTraceProcessor(
+		cfg,
+		nextTraceConsumer,
+		kp,
+		processorhelper.WithCapabilities(processorCapabilities),
+		processorhelper.WithStart(kp.Start),
+		processorhelper.WithShutdown(kp.Shutdown))
+}
+
+func createMetricsProcessorWithOptions(
+	_ context.Context,
+	params component.ProcessorCreateParams,
+	cfg configmodels.Processor,
+	nextMetricsConsumer consumer.MetricsConsumer,
+	options ...Option,
+) (component.MetricsProcessor, error) {
+	kp, err := createKubernetesProcessor(params, cfg, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return processorhelper.NewMetricsProcessor(
+		cfg,
+		nextMetricsConsumer,
+		kp,
+		processorhelper.WithCapabilities(processorCapabilities),
+		processorhelper.WithStart(kp.Start),
+		processorhelper.WithShutdown(kp.Shutdown))
+}
+
+func createLogsProcessorWithOptions(
+	_ context.Context,
+	params component.ProcessorCreateParams,
+	cfg configmodels.Processor,
+	nextLogsConsumer consumer.LogsConsumer,
+	options ...Option,
+) (component.LogsProcessor, error) {
+	kp, err := createKubernetesProcessor(params, cfg, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return processorhelper.NewLogsProcessor(
+		cfg,
+		nextLogsConsumer,
+		kp,
+		processorhelper.WithCapabilities(processorCapabilities),
+		processorhelper.WithStart(kp.Start),
+		processorhelper.WithShutdown(kp.Shutdown))
+}
+
+func createKubernetesProcessor(
+	params component.ProcessorCreateParams,
+	cfg configmodels.Processor,
+	options ...Option,
+) (*kubernetesprocessor, error) {
+	kp := &kubernetesprocessor{logger: params.Logger}
+
+	allOptions := append(createProcessorOpts(cfg), options...)
+
+	for _, opt := range allOptions {
+		if err := opt(kp); err != nil {
+			return nil, err
+		}
+	}
+
+	// This might have been set by an option already
+	if kp.kc == nil {
+		err := kp.initKubeClient(kp.logger, kubeClientProvider)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return kp, nil
 }
 
 func createProcessorOpts(cfg configmodels.Processor) []Option {

--- a/processor/k8sprocessor/factory_test.go
+++ b/processor/k8sprocessor/factory_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
+	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.uber.org/zap"
 )
 
@@ -33,26 +34,40 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 func TestCreateProcessor(t *testing.T) {
 	factory := NewFactory()
+
+	realClient := kubeClientProvider
 	kubeClientProvider = newFakeClient
+
 	cfg := factory.CreateDefaultConfig()
 	params := component.ProcessorCreateParams{Logger: zap.NewNop()}
 
-	tp, err := factory.CreateTraceProcessor(context.Background(), params, nil, cfg)
+	tp, err := factory.CreateTraceProcessor(context.Background(), params, exportertest.NewNopTraceExporter(), cfg)
 	assert.NotNil(t, tp)
 	assert.NoError(t, err)
 
-	mp, err := factory.CreateMetricsProcessor(context.Background(), params, nil, cfg)
+	mp, err := factory.CreateMetricsProcessor(context.Background(), params, exportertest.NewNopMetricsExporter(), cfg)
 	assert.NotNil(t, mp)
+	assert.NoError(t, err)
+
+	lp, err := factory.CreateLogsProcessor(context.Background(), params, cfg, exportertest.NewNopLogsExporter())
+	assert.NotNil(t, lp)
 	assert.NoError(t, err)
 
 	oCfg := cfg.(*Config)
 	oCfg.Passthrough = true
 
-	tp, err = factory.CreateTraceProcessor(context.Background(), params, nil, cfg)
+	tp, err = factory.CreateTraceProcessor(context.Background(), params, exportertest.NewNopTraceExporter(), cfg)
 	assert.NotNil(t, tp)
 	assert.NoError(t, err)
 
-	mp, err = factory.CreateMetricsProcessor(context.Background(), params, nil, cfg)
+	mp, err = factory.CreateMetricsProcessor(context.Background(), params, exportertest.NewNopMetricsExporter(), cfg)
 	assert.NotNil(t, mp)
 	assert.NoError(t, err)
+
+	lp, err = factory.CreateLogsProcessor(context.Background(), params, cfg, exportertest.NewNopLogsExporter())
+	assert.NotNil(t, lp)
+	assert.NoError(t, err)
+
+	// Switch it back so other tests run afterwards will not fail on unexpected state
+	kubeClientProvider = realClient
 }


### PR DESCRIPTION
**Description:** 

Add logs support to `k8sprocessor`

Along the way, leverages `processorhelper` factory methods and does a fair amount of refactoring, to reduce boilerplate in tests

Also, unifies the behavior or metadata assignment, specifically:
* allows to use context source IP address (if available) for all types of data
* checks for presence of IP address in `host.hostname` for metrics (as it was before) - perhaps this should be extended to logs as well? I enabled it tentatively

Since the scope of that change goes beyound just adding logs support, I am starting with a draft PR to check if this idea is going in the right direction. As the next step, I was planning to switch to OTLP-based internal models of metrics for remaining test cases and do manual tests

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/1654

**Testing:** Unit tests extended to cover logs, manual tests to follow

**Documentation:** Minor updates to `doc.go` to mention logs are covered now too