### PR TITLE
exporters/datadog: remove trace support for windows for now

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -22,3 +22,7 @@ datadog:
 The hostname, environment, service and version can be set in the configuration for unified service tagging.
 
 See the sample configuration file under the `example` folder for other available options.
+
+## Trace Export Configuration
+
+_Note: Trace Export is not supported on windows at the moment_

--- a/exporter/datadogexporter/model.go
+++ b/exporter/datadogexporter/model.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package datadogexporter
 
 import (

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package datadogexporter
 
 import (

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package datadogexporter
 
 import (


### PR DESCRIPTION
This PR removes windows support for trace export for the datadog exporter for windows as it relies on packages which use cgo/gcc, which are causing the `windows-test` build step to fail https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1228. 

It should fix the failing build on master, cc @tigrannajaryan @mx-psi @james-bebbington 