### PR TITLE
SignalFx exporter: Add host metadata synchronization

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -46,6 +46,13 @@ The following configuration options can also be configured:
 - `translation_rules`: Set of rules on how to translate metrics to a SignalFx 
   compatible format. Rules defined in `translation/constants.go` are used by 
   default. Applicable only when `send_compatible_metrics` set to `true`.
+- `sync_host_metadata`: Defines whether the exporter should scrape host metadata
+  and send it as property updates to SignalFx backend. Disabled by default.
+  IMPORTANT: Host metadata synchronization relies on `resourcedetection` 
+  processor. If this option is enabled make sure that `resourcedetection` 
+  processor is enabled in the pipeline with one of the cloud provider detectors
+  or environment variable detector setting a unique value to `host.name` attribute 
+  within your k8s cluster. And keep `override=true` in resourcedetection config.
 
 Example:
 

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -73,6 +73,16 @@ type Config struct {
 	// DeltaTranslationTTL specifies in seconds the max duration to keep the most recent datapoint for any
 	// `delta_metric` specified in TranslationRules. Default is 3600s.
 	DeltaTranslationTTL int64 `mapstructure:"delta_translation_ttl"`
+
+	// SyncHostMetadata defines if the exporter should scrape host metadata and
+	// sends it as property updates to SignalFx backend.
+	// IMPORTANT: Host metadata synchronization relies on `resourcedetection` processor.
+	//            If this option is enabled make sure that `resourcedetection` processor
+	//            is enabled in the pipeline with one of the cloud provider detectors
+	//            or environment variable detector setting a unique value to
+	//            `host.name` attribute within your k8s cluster. Also keep override
+	//            And keep `override=true` in resourcedetection config.
+	SyncHostMetadata bool `mapstructure:"sync_host_metadata"`
 }
 
 func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -98,6 +98,7 @@ func TestConfig_getOptionsFromConfig(t *testing.T) {
 		Headers               map[string]string
 		SendCompatibleMetrics bool
 		TranslationRules      []translation.Rule
+		SyncHostMetadata      bool
 	}
 	tests := []struct {
 		name    string
@@ -215,6 +216,7 @@ func TestConfig_getOptionsFromConfig(t *testing.T) {
 				Headers:               tt.fields.Headers,
 				SendCompatibleMetrics: tt.fields.SendCompatibleMetrics,
 				TranslationRules:      tt.fields.TranslationRules,
+				SyncHostMetadata:      tt.fields.SyncHostMetadata,
 			}
 			got, err := cfg.getOptionsFromConfig()
 			if (err != nil) != tt.wantErr {

--- a/exporter/signalfxexporter/dimensions/metadata.go
+++ b/exporter/signalfxexporter/dimensions/metadata.go
@@ -25,6 +25,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/collection"
 )
 
+// MetadataUpdateClient is an interface for pushing metadata updates
+type MetadataUpdateClient interface {
+	PushMetadata([]*collection.MetadataUpdate) error
+}
+
 var propNameSanitizer = strings.NewReplacer(
 	".", "_",
 	"/", "_")

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -73,6 +73,16 @@ func TestNew(t *testing.T) {
 				Headers:     nil,
 			},
 		},
+		{
+			name: "create exporter with host metadata syncer",
+			config: &Config{
+				AccessToken:      "someToken",
+				Realm:            "xyz",
+				Timeout:          1 * time.Second,
+				Headers:          nil,
+				SyncHostMetadata: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -181,7 +181,7 @@ func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
 	// Expected values has to be updated once default config changed
 	assert.Equal(t, 48, len(config.TranslationRules))
 	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
-	assert.Equal(t, 32, len(config.TranslationRules[0].Mapping))
+	assert.Equal(t, 33, len(config.TranslationRules[0].Mapping))
 }
 
 func TestCreateMetricsExporterWithSpecifiedTranslaitonRules(t *testing.T) {

--- a/exporter/signalfxexporter/go.sum
+++ b/exporter/signalfxexporter/go.sum
@@ -1119,6 +1119,7 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io/collector v0.11.0/go.mod h1:tJNTr3RWiwUyYKI6dtlHY+G/jfKa/+Ewv6MvmwLiqoE=
 go.opentelemetry.io/collector v0.11.1-0.20200924160956-8690937037da h1:W990SgXqeewmIaj1I53yr253Kdl7+7yu6wPB/jUlxIo=
 go.opentelemetry.io/collector v0.11.1-0.20200924160956-8690937037da/go.mod h1:tJNTr3RWiwUyYKI6dtlHY+G/jfKa/+Ewv6MvmwLiqoE=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/exporter/signalfxexporter/hostmetadata/metadata.go
+++ b/exporter/signalfxexporter/hostmetadata/metadata.go
@@ -1,0 +1,147 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostmetadata
+
+import (
+	"sync"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/dimensions"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/collection"
+)
+
+var (
+	// Resource attribute that used as fallback if there are no cloud provider attributes.
+	extraHostIDAttribute = conventions.AttributeHostName
+)
+
+// Syncer is a config structure for host metadata syncer.
+type Syncer struct {
+	logger    *zap.Logger
+	dimClient dimensions.MetadataUpdateClient
+	once      sync.Once
+}
+
+// NewSyncer creates new instance of host metadata syncer.
+func NewSyncer(logger *zap.Logger, dimClient dimensions.MetadataUpdateClient) *Syncer {
+	return &Syncer{
+		logger:    logger,
+		dimClient: dimClient,
+	}
+}
+
+func (s *Syncer) Sync(md pdata.Metrics) {
+	// skip if already synced or if metrics data is empty
+	if md.ResourceMetrics().Len() == 0 {
+		return
+	}
+	s.once.Do(func() {
+		s.syncOnResource(md.ResourceMetrics().At(0).Resource())
+	})
+}
+
+func (s *Syncer) syncOnResource(res pdata.Resource) {
+	// If resourcedetection processor is enabled, all the metrics should have resource attributes
+	// that can be used to update host metadata.
+	// Based of this assumption we check just one ResourceMetrics object,
+	hostID, ok := getHostIDFromResource(res)
+	if !ok {
+		// if no attributes found, we assume that resourcedetection is not enabled or
+		// it doesn't set right attributes, and we do not retry.
+		s.logger.Error("Not found any host attributes. Host metadata synchronization skipped. " +
+			"Make sure that \"resourcedetection\" processor is enabled in the pipeline with one of " +
+			"the cloud provider detectors or environment variable detector setting \"host.name\" attribute")
+		return
+	}
+
+	props := s.scrapeHostProperties()
+	if len(props) == 0 {
+		// do not retry if scraping failed.
+		s.logger.Error("Failed to fetch system properties. Host metadata synchronization skipped")
+		return
+	}
+
+	metadataUpdate := s.prepareMetadataUpdate(props, hostID)
+	err := s.dimClient.PushMetadata([]*collection.MetadataUpdate{metadataUpdate})
+	if err != nil {
+		s.logger.Error("Failed to push host metadata update", zap.Error(err))
+		return
+	}
+
+	s.logger.Info("Host metadata synchronized")
+}
+
+func (s *Syncer) prepareMetadataUpdate(props map[string]string, hostID splunk.HostID) *collection.MetadataUpdate {
+	return &collection.MetadataUpdate{
+		ResourceIDKey: string(hostID.Key),
+		ResourceID:    collection.ResourceID(hostID.ID),
+		MetadataDelta: collection.MetadataDelta{
+			MetadataToUpdate: props,
+		},
+	}
+}
+
+func (s *Syncer) scrapeHostProperties() map[string]string {
+	props := make(map[string]string)
+
+	cpu, err := getCPU()
+	if err == nil {
+		for k, v := range cpu.toStringMap() {
+			props[k] = v
+		}
+	} else {
+		s.logger.Warn("Failed to scrape host hostCPU metadata", zap.Error(err))
+	}
+
+	mem, err := getMemory()
+	if err == nil {
+		for k, v := range mem.toStringMap() {
+			props[k] = v
+		}
+	} else {
+		s.logger.Warn("Failed to scrape host memory metadata", zap.Error(err))
+	}
+
+	os, err := getOS()
+	if err == nil {
+		for k, v := range os.toStringMap() {
+			props[k] = v
+		}
+	} else {
+		s.logger.Warn("Failed to scrape host hostOS metadata", zap.Error(err))
+	}
+
+	return props
+}
+
+func getHostIDFromResource(res pdata.Resource) (splunk.HostID, bool) {
+	hostID, ok := splunk.ResourceToHostID(res)
+	if ok {
+		return hostID, ok
+	}
+
+	if attr, ok := res.Attributes().Get(extraHostIDAttribute); ok {
+		return splunk.HostID{
+			Key: splunk.HostIDKey(extraHostIDAttribute),
+			ID:  attr.StringVal(),
+		}, true
+	}
+
+	return splunk.HostID{}, false
+}

--- a/exporter/signalfxexporter/hostmetadata/metadata_linux_test.go
+++ b/exporter/signalfxexporter/hostmetadata/metadata_linux_test.go
@@ -1,0 +1,24 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostmetadata
+
+import "syscall"
+
+func mockSyscallUname() {
+	syscallUname = func(in *syscall.Utsname) error {
+		in.Machine = [65]int8{}
+		return nil
+	}
+}

--- a/exporter/signalfxexporter/hostmetadata/metadata_others_test.go
+++ b/exporter/signalfxexporter/hostmetadata/metadata_others_test.go
@@ -1,0 +1,19 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package hostmetadata
+
+func mockSyscallUname() {}

--- a/exporter/signalfxexporter/hostmetadata/metadata_test.go
+++ b/exporter/signalfxexporter/hostmetadata/metadata_test.go
@@ -1,0 +1,319 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostmetadata
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/collection"
+)
+
+func TestSyncMetadata(t *testing.T) {
+	tests := []struct {
+		name               string
+		cpuStat            cpu.InfoStat
+		cpuStatErr         error
+		memStat            mem.VirtualMemoryStat
+		memStatErr         error
+		hostStat           host.InfoStat
+		hostStatErr        error
+		pushFail           bool
+		metricsData        pdata.Metrics
+		wantMetadataUpdate []*collection.MetadataUpdate
+		wantLogs           []string
+	}{
+		{
+			name: "all_stats_available",
+			cpuStat: cpu.InfoStat{
+				Cores:     4,
+				ModelName: "testprocessor",
+			},
+			cpuStatErr: nil,
+			memStat: mem.VirtualMemoryStat{
+				Total: 2048,
+			},
+			memStatErr: nil,
+			hostStat: host.InfoStat{
+				OS:            "linux",
+				Platform:      "linux1",
+				KernelVersion: "4.14.121",
+			},
+			hostStatErr: nil,
+			pushFail:    false,
+			metricsData: generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			wantMetadataUpdate: []*collection.MetadataUpdate{
+				{
+					ResourceIDKey: extraHostIDAttribute,
+					ResourceID:    "host1",
+					MetadataDelta: collection.MetadataDelta{
+						MetadataToUpdate: map[string]string{
+							"host_cpu_cores":      "4",
+							"host_cpu_model":      "testprocessor",
+							"host_logical_cpus":   "1",
+							"host_physical_cpus":  "1",
+							"host_processor":      "",
+							"host_machine":        "",
+							"host_mem_total":      "2",
+							"host_kernel_name":    "linux",
+							"host_kernel_release": "4.14.121",
+							"host_linux_version":  "",
+							"host_kernel_version": "",
+							"host_os_name":        "linux1",
+						},
+					},
+				},
+			},
+			wantLogs: []string{},
+		},
+		{
+			name: "no_host_stats",
+			cpuStat: cpu.InfoStat{
+				Cores:     4,
+				ModelName: "testprocessor",
+			},
+			cpuStatErr: nil,
+			memStat: mem.VirtualMemoryStat{
+				Total: 2048,
+			},
+			memStatErr:  nil,
+			hostStat:    host.InfoStat{},
+			hostStatErr: errors.New("failed"),
+			pushFail:    false,
+			metricsData: generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			wantMetadataUpdate: []*collection.MetadataUpdate{
+				{
+					ResourceIDKey: extraHostIDAttribute,
+					ResourceID:    "host1",
+					MetadataDelta: collection.MetadataDelta{
+						MetadataToUpdate: map[string]string{
+							"host_cpu_cores":     "4",
+							"host_cpu_model":     "testprocessor",
+							"host_logical_cpus":  "1",
+							"host_physical_cpus": "1",
+							"host_processor":     "",
+							"host_machine":       "",
+							"host_mem_total":     "2",
+						},
+					},
+				},
+			},
+			wantLogs: []string{"Failed to scrape host hostOS metadata"},
+		},
+		{
+			name:       "mem_stats_only",
+			cpuStat:    cpu.InfoStat{},
+			cpuStatErr: errors.New("failed"),
+			memStat: mem.VirtualMemoryStat{
+				Total: 2048,
+			},
+			memStatErr:  nil,
+			hostStat:    host.InfoStat{},
+			hostStatErr: errors.New("failed"),
+			pushFail:    false,
+			metricsData: generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			wantMetadataUpdate: []*collection.MetadataUpdate{
+				{
+					ResourceIDKey: extraHostIDAttribute,
+					ResourceID:    "host1",
+					MetadataDelta: collection.MetadataDelta{
+						MetadataToUpdate: map[string]string{
+							"host_mem_total": "2",
+						},
+					},
+				},
+			},
+			wantLogs: []string{
+				"Failed to scrape host hostCPU metadata",
+				"Failed to scrape host hostOS metadata",
+			},
+		},
+		{
+			name:               "no_stats",
+			cpuStat:            cpu.InfoStat{},
+			cpuStatErr:         errors.New("failed"),
+			memStat:            mem.VirtualMemoryStat{},
+			memStatErr:         errors.New("failed"),
+			hostStat:           host.InfoStat{},
+			hostStatErr:        errors.New("failed"),
+			metricsData:        generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			wantMetadataUpdate: nil,
+			wantLogs: []string{
+				"Failed to scrape host hostCPU metadata",
+				"Failed to scrape host memory metadata",
+				"Failed to scrape host hostOS metadata",
+				"Failed to fetch system properties. Host metadata synchronization skipped",
+			},
+		},
+		{
+			name: "failed_push",
+			cpuStat: cpu.InfoStat{
+				Cores: 1,
+			},
+			cpuStatErr: nil,
+			memStat:    mem.VirtualMemoryStat{},
+			memStatErr: nil,
+			hostStat: host.InfoStat{
+				OS: "linux",
+			},
+			hostStatErr:        nil,
+			pushFail:           true,
+			metricsData:        generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			wantMetadataUpdate: nil,
+			wantLogs:           []string{"Failed to push host metadata update"},
+		},
+		{
+			name:       "mem_stats_on_gcp",
+			cpuStat:    cpu.InfoStat{},
+			cpuStatErr: errors.New("failed"),
+			memStat: mem.VirtualMemoryStat{
+				Total: 2048,
+			},
+			memStatErr:  nil,
+			hostStat:    host.InfoStat{},
+			hostStatErr: errors.New("failed"),
+			pushFail:    false,
+			metricsData: generateSampleMetricsData(map[string]string{
+				conventions.AttributeCloudProvider: "gcp",
+				conventions.AttributeCloudAccount:  "1234",
+				conventions.AttributeHostID:        "i-abc",
+			}),
+			wantMetadataUpdate: []*collection.MetadataUpdate{
+				{
+					ResourceIDKey: string(splunk.HostIDKeyGCP),
+					ResourceID:    "1234_i-abc",
+					MetadataDelta: collection.MetadataDelta{
+						MetadataToUpdate: map[string]string{
+							"host_mem_total": "2",
+						},
+					},
+				},
+			},
+			wantLogs: []string{
+				"Failed to scrape host hostCPU metadata",
+				"Failed to scrape host hostOS metadata",
+			},
+		},
+		{
+			name:     "no_host_id_attrs",
+			cpuStat:  cpu.InfoStat{},
+			pushFail: false,
+			metricsData: generateSampleMetricsData(map[string]string{
+				"random": "attribute",
+			}),
+			wantMetadataUpdate: nil,
+			wantLogs: []string{
+				"Not found any host attributes. Host metadata synchronization skipped. " +
+					"Make sure that \"resourcedetection\" processor is enabled in the pipeline with one of " +
+					"the cloud provider detectors or environment variable detector setting \"host.name\" attribute",
+			},
+		},
+		{
+			name:               "empty_metrics_data",
+			pushFail:           false,
+			metricsData:        pdata.NewMetrics(),
+			wantMetadataUpdate: nil,
+			wantLogs:           []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedLogger, logs := observer.New(zapcore.WarnLevel)
+			logger := zap.New(observedLogger)
+			dimClient := &fakeDimClient{fail: tt.pushFail}
+			syncer := NewSyncer(logger, dimClient)
+
+			// mock system stats calls.
+			os.Setenv("HOST_ETC", ".")
+			defer os.Unsetenv("HOST_ETC")
+			cpuInfo = func(context.Context) ([]cpu.InfoStat, error) {
+				return []cpu.InfoStat{tt.cpuStat}, tt.cpuStatErr
+			}
+			cpuCounts = func(context.Context, bool) (int, error) { return 1, nil }
+			memVirtualMemory = func() (*mem.VirtualMemoryStat, error) {
+				return &tt.memStat, tt.memStatErr
+			}
+			hostInfo = func() (*host.InfoStat, error) {
+				return &tt.hostStat, tt.hostStatErr
+			}
+			mockSyscallUname()
+
+			syncer.Sync(tt.metricsData)
+
+			if tt.wantMetadataUpdate != nil {
+				require.Equal(t, 1, len(dimClient.getMetadataUpdates()))
+				require.EqualValues(t, tt.wantMetadataUpdate, dimClient.getMetadataUpdates()[0])
+			} else {
+				require.Equal(t, 0, len(dimClient.getMetadataUpdates()))
+			}
+
+			require.Equal(t, len(tt.wantLogs), logs.Len())
+			for i, log := range logs.All() {
+				assert.Equal(t, tt.wantLogs[i], log.Message)
+			}
+
+		})
+	}
+}
+
+type fakeDimClient struct {
+	sync.Mutex
+	fail            bool
+	metadataUpdates [][]*collection.MetadataUpdate
+}
+
+func (dc *fakeDimClient) PushMetadata(metadataUpdates []*collection.MetadataUpdate) error {
+	if dc.fail {
+		return errors.New("failed")
+	}
+	dc.Lock()
+	defer dc.Unlock()
+	dc.metadataUpdates = append(dc.metadataUpdates, metadataUpdates)
+	return nil
+}
+
+func (dc *fakeDimClient) getMetadataUpdates() [][]*collection.MetadataUpdate {
+	dc.Lock()
+	defer dc.Unlock()
+	return dc.metadataUpdates
+}
+
+func generateSampleMetricsData(attrs map[string]string) pdata.Metrics {
+	m := pdata.NewMetrics()
+	rm := m.ResourceMetrics()
+	rm.Resize(1)
+	rm.At(0).InitEmpty()
+	res := rm.At(0).Resource()
+	res.InitEmpty()
+	for k, v := range attrs {
+		res.Attributes().InsertString(k, v)
+	}
+	return m
+}

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -47,6 +47,7 @@ translation_rules:
     k8s.resourcequota.uid: kubernetes_uid
     k8s.statefulset.name: kubernetes_name
     k8s.statefulset.uid: kubernetes_uid
+    host.name: host
 
     # properties
     cronjob_uid: cronJob_uid


### PR DESCRIPTION
**Description:** 
This change introduces host metadata updates functionality in Signalfx exporter. Synchronization happens once first metric batch is received. It looks for dimensions set by resourcedetection processor
