### PR TITLE
elasticexporter: translate deployment.environment

### DIFF
--- a/exporter/elasticexporter/internal/translator/elastic/metadata.go
+++ b/exporter/elasticexporter/internal/translator/elastic/metadata.go
@@ -45,6 +45,8 @@ func EncodeResourceMetadata(resource pdata.Resource, w *fastjson.Writer) {
 			case conventions.AttributeServiceInstance:
 				serviceNode.ConfiguredName = truncate(v.StringVal())
 				service.Node = &serviceNode
+			case conventions.AttributeDeploymentEnvironment:
+				service.Environment = truncate(v.StringVal())
 
 			case conventions.AttributeTelemetrySDKName:
 				agent.Name = truncate(v.StringVal())

--- a/exporter/elasticexporter/internal/translator/elastic/metadata_test.go
+++ b/exporter/elasticexporter/internal/translator/elastic/metadata_test.go
@@ -66,6 +66,14 @@ func TestMetadataServiceInstance(t *testing.T) {
 	}, out.service.Node)
 }
 
+func TestMetadataServiceEnvironment(t *testing.T) {
+	resource := resourceFromAttributesMap(map[string]pdata.AttributeValue{
+		"deployment.environment": pdata.NewAttributeValueString("foo"),
+	})
+	out := metadataWithResource(t, resource)
+	assert.Equal(t, "foo", out.service.Environment)
+}
+
 func TestMetadataSystemHostname(t *testing.T) {
 	resource := resourceFromAttributesMap(map[string]pdata.AttributeValue{
 		"host.hostname": pdata.NewAttributeValueString("foo"),


### PR DESCRIPTION
Translate the `deployment.environment` resource attribute to Elastic APM's semantically equivalent `service.environment`.

Closes #438