### PR TITLE
the tests seem to expect UTZ 

### DIFF
--- a/exporter/honeycombexporter/translator.go
+++ b/exporter/honeycombexporter/translator.go
@@ -68,7 +68,7 @@ func timestampToTime(ts *timestamppb.Timestamp) (t time.Time) {
 	if ts == nil {
 		return
 	}
-	return time.Unix(ts.Seconds, int64(ts.Nanos))
+	return time.Unix(ts.Seconds, int64(ts.Nanos)).UTC()
 }
 
 // getStatusCode returns the status code


### PR DESCRIPTION
**Description:**

The tests were failing while running locally.
The time zone of `opencensus.start_timestamp` was the local time `+02:00` instead of `Z`.