### PR TITLE
3/3 Extend Windows Performance Counters Receiver to support counters with instances

### DIFF
--- a/receiver/windowsperfcountersreceiver/config_test.go
+++ b/receiver/windowsperfcountersreceiver/config_test.go
@@ -84,6 +84,7 @@ func TestLoadConfig_Error(t *testing.T) {
 		noPerfCountersErr             = "must specify at least one perf counter"
 		noObjectNameErr               = "must specify object name for all perf counters"
 		noCountersErr                 = `perf counter for object "%s" does not specify any counters`
+		emptyInstanceErr              = `perf counter for object "%s" includes an empty instance`
 	)
 
 	testCases := []testCase{
@@ -108,9 +109,21 @@ func TestLoadConfig_Error(t *testing.T) {
 			expectedErr: fmt.Sprintf("%s: %s", errorPrefix, fmt.Sprintf(noCountersErr, "object")),
 		},
 		{
-			name:        "AllErrors",
-			cfgFile:     "config-allerrors.yaml",
-			expectedErr: fmt.Sprintf("%s: [%s; %s; %s]", errorPrefix, negativeCollectionIntervalErr, fmt.Sprintf(noCountersErr, "object"), noObjectNameErr),
+			name:        "EmptyInstance",
+			cfgFile:     "config-emptyinstance.yaml",
+			expectedErr: fmt.Sprintf("%s: %s", errorPrefix, fmt.Sprintf(emptyInstanceErr, "object")),
+		},
+		{
+			name:    "AllErrors",
+			cfgFile: "config-allerrors.yaml",
+			expectedErr: fmt.Sprintf(
+				"%s: [%s; %s; %s; %s]",
+				errorPrefix,
+				negativeCollectionIntervalErr,
+				fmt.Sprintf(emptyInstanceErr, "object"),
+				fmt.Sprintf(noCountersErr, "object"),
+				noObjectNameErr,
+			),
 		},
 	}
 

--- a/receiver/windowsperfcountersreceiver/config_windows.go
+++ b/receiver/windowsperfcountersreceiver/config_windows.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package windowsperfcountersreceiver
+
+func (pc *PerfCounterConfig) instances() []string {
+	if len(pc.Instances) == 0 {
+		return []string{""}
+	}
+
+	for _, instance := range pc.Instances {
+		if instance == "*" {
+			return []string{"*"}
+		}
+	}
+
+	return pc.Instances
+}

--- a/receiver/windowsperfcountersreceiver/example_config.yaml
+++ b/receiver/windowsperfcountersreceiver/example_config.yaml
@@ -9,6 +9,14 @@ receivers:
       - object: "Memory"
         counters:
           - "Committed Bytes"
+      - object: "Processor"
+        instances: "*"
+        counters:
+          - "% Processor Time"
+      - object: "Processor"
+        instances: [1, 2]
+        counters:
+          - "% Idle Time"
 
 exporters:
   logging:

--- a/receiver/windowsperfcountersreceiver/testdata/config-emptyinstance.yaml
+++ b/receiver/windowsperfcountersreceiver/testdata/config-emptyinstance.yaml
@@ -1,10 +1,10 @@
 receivers:
   windowsperfcounters:
-    collection_interval: -1m
     perfcounters:
-      - 
       - object: "object"
-        instances: [ "instance", "", "*" ]
+        instances: [""]
+        counters:
+          - "counter"
 
 processors:
   exampleprocessor:

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -30,17 +30,18 @@ import (
 )
 
 type mockPerfCounter struct {
+	path      string
 	scrapeErr error
 	closeErr  error
 }
 
-func newMockPerfCounter(scrapeErr, closeErr error) *mockPerfCounter {
-	return &mockPerfCounter{scrapeErr: scrapeErr, closeErr: closeErr}
+func newMockPerfCounter(path string, scrapeErr, closeErr error) *mockPerfCounter {
+	return &mockPerfCounter{path: path, scrapeErr: scrapeErr, closeErr: closeErr}
 }
 
 // Path
 func (mpc *mockPerfCounter) Path() string {
-	return ""
+	return mpc.path
 }
 
 // ScrapeData
@@ -54,16 +55,22 @@ func (mpc *mockPerfCounter) Close() error {
 }
 
 func Test_WindowsPerfCounterScraper(t *testing.T) {
+	type expectedMetric struct {
+		name                string
+		instanceLabelValues []string
+	}
+
 	type testCase struct {
 		name string
 		cfg  *Config
 
-		newErr        string
-		initializeErr string
-		scrapeErr     error
-		closeErr      error
+		newErr          string
+		mockCounterPath string
+		initializeErr   string
+		scrapeErr       error
+		closeErr        error
 
-		expectedMetrics int
+		expectedMetrics []expectedMetric
 	}
 
 	defaultConfig := &Config{
@@ -75,8 +82,21 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:            "Standard",
-			expectedMetrics: 1,
+			name: "Standard",
+			cfg: &Config{
+				PerfCounters: []PerfCounterConfig{
+					{Object: "Memory", Counters: []string{"Committed Bytes"}},
+					{Object: "Processor", Instances: []string{"*"}, Counters: []string{"% Processor Time"}},
+					{Object: "Processor", Instances: []string{"1", "2"}, Counters: []string{"% Idle Time"}},
+				},
+				ScraperControllerSettings: receiverhelper.ScraperControllerSettings{CollectionInterval: time.Minute},
+			},
+			expectedMetrics: []expectedMetric{
+				{name: `\Memory\Committed Bytes`},
+				{name: `\Processor(*)\% Processor Time`, instanceLabelValues: []string{"*"}},
+				{name: `\Processor(1)\% Idle Time`, instanceLabelValues: []string{"1"}},
+				{name: `\Processor(2)\% Idle Time`, instanceLabelValues: []string{"2"}},
+			},
 		},
 		{
 			name: "InvalidCounter",
@@ -93,7 +113,7 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 				},
 				ScraperControllerSettings: receiverhelper.ScraperControllerSettings{CollectionInterval: time.Minute},
 			},
-			initializeErr: "The specified object was not found on the computer.\r\n",
+			initializeErr: "error initializing counter \\Invalid Object\\Invalid Counter: The specified object was not found on the computer.\r\n",
 		},
 		{
 			name:      "ScrapeError",
@@ -101,7 +121,7 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 		},
 		{
 			name:            "CloseError",
-			expectedMetrics: 1,
+			expectedMetrics: []expectedMetric{{name: ""}},
 			closeErr:        errors.New("err1"),
 		},
 	}
@@ -125,9 +145,9 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			if test.scrapeErr != nil || test.closeErr != nil {
+			if test.mockCounterPath != "" || test.scrapeErr != nil || test.closeErr != nil {
 				for i := range scraper.counters {
-					scraper.counters[i] = newMockPerfCounter(test.scrapeErr, test.closeErr)
+					scraper.counters[i] = newMockPerfCounter(test.mockCounterPath, test.scrapeErr, test.closeErr)
 				}
 			}
 
@@ -138,7 +158,47 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assert.Equal(t, test.expectedMetrics, metrics.Len())
+			require.Equal(t, len(test.expectedMetrics), metrics.Len())
+			for i, e := range test.expectedMetrics {
+				metric := metrics.At(i)
+				assert.Equal(t, e.name, metric.Name())
+
+				ddp := metric.DoubleGauge().DataPoints()
+
+				var allInstances bool
+				for _, v := range e.instanceLabelValues {
+					if v == "*" {
+						allInstances = true
+						break
+					}
+				}
+
+				if allInstances {
+					require.GreaterOrEqual(t, ddp.Len(), 1)
+				} else {
+					expectedDataPoints := 1
+					if len(e.instanceLabelValues) > 0 {
+						expectedDataPoints = len(e.instanceLabelValues)
+					}
+
+					require.Equal(t, expectedDataPoints, ddp.Len())
+				}
+
+				if len(e.instanceLabelValues) > 0 {
+					instanceLabelValues := make([]string, 0, ddp.Len())
+					for i := 0; i < ddp.Len(); i++ {
+						instanceLabelValue, ok := ddp.At(i).LabelsMap().Get(instanceLabelName)
+						require.Truef(t, ok, "data point was missing %q label", instanceLabelName)
+						instanceLabelValues = append(instanceLabelValues, instanceLabelValue)
+					}
+
+					if !allInstances {
+						for _, v := range e.instanceLabelValues {
+							assert.Contains(t, instanceLabelValues, v)
+						}
+					}
+				}
+			}
 
 			err = scraper.close(context.Background())
 			if test.closeErr != nil {


### PR DESCRIPTION
**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1088

**Description:** Extend the Windows Performance Counters Receiver to support counters that includes "instances".

**Testing:** Coverage is not reported for code behind non-Linux build flags, but it is over 95% on Windows for this component:
```bash
> go test -coverprofile="coverage.txt" -covermode="atomic"
PASS
coverage: 96.5% of statements
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver  0.660s
```