### PR TITLE
exporter/elasticexporter: initial metrics support

### DIFF
--- a/exporter/elasticexporter/config_test.go
+++ b/exporter/elasticexporter/config_test.go
@@ -67,8 +67,14 @@ func TestConfigValidate(t *testing.T) {
 	require.Error(t, err)
 	assert.EqualError(t, err, "cannot configure Elastic APM trace exporter: invalid config: APMServerURL must be specified")
 
+	_, err = factory.CreateMetricsExporter(context.Background(), params, cfg)
+	require.Error(t, err)
+	assert.EqualError(t, err, "cannot configure Elastic APM metrics exporter: invalid config: APMServerURL must be specified")
+
 	cfg.APMServerURL = "foo"
 	_, err = factory.CreateTraceExporter(context.Background(), params, cfg)
+	assert.NoError(t, err)
+	_, err = factory.CreateMetricsExporter(context.Background(), params, cfg)
 	assert.NoError(t, err)
 }
 

--- a/exporter/elasticexporter/exporter.go
+++ b/exporter/elasticexporter/exporter.go
@@ -60,6 +60,30 @@ func newElasticTraceExporter(
 	})
 }
 
+func newElasticMetricsExporter(
+	params component.ExporterCreateParams,
+	cfg configmodels.Exporter,
+) (component.MetricsExporter, error) {
+	exporter, err := newElasticExporter(cfg.(*Config), params.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("cannot configure Elastic APM trace exporter: %v", err)
+	}
+	return exporterhelper.NewMetricsExporter(cfg, func(ctx context.Context, input pdata.Metrics) (int, error) {
+		var dropped int
+		var errs []error
+		resourceMetricsSlice := input.ResourceMetrics()
+		for i := 0; i < resourceMetricsSlice.Len(); i++ {
+			resourceMetrics := resourceMetricsSlice.At(i)
+			n, err := exporter.ExportResourceMetrics(ctx, resourceMetrics)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			dropped += n
+		}
+		return dropped, componenterror.CombineErrors(errs)
+	})
+}
+
 type elasticExporter struct {
 	transport transport.Transport
 	logger    *zap.Logger
@@ -130,6 +154,32 @@ func (e *elasticExporter) ExportResourceSpans(ctx context.Context, rs pdata.Reso
 		return count, err
 	}
 	return len(errs), componenterror.CombineErrors(errs)
+}
+
+// ExportResourceMetrics exports OTLP metrics to Elastic APM Server,
+// returning the number of metrics that were dropped along with any errors.
+func (e *elasticExporter) ExportResourceMetrics(ctx context.Context, rm pdata.ResourceMetrics) (int, error) {
+	var w fastjson.Writer
+	elastic.EncodeResourceMetadata(rm.Resource(), &w)
+	var errs []error
+	var totalDropped int
+	instrumentationLibraryMetricsSlice := rm.InstrumentationLibraryMetrics()
+	for i := 0; i < instrumentationLibraryMetricsSlice.Len(); i++ {
+		instrumentationLibraryMetrics := instrumentationLibraryMetricsSlice.At(i)
+		instrumentationLibrary := instrumentationLibraryMetrics.InstrumentationLibrary()
+		metrics := instrumentationLibraryMetrics.Metrics()
+		before := w.Size()
+		dropped, err := elastic.EncodeMetrics(metrics, instrumentationLibrary, &w)
+		if err != nil {
+			w.Rewind(before)
+			errs = append(errs, err)
+		}
+		totalDropped += dropped
+	}
+	if err := e.sendEvents(ctx, &w); err != nil {
+		return totalDropped, err
+	}
+	return totalDropped, componenterror.CombineErrors(errs)
 }
 
 func (e *elasticExporter) sendEvents(ctx context.Context, w *fastjson.Writer) error {

--- a/exporter/elasticexporter/exporter.go
+++ b/exporter/elasticexporter/exporter.go
@@ -66,7 +66,7 @@ func newElasticMetricsExporter(
 ) (component.MetricsExporter, error) {
 	exporter, err := newElasticExporter(cfg.(*Config), params.Logger)
 	if err != nil {
-		return nil, fmt.Errorf("cannot configure Elastic APM trace exporter: %v", err)
+		return nil, fmt.Errorf("cannot configure Elastic APM metrics exporter: %v", err)
 	}
 	return exporterhelper.NewMetricsExporter(cfg, func(ctx context.Context, input pdata.Metrics) (int, error) {
 		var dropped int

--- a/exporter/elasticexporter/exporter_test.go
+++ b/exporter/elasticexporter/exporter_test.go
@@ -28,10 +28,15 @@ import (
 	"go.elastic.co/apm/transport/transporttest"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.uber.org/zap"
 )
 
 func TestTraceExporter(t *testing.T) {
+	cleanup, err := obsreporttest.SetupRecordedMetricsTest()
+	require.NoError(t, err)
+	defer cleanup()
+
 	factory := NewFactory()
 	recorder, cfg := newRecorder(t)
 	params := component.ExporterCreateParams{Logger: zap.NewNop()}
@@ -50,13 +55,20 @@ func TestTraceExporter(t *testing.T) {
 
 	err = te.ConsumeTraces(context.Background(), traces)
 	assert.NoError(t, err)
+	obsreporttest.CheckExporterTracesViews(t, "elastic", 1, 0)
 
 	payloads := recorder.Payloads()
 	require.Len(t, payloads.Transactions, 1)
 	assert.Equal(t, "foobar", payloads.Transactions[0].Name)
+
+	assert.NoError(t, te.Shutdown(context.Background()))
 }
 
 func TestMetricsExporter(t *testing.T) {
+	cleanup, err := obsreporttest.SetupRecordedMetricsTest()
+	require.NoError(t, err)
+	defer cleanup()
+
 	factory := NewFactory()
 	recorder, cfg := newRecorder(t)
 	params := component.ExporterCreateParams{Logger: zap.NewNop()}
@@ -64,25 +76,55 @@ func TestMetricsExporter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, me, "failed to create metrics exporter")
 
-	metrics := pdata.NewMetrics()
-	resourceMetrics := metrics.ResourceMetrics()
-	resourceMetrics.Resize(1)
-	resourceMetrics.At(0).InitEmpty()
-	resourceMetrics.At(0).InstrumentationLibraryMetrics().Resize(1)
-	resourceMetrics.At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(1)
-	metric := resourceMetrics.At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
-	metric.SetName("foobar")
-	metric.SetDataType(pdata.MetricDataTypeDoubleGauge)
-	metric.DoubleGauge().InitEmpty()
-	metric.DoubleGauge().DataPoints().Resize(1)
-	metric.DoubleGauge().DataPoints().At(0).SetValue(123)
-
-	err = me.ConsumeMetrics(context.Background(), metrics)
+	err = me.ConsumeMetrics(context.Background(), sampleMetrics())
 	assert.NoError(t, err)
 
 	payloads := recorder.Payloads()
-	require.Len(t, payloads.Metrics, 1)
+	require.Len(t, payloads.Metrics, 2)
 	assert.Contains(t, payloads.Metrics[0].Samples, "foobar")
+	obsreporttest.CheckExporterMetricsViews(t, "elastic", 2, 0)
+
+	assert.NoError(t, me.Shutdown(context.Background()))
+}
+
+func TestMetricsExporterSendError(t *testing.T) {
+	cleanup, err := obsreporttest.SetupRecordedMetricsTest()
+	require.NoError(t, err)
+	defer cleanup()
+
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	eCfg := cfg.(*Config)
+	eCfg.APMServerURL = "http://testing.invalid"
+
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+	me, err := factory.CreateMetricsExporter(context.Background(), params, cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, me, "failed to create metrics exporter")
+
+	err = me.ConsumeMetrics(context.Background(), sampleMetrics())
+	assert.Error(t, err)
+	obsreporttest.CheckExporterMetricsViews(t, "elastic", 0, 2)
+
+	assert.NoError(t, me.Shutdown(context.Background()))
+}
+
+func sampleMetrics() pdata.Metrics {
+	metrics := pdata.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics()
+	resourceMetrics.Resize(2)
+	for i := 0; i < 2; i++ {
+		resourceMetrics.At(i).InitEmpty()
+		resourceMetrics.At(i).InstrumentationLibraryMetrics().Resize(1)
+		resourceMetrics.At(i).InstrumentationLibraryMetrics().At(0).Metrics().Resize(1)
+		metric := resourceMetrics.At(i).InstrumentationLibraryMetrics().At(0).Metrics().At(0)
+		metric.SetName("foobar")
+		metric.SetDataType(pdata.MetricDataTypeDoubleGauge)
+		metric.DoubleGauge().InitEmpty()
+		metric.DoubleGauge().DataPoints().Resize(1)
+		metric.DoubleGauge().DataPoints().At(0).SetValue(123)
+	}
+	return metrics
 }
 
 // newRecorder returns a go.elastic.co/apm/transport/transporrtest.RecorderTransport,

--- a/exporter/elasticexporter/factory.go
+++ b/exporter/elasticexporter/factory.go
@@ -32,7 +32,9 @@ func NewFactory() component.ExporterFactory {
 	return exporterhelper.NewFactory(
 		typeStr,
 		createDefaultConfig,
-		exporterhelper.WithTraces(createTraceExporter))
+		exporterhelper.WithTraces(createTraceExporter),
+		exporterhelper.WithMetrics(createMetricsExporter),
+	)
 }
 
 func createDefaultConfig() configmodels.Exporter {
@@ -50,4 +52,12 @@ func createTraceExporter(
 	cfg configmodels.Exporter,
 ) (component.TraceExporter, error) {
 	return newElasticTraceExporter(params, cfg)
+}
+
+func createMetricsExporter(
+	ctx context.Context,
+	params component.ExporterCreateParams,
+	cfg configmodels.Exporter,
+) (component.MetricsExporter, error) {
+	return newElasticMetricsExporter(params, cfg)
 }

--- a/exporter/elasticexporter/factory_test.go
+++ b/exporter/elasticexporter/factory_test.go
@@ -50,7 +50,6 @@ func TestCreateExporter(t *testing.T) {
 		component.ExporterCreateParams{Logger: zap.NewNop()},
 		eCfg,
 	)
-	assert.Error(t, err)
-	assert.EqualError(t, err, "telemetry type is not supported")
-	assert.Nil(t, me)
+	assert.NoError(t, err)
+	assert.NotNil(t, me, "failed to create metrics exporter")
 }

--- a/exporter/elasticexporter/internal/translator/elastic/metrics.go
+++ b/exporter/elasticexporter/internal/translator/elastic/metrics.go
@@ -1,0 +1,219 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package elastic contains an opentelemetry-collector exporter
+// for Elastic APM.
+package elastic
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"go.elastic.co/apm/model"
+	"go.elastic.co/fastjson"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// EncodeMetrics encodes an OpenTelemetry metrics slice, and instrumentation
+// library information, as one or more metricset lines, writing to w.
+func EncodeMetrics(otlpMetrics pdata.MetricSlice, otlpLibrary pdata.InstrumentationLibrary, w *fastjson.Writer) (dropped int, _ error) {
+	var metricsets metricsets
+	for i := 0; i < otlpMetrics.Len(); i++ {
+		metric := otlpMetrics.At(i)
+		if metric.IsNil() {
+			dropped++
+			continue
+		}
+
+		name := metric.Name()
+		switch metric.DataType() {
+		case pdata.MetricDataTypeIntGauge:
+			intGauge := metric.IntGauge()
+			if intGauge.IsNil() {
+				dropped++
+				continue
+			}
+			dps := intGauge.DataPoints()
+			for i := 0; i < dps.Len(); i++ {
+				dp := dps.At(i)
+				if dp.IsNil() {
+					dropped++
+					continue
+				}
+				metricsets.upsert(model.Metrics{
+					Timestamp: asTime(dp.Timestamp()),
+					Labels:    asStringMap(dp.LabelsMap()),
+					Samples: map[string]model.Metric{name: {
+						Value: float64(dp.Value()),
+					}},
+				})
+			}
+		case pdata.MetricDataTypeDoubleGauge:
+			doubleGauge := metric.DoubleGauge()
+			if doubleGauge.IsNil() {
+				dropped++
+				continue
+			}
+			dps := doubleGauge.DataPoints()
+			for i := 0; i < dps.Len(); i++ {
+				dp := dps.At(i)
+				if dp.IsNil() {
+					dropped++
+					continue
+				}
+				metricsets.upsert(model.Metrics{
+					Timestamp: asTime(dp.Timestamp()),
+					Labels:    asStringMap(dp.LabelsMap()),
+					Samples: map[string]model.Metric{name: {
+						Value: dp.Value(),
+					}},
+				})
+			}
+		case pdata.MetricDataTypeIntSum:
+			intSum := metric.IntSum()
+			if intSum.IsNil() {
+				dropped++
+				continue
+			}
+			dps := intSum.DataPoints()
+			for i := 0; i < dps.Len(); i++ {
+				dp := dps.At(i)
+				if dp.IsNil() {
+					dropped++
+					continue
+				}
+				metricsets.upsert(model.Metrics{
+					Timestamp: asTime(dp.Timestamp()),
+					Labels:    asStringMap(dp.LabelsMap()),
+					Samples: map[string]model.Metric{name: {
+						Value: float64(dp.Value()),
+					}},
+				})
+			}
+		case pdata.MetricDataTypeDoubleSum:
+			doubleSum := metric.DoubleSum()
+			if doubleSum.IsNil() {
+				dropped++
+				continue
+			}
+			dps := doubleSum.DataPoints()
+			for i := 0; i < dps.Len(); i++ {
+				dp := dps.At(i)
+				if dp.IsNil() {
+					dropped++
+					continue
+				}
+				metricsets.upsert(model.Metrics{
+					Timestamp: asTime(dp.Timestamp()),
+					Labels:    asStringMap(dp.LabelsMap()),
+					Samples: map[string]model.Metric{name: {
+						Value: dp.Value(),
+					}},
+				})
+			}
+		case pdata.MetricDataTypeIntHistogram:
+			// TODO(axw) requires https://github.com/elastic/apm-server/issues/3195
+			intHistogram := metric.IntHistogram()
+			if intHistogram.IsNil() {
+				dropped++
+				continue
+			}
+			dropped += intHistogram.DataPoints().Len()
+		case pdata.MetricDataTypeDoubleHistogram:
+			// TODO(axw) requires https://github.com/elastic/apm-server/issues/3195
+			doubleHistogram := metric.DoubleHistogram()
+			if doubleHistogram.IsNil() {
+				dropped++
+				continue
+			}
+			dropped += doubleHistogram.DataPoints().Len()
+		default:
+			// Unknown type, so just increment dropped by 1 as a best effort.
+			dropped++
+		}
+	}
+	for _, metricset := range metricsets {
+		w.RawString(`{"metricset":`)
+		if err := metricset.MarshalFastJSON(w); err != nil {
+			return dropped, err
+		}
+		w.RawString("}\n")
+	}
+	return dropped, nil
+}
+
+func asTime(in pdata.TimestampUnixNano) model.Time {
+	return model.Time(time.Unix(0, int64(in)))
+}
+
+func asStringMap(in pdata.StringMap) model.StringMap {
+	var out model.StringMap
+	in.Sort()
+	in.ForEach(func(k string, v pdata.StringValue) {
+		out = append(out, model.StringMapItem{
+			Key:   k,
+			Value: v.Value(),
+		})
+	})
+	return out
+}
+
+type metricsets []model.Metrics
+
+func (ms *metricsets) upsert(m model.Metrics) {
+	i := ms.search(m)
+	if i < len(*ms) && compareMetricsets((*ms)[i], m) == 0 {
+		existing := (*ms)[i]
+		for k, v := range m.Samples {
+			existing.Samples[k] = v
+		}
+	} else {
+		head := (*ms)[:i]
+		tail := append([]model.Metrics{m}, (*ms)[i:]...)
+		*ms = append(head, tail...)
+	}
+}
+
+func (ms *metricsets) search(m model.Metrics) int {
+	return sort.Search(len(*ms), func(i int) bool {
+		return compareMetricsets((*ms)[i], m) >= 0
+	})
+}
+
+func compareMetricsets(a, b model.Metrics) int {
+	atime, btime := time.Time(a.Timestamp), time.Time(b.Timestamp)
+	if atime.Before(btime) {
+		return -1
+	} else if atime.After(btime) {
+		return 1
+	}
+	n := len(a.Labels) - len(b.Labels)
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	}
+	for i, la := range a.Labels {
+		lb := b.Labels[i]
+		if n := strings.Compare(la.Key, lb.Key); n != 0 {
+			return n
+		}
+		if n := strings.Compare(la.Value, lb.Value); n != 0 {
+			return n
+		}
+	}
+	return 0
+}

--- a/exporter/elasticexporter/internal/translator/elastic/metrics.go
+++ b/exporter/elasticexporter/internal/translator/elastic/metrics.go
@@ -28,6 +28,9 @@ import (
 
 // EncodeMetrics encodes an OpenTelemetry metrics slice, and instrumentation
 // library information, as one or more metricset lines, writing to w.
+//
+// TODO(axw) otlpLibrary is currently not used. We should consider recording
+// it as metadata.
 func EncodeMetrics(otlpMetrics pdata.MetricSlice, otlpLibrary pdata.InstrumentationLibrary, w *fastjson.Writer) (dropped int, _ error) {
 	var metricsets metricsets
 	for i := 0; i < otlpMetrics.Len(); i++ {

--- a/exporter/elasticexporter/internal/translator/elastic/metrics_test.go
+++ b/exporter/elasticexporter/internal/translator/elastic/metrics_test.go
@@ -1,0 +1,123 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elastic_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.elastic.co/apm/model"
+	"go.elastic.co/apm/transport/transporttest"
+	"go.elastic.co/fastjson"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticexporter/internal/translator/elastic"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestEncodeMetrics(t *testing.T) {
+	var w fastjson.Writer
+	var recorder transporttest.RecorderTransport
+	elastic.EncodeResourceMetadata(pdata.NewResource(), &w)
+
+	instrumentationLibraryMetrics := pdata.NewInstrumentationLibraryMetrics()
+	instrumentationLibraryMetrics.InitEmpty()
+	metrics := instrumentationLibraryMetrics.Metrics()
+	metrics.Resize(3)
+
+	timestamp0 := time.Unix(123, 0).UTC()
+	timestamp1 := time.Unix(456, 0).UTC()
+
+	metric := metrics.At(0)
+	metric.SetName("double_gauge_metric")
+	metric.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	doubleGauge := metric.DoubleGauge()
+	doubleGauge.InitEmpty()
+	doubleGauge.DataPoints().Resize(4)
+	doubleGauge.DataPoints().At(0).SetTimestamp(pdata.TimestampUnixNano(timestamp0.UnixNano()))
+	doubleGauge.DataPoints().At(0).SetValue(123)
+	doubleGauge.DataPoints().At(1).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	doubleGauge.DataPoints().At(1).SetValue(456)
+	doubleGauge.DataPoints().At(1).LabelsMap().InitFromMap(map[string]string{"k": "v"})
+	doubleGauge.DataPoints().At(2).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	doubleGauge.DataPoints().At(2).SetValue(789)
+	doubleGauge.DataPoints().At(3).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	doubleGauge.DataPoints().At(3).SetValue(101112)
+	doubleGauge.DataPoints().At(3).LabelsMap().InitFromMap(map[string]string{"k": "v2"})
+
+	metric = metrics.At(1)
+	metric.SetName("int_sum_metric")
+	metric.SetDataType(pdata.MetricDataTypeIntSum)
+	intSum := metric.IntSum()
+	intSum.InitEmpty()
+	intSum.DataPoints().Resize(3)
+	intSum.DataPoints().At(0).SetTimestamp(pdata.TimestampUnixNano(timestamp0.UnixNano()))
+	intSum.DataPoints().At(0).SetValue(321)
+	intSum.DataPoints().At(1).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	intSum.DataPoints().At(1).SetValue(654)
+	intSum.DataPoints().At(1).LabelsMap().InitFromMap(map[string]string{"k": "v"})
+	intSum.DataPoints().At(2).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	intSum.DataPoints().At(2).SetValue(101112)
+	intSum.DataPoints().At(2).LabelsMap().InitFromMap(map[string]string{"k2": "v"})
+
+	// Histograms are currently not supported, and will be ignored.
+	metric = metrics.At(2)
+	metric.SetName("double_histogram_metric")
+	metric.SetDataType(pdata.MetricDataTypeDoubleHistogram)
+	doubleHistogram := metric.DoubleHistogram()
+	doubleHistogram.InitEmpty()
+	doubleHistogram.DataPoints().Resize(1)
+
+	dropped, err := elastic.EncodeMetrics(metrics, instrumentationLibraryMetrics.InstrumentationLibrary(), &w)
+	require.NoError(t, err)
+	assert.Equal(t, 1, dropped) // histogram dropped
+	sendStream(t, &w, &recorder)
+
+	payloads := recorder.Payloads()
+	assert.Equal(t, []model.Metrics{{
+		Timestamp: model.Time(timestamp0),
+		Samples: map[string]model.Metric{
+			"double_gauge_metric": {Value: 123},
+			"int_sum_metric":      {Value: 321},
+		},
+	}, {
+		Timestamp: model.Time(timestamp1),
+		Samples: map[string]model.Metric{
+			"double_gauge_metric": {Value: 789},
+		},
+	}, {
+		Timestamp: model.Time(timestamp1),
+		Labels:    model.StringMap{{Key: "k", Value: "v"}},
+		Samples: map[string]model.Metric{
+			"double_gauge_metric": {Value: 456},
+			"int_sum_metric":      {Value: 654},
+		},
+	}, {
+		Timestamp: model.Time(timestamp1),
+		Labels:    model.StringMap{{Key: "k", Value: "v2"}},
+		Samples: map[string]model.Metric{
+			"double_gauge_metric": {Value: 101112},
+		},
+	}, {
+		Timestamp: model.Time(timestamp1),
+		Labels:    model.StringMap{{Key: "k2", Value: "v"}},
+		Samples: map[string]model.Metric{
+			"int_sum_metric": {Value: 101112},
+		},
+	}}, payloads.Metrics)
+
+	assert.Empty(t, payloads.Errors)
+}

--- a/exporter/elasticexporter/internal/translator/elastic/metrics_test.go
+++ b/exporter/elasticexporter/internal/translator/elastic/metrics_test.go
@@ -36,86 +36,150 @@ func TestEncodeMetrics(t *testing.T) {
 	instrumentationLibraryMetrics := pdata.NewInstrumentationLibraryMetrics()
 	instrumentationLibraryMetrics.InitEmpty()
 	metrics := instrumentationLibraryMetrics.Metrics()
-	metrics.Resize(3)
+	appendMetric := func(name string, dataType pdata.MetricDataType) pdata.Metric {
+		n := metrics.Len()
+		metrics.Resize(n + 1)
+		metric := metrics.At(n)
+		metric.SetName(name)
+		metric.SetDataType(dataType)
+		return metric
+	}
 
 	timestamp0 := time.Unix(123, 0).UTC()
 	timestamp1 := time.Unix(456, 0).UTC()
 
-	metric := metrics.At(0)
-	metric.SetName("double_gauge_metric")
-	metric.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	var expectDropped int
+
+	// Nil metrics should be dropped.
+	metrics.Append(pdata.NewMetric())
+	expectDropped++
+
+	for dataType := pdata.MetricDataTypeNone; dataType.String() != ""; dataType++ {
+		// Non-nil metrics with nil data-type specific values should be dropped.
+		appendMetric("nil_"+dataType.String(), dataType)
+		expectDropped++
+	}
+
+	metric := appendMetric("int_gauge_metric", pdata.MetricDataTypeIntGauge)
+	intGauge := metric.IntGauge()
+	intGauge.InitEmpty()
+	intGauge.DataPoints().Resize(4)
+	intGauge.DataPoints().At(0).SetTimestamp(pdata.TimestampUnixNano(timestamp0.UnixNano()))
+	intGauge.DataPoints().At(0).SetValue(1)
+	intGauge.DataPoints().At(1).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	intGauge.DataPoints().At(1).SetValue(2)
+	intGauge.DataPoints().At(1).LabelsMap().InitFromMap(map[string]string{"k": "v"})
+	intGauge.DataPoints().At(2).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	intGauge.DataPoints().At(2).SetValue(3)
+	intGauge.DataPoints().At(3).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	intGauge.DataPoints().At(3).SetValue(4)
+	intGauge.DataPoints().At(3).LabelsMap().InitFromMap(map[string]string{"k": "v2"})
+	// Nil data point should be dropped
+	intGauge.DataPoints().Append(pdata.NewIntDataPoint())
+	expectDropped++
+
+	metric = appendMetric("double_gauge_metric", pdata.MetricDataTypeDoubleGauge)
 	doubleGauge := metric.DoubleGauge()
 	doubleGauge.InitEmpty()
 	doubleGauge.DataPoints().Resize(4)
 	doubleGauge.DataPoints().At(0).SetTimestamp(pdata.TimestampUnixNano(timestamp0.UnixNano()))
-	doubleGauge.DataPoints().At(0).SetValue(123)
+	doubleGauge.DataPoints().At(0).SetValue(5)
 	doubleGauge.DataPoints().At(1).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
-	doubleGauge.DataPoints().At(1).SetValue(456)
+	doubleGauge.DataPoints().At(1).SetValue(6)
 	doubleGauge.DataPoints().At(1).LabelsMap().InitFromMap(map[string]string{"k": "v"})
 	doubleGauge.DataPoints().At(2).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
-	doubleGauge.DataPoints().At(2).SetValue(789)
+	doubleGauge.DataPoints().At(2).SetValue(7)
 	doubleGauge.DataPoints().At(3).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
-	doubleGauge.DataPoints().At(3).SetValue(101112)
+	doubleGauge.DataPoints().At(3).SetValue(8)
 	doubleGauge.DataPoints().At(3).LabelsMap().InitFromMap(map[string]string{"k": "v2"})
+	// Nil data point should be dropped
+	doubleGauge.DataPoints().Append(pdata.NewDoubleDataPoint())
+	expectDropped++
 
-	metric = metrics.At(1)
-	metric.SetName("int_sum_metric")
-	metric.SetDataType(pdata.MetricDataTypeIntSum)
+	metric = appendMetric("int_sum_metric", pdata.MetricDataTypeIntSum)
 	intSum := metric.IntSum()
 	intSum.InitEmpty()
 	intSum.DataPoints().Resize(3)
 	intSum.DataPoints().At(0).SetTimestamp(pdata.TimestampUnixNano(timestamp0.UnixNano()))
-	intSum.DataPoints().At(0).SetValue(321)
+	intSum.DataPoints().At(0).SetValue(9)
 	intSum.DataPoints().At(1).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
-	intSum.DataPoints().At(1).SetValue(654)
+	intSum.DataPoints().At(1).SetValue(10)
 	intSum.DataPoints().At(1).LabelsMap().InitFromMap(map[string]string{"k": "v"})
 	intSum.DataPoints().At(2).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
-	intSum.DataPoints().At(2).SetValue(101112)
+	intSum.DataPoints().At(2).SetValue(11)
 	intSum.DataPoints().At(2).LabelsMap().InitFromMap(map[string]string{"k2": "v"})
+	// Nil data point should be dropped
+	intSum.DataPoints().Append(pdata.NewIntDataPoint())
+	expectDropped++
+
+	metric = appendMetric("double_sum_metric", pdata.MetricDataTypeDoubleSum)
+	doubleSum := metric.DoubleSum()
+	doubleSum.InitEmpty()
+	doubleSum.DataPoints().Resize(3)
+	doubleSum.DataPoints().At(0).SetTimestamp(pdata.TimestampUnixNano(timestamp0.UnixNano()))
+	doubleSum.DataPoints().At(0).SetValue(12)
+	doubleSum.DataPoints().At(1).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	doubleSum.DataPoints().At(1).SetValue(13)
+	doubleSum.DataPoints().At(1).LabelsMap().InitFromMap(map[string]string{"k": "v"})
+	doubleSum.DataPoints().At(2).SetTimestamp(pdata.TimestampUnixNano(timestamp1.UnixNano()))
+	doubleSum.DataPoints().At(2).SetValue(14)
+	doubleSum.DataPoints().At(2).LabelsMap().InitFromMap(map[string]string{"k2": "v"})
+	// Nil data point should be dropped
+	doubleSum.DataPoints().Append(pdata.NewDoubleDataPoint())
+	expectDropped++
 
 	// Histograms are currently not supported, and will be ignored.
-	metric = metrics.At(2)
-	metric.SetName("double_histogram_metric")
-	metric.SetDataType(pdata.MetricDataTypeDoubleHistogram)
-	doubleHistogram := metric.DoubleHistogram()
-	doubleHistogram.InitEmpty()
-	doubleHistogram.DataPoints().Resize(1)
+	metric = appendMetric("double_histogram_metric", pdata.MetricDataTypeDoubleHistogram)
+	metric.DoubleHistogram().InitEmpty()
+	metric.DoubleHistogram().DataPoints().Resize(1)
+	expectDropped++
+	metric = appendMetric("int_histogram_metric", pdata.MetricDataTypeIntHistogram)
+	metric.IntHistogram().InitEmpty()
+	metric.IntHistogram().DataPoints().Resize(1)
+	expectDropped++
 
 	dropped, err := elastic.EncodeMetrics(metrics, instrumentationLibraryMetrics.InstrumentationLibrary(), &w)
 	require.NoError(t, err)
-	assert.Equal(t, 1, dropped) // histogram dropped
+	assert.Equal(t, expectDropped, dropped)
 	sendStream(t, &w, &recorder)
 
 	payloads := recorder.Payloads()
 	assert.Equal(t, []model.Metrics{{
 		Timestamp: model.Time(timestamp0),
 		Samples: map[string]model.Metric{
-			"double_gauge_metric": {Value: 123},
-			"int_sum_metric":      {Value: 321},
+			"double_gauge_metric": {Value: 5},
+			"double_sum_metric":   {Value: 12},
+			"int_gauge_metric":    {Value: 1},
+			"int_sum_metric":      {Value: 9},
 		},
 	}, {
 		Timestamp: model.Time(timestamp1),
 		Samples: map[string]model.Metric{
-			"double_gauge_metric": {Value: 789},
+			"double_gauge_metric": {Value: 7},
+			"int_gauge_metric":    {Value: 3},
 		},
 	}, {
 		Timestamp: model.Time(timestamp1),
 		Labels:    model.StringMap{{Key: "k", Value: "v"}},
 		Samples: map[string]model.Metric{
-			"double_gauge_metric": {Value: 456},
-			"int_sum_metric":      {Value: 654},
+			"double_gauge_metric": {Value: 6},
+			"double_sum_metric":   {Value: 13},
+			"int_gauge_metric":    {Value: 2},
+			"int_sum_metric":      {Value: 10},
 		},
 	}, {
 		Timestamp: model.Time(timestamp1),
 		Labels:    model.StringMap{{Key: "k", Value: "v2"}},
 		Samples: map[string]model.Metric{
-			"double_gauge_metric": {Value: 101112},
+			"double_gauge_metric": {Value: 8},
+			"int_gauge_metric":    {Value: 4},
 		},
 	}, {
 		Timestamp: model.Time(timestamp1),
 		Labels:    model.StringMap{{Key: "k2", Value: "v"}},
 		Samples: map[string]model.Metric{
-			"int_sum_metric": {Value: 101112},
+			"double_sum_metric": {Value: 14},
+			"int_sum_metric":    {Value: 11},
 		},
 	}}, payloads.Metrics)
 

--- a/exporter/elasticexporter/internal/translator/elastic/metrics_test.go
+++ b/exporter/elasticexporter/internal/translator/elastic/metrics_test.go
@@ -23,9 +23,9 @@ import (
 	"go.elastic.co/apm/model"
 	"go.elastic.co/apm/transport/transporttest"
 	"go.elastic.co/fastjson"
+	"go.opentelemetry.io/collector/consumer/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticexporter/internal/translator/elastic"
-	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 func TestEncodeMetrics(t *testing.T) {

--- a/exporter/elasticexporter/internal/translator/elastic/traces.go
+++ b/exporter/elasticexporter/internal/translator/elastic/traces.go
@@ -31,6 +31,8 @@ import (
 
 // EncodeSpan encodes an OpenTelemetry span, and instrumentation library information,
 // as a transaction or span line, writing to w.
+//
+// TODO(axw) otlpLibrary is currently not used. We should consider recording it as metadata.
 func EncodeSpan(otlpSpan pdata.Span, otlpLibrary pdata.InstrumentationLibrary, w *fastjson.Writer) error {
 	var spanID, parentID model.SpanID
 	var traceID model.TraceID


### PR DESCRIPTION
**Description:**

This change introduces initial support for exporting basic sum and gauge metrics to Elastic APM.

Due to current limitations in the Elastic APM metrics protocol, we do not yet support histograms, distinguish doubles from integers, or record units. These issues will be addressed in future updates.

**Testing:** <Describe what testing was performed and which tests were added.>

Added unit tests, and manually tested with the hostmetrics receiver. Example process memory metrics in Elasticsearch:

![image](https://user-images.githubusercontent.com/843579/94887789-c79ef680-04a9-11eb-9b2e-1696045d6c8c.png)