### PR TITLE
k8sprocessor: Rename default attr names for label/annotation extraction

### DIFF
--- a/processor/k8sprocessor/config.go
+++ b/processor/k8sprocessor/config.go
@@ -70,13 +70,14 @@ type ExtractConfig struct {
 // FieldExtractConfig allows specifying an extraction rule to extract a value from exactly one field.
 //
 // The field accepts a list FilterExtractConfig map. The map accepts three keys
-//     tag-name, key and regex
+//     tag_name, key and regex
 //
-// - tag-name represents the name of the tag that will be added to the span.
+// - tag_name represents the name of the tag that will be added to the span.
 //   When not specified a default tag name will be used of the format:
-//       k8s.<annotation>.<annotation key>
-//   For example, if tag-name is not specified and the key is git_sha,
-//   then the span name will be `k8s.annotation.deployment.git_sha`.
+//       k8s.pod.annotations.<annotation key>
+//       k8s.pod.labels.<label key>
+//   For example, if tag_name is not specified and the key is git_sha,
+//   then the attribute name will be `k8s.pod.annotations.git_sha`.
 //
 // - key represents the annotation name. This must exactly match an annotation name.
 //

--- a/processor/k8sprocessor/options.go
+++ b/processor/k8sprocessor/options.go
@@ -104,7 +104,7 @@ func WithExtractMetadata(fields ...string) Option {
 // WithExtractLabels allows specifying options to control extraction of pod labels.
 func WithExtractLabels(labels ...FieldExtractConfig) Option {
 	return func(p *kubernetesprocessor) error {
-		labels, err := extractFieldRules("label", labels...)
+		labels, err := extractFieldRules("labels", labels...)
 		if err != nil {
 			return err
 		}
@@ -116,7 +116,7 @@ func WithExtractLabels(labels ...FieldExtractConfig) Option {
 // WithExtractAnnotations allows specifying options to control extraction of pod annotations tags.
 func WithExtractAnnotations(annotations ...FieldExtractConfig) Option {
 	return func(p *kubernetesprocessor) error {
-		annotations, err := extractFieldRules("annotation", annotations...)
+		annotations, err := extractFieldRules("annotations", annotations...)
 		if err != nil {
 			return err
 		}
@@ -130,7 +130,7 @@ func extractFieldRules(fieldType string, fields ...FieldExtractConfig) ([]kube.F
 	for _, a := range fields {
 		name := a.TagName
 		if name == "" {
-			name = fmt.Sprintf("k8s.%s.%s", fieldType, a.Key)
+			name = fmt.Sprintf("k8s.pod.%s.%s", fieldType, a.Key)
 		}
 
 		var r *regexp.Regexp

--- a/processor/k8sprocessor/options_test.go
+++ b/processor/k8sprocessor/options_test.go
@@ -497,14 +497,14 @@ func Test_extractFieldRules(t *testing.T) {
 	}{
 		{
 			"default",
-			args{"field", []FieldExtractConfig{
+			args{"labels", []FieldExtractConfig{
 				{
 					Key: "key",
 				},
 			}},
 			[]kube.FieldExtractionRule{
 				{
-					Name: "k8s.field.key",
+					Name: "k8s.pod.labels.key",
 					Key:  "key",
 				},
 			},


### PR DESCRIPTION
**Description:** 

If no key_name is specified in the `FieldExtractConfig`, the following attributes keys are generated by default:
- k8s.label.<label_name>
- k8s.annotation.<annotation_name>

It is not aligned with the existing conventions and not specific enough. 

Since the fields are extracted from pods only, we should change it to the following attribute names:
- k8s.pod.labels.<label_name>
- k8s.pod.annotations.<annotation_name>

It'll also allow us to extract any labels/annotations from other k8s objects and won't cause conflicts

**Documentation:** Updated documentation part for extractions