### PR TITLE
Remove mentions of Kubernetes in metadata updates

### DIFF
--- a/exporter/signalfxexporter/dimensions/metadata.go
+++ b/exporter/signalfxexporter/dimensions/metadata.go
@@ -30,7 +30,7 @@ var propNameSanitizer = strings.NewReplacer(
 	"/", "_")
 
 func getDimensionUpdateFromMetadata(
-	metadata collection.KubernetesMetadataUpdate,
+	metadata collection.MetadataUpdate,
 	metricTranslator *translation.MetricTranslator,
 ) *DimensionUpdate {
 
@@ -53,7 +53,7 @@ func getDimensionUpdateFromMetadata(
 }
 
 func getPropertiesAndTags(
-	kmu collection.KubernetesMetadataUpdate,
+	kmu collection.MetadataUpdate,
 	translate func(string) string,
 ) (map[string]*string, map[string]bool) {
 	properties := map[string]*string{}
@@ -105,7 +105,7 @@ func getPropertiesAndTags(
 	return properties, tags
 }
 
-func (dc *DimensionClient) PushKubernetesMetadata(metadata []*collection.KubernetesMetadataUpdate) error {
+func (dc *DimensionClient) PushMetadata(metadata []*collection.MetadataUpdate) error {
 	var errs []error
 	for _, m := range metadata {
 		dimensionUpdate := getDimensionUpdateFromMetadata(*m, dc.metricTranslator)

--- a/exporter/signalfxexporter/dimensions/metadata_test.go
+++ b/exporter/signalfxexporter/dimensions/metadata_test.go
@@ -33,7 +33,7 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 		},
 	}, 1)
 	type args struct {
-		metadata         collection.KubernetesMetadataUpdate
+		metadata         collection.MetadataUpdate
 		metricTranslator *translation.MetricTranslator
 	}
 	tests := []struct {
@@ -44,7 +44,7 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 		{
 			"Test tags update",
 			args{
-				metadata: collection.KubernetesMetadataUpdate{
+				metadata: collection.MetadataUpdate{
 					ResourceIDKey: "name",
 					ResourceID:    "val",
 					MetadataDelta: collection.MetadataDelta{
@@ -72,7 +72,7 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 		{
 			"Test properties update",
 			args{
-				metadata: collection.KubernetesMetadataUpdate{
+				metadata: collection.MetadataUpdate{
 					ResourceIDKey: "name",
 					ResourceID:    "val",
 					MetadataDelta: collection.MetadataDelta{
@@ -105,7 +105,7 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 		{
 			"Test with unsupported characters",
 			args{
-				metadata: collection.KubernetesMetadataUpdate{
+				metadata: collection.MetadataUpdate{
 					ResourceIDKey: "name",
 					ResourceID:    "val",
 					MetadataDelta: collection.MetadataDelta{
@@ -143,7 +143,7 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 		{
 			"Test dimensions translation",
 			args{
-				metadata: collection.KubernetesMetadataUpdate{
+				metadata: collection.MetadataUpdate{
 					ResourceIDKey: "name",
 					ResourceID:    "val",
 					MetadataDelta: collection.MetadataDelta{

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -35,9 +35,9 @@ import (
 )
 
 type signalfxExporter struct {
-	logger                 *zap.Logger
-	pushMetricsData        func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error)
-	pushKubernetesMetadata func(metadata []*collection.KubernetesMetadataUpdate) error
+	logger          *zap.Logger
+	pushMetricsData func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error)
+	pushMetadata    func(metadata []*collection.MetadataUpdate) error
 }
 
 type exporterOptions struct {
@@ -102,9 +102,9 @@ func newSignalFxExporter(
 	dimClient.Start()
 
 	return signalfxExporter{
-		logger:                 logger,
-		pushMetricsData:        dpClient.pushMetricsData,
-		pushKubernetesMetadata: dimClient.PushKubernetesMetadata,
+		logger:          logger,
+		pushMetricsData: dpClient.pushMetricsData,
+		pushMetadata:    dimClient.PushMetadata,
 	}, nil
 }
 
@@ -125,6 +125,6 @@ func (se signalfxExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics)
 	return err
 }
 
-func (se signalfxExporter) ConsumeKubernetesMetadata(metadata []*collection.KubernetesMetadataUpdate) error {
-	return se.pushKubernetesMetadata(metadata)
+func (se signalfxExporter) ConsumeMetadata(metadata []*collection.MetadataUpdate) error {
+	return se.pushMetadata(metadata)
 }

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -461,9 +461,9 @@ func generateLargeBatch() pdata.Metrics {
 	return internaldata.OCSliceToMetrics(mds)
 }
 
-func TestConsumeKubernetesMetadata(t *testing.T) {
+func TestConsumeMetadata(t *testing.T) {
 	type args struct {
-		metadata []*collection.KubernetesMetadataUpdate
+		metadata []*collection.MetadataUpdate
 	}
 	type fields struct {
 		payLoad map[string]interface{}
@@ -488,7 +488,7 @@ func TestConsumeKubernetesMetadata(t *testing.T) {
 				},
 			},
 			args{
-				[]*collection.KubernetesMetadataUpdate{
+				[]*collection.MetadataUpdate{
 					{
 						ResourceIDKey: "key",
 						ResourceID:    "id",
@@ -522,7 +522,7 @@ func TestConsumeKubernetesMetadata(t *testing.T) {
 				},
 			},
 			args{
-				[]*collection.KubernetesMetadataUpdate{
+				[]*collection.MetadataUpdate{
 					{
 						ResourceIDKey: "key",
 						ResourceID:    "id",
@@ -557,7 +557,7 @@ func TestConsumeKubernetesMetadata(t *testing.T) {
 				},
 			},
 			args{
-				[]*collection.KubernetesMetadataUpdate{
+				[]*collection.MetadataUpdate{
 					{
 						ResourceIDKey: "key",
 						ResourceID:    "id",
@@ -650,11 +650,11 @@ func TestConsumeKubernetesMetadata(t *testing.T) {
 			dimClient.Start()
 
 			se := signalfxExporter{
-				logger:                 logger,
-				pushKubernetesMetadata: dimClient.PushKubernetesMetadata,
+				logger:       logger,
+				pushMetadata: dimClient.PushMetadata,
 			}
 
-			err = se.ConsumeKubernetesMetadata(tt.args.metadata)
+			err = se.ConsumeMetadata(tt.args.metadata)
 
 			// Wait for requests to be handled by the mocked server before assertion.
 			wg.Wait()

--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -69,11 +69,11 @@ following interface. If an exporter that does not implement the interface is lis
 startup will fail.
 
 ```yaml
-type KubernetesMetadataExporter interface {
-  ConsumeKubernetesMetadata(metadata []*KubernetesMetadataUpdate) error
+type MetadataExporter interface {
+  ConsumeMetadata(metadata []*MetadataUpdate) error
 }
 
-type KubernetesMetadataUpdate struct {
+type MetadataUpdate struct {
   ResourceIDKey string
   ResourceID    ResourceID
   MetadataDelta

--- a/receiver/k8sclusterreceiver/collection/metadata.go
+++ b/receiver/k8sclusterreceiver/collection/metadata.go
@@ -83,17 +83,17 @@ func mergeKubernetesMetadataMaps(maps ...map[ResourceID]*KubernetesMetadata) map
 	return out
 }
 
-// KubernetesMetadataExporter provides an interface to implement
-// ConsumeKubernetesMetadata in Exporters that support metadata.
-type KubernetesMetadataExporter interface {
-	// ConsumeKubernetesMetadata will be invoked every time there's an
-	// update to a resource that results in one or more KubernetesMetadataUpdate.
-	ConsumeKubernetesMetadata(metadata []*KubernetesMetadataUpdate) error
+// MetadataExporter provides an interface to implement
+// ConsumeMetadata in Exporters that support metadata.
+type MetadataExporter interface {
+	// ConsumeMetadata will be invoked every time there's an
+	// update to a resource that results in one or more MetadataUpdate.
+	ConsumeMetadata(metadata []*MetadataUpdate) error
 }
 
-// KubernetesMetadataUpdate provides a delta view of metadata on a resource between
+// MetadataUpdate provides a delta view of metadata on a resource between
 // two revisions of a resource.
-type KubernetesMetadataUpdate struct {
+type MetadataUpdate struct {
 	// ResourceIDKey is the label key of UID label for the resource.
 	ResourceIDKey string
 	// ResourceID is the Kubernetes UID of the resource. In case of
@@ -102,17 +102,17 @@ type KubernetesMetadataUpdate struct {
 	MetadataDelta
 }
 
-// GetKubernetesMetadataUpdate processes kubernetes metadata updates and returns
+// GetMetadataUpdate processes metadata updates and returns
 // a map of a delta of metadata mapped to each resource.
-func GetKubernetesMetadataUpdate(old, new map[ResourceID]*KubernetesMetadata) []*KubernetesMetadataUpdate {
-	var out []*KubernetesMetadataUpdate
+func GetMetadataUpdate(old, new map[ResourceID]*KubernetesMetadata) []*MetadataUpdate {
+	var out []*MetadataUpdate
 
 	for id, oldMetadata := range old {
 		// if an object with the same id has a previous revision, take a delta
 		// of the metadata.
 		if newMetadata, ok := new[id]; ok {
 			if metadataDelta := getMetadataDelta(oldMetadata.metadata, newMetadata.metadata); metadataDelta != nil {
-				out = append(out, &KubernetesMetadataUpdate{
+				out = append(out, &MetadataUpdate{
 					ResourceIDKey: oldMetadata.resourceIDKey,
 					ResourceID:    id,
 					MetadataDelta: *metadataDelta,
@@ -126,7 +126,7 @@ func GetKubernetesMetadataUpdate(old, new map[ResourceID]*KubernetesMetadata) []
 	for id, km := range new {
 		// if an id is seen for the first time, all metadata need to be added.
 		if _, ok := old[id]; !ok {
-			out = append(out, &KubernetesMetadataUpdate{
+			out = append(out, &MetadataUpdate{
 				ResourceIDKey: km.resourceIDKey,
 				ResourceID:    id,
 				MetadataDelta: MetadataDelta{MetadataToAdd: km.metadata},

--- a/receiver/k8sclusterreceiver/mock_exporter_test.go
+++ b/receiver/k8sclusterreceiver/mock_exporter_test.go
@@ -68,6 +68,6 @@ func (m mockExporterWithK8sMetadata) Shutdown(context.Context) error {
 	return nil
 }
 
-func (m mockExporterWithK8sMetadata) ConsumeKubernetesMetadata([]*collection.KubernetesMetadataUpdate) error {
+func (m mockExporterWithK8sMetadata) ConsumeMetadata([]*collection.MetadataUpdate) error {
 	return nil
 }

--- a/receiver/k8sclusterreceiver/watcher.go
+++ b/receiver/k8sclusterreceiver/watcher.go
@@ -42,7 +42,7 @@ type resourceWatcher struct {
 	metadataConsumers     []metadataConsumer
 }
 
-type metadataConsumer func(metadata []*collection.KubernetesMetadataUpdate) error
+type metadataConsumer func(metadata []*collection.MetadataUpdate) error
 
 // newResourceWatcher creates a Kubernetes resource watcher.
 func newResourceWatcher(
@@ -146,11 +146,11 @@ func (rw *resourceWatcher) setupMetadataExporters(
 		if !metadataExportersSet[cfg.Name()] {
 			continue
 		}
-		kme, ok := exp.(collection.KubernetesMetadataExporter)
+		kme, ok := exp.(collection.MetadataExporter)
 		if !ok {
-			return fmt.Errorf("%s exporter does not implement KubernetesMetadataExporter", cfg.Name())
+			return fmt.Errorf("%s exporter does not implement MetadataExporter", cfg.Name())
 		}
-		out = append(out, kme.ConsumeKubernetesMetadata)
+		out = append(out, kme.ConsumeMetadata)
 		rw.logger.Info("Configured Kubernetes MetadataExporter",
 			zap.String("exporter_name", cfg.Name()),
 		)
@@ -180,13 +180,13 @@ func validateMetadataExporters(metadataExporters map[string]bool,
 func (rw *resourceWatcher) syncMetadataUpdate(oldMetadata,
 	newMetadata map[collection.ResourceID]*collection.KubernetesMetadata) {
 
-	kubernetesMetadataUpdate := collection.GetKubernetesMetadataUpdate(oldMetadata, newMetadata)
-	if len(kubernetesMetadataUpdate) == 0 {
+	metadataUpdate := collection.GetMetadataUpdate(oldMetadata, newMetadata)
+	if len(metadataUpdate) == 0 {
 		return
 	}
 
 	// TODO: Asynchronously invoke consumers
 	for _, consume := range rw.metadataConsumers {
-		consume(kubernetesMetadataUpdate)
+		consume(metadataUpdate)
 	}
 }

--- a/receiver/k8sclusterreceiver/watcher_test.go
+++ b/receiver/k8sclusterreceiver/watcher_test.go
@@ -51,7 +51,7 @@ func TestSetupMetadataExporters(t *testing.T) {
 		{
 			"Supported exporter",
 			fields{
-				metadataConsumers: []metadataConsumer{(&mockExporterWithK8sMetadata{}).ConsumeKubernetesMetadata},
+				metadataConsumers: []metadataConsumer{(&mockExporterWithK8sMetadata{}).ConsumeMetadata},
 			},
 			args{exporters: map[configmodels.Exporter]component.Exporter{
 				mockExporterConfig{ExporterName: "exampleexporter"}: mockExporterWithK8sMetadata{},


### PR DESCRIPTION
Metadata updates can be applied to any kind of metadata, not only Kubernetes. Keep "kubernetes metadata" in k8s cluster receiver, and use more generic "metadata update" in SignalFx exporter. It's preparation work for host metadata.
