### PR TITLE
Bump CPU usage limit for TestMetric10kDPS/OpenCensus to avoid test failures

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -36,7 +36,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOCMetricDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 70,
+				ExpectedMaxCPU: 85,
 				ExpectedMaxRAM: 70,
 			},
 		},


### PR DESCRIPTION
This is already increased in the core repo, just making the same change in this repo.
