### PR TITLE
add Datadog Trace Export Configuration

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -1,6 +1,6 @@
 # Datadog Exporter
 
-This exporter sends metric data to [Datadog](https://datadoghq.com).
+This exporter sends metric and trace data to [Datadog](https://datadoghq.com).
 
 ## Configuration
 

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -60,6 +60,18 @@ type MetricsConfig struct {
 	confignet.TCPAddr `mapstructure:",squash"`
 }
 
+// TracesConfig defines the traces exporter specific configuration options
+type TracesConfig struct {
+	// TCPAddr.Endpoint is the host of the Datadog intake server to send traces to.
+	// If unset, the value is obtained from the Site.
+	confignet.TCPAddr `mapstructure:",squash"`
+
+	// SampleRate is the rate at which to sample this event. Default is 1,
+	// meaning no sampling. If you want to send one event out of every 250
+	// times Send() is called, you would specify 250 here.
+	SampleRate uint `mapstructure:"sample_rate"`
+}
+
 // TagsConfig defines the tag-related configuration
 // It is embedded in the configuration
 type TagsConfig struct {
@@ -121,6 +133,9 @@ type Config struct {
 
 	// Metrics defines the Metrics exporter specific configuration
 	Metrics MetricsConfig `mapstructure:"metrics"`
+
+	// Traces defines the Traces exporter specific configuration
+	Traces TracesConfig `mapstructure:"traces"`
 }
 
 // Sanitize tries to sanitize a given configuration
@@ -128,6 +143,10 @@ func (c *Config) Sanitize() error {
 	// Add '.' at the end of namespace
 	if c.Metrics.Namespace != "" && !strings.HasSuffix(c.Metrics.Namespace, ".") {
 		c.Metrics.Namespace = c.Metrics.Namespace + "."
+	}
+
+	if c.TagsConfig.Env == "" {
+		c.TagsConfig.Env = "none"
 	}
 
 	if c.API.Key == "" {
@@ -139,6 +158,10 @@ func (c *Config) Sanitize() error {
 	// Set the endpoint based on the Site
 	if c.Metrics.TCPAddr.Endpoint == "" {
 		c.Metrics.TCPAddr.Endpoint = fmt.Sprintf("https://api.%s", c.API.Site)
+	}
+
+	if c.Traces.TCPAddr.Endpoint == "" {
+		c.Traces.TCPAddr.Endpoint = fmt.Sprintf("https://trace.agent.%s", c.API.Site)
 	}
 
 	return nil

--- a/exporter/datadogexporter/config_test.go
+++ b/exporter/datadogexporter/config_test.go
@@ -74,7 +74,6 @@ func TestLoadConfig(t *testing.T) {
 				Endpoint: "https://trace.agent.datadoghq.eu",
 			},
 		},
-
 	}, apiConfig)
 
 	invalidConfig2 := cfg.Exporters["datadog/invalid"].(*Config)

--- a/exporter/datadogexporter/config_test.go
+++ b/exporter/datadogexporter/config_test.go
@@ -67,6 +67,14 @@ func TestLoadConfig(t *testing.T) {
 				Endpoint: "https://api.datadoghq.eu",
 			},
 		},
+
+		Traces: TracesConfig{
+			SampleRate: 1,
+			TCPAddr: confignet.TCPAddr{
+				Endpoint: "https://trace.agent.datadoghq.eu",
+			},
+		},
+
 	}, apiConfig)
 
 	invalidConfig2 := cfg.Exporters["datadog/invalid"].(*Config)

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -73,6 +73,24 @@ exporters:
       #
       # endpoint: https://api.datadoghq.com
 
+    ## @param traces - custom object - optional
+    ## Trace exporter specific configuration.
+    #
+    # traces:
+      ## @param sample_rate - integer - optional - default: 1
+      #  The rate at which to sample traces. Default is 1 (Always Sample),
+      #  meaning no sampling. If you want to send one event out of every 250
+      #  you would specify 250.
+      #
+      # sample_rate: 1
+
+      ## @param endpoint - string - optional
+      ## The host of the Datadog intake server to send traces to.
+      ## If unset the value is obtained through the `site` parameter in the `api` section.
+      #
+      # endpoint: https://api.datadoghq.com
+      
+
 service:
   pipelines:
     traces:

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -61,5 +61,12 @@ func createDefaultConfig() configmodels.Exporter {
 				Endpoint: "", // set during config sanitization
 			},
 		},
+
+		Traces: TracesConfig{
+			SampleRate: 1,
+			TCPAddr: confignet.TCPAddr{
+				Endpoint: "", // set during config sanitization
+			},
+		},
 	}
 }

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -41,6 +41,9 @@ func TestCreateDefaultConfig(t *testing.T) {
 		},
 
 		API: APIConfig{Site: "datadoghq.com"},
+		Traces: TracesConfig{
+			SampleRate: 1,
+		},
 	}, cfg, "failed to create default config")
 
 	assert.NoError(t, configcheck.ValidateConfig(cfg))

--- a/exporter/datadogexporter/testdata/config.yaml
+++ b/exporter/datadogexporter/testdata/config.yaml
@@ -21,13 +21,24 @@ exporters:
     metrics:
       namespace: opentelemetry
 
+    traces:
+      sample_rate: 1
+
   datadog/invalid:
     metrics:
+      endpoint: "invalid:"
+    
+    traces:
       endpoint: "invalid:"
 
 service:
   pipelines:
     metrics:
+      receivers: [examplereceiver]
+      processors: [exampleprocessor]
+      exporters: [datadog/api, datadog/invalid]
+
+    traces:
       receivers: [examplereceiver]
       processors: [exampleprocessor]
       exporters: [datadog/api, datadog/invalid]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR adds Trace export configuration to the Datadog exporter overall structure, following the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-collector/blob/master/CONTRIBUTING.md#when-adding-a-new-component).

This adds the configuration necessary to then add the ability to export traces directly to Datadog's backend (agentless).

After the configuration is confirmed we plan to make additional PRs to bring in the actual bulk code for exporting traces. Contribution guidelines state we should break this up, but you can find this work in progress (though functional) [here, on the our fork, for context](https://github.com/DataDog/opentelemetry-collector-contrib/pull/38).

You can also find additional work for metric export code in [this pr](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1178). I don't think these are tightly coupled but happy to rebase if one gets merged before the other.

Any feedback or comments here are welcome and we'll try to prioritise, as well as if you have any feedback on in progress work on our fork. I'm also available on gitter for anything ad-hoc. We're keen to get both the metric and trace code into the collector and support it however necessary.

Cheers, Eric

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Added unit tests, tested full version (available on our fork) on an end to end testing environment.

**Documentation:** This adds the README for the exporter with the intended instructions for the full trace exporter.

