### PR TITLE
Enable docker stats receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `dockerstats` receiver as top level component (#1081)
+
 ## v0.10.0
 
 # 🎉 OpenTelemetry Collector Contrib v0.10.0 (Beta) 🎉

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Learn more about roles in the [community repository](https://github.com/open-tel
 | awsxrayreceiver                | @kbrockhoff @anuraaga     |
 | carbonreceiver                 | @pjanotti                 |
 | collectdreceiver               | @owais                    |
+| dockerstatsreceiver            | @rmfitzpatrick            |
 | k8sclusterreceiver             | @asuresh4                 |
 | kubeletstatsreceiver           | @pmcollins @asuresh4      |
 | prometheusexecreceiver         | @keitwb @james-bebbington |

--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -42,6 +42,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver"
@@ -91,6 +92,7 @@ func components() (component.Factories, error) {
 		statsdreceiver.NewFactory(),
 		awsxrayreceiver.NewFactory(),
 		splunkhecreceiver.NewFactory(),
+		dockerstatsreceiver.NewFactory(),
 	}
 	for _, rcv := range factories.Receivers {
 		receivers = append(receivers, rcv)

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
**Description:** Adding a feature - Adds the docker stats receiver as a top level component.

**Testing:** tested manually w/ utilizing config.

**Documentation:** Updated owner section and changelog.