### PR TITLE
[AwsEcsMetricsReceiver] Add codes to read data from ECS endpoint

### DIFF
--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/client.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/client.go
@@ -19,7 +19,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -94,11 +93,11 @@ func (c *clientImpl) Get(path string) ([]byte, error) {
 	}()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.WithMessage(err, "failed to read response body")
+		return nil, fmt.Errorf("failed to read response body %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("task metadata endpoint request GET %s failed - %q, response: %q",
+		return nil, fmt.Errorf("request GET %s failed - %q, response: %q",
 			req.URL.String(), resp.Status, string(body))
 	}
 	return body, nil

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/client.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/client.go
@@ -1,0 +1,115 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecscontainermetrics
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// Client defines the rest client interface
+type Client interface {
+	Get(path string) ([]byte, error)
+}
+
+// NewClientProvider creates the default rest client provider
+func NewClientProvider(endpoint string, logger *zap.Logger) ClientProvider {
+	return &defaultClientProvider{
+		endpoint: endpoint,
+		logger:   logger,
+	}
+}
+
+// ClientProvider defines
+type ClientProvider interface {
+	BuildClient() Client
+}
+
+type defaultClientProvider struct {
+	endpoint string
+	logger   *zap.Logger
+}
+
+func (dcp *defaultClientProvider) BuildClient() Client {
+	return defaultClient(
+		dcp.endpoint,
+		dcp.logger,
+	)
+}
+
+func defaultClient(
+	endpoint string,
+	logger *zap.Logger,
+) *clientImpl {
+	tr := defaultTransport()
+	return &clientImpl{
+		baseURL:    endpoint,
+		httpClient: http.Client{Transport: tr},
+		logger:     logger,
+	}
+}
+
+func defaultTransport() *http.Transport {
+	return http.DefaultTransport.(*http.Transport).Clone()
+}
+
+var _ Client = (*clientImpl)(nil)
+
+type clientImpl struct {
+	baseURL    string
+	httpClient http.Client
+	logger     *zap.Logger
+}
+
+func (c *clientImpl) Get(path string) ([]byte, error) {
+	req, err := c.buildReq(path)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		closeErr := resp.Body.Close()
+		if closeErr != nil {
+			c.logger.Warn("Failed to close response body", zap.Error(closeErr))
+		}
+	}()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to read response body")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("task metadata endpoint request GET %s failed - %q, response: %q",
+			req.URL.String(), resp.Status, string(body))
+	}
+	return body, nil
+}
+
+func (c *clientImpl) buildReq(path string) (*http.Request, error) {
+	url := c.baseURL + path
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/client_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/client_test.go
@@ -15,12 +15,12 @@
 package awsecscontainermetrics
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -145,7 +145,7 @@ type fakeRoundTripper struct {
 
 func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if f.failOnRT {
-		return nil, errors.New("failOnRT == true")
+		return nil, fmt.Errorf("failOnRT == true")
 	}
 	f.header = req.Header
 	f.method = req.Method
@@ -167,7 +167,7 @@ func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 			onClose: func() error {
 				f.closed = true
 				if f.errOnClose {
-					return errors.New("")
+					return fmt.Errorf("error on close")
 				}
 				return nil
 			},
@@ -180,7 +180,7 @@ var _ io.Reader = (*failingReader)(nil)
 type failingReader struct{}
 
 func (f *failingReader) Read([]byte) (n int, err error) {
-	return 0, errors.New("")
+	return 0, fmt.Errorf("error on read")
 }
 
 var _ io.ReadCloser = (*fakeReadCloser)(nil)

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/client_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/client_test.go
@@ -1,0 +1,195 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecscontainermetrics
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestClient(t *testing.T) {
+	tr := &fakeRoundTripper{}
+	baseURL := "http://localhost:8080"
+	client := &clientImpl{
+		baseURL:    baseURL,
+		httpClient: http.Client{Transport: tr},
+	}
+	require.False(t, tr.closed)
+	resp, err := client.Get("/stats")
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(resp))
+	require.True(t, tr.closed)
+	require.Equal(t, baseURL+"/stats", tr.url)
+	require.Equal(t, 1, len(tr.header))
+	require.Equal(t, "application/json", tr.header["Content-Type"][0])
+	require.Equal(t, "GET", tr.method)
+}
+
+func TestNewClientProvider(t *testing.T) {
+	provider := NewClientProvider("http://localhost:8080", zap.NewNop())
+	require.NotNil(t, provider)
+	_, ok := provider.(*defaultClientProvider)
+	require.True(t, ok)
+
+	client := provider.BuildClient()
+	require.Equal(t, "http://localhost:8080", string(client.(*clientImpl).baseURL))
+}
+
+func TestDefaultClient(t *testing.T) {
+	endpoint := "http://localhost:8080"
+	client := defaultClient(endpoint, zap.NewNop())
+	require.NotNil(t, client.httpClient.Transport)
+	require.Equal(t, endpoint, client.baseURL)
+}
+
+func TestBuildReq(t *testing.T) {
+	p := &defaultClientProvider{
+		endpoint: "http://localhost:8080",
+		logger:   zap.NewNop(),
+	}
+	cl := p.BuildClient()
+	req, err := cl.(*clientImpl).buildReq("/test")
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	require.Equal(t, "application/json", req.Header["Content-Type"][0])
+}
+
+func TestBuildBadReq(t *testing.T) {
+	p := &defaultClientProvider{
+		endpoint: "http://localhost:8080",
+		logger:   zap.NewNop(),
+	}
+	cl := p.BuildClient()
+	_, err := cl.(*clientImpl).buildReq(" ")
+	require.Error(t, err)
+}
+
+func TestGetBad(t *testing.T) {
+	p := &defaultClientProvider{
+		endpoint: "http://localhost:8080",
+		logger:   zap.NewNop(),
+	}
+	cl := p.BuildClient()
+	resp, err := cl.(*clientImpl).Get(" ")
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestFailedRT(t *testing.T) {
+	tr := &fakeRoundTripper{failOnRT: true}
+	baseURL := "http://localhost:8080"
+	client := &clientImpl{
+		baseURL:    baseURL,
+		httpClient: http.Client{Transport: tr},
+	}
+	_, err := client.Get("/test")
+	require.Error(t, err)
+}
+
+func TestErrOnRead(t *testing.T) {
+	tr := &fakeRoundTripper{errOnRead: true}
+	baseURL := "http://localhost:8080"
+	client := &clientImpl{
+		baseURL:    baseURL,
+		httpClient: http.Client{Transport: tr},
+		logger:     zap.NewNop(),
+	}
+	resp, err := client.Get("/foo")
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+func TestErrCode(t *testing.T) {
+	tr := &fakeRoundTripper{errCode: true}
+	baseURL := "http://localhost:9876"
+	client := &clientImpl{
+		baseURL:    baseURL,
+		httpClient: http.Client{Transport: tr},
+		logger:     zap.NewNop(),
+	}
+	resp, err := client.Get("/foo")
+	require.Error(t, err)
+	require.Nil(t, resp)
+}
+
+var _ http.RoundTripper = (*fakeRoundTripper)(nil)
+
+type fakeRoundTripper struct {
+	closed     bool
+	header     http.Header
+	method     string
+	url        string
+	failOnRT   bool
+	errOnClose bool
+	errOnRead  bool
+	errCode    bool
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if f.failOnRT {
+		return nil, errors.New("failOnRT == true")
+	}
+	f.header = req.Header
+	f.method = req.Method
+	f.url = req.URL.String()
+	var reader io.Reader
+	if f.errOnRead {
+		reader = &failingReader{}
+	} else {
+		reader = strings.NewReader("hello")
+	}
+	statusCode := 200
+	if f.errCode {
+		statusCode = 503
+	}
+	return &http.Response{
+		StatusCode: statusCode,
+		Body: &fakeReadCloser{
+			Reader: reader,
+			onClose: func() error {
+				f.closed = true
+				if f.errOnClose {
+					return errors.New("")
+				}
+				return nil
+			},
+		},
+	}, nil
+}
+
+var _ io.Reader = (*failingReader)(nil)
+
+type failingReader struct{}
+
+func (f *failingReader) Read([]byte) (n int, err error) {
+	return 0, errors.New("")
+}
+
+var _ io.ReadCloser = (*fakeReadCloser)(nil)
+
+type fakeReadCloser struct {
+	io.Reader
+	onClose func() error
+}
+
+func (f *fakeReadCloser) Close() error {
+	return f.onClose()
+}

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/constant.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/constant.go
@@ -30,6 +30,10 @@ const (
 	ContainerPrefix    = "container."
 	MetricResourceType = "aoc.ecs"
 
+	ENDPOINT         = "ECS_CONTAINER_METADATA_URI_V4"
+	TaskStatsPath    = "/task/stats"
+	TaskMetadataPath = "/task"
+
 	AttributeMemoryUsage    = "memory.usage"
 	AttributeMemoryMaxUsage = "memory.usage.max"
 	AttributeMemoryLimit    = "memory.usage.limit"

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/constant.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/constant.go
@@ -30,7 +30,7 @@ const (
 	ContainerPrefix    = "container."
 	MetricResourceType = "aoc.ecs"
 
-	ENDPOINT         = "ECS_CONTAINER_METADATA_URI_V4"
+	EndpointEnvKey   = "ECS_CONTAINER_METADATA_URI_V4"
 	TaskStatsPath    = "/task/stats"
 	TaskMetadataPath = "/task"
 

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics.go
@@ -1,0 +1,26 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecscontainermetrics
+
+import (
+	"go.opentelemetry.io/collector/consumer/consumerdata"
+)
+
+func MetricsData(containerStatsMap map[string]ContainerStats, metadata TaskMetadata, typeStr string) []*consumerdata.MetricsData {
+	acc := &metricDataAccumulator{}
+	acc.getMetricsData(containerStatsMap, metadata)
+
+	return acc.md
+}

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics.go
@@ -18,7 +18,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 )
 
-func MetricsData(containerStatsMap map[string]ContainerStats, metadata TaskMetadata, typeStr string) []*consumerdata.MetricsData {
+func MetricsData(containerStatsMap map[string]ContainerStats, metadata TaskMetadata) []*consumerdata.MetricsData {
 	acc := &metricDataAccumulator{}
 	acc.getMetricsData(containerStatsMap, metadata)
 

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper_test.go
@@ -109,6 +109,11 @@ func TestExtractStorageUsage(t *testing.T) {
 
 	require.EqualValues(t, v, read)
 	require.EqualValues(t, v, write)
+
+	read, write = extractStorageUsage(nil)
+	v = uint64(0)
+	require.EqualValues(t, v, read)
+	require.EqualValues(t, v, write)
 }
 
 func TestGetNetworkStats(t *testing.T) {

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_test.go
@@ -106,6 +106,6 @@ func TestMetricData(t *testing.T) {
 	cstats := make(map[string]ContainerStats)
 	cstats["001"] = containerStats
 
-	md := MetricsData(cstats, tm, "test-ecs-receiver")
+	md := MetricsData(cstats, tm)
 	require.Less(t, 0, len(md))
 }

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_test.go
@@ -1,0 +1,111 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package awsecscontainermetrics
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricSampleFile(t *testing.T) {
+	data, err := ioutil.ReadFile("../testdata/task_stats.json")
+	require.NoError(t, err)
+	require.NotNil(t, data)
+}
+
+func TestMetricData(t *testing.T) {
+	v := uint64(1)
+	f := float64(1.0)
+
+	memStats := make(map[string]uint64)
+	memStats["cache"] = v
+
+	mem := MemoryStats{
+		Usage:          &v,
+		MaxUsage:       &v,
+		Limit:          &v,
+		MemoryReserved: &v,
+		MemoryUtilized: &v,
+		Stats:          memStats,
+	}
+
+	disk := DiskStats{
+		IoServiceBytesRecursives: []IoServiceBytesRecursive{
+			{Op: "Read", Value: &v},
+			{Op: "Write", Value: &v},
+			{Op: "Total", Value: &v},
+		},
+	}
+
+	net := make(map[string]NetworkStats)
+	net["eth0"] = NetworkStats{
+		RxBytes:   &v,
+		RxPackets: &v,
+		RxErrors:  &v,
+		RxDropped: &v,
+		TxBytes:   &v,
+		TxPackets: &v,
+		TxErrors:  &v,
+		TxDropped: &v,
+	}
+
+	netRate := NetworkRateStats{
+		RxBytesPerSecond: &f,
+		TxBytesPerSecond: &f,
+	}
+
+	percpu := []*uint64{&v, &v}
+	cpuUsage := CPUUsage{
+		TotalUsage:        &v,
+		UsageInKernelmode: &v,
+		UsageInUserMode:   &v,
+		PerCPUUsage:       percpu,
+	}
+
+	cpuStats := CPUStats{
+		CPUUsage:       cpuUsage,
+		OnlineCpus:     &v,
+		SystemCPUUsage: &v,
+		CPUUtilized:    &v,
+		CPUReserved:    &v,
+	}
+	containerStats := ContainerStats{
+		Name:        "test",
+		ID:          "001",
+		Memory:      mem,
+		Disk:        disk,
+		Network:     net,
+		NetworkRate: netRate,
+		CPU:         cpuStats,
+	}
+
+	tm := TaskMetadata{
+		Cluster:  "cluster-1",
+		TaskARN:  "arn:aws:some-value/001",
+		Family:   "task-def-family-1",
+		Revision: "task-def-version",
+		Containers: []ContainerMetadata{
+			{ContainerName: "container-1", DockerID: "001", DockerName: "docker-container-1", Limits: Limit{CPU: &f, Memory: &v}},
+		},
+		Limits: Limit{CPU: &f, Memory: &v},
+	}
+
+	cstats := make(map[string]ContainerStats)
+	cstats["001"] = containerStats
+
+	md := MetricsData(cstats, tm, "test-ecs-receiver")
+	require.Less(t, 0, len(md))
+}

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/rest_client.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/rest_client.go
@@ -1,0 +1,44 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecscontainermetrics
+
+// RestClient is swappable for testing.
+type RestClient interface {
+	EndpointResponse() ([]byte, []byte, error)
+}
+
+// HTTPRestClient is a thin wrapper around an ecs task metadata client, encapsulating endpoints
+// and their corresponding http methods.
+type HTTPRestClient struct {
+	client Client
+}
+
+// NewRestClient creates a new copy of the Rest Client
+func NewRestClient(client Client) *HTTPRestClient {
+	return &HTTPRestClient{client: client}
+}
+
+// EndpointResponse gets the task metadata and docker stats from ECS Task Metadata Endpoint
+func (c *HTTPRestClient) EndpointResponse() ([]byte, []byte, error) {
+	taskStats, err := c.client.Get(TaskStatsPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	taskMetadata, err := c.client.Get(TaskMetadataPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return taskStats, taskMetadata, nil
+}

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/rest_client_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/rest_client_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecscontainermetrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestClient(t *testing.T) {
+	rest := NewRestClient(&fakeClient{})
+	stats, metadata, err := rest.EndpointResponse()
+
+	require.Nil(t, err)
+	require.Equal(t, "/task/stats", string(stats))
+	require.Equal(t, "/task", string(metadata))
+}
+
+var _ Client = (*fakeClient)(nil)
+
+type fakeClient struct{}
+
+func (f *fakeClient) Get(path string) ([]byte, error) {
+	return []byte(path), nil
+}

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/stats_provider.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/stats_provider.go
@@ -16,6 +16,7 @@ package awsecscontainermetrics
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // StatsProvider wraps a RestClient, returning an unmarshaled metadata and docker stats
@@ -35,14 +36,17 @@ func (p *StatsProvider) GetStats() (map[string]ContainerStats, TaskMetadata, err
 
 	taskStats, taskMetadata, err := p.rc.EndpointResponse()
 	if err != nil {
-		return stats, metadata, err
+		return stats, metadata, fmt.Errorf("cannot read data from task metadata endpoint: %w", err)
 	}
 
 	err = json.Unmarshal(taskStats, &stats)
 	if err != nil {
-		return stats, metadata, err
+		return stats, metadata, fmt.Errorf("cannot unmarshall task stats: %w", err)
 	}
 
 	err = json.Unmarshal(taskMetadata, &metadata)
-	return stats, metadata, err
+	if err != nil {
+		return stats, metadata, fmt.Errorf("cannot unmarshall task metadata: %w", err)
+	}
+	return stats, metadata, nil
 }

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/stats_provider.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/stats_provider.go
@@ -1,0 +1,48 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecscontainermetrics
+
+import (
+	"encoding/json"
+)
+
+// StatsProvider wraps a RestClient, returning an unmarshaled metadata and docker stats
+type StatsProvider struct {
+	rc RestClient
+}
+
+// NewStatsProvider returns a new stats provider
+func NewStatsProvider(rc RestClient) *StatsProvider {
+	return &StatsProvider{rc: rc}
+}
+
+// GetStats calls the ecs task metadata endpoint and unmarshals the data
+func (p *StatsProvider) GetStats() (map[string]ContainerStats, TaskMetadata, error) {
+	stats := make(map[string]ContainerStats)
+	var metadata TaskMetadata
+
+	taskStats, taskMetadata, err := p.rc.EndpointResponse()
+	if err != nil {
+		return stats, metadata, err
+	}
+
+	err = json.Unmarshal(taskStats, &stats)
+	if err != nil {
+		return stats, metadata, err
+	}
+
+	err = json.Unmarshal(taskMetadata, &metadata)
+	return stats, metadata, err
+}

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/stats_provider_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/stats_provider_test.go
@@ -1,0 +1,85 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecscontainermetrics
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testRestClient struct {
+	fail        bool
+	invalidJSON bool
+}
+
+func (f testRestClient) EndpointResponse() ([]byte, []byte, error) {
+	if f.fail {
+		return []byte{}, []byte{}, errors.New("failed")
+	}
+	if f.invalidJSON {
+		return []byte("wrong-json-body"), []byte("wrong-json-body"), nil
+	}
+
+	taskStats, err := ioutil.ReadFile("../testdata/task_stats.json")
+	if err != nil {
+		return nil, nil, err
+	}
+	taskMetadata, err := ioutil.ReadFile("../testdata/task_metadata.json")
+	if err != nil {
+		return nil, nil, err
+	}
+	return taskStats, taskMetadata, nil
+}
+
+func TestGetStats(t *testing.T) {
+	tests := []struct {
+		name      string
+		client    RestClient
+		wantError string
+	}{
+		{
+			name:      "success",
+			client:    &testRestClient{},
+			wantError: "",
+		},
+		{
+			name:      "failure",
+			client:    &testRestClient{fail: true},
+			wantError: "failed",
+		},
+		{
+			name:      "invalid-json",
+			client:    &testRestClient{invalidJSON: true},
+			wantError: "invalid character 'w' looking for beginning of value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewStatsProvider(tt.client)
+			stats, metadata, err := provider.GetStats()
+			if tt.wantError == "" {
+				require.NoError(t, err)
+				require.Less(t, 0, len(stats))
+				require.Equal(t, "test200", metadata.Cluster)
+			} else {
+				assert.Equal(t, tt.wantError, err.Error())
+			}
+		})
+	}
+}

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/stats_provider_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/stats_provider_test.go
@@ -15,10 +15,10 @@
 package awsecscontainermetrics
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ type testRestClient struct {
 
 func (f testRestClient) EndpointResponse() ([]byte, []byte, error) {
 	if f.fail {
-		return []byte{}, []byte{}, errors.New("failed")
+		return []byte{}, []byte{}, fmt.Errorf("failed")
 	}
 	if f.invalidJSON {
 		return []byte("wrong-json-body"), []byte("wrong-json-body"), nil

--- a/receiver/awsecscontainermetricsreceiver/factory.go
+++ b/receiver/awsecscontainermetricsreceiver/factory.go
@@ -17,6 +17,7 @@ package awsecscontainermetricsreceiver
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -69,13 +70,17 @@ func createMetricsReceiver(
 		return nil, fmt.Errorf("no environment variable found for %s", awsecscontainermetrics.EndpointEnvKey)
 	}
 
-	rest := restClient(params.Logger, ecsTaskMetadataEndpointV4)
+	endpoint, err := url.ParseRequestURI(ecsTaskMetadataEndpointV4)
+	if err != nil {
+		return nil, err
+	}
+	rest := restClient(params.Logger, *endpoint)
 
 	rCfg := baseCfg.(*Config)
 	return New(params.Logger, rCfg, consumer, rest)
 }
 
-func restClient(logger *zap.Logger, endpoint string) awsecscontainermetrics.RestClient {
+func restClient(logger *zap.Logger, endpoint url.URL) awsecscontainermetrics.RestClient {
 	clientProvider := awsecscontainermetrics.NewClientProvider(endpoint, logger)
 
 	client := clientProvider.BuildClient()

--- a/receiver/awsecscontainermetricsreceiver/factory.go
+++ b/receiver/awsecscontainermetricsreceiver/factory.go
@@ -34,7 +34,7 @@ const (
 	// Key to invoke this receiver (awsecscontainermetrics)
 	typeStr = "awsecscontainermetrics"
 
-	// Default collection interval. In every 20s the receiver will collect metrics from Amazon ECS Task Metadata Endpoint
+	// Default collection interval. Every 20s the receiver will collect metrics from Amazon ECS Task Metadata Endpoint
 	defaultCollectionInterval = 20 * time.Second
 )
 
@@ -64,9 +64,9 @@ func createMetricsReceiver(
 	baseCfg configmodels.Receiver,
 	consumer consumer.MetricsConsumer,
 ) (component.MetricsReceiver, error) {
-	ecsTaskMetadataEndpointV4 := os.Getenv(awsecscontainermetrics.ENDPOINT)
+	ecsTaskMetadataEndpointV4 := os.Getenv(awsecscontainermetrics.EndpointEnvKey)
 	if ecsTaskMetadataEndpointV4 == "" {
-		return nil, fmt.Errorf("no environment variable found for %s", awsecscontainermetrics.ENDPOINT)
+		return nil, fmt.Errorf("no environment variable found for %s", awsecscontainermetrics.EndpointEnvKey)
 	}
 
 	rest := restClient(params.Logger, ecsTaskMetadataEndpointV4)

--- a/receiver/awsecscontainermetricsreceiver/factory.go
+++ b/receiver/awsecscontainermetricsreceiver/factory.go
@@ -16,22 +16,29 @@ package awsecscontainermetricsreceiver
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics"
 )
 
+// Factory for awscontainermetrics
 const (
+	// Key to invoke this receiver (awsecscontainermetrics)
 	typeStr = "awsecscontainermetrics"
 
-	// Default collection interval
+	// Default collection interval. In every 20s the receiver will collect metrics from Amazon ECS Task Metadata Endpoint
 	defaultCollectionInterval = 20 * time.Second
 )
 
-// NewFactory creates a factory for Aws ECS Container Metrics receiver.
+// NewFactory creates a factory for AWS ECS Container Metrics receiver.
 func NewFactory() component.ReceiverFactory {
 	return receiverhelper.NewFactory(
 		typeStr,
@@ -39,6 +46,7 @@ func NewFactory() component.ReceiverFactory {
 		receiverhelper.WithMetrics(createMetricsReceiver))
 }
 
+// createDefaultConfig returns a default config for the receiver.
 func createDefaultConfig() configmodels.Receiver {
 	return &Config{
 		ReceiverSettings: configmodels.ReceiverSettings{
@@ -49,12 +57,29 @@ func createDefaultConfig() configmodels.Receiver {
 	}
 }
 
+// CreateMetricsReceiver creates an AWS ECS Container Metrics receiver.
 func createMetricsReceiver(
-	_ context.Context,
+	ctx context.Context,
 	params component.ReceiverCreateParams,
-	cfg configmodels.Receiver,
-	nextConsumer consumer.MetricsConsumer,
+	baseCfg configmodels.Receiver,
+	consumer consumer.MetricsConsumer,
 ) (component.MetricsReceiver, error) {
-	rCfg := cfg.(*Config)
-	return newAwsEcsContainerMetricsReceiver(params.Logger, rCfg, nextConsumer)
+	ecsTaskMetadataEndpointV4 := os.Getenv(awsecscontainermetrics.ENDPOINT)
+	if ecsTaskMetadataEndpointV4 == "" {
+		return nil, fmt.Errorf("no environment variable found for %s", awsecscontainermetrics.ENDPOINT)
+	}
+
+	rest := restClient(params.Logger, ecsTaskMetadataEndpointV4)
+
+	rCfg := baseCfg.(*Config)
+	return New(params.Logger, rCfg, consumer, rest)
+}
+
+func restClient(logger *zap.Logger, endpoint string) awsecscontainermetrics.RestClient {
+	clientProvider := awsecscontainermetrics.NewClientProvider(endpoint, logger)
+
+	client := clientProvider.BuildClient()
+	rest := awsecscontainermetrics.NewRestClient(client)
+
+	return rest
 }

--- a/receiver/awsecscontainermetricsreceiver/factory_test.go
+++ b/receiver/awsecscontainermetricsreceiver/factory_test.go
@@ -16,6 +16,7 @@ package awsecscontainermetricsreceiver
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"testing"
 
@@ -45,7 +46,7 @@ func TestCreateMetricsReceiver(t *testing.T) {
 }
 
 func TestCreateMetricsReceiverWithEnv(t *testing.T) {
-	os.Setenv(awsecscontainermetrics.EndpointEnvKey, "TEST_ENV_VAR")
+	os.Setenv(awsecscontainermetrics.EndpointEnvKey, "http://www.test.com")
 
 	metricsReceiver, err := createMetricsReceiver(
 		context.Background(),
@@ -55,7 +56,19 @@ func TestCreateMetricsReceiverWithEnv(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, metricsReceiver)
+}
 
+func TestCreateMetricsReceiverWithBadUrl(t *testing.T) {
+	os.Setenv(awsecscontainermetrics.EndpointEnvKey, "bad-url-format")
+
+	metricsReceiver, err := createMetricsReceiver(
+		context.Background(),
+		component.ReceiverCreateParams{Logger: zap.NewNop()},
+		createDefaultConfig(),
+		&testbed.MockMetricConsumer{},
+	)
+	require.Error(t, err)
+	require.Nil(t, metricsReceiver)
 }
 
 func TestCreateMetricsReceiverWithNilConsumer(t *testing.T) {
@@ -68,11 +81,11 @@ func TestCreateMetricsReceiverWithNilConsumer(t *testing.T) {
 
 	require.Error(t, err, "Nil Comsumer")
 	require.Nil(t, metricsReceiver)
-
 }
 
 func TestRestClient(t *testing.T) {
-	rest := restClient(nil, "")
+	u, _ := url.Parse("http://www.test.com")
+	rest := restClient(nil, *u)
 
 	require.NotNil(t, rest)
 }

--- a/receiver/awsecscontainermetricsreceiver/factory_test.go
+++ b/receiver/awsecscontainermetricsreceiver/factory_test.go
@@ -16,11 +16,11 @@ package awsecscontainermetricsreceiver
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/testbed/testbed"
 	"go.uber.org/zap"
@@ -38,8 +38,22 @@ func TestCreateMetricsReceiver(t *testing.T) {
 		createDefaultConfig(),
 		&testbed.MockMetricConsumer{},
 	)
+	require.Error(t, err, "No Env Variable Error")
+	require.Nil(t, metricsReceiver)
+}
+
+func TestCreateMetricsReceiverWithEnv(t *testing.T) {
+	os.Setenv("ECS_CONTAINER_METADATA_URI_V4", "TEST_ENV_VAR")
+
+	metricsReceiver, err := createMetricsReceiver(
+		context.Background(),
+		component.ReceiverCreateParams{Logger: zap.NewNop()},
+		createDefaultConfig(),
+		&testbed.MockMetricConsumer{},
+	)
 	require.NoError(t, err)
 	require.NotNil(t, metricsReceiver)
+
 }
 
 func TestCreateMetricsReceiverWithNilConsumer(t *testing.T) {
@@ -49,6 +63,14 @@ func TestCreateMetricsReceiverWithNilConsumer(t *testing.T) {
 		createDefaultConfig(),
 		nil,
 	)
+
+	require.Error(t, err, "Nil Comsumer")
 	require.Nil(t, metricsReceiver)
-	require.Equal(t, err, componenterror.ErrNilNextConsumer)
+
+}
+
+func TestRestClient(t *testing.T) {
+	rest := restClient(nil, "")
+
+	require.NotNil(t, rest)
 }

--- a/receiver/awsecscontainermetricsreceiver/factory_test.go
+++ b/receiver/awsecscontainermetricsreceiver/factory_test.go
@@ -24,6 +24,8 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/testbed/testbed"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics"
 )
 
 func TestValidConfig(t *testing.T) {
@@ -43,7 +45,7 @@ func TestCreateMetricsReceiver(t *testing.T) {
 }
 
 func TestCreateMetricsReceiverWithEnv(t *testing.T) {
-	os.Setenv("ECS_CONTAINER_METADATA_URI_V4", "TEST_ENV_VAR")
+	os.Setenv(awsecscontainermetrics.EndpointEnvKey, "TEST_ENV_VAR")
 
 	metricsReceiver, err := createMetricsReceiver(
 		context.Background(),

--- a/receiver/awsecscontainermetricsreceiver/go.mod
+++ b/receiver/awsecscontainermetricsreceiver/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/golang/protobuf v1.4.2
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.11.1-0.20200924160956-8690937037da
 	go.uber.org/zap v1.16.0

--- a/receiver/awsecscontainermetricsreceiver/receiver.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver.go
@@ -94,7 +94,8 @@ func (aecmr *awsEcsContainerMetricsReceiver) collectDataFromEndpoint(ctx context
 		return err
 	}
 
-	mds := awsecscontainermetrics.MetricsData(stats, metadata, typeStr)
+	// TODO: report self metrics using obsreport
+	mds := awsecscontainermetrics.MetricsData(stats, metadata)
 	for _, md := range mds {
 		metrics := internaldata.OCToMetrics(*md)
 		err = aecmr.nextConsumer.ConsumeMetrics(ctx, metrics)

--- a/receiver/awsecscontainermetricsreceiver/receiver.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver.go
@@ -36,13 +36,16 @@ type awsEcsContainerMetricsReceiver struct {
 	nextConsumer consumer.MetricsConsumer
 	config       *Config
 	cancel       context.CancelFunc
+	restClient   awsecscontainermetrics.RestClient
+	provider     *awsecscontainermetrics.StatsProvider
 }
 
-// newAwsEcsContainerMetricsReceiver creates the aws ecs container metrics receiver with the given parameters.
-func newAwsEcsContainerMetricsReceiver(
+// New creates the aws ecs container metrics receiver with the given parameters.
+func New(
 	logger *zap.Logger,
 	config *Config,
-	nextConsumer consumer.MetricsConsumer) (component.MetricsReceiver, error) {
+	nextConsumer consumer.MetricsConsumer,
+	rest awsecscontainermetrics.RestClient) (component.MetricsReceiver, error) {
 	if nextConsumer == nil {
 		return nil, componenterror.ErrNilNextConsumer
 	}
@@ -51,6 +54,7 @@ func newAwsEcsContainerMetricsReceiver(
 		logger:       logger,
 		nextConsumer: nextConsumer,
 		config:       config,
+		restClient:   rest,
 	}
 	return r, nil
 }
@@ -65,7 +69,7 @@ func (aecmr *awsEcsContainerMetricsReceiver) Start(ctx context.Context, host com
 		for {
 			select {
 			case <-ticker.C:
-				aecmr.collectDataFromEndpoint(ctx)
+				aecmr.collectDataFromEndpoint(ctx, typeStr)
 			case <-ctx.Done():
 				return
 			}
@@ -81,10 +85,23 @@ func (aecmr *awsEcsContainerMetricsReceiver) Shutdown(context.Context) error {
 }
 
 // collectDataFromEndpoint collects container stats from Amazon ECS Task Metadata Endpoint
-// TODO: Replace with acutal logic.
-func (aecmr *awsEcsContainerMetricsReceiver) collectDataFromEndpoint(ctx context.Context) error {
-	md := awsecscontainermetrics.GenerateDummyMetrics()
+func (aecmr *awsEcsContainerMetricsReceiver) collectDataFromEndpoint(ctx context.Context, typeStr string) error {
+	aecmr.provider = awsecscontainermetrics.NewStatsProvider(aecmr.restClient)
+	stats, metadata, err := aecmr.provider.GetStats()
 
-	err := aecmr.nextConsumer.ConsumeMetrics(ctx, internaldata.OCToMetrics(md))
-	return err
+	if err != nil {
+		aecmr.logger.Error("Failed to collect stats", zap.Error(err))
+		return err
+	}
+
+	mds := awsecscontainermetrics.MetricsData(stats, metadata, typeStr)
+	for _, md := range mds {
+		metrics := internaldata.OCToMetrics(*md)
+		err = aecmr.nextConsumer.ConsumeMetrics(ctx, metrics)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/receiver/awsecscontainermetricsreceiver/receiver_test.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver_test.go
@@ -16,6 +16,8 @@ package awsecscontainermetricsreceiver
 
 import (
 	"context"
+	"errors"
+	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,12 +26,28 @@ import (
 	"go.uber.org/zap"
 )
 
+type fakeRestClient struct {
+}
+
+func (f fakeRestClient) EndpointResponse() ([]byte, []byte, error) {
+	taskStats, err := ioutil.ReadFile("testdata/task_stats.json")
+	if err != nil {
+		return nil, nil, err
+	}
+	taskMetadata, err := ioutil.ReadFile("testdata/task_metadata.json")
+	if err != nil {
+		return nil, nil, err
+	}
+	return taskStats, taskMetadata, nil
+}
+
 func TestReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	metricsReceiver, err := newAwsEcsContainerMetricsReceiver(
+	metricsReceiver, err := New(
 		zap.NewNop(),
 		cfg,
 		exportertest.NewNopMetricsExporter(),
+		&fakeRestClient{},
 	)
 
 	require.NoError(t, err)
@@ -45,12 +63,26 @@ func TestReceiver(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestReceiverForNilConsumer(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	metricsReceiver, err := New(
+		zap.NewNop(),
+		cfg,
+		nil,
+		&fakeRestClient{},
+	)
+
+	require.NotNil(t, err)
+	require.Nil(t, metricsReceiver)
+}
+
 func TestCollectDataFromEndpoint(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	metricsReceiver, err := newAwsEcsContainerMetricsReceiver(
+	metricsReceiver, err := New(
 		zap.NewNop(),
 		cfg,
 		new(exportertest.SinkMetricsExporter),
+		&fakeRestClient{},
 	)
 
 	require.NoError(t, err)
@@ -59,6 +91,64 @@ func TestCollectDataFromEndpoint(t *testing.T) {
 	r := metricsReceiver.(*awsEcsContainerMetricsReceiver)
 	ctx := context.Background()
 
-	err = r.collectDataFromEndpoint(ctx)
+	err = r.collectDataFromEndpoint(ctx, "")
 	require.NoError(t, err)
+}
+
+func TestCollectDataFromEndpointWithConsumerError(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+
+	sme := new(exportertest.SinkMetricsExporter)
+	e := errors.New("Test Error for Metrics Consumer")
+	sme.SetConsumeMetricsError(e)
+
+	metricsReceiver, err := New(
+		zap.NewNop(),
+		cfg,
+		sme,
+		&fakeRestClient{},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, metricsReceiver)
+
+	r := metricsReceiver.(*awsEcsContainerMetricsReceiver)
+	ctx := context.Background()
+
+	err = r.collectDataFromEndpoint(ctx, "")
+	require.EqualError(t, err, "Test Error for Metrics Consumer")
+}
+
+type invalidFakeClient struct {
+}
+
+func (f invalidFakeClient) EndpointResponse() ([]byte, []byte, error) {
+	taskStats, err := ioutil.ReadFile("testdata/wrong_file.json")
+	if err != nil {
+		return nil, nil, err
+	}
+	taskMetadata, err := ioutil.ReadFile("testdata/wrong_file.json")
+	if err != nil {
+		return nil, nil, err
+	}
+	return taskStats, taskMetadata, nil
+}
+
+func TestCollectDataFromEndpointWithEndpointError(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	metricsReceiver, err := New(
+		zap.NewNop(),
+		cfg,
+		new(exportertest.SinkMetricsExporter),
+		&invalidFakeClient{},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, metricsReceiver)
+
+	r := metricsReceiver.(*awsEcsContainerMetricsReceiver)
+	ctx := context.Background()
+
+	err = r.collectDataFromEndpoint(ctx, "")
+	require.Error(t, err)
 }

--- a/receiver/awsecscontainermetricsreceiver/receiver_test.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver_test.go
@@ -16,7 +16,7 @@ package awsecscontainermetricsreceiver
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -99,7 +99,7 @@ func TestCollectDataFromEndpointWithConsumerError(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 
 	sme := new(exportertest.SinkMetricsExporter)
-	e := errors.New("Test Error for Metrics Consumer")
+	e := fmt.Errorf("Test Error for Metrics Consumer")
 	sme.SetConsumeMetricsError(e)
 
 	metricsReceiver, err := New(


### PR DESCRIPTION
**Description:** 
This change adds codes to read actual metrics data from Amazon ECS task metadata endpoint.

**Link to tracking Issue:** 
#457 

**Testing:**
Unit tests added. 

**Documentation:** 
README added.