### PR TITLE
internal/splunk: fallback to host if cloud resource id not found

### DIFF
--- a/exporter/signalfxexporter/hostmetadata/metadata_test.go
+++ b/exporter/signalfxexporter/hostmetadata/metadata_test.go
@@ -68,10 +68,10 @@ func TestSyncMetadata(t *testing.T) {
 			},
 			hostStatErr: nil,
 			pushFail:    false,
-			metricsData: generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			metricsData: generateSampleMetricsData(map[string]string{conventions.AttributeHostName: "host1"}),
 			wantMetadataUpdate: []*collection.MetadataUpdate{
 				{
-					ResourceIDKey: extraHostIDAttribute,
+					ResourceIDKey: conventions.AttributeHostName,
 					ResourceID:    "host1",
 					MetadataDelta: collection.MetadataDelta{
 						MetadataToUpdate: map[string]string{
@@ -107,10 +107,10 @@ func TestSyncMetadata(t *testing.T) {
 			hostStat:    host.InfoStat{},
 			hostStatErr: errors.New("failed"),
 			pushFail:    false,
-			metricsData: generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			metricsData: generateSampleMetricsData(map[string]string{conventions.AttributeHostName: "host1"}),
 			wantMetadataUpdate: []*collection.MetadataUpdate{
 				{
-					ResourceIDKey: extraHostIDAttribute,
+					ResourceIDKey: conventions.AttributeHostName,
 					ResourceID:    "host1",
 					MetadataDelta: collection.MetadataDelta{
 						MetadataToUpdate: map[string]string{
@@ -138,10 +138,10 @@ func TestSyncMetadata(t *testing.T) {
 			hostStat:    host.InfoStat{},
 			hostStatErr: errors.New("failed"),
 			pushFail:    false,
-			metricsData: generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			metricsData: generateSampleMetricsData(map[string]string{conventions.AttributeHostName: "host1"}),
 			wantMetadataUpdate: []*collection.MetadataUpdate{
 				{
-					ResourceIDKey: extraHostIDAttribute,
+					ResourceIDKey: conventions.AttributeHostName,
 					ResourceID:    "host1",
 					MetadataDelta: collection.MetadataDelta{
 						MetadataToUpdate: map[string]string{
@@ -163,7 +163,7 @@ func TestSyncMetadata(t *testing.T) {
 			memStatErr:         errors.New("failed"),
 			hostStat:           host.InfoStat{},
 			hostStatErr:        errors.New("failed"),
-			metricsData:        generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			metricsData:        generateSampleMetricsData(map[string]string{conventions.AttributeHostName: "host1"}),
 			wantMetadataUpdate: nil,
 			wantLogs: []string{
 				"Failed to scrape host hostCPU metadata",
@@ -185,7 +185,7 @@ func TestSyncMetadata(t *testing.T) {
 			},
 			hostStatErr:        nil,
 			pushFail:           true,
-			metricsData:        generateSampleMetricsData(map[string]string{extraHostIDAttribute: "host1"}),
+			metricsData:        generateSampleMetricsData(map[string]string{conventions.AttributeHostName: "host1"}),
 			wantMetadataUpdate: nil,
 			wantLogs:           []string{"Failed to push host metadata update"},
 		},

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,11 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.32/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go v1.34.33 h1:ymkFm0rNPEOlgjyX3ojEd4zqzW6kGICBkqWs7LqgHtU=
+github.com/aws/aws-sdk-go v1.34.28 h1:sscPpn/Ns3i0F4HPEWAVcwdIRaZZCuL7llJ2/60yPIk=
+github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
+github.com/aws/aws-sdk-go v1.34.30 h1:izATc/E0+HcT5YHmaQVjn7GHCoqaBxn0PGo6Zq5UNFA=
+github.com/aws/aws-sdk-go v1.34.30/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
+github.com/aws/aws-sdk-go v1.34.32/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go v1.34.33/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
@@ -726,6 +731,7 @@ github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d/go.mod h1:+NfK9FKe
 github.com/hetznercloud/hcloud-go v1.21.1 h1:LWNozxiZhKmeMqYbAS7KsAcPcxg47afCnTeLKmN+n7w=
 github.com/hetznercloud/hcloud-go v1.21.1/go.mod h1:xng8lbDUg+xM1dgc0yGHX5EeqbwIq7UYlMWMTx3SQVg=
 github.com/honeycombio/libhoney-go v1.14.1 h1:TyFJrPua66YodzBf/eyi0nWEOL/YMhtegkAHVBocUa8=
+github.com/honeycombio/libhoney-go v1.14.0/go.mod h1:SPNdLieCW/Ryt6cAIeELQENobj8H9bYXezWkA5ZI+u4=
 github.com/honeycombio/libhoney-go v1.14.1/go.mod h1:SPNdLieCW/Ryt6cAIeELQENobj8H9bYXezWkA5ZI+u4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
@@ -754,6 +760,8 @@ github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrO
 github.com/jaegertracing/jaeger v1.15.1/go.mod h1:LUWPSnzNPGRubM8pk0inANGitpiMOOxihXx0+53llXI=
 github.com/jaegertracing/jaeger v1.19.1/go.mod h1:2GVHuF9OIfRw2N6ZMoEgRGL+GJxvDLVtALDWxOINqDk=
 github.com/jaegertracing/jaeger v1.19.2 h1:JX1ty1wlkk3JENyfXNMRAxGClwErTyzEKbQAFktYpOc=
+github.com/jaegertracing/jaeger v1.18.2-0.20200707061226-97d2319ff2be/go.mod h1:yoD2o9xdj6o4XHjlJOZMYI+1QeqhrcKqz7/mXFrQzDE=
+github.com/jaegertracing/jaeger v1.19.1/go.mod h1:2GVHuF9OIfRw2N6ZMoEgRGL+GJxvDLVtALDWxOINqDk=
 github.com/jaegertracing/jaeger v1.19.2/go.mod h1:2GVHuF9OIfRw2N6ZMoEgRGL+GJxvDLVtALDWxOINqDk=
 github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
@@ -1193,6 +1201,7 @@ github.com/signalfx/opencensus-go-exporter-kinesis v0.6.3 h1:ooYCDeKtuwmT+HNBkv/
 github.com/signalfx/opencensus-go-exporter-kinesis v0.6.3/go.mod h1:iKTZPIUUpRI9Hp2yAMb2qNXl6itkEd2pxAznG08Y6YU=
 github.com/signalfx/sapm-proto v0.4.0/go.mod h1:x3gtwJ1GRejtkghB4nYpwixh2zqJrLbPU959ZNhM0Fk=
 github.com/signalfx/sapm-proto v0.6.0 h1:SpcBPBN7mllCaittxvTmXM4zCob79ytb9DEHsZ9jLF0=
+github.com/signalfx/sapm-proto v0.5.3/go.mod h1:irslr5i7XlHJTm1CpRy+llvf4COzF5K6Je05RkhetTE=
 github.com/signalfx/sapm-proto v0.6.0/go.mod h1:2uHysA4VySJpaZKEvsceKew2aNclf5Bu45bfbNwgbhI=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -1382,6 +1391,7 @@ go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9E
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
+go.uber.org/zap v1.15.0/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.16.0 h1:uFRZXykJGK9lLY4HtgSw44DnIcAM+kRBP7x5m+NpAOM=
 go.uber.org/zap v1.16.0/go.mod h1:MA8QOfq0BHJwdXa996Y4dYkAqRKB8/1K1QMMZVaNZjQ=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1597,6 +1607,7 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/common/splunk/hostid.go
+++ b/internal/common/splunk/hostid.go
@@ -31,6 +31,8 @@ const (
 	HostIDKeyAWS HostIDKey = "AWSUniqueId"
 	// GCP
 	HostIDKeyGCP HostIDKey = "gcp_id"
+	// Host
+	HostIDKeyHost HostIDKey = conventions.AttributeHostName
 )
 
 // HostID is a unique key and value (usually used as a dimension) to uniquely identify a host
@@ -76,6 +78,13 @@ func ResourceToHostID(res pdata.Resource) (HostID, bool) {
 		return HostID{
 			Key: HostIDKeyGCP,
 			ID:  fmt.Sprintf("%s_%s", cloudAccount, hostID),
+		}, true
+	}
+
+	if attr, ok := res.Attributes().Get(conventions.AttributeHostName); ok {
+		return HostID{
+			Key: HostIDKeyHost,
+			ID:  attr.StringVal(),
 		}, true
 	}
 

--- a/internal/common/splunk/hostid_test.go
+++ b/internal/common/splunk/hostid_test.go
@@ -33,6 +33,17 @@ var (
 		attr.InsertString(conventions.AttributeHostID, "i-abcd")
 		return res
 	}()
+	ec2WithHost = func() pdata.Resource {
+		res := pdata.NewResource()
+		res.InitEmpty()
+		attr := res.Attributes()
+		attr.InsertString(conventions.AttributeCloudProvider, "aws")
+		attr.InsertString(conventions.AttributeCloudAccount, "1234")
+		attr.InsertString(conventions.AttributeCloudRegion, "us-west-2")
+		attr.InsertString(conventions.AttributeHostID, "i-abcd")
+		attr.InsertString(conventions.AttributeHostName, "localhost")
+		return res
+	}()
 	ec2PartialResource = func() pdata.Resource {
 		res := pdata.NewResource()
 		res.InitEmpty()
@@ -56,6 +67,13 @@ var (
 		attr := res.Attributes()
 		attr.InsertString(conventions.AttributeCloudProvider, "gcp")
 		attr.InsertString(conventions.AttributeCloudAccount, "1234")
+		return res
+	}()
+	hostResource = func() pdata.Resource {
+		res := pdata.NewResource()
+		res.InitEmpty()
+		attr := res.Attributes()
+		attr.InsertString(conventions.AttributeHostName, "localhost")
 		return res
 	}()
 	unknownResource = func() pdata.Resource {
@@ -89,6 +107,15 @@ func TestResourceToHostID(t *testing.T) {
 			ok: true,
 		},
 		{
+			name: "ec2 with hostname prefers ec2",
+			args: args{ec2WithHost},
+			want: HostID{
+				Key: "AWSUniqueId",
+				ID:  "i-abcd_us-west-2_1234",
+			},
+			ok: true,
+		},
+		{
 			name: "gcp",
 			args: args{gcpResource},
 			want: HostID{
@@ -114,6 +141,15 @@ func TestResourceToHostID(t *testing.T) {
 			args: args{unknownResource},
 			want: HostID{},
 			ok:   false,
+		},
+		{
+			name: "host provider",
+			args: args{hostResource},
+			want: HostID{
+				Key: "host.name",
+				ID:  "localhost",
+			},
+			ok: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
APM correlation will need to do same thing so add fallback logic in common.
