### PR TITLE
Signalfx exporter: add an option to exclude metrics

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -53,6 +53,9 @@ The following configuration options can also be configured:
   processor is enabled in the pipeline with one of the cloud provider detectors
   or environment variable detector setting a unique value to `host.name` attribute 
   within your k8s cluster. And keep `override=true` in resourcedetection config.
+- `exclude_metrics`: metric names that will be excluded from sending
+  to Signalfx backend. If `send_compatible_metrics` or `translation_rules` 
+  options are enabled, the exclusion will be applied on translated metrics.
 
 Example:
 

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -83,6 +83,11 @@ type Config struct {
 	//            `host.name` attribute within your k8s cluster. Also keep override
 	//            And keep `override=true` in resourcedetection config.
 	SyncHostMetadata bool `mapstructure:"sync_host_metadata"`
+
+	// ExcludeMetrics defines metrics that will be excluded from sending to Signalfx
+	// backend. If translations enabled with SendCompatibleMetrics or TranslationRules
+	// options, the exclusion will be applied on translated metrics.
+	ExcludeMetrics []string `mapstructure:"exclude_metrics"`
 }
 
 func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -214,6 +214,57 @@ func TestCreateMetricsExporterWithSpecifiedTranslaitonRules(t *testing.T) {
 	assert.Equal(t, "new_dimension", config.TranslationRules[0].Mapping["old_dimension"])
 }
 
+func TestCreateMetricsExporterWithExcludedMetrics(t *testing.T) {
+	config := &Config{
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: configmodels.Type(typeStr),
+			NameVal: typeStr,
+		},
+		AccessToken:    "testToken",
+		Realm:          "us1",
+		ExcludeMetrics: []string{"metric1"},
+	}
+
+	te, err := createMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, config)
+	require.NoError(t, err)
+	require.NotNil(t, te)
+
+	assert.Equal(t, 1, len(config.TranslationRules))
+	assert.Equal(t, translation.ActionDropMetrics, config.TranslationRules[0].Action)
+	assert.Equal(t, 1, len(config.TranslationRules[0].MetricNames))
+	assert.True(t, config.TranslationRules[0].MetricNames["metric1"])
+}
+
+func TestCreateMetricsExporterWithDefinedRulesAndExcludedMetrics(t *testing.T) {
+	config := &Config{
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: configmodels.Type(typeStr),
+			NameVal: typeStr,
+		},
+		AccessToken: "testToken",
+		Realm:       "us1",
+		TranslationRules: []translation.Rule{
+			{
+				Action: translation.ActionRenameDimensionKeys,
+				Mapping: map[string]string{
+					"old_dimension": "new_dimension",
+				},
+			},
+		},
+		ExcludeMetrics: []string{"metric1"},
+	}
+
+	te, err := createMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, config)
+	require.NoError(t, err)
+	require.NotNil(t, te)
+
+	assert.Equal(t, 2, len(config.TranslationRules))
+	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
+	assert.Equal(t, translation.ActionDropMetrics, config.TranslationRules[1].Action)
+	assert.Equal(t, 1, len(config.TranslationRules[1].MetricNames))
+	assert.True(t, config.TranslationRules[1].MetricNames["metric1"])
+}
+
 func TestDefaultTranslationRules(t *testing.T) {
 	rules, err := loadDefaultTranslationRules()
 	require.NoError(t, err)

--- a/exporter/signalfxexporter/translation/defaultrules.go
+++ b/exporter/signalfxexporter/translation/defaultrules.go
@@ -1,0 +1,27 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translation
+
+// GetExcludeMetricsRule returns DropMetrics translation rule for provided metrics slice
+func GetExcludeMetricsRule(excludeMetrics []string) Rule {
+	rule := Rule{
+		Action:      ActionDropMetrics,
+		MetricNames: map[string]bool{},
+	}
+	for _, m := range excludeMetrics {
+		rule.MetricNames[m] = true
+	}
+	return rule
+}

--- a/exporter/signalfxexporter/translation/defaultrules_test.go
+++ b/exporter/signalfxexporter/translation/defaultrules_test.go
@@ -1,0 +1,29 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetExcludeMetricsRule(t *testing.T) {
+	rule := GetExcludeMetricsRule([]string{"m1", "m2"})
+	assert.Equal(t, rule.Action, ActionDropMetrics)
+	assert.Equal(t, 2, len(rule.MetricNames))
+	assert.False(t, rule.MetricNames["m0"])
+	assert.True(t, rule.MetricNames["m1"])
+}


### PR DESCRIPTION
We need an ability to exclude some metrics on Signalfx exporter side. Filtering processor cannot be used if metrics used for translations before they can be dropped.
