### PR TITLE
Align Memory limit for TestTrace10kSPS with core

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -47,7 +47,7 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 39,
-				ExpectedMaxRAM: 70,
+				ExpectedMaxRAM: 82,
 			},
 		},
 		{


### PR DESCRIPTION
Matches limit in core: https://github.com/open-telemetry/opentelemetry-collector/blob/master/testbed/tests/trace_test.go#L64