### PR TITLE
Define emitter operator as bridge from stanza pipeline to receiver

### DIFF
--- a/receiver/stanzareceiver/emitter.go
+++ b/receiver/stanzareceiver/emitter.go
@@ -1,0 +1,62 @@
+package stanzareceiver
+
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"context"
+	"sync"
+
+	"github.com/observiq/stanza/entry"
+	"github.com/observiq/stanza/operator/helper"
+	"go.uber.org/zap"
+)
+
+// LogEmitter is a stanza operator that emits log entries to a channel
+type LogEmitter struct {
+	helper.OutputOperator
+	logChan  chan *entry.Entry
+	stopOnce sync.Once
+}
+
+// NewLogEmitter creates a new receiver output
+func NewLogEmitter(logger *zap.SugaredLogger) *LogEmitter {
+	return &LogEmitter{
+		OutputOperator: helper.OutputOperator{
+			BasicOperator: helper.BasicOperator{
+				OperatorID:    "log_emitter",
+				OperatorType:  "log_emitter",
+				SugaredLogger: logger,
+			},
+		},
+		logChan: make(chan *entry.Entry),
+	}
+}
+
+// Process will emit an entry to the output channel
+func (e *LogEmitter) Process(ctx context.Context, ent *entry.Entry) error {
+	select {
+	case e.logChan <- ent:
+	case <-ctx.Done():
+	}
+	return nil
+}
+
+// Stop will close the log channel
+func (e *LogEmitter) Stop() error {
+	e.stopOnce.Do(func() {
+		close(e.logChan)
+	})
+	return nil
+}

--- a/receiver/stanzareceiver/emitter_test.go
+++ b/receiver/stanzareceiver/emitter_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stanzareceiver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/observiq/stanza/entry"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestLogEmitter(t *testing.T) {
+
+	emitter := NewLogEmitter(zaptest.NewLogger(t).Sugar())
+	defer emitter.Stop()
+
+	in := entry.New()
+
+	go func() {
+		require.NoError(t, emitter.Process(context.Background(), in))
+	}()
+
+	select {
+	case out := <-emitter.logChan:
+		require.Equal(t, in, out)
+	case <-time.After(time.Second):
+		require.FailNow(t, "Timed out waiting for output")
+	}
+}

--- a/receiver/stanzareceiver/factory.go
+++ b/receiver/stanzareceiver/factory.go
@@ -55,9 +55,12 @@ func createLogsReceiver(
 
 	obsConfig := cfg.(*Config)
 
+	emitter := NewLogEmitter(params.Logger.Sugar())
+
 	logAgent, err := stanza.NewBuilder(&stanza.Config{Pipeline: obsConfig.Pipeline}, params.Logger.Sugar()).
 		WithPluginDir(obsConfig.PluginDir).
 		WithDatabaseFile(obsConfig.OffsetsFile).
+		WithDefaultOutput(emitter).
 		Build()
 	if err != nil {
 		return nil, err
@@ -65,6 +68,7 @@ func createLogsReceiver(
 
 	return &stanzareceiver{
 		agent:    logAgent,
+		emitter:  emitter,
 		consumer: nextConsumer,
 		logger:   params.Logger,
 	}, nil

--- a/receiver/stanzareceiver/receiver.go
+++ b/receiver/stanzareceiver/receiver.go
@@ -25,6 +25,7 @@ import (
 
 type stanzareceiver struct {
 	agent    *stanza.LogAgent
+	emitter  *LogEmitter
 	consumer consumer.LogsConsumer
 	logger   *zap.Logger
 }


### PR DESCRIPTION
**Description:**
This PR adds a stanza "operator", which I've named "emitter". The purpose of this operator is to provide a mechanism for transmitting logs from the stanza pipeline to the stanza receiver. 

To explain this another way, consider that stanza has its own pipeline, which is made up of operators. This pipeline is very much analogous to OT's pipelines. This new operator serves a similar purpose to an OT exporter, in that it is the final step in the stanza pipeline.

Users will not need to be aware of the emitter (will not need to explicitly include it in their stanza pipeline) because it is being set as the default output operator, via the `WithDefaultOutput(emitter)` line in `factory.go`.

This PR is a continuation of #1096 (also see #1092 for additional context). The reason I've chosen this subset of functionality for the next PR in this effort, is that the receiver implementation will depend on receiving logs from the emitter. Although this functionality is a bit of an aside, I think it's worth considering before the receiver implementation.

**Testing:**
Emitter operator is fully unit tested.
