### PR TITLE
Remove InstrumentationLibrary dimension in CloudWatch EMF Logs if it is undefined

### DIFF
--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -32,7 +32,8 @@ const (
 	CleanInterval = 5 * time.Minute
 	MinTimeDiff   = 50 * time.Millisecond // We assume 50 milli-seconds is the minimal gap between two collected data sample to be valid to calculate delta
 
-	OtlibDimensionKey            = "OTLib"
+	// OTel instrumentation lib name as dimension
+	OTellibDimensionKey          = "OTelLib"
 	defaultNameSpace             = "default"
 	noInstrumentationLibraryName = "Undefined"
 
@@ -79,6 +80,7 @@ type CWMetricStats struct {
 func TranslateOtToCWMetric(rm *pdata.ResourceMetrics, dimensionRollupOption string, namespace string) ([]*CWMetrics, int) {
 	var cwMetricLists []*CWMetrics
 	totalDroppedMetrics := 0
+	var instrumentationLibName string
 
 	if len(namespace) == 0 && !rm.Resource().IsNil() {
 		serviceName, svcNameOk := rm.Resource().Attributes().Get(conventions.AttributeServiceName)
@@ -103,10 +105,10 @@ func TranslateOtToCWMetric(rm *pdata.ResourceMetrics, dimensionRollupOption stri
 			continue
 		}
 		if ilm.InstrumentationLibrary().IsNil() {
-			ilm.InstrumentationLibrary().InitEmpty()
-			ilm.InstrumentationLibrary().SetName(noInstrumentationLibraryName)
+			instrumentationLibName = noInstrumentationLibraryName
+		} else {
+			instrumentationLibName = ilm.InstrumentationLibrary().Name()
 		}
-		OTLib := ilm.InstrumentationLibrary().Name()
 
 		metrics := ilm.Metrics()
 		for k := 0; k < metrics.Len(); k++ {
@@ -115,7 +117,7 @@ func TranslateOtToCWMetric(rm *pdata.ResourceMetrics, dimensionRollupOption stri
 				totalDroppedMetrics++
 				continue
 			}
-			cwMetricList := getMeasurements(&metric, namespace, OTLib, dimensionRollupOption)
+			cwMetricList := getMeasurements(&metric, namespace, instrumentationLibName, dimensionRollupOption)
 			cwMetricLists = append(cwMetricLists, cwMetricList...)
 		}
 	}
@@ -148,7 +150,7 @@ func TranslateCWMetricToEMF(cwMetricLists []*CWMetrics) []*LogEvent {
 	return ples
 }
 
-func getMeasurements(metric *pdata.Metric, namespace string, OTLib string, dimensionRollupOption string) []*CWMetrics {
+func getMeasurements(metric *pdata.Metric, namespace string, instrumentationLibName string, dimensionRollupOption string) []*CWMetrics {
 	var result []*CWMetrics
 
 	// metric measure data from OT
@@ -170,7 +172,7 @@ func getMeasurements(metric *pdata.Metric, namespace string, OTLib string, dimen
 			if dp.IsNil() {
 				continue
 			}
-			cwMetric := buildCWMetricFromDP(dp, metric, namespace, metricSlice, OTLib, dimensionRollupOption)
+			cwMetric := buildCWMetricFromDP(dp, metric, namespace, metricSlice, instrumentationLibName, dimensionRollupOption)
 			if cwMetric != nil {
 				result = append(result, cwMetric)
 			}
@@ -185,7 +187,7 @@ func getMeasurements(metric *pdata.Metric, namespace string, OTLib string, dimen
 			if dp.IsNil() {
 				continue
 			}
-			cwMetric := buildCWMetricFromDP(dp, metric, namespace, metricSlice, OTLib, dimensionRollupOption)
+			cwMetric := buildCWMetricFromDP(dp, metric, namespace, metricSlice, instrumentationLibName, dimensionRollupOption)
 			if cwMetric != nil {
 				result = append(result, cwMetric)
 			}
@@ -200,7 +202,7 @@ func getMeasurements(metric *pdata.Metric, namespace string, OTLib string, dimen
 			if dp.IsNil() {
 				continue
 			}
-			cwMetric := buildCWMetricFromDP(dp, metric, namespace, metricSlice, OTLib, dimensionRollupOption)
+			cwMetric := buildCWMetricFromDP(dp, metric, namespace, metricSlice, instrumentationLibName, dimensionRollupOption)
 			if cwMetric != nil {
 				result = append(result, cwMetric)
 			}
@@ -215,7 +217,7 @@ func getMeasurements(metric *pdata.Metric, namespace string, OTLib string, dimen
 			if dp.IsNil() {
 				continue
 			}
-			cwMetric := buildCWMetricFromDP(dp, metric, namespace, metricSlice, OTLib, dimensionRollupOption)
+			cwMetric := buildCWMetricFromDP(dp, metric, namespace, metricSlice, instrumentationLibName, dimensionRollupOption)
 			if cwMetric != nil {
 				result = append(result, cwMetric)
 			}
@@ -230,7 +232,7 @@ func getMeasurements(metric *pdata.Metric, namespace string, OTLib string, dimen
 			if dp.IsNil() {
 				continue
 			}
-			cwMetric := buildCWMetricFromHistogram(dp, metric, namespace, metricSlice, OTLib, dimensionRollupOption)
+			cwMetric := buildCWMetricFromHistogram(dp, metric, namespace, metricSlice, instrumentationLibName, dimensionRollupOption)
 			if cwMetric != nil {
 				result = append(result, cwMetric)
 			}
@@ -239,7 +241,7 @@ func getMeasurements(metric *pdata.Metric, namespace string, OTLib string, dimen
 	return result
 }
 
-func buildCWMetricFromDP(dp interface{}, pmd *pdata.Metric, namespace string, metricSlice []map[string]string, OTLib string, dimensionRollupOption string) *CWMetrics {
+func buildCWMetricFromDP(dp interface{}, pmd *pdata.Metric, namespace string, metricSlice []map[string]string, instrumentationLibName string, dimensionRollupOption string) *CWMetrics {
 	// fields contains metric and dimensions key/value pairs
 	fieldsPairs := make(map[string]interface{})
 	var dimensionArray [][]string
@@ -257,9 +259,13 @@ func buildCWMetricFromDP(dp interface{}, pmd *pdata.Metric, namespace string, me
 		fieldsPairs[k] = v.Value()
 		dimensionSlice = append(dimensionSlice, k)
 	})
-	// add OTLib as an additional dimension
-	fieldsPairs[OtlibDimensionKey] = OTLib
-	dimensionArray = append(dimensionArray, append(dimensionSlice, OtlibDimensionKey))
+	// add OTel instrumentation lib name as an additional dimension if it is defined
+	if instrumentationLibName != noInstrumentationLibraryName {
+		fieldsPairs[OTellibDimensionKey] = instrumentationLibName
+		dimensionArray = append(dimensionArray, append(dimensionSlice, OTellibDimensionKey))
+	} else {
+		dimensionArray = append(dimensionArray, dimensionSlice)
+	}
 
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 	var metricVal interface{}
@@ -279,7 +285,7 @@ func buildCWMetricFromDP(dp interface{}, pmd *pdata.Metric, namespace string, me
 	fieldsPairs[pmd.Name()] = metricVal
 
 	// EMF dimension attr takes list of list on dimensions. Including single/zero dimension rollup
-	rollupDimensionArray := dimensionRollup(dimensionRollupOption, dimensionSlice)
+	rollupDimensionArray := dimensionRollup(dimensionRollupOption, dimensionSlice, instrumentationLibName)
 	if len(rollupDimensionArray) > 0 {
 		dimensionArray = append(dimensionArray, rollupDimensionArray...)
 	}
@@ -299,7 +305,7 @@ func buildCWMetricFromDP(dp interface{}, pmd *pdata.Metric, namespace string, me
 	return cwMetric
 }
 
-func buildCWMetricFromHistogram(metric pdata.DoubleHistogramDataPoint, pmd *pdata.Metric, namespace string, metricSlice []map[string]string, OTLib string, dimensionRollupOption string) *CWMetrics {
+func buildCWMetricFromHistogram(metric pdata.DoubleHistogramDataPoint, pmd *pdata.Metric, namespace string, metricSlice []map[string]string, instrumentationLibName string, dimensionRollupOption string) *CWMetrics {
 	// fields contains metric and dimensions key/value pairs
 	fieldsPairs := make(map[string]interface{})
 	var dimensionArray [][]string
@@ -311,9 +317,13 @@ func buildCWMetricFromHistogram(metric pdata.DoubleHistogramDataPoint, pmd *pdat
 		fieldsPairs[k] = v.Value()
 		dimensionSlice = append(dimensionSlice, k)
 	})
-	// add OTLib as an additional dimension
-	fieldsPairs[OtlibDimensionKey] = OTLib
-	dimensionArray = append(dimensionArray, append(dimensionSlice, OtlibDimensionKey))
+	// add OTel instrumentation lib name as an additional dimension if it is defined
+	if instrumentationLibName != noInstrumentationLibraryName {
+		fieldsPairs[OTellibDimensionKey] = instrumentationLibName
+		dimensionArray = append(dimensionArray, append(dimensionSlice, OTellibDimensionKey))
+	} else {
+		dimensionArray = append(dimensionArray, dimensionSlice)
+	}
 
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 
@@ -327,7 +337,7 @@ func buildCWMetricFromHistogram(metric pdata.DoubleHistogramDataPoint, pmd *pdat
 	fieldsPairs[pmd.Name()] = metricStats
 
 	// EMF dimension attr takes list of list on dimensions. Including single/zero dimension rollup
-	rollupDimensionArray := dimensionRollup(dimensionRollupOption, dimensionSlice)
+	rollupDimensionArray := dimensionRollup(dimensionRollupOption, dimensionSlice, instrumentationLibName)
 	if len(rollupDimensionArray) > 0 {
 		dimensionArray = append(dimensionArray, rollupDimensionArray...)
 	}
@@ -404,12 +414,15 @@ func calculateRate(fields map[string]interface{}, val interface{}, timestamp int
 	return metricRate
 }
 
-func dimensionRollup(dimensionRollupOption string, originalDimensionSlice []string) [][]string {
+func dimensionRollup(dimensionRollupOption string, originalDimensionSlice []string, instrumentationLibName string) [][]string {
 	var rollupDimensionArray [][]string
-	dimensionZero := []string{OtlibDimensionKey}
+	var dimensionZero []string
+	if instrumentationLibName != noInstrumentationLibraryName {
+		dimensionZero = append(dimensionZero, OTellibDimensionKey)
+	}
 	if dimensionRollupOption == ZeroAndSingleDimensionRollup {
 		//"Zero" dimension rollup
-		if len(originalDimensionSlice) > 0 {
+		if len(originalDimensionSlice) > 0 && len(dimensionZero) > 0 {
 			rollupDimensionArray = append(rollupDimensionArray, dimensionZero)
 		}
 	}

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -416,13 +416,13 @@ func calculateRate(fields map[string]interface{}, val interface{}, timestamp int
 
 func dimensionRollup(dimensionRollupOption string, originalDimensionSlice []string, instrumentationLibName string) [][]string {
 	var rollupDimensionArray [][]string
-	var dimensionZero []string
+	dimensionZero := []string{}
 	if instrumentationLibName != noInstrumentationLibraryName {
 		dimensionZero = append(dimensionZero, OTellibDimensionKey)
 	}
 	if dimensionRollupOption == ZeroAndSingleDimensionRollup {
 		//"Zero" dimension rollup
-		if len(originalDimensionSlice) > 0 && len(dimensionZero) > 0 {
+		if len(originalDimensionSlice) > 0 {
 			rollupDimensionArray = append(rollupDimensionArray, dimensionZero)
 		}
 	}

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -31,9 +31,235 @@ import (
 	"go.opentelemetry.io/collector/translator/internaldata"
 )
 
-func TestTranslateOtToCWMetric(t *testing.T) {
+func TestTranslateOtToCWMetricWithInstrLibrary(t *testing.T) {
 
+	md := createMetricTestData()
+	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
+	ilms := rm.InstrumentationLibraryMetrics()
+	ilm := ilms.At(0)
+	ilm.InstrumentationLibrary().InitEmpty()
+	ilm.InstrumentationLibrary().SetName("cloudwatch-lib")
+	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+	assert.Equal(t, 1, totalDroppedMetrics)
+	assert.NotNil(t, cwm)
+	assert.Equal(t, 5, len(cwm))
+	assert.Equal(t, 1, len(cwm[0].Measurements))
+
+	met := cwm[0]
+
+	assert.Equal(t, met.Fields["spanCounter"], 0)
+	assert.Equal(t, "myServiceNS/myServiceName", met.Measurements[0].Namespace)
+	assert.Equal(t, 4, len(met.Measurements[0].Dimensions))
+	dimensions := met.Measurements[0].Dimensions[0]
+	sort.Strings(dimensions)
+	assert.Equal(t, []string{OTellibDimensionKey, "isItAnError", "spanName"}, dimensions)
+	assert.Equal(t, 1, len(met.Measurements[0].Metrics))
+	assert.Equal(t, "spanCounter", met.Measurements[0].Metrics[0]["Name"])
+	assert.Equal(t, "Count", met.Measurements[0].Metrics[0]["Unit"])
+}
+
+func TestTranslateOtToCWMetricWithoutInstrLibrary(t *testing.T) {
+
+	md := createMetricTestData()
+	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
+	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+	assert.Equal(t, 1, totalDroppedMetrics)
+	assert.NotNil(t, cwm)
+	assert.Equal(t, 5, len(cwm))
+	assert.Equal(t, 1, len(cwm[0].Measurements))
+
+	met := cwm[0]
+	assert.NotContains(t, met.Fields, OTellibDimensionKey)
+	assert.Equal(t, met.Fields["spanCounter"], 0)
+
+	assert.Equal(t, "myServiceNS/myServiceName", met.Measurements[0].Namespace)
+	assert.Equal(t, 3, len(met.Measurements[0].Dimensions))
+	dimensions := met.Measurements[0].Dimensions[0]
+	sort.Strings(dimensions)
+	assert.Equal(t, []string{"isItAnError", "spanName"}, dimensions)
+	assert.Equal(t, 1, len(met.Measurements[0].Metrics))
+	assert.Equal(t, "spanCounter", met.Measurements[0].Metrics[0]["Name"])
+	assert.Equal(t, "Count", met.Measurements[0].Metrics[0]["Unit"])
+}
+
+func TestTranslateOtToCWMetricWithNameSpace(t *testing.T) {
 	md := consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
+		},
+		Resource: &resourcepb.Resource{
+			Labels: map[string]string{
+				conventions.AttributeServiceName: "myServiceName",
+			},
+		},
+		Metrics: []*metricspb.Metric{},
+	}
+	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
+	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+	assert.Equal(t, 0, totalDroppedMetrics)
+	assert.Nil(t, cwm)
+	assert.Equal(t, 0, len(cwm))
+	md = consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
+		},
+		Resource: &resourcepb.Resource{
+			Labels: map[string]string{
+				conventions.AttributeServiceNamespace: "myServiceNS",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan", HasValue: true},
+							{Value: "false", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+				},
+				Timeseries: []*metricspb.TimeSeries{},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanGaugeCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_GAUGE_INT64,
+				},
+				Timeseries: []*metricspb.TimeSeries{},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanGaugeDoubleCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+				},
+				Timeseries: []*metricspb.TimeSeries{},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanDoubleCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
+				},
+				Timeseries: []*metricspb.TimeSeries{},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanDoubleCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
+				},
+				Timeseries: []*metricspb.TimeSeries{},
+			},
+		},
+	}
+	rm = internaldata.OCToMetrics(md).ResourceMetrics().At(0)
+	cwm, totalDroppedMetrics = TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+	assert.Equal(t, 0, totalDroppedMetrics)
+	assert.NotNil(t, cwm)
+	assert.Equal(t, 1, len(cwm))
+
+	met := cwm[0]
+	assert.Equal(t, "myServiceNS", met.Measurements[0].Namespace)
+}
+
+func TestTranslateCWMetricToEMF(t *testing.T) {
+	cwMeasurement := CwMeasurement{
+		Namespace:  "test-emf",
+		Dimensions: [][]string{{"OTelLib"}, {"OTelLib", "spanName"}},
+		Metrics: []map[string]string{{
+			"Name": "spanCounter",
+			"Unit": "Count",
+		}},
+	}
+	timestamp := int64(1596151098037)
+	fields := make(map[string]interface{})
+	fields["OTelLib"] = "cloudwatch-otel"
+	fields["spanName"] = "test"
+	fields["spanCounter"] = 0
+
+	met := &CWMetrics{
+		Timestamp:    timestamp,
+		Fields:       fields,
+		Measurements: []CwMeasurement{cwMeasurement},
+	}
+	inputLogEvent := TranslateCWMetricToEMF([]*CWMetrics{met})
+
+	assert.Equal(t, readFromFile("testdata/testTranslateCWMetricToEMF.json"), *inputLogEvent[0].InputLogEvent.Message, "Expect to be equal")
+}
+
+func TestGetMeasurements(t *testing.T) {
+
+}
+
+func TestCalculateRate(t *testing.T) {
+	prevValue := int64(0)
+	curValue := int64(10)
+	fields := make(map[string]interface{})
+	fields["OTelLib"] = "cloudwatch-otel"
+	fields["spanName"] = "test"
+	fields["spanCounter"] = prevValue
+	fields["type"] = "Int64"
+	prevTime := time.Now().UnixNano() / int64(time.Millisecond)
+	curTime := time.Unix(0, prevTime*int64(time.Millisecond)).Add(time.Second*10).UnixNano() / int64(time.Millisecond)
+	rate := calculateRate(fields, prevValue, prevTime)
+	assert.Equal(t, 0, rate)
+	rate = calculateRate(fields, curValue, curTime)
+	assert.Equal(t, int64(1), rate)
+
+	prevDoubleValue := 0.0
+	curDoubleValue := 5.0
+	fields["type"] = "Float64"
+	rate = calculateRate(fields, prevDoubleValue, prevTime)
+	assert.Equal(t, 0, rate)
+	rate = calculateRate(fields, curDoubleValue, curTime)
+	assert.Equal(t, 0.5, rate)
+}
+
+func readFromFile(filename string) string {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+	str := string(data)
+	return str
+}
+
+func createMetricTestData() consumerdata.MetricsData {
+	return consumerdata.MetricsData{
 		Node: &commonpb.Node{
 			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
 		},
@@ -260,199 +486,4 @@ func TestTranslateOtToCWMetric(t *testing.T) {
 			},
 		},
 	}
-	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
-	assert.Equal(t, 1, totalDroppedMetrics)
-	assert.NotNil(t, cwm)
-	assert.Equal(t, 5, len(cwm))
-	assert.Equal(t, 1, len(cwm[0].Measurements))
-
-	met := cwm[0]
-	assert.Equal(t, met.Fields[OtlibDimensionKey], noInstrumentationLibraryName)
-	assert.Equal(t, met.Fields["spanCounter"], 0)
-
-	assert.Equal(t, "myServiceNS/myServiceName", met.Measurements[0].Namespace)
-	assert.Equal(t, 4, len(met.Measurements[0].Dimensions))
-	dimensions := met.Measurements[0].Dimensions[0]
-	sort.Strings(dimensions)
-	assert.Equal(t, []string{OtlibDimensionKey, "isItAnError", "spanName"}, dimensions)
-	assert.Equal(t, 1, len(met.Measurements[0].Metrics))
-	assert.Equal(t, "spanCounter", met.Measurements[0].Metrics[0]["Name"])
-	assert.Equal(t, "Count", met.Measurements[0].Metrics[0]["Unit"])
-}
-
-func TestTranslateOtToCWMetricWithNameSpace(t *testing.T) {
-	md := consumerdata.MetricsData{
-		Node: &commonpb.Node{
-			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
-		},
-		Resource: &resourcepb.Resource{
-			Labels: map[string]string{
-				conventions.AttributeServiceName: "myServiceName",
-			},
-		},
-		Metrics: []*metricspb.Metric{},
-	}
-	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
-	assert.Equal(t, 0, totalDroppedMetrics)
-	assert.Nil(t, cwm)
-	assert.Equal(t, 0, len(cwm))
-	md = consumerdata.MetricsData{
-		Node: &commonpb.Node{
-			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
-		},
-		Resource: &resourcepb.Resource{
-			Labels: map[string]string{
-				conventions.AttributeServiceNamespace: "myServiceNS",
-			},
-		},
-		Metrics: []*metricspb.Metric{
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan", HasValue: true},
-							{Value: "false", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 100,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanGaugeCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_GAUGE_INT64,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanGaugeDoubleCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanDoubleCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanDoubleCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
-				},
-				Timeseries: []*metricspb.TimeSeries{},
-			},
-		},
-	}
-	rm = internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	cwm, totalDroppedMetrics = TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
-	assert.Equal(t, 0, totalDroppedMetrics)
-	assert.NotNil(t, cwm)
-	assert.Equal(t, 1, len(cwm))
-
-	met := cwm[0]
-	assert.Equal(t, "myServiceNS", met.Measurements[0].Namespace)
-}
-
-func TestTranslateCWMetricToEMF(t *testing.T) {
-	cwMeasurement := CwMeasurement{
-		Namespace:  "test-emf",
-		Dimensions: [][]string{{"OTLib"}, {"OTLib", "spanName"}},
-		Metrics: []map[string]string{{
-			"Name": "spanCounter",
-			"Unit": "Count",
-		}},
-	}
-	timestamp := int64(1596151098037)
-	fields := make(map[string]interface{})
-	fields["OTLib"] = "cloudwatch-otel"
-	fields["spanName"] = "test"
-	fields["spanCounter"] = 0
-
-	met := &CWMetrics{
-		Timestamp:    timestamp,
-		Fields:       fields,
-		Measurements: []CwMeasurement{cwMeasurement},
-	}
-	inputLogEvent := TranslateCWMetricToEMF([]*CWMetrics{met})
-
-	assert.Equal(t, readFromFile("testdata/testTranslateCWMetricToEMF.json"), *inputLogEvent[0].InputLogEvent.Message, "Expect to be equal")
-}
-
-func TestGetMeasurements(t *testing.T) {
-
-}
-
-func TestCalculateRate(t *testing.T) {
-	prevValue := int64(0)
-	curValue := int64(10)
-	fields := make(map[string]interface{})
-	fields["OTLib"] = "cloudwatch-otel"
-	fields["spanName"] = "test"
-	fields["spanCounter"] = prevValue
-	fields["type"] = "Int64"
-	prevTime := time.Now().UnixNano() / int64(time.Millisecond)
-	curTime := time.Unix(0, prevTime*int64(time.Millisecond)).Add(time.Second*10).UnixNano() / int64(time.Millisecond)
-	rate := calculateRate(fields, prevValue, prevTime)
-	assert.Equal(t, 0, rate)
-	rate = calculateRate(fields, curValue, curTime)
-	assert.Equal(t, int64(1), rate)
-
-	prevDoubleValue := 0.0
-	curDoubleValue := 5.0
-	fields["type"] = "Float64"
-	rate = calculateRate(fields, prevDoubleValue, prevTime)
-	assert.Equal(t, 0, rate)
-	rate = calculateRate(fields, curDoubleValue, curTime)
-	assert.Equal(t, 0.5, rate)
-}
-
-func readFromFile(filename string) string {
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		panic(err)
-	}
-	str := string(data)
-	return str
 }

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -50,12 +50,23 @@ func TestTranslateOtToCWMetricWithInstrLibrary(t *testing.T) {
 	assert.Equal(t, met.Fields["spanCounter"], 0)
 	assert.Equal(t, "myServiceNS/myServiceName", met.Measurements[0].Namespace)
 	assert.Equal(t, 4, len(met.Measurements[0].Dimensions))
-	dimensions := met.Measurements[0].Dimensions[0]
-	sort.Strings(dimensions)
-	assert.Equal(t, []string{OTellibDimensionKey, "isItAnError", "spanName"}, dimensions)
+	dimensionSetOne := met.Measurements[0].Dimensions[0]
+	sort.Strings(dimensionSetOne)
+	assert.Equal(t, []string{OTellibDimensionKey, "isItAnError", "spanName"}, dimensionSetOne)
 	assert.Equal(t, 1, len(met.Measurements[0].Metrics))
 	assert.Equal(t, "spanCounter", met.Measurements[0].Metrics[0]["Name"])
 	assert.Equal(t, "Count", met.Measurements[0].Metrics[0]["Unit"])
+
+	dimensionSetTwo := met.Measurements[0].Dimensions[1]
+	assert.Equal(t, []string{OTellibDimensionKey}, dimensionSetTwo)
+
+	dimensionSetThree := met.Measurements[0].Dimensions[2]
+	sort.Strings(dimensionSetThree)
+	assert.Equal(t, []string{OTellibDimensionKey, "spanName"}, dimensionSetThree)
+
+	dimensionSetFour := met.Measurements[0].Dimensions[3]
+	sort.Strings(dimensionSetFour)
+	assert.Equal(t, []string{OTellibDimensionKey, "isItAnError"}, dimensionSetFour)
 }
 
 func TestTranslateOtToCWMetricWithoutInstrLibrary(t *testing.T) {
@@ -73,13 +84,25 @@ func TestTranslateOtToCWMetricWithoutInstrLibrary(t *testing.T) {
 	assert.Equal(t, met.Fields["spanCounter"], 0)
 
 	assert.Equal(t, "myServiceNS/myServiceName", met.Measurements[0].Namespace)
-	assert.Equal(t, 3, len(met.Measurements[0].Dimensions))
-	dimensions := met.Measurements[0].Dimensions[0]
-	sort.Strings(dimensions)
-	assert.Equal(t, []string{"isItAnError", "spanName"}, dimensions)
+	assert.Equal(t, 4, len(met.Measurements[0].Dimensions))
+	dimensionSetOne := met.Measurements[0].Dimensions[0]
+	sort.Strings(dimensionSetOne)
+	assert.Equal(t, []string{"isItAnError", "spanName"}, dimensionSetOne)
 	assert.Equal(t, 1, len(met.Measurements[0].Metrics))
 	assert.Equal(t, "spanCounter", met.Measurements[0].Metrics[0]["Name"])
 	assert.Equal(t, "Count", met.Measurements[0].Metrics[0]["Unit"])
+
+	// zero dimension metric
+	dimensionSetTwo := met.Measurements[0].Dimensions[1]
+	assert.Equal(t, []string{}, dimensionSetTwo)
+
+	dimensionSetThree := met.Measurements[0].Dimensions[2]
+	sort.Strings(dimensionSetTwo)
+	assert.Equal(t, []string{"spanName"}, dimensionSetThree)
+
+	dimensionSetFour := met.Measurements[0].Dimensions[3]
+	sort.Strings(dimensionSetFour)
+	assert.Equal(t, []string{"isItAnError"}, dimensionSetFour)
 }
 
 func TestTranslateOtToCWMetricWithNameSpace(t *testing.T) {

--- a/exporter/awsemfexporter/testdata/testTranslateCWMetricToEMF.json
+++ b/exporter/awsemfexporter/testdata/testTranslateCWMetricToEMF.json
@@ -1,1 +1,1 @@
-{"OTLib":"cloudwatch-otel","_aws":{"CloudWatchMetrics":[{"Namespace":"test-emf","Dimensions":[["OTLib"],["OTLib","spanName"]],"Metrics":[{"Name":"spanCounter","Unit":"Count"}]}],"Timestamp":1596151098037},"spanCounter":0,"spanName":"test"}
+{"OTelLib":"cloudwatch-otel","_aws":{"CloudWatchMetrics":[{"Namespace":"test-emf","Dimensions":[["OTelLib"],["OTelLib","spanName"]],"Metrics":[{"Name":"spanCounter","Unit":"Count"}]}],"Timestamp":1596151098037},"spanCounter":0,"spanName":"test"}


### PR DESCRIPTION
**Description:** 
In the current AWSEMFExporter, InstrumentationLibrary name is a fixed dimension when converting OTel metrics to CloudWatch EMF(structure logs) metrics. From the testing, there are some cases OTel metrics can be generated without InstrumentationLibrary attached. Eg, `AWSECSMetadataReceiver` generates ECS container Infra metrics without  InstrumentationLibrary.  In this case, we'd like to not add InstrumentationLibrary name as the dimension since it will generated the dimension value with `Undefined`. 

**Link to tracking Issue:** 
N/A

**Testing:** 
unit test