### PR TITLE
Install gcc before running Windows tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,11 @@ jobs:
       - checkout
       - restore_module_cache
       - run:
+          name: Install gcc (for cgo)
+          command: |
+            choco install mingw --version=8.1.0
+            refreshenv
+      - run:
           name: Upgrade golang
           command: |
             choco upgrade golang --version=1.15


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Fix CircleCI `windows-tests` suite.

**Link to tracking Issue:** #1270

**Testing:** The CircleCI `windows-test` passes on this branch

**Documentation:** n/a