### PR TITLE
Disable stability tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ integration-tests-with-cover:
 # Long-running e2e tests
 .PHONY: stability-tests
 stability-tests: otelcontribcol
-	$(MAKE) -C testbed run-stability-tests
+	@echo Stability tests are disabled until we have a stable performance environment.
+	@echo To enable the tests replace this echo by $(MAKE) -C testbed run-stability-tests
 
 .PHONY: gotidy
 gotidy:


### PR DESCRIPTION
Stability tests are not stable on CircleCI because CircleCI
is not stable itself. This causes unnecessary build failures and
delays our work.

I am disabling the tests until we have a proper stable performance testing
environment.
