### PR TITLE
sfxexporter: Revert updates from #1223 for metrics exporter

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -61,7 +61,7 @@ The following configuration options can also be configured:
   or environment variable detector setting a unique value to `host.name` attribute
   within your k8s cluster. And keep `override=true` in resourcedetection config.
 
-In addition, this exporter offers queued retry which is enabled by default.
+In addition, this exporter offers queued retry for logs which is enabled by default.
 Information about queued retry configuration parameters can be found
 [here](https://github.com/open-telemetry/opentelemetry-collector/blob/master/exporter/exporterhelper/README.md).
 

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -33,6 +33,7 @@ import (
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -986,4 +987,19 @@ func BenchmarkExporterConsumeData(b *testing.B) {
 		assert.NoError(b, err)
 		assert.Equal(b, 0, numDroppedTimeSeries)
 	}
+}
+
+// Tests to ensure SignalFx exporter implements collection.MetadataExporter in k8s_cluster receiver.
+func TestSignalFxExporterConsumeMetadata(t *testing.T) {
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig()
+	rCfg := cfg.(*Config)
+	rCfg.AccessToken = "token"
+	rCfg.Realm = "realm"
+	exp, err := f.CreateMetricsExporter(context.Background(), component.ExporterCreateParams{}, rCfg)
+	require.NoError(t, err)
+
+	kme, ok := exp.(collection.MetadataExporter)
+	require.True(t, ok, "SignalFx exporter does not implement collection.MetadataExporter")
+	require.NotNil(t, kme)
 }

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -80,13 +80,7 @@ func createMetricsExporter(
 		return nil, err
 	}
 
-	return exporterhelper.NewMetricsExporter(
-		expCfg,
-		exp.pushMetrics,
-		// explicitly disable since we rely on http.Client timeout logic.
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
-		exporterhelper.WithRetry(expCfg.RetrySettings),
-		exporterhelper.WithQueue(expCfg.QueueSettings))
+	return exp, nil
 }
 
 func setTranslationRules(cfg *Config) error {


### PR DESCRIPTION
**Description:** Since the `signalfx` exporter implements `collection.MetadataExporter`, updates from #1223 to the metrics exporter are not currently compatible. This PR reverts the updates to the metrics exporter introduced by #1223  and adds a test around this.

**Testing:** Added a test.

**Documentation:** Clarified in README