### PR TITLE
Add API key validation

### DIFF
--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -18,7 +18,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -27,6 +26,8 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtest"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/testutils"
 )
 
 // Test that the factory creates the default configuration

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -1,4 +1,6 @@
-module github.com/DataDog/opentelemetry-collector-contrib/exporter/datadogexporter
+module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
+
+replace gopkg.in/zorkian/go-datadog-api.v2 v2.29.0 => github.com/zorkian/go-datadog-api v2.29.1-0.20201007103024-437d51d487bf+incompatible
 
 go 1.15
 

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -1,8 +1,8 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
 
-replace gopkg.in/zorkian/go-datadog-api.v2 v2.29.0 => github.com/zorkian/go-datadog-api v2.29.1-0.20201007103024-437d51d487bf+incompatible
+go 1.14
 
-go 1.15
+replace gopkg.in/zorkian/go-datadog-api.v2 v2.29.0 => github.com/zorkian/go-datadog-api v2.29.1-0.20201007103024-437d51d487bf+incompatible
 
 require (
 	github.com/stretchr/testify v1.6.1

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -819,6 +819,8 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/open-telemetry/opentelemetry-collector-contrib v0.11.0 h1:1rkTd2NRFlGEV4uXdZUJnwpSwRNOujt8t/VHIiG92K0=
+github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.0.0-20201006220054-a07f2c3676cf h1:9OTRalfPNRXeZ2Ma+VF52Gbt1x0Wab0eEFpUP8Zz8Pc=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
@@ -1102,6 +1104,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zorkian/go-datadog-api v2.29.0+incompatible h1:uZZg0POZ6tLmVFtjUSaTZYwR6Q6RrHx6f/blTEDn8dA=
 github.com/zorkian/go-datadog-api v2.29.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
+github.com/zorkian/go-datadog-api v2.29.1-0.20201007103024-437d51d487bf+incompatible h1:8b9UOZ4GcsZJNR3Z6ETckvwp7bA8Eutek3ME0VmJbWg=
+github.com/zorkian/go-datadog-api v2.29.1-0.20201007103024-437d51d487bf+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
@@ -1188,6 +1192,7 @@ golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
+golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -29,9 +29,25 @@ type metricsExporter struct {
 	tags   []string
 }
 
+func validateAPIKey(logger *zap.Logger, client *datadog.Client) {
+	logger.Info("Validating API key.")
+	res, err := client.Validate()
+	if err != nil {
+		logger.Warn("Error while validating API key.", zap.Error(err))	
+	}
+
+	if res {
+		logger.Info("API key validation successful.")
+	} else {
+		logger.Warn("API key validation failed.")
+	}
+}
+
 func newMetricsExporter(logger *zap.Logger, cfg *Config) (*metricsExporter, error) {
 	client := datadog.NewClient(cfg.API.Key, "")
 	client.SetBaseUrl(cfg.Metrics.TCPAddr.Endpoint)
+
+	validateAPIKey(logger, client)
 
 	// Calculate tags at startup
 	tags := cfg.TagsConfig.GetTags(false)

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -33,7 +33,7 @@ func validateAPIKey(logger *zap.Logger, client *datadog.Client) {
 	logger.Info("Validating API key.")
 	res, err := client.Validate()
 	if err != nil {
-		logger.Warn("Error while validating API key.", zap.Error(err))	
+		logger.Warn("Error while validating API key.", zap.Error(err))
 	}
 
 	if res {

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -17,15 +17,31 @@ package datadogexporter
 import (
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"gopkg.in/zorkian/go-datadog-api.v2"
+	"go.opentelemetry.io/collector/config/confignet"
+
 )
 
 func TestNewExporter(t *testing.T) {
-	cfg := &Config{}
-	cfg.API.Key = "ddog_32_characters_long_api_key1"
+	server := testutils.DatadogServerMock()
+	defer server.Close()
+
+	cfg := &Config{
+		API: APIConfig{
+			Key: "ddog_32_characters_long_api_key1",
+		},
+		Metrics: MetricsConfig{
+			TCPAddr: confignet.TCPAddr{
+				Endpoint: server.URL,
+			},
+		},
+	}
+	
+	cfg.Sanitize()
 	logger := zap.NewNop()
 
 	// The client should have been created correctly
@@ -35,7 +51,14 @@ func TestNewExporter(t *testing.T) {
 }
 
 func TestProcessMetrics(t *testing.T) {
+	server := testutils.DatadogServerMock()
+	defer server.Close()
+
 	cfg := &Config{
+		API: APIConfig{
+			Key: "ddog_32_characters_long_api_key1",
+			Site: "datadoghq.com",
+		},
 		TagsConfig: TagsConfig{
 			Hostname: "test_host",
 			Env:      "test_env",
@@ -43,8 +66,13 @@ func TestProcessMetrics(t *testing.T) {
 		},
 		Metrics: MetricsConfig{
 			Namespace: "test.",
+			TCPAddr: confignet.TCPAddr{
+				Endpoint: server.URL,
+			},
 		},
 	}
+	cfg.Sanitize()
+
 	logger := zap.NewNop()
 
 	exp, err := newMetricsExporter(logger, cfg)

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -17,13 +17,13 @@ package datadogexporter
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/confignet"
 	"go.uber.org/zap"
 	"gopkg.in/zorkian/go-datadog-api.v2"
-	"go.opentelemetry.io/collector/config/confignet"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/testutils"
 )
 
 func TestNewExporter(t *testing.T) {
@@ -40,7 +40,7 @@ func TestNewExporter(t *testing.T) {
 			},
 		},
 	}
-	
+
 	cfg.Sanitize()
 	logger := zap.NewNop()
 
@@ -57,7 +57,6 @@ func TestProcessMetrics(t *testing.T) {
 	cfg := &Config{
 		API: APIConfig{
 			Key: "ddog_32_characters_long_api_key1",
-			Site: "datadoghq.com",
 		},
 		TagsConfig: TagsConfig{
 			Hostname: "test_host",

--- a/exporter/datadogexporter/testutils/test_utils.go
+++ b/exporter/datadogexporter/testutils/test_utils.go
@@ -1,0 +1,29 @@
+package testutils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+)
+
+// DatadogServerMock mocks a Datadog backend server
+func DatadogServerMock() *httptest.Server {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/api/v1/validate", validateAPIKeyEndpoint)
+ 
+	srv := httptest.NewServer(handler)
+ 
+	return srv
+}
+ 
+type validateAPIKeyResponse struct {
+	Valid bool `json:"valid"`
+}
+
+func validateAPIKeyEndpoint(w http.ResponseWriter, r *http.Request) {
+	res := validateAPIKeyResponse{Valid: true}
+	resJSON, _ := json.Marshal(res)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(resJSON)
+}

--- a/exporter/datadogexporter/testutils/test_utils.go
+++ b/exporter/datadogexporter/testutils/test_utils.go
@@ -10,12 +10,12 @@ import (
 func DatadogServerMock() *httptest.Server {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/api/v1/validate", validateAPIKeyEndpoint)
- 
+
 	srv := httptest.NewServer(handler)
- 
+
 	return srv
 }
- 
+
 type validateAPIKeyResponse struct {
 	Valid bool `json:"valid"`
 }

--- a/exporter/datadogexporter/testutils/test_utils.go
+++ b/exporter/datadogexporter/testutils/test_utils.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testutils
 
 import (


### PR DESCRIPTION
**Description:** 

Adds API key validation to the Datadog metrics exporter.
When created, the Datadog metrics exporter now sends a requests to the `/api/v1/validate` endpoint of the Datadog backend to check that the configured API key is valid. If it's not, a warning log is emitted.

**Link to tracking Issue:** n/a

**Testing:** Tests were amended to take into account that validation call. Test utils were added to mock an HTTP server that performs validation.
