### PR TITLE
Change the internal awsxray version

### DIFF
--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -5,10 +5,9 @@ go 1.14
 require (
 	github.com/aws/aws-sdk-go v1.35.2
 	github.com/google/uuid v1.1.2
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray v0.11.0
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.11.1-0.20201006165100-07236c11fb27
 	go.uber.org/zap v1.16.0
 )
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray => ./../../internal/awsxray


### PR DESCRIPTION
**Description:**  Changed the internal awsxray version from local directory to a detailed version.
 - We can import the awsxray receiver successfully.


**Testing:**  I tested it in my local, and the version works fine.

