### PR TITLE
sfxexporter: Update disk.summary_utilization translation rule to accommodate new labels

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -180,7 +180,7 @@ func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
 
 	// Validate that default translation rules are loaded
 	// Expected values has to be updated once default config changed
-	assert.Equal(t, 49, len(config.TranslationRules))
+	assert.Equal(t, 51, len(config.TranslationRules))
 	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
 	assert.Equal(t, 33, len(config.TranslationRules[0].Mapping))
 }

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -378,10 +378,17 @@ translation_rules:
     system.filesystem.usage: disk.summary_total
 - action: aggregate_metric
   metric_name: disk.summary_total
+  aggregation_method: avg
+  without_dimensions:
+    - mode
+    - mountpoint
+- action: aggregate_metric
+  metric_name: disk.summary_total
   aggregation_method: sum
   without_dimensions:
     - state
     - device
+    - type
 
 # convert filesystem metrics
 - action: split_metric
@@ -401,12 +408,19 @@ translation_rules:
 # df_complex.used_total
 - action: copy_metrics
   mapping:
-    df_complex.used: df_complex.used_total 
+    df_complex.used: df_complex.used_total
+- action: aggregate_metric
+  metric_name: df_complex.used_total
+  aggregation_method: avg
+  without_dimensions:
+    - mode
+    - mountpoint
 - action: aggregate_metric
   metric_name: df_complex.used_total
   aggregation_method: sum
   without_dimensions:
   - device
+  - type
 
 # disk utilization
 - action: calculate_new_metric


### PR DESCRIPTION
Update translation rules to mean over "mode" and "mountpoint"  which are recently added labels to the filesystems scraper in hostmetrics receiver. This will ensure utilization is not double counted across mountpoints of a single device. Also, add "type" (also a newly added label) to existing translation rules to sum across fs types as well apart from device name.