### PR TITLE
Add SignalFx Event Support to SignalFx Exporter

### DIFF
--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path"
 	"time"
 
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -41,7 +40,7 @@ type Config struct {
 	// intended for tests and debugging. The value of Realm is ignored if the
 	// URL is specified. If a path is not included the exporter will
 	// automatically append the appropriate path, eg.: "v2/datapoint".
-	// If a path is specified it will use the one set by the config.
+	// If a path is specified it will act as a prefix.
 	IngestURL string `mapstructure:"ingest_url"`
 
 	// APIURL is the destination to where SignalFx metadata will be sent. This
@@ -132,7 +131,7 @@ func (cfg *Config) validateConfig() error {
 
 func (cfg *Config) getIngestURL() (out *url.URL, err error) {
 	if cfg.IngestURL == "" {
-		out, err = url.Parse(fmt.Sprintf("https://ingest.%s.signalfx.com/v2/datapoint", cfg.Realm))
+		out, err = url.Parse(fmt.Sprintf("https://ingest.%s.signalfx.com", cfg.Realm))
 		if err != nil {
 			return out, err
 		}
@@ -141,9 +140,6 @@ func (cfg *Config) getIngestURL() (out *url.URL, err error) {
 		out, err = url.Parse(cfg.IngestURL)
 		if err != nil {
 			return out, err
-		}
-		if out.Path == "" || out.Path == "/" {
-			out.Path = path.Join(out.Path, "v2/datapoint")
 		}
 	}
 

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -117,7 +117,7 @@ func TestConfig_getOptionsFromConfig(t *testing.T) {
 				ingestURL: &url.URL{
 					Scheme: "https",
 					Host:   "ingest.us1.signalfx.com",
-					Path:   "/v2/datapoint",
+					Path:   "/",
 				},
 				apiURL: &url.URL{
 					Scheme: "https",
@@ -140,7 +140,7 @@ func TestConfig_getOptionsFromConfig(t *testing.T) {
 				ingestURL: &url.URL{
 					Scheme: "https",
 					Host:   "ingest.us0.signalfx.com",
-					Path:   "/v2/datapoint",
+					Path:   "",
 				},
 				apiURL: &url.URL{
 					Scheme: "https",

--- a/exporter/signalfxexporter/eventclient.go
+++ b/exporter/signalfxexporter/eventclient.go
@@ -1,0 +1,144 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalfxexporter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strings"
+
+	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/translation"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
+)
+
+// sfxEventClient sends the data to the SignalFx backend.
+type sfxEventClient struct {
+	sfxClientBase
+	logger                 *zap.Logger
+	accessTokenPassthrough bool
+}
+
+func (s *sfxEventClient) pushResourceLogs(
+	ctx context.Context,
+	rls pdata.ResourceLogs,
+) (int, error) {
+	accessToken := s.retrieveAccessToken(rls)
+
+	var sfxEvents []*sfxpb.Event
+	numDroppedLogRecords := 0
+
+	ills := rls.InstrumentationLibraryLogs()
+	for j := 0; j < ills.Len(); j++ {
+		ill := ills.At(j)
+
+		events, dropped := translation.LogSliceToSignalFxV2(s.logger, ill.Logs())
+		sfxEvents = append(sfxEvents, events...)
+		numDroppedLogRecords += dropped
+	}
+
+	body, compressed, err := s.encodeBody(sfxEvents)
+	if err != nil {
+		return countRecords(rls), consumererror.Permanent(err)
+	}
+
+	eventURL := *s.ingestURL
+	if !strings.HasSuffix(eventURL.Path, "v2/event") {
+		eventURL.Path = path.Join(eventURL.Path, "v2/event")
+	}
+	req, err := http.NewRequest("POST", eventURL.String(), body)
+	if err != nil {
+		return countRecords(rls), consumererror.Permanent(err)
+	}
+
+	for k, v := range s.headers {
+		req.Header.Set(k, v)
+	}
+
+	if s.accessTokenPassthrough && accessToken != "" {
+		req.Header.Set(splunk.SFxAccessTokenHeader, accessToken)
+	}
+
+	if compressed {
+		req.Header.Set("Content-Encoding", "gzip")
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return countRecords(rls), err
+	}
+
+	defer func() {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	// SignalFx accepts all 2XX codes.
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err = fmt.Errorf(
+			"HTTP %d %q for %q: %s",
+			resp.StatusCode,
+			http.StatusText(resp.StatusCode),
+			req.URL,
+			body)
+		return countRecords(rls), err
+	}
+
+	return numDroppedLogRecords, nil
+}
+
+func (s *sfxEventClient) encodeBody(events []*sfxpb.Event) (bodyReader io.Reader, compressed bool, err error) {
+	msg := sfxpb.EventUploadMessage{
+		Events: events,
+	}
+	body, err := msg.Marshal()
+	if err != nil {
+		return nil, false, err
+	}
+	return s.getReader(body)
+}
+
+func (s *sfxEventClient) retrieveAccessToken(rl pdata.ResourceLogs) string {
+	if rl.IsNil() || rl.Resource().IsNil() {
+		return ""
+	}
+	attrs := rl.Resource().Attributes()
+	if accessToken, ok := attrs.Get(splunk.SFxAccessTokenLabel); ok && accessToken.Type() == pdata.AttributeValueSTRING {
+		// Drop internally passed access token in all cases
+		attrs.Delete(splunk.SFxAccessTokenLabel)
+		return accessToken.StringVal()
+	}
+	return ""
+}
+
+func countRecords(rs pdata.ResourceLogs) int {
+	logCount := 0
+
+	ill := rs.InstrumentationLibraryLogs()
+	for i := 0; i < ill.Len(); i++ {
+		logs := ill.At(i)
+		logCount += logs.Logs().Len()
+	}
+	return logCount
+}

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/obsreport"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/dimensions"
@@ -35,9 +36,10 @@ import (
 )
 
 type signalfxExporter struct {
-	logger          *zap.Logger
-	pushMetricsData func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error)
-	pushMetadata    func(metadata []*collection.MetadataUpdate) error
+	logger           *zap.Logger
+	pushMetricsData  func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error)
+	pushMetadata     func(metadata []*collection.MetadataUpdate) error
+	pushResourceLogs func(ctx context.Context, ld pdata.ResourceLogs) (droppedLogRecords int, err error)
 }
 
 type exporterOptions struct {
@@ -54,7 +56,6 @@ func newSignalFxExporter(
 	config *Config,
 	logger *zap.Logger,
 ) (component.MetricsExporter, error) {
-
 	if config == nil {
 		return nil, errors.New("nil config")
 	}
@@ -68,17 +69,17 @@ func newSignalFxExporter(
 	headers := buildHeaders(config)
 
 	dpClient := &sfxDPClient{
-		ingestURL: options.ingestURL,
-		headers:   headers,
-		client: &http.Client{
-			// TODO: What other settings of http.Client to expose via config?
-			//  Or what others change from default values?
-			Timeout: config.Timeout,
+		sfxClientBase: sfxClientBase{
+			ingestURL: options.ingestURL,
+			headers:   headers,
+			client: &http.Client{
+				// TODO: What other settings of http.Client to expose via config?
+				//  Or what others change from default values?
+				Timeout: config.Timeout,
+			},
+			zippers: newGzipPool(),
 		},
-		logger: logger,
-		zippers: sync.Pool{New: func() interface{} {
-			return gzip.NewWriter(nil)
-		}},
+		logger:                 logger,
 		accessTokenPassthrough: config.AccessTokenPassthrough,
 		converter:              translation.NewMetricsConverter(logger, options.metricTranslator),
 	}
@@ -108,6 +109,46 @@ func newSignalFxExporter(
 	}, nil
 }
 
+func newGzipPool() sync.Pool {
+	return sync.Pool{New: func() interface{} {
+		return gzip.NewWriter(nil)
+	}}
+}
+
+func NewEventExporter(config *Config, logger *zap.Logger) (component.LogsExporter, error) {
+	if config == nil {
+		return nil, errors.New("nil config")
+	}
+
+	options, err := config.getOptionsFromConfig()
+	if err != nil {
+		return nil,
+			fmt.Errorf("failed to process %q config: %v", config.Name(), err)
+	}
+
+	headers := buildHeaders(config)
+
+	eventClient := &sfxEventClient{
+		sfxClientBase: sfxClientBase{
+			ingestURL: options.ingestURL,
+			headers:   headers,
+			client: &http.Client{
+				// TODO: What other settings of http.Client to expose via config?
+				//  Or what others change from default values?
+				Timeout: config.Timeout,
+			},
+			zippers: newGzipPool(),
+		},
+		logger:                 logger,
+		accessTokenPassthrough: config.AccessTokenPassthrough,
+	}
+
+	return signalfxExporter{
+		logger:           logger,
+		pushResourceLogs: eventClient.pushResourceLogs,
+	}, nil
+}
+
 func (se signalfxExporter) Start(context.Context, component.Host) error {
 	return nil
 }
@@ -122,6 +163,22 @@ func (se signalfxExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics)
 	numReceivedTimeSeries, numPoints := md.MetricAndDataPointCount()
 
 	obsreport.EndMetricsExportOp(ctx, numPoints, numReceivedTimeSeries, numDroppedTimeSeries, err)
+	return err
+}
+
+func (se signalfxExporter) ConsumeLogs(ctx context.Context, ld pdata.Logs) error {
+	ctx = obsreport.StartLogsExportOp(ctx, typeStr)
+
+	var numDroppedRecords int
+	var err error
+	rls := ld.ResourceLogs()
+	for i := 0; i < rls.Len(); i++ {
+		dropped, thisErr := se.pushResourceLogs(ctx, rls.At(i))
+		numDroppedRecords += dropped
+		err = multierr.Append(err, thisErr)
+	}
+
+	obsreport.EndLogsExportOp(ctx, ld.LogRecordCount(), numDroppedRecords, err)
 	return err
 }
 

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -41,7 +41,8 @@ func NewFactory() component.ExporterFactory {
 	return exporterhelper.NewFactory(
 		typeStr,
 		createDefaultConfig,
-		exporterhelper.WithMetrics(createMetricsExporter))
+		exporterhelper.WithMetrics(createMetricsExporter),
+		exporterhelper.WithLogs(createLogsExporter))
 }
 
 func createDefaultConfig() configmodels.Exporter {
@@ -95,4 +96,14 @@ func loadDefaultTranslationRules() ([]translation.Rule, error) {
 	}
 
 	return config.TranslationRules, nil
+}
+
+func createLogsExporter(
+	_ context.Context,
+	params component.ExporterCreateParams,
+	cfg configmodels.Exporter,
+) (component.LogsExporter, error) {
+	oCfg := cfg.(*Config)
+
+	return NewEventExporter(oCfg, params.Logger)
 }

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -78,6 +78,13 @@ func TestCreateInstanceViaFactory(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, exp)
 
+	logExp, err := factory.CreateLogsExporter(
+		context.Background(),
+		component.ExporterCreateParams{Logger: zap.NewNop()},
+		cfg)
+	assert.NoError(t, err)
+	require.NotNil(t, logExp)
+
 	assert.NoError(t, exp.Shutdown(context.Background()))
 }
 

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.2
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.10.1-0.20200922190504-eb2127131b29
+	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.16.0
 	google.golang.org/protobuf v1.25.0
 )

--- a/exporter/signalfxexporter/go.sum
+++ b/exporter/signalfxexporter/go.sum
@@ -277,6 +277,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
@@ -492,6 +493,7 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -516,6 +518,7 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/googleapis/gnostic v0.5.1 h1:A8Yhf6EtqTv9RMsU6MQTyrtV1TjWlR6xU9BsZIwuTCM=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/gookit/color v1.2.5 h1:s1gzb/fg3HhkSLKyWVUsZcVBUo+R1TwEYTmmxH8gGFg=
+github.com/gookit/color v1.2.5/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gookit/color v1.2.5/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.12.0 h1:mZrie07npp6ODiwHZolTicr5jV8Ogn43AvAsSMm6Ork=
@@ -802,6 +805,7 @@ github.com/nishanths/exhaustive v0.0.0-20200811152831-6cf413ae40e0 h1:eMV1t2NQRc
 github.com/nishanths/exhaustive v0.0.0-20200811152831-6cf413ae40e0/go.mod h1:wBEpHwM2OdmeNpdCvRPUlkEbBuaFmcK4Wv8Q7FuGW3c=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
@@ -815,7 +819,9 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.13.0 h1:M76yO2HkZASFjXL0HSoZJ1AYEmQxNJmY41Jx1zNUq1Y=
+github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/ginkgo v1.13.0/go.mod h1:+REjRxOmWfHCjfv9TTWB1jD1Frx4XydAD3zm1lskyM0=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -824,6 +830,7 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
+github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -965,12 +972,16 @@ github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e/go.mod h1:gi+0
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
+github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
+github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
+github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sectioneight/md-to-godoc v0.0.0-20161108233149-55e43be6c335/go.mod h1:lPZq22klO8la1kyImIDhrGytugMV0TsrsZB55a+xxI0=
 github.com/securego/gosec v0.0.0-20200203094520-d13bb6d2420c h1:pThusIwnQVcKbuZSds3HgB/ODEqxMqZf/SgVp89JXY0=
 github.com/securego/gosec v0.0.0-20200203094520-d13bb6d2420c/go.mod h1:gp0gaHj0WlmPh9BdsTmo1aq6C27yIPWdxCKGFGdVKBE=
 github.com/securego/gosec/v2 v2.4.0 h1:ivAoWcY5DMs9n04Abc1VkqZBO0FL0h4ShTcVsC53lCE=
+github.com/securego/gosec/v2 v2.4.0/go.mod h1:0/Q4cjmlFDfDUj1+Fib61sc+U5IQb2w+Iv9/C3wPVko=
 github.com/securego/gosec/v2 v2.4.0/go.mod h1:0/Q4cjmlFDfDUj1+Fib61sc+U5IQb2w+Iv9/C3wPVko=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
@@ -1029,6 +1040,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
+github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
+github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/ssgreg/nlreturn/v2 v2.1.0 h1:6/s4Rc49L6Uo6RLjhWZGBpWWjfzk2yrf1nIW8m4wgVA=
 github.com/ssgreg/nlreturn/v2 v2.1.0/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
@@ -1059,6 +1072,7 @@ github.com/tcnksm/go-latest v0.0.0-20170313132115-e3007ae9052e/go.mod h1:d7u6HkT
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2 h1:Xr9gkxfOP0KQWXKNqmwe8vEeSUiUj4Rlee9CMVX2ZUQ=
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tetafro/godot v0.4.8 h1:h61+hQraWhdI6WYqMwAwZYCE5yxL6a9/Orw4REbabSU=
+github.com/tetafro/godot v0.4.8/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/tetafro/godot v0.4.8/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e h1:RumXZ56IrCj4CL+g1b9OL/oH0QnsF976bC8xQFYUD5Q=
@@ -1124,6 +1138,8 @@ go.opentelemetry.io/collector v0.10.1-0.20200922190504-eb2127131b29/go.mod h1:tJ
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
+go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -1237,6 +1253,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200528225125-3c3fba18258b/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -1315,9 +1332,12 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 h1:OjiUf46hAmXblsZdnoSXsEUSKU8r1UEzcL5RVZ4gO9Y=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200821140526-fda516888d29 h1:mNuhGagCf3lDDm5C0376C/sxh6V7fy9WbdEu/YDNA04=
 golang.org/x/sys v0.0.0-20200821140526-fda516888d29/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1406,6 +1426,9 @@ golang.org/x/tools v0.0.0-20200603131246-cc40288be839/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200625211823-6506e20df31f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200701041122-1837592efa10/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200701041122-1837592efa10/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305 h1:yaM5S0KcY0lIoZo7Fl+oi91b/DdlU2zuWpfHrpWbCS0=
+golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200822203824-307de81be3f4 h1:r0nbB2EeRbGpnVeqxlkgiBpNi/bednpSg78qzZGOuv0=
@@ -1487,10 +1510,14 @@ google.golang.org/grpc v1.28.0-pre/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7K
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.31.0 h1:T7P4R73V3SSDPhH7WW7ATbfViLtmamH0DKrP3f9AuDI=
+google.golang.org/grpc v1.31.0 h1:T7P4R73V3SSDPhH7WW7ATbfViLtmamH0DKrP3f9AuDI=
+google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9 h1:f+/+gfZ/tfaHBXXiv1gWRmCej6wlX3mLY4bnLpI99wk=
+google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9/go.mod h1:5j1uub0jRGhRiSghIlrThmBUgcgLXOVJQ/l1getT4uo=
 google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9/go.mod h1:5j1uub0jRGhRiSghIlrThmBUgcgLXOVJQ/l1getT4uo=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -1563,6 +1590,7 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.5 h1:nI5egYTGJakVyOryqLs1cQO5dO0ksin5XXs2pspk75k=
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.18.8/go.mod h1:d/CXqwWv+Z2XEG1LgceeDmHQwpUJhROPx16SlxJgERY=
 k8s.io/api v0.19.2 h1:q+/krnHWKsL7OBZg/rxnycsl9569Pud76UJ77MvKXms=
 k8s.io/api v0.19.2/go.mod h1:IQpK0zFQ1xc5iNIQPqzgoOwuFugaYHK4iCknlAQP9nI=
@@ -1578,6 +1606,7 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/klog/v2 v2.2.0 h1:XRvcwJozkgZ1UQJmfMGpvRthQHOvihEhYtDfAaxMz/A=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
@@ -1602,6 +1631,7 @@ rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
+sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1 h1:YXTMot5Qz/X1iBRJhAt+vI+HVttY0WkSqqhKxQ0xVbA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/exporter/signalfxexporter/translation/logdata_to_signalfxv2.go
+++ b/exporter/signalfxexporter/translation/logdata_to_signalfxv2.go
@@ -1,0 +1,119 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translation
+
+import (
+	"fmt"
+
+	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
+)
+
+func LogSliceToSignalFxV2(
+	logger *zap.Logger,
+	logs pdata.LogSlice,
+) ([]*sfxpb.Event, int) {
+	events := make([]*sfxpb.Event, 0, logs.Len())
+	numDroppedLogRecords := 0
+
+	for i := 0; i < logs.Len(); i++ {
+		lr := logs.At(i)
+		event, ok := convertLogRecord(lr, logger)
+		if !ok {
+			numDroppedLogRecords++
+			continue
+		}
+		events = append(events, event)
+	}
+
+	return events, numDroppedLogRecords
+}
+
+func convertLogRecord(lr pdata.LogRecord, logger *zap.Logger) (*sfxpb.Event, bool) {
+	attrs := lr.Attributes()
+
+	categoryVal, ok := attrs.Get(splunk.SFxEventCategoryKey)
+	if !ok {
+		return nil, false
+	}
+
+	var event sfxpb.Event
+
+	if categoryVal.Type() == pdata.AttributeValueINT {
+		asCat := sfxpb.EventCategory(categoryVal.IntVal())
+		event.Category = &asCat
+		attrs.Delete(splunk.SFxEventCategoryKey)
+	}
+
+	if mapVal, ok := attrs.Get(splunk.SFxEventPropertiesKey); ok && mapVal.Type() == pdata.AttributeValueMAP {
+		mapVal.MapVal().ForEach(func(k string, v pdata.AttributeValue) {
+			val, err := attributeValToPropertyVal(v)
+			if err != nil {
+				logger.Debug("Failed to convert log record property value to SignalFx property value", zap.Error(err), zap.String("key", k))
+				return
+			}
+
+			event.Properties = append(event.Properties, &sfxpb.Property{
+				Key:   k,
+				Value: val,
+			})
+		})
+	}
+	attrs.Delete(splunk.SFxEventPropertiesKey)
+
+	attrs.ForEach(func(k string, v pdata.AttributeValue) {
+		if v.Type() != pdata.AttributeValueSTRING {
+			logger.Debug("Failed to convert log record attribute value to SignalFx property value, key is not a string", zap.String("key", k))
+			return
+		}
+
+		event.Dimensions = append(event.Dimensions, &sfxpb.Dimension{
+			Key:   k,
+			Value: v.StringVal(),
+		})
+	})
+
+	event.EventType = lr.Name()
+	// Convert nanoseconds to nearest milliseconds, which is the unit of
+	// SignalFx event timestamps.
+	event.Timestamp = int64(lr.Timestamp()) / 1e6
+
+	return &event, true
+}
+
+func attributeValToPropertyVal(v pdata.AttributeValue) (*sfxpb.PropertyValue, error) {
+	var val sfxpb.PropertyValue
+	switch v.Type() {
+	case pdata.AttributeValueINT:
+		asInt := v.IntVal()
+		val.IntValue = &asInt
+	case pdata.AttributeValueBOOL:
+		asBool := v.BoolVal()
+		val.BoolValue = &asBool
+	case pdata.AttributeValueDOUBLE:
+		asDouble := v.DoubleVal()
+		val.DoubleValue = &asDouble
+	case pdata.AttributeValueSTRING:
+		asString := v.StringVal()
+		val.StrValue = &asString
+	default:
+		return nil, fmt.Errorf("attribute value type %q not supported in SignalFx events", v.Type().String())
+	}
+
+	return &val, nil
+}

--- a/exporter/signalfxexporter/translation/logdata_to_signalfxv2_test.go
+++ b/exporter/signalfxexporter/translation/logdata_to_signalfxv2_test.go
@@ -1,0 +1,179 @@
+// Copyright -c Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translation
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+// This is basically the reverse of the test in the signalfxreceiver for
+// converting from events to logs
+func TestLogDataToSignalFxEvents(t *testing.T) {
+	now := time.Now()
+	msec := now.UnixNano() / 1e6
+
+	// Put it on stack or heap so we can take a ref to it.
+	userDefinedCat := sfxpb.EventCategory_USER_DEFINED
+
+	buildDefaultSFxEvent := func() *sfxpb.Event {
+		return &sfxpb.Event{
+			EventType:  "shutdown",
+			Timestamp:  msec,
+			Category:   &userDefinedCat,
+			Dimensions: buildNDimensions(3),
+			Properties: mapToEventProps(map[string]interface{}{
+				"env":      "prod",
+				"isActive": true,
+				"rack":     5,
+				"temp":     40.5,
+			}),
+		}
+	}
+
+	buildDefaultLogs := func() pdata.LogSlice {
+		logSlice := pdata.NewLogSlice()
+
+		logSlice.Resize(1)
+		l := logSlice.At(0)
+
+		l.SetName("shutdown")
+		l.SetTimestamp(pdata.TimestampUnixNano(now.Truncate(time.Millisecond).UnixNano()))
+		attrs := l.Attributes()
+
+		attrs.InitFromMap(map[string]pdata.AttributeValue{
+			"k0": pdata.NewAttributeValueString("v0"),
+			"k1": pdata.NewAttributeValueString("v1"),
+			"k2": pdata.NewAttributeValueString("v2"),
+		})
+
+		propMap := pdata.NewAttributeMap()
+		propMap.InitFromMap(map[string]pdata.AttributeValue{
+			"env":      pdata.NewAttributeValueString("prod"),
+			"isActive": pdata.NewAttributeValueBool(true),
+			"rack":     pdata.NewAttributeValueInt(5),
+			"temp":     pdata.NewAttributeValueDouble(40.5),
+		})
+		propMap.Sort()
+		propMapVal := pdata.NewAttributeValueMap()
+		propMapVal.SetMapVal(propMap)
+		attrs.Insert("com.splunk.signalfx.event_properties", propMapVal)
+		attrs.Insert("com.splunk.signalfx.event_category", pdata.NewAttributeValueInt(int64(sfxpb.EventCategory_USER_DEFINED)))
+
+		l.Attributes().Sort()
+
+		return logSlice
+	}
+
+	tests := []struct {
+		name       string
+		sfxEvents  []*sfxpb.Event
+		logData    pdata.LogSlice
+		numDropped int
+	}{
+		{
+			name:      "default",
+			sfxEvents: []*sfxpb.Event{buildDefaultSFxEvent()},
+			logData:   buildDefaultLogs(),
+		},
+		{
+			name: "missing category",
+			sfxEvents: func() []*sfxpb.Event {
+				e := buildDefaultSFxEvent()
+				e.Category = nil
+				return []*sfxpb.Event{e}
+			}(),
+			logData: func() pdata.LogSlice {
+				lrs := buildDefaultLogs()
+				lrs.At(0).Attributes().Upsert("com.splunk.signalfx.event_category", pdata.NewAttributeValueNull())
+				return lrs
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events, dropped := LogSliceToSignalFxV2(zap.NewNop(), tt.logData)
+			for i := 0; i < tt.logData.Len(); i++ {
+				tt.logData.At(i).Attributes().Sort()
+			}
+
+			for k := range events {
+				sort.Slice(events[k].Properties, func(i, j int) bool {
+					return events[k].Properties[i].Key < events[k].Properties[j].Key
+				})
+				sort.Slice(events[k].Dimensions, func(i, j int) bool {
+					return events[k].Dimensions[i].Key < events[k].Dimensions[j].Key
+				})
+			}
+			assert.Equal(t, tt.sfxEvents, events)
+			assert.Equal(t, tt.numDropped, dropped)
+		})
+	}
+}
+
+func mapToEventProps(m map[string]interface{}) []*sfxpb.Property {
+	var out []*sfxpb.Property
+	for k, v := range m {
+		var pval sfxpb.PropertyValue
+
+		switch t := v.(type) {
+		case string:
+			pval.StrValue = &t
+		case int:
+			asInt := int64(t)
+			pval.IntValue = &asInt
+		case int64:
+			pval.IntValue = &t
+		case bool:
+			pval.BoolValue = &t
+		case float64:
+			pval.DoubleValue = &t
+		default:
+			panic(fmt.Sprintf("invalid type: %v", v))
+		}
+
+		out = append(out, &sfxpb.Property{
+			Key:   k,
+			Value: &pval,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Key < out[j].Key
+	})
+	return out
+}
+
+func buildNDimensions(n uint) []*sfxpb.Dimension {
+	d := make([]*sfxpb.Dimension, 0, n)
+	for i := uint(0); i < n; i++ {
+		idx := int(i)
+		suffix := strconv.Itoa(idx)
+		d = append(d, &sfxpb.Dimension{
+			Key:   "k" + suffix,
+			Value: "v" + suffix,
+		})
+	}
+	return d
+}


### PR DESCRIPTION
This consumes the logs generated by the SignalFx receiver that
come from events.

Ignore the first commit and only focus on the second.  It contains dependent code from #1035  that this PR depends on to build properly.