### PR TITLE
Fixed typo in systemd service file

### DIFF
--- a/internal/buildscripts/packaging/fpm/otel-contrib-collector.service
+++ b/internal/buildscripts/packaging/fpm/otel-contrib-collector.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=OpenTelemety Contrib Collector
+Description=OpenTelemetry Contrib Collector
 After=network.target
 
 [Service]


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

**Description:** Fixed typo in the systemd service file.

**Link to tracking Issue:** None.

**Testing:** None.

**Documentation:** None.
