### PR TITLE
[datadogexporter] Add metrics exporter

### DIFF
--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadogexporter
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+)
+
+type metricsExporter struct {
+	logger *zap.Logger
+	cfg    *Config
+	client *datadog.Client
+	tags   []string
+}
+
+func newMetricsExporter(logger *zap.Logger, cfg *Config) (*metricsExporter, error) {
+	client := datadog.NewClient(cfg.API.Key, "")
+	client.SetBaseUrl(cfg.Metrics.TCPAddr.Endpoint)
+
+	// Calculate tags at startup
+	tags := cfg.TagsConfig.GetTags(false)
+
+	return &metricsExporter{logger, cfg, client, tags}, nil
+}
+
+func (exp *metricsExporter) processMetrics(metrics []datadog.Metric) {
+	addNamespace := exp.cfg.Metrics.Namespace != ""
+	overrideHostname := exp.cfg.Hostname != ""
+	addTags := len(exp.tags) > 0
+
+	for i := range metrics {
+		if addNamespace {
+			newName := exp.cfg.Metrics.Namespace + *metrics[i].Metric
+			metrics[i].Metric = &newName
+		}
+
+		if overrideHostname || metrics[i].GetHost() == "" {
+			metrics[i].Host = GetHost(exp.cfg)
+		}
+
+		if addTags {
+			metrics[i].Tags = append(metrics[i].Tags, exp.tags...)
+		}
+
+	}
+}
+
+func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pdata.Metrics) (int, error) {
+	metrics, droppedTimeSeries := MapMetrics(exp.logger, exp.cfg.Metrics, md)
+	exp.processMetrics(metrics)
+
+	err := exp.client.PostMetrics(metrics)
+	return droppedTimeSeries, err
+}

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datadogexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+)
+
+func TestNewExporter(t *testing.T) {
+	cfg := &Config{}
+	cfg.API.Key = "ddog_32_characters_long_api_key1"
+	logger := zap.NewNop()
+
+	// The client should have been created correctly
+	exp, err := newMetricsExporter(logger, cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, exp)
+}
+
+func TestProcessMetrics(t *testing.T) {
+	cfg := &Config{
+		TagsConfig: TagsConfig{
+			Hostname: "test_host",
+			Env:      "test_env",
+			Tags:     []string{"key:val"},
+		},
+		Metrics: MetricsConfig{
+			Namespace: "test.",
+		},
+	}
+	logger := zap.NewNop()
+
+	exp, err := newMetricsExporter(logger, cfg)
+
+	require.NoError(t, err)
+
+	metrics := []datadog.Metric{
+		newGauge(
+			"metric_name",
+			0,
+			0,
+			[]string{"key2:val2"},
+		),
+	}
+
+	exp.processMetrics(metrics)
+
+	assert.Equal(t, "test_host", *metrics[0].Host)
+	assert.Equal(t, "test.metric_name", *metrics[0].Metric)
+	assert.ElementsMatch(t,
+		[]string{"key:val", "env:test_env", "key2:val2"},
+		metrics[0].Tags,
+	)
+
+}


### PR DESCRIPTION
**Description:**  Add metrics exporter for Datadog. It uses the `zorkian/go-datadog-api` module to post the metrics to the backend.

**Link to tracking Issue:** n/a

**Testing:** Added unit tests, performed end to end tests against Datadog's backend.

**Documentation:** Documentation was added on previous PRs