### PR TITLE
Skipping flaky test for carbonexporter

### DIFF
--- a/exporter/carbonexporter/exporter_test.go
+++ b/exporter/carbonexporter/exporter_test.go
@@ -80,6 +80,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestConsumeMetricsData(t *testing.T) {
+	t.Skip("skipping flaky test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/396")
 	smallBatch := internaldata.OCToMetrics(consumerdata.MetricsData{
 		Metrics: []*metricspb.Metric{
 			metricstestutil.Gauge(


### PR DESCRIPTION
Skipping flaky test until reasons for instability can be investigated. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/396