### PR TITLE
awsecscontainermetrics: check for empty network rate stats and set zero

### DIFF
--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper.go
@@ -26,6 +26,7 @@ func getContainerMetrics(stats ContainerStats) ECSMetrics {
 	netStatArray := getNetworkStats(stats.Network)
 
 	storageReadBytes, storageWriteBytes := extractStorageUsage(&stats.Disk)
+	floatZero := float64(1.0)
 
 	m := ECSMetrics{}
 
@@ -42,8 +43,13 @@ func getContainerMetrics(stats ContainerStats) ECSMetrics {
 	m.SystemCPUUsage = *stats.CPU.SystemCPUUsage
 	m.CPUUtilized = cpuUtilized
 
-	m.NetworkRateRxBytesPerSecond = *stats.NetworkRate.TxBytesPerSecond
-	m.NetworkRateTxBytesPerSecond = *stats.NetworkRate.TxBytesPerSecond
+	if stats.NetworkRate == (NetworkRateStats{}) {
+		m.NetworkRateRxBytesPerSecond = floatZero
+		m.NetworkRateTxBytesPerSecond = floatZero
+	} else {
+		m.NetworkRateRxBytesPerSecond = *stats.NetworkRate.TxBytesPerSecond
+		m.NetworkRateTxBytesPerSecond = *stats.NetworkRate.TxBytesPerSecond
+	}
 
 	m.NetworkRxBytes = netStatArray[0]
 	m.NetworkRxPackets = netStatArray[1]

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper.go
@@ -26,7 +26,7 @@ func getContainerMetrics(stats ContainerStats) ECSMetrics {
 	netStatArray := getNetworkStats(stats.Network)
 
 	storageReadBytes, storageWriteBytes := extractStorageUsage(&stats.Disk)
-	floatZero := float64(1.0)
+	floatZero := float64(0)
 
 	m := ECSMetrics{}
 
@@ -47,7 +47,7 @@ func getContainerMetrics(stats ContainerStats) ECSMetrics {
 		m.NetworkRateRxBytesPerSecond = floatZero
 		m.NetworkRateTxBytesPerSecond = floatZero
 	} else {
-		m.NetworkRateRxBytesPerSecond = *stats.NetworkRate.TxBytesPerSecond
+		m.NetworkRateRxBytesPerSecond = *stats.NetworkRate.RxBytesPerSecond
 		m.NetworkRateTxBytesPerSecond = *stats.NetworkRate.TxBytesPerSecond
 	}
 

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper_test.go
@@ -94,6 +94,21 @@ func TestGetContainerAndTaskMetrics(t *testing.T) {
 	require.EqualValues(t, v, taskMetrics.MemoryUsage)
 	require.EqualValues(t, v, taskMetrics.MemoryMaxUsage)
 	require.EqualValues(t, v, taskMetrics.StorageReadBytes)
+
+	containerStats = ContainerStats{
+		Name:        "test",
+		ID:          "001",
+		Memory:      mem,
+		Disk:        disk,
+		Network:     net,
+		NetworkRate: NetworkRateStats{},
+		CPU:         cpuStats,
+	}
+	containerMetrics = getContainerMetrics(containerStats)
+	require.NotNil(t, containerMetrics)
+
+	require.EqualValues(t, f, containerMetrics.NetworkRateRxBytesPerSecond)
+	require.EqualValues(t, f, containerMetrics.NetworkRateTxBytesPerSecond)
 }
 
 func TestExtractStorageUsage(t *testing.T) {

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics_helper_test.go
@@ -23,6 +23,7 @@ import (
 func TestGetContainerAndTaskMetrics(t *testing.T) {
 	v := uint64(1)
 	f := float64(1.0)
+	floatZero := float64(0)
 
 	memStats := make(map[string]uint64)
 	memStats["cache"] = v
@@ -107,8 +108,8 @@ func TestGetContainerAndTaskMetrics(t *testing.T) {
 	containerMetrics = getContainerMetrics(containerStats)
 	require.NotNil(t, containerMetrics)
 
-	require.EqualValues(t, f, containerMetrics.NetworkRateRxBytesPerSecond)
-	require.EqualValues(t, f, containerMetrics.NetworkRateTxBytesPerSecond)
+	require.EqualValues(t, floatZero, containerMetrics.NetworkRateRxBytesPerSecond)
+	require.EqualValues(t, floatZero, containerMetrics.NetworkRateTxBytesPerSecond)
 }
 
 func TestExtractStorageUsage(t *testing.T) {


### PR DESCRIPTION

**Description:** <Describe what has changed.>
Fixing a bug: `awsecscontainermetrics` receiver works fine for the latest version of AWS ECS Agent. However, if customer uses an older version than 1.44.0, it throws a null pointer exception. This change adds a check for empty network stats (which occurs only if the Agent is under 1.44.0) and sets zero.

**Link to tracking Issue:** 
#1259 

**Testing:** 
Unit test added
