### PR TITLE
jmx metrics extension: Initial subprocess manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ OTEL_VERSION=master
 # Modules to run integration tests on.
 # XXX: Find a way to automatically populate this. Too slow to run across all modules when there are just a few.
 INTEGRATION_TEST_MODULES := \
+	extension/jmxmetricsextension/subprocess \
 	receiver/dockerstatsreceiver \
 	receiver/redisreceiver \
 	internal/common

--- a/extension/jmxmetricsextension/go.mod
+++ b/extension/jmxmetricsextension/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/jmxme
 go 1.14
 
 require (
+	github.com/shirou/gopsutil v2.20.6+incompatible
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.11.1-0.20200924160956-8690937037da
 	go.uber.org/zap v1.16.0

--- a/extension/jmxmetricsextension/go.mod
+++ b/extension/jmxmetricsextension/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/shirou/gopsutil v2.20.6+incompatible
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.11.1-0.20200924160956-8690937037da
+	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0
 )
 

--- a/extension/jmxmetricsextension/go.sum
+++ b/extension/jmxmetricsextension/go.sum
@@ -1105,6 +1105,7 @@ go.opentelemetry.io/collector v0.11.1-0.20200924160956-8690937037da/go.mod h1:tJ
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=

--- a/extension/jmxmetricsextension/subprocess/Makefile
+++ b/extension/jmxmetricsextension/subprocess/Makefile
@@ -1,0 +1,1 @@
+include ../../../Makefile.Common

--- a/extension/jmxmetricsextension/subprocess/integration_test.go
+++ b/extension/jmxmetricsextension/subprocess/integration_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build integration
+// +build integration !windows
 
 package subprocess
 

--- a/extension/jmxmetricsextension/subprocess/integration_test.go
+++ b/extension/jmxmetricsextension/subprocess/integration_test.go
@@ -1,0 +1,277 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build integration
+
+package subprocess
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shirou/gopsutil/process"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+const scriptContents = `#!/bin/sh
+echo "Env:" $(env)
+echo "Stdin:" $(cat -)
+
+# this will be canceled and shouldn't influence overall test time
+sleep 60
+`
+
+// prepareSubprocess will create a Subprocess based on a temporary script.
+// It returns a pointer to the pointer to psutil process info and a closure to set its
+// value from the running process once started.
+func prepareSubprocess(t *testing.T, conf *Config) (*Subprocess, **process.Process, func() bool, func()) {
+	logCore, _ := observer.New(zap.DebugLevel)
+	logger := zap.New(logCore)
+
+	scriptFile, err := ioutil.TempFile("", "subproc")
+	require.NoError(t, err)
+
+	cleanup := func() {
+		os.Remove(scriptFile.Name())
+	}
+
+	_, err = scriptFile.Write([]byte(scriptContents))
+	require.NoError(t, err)
+	require.NoError(t, scriptFile.Chmod(0700))
+	scriptFile.Close()
+
+	conf.ExecutablePath = scriptFile.Name()
+	subprocess := NewSubprocess(conf, logger)
+
+	selfPid := int32(os.Getpid())
+	expectedExecutable := fmt.Sprintf("/bin/sh %v", scriptFile.Name())
+
+	var procInfo *process.Process
+	findProcessInfo := func() bool {
+		pid := int32(subprocess.Pid())
+		if pid != -1 {
+			if proc, err := process.NewProcess(int32(subprocess.Pid())); err == nil {
+				if ppid, err := proc.Ppid(); err == nil && ppid == selfPid {
+					if cmdline, err := proc.Cmdline(); err == nil && strings.HasPrefix(cmdline, expectedExecutable) {
+						procInfo = proc
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+
+	return subprocess, &procInfo, findProcessInfo, cleanup
+}
+
+func requireDesiredStdout(t *testing.T, subprocess *Subprocess, desired string) {
+	timer := time.After(5 * time.Second)
+loop:
+	for {
+		select {
+		case <-timer:
+			break loop
+		case out := <-subprocess.Stdout:
+			if out == desired {
+				return
+			}
+		}
+	}
+	t.Fatal("Failed to receive desired stdout")
+}
+
+func TestHappyPathIntegration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	subprocess, procInfo, findProcessInfo, cleanup := prepareSubprocess(t, &Config{})
+	defer cleanup()
+
+	subprocess.Start(ctx)
+	defer subprocess.Shutdown(ctx)
+
+	require.Eventually(t, findProcessInfo, 30*time.Second, 10*time.Millisecond)
+	require.NotNil(t, *procInfo)
+
+	cmdline, err := (*procInfo).Cmdline()
+	require.NoError(t, err)
+	require.Equal(t, "/bin/sh "+subprocess.config.ExecutablePath, cmdline)
+}
+
+func TestWithArgsIntegration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	subprocess, procInfo, findProcessInfo, cleanup := prepareSubprocess(t, &Config{Args: []string{"myArgs"}})
+	defer cleanup()
+
+	subprocess.Start(ctx)
+	defer subprocess.Shutdown(ctx)
+
+	require.Eventually(t, findProcessInfo, 30*time.Second, 10*time.Millisecond)
+	require.NotNil(t, *procInfo)
+
+	cmdline, err := (*procInfo).Cmdline()
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("/bin/sh %v myArgs", subprocess.config.ExecutablePath), cmdline)
+}
+
+func TestWithEnvVarsIntegration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	config := &Config{
+		EnvironmentVariables: map[string]string{
+			"MyEnv1": "MyVal1",
+			"MyEnv2": "MyVal2",
+		},
+	}
+
+	subprocess, procInfo, findProcessInfo, cleanup := prepareSubprocess(t, config)
+	defer cleanup()
+
+	subprocess.Start(ctx)
+	defer subprocess.Shutdown(ctx)
+	require.Eventually(t, findProcessInfo, 30*time.Second, 10*time.Millisecond)
+	require.NotNil(t, *procInfo)
+
+	stdout := <-subprocess.Stdout
+	require.NotEmpty(t, stdout)
+	require.Contains(t, stdout, "MyEnv1=MyVal1")
+	require.Contains(t, stdout, "MyEnv2=MyVal2")
+}
+
+func TestWithAutoRestartIntegration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	subprocess, procInfo, findProcessInfo, cleanup := prepareSubprocess(t, &Config{RestartOnError: true})
+	defer cleanup()
+
+	subprocess.Start(ctx)
+	defer subprocess.Shutdown(ctx)
+
+	require.Eventually(t, findProcessInfo, 30*time.Second, 10*time.Millisecond)
+	require.NotNil(t, *procInfo)
+
+	cmdline, err := (*procInfo).Cmdline()
+	require.NoError(t, err)
+	require.Equal(t, "/bin/sh "+subprocess.config.ExecutablePath, cmdline)
+
+	oldProcPid := (*procInfo).Pid
+	err = (*procInfo).Kill()
+	require.NoError(t, err)
+
+	// Should be restarted
+	require.Eventually(t, findProcessInfo, restartDelay+30*time.Second, 10*time.Millisecond)
+	require.NotNil(t, *procInfo)
+
+	require.NotEqual(t, (*procInfo).Pid, oldProcPid)
+}
+
+func TestSendingStdinIntegration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	subprocess, procInfo, findProcessInfo, cleanup := prepareSubprocess(t, &Config{StdInContents: "mystdincontents"})
+	defer cleanup()
+
+	subprocess.Start(ctx)
+	defer subprocess.Shutdown(ctx)
+
+	require.Eventually(t, findProcessInfo, 30*time.Second, 10*time.Millisecond)
+	require.NotNil(t, *procInfo)
+
+	requireDesiredStdout(t, subprocess, "Stdin: mystdincontents")
+}
+
+func TestSendingStdinFailsIntegration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logCore, logObserver := observer.New(zap.DebugLevel)
+	logger := zap.New(logCore)
+
+	subprocess := NewSubprocess(&Config{ExecutablePath: "echo", Args: []string{"finished"}}, logger)
+
+	intentionalError := fmt.Errorf("intentional failure")
+	subprocess.sendToStdIn = func(contents string, writer io.Writer) error {
+		return intentionalError
+	}
+
+	subprocess.Start(ctx)
+	defer subprocess.Shutdown(ctx)
+
+	matched := func() bool {
+		died := len(logObserver.FilterMessage("subprocess died").All()) == 1
+		errored := len(logObserver.FilterField(zap.Error(intentionalError)).All()) == 1
+		return died && errored
+	}
+
+	require.Eventually(t, matched, 10*time.Second, 10*time.Millisecond)
+}
+
+func TestSubprocessBadExecIntegration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logCore, logObserver := observer.New(zap.DebugLevel)
+	logger := zap.New(logCore)
+
+	subprocess := NewSubprocess(&Config{ExecutablePath: "/does/not/exist"}, logger)
+
+	subprocess.Start(ctx)
+	defer subprocess.Shutdown(ctx)
+
+	matched := func() bool {
+		return len(logObserver.FilterMessage("subprocess died").All()) == 1
+	}
+
+	require.Eventually(t, matched, 10*time.Second, 10*time.Millisecond)
+}
+
+func TestSubprocessSuccessfullyReturnsIntegration(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	subprocess := NewSubprocess(&Config{ExecutablePath: "echo", Args: []string{"finished"}}, zap.NewNop())
+
+	subprocess.Start(ctx)
+	defer subprocess.Shutdown(ctx)
+
+	matched := func() bool {
+		_, ok := <-subprocess.shutdownSignal
+		return !ok
+	}
+
+	require.Eventually(t, matched, 10*time.Second, 10*time.Millisecond)
+	requireDesiredStdout(t, subprocess, "finished")
+}

--- a/extension/jmxmetricsextension/subprocess/subprocess.go
+++ b/extension/jmxmetricsextension/subprocess/subprocess.go
@@ -1,0 +1,282 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subprocess
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// exported to be used by jmx metrics extension
+type Config struct {
+	ExecutablePath       string            `mapstructure:"executable_path"`
+	Args                 []string          `mapstructure:"args"`
+	EnvironmentVariables map[string]string `mapstructure:"environment_variables"`
+	StdInContents        string            `mapstructure:"stdin_contents"`
+	RestartOnError       bool              `mapstructure:"restart_on_error"`
+}
+
+// exported to be used by jmx metrics extension
+type Subprocess struct {
+	Stdout         chan string
+	cancel         context.CancelFunc
+	config         *Config
+	envVars        []string
+	logger         *zap.Logger
+	pid            *pid
+	shutdownSignal chan struct{}
+	// configurable for testing purposes
+	sendToStdIn func(string, io.Writer) error
+}
+
+type pid struct {
+	pid     int
+	pidLock sync.Mutex
+}
+
+func (p *pid) setPid(pid int) {
+	p.pidLock.Lock()
+	defer p.pidLock.Unlock()
+	p.pid = pid
+}
+
+func (p *pid) getPid() int {
+	p.pidLock.Lock()
+	defer p.pidLock.Unlock()
+	return p.pid
+}
+
+func (subprocess *Subprocess) Pid() int {
+	return subprocess.pid.getPid()
+}
+
+// exported to be used by jmx metrics extension
+func NewSubprocess(conf *Config, logger *zap.Logger) *Subprocess {
+	return &Subprocess{
+		Stdout:         make(chan string),
+		pid:            &pid{pid: -1, pidLock: sync.Mutex{}},
+		config:         conf,
+		logger:         logger,
+		shutdownSignal: make(chan struct{}),
+		sendToStdIn:    sendToStdIn,
+	}
+}
+
+// A global var that is available only for testing
+var restartDelay = 5 * time.Second
+
+const (
+	Starting     = "Starting"
+	Running      = "Running"
+	ShuttingDown = "ShuttingDown"
+	Stopped      = "Stopped"
+	Restarting   = "Restarting"
+	Errored      = "Errored"
+)
+
+func (subprocess *Subprocess) Start(ctx context.Context) error {
+	var cancelCtx context.Context
+	cancelCtx, subprocess.cancel = context.WithCancel(ctx)
+
+	for k, v := range subprocess.config.EnvironmentVariables {
+		joined := fmt.Sprintf("%v=%v", k, v)
+		subprocess.envVars = append(subprocess.envVars, joined)
+	}
+
+	go func() {
+		subprocess.run(cancelCtx) // will block for lifetime of process
+		close(subprocess.shutdownSignal)
+	}()
+	return nil
+}
+
+// Shutdown is invoked during service shutdown.
+func (subprocess *Subprocess) Shutdown(ctx context.Context) error {
+	subprocess.cancel()
+	t := time.NewTimer(5 * time.Second)
+
+	// Wait for the subprocess to exit or the timeout period to elapse
+	select {
+	case <-ctx.Done():
+	case <-subprocess.shutdownSignal:
+	case <-t.C:
+	}
+
+	return nil
+}
+
+// Core event loop
+func (subprocess *Subprocess) run(ctx context.Context) {
+	var cmd *exec.Cmd
+	var err error
+	var stdin io.WriteCloser
+	var stdout io.ReadCloser
+
+	// writer is signalWhenProcessReturned() and closer is this loop, so we need synchronization
+	processReturned := make(chan error)
+	processReturnedOpen := &atomic.Value{}
+	processReturnedOpen.Store(true)
+	processReturnedLock := &sync.Mutex{}
+
+	state := Starting
+	for {
+		subprocess.logger.Debug("subprocess changed state", zap.String("state", state))
+
+		switch state {
+		case Starting:
+			cmd, stdin, stdout = createCommand(
+				subprocess.config.ExecutablePath,
+				subprocess.config.Args,
+				subprocess.envVars,
+			)
+
+			go collectStdout(stdout, subprocess.Stdout, subprocess.logger)
+
+			subprocess.logger.Debug("starting subprocess", zap.String("command", cmd.String()))
+			err = cmd.Start()
+			if err != nil {
+				state = Errored
+				continue
+			}
+			subprocess.pid.setPid(cmd.Process.Pid)
+
+			go signalWhenProcessReturned(cmd, processReturned, processReturnedLock, processReturnedOpen)
+
+			state = Running
+		case Running:
+			err = subprocess.sendToStdIn(subprocess.config.StdInContents, stdin)
+			stdin.Close()
+			if err != nil {
+				state = Errored
+				continue
+			}
+
+			select {
+			case err = <-processReturned:
+				if err != nil && ctx.Err() == nil {
+					err = fmt.Errorf("unexpected shutdown: %w", err)
+					// We aren't supposed to shutdown yet so this is an error state.
+					state = Errored
+					continue
+				}
+				// We must close this channel or can wait indefinitely at ShuttingDown
+				processReturnedLock.Lock()
+				close(processReturned)
+				processReturnedOpen.Store(false)
+				processReturnedLock.Unlock()
+				state = ShuttingDown
+			case <-ctx.Done(): // context-based cancel.
+				state = ShuttingDown
+			}
+		case Errored:
+			subprocess.logger.Error("subprocess died", zap.Error(err))
+			if subprocess.config.RestartOnError {
+				subprocess.pid.setPid(-1)
+				state = Restarting
+			} else {
+				// We must close this channel or can wait indefinitely at ShuttingDown
+				processReturnedLock.Lock()
+				close(processReturned)
+				processReturnedOpen.Store(false)
+				processReturnedLock.Unlock()
+				state = ShuttingDown
+			}
+		case ShuttingDown:
+			if cmd.Process != nil {
+				cmd.Process.Signal(syscall.SIGTERM)
+			}
+			<-processReturned
+			stdout.Close()
+			subprocess.pid.setPid(-1)
+			state = Stopped
+		case Restarting:
+			stdout.Close()
+			stdin.Close()
+			time.Sleep(restartDelay)
+			state = Starting
+		case Stopped:
+			return
+		}
+	}
+}
+
+func signalWhenProcessReturned(cmd *exec.Cmd, processReturned chan<- error, lock *sync.Mutex, open *atomic.Value) {
+	err := cmd.Wait()
+	// we cannot close here as we may need to restart and channel persists in loop.
+	// here we ensure we only write to open channel
+	lock.Lock()
+	defer lock.Unlock()
+	if open.Load().(bool) {
+		processReturned <- err
+	}
+}
+
+func collectStdout(stdout io.Reader, stdoutChan chan<- string, logger *zap.Logger) {
+	scanner := bufio.NewScanner(stdout)
+
+	for scanner.Scan() {
+		text := scanner.Text()
+		if text != "" {
+			stdoutChan <- text
+			logger.Debug(text)
+		}
+	}
+	// Returns when stdout is closed when the process ends
+}
+
+func sendToStdIn(contents string, writer io.Writer) error {
+	if contents == "" {
+		return nil
+	}
+
+	_, err := writer.Write([]byte(contents))
+	return err
+}
+
+func createCommand(execPath string, args, envVars []string) (*exec.Cmd, io.WriteCloser, io.ReadCloser) {
+	cmd := exec.Command(execPath, args...)
+
+	var env []string
+	env = append(env, os.Environ()...)
+	cmd.Env = append(env, envVars...)
+
+	inReader, inWriter, err := os.Pipe()
+	if err != nil {
+		panic("Input pipe could not be created for subprocess")
+	}
+
+	cmd.Stdin = inReader
+
+	outReader, outWriter, err := os.Pipe()
+	if err != nil {
+		panic("Output pipe could not be created for subprocess")
+	}
+	cmd.Stdout = outWriter
+	cmd.Stderr = outWriter
+
+	applyOSSpecificCmdModifications(cmd)
+
+	return cmd, inWriter, outReader
+}

--- a/extension/jmxmetricsextension/subprocess/subprocess.go
+++ b/extension/jmxmetricsextension/subprocess/subprocess.go
@@ -53,7 +53,7 @@ type Subprocess struct {
 	config         *Config
 	envVars        []string
 	logger         *zap.Logger
-	pid            *pid
+	pid            pid
 	shutdownSignal chan struct{}
 	// configurable for testing purposes
 	sendToStdIn func(string, io.Writer) error
@@ -77,10 +77,11 @@ func (p *pid) getPid() int {
 }
 
 func (subprocess *Subprocess) Pid() int {
-	if subprocess.pid == nil {
+	pid := subprocess.pid.getPid()
+	if pid == 0 {
 		return noPid
 	}
-	return subprocess.pid.getPid()
+	return pid
 }
 
 // exported to be used by jmx metrics extension
@@ -96,7 +97,7 @@ func NewSubprocess(conf *Config, logger *zap.Logger) *Subprocess {
 
 	return &Subprocess{
 		Stdout:         make(chan string),
-		pid:            &pid{pid: noPid, pidLock: sync.Mutex{}},
+		pid:            pid{pid: noPid, pidLock: sync.Mutex{}},
 		config:         conf,
 		logger:         logger,
 		shutdownSignal: make(chan struct{}),

--- a/extension/jmxmetricsextension/subprocess/subprocess_linux.go
+++ b/extension/jmxmetricsextension/subprocess/subprocess_linux.go
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package subprocess
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func applyOSSpecificCmdModifications(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		// This is Linux-specific and will cause the subprocess to be killed by the OS if
+		// the collector dies
+		Pdeathsig: syscall.SIGTERM,
+	}
+}

--- a/extension/jmxmetricsextension/subprocess/subprocess_others.go
+++ b/extension/jmxmetricsextension/subprocess/subprocess_others.go
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package subprocess
+
+import (
+	"os/exec"
+)
+
+func applyOSSpecificCmdModifications(_ *exec.Cmd) {}

--- a/extension/jmxmetricsextension/subprocess/subprocess_test.go
+++ b/extension/jmxmetricsextension/subprocess/subprocess_test.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subprocess
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestSubprocessAndConfig(t *testing.T) {
+	logger := zap.NewNop()
+	config := &Config{}
+	subprocess := NewSubprocess(config, logger)
+	require.NotNil(t, subprocess)
+	require.Same(t, config, subprocess.config)
+	require.Same(t, logger, subprocess.logger)
+	require.NotNil(t, subprocess.Stdout)
+}
+
+func TestShutdownTimeout(t *testing.T) {
+	logger := zap.NewNop()
+	subprocess := NewSubprocess(nil, logger)
+	require.NotNil(t, subprocess)
+
+	_, cancel := context.WithCancel(context.Background())
+	subprocess.cancel = cancel
+
+	t0 := time.Now()
+	err := subprocess.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	elapsed := int64(time.Since(t0))
+	require.GreaterOrEqual(t, elapsed, int64(5*time.Second))
+}

--- a/extension/jmxmetricsextension/subprocess/subprocess_test.go
+++ b/extension/jmxmetricsextension/subprocess/subprocess_test.go
@@ -65,3 +65,16 @@ func TestShutdownTimeout(t *testing.T) {
 	require.GreaterOrEqual(t, elapsed, int64(10*time.Millisecond))
 	require.GreaterOrEqual(t, int64(20*time.Millisecond), elapsed)
 }
+
+func TestPidAccessors(t *testing.T) {
+	subprocess := &Subprocess{}
+	require.Equal(t, -1, subprocess.Pid())
+
+	subprocess = NewSubprocess(&Config{}, nil)
+	require.Equal(t, -1, subprocess.Pid())
+
+	subprocess.pid.setPid(123)
+	require.Equal(t, 123, subprocess.pid.getPid())
+	require.Equal(t, 123, subprocess.Pid())
+
+}


### PR DESCRIPTION
**Description:**
Adding a feature - adding a subprocess manager to the jmx metrics extension that will be capable of managing child java processes.  This is largely a port of https://github.com/open-telemetry/opentelemetry-collector/blob/master/extension/fluentbitextension/process.go and could potentially be relocated to collector core to satisfy https://github.com/open-telemetry/opentelemetry-collector/issues/1492 in the future.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Integration and unit tests

**Documentation:** None required, other than changelog that will occur later.