### PR TITLE
Align CPU limit for TestStabilityMetricsOpenCensus with load tests

### DIFF
--- a/testbed/stabilitytests/metric_test.go
+++ b/testbed/stabilitytests/metric_test.go
@@ -46,7 +46,7 @@ func TestStabilityMetricsOpenCensus(t *testing.T) {
 		testbed.NewOCMetricDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 		testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 		testbed.ResourceSpec{
-			ExpectedMaxCPU:      70,
+			ExpectedMaxCPU:      85,
 			ExpectedMaxRAM:      86,
 			ResourceCheckPeriod: resourceCheckPeriod,
 		},


### PR DESCRIPTION
CPU limits were bumped in load tests after changes in internal data format conversions. need to do the same for stability tests
