### PR TITLE
OBSVS-369: Swapped kinesis opencensus producer with omnition producer

### DIFF
--- a/exporter/kinesisexporter/config.go
+++ b/exporter/kinesisexporter/config.go
@@ -47,9 +47,5 @@ type Config struct {
 	AWS AWSConfig `mapstructure:"aws"`
 	KPL KPLConfig `mapstructure:"kpl"`
 
-	QueueSize            int `mapstructure:"queue_size"`
-	NumWorkers           int `mapstructure:"num_workers"`
-	MaxBytesPerBatch     int `mapstructure:"max_bytes_per_batch"`
-	MaxBytesPerSpan      int `mapstructure:"max_bytes_per_span"`
-	FlushIntervalSeconds int `mapstructure:"flush_interval_seconds"`
+	ExportFormat string `mapstructure:"export_format"`
 }

--- a/exporter/kinesisexporter/config_test.go
+++ b/exporter/kinesisexporter/config_test.go
@@ -56,12 +56,6 @@ func TestDefaultConfig(t *testing.T) {
 				FlushIntervalSeconds: 5,
 				MaxConnections:       24,
 			},
-
-			QueueSize:            100000,
-			NumWorkers:           8,
-			FlushIntervalSeconds: 5,
-			MaxBytesPerBatch:     100000,
-			MaxBytesPerSpan:      900000,
 		},
 	)
 }
@@ -69,7 +63,6 @@ func TestDefaultConfig(t *testing.T) {
 func TestConfig(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.Nil(t, err)
-
 	factory := NewFactory()
 	factories.Exporters[factory.Type()] = factory
 	cfg, err := configtest.LoadConfigFile(
@@ -104,12 +97,6 @@ func TestConfig(t *testing.T) {
 				MaxRetries:           17,
 				MaxBackoffSeconds:    18,
 			},
-
-			QueueSize:            1,
-			NumWorkers:           2,
-			FlushIntervalSeconds: 3,
-			MaxBytesPerBatch:     4,
-			MaxBytesPerSpan:      5,
 		},
 	)
 }

--- a/exporter/kinesisexporter/go.mod
+++ b/exporter/kinesisexporter/go.mod
@@ -3,6 +3,8 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kinesi
 go 1.14
 
 require (
+	github.com/aws/aws-sdk-go v1.34.9
+	github.com/signalfx/omnition-kinesis-producer v0.5.0
 	github.com/signalfx/opencensus-go-exporter-kinesis v0.6.3
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.12.0

--- a/exporter/kinesisexporter/testdata/config.yaml
+++ b/exporter/kinesisexporter/testdata/config.yaml
@@ -3,12 +3,7 @@ receivers:
 
 exporters:
   kinesis:
-    queue_size: 1
-    num_workers: 2
-    flush_interval_seconds: 3
-    max_bytes_per_batch: 4
-    max_bytes_per_span: 5
-
+    export_format: ""
     aws:
         stream_name: test-stream
         region: mars-1


### PR DESCRIPTION
**Description:** 
Swapping out opencensus kinesis producer with omnition kinesis producer to enable OTEL compatibility 

**Testing:**
* Modified test yaml file for config_test.go and ran the tests.