### PR TITLE
Use fixed, mock credentials in emfexporter test.

### DIFF
--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -34,6 +34,11 @@ import (
 	"go.uber.org/zap"
 )
 
+func init() {
+	os.Setenv("AWS_ACCESS_KEY_ID", "test")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+}
+
 type mockPusher struct {
 	mock.Mock
 }


### PR DESCRIPTION
**Description:** Set environment variables for AWS credentials to mock values. From what I can tell, the test fails if someone has valid AWS credentials on their machine currently, so to make behavior consistent we need the test to setup fixed creds.

**Link to tracking Issue:** Fixes #1149

**Testing:** Unit tests