### PR TITLE
K8s processor refactoring

### DIFF
--- a/processor/k8sprocessor/factory.go
+++ b/processor/k8sprocessor/factory.go
@@ -32,6 +32,7 @@ const (
 )
 
 var kubeClientProvider = kube.ClientProvider(nil)
+var processorCapabilities = component.ProcessorCapabilities{MutatesConsumedData: true}
 
 // NewFactory returns a new factory for the k8s processor.
 func NewFactory() component.ProcessorFactory {
@@ -53,21 +54,89 @@ func createDefaultConfig() configmodels.Processor {
 }
 
 func createTraceProcessor(
-	_ context.Context,
+	ctx context.Context,
 	params component.ProcessorCreateParams,
 	cfg configmodels.Processor,
 	nextTraceConsumer consumer.TraceConsumer,
 ) (component.TraceProcessor, error) {
-	return newTraceProcessor(params.Logger, nextTraceConsumer, kubeClientProvider, createProcessorOpts(cfg)...)
+	return createTraceProcessorWithOptions(ctx, params, cfg, nextTraceConsumer)
 }
 
 func createMetricsProcessor(
-	_ context.Context,
+	ctx context.Context,
 	params component.ProcessorCreateParams,
 	cfg configmodels.Processor,
 	nextMetricsConsumer consumer.MetricsConsumer,
 ) (component.MetricsProcessor, error) {
-	return newMetricsProcessor(params.Logger, nextMetricsConsumer, kubeClientProvider, createProcessorOpts(cfg)...)
+	return createMetricsProcessorWithOptions(ctx, params, cfg, nextMetricsConsumer)
+}
+
+func createTraceProcessorWithOptions(
+	_ context.Context,
+	params component.ProcessorCreateParams,
+	cfg configmodels.Processor,
+	nextTraceConsumer consumer.TraceConsumer,
+	options ...Option,
+) (component.TraceProcessor, error) {
+	kp, err := createKubernetesProcessor(params, cfg, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return processorhelper.NewTraceProcessor(
+		cfg,
+		nextTraceConsumer,
+		kp,
+		processorhelper.WithCapabilities(processorCapabilities),
+		processorhelper.WithStart(kp.Start),
+		processorhelper.WithShutdown(kp.Shutdown))
+}
+
+func createMetricsProcessorWithOptions(
+	_ context.Context,
+	params component.ProcessorCreateParams,
+	cfg configmodels.Processor,
+	nextMetricsConsumer consumer.MetricsConsumer,
+	options ...Option,
+) (component.MetricsProcessor, error) {
+	kp, err := createKubernetesProcessor(params, cfg, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return processorhelper.NewMetricsProcessor(
+		cfg,
+		nextMetricsConsumer,
+		kp,
+		processorhelper.WithCapabilities(processorCapabilities),
+		processorhelper.WithStart(kp.Start),
+		processorhelper.WithShutdown(kp.Shutdown))
+}
+
+func createKubernetesProcessor(
+	params component.ProcessorCreateParams,
+	cfg configmodels.Processor,
+	options ...Option,
+) (*kubernetesprocessor, error) {
+	kp := &kubernetesprocessor{logger: params.Logger}
+
+	allOptions := append(createProcessorOpts(cfg), options...)
+
+	for _, opt := range allOptions {
+		if err := opt(kp); err != nil {
+			return nil, err
+		}
+	}
+
+	// This might have been set by an option already
+	if kp.kc == nil {
+		err := kp.initKubeClient(kp.logger, kubeClientProvider)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return kp, nil
 }
 
 func createProcessorOpts(cfg configmodels.Processor) []Option {

--- a/processor/k8sprocessor/ip_extractor.go
+++ b/processor/k8sprocessor/ip_extractor.go
@@ -1,0 +1,58 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sprocessor
+
+import (
+	"net"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+)
+
+type ipExtractor func(attrs pdata.AttributeMap) string
+
+// k8sIPFromAttributes checks if the application, a collector/agent or a prior
+// processor has already annotated the batch with IP and if so, uses it
+func k8sIPFromAttributes() ipExtractor {
+	return func(attrs pdata.AttributeMap) string {
+		ip := stringAttributeFromMap(attrs, k8sIPLabelName)
+		if ip == "" {
+			ip = stringAttributeFromMap(attrs, clientIPLabelName)
+		}
+		return ip
+	}
+}
+
+// k8sIPFromHostnameAttributes leverages the observation that most of the metric receivers
+// uses "host.hostname" resource label to identify metrics origin. In k8s environment,
+// it's set to a pod IP address. If the value doesn't represent an IP address, we skip it.
+func k8sIPFromHostnameAttributes() ipExtractor {
+	return func(attrs pdata.AttributeMap) string {
+		hostname := stringAttributeFromMap(attrs, conventions.AttributeHostHostname)
+		if net.ParseIP(hostname) != nil {
+			return hostname
+		}
+		return ""
+	}
+}
+
+func stringAttributeFromMap(attrs pdata.AttributeMap, key string) string {
+	if val, ok := attrs.Get(key); ok {
+		if val.Type() == pdata.AttributeValueSTRING {
+			return val.StringVal()
+		}
+	}
+	return ""
+}

--- a/processor/k8sprocessor/processor_test.go
+++ b/processor/k8sprocessor/processor_test.go
@@ -20,187 +20,357 @@ import (
 	"testing"
 	"time"
 
-	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"go.opentelemetry.io/collector/translator/internaldata"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/kube"
 )
 
-func TestNewTraceProcessor(t *testing.T) {
-	_, err := newTraceProcessor(
-		zap.NewNop(),
-		exportertest.NewNopTraceExporter(),
-		newFakeClient,
+func newTraceProcessor(cfg configmodels.Processor, nextTraceConsumer consumer.TraceConsumer, options ...Option) (component.TraceProcessor, error) {
+	opts := append(options, withKubeClientProvider(newFakeClient))
+	return createTraceProcessorWithOptions(
+		context.Background(),
+		component.ProcessorCreateParams{Logger: zap.NewNop()},
+		cfg,
+		nextTraceConsumer,
+		opts...,
 	)
-	require.NoError(t, err)
 }
 
-func TestTraceProcessorBadOption(t *testing.T) {
-	opt := func(p *kubernetesprocessor) error {
-		return fmt.Errorf("bad option")
+func newMetricsProcessor(cfg configmodels.Processor, nextMetricsConsumer consumer.MetricsConsumer, options ...Option) (component.MetricsProcessor, error) {
+	opts := append(options, withKubeClientProvider(newFakeClient))
+	return createMetricsProcessorWithOptions(
+		context.Background(),
+		component.ProcessorCreateParams{Logger: zap.NewNop()},
+		cfg,
+		nextMetricsConsumer,
+		opts...,
+	)
+}
+
+// withKubeClientProvider sets the specific implementation for getting K8s Client instances
+func withKubeClientProvider(kcp kube.ClientProvider) Option {
+	return func(p *kubernetesprocessor) error {
+		return p.initKubeClient(p.logger, kcp)
 	}
-	p, err := newTraceProcessor(
-		zap.NewNop(),
-		exportertest.NewNopTraceExporter(),
-		newFakeClient,
-		opt,
-	)
-	assert.Nil(t, p)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "bad option")
 }
 
-func TestTraceProcessorBadClientProvider(t *testing.T) {
+// withExtractKubernetesProcessorInto allows to pull the internal model easily even when processorhelper factory is used
+func withExtractKubernetesProcessorInto(kp **kubernetesprocessor) Option {
+	return func(p *kubernetesprocessor) error {
+		*kp = p
+		return nil
+	}
+}
+
+type multiTest struct {
+	t *testing.T
+
+	tp component.TraceProcessor
+	mp component.MetricsProcessor
+
+	nextTrace   *exportertest.SinkTraceExporter
+	nextMetrics *exportertest.SinkMetricsExporter
+
+	kpTrace   *kubernetesprocessor
+	kpMetrics *kubernetesprocessor
+}
+
+func newMultiTest(
+	t *testing.T,
+	cfg configmodels.Processor,
+	errFunc func(err error),
+	options ...Option,
+) *multiTest {
+	m := &multiTest{
+		t:           t,
+		nextTrace:   &exportertest.SinkTraceExporter{},
+		nextMetrics: &exportertest.SinkMetricsExporter{},
+	}
+
+	tp, err := newTraceProcessor(cfg, m.nextTrace, append(options, withExtractKubernetesProcessorInto(&m.kpTrace))...)
+	if errFunc == nil {
+		assert.NotNil(t, tp)
+		require.NoError(t, err)
+	} else {
+		assert.Nil(t, tp)
+		errFunc(err)
+	}
+
+	mp, err := newMetricsProcessor(cfg, m.nextMetrics, append(options, withExtractKubernetesProcessorInto(&m.kpMetrics))...)
+	if errFunc == nil {
+		assert.NotNil(t, mp)
+		require.NoError(t, err)
+	} else {
+		assert.Nil(t, mp)
+		errFunc(err)
+	}
+
+	m.tp = tp
+	m.mp = mp
+	return m
+}
+
+func (m *multiTest) testConsume(
+	ctx context.Context,
+	traces pdata.Traces,
+	metrics pdata.Metrics,
+	errFunc func(err error),
+) {
+	errs := []error{
+		m.tp.ConsumeTraces(ctx, traces),
+		m.mp.ConsumeMetrics(ctx, metrics),
+	}
+
+	for _, err := range errs {
+		if errFunc != nil {
+			errFunc(err)
+		}
+	}
+}
+
+func (m *multiTest) kubernetesProcessorOperation(kpOp func(kp *kubernetesprocessor)) {
+	kpOp(m.kpTrace)
+	kpOp(m.kpMetrics)
+}
+
+func (m *multiTest) assertBatchesLen(batchesLen int) {
+	require.Len(m.t, m.nextTrace.AllTraces(), batchesLen)
+	require.Len(m.t, m.nextMetrics.AllMetrics(), batchesLen)
+}
+
+func (m *multiTest) assertResourceObjectLen(batchNo int, rsObjectLen int) {
+	assert.Equal(m.t, m.nextTrace.AllTraces()[batchNo].ResourceSpans().Len(), rsObjectLen)
+	assert.Equal(m.t, m.nextMetrics.AllMetrics()[batchNo].ResourceMetrics().Len(), rsObjectLen)
+}
+
+func (m *multiTest) assertResourceAttributesLen(batchNo int, resourceObjectNo int, attrsLen int) {
+	assert.Equal(m.t, m.nextTrace.AllTraces()[batchNo].ResourceSpans().At(resourceObjectNo).Resource().Attributes().Len(), attrsLen)
+	assert.Equal(m.t, m.nextMetrics.AllMetrics()[batchNo].ResourceMetrics().At(resourceObjectNo).Resource().Attributes().Len(), attrsLen)
+}
+
+func (m *multiTest) assertResource(batchNum int, resourceObjectNum int, resourceFunc func(res pdata.Resource)) {
+	rss := m.nextTrace.AllTraces()[batchNum].ResourceSpans()
+	r := rss.At(resourceObjectNum).Resource()
+
+	if resourceFunc != nil {
+		resourceFunc(r)
+	}
+}
+
+func TestNewProcessor(t *testing.T) {
+	cfg := NewFactory().CreateDefaultConfig()
+
+	newMultiTest(t, cfg, nil)
+}
+
+func TestProcessorBadConfig(t *testing.T) {
+	cfg := NewFactory().CreateDefaultConfig()
+	oCfg := cfg.(*Config)
+	oCfg.Extract.Metadata = []string{"bad-attribute"}
+
+	newMultiTest(t, cfg, func(err error) {
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "\"bad-attribute\" is not a supported metadata field")
+	})
+}
+
+func TestProcessorBadClientProvider(t *testing.T) {
 	clientProvider := func(_ *zap.Logger, _ k8sconfig.APIConfig, _ kube.ExtractionRules, _ kube.Filters, _ kube.APIClientsetProvider, _ kube.InformerProvider) (kube.Client, error) {
 		return nil, fmt.Errorf("bad client error")
 	}
-	p, err := newTraceProcessor(
-		zap.NewNop(),
-		exportertest.NewNopTraceExporter(),
-		clientProvider,
-	)
 
-	assert.Nil(t, p)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "bad client error")
+	newMultiTest(t, NewFactory().CreateDefaultConfig(), func(err error) {
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "bad client error")
+	}, withKubeClientProvider(clientProvider))
 }
 
-func generateTraces() pdata.Traces {
+type generateResourceFunc func(res pdata.Resource)
+
+func generateTraces(resourceFunc ...generateResourceFunc) pdata.Traces {
 	t := pdata.NewTraces()
 	rs := t.ResourceSpans()
 	rs.Resize(1)
 	rs.At(0).InitEmpty()
 	rs.At(0).InstrumentationLibrarySpans().Resize(1)
 	rs.At(0).InstrumentationLibrarySpans().At(0).Spans().Resize(1)
+	for _, resFun := range resourceFunc {
+		res := rs.At(0).Resource()
+		if res.IsNil() {
+			res.InitEmpty()
+		}
+		resFun(res)
+	}
 	span := rs.At(0).InstrumentationLibrarySpans().At(0).Spans().At(0)
 	span.SetName("foobar")
 	return t
 }
 
-func TestIPDetection(t *testing.T) {
-	next := &exportertest.SinkTraceExporter{}
-	kp, err := newTraceProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
-	)
-	require.NoError(t, err)
+func generateMetrics(resourceFunc ...generateResourceFunc) pdata.Metrics {
+	m := pdata.NewMetrics()
+	ms := m.ResourceMetrics()
+	ms.Resize(1)
+	ms.At(0).InitEmpty()
+	ms.At(0).InstrumentationLibraryMetrics().Resize(1)
+	ms.At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(1)
+	for _, resFun := range resourceFunc {
+		res := ms.At(0).Resource()
+		if res.IsNil() {
+			res.InitEmpty()
+		}
+		resFun(res)
+	}
+	metric := ms.At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
+	metric.SetName("foobar")
+	return m
+}
+
+func withPassthroughIP(passthroughIP string) generateResourceFunc {
+	return func(res pdata.Resource) {
+		res.Attributes().InsertString(k8sIPLabelName, passthroughIP)
+	}
+}
+
+func withHostname(hostname string) generateResourceFunc {
+	return func(res pdata.Resource) {
+		res.Attributes().InsertString(conventions.AttributeHostHostname, hostname)
+	}
+}
+
+func TestIPDetectionFromContext(t *testing.T) {
+	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
 
 	ctx := client.NewContext(context.Background(), &client.Client{IP: "1.1.1.1"})
-	err = kp.ConsumeTraces(ctx, generateTraces())
-	require.NoError(t, err)
+	m.testConsume(
+		ctx,
+		generateTraces(),
+		generateMetrics(),
+		func(err error) {
+			assert.NoError(t, err)
+		})
 
-	require.Len(t, next.AllTraces(), 1)
-	rss := next.AllTraces()[0].ResourceSpans()
-	assert.Equal(t, 1, rss.Len())
-
-	r := rss.At(0).Resource()
-	require.False(t, r.IsNil())
-	assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
+	m.assertBatchesLen(1)
+	m.assertResourceObjectLen(0, 1)
+	m.assertResource(0, 0, func(r pdata.Resource) {
+		require.False(t, r.IsNil())
+		assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
+	})
 }
 
 func TestNilBatch(t *testing.T) {
-	next := &exportertest.SinkTraceExporter{}
-	kp, err := newTraceProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
-	)
-	require.NoError(t, err)
+	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
+	m.testConsume(
+		context.Background(),
+		pdata.NewTraces(),
+		pdata.NewMetrics(),
+		func(err error) {
+			assert.NoError(t, err)
+		})
 
-	err = kp.ConsumeTraces(context.Background(), pdata.NewTraces())
-	require.NoError(t, err)
-	require.Len(t, next.AllTraces(), 1)
+	m.assertBatchesLen(1)
 }
 
-func TestTraceProcessorNoAttrs(t *testing.T) {
-	next := &exportertest.SinkTraceExporter{}
-	p, err := newTraceProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
+func TestProcessorNoAttrs(t *testing.T) {
+	m := newMultiTest(
+		t,
+		NewFactory().CreateDefaultConfig(),
+		nil,
 		WithExtractMetadata(metadataPodName),
 	)
-	require.NoError(t, err)
-	kp := p.(*kubernetesprocessor)
-	kc := kp.kc.(*fakeClient)
+
 	ctx := client.NewContext(context.Background(), &client.Client{IP: "1.1.1.1"})
 
 	// pod doesn't have attrs to add
-	kc.Pods["1.1.1.1"] = &kube.Pod{Name: "PodA"}
-	assert.NoError(t, p.ConsumeTraces(ctx, generateTraces()))
-	require.Len(t, next.AllTraces(), 1)
-	rss := next.AllTraces()[0]
-	rs := rss.ResourceSpans()
-	assert.Equal(t, 1, rs.Len())
-	assert.Equal(t, 1, rs.At(0).Resource().Attributes().Len())
+	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
+		kp.kc.(*fakeClient).Pods["1.1.1.1"] = &kube.Pod{Name: "PodA"}
+	})
+
+	m.testConsume(
+		ctx,
+		generateTraces(),
+		generateMetrics(),
+		func(err error) {
+			assert.NoError(t, err)
+		})
+
+	m.assertBatchesLen(1)
+	m.assertResourceObjectLen(0, 1)
+	m.assertResourceAttributesLen(0, 0, 1)
 
 	// attrs should be added now
-	kc.Pods["1.1.1.1"] = &kube.Pod{
-		Name: "PodA",
-		Attributes: map[string]string{
-			"k":  "v",
-			"1":  "2",
-			"aa": "b",
-		},
-	}
-	assert.NoError(t, p.ConsumeTraces(ctx, generateTraces()))
-	require.NoError(t, err)
-	require.Len(t, next.AllTraces(), 2)
-	rss = next.AllTraces()[1]
-	rs = rss.ResourceSpans()
-	assert.Equal(t, 1, rs.Len())
-	assert.Equal(t, 4, rs.At(0).Resource().Attributes().Len())
+	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
+		kp.kc.(*fakeClient).Pods["1.1.1.1"] = &kube.Pod{
+			Name: "PodA",
+			Attributes: map[string]string{
+				"k":  "v",
+				"1":  "2",
+				"aa": "b",
+			},
+		}
+	})
+
+	m.testConsume(
+		ctx,
+		generateTraces(),
+		generateMetrics(),
+		func(err error) {
+			assert.NoError(t, err)
+		})
+
+	m.assertBatchesLen(2)
+	m.assertResourceObjectLen(1, 1)
+	m.assertResourceAttributesLen(1, 0, 4)
 
 	// passthrough doesn't add attrs
-	kp.passthroughMode = true
-	assert.NoError(t, p.ConsumeTraces(ctx, generateTraces()))
-	require.Len(t, next.AllTraces(), 3)
-	rss = next.AllTraces()[2]
-	rs = rss.ResourceSpans()
-	assert.Equal(t, 1, rs.Len())
-	assert.Equal(t, 1, rs.At(0).Resource().Attributes().Len())
+	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
+		kp.passthroughMode = true
+	})
+	m.testConsume(
+		ctx,
+		generateTraces(),
+		generateMetrics(),
+		func(err error) {
+			assert.NoError(t, err)
+		})
 
+	m.assertBatchesLen(3)
+	m.assertResourceObjectLen(2, 1)
+	m.assertResourceAttributesLen(2, 0, 1)
 }
 
 func TestNoIP(t *testing.T) {
-	next := &exportertest.SinkTraceExporter{}
-	kp, err := newTraceProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
+	m := newMultiTest(
+		t,
+		NewFactory().CreateDefaultConfig(),
+		nil,
 	)
-	require.NoError(t, err)
 
-	err = kp.ConsumeTraces(context.Background(), generateTraces())
-	require.NoError(t, err)
+	m.testConsume(context.Background(), generateTraces(), generateMetrics(), nil)
 
-	require.Len(t, next.AllTraces(), 1)
-	rss := next.AllTraces()[0]
-	rs := rss.ResourceSpans()
-	assert.Equal(t, 1, rs.Len())
-	assert.True(t, rs.At(0).Resource().IsNil())
+	m.assertBatchesLen(1)
+	m.assertResourceObjectLen(0, 1)
+	m.assertResource(0, 0, func(res pdata.Resource) {
+		assert.True(t, res.IsNil())
+	})
 }
 
 func TestIPSource(t *testing.T) {
-	next := &exportertest.SinkTraceExporter{}
-	kp, err := newTraceProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
+	m := newMultiTest(
+		t,
+		NewFactory().CreateDefaultConfig(),
+		nil,
 	)
-	require.NoError(t, err)
 
 	type testCase struct {
 		name, resourceIP, resourceK8SIP, contextIP, out string
@@ -233,40 +403,43 @@ func TestIPSource(t *testing.T) {
 			if tc.contextIP != "" {
 				ctx = client.NewContext(context.Background(), &client.Client{IP: tc.contextIP})
 			}
+
 			traces := generateTraces()
-			resource := traces.ResourceSpans().At(0).Resource()
-			if resource.IsNil() {
-				resource.InitEmpty()
+			metrics := generateMetrics()
+
+			resources := []pdata.Resource{
+				traces.ResourceSpans().At(0).Resource(),
+				metrics.ResourceMetrics().At(0).Resource(),
 			}
-			if tc.resourceK8SIP != "" {
-				resource.Attributes().InsertString(k8sIPLabelName, tc.resourceK8SIP)
+
+			for _, res := range resources {
+				if res.IsNil() {
+					res.InitEmpty()
+				}
+				if tc.resourceK8SIP != "" {
+					res.Attributes().InsertString(k8sIPLabelName, tc.resourceK8SIP)
+				}
+				if tc.resourceIP != "" {
+					res.Attributes().InsertString(clientIPLabelName, tc.resourceIP)
+				}
 			}
-			if tc.resourceIP != "" {
-				resource.Attributes().InsertString(clientIPLabelName, tc.resourceIP)
-			}
-			err := kp.ConsumeTraces(ctx, traces)
-			require.NoError(t, err)
-			res := next.AllTraces()[i].ResourceSpans().At(0).Resource()
-			require.Len(t, next.AllTraces(), i+1)
-			require.False(t, res.IsNil())
-			assertResourceHasStringAttribute(t, res, "k8s.pod.ip", tc.out)
+
+			m.testConsume(ctx, traces, metrics, nil)
+			m.assertBatchesLen(i + 1)
+			m.assertResource(i, 0, func(res pdata.Resource) {
+				require.False(t, res.IsNil())
+				assertResourceHasStringAttribute(t, res, "k8s.pod.ip", tc.out)
+			})
 		})
 	}
 }
 
-func TestTraceProcessorAddLabels(t *testing.T) {
-	next := &exportertest.SinkTraceExporter{}
-	p, err := newTraceProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
+func TestProcessorAddLabels(t *testing.T) {
+	m := newMultiTest(
+		t,
+		NewFactory().CreateDefaultConfig(),
+		nil,
 	)
-	require.NoError(t, err)
-
-	kp, ok := p.(*kubernetesprocessor)
-	assert.True(t, ok)
-	kc, ok := kp.kc.(*fakeClient)
-	assert.True(t, ok)
 
 	tests := map[string]map[string]string{
 		"1": {
@@ -274,230 +447,87 @@ func TestTraceProcessorAddLabels(t *testing.T) {
 			"ns":          "default",
 			"another tag": "value",
 		},
-		"2": {},
+		"2": {
+			"pod": "test-12",
+		},
 	}
 	for ip, attrs := range tests {
-		kc.Pods[ip] = &kube.Pod{Attributes: attrs}
+		m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
+			kp.kc.(*fakeClient).Pods[ip] = &kube.Pod{Attributes: attrs}
+		})
 	}
 
 	var i int
 	for ip, attrs := range tests {
 		ctx := client.NewContext(context.Background(), &client.Client{IP: ip})
-		err = p.ConsumeTraces(ctx, generateTraces())
-		require.NoError(t, err)
+		m.testConsume(
+			ctx,
+			generateTraces(),
+			generateMetrics(),
+			func(err error) {
+				assert.NoError(t, err)
+			})
 
-		require.Len(t, next.AllTraces(), i+1)
-		td := next.AllTraces()[i]
-		rss := td.ResourceSpans()
-		require.Equal(t, rss.Len(), 1)
-		r := rss.At(0).Resource()
-		require.False(t, r.IsNil())
-		assertResourceHasStringAttribute(t, r, "k8s.pod.ip", ip)
-		for k, v := range attrs {
-			assertResourceHasStringAttribute(t, r, k, v)
-		}
+		m.assertBatchesLen(i + 1)
+		m.assertResourceObjectLen(i, 1)
+		m.assertResource(i, 0, func(res pdata.Resource) {
+			require.False(t, res.IsNil())
+			assertResourceHasStringAttribute(t, res, "k8s.pod.ip", ip)
+			for k, v := range attrs {
+				assertResourceHasStringAttribute(t, res, k, v)
+			}
+		})
+
 		i++
 	}
 }
 
-func TestPassthroughStart(t *testing.T) {
-	next := &exportertest.SinkTraceExporter{}
-	opts := []Option{WithPassthrough()}
-
-	p, err := newTraceProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
-		opts...,
-	)
-	require.NoError(t, err)
-
-	// Just make sure this doesn't fail when Passthrough is enabled
-	assert.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
-	assert.NoError(t, p.Shutdown(context.Background()))
-}
-
-func TestRealClient(t *testing.T) {
-	p, err := newTraceProcessor(
-		zap.NewNop(),
-		exportertest.NewNopTraceExporter(),
+func TestProcessorPicksUpPassthoughPodIp(t *testing.T) {
+	m := newMultiTest(
+		t,
+		NewFactory().CreateDefaultConfig(),
 		nil,
-		WithAPIConfig(k8sconfig.APIConfig{AuthType: "none"}),
-	)
-	assert.Nil(t, p)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "unable to load k8s config, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
-}
-
-func TestCapabilities(t *testing.T) {
-	p, err := newTraceProcessor(zap.NewNop(), exportertest.NewNopTraceExporter(), newFakeClient)
-	assert.NoError(t, err)
-	caps := p.GetCapabilities()
-	assert.True(t, caps.MutatesConsumedData)
-}
-
-func TestStartStop(t *testing.T) {
-	p, err := newTraceProcessor(
-		zap.NewNop(),
-		exportertest.NewNopTraceExporter(),
-		newFakeClient,
-	)
-	require.NoError(t, err)
-
-	assert.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
-	assert.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
-
-	pr := p.(*kubernetesprocessor)
-	client := pr.kc.(*fakeClient)
-	controller := client.Informer.GetController().(*kube.FakeController)
-
-	assert.False(t, controller.HasStopped())
-	assert.NoError(t, p.Shutdown(context.Background()))
-	time.Sleep(time.Millisecond * 500)
-	assert.True(t, controller.HasStopped())
-}
-
-func TestNewMetricsProcessor(t *testing.T) {
-	_, err := newMetricsProcessor(
-		zap.NewNop(),
-		exportertest.NewNopMetricsExporter(),
-		newFakeClient,
-	)
-	require.NoError(t, err)
-}
-
-func TestMetricsProcessorBadOption(t *testing.T) {
-	opt := func(p *kubernetesprocessor) error {
-		return fmt.Errorf("bad option")
-	}
-	p, err := newMetricsProcessor(
-		zap.NewNop(),
-		exportertest.NewNopMetricsExporter(),
-		newFakeClient,
-		opt,
-	)
-	assert.Nil(t, p)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "bad option")
-}
-
-func TestMetricsProcessorBadClientProvider(t *testing.T) {
-	clientProvider := func(_ *zap.Logger, _ k8sconfig.APIConfig, _ kube.ExtractionRules, _ kube.Filters, _ kube.APIClientsetProvider, _ kube.InformerProvider) (kube.Client, error) {
-		return nil, fmt.Errorf("bad client error")
-	}
-	p, err := newMetricsProcessor(
-		zap.NewNop(),
-		exportertest.NewNopMetricsExporter(),
-		clientProvider,
 	)
 
-	assert.Nil(t, p)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "bad client error")
+	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
+		kp.kc.(*fakeClient).Pods["2.2.2.2"] = &kube.Pod{
+			Name: "PodA",
+			Attributes: map[string]string{
+				"k": "v",
+				"1": "2",
+			},
+		}
+	})
+
+	m.testConsume(
+		context.Background(),
+		generateTraces(withPassthroughIP("2.2.2.2")),
+		generateMetrics(withPassthroughIP("2.2.2.2")),
+		func(err error) {
+			assert.NoError(t, err)
+		})
+
+	m.assertBatchesLen(1)
+	m.assertResourceObjectLen(0, 1)
+	m.assertResourceAttributesLen(0, 0, 3)
+
+	m.assertResource(0, 0, func(res pdata.Resource) {
+		assertResourceHasStringAttribute(t, res, k8sIPLabelName, "2.2.2.2")
+		assertResourceHasStringAttribute(t, res, "k", "v")
+		assertResourceHasStringAttribute(t, res, "1", "2")
+	})
 }
 
-func TestMetricsProcessorNoAttrs(t *testing.T) {
+func TestMetricsProcessorHostname(t *testing.T) {
 	next := &exportertest.SinkMetricsExporter{}
+	var kp *kubernetesprocessor
 	p, err := newMetricsProcessor(
-		zap.NewNop(),
+		NewFactory().CreateDefaultConfig(),
 		next,
-		newFakeClient,
 		WithExtractMetadata(metadataPodName),
+		withExtractKubernetesProcessorInto(&kp),
 	)
 	require.NoError(t, err)
-	kp := p.(*kubernetesprocessor)
-	kc := kp.kc.(*fakeClient)
-
-	// pod doesn't have attrs to add
-	kc.Pods["1.1.1.1"] = &kube.Pod{Name: "PodA"}
-	metrics := generateMetricsWithHostname()
-
-	assert.NoError(t, p.ConsumeMetrics(context.Background(), metrics))
-	require.Len(t, next.AllMetrics(), 1)
-	mds := internaldata.MetricsToOC(next.AllMetrics()[0])
-	require.Equal(t, len(mds), 1)
-	md := mds[0]
-	require.Equal(t, 1, len(md.Resource.Labels))
-	gotIP, ok := md.Resource.Labels["k8s.pod.ip"]
-	assert.True(t, ok)
-	assert.Equal(t, "1.1.1.1", gotIP)
-
-	// attrs should be added now
-	kc.Pods["1.1.1.1"] = &kube.Pod{
-		Name: "PodA",
-		Attributes: map[string]string{
-			"k":  "v",
-			"1":  "2",
-			"aa": "b",
-		},
-	}
-
-	assert.NoError(t, p.ConsumeMetrics(context.Background(), metrics))
-	require.Len(t, next.AllMetrics(), 2)
-	mds = internaldata.MetricsToOC(next.AllMetrics()[1])
-	require.Equal(t, len(mds), 1)
-	md = mds[0]
-	require.Equal(t, 4, len(md.Resource.Labels))
-	gotIP, ok = md.Resource.Labels["k8s.pod.ip"]
-	assert.True(t, ok)
-	assert.Equal(t, "1.1.1.1", gotIP)
-	gotAttr, ok := md.Resource.Labels["aa"]
-	assert.True(t, ok)
-	assert.Equal(t, "b", gotAttr)
-
-	// passthrough doesn't add attrs
-	metrics = generateMetricsWithHostname()
-	kp.passthroughMode = true
-	assert.NoError(t, p.ConsumeMetrics(context.Background(), metrics))
-	require.Len(t, next.AllMetrics(), 3)
-	mds = internaldata.MetricsToOC(next.AllMetrics()[2])
-	require.Equal(t, len(mds), 1)
-	md = mds[0]
-	require.Equal(t, 1, len(md.Resource.Labels))
-}
-
-func TestMetricsProcessorPicksUpPassthoughPodIp(t *testing.T) {
-	next := &exportertest.SinkMetricsExporter{}
-	p, err := newMetricsProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
-		WithExtractMetadata(metadataPodName),
-	)
-	require.NoError(t, err)
-	kp := p.(*kubernetesprocessor)
-	kc := kp.kc.(*fakeClient)
-	kc.Pods["2.2.2.2"] = &kube.Pod{
-		Name: "PodA",
-		Attributes: map[string]string{
-			"k": "v",
-			"1": "2",
-		},
-	}
-
-	metrics := generateMetricsWithPodIP()
-
-	assert.NoError(t, p.ConsumeMetrics(context.Background(), metrics))
-	require.Len(t, next.AllMetrics(), 1)
-	mds := internaldata.MetricsToOC(next.AllMetrics()[0])
-	require.Equal(t, len(mds), 1)
-	md := mds[0]
-	require.Equal(t, 3, len(md.Resource.Labels))
-	require.Equal(t, "2.2.2.2", md.Resource.Labels[k8sIPLabelName])
-	require.Equal(t, "v", md.Resource.Labels["k"])
-	require.Equal(t, "2", md.Resource.Labels["1"])
-}
-
-func TestMetricsProcessorInvalidIP(t *testing.T) {
-	next := &exportertest.SinkMetricsExporter{}
-	p, err := newMetricsProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
-		WithExtractMetadata(metadataPodName),
-	)
-	require.NoError(t, err)
-	kp := p.(*kubernetesprocessor)
 	kc := kp.kc.(*fakeClient)
 
 	// invalid ip should not be used to lookup k8s pod
@@ -509,125 +539,114 @@ func TestMetricsProcessorInvalidIP(t *testing.T) {
 			"aa": "b",
 		},
 	}
-	metrics := generateMetricsWithHostname()
-	mds := internaldata.MetricsToOC(metrics)
-	require.Len(t, mds, 1)
-	mds[0].Node.Identifier.HostName = "invalid-ip"
-
-	assert.NoError(t, p.ConsumeMetrics(context.Background(), internaldata.OCSliceToMetrics(mds)))
-	require.Len(t, next.AllMetrics(), 1)
-	mds = internaldata.MetricsToOC(next.AllMetrics()[0])
-	require.Equal(t, len(mds), 1)
-	md := mds[0]
-	assert.Len(t, md.Resource.Labels, 0)
-}
-
-func TestMetricsProcessorAddLabels(t *testing.T) {
-	next := &exportertest.SinkMetricsExporter{}
-	p, err := newMetricsProcessor(
-		zap.NewNop(),
-		next,
-		newFakeClient,
-	)
-	require.NoError(t, err)
-
-	kp, ok := p.(*kubernetesprocessor)
-	assert.True(t, ok)
-	kc, ok := kp.kc.(*fakeClient)
-	assert.True(t, ok)
-
-	tests := map[string]map[string]string{
-		"1.2.3.4": {
-			"pod":         "test-2323",
-			"ns":          "default",
-			"another tag": "value",
-		},
-		"2.3.4.5": {
-			"pod": "test-12",
+	kc.Pods["3.3.3.3"] = &kube.Pod{
+		Name: "PodA",
+		Attributes: map[string]string{
+			"kk": "vv",
 		},
 	}
-	for ip, attrs := range tests {
-		kc.Pods[ip] = &kube.Pod{Attributes: attrs}
+
+	type testCase struct {
+		name, hostname string
+		expectedAttrs  map[string]string
 	}
 
-	for ip := range tests {
-		attrs := tests[ip]
-		t.Run(ip, func(t *testing.T) {
-			next.Reset()
-			metrics := generateMetricsWithHostname()
-			mds := internaldata.MetricsToOC(metrics)
-			mds[0].Node.Identifier.HostName = ip
+	testCases := []testCase{
+		{
+			name:     "invalid IP in hostname",
+			hostname: "invalid-ip",
+			expectedAttrs: map[string]string{
+				conventions.AttributeHostHostname: "invalid-ip",
+			},
+		},
+		{
+			name:     "valid IP in hostname",
+			hostname: "3.3.3.3",
+			expectedAttrs: map[string]string{
+				conventions.AttributeHostHostname: "3.3.3.3",
+				k8sIPLabelName:                    "3.3.3.3",
+				"kk":                              "vv",
+			},
+		},
+	}
 
-			err = p.ConsumeMetrics(context.Background(), internaldata.OCSliceToMetrics(mds))
-			require.NoError(t, err)
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics := generateMetrics(withHostname(tc.hostname))
+			assert.NoError(t, p.ConsumeMetrics(context.Background(), metrics))
+			require.Len(t, next.AllMetrics(), i+1)
 
-			require.Len(t, next.AllMetrics(), 1)
-			mds = internaldata.MetricsToOC(next.AllMetrics()[0])
-			require.Len(t, mds, 1)
-			md := mds[0]
-			require.Lenf(t, md.Resource.Labels, len(attrs)+1, "%v", md.Node)
-			gotIP, ok := md.Resource.Labels["k8s.pod.ip"]
-			assert.True(t, ok)
-			assert.Equal(t, ip, gotIP)
-			for k, v := range attrs {
-				got, ok := attrs[k]
-				assert.True(t, ok)
-				assert.Equal(t, v, got)
+			md := next.AllMetrics()[i]
+			require.Equal(t, 1, md.ResourceMetrics().Len())
+			res := md.ResourceMetrics().At(0).Resource()
+			assert.Equal(t, len(tc.expectedAttrs), res.Attributes().Len())
+			for k, v := range tc.expectedAttrs {
+				assertResourceHasStringAttribute(t, res, k, v)
 			}
 		})
 	}
+
 }
 
-func generateMetricsWithHostname() pdata.Metrics {
-	md := consumerdata.MetricsData{
-		Node: &commonpb.Node{
-			Identifier: &commonpb.ProcessIdentifier{
-				HostName: "1.1.1.1",
-			},
-		},
-		Metrics: []*metricspb.Metric{
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name: "my-metric",
-					Type: metricspb.MetricDescriptor_GAUGE_INT64,
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						Points: []*metricspb.Point{
-							{Value: &metricspb.Point_Int64Value{Int64Value: 123}},
-						},
-					},
-				},
-			},
-		},
-	}
-	return internaldata.OCToMetrics(md)
+func TestPassthroughStart(t *testing.T) {
+	next := &exportertest.SinkTraceExporter{}
+	opts := []Option{WithPassthrough()}
+
+	p, err := newTraceProcessor(
+		NewFactory().CreateDefaultConfig(),
+		next,
+		opts...,
+	)
+	require.NoError(t, err)
+
+	// Just make sure this doesn't fail when Passthrough is enabled
+	assert.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, p.Shutdown(context.Background()))
 }
 
-func generateMetricsWithPodIP() pdata.Metrics {
-	md := consumerdata.MetricsData{
-		Resource: &resourcepb.Resource{
-			Labels: map[string]string{
-				k8sIPLabelName: "2.2.2.2",
-			},
+func TestRealClient(t *testing.T) {
+	newMultiTest(
+		t,
+		NewFactory().CreateDefaultConfig(),
+		func(err error) {
+			assert.Error(t, err)
+			assert.Equal(t, err.Error(), "unable to load k8s config, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
 		},
-		Metrics: []*metricspb.Metric{
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name: "my-metric",
-					Type: metricspb.MetricDescriptor_GAUGE_INT64,
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						Points: []*metricspb.Point{
-							{Value: &metricspb.Point_Int64Value{Int64Value: 123}},
-						},
-					},
-				},
-			},
-		},
-	}
-	return internaldata.OCToMetrics(md)
+		withKubeClientProvider(kubeClientProvider),
+		WithAPIConfig(k8sconfig.APIConfig{AuthType: "none"}),
+	)
+}
+
+func TestCapabilities(t *testing.T) {
+	p, err := newTraceProcessor(
+		NewFactory().CreateDefaultConfig(),
+		exportertest.NewNopTraceExporter(),
+	)
+	assert.NoError(t, err)
+	caps := p.GetCapabilities()
+	assert.True(t, caps.MutatesConsumedData)
+}
+
+func TestStartStop(t *testing.T) {
+	var kp *kubernetesprocessor
+	p, err := newTraceProcessor(
+		NewFactory().CreateDefaultConfig(),
+		exportertest.NewNopTraceExporter(),
+		withExtractKubernetesProcessorInto(&kp),
+	)
+	require.NoError(t, err)
+
+	assert.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
+
+	assert.NotNil(t, kp)
+	kc := kp.kc.(*fakeClient)
+	controller := kc.Informer.GetController().(*kube.FakeController)
+
+	assert.False(t, controller.HasStopped())
+	assert.NoError(t, p.Shutdown(context.Background()))
+	time.Sleep(time.Millisecond * 500)
+	assert.True(t, controller.HasStopped())
 }
 
 func assertResourceHasStringAttribute(t *testing.T, r pdata.Resource, k, v string) {


### PR DESCRIPTION
**Description:** 

While working on adding log support to `k8sprocessor` I noticed several areas for improvement:
* switch to `processorhelper` factory methods
* switch to internal Metrics model
* use common testcases for all types of records (traces, metrics and soon - logs)

As suggested in #1019 , I am breaking down the original (draft) change into two pieces. When this gets accepted adding the logs (which is going to be simple) will follow

**Link to tracking Issue:** N/A

**Testing:** Unit test updated, manual tests to follow

**Documentation:** N/A