### PR TITLE
Fix version tag regex to trigger publish-stable job for v0.10.0 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9].[0-9].[0-9]+.*/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
       - spawn-stability-tests-job:
           requires:
             - lint
@@ -246,7 +246,7 @@ workflows:
             - cross-compile
           filters:
             tags:
-              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
       - build-package:
           name: rpm-package
           package_type: rpm
@@ -254,7 +254,7 @@ workflows:
             - cross-compile
           filters:
             tags:
-              only: /^v([0-9])+.([0-9])+.([0-9])+.*/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
 
 jobs:
   setup:


### PR DESCRIPTION
v0.10.0 tag doesn't match existing regex in to trigger publish-stable job in CircleCI