### PR TITLE
k8sclusterreceiver: Standardize metric names

### DIFF
--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -44,7 +44,7 @@ with detailed sample configurations [here](./testdata/config.yaml).
 ### node_conditions_to_report
 
 For example, with the config below the receiver will emit two metrics
-`kubernetes/node/condition_ready` and `kubernetes/node/condition_memory_pressure`, one
+`k8s.node.condition_ready` and `k8s.node.condition_memory_pressure`, one
 for each condition in the config. The value will be `1` if the `ConditionStatus` for the
 corresponding `Condition` is `True`, `0` if it is `False` and -1 if it is `Unknown`.
 

--- a/receiver/k8sclusterreceiver/collection/containers.go
+++ b/receiver/k8sclusterreceiver/collection/containers.go
@@ -37,7 +37,7 @@ const (
 )
 
 var containerRestartMetric = &metricspb.MetricDescriptor{
-	Name: "k8s/container/restarts",
+	Name: "k8s.container.restarts",
 	Description: "How many times the container has restarted in the recent past. " +
 		"This value is pulled directly from the K8s API and the value can go indefinitely high" +
 		" and be reset to 0 at any time depending on how your kubelet is configured to prune" +
@@ -50,7 +50,7 @@ var containerRestartMetric = &metricspb.MetricDescriptor{
 }
 
 var containerReadyMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/container/ready",
+	Name:        "k8s.container.ready",
 	Description: "Whether a container has passed its readiness probe (0 for no, 1 for yes)",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
@@ -114,7 +114,7 @@ func getSpecMetricsForContainer(c corev1.Container) []*metricspb.Metric {
 			metrics = append(metrics,
 				&metricspb.Metric{
 					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name:        fmt.Sprintf("k8s/container/%s/%s", k, t.typ),
+						Name:        fmt.Sprintf("k8s.container.%s_%s", k, t.typ),
 						Description: t.description,
 						Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 					},

--- a/receiver/k8sclusterreceiver/collection/cronjobs.go
+++ b/receiver/k8sclusterreceiver/collection/cronjobs.go
@@ -30,7 +30,7 @@ const (
 )
 
 var activeJobs = &metricspb.MetricDescriptor{
-	Name:        "k8s/cronjob/active_jobs",
+	Name:        "k8s.cronjob.active_jobs",
 	Description: "The number of actively running jobs for a cronjob",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/cronjobs_test.go
+++ b/receiver/k8sclusterreceiver/collection/cronjobs_test.go
@@ -44,7 +44,7 @@ func TestCronJobMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[0], "k8s/cronjob/active_jobs",
+	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[0], "k8s.cronjob.active_jobs",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 }
 

--- a/receiver/k8sclusterreceiver/collection/daemonsets.go
+++ b/receiver/k8sclusterreceiver/collection/daemonsets.go
@@ -24,28 +24,28 @@ import (
 )
 
 var daemonSetCurrentScheduledMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/daemon_set/current_scheduled_nodes",
+	Name:        "k8s.daemonset.current_scheduled_nodes",
 	Description: "Number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var daemonSetDesiredScheduledMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/daemon_set/desired_scheduled_nodes",
+	Name:        "k8s.daemonset.desired_scheduled_nodes",
 	Description: "Number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var daemonSetMisScheduledMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/daemon_set/misscheduled_nodes",
+	Name:        "k8s.daemonset.misscheduled_nodes",
 	Description: "Number of nodes that are running the daemon pod, but are not supposed to run the daemon pod",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var daemonSetReadyMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/daemon_set/ready_nodes",
+	Name:        "k8s.daemonset.ready_nodes",
 	Description: "Number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/daemonsets_test.go
+++ b/receiver/k8sclusterreceiver/collection/daemonsets_test.go
@@ -44,16 +44,16 @@ func TestDaemonsetMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, rm.metrics[0], "k8s/daemon_set/current_scheduled_nodes",
+	testutils.AssertMetrics(t, rm.metrics[0], "k8s.daemonset.current_scheduled_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 
-	testutils.AssertMetrics(t, rm.metrics[1], "k8s/daemon_set/desired_scheduled_nodes",
+	testutils.AssertMetrics(t, rm.metrics[1], "k8s.daemonset.desired_scheduled_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 5)
 
-	testutils.AssertMetrics(t, rm.metrics[2], "k8s/daemon_set/misscheduled_nodes",
+	testutils.AssertMetrics(t, rm.metrics[2], "k8s.daemonset.misscheduled_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1)
 
-	testutils.AssertMetrics(t, rm.metrics[3], "k8s/daemon_set/ready_nodes",
+	testutils.AssertMetrics(t, rm.metrics[3], "k8s.daemonset.ready_nodes",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 }
 

--- a/receiver/k8sclusterreceiver/collection/deployments_test.go
+++ b/receiver/k8sclusterreceiver/collection/deployments_test.go
@@ -44,10 +44,10 @@ func TestDeploymentMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, rm.metrics[0], "k8s/deployment/desired",
+	testutils.AssertMetrics(t, rm.metrics[0], "k8s.deployment.desired",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetrics(t, rm.metrics[1], "k8s/deployment/available",
+	testutils.AssertMetrics(t, rm.metrics[1], "k8s.deployment.available",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 }
 

--- a/receiver/k8sclusterreceiver/collection/hpa.go
+++ b/receiver/k8sclusterreceiver/collection/hpa.go
@@ -24,28 +24,28 @@ import (
 )
 
 var hpaMaxReplicasMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/hpa/max_replicas",
+	Name:        "k8s.hpa.max_replicas",
 	Description: "Maximum number of replicas to which the autoscaler can scale up",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var hpaMinReplicasMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/hpa/min_replicas",
+	Name:        "k8s.hpa.min_replicas",
 	Description: "Minimum number of replicas to which the autoscaler can scale down",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var hpaCurrentReplicasMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/hpa/current_replicas",
+	Name:        "k8s.hpa.current_replicas",
 	Description: "Current number of pod replicas managed by this autoscaler",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var hpaDesiredReplicasMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/hpa/desired_replicas",
+	Name:        "k8s.hpa.desired_replicas",
 	Description: "Desired number of pod replicas managed by this autoscaler",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/hpa_test.go
+++ b/receiver/k8sclusterreceiver/collection/hpa_test.go
@@ -44,16 +44,16 @@ func TestHPAMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, rm.metrics[0], "k8s/hpa/max_replicas",
+	testutils.AssertMetrics(t, rm.metrics[0], "k8s.hpa.max_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetrics(t, rm.metrics[1], "k8s/hpa/min_replicas",
+	testutils.AssertMetrics(t, rm.metrics[1], "k8s.hpa.min_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
-	testutils.AssertMetrics(t, rm.metrics[2], "k8s/hpa/current_replicas",
+	testutils.AssertMetrics(t, rm.metrics[2], "k8s.hpa.current_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 5)
 
-	testutils.AssertMetrics(t, rm.metrics[3], "k8s/hpa/desired_replicas",
+	testutils.AssertMetrics(t, rm.metrics[3], "k8s.hpa.desired_replicas",
 		metricspb.MetricDescriptor_GAUGE_INT64, 7)
 }
 

--- a/receiver/k8sclusterreceiver/collection/jobs.go
+++ b/receiver/k8sclusterreceiver/collection/jobs.go
@@ -24,35 +24,35 @@ import (
 )
 
 var podsActiveMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/job/active_pods",
+	Name:        "k8s.job.active_pods",
 	Description: "The number of actively running pods for a job",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var podsDesiredCompletedMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/job/desired_successful_pods",
+	Name:        "k8s.job.desired_successful_pods",
 	Description: "The desired number of successfully finished pods the job should be run with",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var podsFailedMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/job/failed_pods",
+	Name:        "k8s.job.failed_pods",
 	Description: "The number of pods which reached phase Failed for a job",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var podsMaxParallelMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/job/max_parallel_pods",
+	Name:        "k8s.job.max_parallel_pods",
 	Description: "The max desired number of pods the job should run at any given time",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var podsSuccessfulMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/job/successful_pods",
+	Name:        "k8s.job.successful_pods",
 	Description: "The number of pods which reached phase Succeeded for a job",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/jobs_test.go
+++ b/receiver/k8sclusterreceiver/collection/jobs_test.go
@@ -43,19 +43,19 @@ func TestJobMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[0], "k8s/job/active_pods",
+	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[0], "k8s.job.active_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
-	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[1], "k8s/job/desired_successful_pods",
+	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[1], "k8s.job.desired_successful_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[2], "k8s/job/failed_pods",
+	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[2], "k8s.job.failed_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 
-	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[3], "k8s/job/max_parallel_pods",
+	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[3], "k8s.job.max_parallel_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 2)
 
-	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[4], "k8s/job/successful_pods",
+	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[4], "k8s.job.successful_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 }
 

--- a/receiver/k8sclusterreceiver/collection/namespaces.go
+++ b/receiver/k8sclusterreceiver/collection/namespaces.go
@@ -27,7 +27,7 @@ func getMetricsForNamespace(ns *corev1.Namespace) []*resourceMetrics {
 	metrics := []*metricspb.Metric{
 		{
 			MetricDescriptor: &metricspb.MetricDescriptor{
-				Name:        "k8s/namespace/phase",
+				Name:        "k8s.namespace.phase",
 				Description: "The current phase of namespaces (1 for active and 0 for terminating)",
 				Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 			},

--- a/receiver/k8sclusterreceiver/collection/namespaces_test.go
+++ b/receiver/k8sclusterreceiver/collection/namespaces_test.go
@@ -42,7 +42,7 @@ func TestNamespaceMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[0], "k8s/namespace/phase",
+	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[0], "k8s.namespace.phase",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 }
 

--- a/receiver/k8sclusterreceiver/collection/nodes.go
+++ b/receiver/k8sclusterreceiver/collection/nodes.go
@@ -61,7 +61,7 @@ func getMetricsForNode(node *corev1.Node, nodeConditionTypesToReport []string) [
 }
 
 func getNodeConditionMetric(nodeConditionTypeValue string) string {
-	return fmt.Sprintf("k8s/node/condition_%s", strcase.ToSnake(nodeConditionTypeValue))
+	return fmt.Sprintf("k8s.node.condition_%s", strcase.ToSnake(nodeConditionTypeValue))
 }
 
 func getResourceForNode(node *corev1.Node) *resourcepb.Resource {

--- a/receiver/k8sclusterreceiver/collection/nodes_test.go
+++ b/receiver/k8sclusterreceiver/collection/nodes_test.go
@@ -42,10 +42,10 @@ func TestNodeMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[0], "k8s/node/condition_ready",
+	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[0], "k8s.node.condition_ready",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1)
 
-	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[1], "k8s/node/condition_memory_pressure",
+	testutils.AssertMetrics(t, actualResourceMetrics[0].metrics[1], "k8s.node.condition_memory_pressure",
 		metricspb.MetricDescriptor_GAUGE_INT64, 0)
 }
 
@@ -83,15 +83,15 @@ func TestGetNodeConditionMetric(t *testing.T) {
 	}{
 		{"Metric for Node condition Ready",
 			"Ready",
-			"k8s/node/condition_ready",
+			"k8s.node.condition_ready",
 		},
 		{"Metric for Node condition MemoryPressure",
 			"MemoryPressure",
-			"k8s/node/condition_memory_pressure",
+			"k8s.node.condition_memory_pressure",
 		},
 		{"Metric for Node condition DiskPressure",
 			"DiskPressure",
-			"k8s/node/condition_disk_pressure",
+			"k8s.node.condition_disk_pressure",
 		},
 	}
 

--- a/receiver/k8sclusterreceiver/collection/pods.go
+++ b/receiver/k8sclusterreceiver/collection/pods.go
@@ -39,7 +39,7 @@ const (
 )
 
 var podPhaseMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/pod/phase",
+	Name:        "k8s.pod.phase",
 	Description: "Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }

--- a/receiver/k8sclusterreceiver/collection/pods_test.go
+++ b/receiver/k8sclusterreceiver/collection/pods_test.go
@@ -60,7 +60,7 @@ func TestPodAndContainerMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, rm.Metrics[0], "k8s/pod/phase",
+	testutils.AssertMetrics(t, rm.Metrics[0], "k8s.pod.phase",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 
 	rm = rms[1]
@@ -79,16 +79,16 @@ func TestPodAndContainerMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, rm.Metrics[0], "k8s/container/restarts",
+	testutils.AssertMetrics(t, rm.Metrics[0], "k8s.container.restarts",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 
-	testutils.AssertMetrics(t, rm.Metrics[1], "k8s/container/ready",
+	testutils.AssertMetrics(t, rm.Metrics[1], "k8s.container.ready",
 		metricspb.MetricDescriptor_GAUGE_INT64, 1)
 
-	testutils.AssertMetrics(t, rm.Metrics[2], "k8s/container/cpu/request",
+	testutils.AssertMetrics(t, rm.Metrics[2], "k8s.container.cpu_request",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10000)
 
-	testutils.AssertMetrics(t, rm.Metrics[3], "k8s/container/cpu/limit",
+	testutils.AssertMetrics(t, rm.Metrics[3], "k8s.container.cpu_limit",
 		metricspb.MetricDescriptor_GAUGE_INT64, 20000)
 }
 

--- a/receiver/k8sclusterreceiver/collection/replica.go
+++ b/receiver/k8sclusterreceiver/collection/replica.go
@@ -26,7 +26,7 @@ func getReplicaMetrics(resource string, desired, available int32) []*metricspb.M
 	return []*metricspb.Metric{
 		{
 			MetricDescriptor: &metricspb.MetricDescriptor{
-				Name:        fmt.Sprintf("k8s/%s/desired", resource),
+				Name:        fmt.Sprintf("k8s.%s.desired", resource),
 				Description: fmt.Sprintf("Number of desired pods in this %s", resource),
 				Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 				Unit:        "1",
@@ -35,7 +35,7 @@ func getReplicaMetrics(resource string, desired, available int32) []*metricspb.M
 		},
 		{
 			MetricDescriptor: &metricspb.MetricDescriptor{
-				Name:        fmt.Sprintf("k8s/%s/available", resource),
+				Name:        fmt.Sprintf("k8s.%s.available", resource),
 				Description: fmt.Sprintf("Total number of available pods (ready for at least minReadySeconds) targeted by this %s", resource),
 				Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 				Unit:        "1",

--- a/receiver/k8sclusterreceiver/collection/replicasets.go
+++ b/receiver/k8sclusterreceiver/collection/replicasets.go
@@ -29,7 +29,7 @@ func getMetricsForReplicaSet(rs *appsv1.ReplicaSet) []*resourceMetrics {
 		{
 			resource: getResourceForReplicaSet(rs),
 			metrics: getReplicaMetrics(
-				"replica_set",
+				"replicaset",
 				*rs.Spec.Replicas,
 				rs.Status.AvailableReplicas,
 			),

--- a/receiver/k8sclusterreceiver/collection/replicasets_test.go
+++ b/receiver/k8sclusterreceiver/collection/replicasets_test.go
@@ -15,10 +15,41 @@
 package collection
 
 import (
+	"testing"
+
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/testutils"
 )
+
+func TestReplicasetMetrics(t *testing.T) {
+	rs := newReplicaSet("1")
+
+	actualResourceMetrics := getMetricsForReplicaSet(rs)
+
+	require.Equal(t, 1, len(actualResourceMetrics))
+	require.Equal(t, 2, len(actualResourceMetrics[0].metrics))
+
+	rm := actualResourceMetrics[0]
+	testutils.AssertResource(t, rm.resource, k8sType,
+		map[string]string{
+			"k8s.replicaset.uid":  "test-replicaset-1-uid",
+			"k8s.replicaset.name": "test-replicaset-1",
+			"k8s.namespace.name":  "test-namespace",
+			"k8s.cluster.name":    "test-cluster",
+		},
+	)
+
+	testutils.AssertMetrics(t, rm.metrics[0], "k8s.replicaset.desired",
+		metricspb.MetricDescriptor_GAUGE_INT64, 3)
+
+	testutils.AssertMetrics(t, rm.metrics[1], "k8s.replicaset.available",
+		metricspb.MetricDescriptor_GAUGE_INT64, 2)
+}
 
 func newReplicaSet(id string) *appsv1.ReplicaSet {
 	return &appsv1.ReplicaSet{
@@ -32,7 +63,15 @@ func newReplicaSet(id string) *appsv1.ReplicaSet {
 				"foo1": "",
 			},
 		},
-		Spec:   appsv1.ReplicaSetSpec{},
-		Status: appsv1.ReplicaSetStatus{},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: func() *int32 {
+				var out int32
+				out = 3
+				return &out
+			}(),
+		},
+		Status: appsv1.ReplicaSetStatus{
+			AvailableReplicas: 2,
+		},
 	}
 }

--- a/receiver/k8sclusterreceiver/collection/replicasets_test.go
+++ b/receiver/k8sclusterreceiver/collection/replicasets_test.go
@@ -65,8 +65,7 @@ func newReplicaSet(id string) *appsv1.ReplicaSet {
 		},
 		Spec: appsv1.ReplicaSetSpec{
 			Replicas: func() *int32 {
-				var out int32
-				out = 3
+				var out int32 = 3
 				return &out
 			}(),
 		},

--- a/receiver/k8sclusterreceiver/collection/resourcequotas.go
+++ b/receiver/k8sclusterreceiver/collection/resourcequotas.go
@@ -26,7 +26,7 @@ import (
 )
 
 var resourceQuotaHardLimitMetric = &metricspb.MetricDescriptor{
-	Name: "k8s/resource_quota/hard_limt",
+	Name: "k8s.resource_quota.hard_limt",
 	Description: "The upper limit for a particular resource in a specific namespace." +
 		" Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores",
 	Type: metricspb.MetricDescriptor_GAUGE_INT64,
@@ -36,7 +36,7 @@ var resourceQuotaHardLimitMetric = &metricspb.MetricDescriptor{
 }
 
 var resourceQuotaUsedMetric = &metricspb.MetricDescriptor{
-	Name: "k8s/resource_quota/used",
+	Name: "k8s.resource_quota.used",
 	Description: "The usage for a particular resource in a specific namespace." +
 		" Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores",
 	Type: metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/resourcequotas.go
+++ b/receiver/k8sclusterreceiver/collection/resourcequotas.go
@@ -26,7 +26,7 @@ import (
 )
 
 var resourceQuotaHardLimitMetric = &metricspb.MetricDescriptor{
-	Name: "k8s.resource_quota.hard_limt",
+	Name: "k8s.resource_quota.hard_limit",
 	Description: "The upper limit for a particular resource in a specific namespace." +
 		" Will only be sent if a quota is specified. CPU requests/limits will be sent as millicores",
 	Type: metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/resourcequotas_test.go
+++ b/receiver/k8sclusterreceiver/collection/resourcequotas_test.go
@@ -44,10 +44,10 @@ func TestRequestQuotaMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].metrics[0], "k8s/resource_quota/hard_limt",
+	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].metrics[0], "k8s.resource_quota.hard_limt",
 		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "requests.cpu"}, 2000)
 
-	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].metrics[1], "k8s/resource_quota/used",
+	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].metrics[1], "k8s.resource_quota.used",
 		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "requests.cpu"}, 1000)
 }
 

--- a/receiver/k8sclusterreceiver/collection/resourcequotas_test.go
+++ b/receiver/k8sclusterreceiver/collection/resourcequotas_test.go
@@ -44,7 +44,7 @@ func TestRequestQuotaMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].metrics[0], "k8s.resource_quota.hard_limt",
+	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].metrics[0], "k8s.resource_quota.hard_limit",
 		metricspb.MetricDescriptor_GAUGE_INT64, map[string]string{"resource": "requests.cpu"}, 2000)
 
 	testutils.AssertMetricsWithLabels(t, actualResourceMetrics[0].metrics[1], "k8s.resource_quota.used",

--- a/receiver/k8sclusterreceiver/collection/statefulsets.go
+++ b/receiver/k8sclusterreceiver/collection/statefulsets.go
@@ -30,28 +30,28 @@ const (
 )
 
 var statefulSetReplicasDesiredMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/stateful_set/desired_pods",
+	Name:        "k8s.statefulset.desired_pods",
 	Description: "Number of desired pods in the stateful set (the `spec.replicas` field)",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var statefulSetReplicasReadyMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/stateful_set/ready_pods",
+	Name:        "k8s.statefulset.ready_pods",
 	Description: "Number of pods created by the stateful set that have the `Ready` condition",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var statefulSetReplicasCurrentMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/stateful_set/current_pods",
+	Name:        "k8s.statefulset.current_pods",
 	Description: "The number of pods created by the StatefulSet controller from the StatefulSet version",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 }
 
 var statefulSetReplicasUpdatedMetric = &metricspb.MetricDescriptor{
-	Name:        "k8s/stateful_set/updated_pods",
+	Name:        "k8s.statefulset.updated_pods",
 	Description: "Number of pods created by the StatefulSet controller from the StatefulSet version",
 	Unit:        "1",
 	Type:        metricspb.MetricDescriptor_GAUGE_INT64,

--- a/receiver/k8sclusterreceiver/collection/statefulsets_test.go
+++ b/receiver/k8sclusterreceiver/collection/statefulsets_test.go
@@ -44,16 +44,16 @@ func TestStatefulsettMetrics(t *testing.T) {
 		},
 	)
 
-	testutils.AssertMetrics(t, rm.metrics[0], "k8s/stateful_set/desired_pods",
+	testutils.AssertMetrics(t, rm.metrics[0], "k8s.statefulset.desired_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 10)
 
-	testutils.AssertMetrics(t, rm.metrics[1], "k8s/stateful_set/ready_pods",
+	testutils.AssertMetrics(t, rm.metrics[1], "k8s.statefulset.ready_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 7)
 
-	testutils.AssertMetrics(t, rm.metrics[2], "k8s/stateful_set/current_pods",
+	testutils.AssertMetrics(t, rm.metrics[2], "k8s.statefulset.current_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 5)
 
-	testutils.AssertMetrics(t, rm.metrics[3], "k8s/stateful_set/updated_pods",
+	testutils.AssertMetrics(t, rm.metrics[3], "k8s.statefulset.updated_pods",
 		metricspb.MetricDescriptor_GAUGE_INT64, 3)
 }
 


### PR DESCRIPTION
**Description:** 
- Replace "/" with "." in metric names
- daemon_set -> daemonset, stateful_set -> statefulset, replica_set -> replicaset to match conventions
- k8s/container/<resource_type>/<request | limit> -> k8s.container.<resource_type>_<request | limit>

**Testing:** Updated tests

**Documentation:** Updated references in README.