### PR TITLE
[SplunkHecExporter] Don't send 'zero' timestamps to Splunk HEC.

### DIFF
--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -344,7 +344,9 @@ func Test_nilInstrumentationLogs(t *testing.T) {
 
 func Test_nanoTimestampToEpochMilliseconds(t *testing.T) {
 	splunkTs := nanoTimestampToEpochMilliseconds(1001000000)
-	assert.Equal(t, 1.001, splunkTs)
+	assert.Equal(t, 1.001, *splunkTs)
 	splunkTs = nanoTimestampToEpochMilliseconds(1001990000)
-	assert.Equal(t, 1.002, splunkTs)
+	assert.Equal(t, 1.002, *splunkTs)
+	splunkTs = nanoTimestampToEpochMilliseconds(0)
+	assert.True(t, nil == splunkTs)
 }

--- a/exporter/splunkhecexporter/metricdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk_test.go
@@ -192,7 +192,7 @@ func getFieldValue(metric *splunk.Event) string {
 
 func commonSplunkMetric(
 	metricName string,
-	ts float64,
+	ts *float64,
 	keys []string,
 	values []string,
 	val interface{},
@@ -213,7 +213,7 @@ func commonSplunkMetric(
 
 func expectedFromDistribution(
 	metricName string,
-	ts float64,
+	ts *float64,
 	keys []string,
 	values []string,
 	distributionTimeSeries *metricspb.TimeSeries,
@@ -250,10 +250,15 @@ func expectedFromDistribution(
 
 func TestTimestampFormat(t *testing.T) {
 	ts := timestamppb.Timestamp{Seconds: 32, Nanos: 1000345}
-	assert.Equal(t, 32.001, timestampToEpochMilliseconds(&ts))
+	assert.Equal(t, 32.001, *timestampToEpochMilliseconds(&ts))
 }
 
 func TestTimestampFormatRounding(t *testing.T) {
 	ts := timestamppb.Timestamp{Seconds: 32, Nanos: 1999345}
-	assert.Equal(t, 32.002, timestampToEpochMilliseconds(&ts))
+	assert.Equal(t, 32.002, *timestampToEpochMilliseconds(&ts))
+}
+
+func TestNilTimeWhenTimestampIsZero(t *testing.T) {
+	ts := timestamppb.Timestamp{Seconds: 0, Nanos: 0}
+	assert.True(t, nil == timestampToEpochMilliseconds(&ts))
 }

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -36,7 +36,7 @@ type AccessTokenPassthroughConfig struct {
 
 // Event represents a metric in Splunk HEC format
 type Event struct {
-	Time       float64                `json:"time"`                 // epoch time
+	Time       *float64               `json:"time,omitempty"`       // optional epoch time - set to nil if the event timestamp is missing or unknown
 	Host       string                 `json:"host"`                 // hostname
 	Source     string                 `json:"source,omitempty"`     // optional description of the source of the event; typically the app's name
 	SourceType string                 `json:"sourcetype,omitempty"` // optional name of a Splunk parsing configuration; this is usually inferred by Splunk

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -550,7 +550,7 @@ func Test_splunkhecReceiver_AccessTokenPassthrough(t *testing.T) {
 
 func buildSplunkHecMetricsMsg(time float64, value int64, dimensions uint) *splunk.Event {
 	ev := &splunk.Event{
-		Time:  time,
+		Time:  &time,
 		Event: "metric",
 		Fields: map[string]interface{}{
 			"metric_name:foo": value,
@@ -565,7 +565,7 @@ func buildSplunkHecMetricsMsg(time float64, value int64, dimensions uint) *splun
 
 func buildSplunkHecMsg(time float64, value string, dimensions uint) *splunk.Event {
 	ev := &splunk.Event{
-		Time:   time,
+		Time:   &time,
 		Event:  value,
 		Fields: map[string]interface{}{},
 	}

--- a/receiver/splunkhecreceiver/splunk_to_logdata.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata.go
@@ -53,7 +53,9 @@ func SplunkHecToLogData(logger *zap.Logger, events []*splunk.Event, resourceCust
 
 		// Splunk timestamps are in seconds so convert to nanos by multiplying
 		// by 1 billion.
-		logRecord.SetTimestamp(pdata.TimestampUnixNano(event.Time * 1e9))
+		if event.Time != nil {
+			logRecord.SetTimestamp(pdata.TimestampUnixNano(*event.Time * 1e9))
+		}
 
 		rl.Resource().InitEmpty()
 		attrs := rl.Resource().Attributes()

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -138,11 +138,12 @@ func addDoubleGauge(ts pdata.TimestampUnixNano, value float64, metric pdata.Metr
 	metric.DoubleGauge().DataPoints().Append(doublePt)
 }
 
-func convertTimestamp(sec float64) pdata.TimestampUnixNano {
-	if sec == 0 {
+func convertTimestamp(sec *float64) pdata.TimestampUnixNano {
+	if sec == nil {
 		return 0
 	}
-	return pdata.TimestampUnixNano(sec * 1e9)
+
+	return pdata.TimestampUnixNano(*sec * 1e9)
 }
 
 // Extract dimensions from the Splunk event fields to populate metric data point labels.

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -34,7 +34,7 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 
 	buildDefaultSplunkDataPt := func() *splunk.Event {
 		return &splunk.Event{
-			Time:       sec,
+			Time:       &sec,
 			Host:       "localhost",
 			Source:     "source",
 			SourceType: "sourcetype",
@@ -233,7 +233,7 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 			name: "zero_timestamp",
 			splunkDataPoint: func() *splunk.Event {
 				pt := buildDefaultSplunkDataPt()
-				pt.Time = 0
+				pt.Time = new(float64)
 				return pt
 			}(),
 			wantMetricsData: func() pdata.Metrics {


### PR DESCRIPTION
Don't send 'zero' timestamps to Splunk HEC. - see #965 
