### PR TITLE
Log response error with zap

### DIFF
--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -88,6 +88,7 @@ func NewTraceExporter(config configmodels.Exporter, logger *zap.Logger, cn connA
 				logger.Debug("request: " + input.String())
 				output, localErr := xrayClient.PutTraceSegments(&input)
 				if localErr != nil {
+					logger.Debug("response error", zap.Error(localErr))
 					err = wrapErrorIfBadRequest(&localErr) // record error
 				}
 				if output != nil {


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Currently, even when an error is returned from an exporter, it doesn't seem to be automatically logged. I sort of expected it to but added manual logging instead.