### PR TITLE
Signalfx exporter: make dimension sanitization optional

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -53,6 +53,9 @@ The following configuration options can also be configured:
 - `translation_rules`: Set of rules on how to translate metrics to a SignalFx
   compatible format. Rules defined in `translation/constants.go` are used by
   default. Applicable only when `send_compatible_metrics` set to `true`.
+- `sanitize_dimensions`: Specifies if metric dimensions must be sanitized 
+  before sending them to SignalFx backend, `.` and `/` in dimension names will
+  be replaced with `_`. Default: true.
 - `sync_host_metadata`: Defines whether the exporter should scrape host metadata
   and send it as property updates to SignalFx backend. Disabled by default.
   IMPORTANT: Host metadata synchronization relies on `resourcedetection`

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -66,6 +66,10 @@ type Config struct {
 	// SignalFx naming conventions, "false" by default.
 	SendCompatibleMetrics bool `mapstructure:"send_compatible_metrics"`
 
+	// SanitizeDimensions specifies if metric dimensions must be sanitized before sending them
+	// to SignalFx backend which doesn't fully support "." and "/" in dimension names. Default: true.
+	SanitizeDimensions bool `mapstructure:"sanitize_dimensions"`
+
 	// TranslationRules defines a set of rules how to translate metrics to a SignalFx compatible format
 	// Rules defined in translation/constants.go are used by default.
 	TranslationRules []translation.Rule `mapstructure:"translation_rules"`
@@ -110,8 +114,8 @@ func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {
 	}
 
 	var metricTranslator *translation.MetricTranslator
-	if cfg.SendCompatibleMetrics {
-		metricTranslator, err = translation.NewMetricTranslator(cfg.TranslationRules, cfg.DeltaTranslationTTL)
+	if len(cfg.TranslationRules) > 0 || cfg.SanitizeDimensions {
+		metricTranslator, err = translation.NewMetricTranslator(cfg.TranslationRules, cfg.DeltaTranslationTTL, cfg.SanitizeDimensions)
 		if err != nil {
 			return nil, fmt.Errorf("invalid \"translation_rules\": %v", err)
 		}

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -92,6 +92,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		DeltaTranslationTTL: 3600,
+		SanitizeDimensions:  true,
 	}
 	assert.Equal(t, &expectedCfg, e1)
 

--- a/exporter/signalfxexporter/dimensions/metadata.go
+++ b/exporter/signalfxexporter/dimensions/metadata.go
@@ -16,7 +16,6 @@ package dimensions
 
 import (
 	"fmt"
-	"strings"
 	"sync/atomic"
 
 	"go.opentelemetry.io/collector/component/componenterror"
@@ -30,21 +29,16 @@ type MetadataUpdateClient interface {
 	PushMetadata([]*collection.MetadataUpdate) error
 }
 
-var propNameSanitizer = strings.NewReplacer(
-	".", "_",
-	"/", "_")
-
 func getDimensionUpdateFromMetadata(
 	metadata collection.MetadataUpdate,
 	metricTranslator *translation.MetricTranslator,
 ) *DimensionUpdate {
 
 	translateDimension := func(dim string) string {
-		res := dim
 		if metricTranslator != nil {
-			res = metricTranslator.TranslateDimension(res)
+			return metricTranslator.TranslateDimension(dim)
 		}
-		return propNameSanitizer.Replace(res)
+		return dim
 	}
 
 	properties, tags := getPropertiesAndTags(metadata, translateDimension)

--- a/exporter/signalfxexporter/dimensions/metadata_test.go
+++ b/exporter/signalfxexporter/dimensions/metadata_test.go
@@ -31,7 +31,7 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 				"prope_rty2": "rty2",
 				"prope.rty3": "rty3"},
 		},
-	}, 1)
+	}, 1, true)
 	type args struct {
 		metadata         collection.MetadataUpdate
 		metricTranslator *translation.MetricTranslator
@@ -129,14 +129,14 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 				Name:  "name",
 				Value: "val",
 				Properties: getMapToPointers(map[string]string{
-					"prope_rty1": "value1",
-					"prope_rty2": "",
+					"prope/rty1": "value1",
+					"prope.rty2": "",
 					"prope_rty3": "value33",
-					"prope_rty4": "",
+					"prope.rty4": "",
 				}),
 				Tags: map[string]bool{
-					"ta_g1": true,
-					"ta_g2": false,
+					"ta.g1": true,
+					"ta/g2": false,
 				},
 			},
 		},

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -765,9 +765,9 @@ func TestConsumeMetadata(t *testing.T) {
 			fields{
 				map[string]interface{}{
 					"customProperties": map[string]interface{}{
-						"prop_erty1": "val1",
+						"prop.erty1": "val1",
 						"property2":  nil,
-						"prop_erty3": "val33",
+						"prop.erty3": "val33",
 						"property4":  nil,
 					},
 					"tags":         nil,
@@ -801,10 +801,10 @@ func TestConsumeMetadata(t *testing.T) {
 				map[string]interface{}{
 					"customProperties": map[string]interface{}{},
 					"tags": []interface{}{
-						"tag_1",
+						"tag.1",
 					},
 					"tagsToRemove": []interface{}{
-						"tag_2",
+						"tag/2",
 					},
 				},
 			},
@@ -836,10 +836,10 @@ func TestConsumeMetadata(t *testing.T) {
 						"property3": nil,
 					},
 					"tags": []interface{}{
-						"tag_2",
+						"tag/2",
 					},
 					"tagsToRemove": []interface{}{
-						"tag_1",
+						"tag.1",
 					},
 				},
 			},

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -60,6 +60,7 @@ func createDefaultConfig() configmodels.Exporter {
 		SendCompatibleMetrics: false,
 		TranslationRules:      nil,
 		DeltaTranslationTTL:   3600,
+		SanitizeDimensions:    true,
 	}
 }
 

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -270,7 +270,7 @@ func TestDefaultTranslationRules(t *testing.T) {
 	rules, err := loadDefaultTranslationRules()
 	require.NoError(t, err)
 	require.NotNil(t, rules, "rules are nil")
-	tr, err := translation.NewMetricTranslator(rules, 1)
+	tr, err := translation.NewMetricTranslator(rules, 1, false)
 	require.NoError(t, err)
 	data := testMetricsData()
 
@@ -826,7 +826,7 @@ func testGetTranslator(t *testing.T) *translation.MetricTranslator {
 	rules, err := loadDefaultTranslationRules()
 	require.NoError(t, err)
 	require.NotNil(t, rules, "rules are nil")
-	tr, err := translation.NewMetricTranslator(rules, 3600)
+	tr, err := translation.NewMetricTranslator(rules, 3600, false)
 	require.NoError(t, err)
 	return tr
 }

--- a/exporter/signalfxexporter/translation/converter.go
+++ b/exporter/signalfxexporter/translation/converter.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
-	"unicode"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
@@ -101,7 +99,6 @@ func (c *MetricsConverter) MetricDataToSignalFxV2(mds []consumerdata.MetricsData
 		sfxDataPoints, droppedDPCount = c.metricDataToSfxDataPoints(md, sfxDataPoints)
 		numDroppedTimeSeries += droppedDPCount
 	}
-	sanitizeDataPointDimensions(sfxDataPoints)
 	return sfxDataPoints, numDroppedTimeSeries
 }
 
@@ -375,27 +372,6 @@ func buildSumDataPoint(
 	sumDP.Value = sfxpb.Datum{DoubleValue: sum}
 
 	return &sumDP
-}
-
-// sanitizeDataPointLabels replaces all characters unsupported by SignalFx backend
-// in metric label keys and with "_"
-func sanitizeDataPointDimensions(dps []*sfxpb.DataPoint) {
-	for _, dp := range dps {
-		for _, d := range dp.Dimensions {
-			d.Key = filterKeyChars(d.Key)
-		}
-	}
-}
-
-func filterKeyChars(str string) string {
-	filterMap := func(r rune) rune {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' {
-			return r
-		}
-		return '_'
-	}
-
-	return strings.Map(filterMap, str)
 }
 
 func float64ToDimValue(f float64) string {

--- a/exporter/signalfxexporter/translation/converter_test.go
+++ b/exporter/signalfxexporter/translation/converter_test.go
@@ -360,7 +360,9 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 			wantSfxDataPoints: expectedFromSummary("summary_no_quantiles", tsMSecs, keys, values, summaryNoQuantiles),
 		},
 	}
-	c := NewMetricsConverter(logger, nil)
+	tr, err := NewMetricTranslator([]Rule{}, 1, true)
+	require.NoError(t, err)
+	c := NewMetricsConverter(logger, tr)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotSfxDataPoints, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(tt.metricsDataFn(), nil)
@@ -382,7 +384,7 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 				"old.dim": "new.dim",
 			},
 		},
-	}, 1)
+	}, 1, false)
 	require.NoError(t, err)
 
 	md := []consumerdata.MetricsData{
@@ -418,7 +420,7 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 			MetricType: &gaugeType,
 			Dimensions: []*sfxpb.Dimension{
 				{
-					Key:   "new_dim",
+					Key:   "new.dim",
 					Value: "val1",
 				},
 			},

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -535,7 +535,7 @@ func TestNewMetricTranslator(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mt, err := NewMetricTranslator(tt.trs, 1)
+			mt, err := NewMetricTranslator(tt.trs, 1, false)
 			if tt.wantError == "" {
 				require.NoError(t, err)
 				require.NotNil(t, mt)
@@ -1876,7 +1876,7 @@ func TestTranslateDataPoints(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mt, err := NewMetricTranslator(tt.trs, 1)
+			mt, err := NewMetricTranslator(tt.trs, 1, false)
 			require.NoError(t, err)
 			assert.NotEqualValues(t, tt.want, tt.dps)
 			got := mt.TranslateDataPoints(zap.NewNop(), tt.dps)
@@ -1922,7 +1922,7 @@ func TestTestTranslateDimension(t *testing.T) {
 				"old.dimension": "new.dimension",
 			},
 		},
-	}, 1)
+	}, 1, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, "new_dimension", mt.TranslateDimension("old_dimension"))
@@ -1930,7 +1930,7 @@ func TestTestTranslateDimension(t *testing.T) {
 	assert.Equal(t, "another_dimension", mt.TranslateDimension("another_dimension"))
 
 	// Test no rename_dimension_keys translation rule
-	mt, err = NewMetricTranslator([]Rule{}, 1)
+	mt, err = NewMetricTranslator([]Rule{}, 1, false)
 	require.NoError(t, err)
 	assert.Equal(t, "old_dimension", mt.TranslateDimension("old_dimension"))
 }
@@ -2021,7 +2021,7 @@ func TestNewCalculateNewMetricErrors(t *testing.T) {
 				Operand1Metric: "metric1",
 				Operand2Metric: "metric2",
 				Operator:       MetricOperatorDivision,
-			}}, 1)
+			}}, 1, false)
 			require.NoError(t, err)
 			tr := mt.TranslateDataPoints(logger, dps)
 			require.Equal(t, 2, len(tr))
@@ -2042,7 +2042,7 @@ func TestNewMetricTranslator_InvalidOperator(t *testing.T) {
 		Operand1Metric: "metric1",
 		Operand2Metric: "metric2",
 		Operator:       "*",
-	}}, 1)
+	}}, 1, false)
 	require.Errorf(
 		t,
 		err,
@@ -2198,7 +2198,7 @@ func TestCalculateNewMetric_MatchingDims_Single(t *testing.T) {
 		Operand1Metric: "metric1",
 		Operand2Metric: "metric2",
 		Operator:       "/",
-	}}, 1)
+	}}, 1, true)
 	require.NoError(t, err)
 	m1 := &sfxpb.DataPoint{
 		Metric:     "metric1",
@@ -2249,7 +2249,7 @@ func TestCalculateNewMetric_MatchingDims_Multi(t *testing.T) {
 		Operand1Metric: "metric1",
 		Operand2Metric: "metric2",
 		Operator:       "/",
-	}}, 1)
+	}}, 1, true)
 	require.NoError(t, err)
 	m1 := &sfxpb.DataPoint{
 		Metric:     "metric1",
@@ -2336,7 +2336,7 @@ func TestUnsupportedOperator(t *testing.T) {
 		Operand1Metric: "metric1",
 		Operand2Metric: "metric2",
 		Operator:       "*",
-	}}, 1)
+	}}, 1, true)
 	require.Error(t, err)
 }
 
@@ -2347,7 +2347,7 @@ func TestCalculateNewMetric_Double(t *testing.T) {
 		Operand1Metric: "metric1",
 		Operand2Metric: "metric2",
 		Operator:       "/",
-	}}, 1)
+	}}, 1, true)
 	require.NoError(t, err)
 	m1 := &sfxpb.DataPoint{
 		Metric:     "metric1",
@@ -2590,7 +2590,7 @@ func testConverter(t *testing.T, mapping map[string]string) *MetricsConverter {
 		Action:  ActionDeltaMetric,
 		Mapping: mapping,
 	}}
-	tr, err := NewMetricTranslator(rules, 1)
+	tr, err := NewMetricTranslator(rules, 1, true)
 	require.NoError(t, err)
 
 	c := NewMetricsConverter(zap.NewNop(), tr)


### PR DESCRIPTION
**Description:**
The backend will be ready to accept `.` and `/` in dimension name soon. Need to make it optional before we can disable it completely. 
