### PR TITLE
Add HTTP request/response workpool for signalfx trace/metric correlation

### DIFF
--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.0.0-00010101000000-000000000000
 	github.com/signalfx/sapm-proto v0.5.3
 	github.com/stretchr/testify v1.6.1
-	go.opentelemetry.io/collector v0.11.1-0.20200924160956-8690937037da
+	go.opentelemetry.io/collector v0.11.0
+	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0
 )
 

--- a/exporter/sapmexporter/requests/callbacksender.go
+++ b/exporter/sapmexporter/requests/callbacksender.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requests
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// HTTPClient interface
+type HTTPClient interface {
+	Do(r *http.Request) (*http.Response, error)
+}
+
+type (
+	// RequestFailedCallback is called when the request fails.
+	RequestFailedCallback func(body []byte, statusCode int, err error)
+	// RequestSuccessCallback is called on HTTP request success (all status codes).
+	RequestSuccessCallback func(statusCode int, body []byte)
+	key                    int
+)
+
+const (
+	requestFailedCallbackKey  key = 1
+	requestSuccessCallbackKey key = 2
+)
+
+// CallbackSender implements HTTPSender to send an HTTP request on the configured client. It sends
+// callbacks on request success/failure taken from the request context.
+type CallbackSender struct {
+	Client HTTPClient
+}
+
+// SendRequest is called to send the given request on the configured HTTP client.
+func (rs *CallbackSender) SendRequest(req *http.Request) error {
+	resp, err := rs.Client.Do(req)
+
+	if err != nil {
+		onRequestFailed(req, nil, 0, err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	// TODO: note that semantics of onRequestSuccess and onRequestFailed changed in ported code. Make sure
+	// consumers of this use the new semantics.
+	if err != nil {
+		err = fmt.Errorf("error making HTTP request to %s: %v", req.URL.String(), err)
+		onRequestFailed(req, body, resp.StatusCode, err)
+		return err
+	}
+
+	onRequestSuccess(req, resp.StatusCode, body)
+	return nil
+}
+
+func onRequestSuccess(req *http.Request, statusCode int, body []byte) {
+	ctx := req.Context()
+	cb, ok := ctx.Value(requestSuccessCallbackKey).(RequestSuccessCallback)
+	if ok {
+		cb(statusCode, body)
+	}
+}
+func onRequestFailed(req *http.Request, body []byte, statusCode int, err error) {
+	ctx := req.Context()
+	cb, ok := ctx.Value(requestFailedCallbackKey).(RequestFailedCallback)
+	if ok {
+		cb(body, statusCode, err)
+	}
+}
+
+// ContextWithSuccess attaches the provided function to the context to be called on success.
+func ContextWithSuccess(ctx context.Context, f RequestSuccessCallback) context.Context {
+	return context.WithValue(ctx, requestSuccessCallbackKey, f)
+}
+
+// ContextWithFailed attaches the provided function to the context to be called on failure.
+func ContextWithFailed(ctx context.Context, f RequestFailedCallback) context.Context {
+	return context.WithValue(ctx, requestFailedCallbackKey, f)
+}

--- a/exporter/sapmexporter/requests/callbacksender_test.go
+++ b/exporter/sapmexporter/requests/callbacksender_test.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requests
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeClient struct {
+	resp *http.Response
+	err  error
+}
+
+func (f *fakeClient) Do(r *http.Request) (*http.Response, error) {
+	return f.resp, f.err
+}
+
+type body struct {
+	reader  io.Reader
+	readErr error
+}
+
+func (b *body) Read(p []byte) (n int, err error) {
+	r, _ := b.reader.Read(p)
+	return r, b.readErr
+}
+
+func (b *body) Close() error {
+	return nil
+}
+
+func TestReadFailed(t *testing.T) {
+	called := false
+	ctx := ContextWithFailed(context.Background(), func(body []byte, statusCode int, err error) {
+		called = true
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
+	require.NoError(t, err)
+	sender := &CallbackSender{Client: &fakeClient{resp: &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Body:       &body{reader: bytes.NewBufferString("sdf"), readErr: errors.New("read failed")}},
+	}}
+	require.EqualError(t, sender.SendRequest(req), "error making HTTP request to http://localhost: read failed")
+	assert.True(t, called)
+}
+
+func TestRequestFailedWithCallback(t *testing.T) {
+	called := false
+	ctx := ContextWithFailed(context.Background(), func(body []byte, statusCode int, err error) {
+		called = true
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
+	require.NoError(t, err)
+	sender := &CallbackSender{Client: &fakeClient{err: errors.New("request error")}}
+	require.Error(t, sender.SendRequest(req))
+	assert.True(t, called)
+}
+
+func TestRequestSucceededWithCallback(t *testing.T) {
+	called := false
+	ctx := ContextWithSuccess(context.Background(), func(statusCode int, body []byte) {
+		called = true
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
+	require.NoError(t, err)
+	sender := &CallbackSender{Client: &fakeClient{resp: &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Body:       &body{reader: bytes.NewBufferString("OK"), readErr: io.EOF},
+	}}}
+	require.NoError(t, sender.SendRequest(req))
+	assert.True(t, called)
+}

--- a/exporter/sapmexporter/requests/diagnostics.go
+++ b/exporter/sapmexporter/requests/diagnostics.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requests
+
+// TODO: Consider sending these once we have a way to send custom metrics.
+// sfxagent.dim_updates_started", map[string]string{"client": rs.clientName}, &rs.TotalRequestsStarted
+// sfxagent.dim_updates_completed", map[string]string{"client": rs.clientName}, &rs.TotalRequestsCompleted
+// sfxagent.dim_updates_failed", map[string]string{"client": rs.clientName}, &rs.TotalRequestsFailed
+// sfxagent.dim_request_senders", map[string]string{"client": rs.clientName}, atomic.LoadInt64(&rs.RunningWorkers)

--- a/exporter/sapmexporter/requests/requestcounter/counter.go
+++ b/exporter/sapmexporter/requests/requestcounter/counter.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requestcounter
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type key int
+
+const (
+	getRequestCountKey       key = 1
+	incrementRequestCountKey key = 2
+	resetRequestCountKey     key = 3
+)
+
+type getRequestCount func() uint32
+type incrementRequestCount func()
+type resetRequestCount func()
+
+// checks if a counter already exists on the context
+func counterExists(ctx context.Context) (exists bool) {
+	if _, exists = ctx.Value(getRequestCountKey).(getRequestCount); !exists {
+		if _, exists = ctx.Value(incrementRequestCountKey).(incrementRequestCount); !exists {
+			_, exists = ctx.Value(resetRequestCountKey).(resetRequestCount)
+		}
+	}
+	return exists
+}
+
+// ContextWithRequestCounter adds a counter to the context if one does not already exist
+func ContextWithRequestCounter(ctx context.Context) context.Context {
+	if counterExists(ctx) {
+		// don't create a new context with counter if a counter already exists on the counter
+		return ctx
+	}
+	var c uint32
+	newCtx := context.WithValue(ctx, getRequestCountKey, getRequestCount(func() uint32 { return atomic.LoadUint32(&c) }))
+	newCtx = context.WithValue(newCtx, incrementRequestCountKey, incrementRequestCount(func() { atomic.AddUint32(&c, 1) }))
+	return context.WithValue(newCtx, resetRequestCountKey, resetRequestCount(func() { atomic.StoreUint32(&c, 0) }))
+}
+
+// ResetRequestCount resets the request counter on the provided context if the context has one
+func ResetRequestCount(ctx context.Context) {
+	if res, ok := ctx.Value(resetRequestCountKey).(resetRequestCount); ok {
+		res()
+	}
+}
+
+// IncrementRequestCount increments the request counter on the provided context if the context has one
+func IncrementRequestCount(ctx context.Context) {
+	if inc, ok := ctx.Value(incrementRequestCountKey).(incrementRequestCount); ok {
+		inc()
+	}
+}
+
+// GetRequestCount retrieves the current request count on the provided context.  It returns 0 if the context does not
+// have a request counter
+func GetRequestCount(ctx context.Context) (count uint32) {
+	if get, ok := ctx.Value(getRequestCountKey).(getRequestCount); ok {
+		count = get()
+	}
+	return count
+}

--- a/exporter/sapmexporter/requests/requestcounter/counter_test.go
+++ b/exporter/sapmexporter/requests/requestcounter/counter_test.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requestcounter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextWithRequestCounter(t *testing.T) {
+	parent := ContextWithRequestCounter(context.Background())
+	assert.True(t, counterExists(parent), "parent context contains counter")
+	assert.Equal(t, uint32(0), GetRequestCount(parent), "parent context with counter is initialized to 0")
+
+	// ensure counter can be incremented
+	IncrementRequestCount(parent)
+	assert.Equal(t, uint32(1), GetRequestCount(parent), "parent context is incremented")
+
+	// ensure child contexts retains the counter
+	child, cancel := context.WithCancel(parent)
+	defer cancel()
+	assert.True(t, counterExists(parent), "child context contains counter")
+	assert.Equal(t, uint32(1), GetRequestCount(child), "child context carried over parent count")
+
+	// ensure increment on child also increments parent
+	IncrementRequestCount(child)
+	assert.Equal(t, uint32(2), GetRequestCount(child), "child context can be incremented")
+	assert.Equal(t, uint32(2), GetRequestCount(parent), "parent context was incremented when child was incremented")
+
+	// ensure increment on parent also increments child
+	IncrementRequestCount(parent)
+	assert.Equal(t, uint32(3), GetRequestCount(parent), "parent context can still still increment counter")
+	assert.Equal(t, uint32(3), GetRequestCount(child), "child context counter was incremented when parent was incremented")
+
+	assert.Equal(t, uint32(3), GetRequestCount(ContextWithRequestCounter(parent)), "trying to get a context with a counter shouldn't not overwrite an existing counter")
+
+	// ensure counter can be reset
+	ResetRequestCount(child)
+	assert.Equal(t, uint32(0), GetRequestCount(parent), "parent context counter was reset")
+	assert.Equal(t, uint32(0), GetRequestCount(child), "child context counter was reset")
+
+	// ensure no error when context with out counter is passed in to functions
+	todo := context.TODO()
+	assert.False(t, counterExists(todo), "plain context shouldn't have a counter")
+	assert.Equal(t, uint32(0), GetRequestCount(todo), "plain context should return count of 0")
+	assert.NotPanics(t, func() { IncrementRequestCount(todo) }, todo, "incrementing a plain counter should not panic")
+	assert.Equal(t, uint32(0), GetRequestCount(todo), "incrementing a plain counter should do nothing")
+}

--- a/exporter/sapmexporter/requests/workpool.go
+++ b/exporter/sapmexporter/requests/workpool.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requests
+
+import (
+	"context"
+	"net/http"
+
+	"go.uber.org/atomic"
+)
+
+// HTTPSender interface is used as callback provided to HTTPWorkPool.
+type HTTPSender interface {
+	SendRequest(req *http.Request) error
+}
+
+// HTTPWorkPool manages a pool of workers for sending HTTP requests in parallel.
+type HTTPWorkPool struct {
+	sender                 HTTPSender
+	ctx                    context.Context
+	requests               chan *http.Request
+	workPool               chan struct{}
+	RunningWorkers         atomic.Int64
+	TotalRequestsWaiting   atomic.Int64
+	TotalRequestsStarted   atomic.Int64
+	TotalRequestsCompleted atomic.Int64
+	TotalRequestsFailed    atomic.Int64
+}
+
+// NewHTTPWorkPool creates a new workpool with the lifetime of the given context. A maximum number of workers
+// specified with workerCount are started. The provided sender is used to process requests.
+func NewHTTPWorkPool(ctx context.Context, workerCount int, sender HTTPSender) *HTTPWorkPool {
+	return &HTTPWorkPool{
+		sender: sender,
+		ctx:    ctx,
+		// Unbuffered so that it blocks clients
+		requests: make(chan *http.Request),
+		// Limits size of work pool.
+		workPool: make(chan struct{}, workerCount),
+	}
+}
+
+// Send the given request object. Will block unless:
+//
+// 1. A worker is available.
+// 2. Workpool has been stopped.
+// 3. Request context is cancelled.
+func (rs *HTTPWorkPool) Send(req *http.Request) {
+	// Slight optimization to avoid spinning up unnecessary workers if there
+	// aren't ever that many updates. Once workers start, they remain for
+	// the life of the workpool.
+	select {
+	// Worker is immediately available.
+	case rs.requests <- req:
+		return
+	default:
+		// Worker is not immediately available.
+		select {
+		// Start a new worker if the work pool isn't at max capacity.
+		case rs.workPool <- struct{}{}:
+			rs.startWorker()
+		default:
+		}
+
+		rs.TotalRequestsWaiting.Inc()
+		// Block until we can get through a request or context is cancelled.
+		select {
+		case <-req.Context().Done():
+		case <-rs.ctx.Done():
+		case rs.requests <- req:
+		}
+
+	}
+}
+
+func (rs *HTTPWorkPool) startWorker() {
+	go rs.processRequests()
+}
+
+func (rs *HTTPWorkPool) processRequests() {
+	rs.RunningWorkers.Inc()
+	defer rs.RunningWorkers.Dec()
+	defer func() {
+		// Not strictly necessary since we don't stop workers except on shutdown but
+		// will keep len(workPool) usually in line with RunningWorkers.
+		<-rs.workPool
+	}()
+
+	for {
+		select {
+		case <-rs.ctx.Done():
+			return
+		case req := <-rs.requests:
+			rs.TotalRequestsStarted.Inc()
+			if err := rs.sender.SendRequest(req); err != nil {
+				rs.TotalRequestsFailed.Inc()
+				continue
+			}
+			rs.TotalRequestsCompleted.Inc()
+		}
+	}
+}

--- a/exporter/sapmexporter/requests/workpool_test.go
+++ b/exporter/sapmexporter/requests/workpool_test.go
@@ -1,0 +1,172 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requests
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var dummyRequest = httptest.NewRequest(http.MethodGet, "http://localhost", nil)
+
+type fakeSender struct {
+	err error
+}
+
+func (f *fakeSender) SendRequest(req *http.Request) error {
+	return f.err
+}
+
+func newWorkPool(t *testing.T, count int, sender HTTPSender) *HTTPWorkPool {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return NewHTTPWorkPool(ctx, count, sender)
+}
+
+// shortWait waits 1 second for condition to evaluate to true.
+func shortWait(t *testing.T, eventually func(t require.TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}), f func() bool) {
+	t.Helper()
+	eventually(t, f, 1*time.Second, 1*time.Millisecond)
+}
+
+func TestNewWorkPool(t *testing.T) {
+	assert.NotNil(t, NewHTTPWorkPool(context.Background(), 1, nil))
+}
+
+func TestNewWorker(t *testing.T) {
+	w := newWorkPool(t, 5, &fakeSender{})
+	assert.Equal(t, 0, len(w.workPool))
+	w.Send(dummyRequest)
+	assert.Equal(t, 1, len(w.workPool))
+}
+
+func TestExistingWorkerReused(t *testing.T) {
+	done := make(chan struct{})
+	w := newWorkPool(t, 1, &signaledSender{done: done})
+	w.Send(dummyRequest)
+	assert.Equal(t, 1, len(w.workPool))
+	done <- struct{}{}
+	shortWait(t, require.Eventually, func() bool {
+		return w.TotalRequestsCompleted.Load() == 1
+	})
+
+	w.Send(dummyRequest)
+	done <- struct{}{}
+
+	shortWait(t, require.Eventually, func() bool {
+		return w.TotalRequestsCompleted.Load() == 2
+	})
+
+	assert.Equal(t, 1, len(w.workPool))
+}
+
+type signaledSender struct {
+	done chan struct{}
+}
+
+func (s *signaledSender) SendRequest(req *http.Request) error {
+	<-s.done
+	return nil
+}
+
+func TestMultipleWorkersCreated(t *testing.T) {
+	done := make(chan struct{})
+	w := newWorkPool(t, 5, &signaledSender{done: done})
+	w.Send(dummyRequest)
+	w.Send(dummyRequest)
+	close(done)
+	shortWait(t, require.Eventually, func() bool {
+		return w.TotalRequestsCompleted.Load() == 2
+	})
+	assert.Equal(t, 2, len(w.workPool))
+}
+
+func TestWorkPoolAtMaxCapacity(t *testing.T) {
+	done := make(chan struct{})
+	w := newWorkPool(t, 3, &signaledSender{done: done})
+	w.Send(dummyRequest)
+	w.Send(dummyRequest)
+	w.Send(dummyRequest)
+	go func() {
+		w.Send(dummyRequest)
+	}()
+	shortWait(t, require.Eventually, func() bool {
+		return w.TotalRequestsWaiting.Load() == 4
+	})
+	close(done)
+	shortWait(t, require.Eventually, func() bool {
+		return w.TotalRequestsCompleted.Load() == 4
+	})
+	assert.Equal(t, 3, len(w.workPool))
+}
+
+func TestShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	defer close(done)
+	w := NewHTTPWorkPool(ctx, 1, &signaledSender{done: done})
+	w.Send(dummyRequest)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		w.Send(dummyRequest)
+		wg.Done()
+	}()
+
+	cancel()
+	wg.Wait()
+}
+
+func TestSendReturnsWhenRequestContextIsCancelled(t *testing.T) {
+	w := NewHTTPWorkPool(context.Background(), 0, &fakeSender{})
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost", nil)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		w.Send(req)
+		wg.Done()
+	}()
+
+	shortWait(t, require.Eventually, func() bool {
+		return w.TotalRequestsWaiting.Load() == 1
+	})
+
+	cancel()
+
+	wg.Wait()
+
+	assert.Equal(t, int64(0), w.TotalRequestsCompleted.Load())
+
+	require.NoError(t, err)
+}
+
+func TestRequestFailed(t *testing.T) {
+	w := newWorkPool(t, 1, &fakeSender{err: errors.New("request failed")})
+	w.Send(dummyRequest)
+	shortWait(t, require.Eventually, func() bool {
+		return w.TotalRequestsFailed.Load() == 1
+	})
+}

--- a/go.sum
+++ b/go.sum
@@ -1341,6 +1341,7 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io/collector v0.11.0/go.mod h1:tJNTr3RWiwUyYKI6dtlHY+G/jfKa/+Ewv6MvmwLiqoE=
 go.opentelemetry.io/collector v0.11.1-0.20200924160956-8690937037da h1:W990SgXqeewmIaj1I53yr253Kdl7+7yu6wPB/jUlxIo=
 go.opentelemetry.io/collector v0.11.1-0.20200924160956-8690937037da/go.mod h1:tJNTr3RWiwUyYKI6dtlHY+G/jfKa/+Ewv6MvmwLiqoE=
 go.opentelemetry.io/otel v0.11.0 h1:IN2tzQa9Gc4ZVKnTaMbPVcHjvzOdg5n9QfnmlqiET7E=


### PR DESCRIPTION
This is the first in several patches to add APM v2 correlation to the
sapmexporter for SignalFx. This adds an HTTP workpool for sending HTTP
requests in parallel.