### PR TITLE
Splunkhec receiver metrics

### DIFF
--- a/exporter/splunkhecexporter/exporter.go
+++ b/exporter/splunkhecexporter/exporter.go
@@ -107,7 +107,7 @@ func buildClient(options *exporterOptions, config *Config, logger *zap.Logger) *
 			"Connection":    "keep-alive",
 			"Content-Type":  "application/json",
 			"User-Agent":    "OpenTelemetry-Collector Splunk Exporter/v0.0.1",
-			"Authorization": splunk.SplunkHECTokenHeader + " " + config.Token,
+			"Authorization": splunk.HECTokenHeader + " " + config.Token,
 		},
 		config: config,
 	}

--- a/internal/common/splunk/common.go
+++ b/internal/common/splunk/common.go
@@ -22,8 +22,8 @@ const (
 	SFxEventCategoryKey   = "com.splunk.signalfx.event_category"
 	SFxEventPropertiesKey = "com.splunk.signalfx.event_properties"
 	SourcetypeLabel       = "com.splunk.sourcetype"
-	SplunkHECTokenHeader  = "Splunk"
-	SplunkHecTokenLabel   = "com.splunk.hec.access_token"
+	HECTokenHeader        = "Splunk"
+	HecTokenLabel         = "com.splunk.hec.access_token"
 	// HecEventMetricType is the type of HEC event. Set to metric, as per https://docs.splunk.com/Documentation/Splunk/8.0.3/Metrics/GetMetricsInOther.
 	HecEventMetricType = "metric"
 )

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -106,7 +106,14 @@ func createMetricsReceiver(
 	consumer consumer.MetricsConsumer,
 ) (component.MetricsReceiver, error) {
 
-	return nil, configerror.ErrDataTypeIsNotSupported
+	rCfg := cfg.(*Config)
+
+	err := rCfg.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewMetricsReceiver(params.Logger, *rCfg, consumer)
 }
 
 // createLogsReceiver creates a logs receiver based on provided config.
@@ -124,5 +131,5 @@ func createLogsReceiver(
 		return nil, err
 	}
 
-	return New(params.Logger, *rCfg, consumer)
+	return NewLogsReceiver(params.Logger, *rCfg, consumer)
 }

--- a/receiver/splunkhecreceiver/factory_test.go
+++ b/receiver/splunkhecreceiver/factory_test.go
@@ -44,8 +44,8 @@ func TestCreateReceiver(t *testing.T) {
 
 	mockMetricsConsumer := exportertest.NewNopMetricsExporter()
 	mReceiver, err := createMetricsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, mockMetricsConsumer)
-	assert.Equal(t, err, configerror.ErrDataTypeIsNotSupported)
-	assert.Nil(t, mReceiver)
+	assert.Nil(t, err, "receiver creation failed")
+	assert.NotNil(t, mReceiver, "receiver creation failed")
 
 	mockTracesConsumer := exportertest.NewNopTraceExporter()
 	tReceiver, err := createTraceReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, mockTracesConsumer)

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -260,10 +260,9 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 }
 
 func (r *splunkReceiver) createResourceCustomizer(req *http.Request) func(pdata.Resource) {
-	customizer := func(resource pdata.Resource) {}
 	if r.config.AccessTokenPassthrough {
 		if accessToken := req.Header.Get(splunk.HECTokenHeader); accessToken != "" {
-			customizer = func(resource pdata.Resource) {
+			return func(resource pdata.Resource) {
 				if resource.IsNil() {
 					resource.InitEmpty()
 				}
@@ -271,7 +270,7 @@ func (r *splunkReceiver) createResourceCustomizer(req *http.Request) func(pdata.
 			}
 		}
 	}
-	return customizer
+	return func(resource pdata.Resource) {}
 }
 
 func (r *splunkReceiver) consumeMetrics(ctx context.Context, events []*splunk.Event, resp http.ResponseWriter, req *http.Request) {

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -48,6 +48,7 @@ const (
 	responseErrUnmarshalBody          = "Failed to unmarshal message body"
 	responseErrInternalServerError    = "Internal Server Error"
 	responseErrUnsupportedMetricEvent = "Unsupported metric event"
+	responseErrUnsupportedLogEvent    = "Unsupported log event"
 
 	// Centralizing some HTTP and related string constants.
 	jsonContentType           = "application/json"
@@ -68,21 +69,53 @@ var (
 	errUnmarshalBodyRespBody  = initJSONResponse(responseErrUnmarshalBody)
 	errInternalServerError    = initJSONResponse(responseErrInternalServerError)
 	errUnsupportedMetricEvent = initJSONResponse(responseErrUnsupportedMetricEvent)
+	errUnsupportedLogEvent    = initJSONResponse(responseErrUnsupportedLogEvent)
 )
 
 // splunkReceiver implements the component.MetricsReceiver for Splunk HEC metric protocol.
 type splunkReceiver struct {
 	sync.Mutex
-	logger      *zap.Logger
-	config      *Config
-	logConsumer consumer.LogsConsumer
-	server      *http.Server
+	logger          *zap.Logger
+	config          *Config
+	logsConsumer    consumer.LogsConsumer
+	metricsConsumer consumer.MetricsConsumer
+	server          *http.Server
 }
 
 var _ component.MetricsReceiver = (*splunkReceiver)(nil)
 
-// New creates the Splunk HEC receiver with the given configuration.
-func New(
+// NewMetricsReceiver creates the Splunk HEC receiver with the given configuration.
+func NewMetricsReceiver(
+	logger *zap.Logger,
+	config Config,
+	nextConsumer consumer.MetricsConsumer,
+) (component.MetricsReceiver, error) {
+	if nextConsumer == nil {
+		return nil, errNilNextConsumer
+	}
+
+	if config.Endpoint == "" {
+		return nil, errEmptyEndpoint
+	}
+
+	r := &splunkReceiver{
+		logger:          logger,
+		config:          &config,
+		metricsConsumer: nextConsumer,
+		server: &http.Server{
+			Addr: config.Endpoint,
+			// TODO: Evaluate what properties should be configurable, for now
+			//		set some hard-coded values.
+			ReadHeaderTimeout: defaultServerTimeout,
+			WriteTimeout:      defaultServerTimeout,
+		},
+	}
+
+	return r, nil
+}
+
+// NewLogsReceiver creates the Splunk HEC receiver with the given configuration.
+func NewLogsReceiver(
 	logger *zap.Logger,
 	config Config,
 	nextConsumer consumer.LogsConsumer,
@@ -96,9 +129,9 @@ func New(
 	}
 
 	r := &splunkReceiver{
-		logger:      logger,
-		config:      &config,
-		logConsumer: nextConsumer,
+		logger:       logger,
+		config:       &config,
+		logsConsumer: nextConsumer,
 		server: &http.Server{
 			Addr: config.Endpoint,
 			// TODO: Evaluate what properties should be configurable, for now
@@ -161,7 +194,9 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 		transport = "https"
 	}
 	ctx := obsreport.ReceiverContext(req.Context(), r.config.Name(), transport, r.config.Name())
-	ctx = obsreport.StartMetricsReceiveOp(ctx, r.config.Name(), transport)
+	if r.logsConsumer == nil {
+		ctx = obsreport.StartMetricsReceiveOp(ctx, r.config.Name(), transport)
+	}
 
 	if req.Method != http.MethodPost {
 		r.failRequest(ctx, resp, http.StatusBadRequest, invalidMethodRespBody, nil)
@@ -194,12 +229,10 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	messagesReceived := 0
 	dec := json.NewDecoder(bodyReader)
 
 	var events []*splunk.Event
 
-	var decodeErr error
 	for dec.More() {
 		var msg splunk.Event
 		err := dec.Decode(&msg)
@@ -208,38 +241,67 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			return
 		}
 		if msg.IsMetric() {
-			// Currently unsupported.
-			r.failRequest(ctx, resp, http.StatusBadRequest, errUnsupportedMetricEvent, err)
+			if r.metricsConsumer == nil {
+				r.failRequest(ctx, resp, http.StatusBadRequest, errUnsupportedMetricEvent, err)
+				return
+			}
+		} else if r.logsConsumer == nil {
+			r.failRequest(ctx, resp, http.StatusBadRequest, errUnsupportedLogEvent, err)
 			return
 		}
 
-		messagesReceived++
 		events = append(events, &msg)
 	}
+	if r.logsConsumer != nil {
+		r.consumeLogs(ctx, events, resp, req)
+	} else {
+		r.consumeMetrics(ctx, events, resp, req)
+	}
+}
 
+func (r *splunkReceiver) createResourceCustomizer(req *http.Request) func(pdata.Resource) {
 	customizer := func(resource pdata.Resource) {}
 	if r.config.AccessTokenPassthrough {
-		if accessToken := req.Header.Get(splunk.SplunkHECTokenHeader); accessToken != "" {
+		if accessToken := req.Header.Get(splunk.HECTokenHeader); accessToken != "" {
 			customizer = func(resource pdata.Resource) {
-				resource.Attributes().InsertString(splunk.SplunkHecTokenLabel, accessToken)
+				if resource.IsNil() {
+					resource.InitEmpty()
+				}
+				resource.Attributes().InsertString(splunk.HecTokenLabel, accessToken)
 			}
 		}
 	}
+	return customizer
+}
 
-	ld, err := SplunkHecToLogData(r.logger, events, customizer)
+func (r *splunkReceiver) consumeMetrics(ctx context.Context, events []*splunk.Event, resp http.ResponseWriter, req *http.Request) {
+	md, _ := SplunkHecToMetricsData(r.logger, events, r.createResourceCustomizer(req))
+
+	decodeErr := r.metricsConsumer.ConsumeMetrics(ctx, md)
+	obsreport.EndMetricsReceiveOp(
+		ctx,
+		typeStr,
+		len(events),
+		len(events),
+		decodeErr)
+
+	if decodeErr != nil {
+		r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, decodeErr)
+	} else {
+		resp.WriteHeader(http.StatusAccepted)
+		resp.Write(okRespBody)
+	}
+}
+
+func (r *splunkReceiver) consumeLogs(ctx context.Context, events []*splunk.Event, resp http.ResponseWriter, req *http.Request) {
+	ld, err := SplunkHecToLogData(r.logger, events, r.createResourceCustomizer(req))
 	if err != nil {
 		r.failRequest(ctx, resp, http.StatusBadRequest, errUnmarshalBodyRespBody, err)
 		return
 	}
 
-	decodeErr = r.logConsumer.ConsumeLogs(ctx, ld)
+	decodeErr := r.logsConsumer.ConsumeLogs(ctx, ld)
 
-	obsreport.EndMetricsReceiveOp(
-		ctx,
-		typeStr,
-		messagesReceived,
-		messagesReceived,
-		decodeErr)
 	if decodeErr != nil {
 		r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, decodeErr)
 	} else {

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -85,7 +85,7 @@ func SplunkHecToMetricsData(logger *zap.Logger, events []*splunk.Event, resource
 				dbl, err := strconv.ParseFloat(*s, 64)
 				if err != nil {
 					numDroppedTimeSeries++
-					logger.Debug("Cannot convert metric",
+					logger.Debug("Cannot convert metric value from string to number",
 						zap.String("metric", metricName))
 				} else {
 					addDoubleGauge(pointTimestamp, dbl, metric, populateLabels)

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -77,17 +77,9 @@ func SplunkHecToMetricsData(logger *zap.Logger, events []*splunk.Event, resource
 			} else if i, ok := metricValue.(*int64); ok {
 				addIntGauge(pointTimestamp, *i, metric, populateLabels)
 			} else if f, ok := metricValue.(float64); ok {
-				if f == float64(int64(f)) {
-					addIntGauge(pointTimestamp, int64(f), metric, populateLabels)
-				} else {
-					addDoubleGauge(pointTimestamp, f, metric, populateLabels)
-				}
+				addDoubleGauge(pointTimestamp, f, metric, populateLabels)
 			} else if f, ok := metricValue.(*float64); ok {
-				if *f == float64(int64(*f)) {
-					addIntGauge(pointTimestamp, int64(*f), metric, populateLabels)
-				} else {
-					addDoubleGauge(pointTimestamp, *f, metric, populateLabels)
-				}
+				addDoubleGauge(pointTimestamp, *f, metric, populateLabels)
 			} else if s, ok := metricValue.(*string); ok {
 				// best effort, cast to string and turn into a number
 				dbl, err := strconv.ParseFloat(*s, 64)

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
@@ -40,7 +41,12 @@ func SplunkHecToMetricsData(logger *zap.Logger, events []*splunk.Event, resource
 
 		metrics := pdata.NewInstrumentationLibraryMetrics()
 		metrics.InitEmpty()
-
+		resourceMetrics.Resource().InitEmpty()
+		attrs := resourceMetrics.Resource().Attributes()
+		attrs.InitEmptyWithCapacity(3)
+		attrs.InsertString(conventions.AttributeHostHostname, event.Host)
+		attrs.InsertString(conventions.AttributeServiceName, event.Source)
+		attrs.InsertString(splunk.SourcetypeLabel, event.SourceType)
 		resourceCustomizer(resourceMetrics.Resource())
 
 		values := event.GetMetricValues()

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -28,7 +28,7 @@ import (
 )
 
 // SplunkHecToMetricsData converts Splunk HEC metric points to
-// consumerdata.MetricsData. Returning the converted data and the number of
+// pdata.Metrics. Returning the converted data and the number of
 // dropped time series.
 func SplunkHecToMetricsData(logger *zap.Logger, events []*splunk.Event, resourceCustomizer func(pdata.Resource)) (pdata.Metrics, int) {
 

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -1,0 +1,167 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunkhecreceiver
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
+)
+
+// SplunkHecToMetricsData converts Splunk HEC metric points to
+// consumerdata.MetricsData. Returning the converted data and the number of
+// dropped time series.
+func SplunkHecToMetricsData(logger *zap.Logger, events []*splunk.Event, resourceCustomizer func(pdata.Resource)) (pdata.Metrics, int) {
+
+	// TODO: not optimized at all, basically regenerating everything for each
+	// 	data point.
+	numDroppedTimeSeries := 0
+	md := pdata.NewMetrics()
+
+	for _, event := range events {
+		resourceMetrics := pdata.NewResourceMetrics()
+		resourceMetrics.InitEmpty()
+
+		metrics := pdata.NewInstrumentationLibraryMetrics()
+		metrics.InitEmpty()
+
+		labelKeys, labelValues := buildLabelKeysAndValues(event.Fields)
+		if len(labelKeys) > 0 {
+			resourceMetrics.Resource().InitEmpty()
+		}
+		for i, k := range labelKeys {
+			resourceMetrics.Resource().Attributes().InsertString(k, labelValues[i])
+		}
+		resourceCustomizer(resourceMetrics.Resource())
+
+		values := event.GetMetricValues()
+		metricNames := make([]string, 0, len(values))
+		for k := range values {
+			metricNames = append(metricNames, k)
+		}
+		sort.Strings(metricNames)
+
+		for _, metricName := range metricNames {
+			pointTimestamp := convertTimestamp(event.Time)
+			metric := pdata.NewMetric()
+			metric.InitEmpty()
+			// TODO currently mapping all values to unspecified.
+			metric.SetDataType(pdata.MetricDataTypeNone)
+			metric.SetName(metricName)
+
+			metricValue := values[metricName]
+			if i, ok := metricValue.(int64); ok {
+				addIntGauge(pointTimestamp, i, metric)
+			} else if i, ok := metricValue.(*int64); ok {
+				addIntGauge(pointTimestamp, *i, metric)
+			} else if f, ok := metricValue.(float64); ok {
+				if f == float64(int64(f)) {
+					addIntGauge(pointTimestamp, int64(f), metric)
+				} else {
+					addDoubleGauge(pointTimestamp, f, metric)
+				}
+			} else if f, ok := metricValue.(*float64); ok {
+				if *f == float64(int64(*f)) {
+					addIntGauge(pointTimestamp, int64(*f), metric)
+				} else {
+					addDoubleGauge(pointTimestamp, *f, metric)
+				}
+			} else if s, ok := metricValue.(*string); ok {
+				// best effort, cast to string and turn into a number
+				dbl, err := strconv.ParseFloat(*s, 64)
+				if err != nil {
+					numDroppedTimeSeries++
+					logger.Debug("Cannot convert metric",
+						zap.String("metric", metricName))
+				} else {
+					addDoubleGauge(pointTimestamp, dbl, metric)
+				}
+			} else {
+				// drop this point as we do not know how to extract a value from it
+				numDroppedTimeSeries++
+				logger.Debug("Cannot convert metric",
+					zap.String("metric", metricName))
+			}
+
+			if metric.DataType() != pdata.MetricDataTypeNone {
+				metrics.Metrics().Append(metric)
+			}
+		}
+		if metrics.Metrics().Len() > 0 {
+			resourceMetrics.InstrumentationLibraryMetrics().Append(metrics)
+			md.ResourceMetrics().Append(resourceMetrics)
+		}
+	}
+
+	return md, numDroppedTimeSeries
+}
+
+func addIntGauge(ts pdata.TimestampUnixNano, value int64, metric pdata.Metric) {
+	intPt := pdata.NewIntDataPoint()
+	intPt.InitEmpty()
+	intPt.SetTimestamp(ts)
+	intPt.SetValue(value)
+	metric.SetDataType(pdata.MetricDataTypeIntGauge)
+	metric.IntGauge().InitEmpty()
+	metric.IntGauge().DataPoints().Append(intPt)
+}
+
+func addDoubleGauge(ts pdata.TimestampUnixNano, value float64, metric pdata.Metric) {
+	doublePt := pdata.NewDoubleDataPoint()
+	doublePt.InitEmpty()
+	doublePt.SetTimestamp(ts)
+	doublePt.SetValue(value)
+	metric.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	metric.DoubleGauge().InitEmpty()
+	metric.DoubleGauge().DataPoints().Append(doublePt)
+}
+
+func convertTimestamp(sec float64) pdata.TimestampUnixNano {
+	if sec == 0 {
+		return 0
+	}
+	return pdata.TimestampUnixNano(sec * 1e9)
+}
+
+func buildLabelKeysAndValues(
+	dimensions map[string]interface{},
+) ([]string, []string) {
+	keys := make([]string, 0, len(dimensions))
+	values := make([]string, 0, len(dimensions))
+	dimensionKeys := make([]string, 0, len(dimensions))
+	for key := range dimensions {
+		dimensionKeys = append(dimensionKeys, key)
+	}
+	sort.Strings(dimensionKeys)
+	for _, key := range dimensionKeys {
+
+		if strings.HasPrefix(key, "metric_name") {
+			continue
+		}
+		if key == "" || dimensions[key] == nil {
+			// TODO: Log or metric for this odd ball?
+			continue
+		}
+		keys = append(keys, key)
+		values = append(values, fmt.Sprintf("%v", dimensions[key]))
+	}
+	return keys, values
+}

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -103,7 +103,7 @@ func SplunkHecToMetricsData(logger *zap.Logger, events []*splunk.Event, resource
 			} else {
 				// drop this point as we do not know how to extract a value from it
 				numDroppedTimeSeries++
-				logger.Debug("Cannot convert metric",
+				logger.Debug("Cannot convert metric, unknown input type",
 					zap.String("metric", metricName))
 			}
 

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -80,6 +80,9 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 				intPt.InitEmpty()
 				intPt.SetValue(14)
 				intPt.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				intPt.LabelsMap().Insert("k0", "v0")
+				intPt.LabelsMap().Insert("k1", "v1")
+				intPt.LabelsMap().Insert("k2", "v2")
 				metricPt.IntGauge().DataPoints().Append(intPt)
 				metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
 
@@ -92,6 +95,9 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 				intPt2.InitEmpty()
 				intPt2.SetValue(15)
 				intPt2.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				intPt2.LabelsMap().Insert("k0", "v0")
+				intPt2.LabelsMap().Insert("k1", "v1")
+				intPt2.LabelsMap().Insert("k2", "v2")
 				metricPt2.IntGauge().DataPoints().Append(intPt2)
 				metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt2)
 
@@ -116,6 +122,9 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 				doublePt.InitEmpty()
 				doublePt.SetValue(13.13)
 				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				doublePt.LabelsMap().Insert("k0", "v0")
+				doublePt.LabelsMap().Insert("k1", "v1")
+				doublePt.LabelsMap().Insert("k2", "v2")
 				metricPt.DoubleGauge().DataPoints().Append(doublePt)
 				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
 				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
@@ -156,6 +165,9 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 				doublePt := pdata.NewDoubleDataPoint()
 				doublePt.InitEmpty()
 				doublePt.SetValue(13.13)
+				doublePt.LabelsMap().Insert("k0", "v0")
+				doublePt.LabelsMap().Insert("k1", "v1")
+				doublePt.LabelsMap().Insert("k2", "v2")
 				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
 				metricPt.DoubleGauge().DataPoints().Append(doublePt)
 				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
@@ -182,6 +194,9 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 				intPt.InitEmpty()
 				intPt.SetValue(13)
 				intPt.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				intPt.LabelsMap().Insert("k0", "v0")
+				intPt.LabelsMap().Insert("k1", "v1")
+				intPt.LabelsMap().Insert("k2", "v2")
 				metricPt.IntGauge().DataPoints().Append(intPt)
 				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
 				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
@@ -189,7 +204,7 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 			}(),
 		},
 		{
-			name: "double_counter_as_string",
+			name: "double_counter_as_string_pointer",
 			splunkDataPoint: func() *splunk.Event {
 				pt := buildDefaultSplunkDataPt()
 				pt.Fields["metric_name:single"] = strPtr("13.13")
@@ -205,6 +220,37 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 				doublePt := pdata.NewDoubleDataPoint()
 				doublePt.InitEmpty()
 				doublePt.SetValue(13.13)
+				doublePt.LabelsMap().Insert("k0", "v0")
+				doublePt.LabelsMap().Insert("k1", "v1")
+				doublePt.LabelsMap().Insert("k2", "v2")
+				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				metricPt.DoubleGauge().DataPoints().Append(doublePt)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
+				return md
+			}(),
+		},
+
+		{
+			name: "double_counter_as_string",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["metric_name:single"] = "13.13"
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				md := buildDefaultMetricsData(nanos)
+				metricPt := pdata.NewMetric()
+				metricPt.InitEmpty()
+				metricPt.SetDataType(pdata.MetricDataTypeDoubleGauge)
+				metricPt.SetName("single")
+				metricPt.DoubleGauge().InitEmpty()
+				doublePt := pdata.NewDoubleDataPoint()
+				doublePt.InitEmpty()
+				doublePt.SetValue(13.13)
+				doublePt.LabelsMap().Insert("k0", "v0")
+				doublePt.LabelsMap().Insert("k1", "v1")
+				doublePt.LabelsMap().Insert("k2", "v2")
 				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
 				metricPt.DoubleGauge().DataPoints().Append(doublePt)
 				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
@@ -232,8 +278,7 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 			}(),
 			wantMetricsData: func() pdata.Metrics {
 				md := buildDefaultMetricsData(nanos)
-				value, _ := md.ResourceMetrics().At(0).Resource().Attributes().Get("k0")
-				value.SetStringVal("")
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).IntGauge().DataPoints().At(0).LabelsMap().Update("k0", "")
 				return md
 			}(),
 		},
@@ -289,10 +334,6 @@ func buildDefaultMetricsData(time int64) pdata.Metrics {
 	resourceMetrics := pdata.NewResourceMetrics()
 	resourceMetrics.InitEmpty()
 	metrics.ResourceMetrics().Append(resourceMetrics)
-	resourceMetrics.Resource().InitEmpty()
-	resourceMetrics.Resource().Attributes().InsertString("k0", "v0")
-	resourceMetrics.Resource().Attributes().InsertString("k1", "v1")
-	resourceMetrics.Resource().Attributes().InsertString("k2", "v2")
 
 	ilm := pdata.NewInstrumentationLibraryMetrics()
 	ilm.InitEmpty()
@@ -304,6 +345,9 @@ func buildDefaultMetricsData(time int64) pdata.Metrics {
 	intPt := pdata.NewIntDataPoint()
 	intPt.InitEmpty()
 	intPt.SetValue(13)
+	intPt.LabelsMap().Insert("k0", "v0")
+	intPt.LabelsMap().Insert("k1", "v1")
+	intPt.LabelsMap().Insert("k2", "v2")
 	intPt.SetTimestamp(pdata.TimestampUnixNano(time))
 	metricPt.IntGauge().DataPoints().Append(intPt)
 	ilm.Metrics().Append(metricPt)

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -334,6 +334,11 @@ func buildDefaultMetricsData(time int64) pdata.Metrics {
 	resourceMetrics := pdata.NewResourceMetrics()
 	resourceMetrics.InitEmpty()
 	metrics.ResourceMetrics().Append(resourceMetrics)
+	resourceMetrics.Resource().InitEmpty()
+	attrs := resourceMetrics.Resource().Attributes()
+	attrs.InsertString("host.hostname", "localhost")
+	attrs.InsertString("service.name", "source")
+	attrs.InsertString("com.splunk.sourcetype", "sourcetype")
 
 	ilm := pdata.NewInstrumentationLibraryMetrics()
 	ilm.InitEmpty()

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -1,0 +1,327 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunkhecreceiver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
+)
+
+func Test_splunkV2ToMetricsData(t *testing.T) {
+	// Timestamps for Splunk have a resolution to the millisecond, where the time is reported in seconds with a floating value to the millisecond.
+	now := time.Now()
+	msecInt64 := now.UnixNano() / 1e6
+	sec := float64(msecInt64) / 1e3
+	nanos := int64(sec * 1e9)
+
+	buildDefaultSplunkDataPt := func() *splunk.Event {
+		return &splunk.Event{
+			Time:       sec,
+			Host:       "localhost",
+			Source:     "source",
+			SourceType: "sourcetype",
+			Index:      "index",
+			Event:      "metrics",
+			Fields: map[string]interface{}{
+				"metric_name:single": int64Ptr(13),
+				"k0":                 "v0",
+				"k1":                 "v1",
+				"k2":                 "v2",
+			},
+		}
+	}
+
+	tests := []struct {
+		name                  string
+		splunkDataPoint       *splunk.Event
+		wantMetricsData       pdata.Metrics
+		wantDroppedTimeseries int
+	}{
+		{
+			name:            "int_gauge",
+			splunkDataPoint: buildDefaultSplunkDataPt(),
+			wantMetricsData: buildDefaultMetricsData(nanos),
+		},
+		{
+			name: "multiple",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["metric_name:yetanother"] = int64Ptr(14)
+				pt.Fields["metric_name:yetanotherandanother"] = int64Ptr(15)
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				metrics := buildDefaultMetricsData(nanos)
+
+				metricPt := pdata.NewMetric()
+				metricPt.InitEmpty()
+				metricPt.SetDataType(pdata.MetricDataTypeIntGauge)
+				metricPt.SetName("yetanother")
+				metricPt.IntGauge().InitEmpty()
+				intPt := pdata.NewIntDataPoint()
+				intPt.InitEmpty()
+				intPt.SetValue(14)
+				intPt.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				metricPt.IntGauge().DataPoints().Append(intPt)
+				metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
+
+				metricPt2 := pdata.NewMetric()
+				metricPt2.InitEmpty()
+				metricPt2.SetDataType(pdata.MetricDataTypeIntGauge)
+				metricPt2.SetName("yetanotherandanother")
+				metricPt2.IntGauge().InitEmpty()
+				intPt2 := pdata.NewIntDataPoint()
+				intPt2.InitEmpty()
+				intPt2.SetValue(15)
+				intPt2.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				metricPt2.IntGauge().DataPoints().Append(intPt2)
+				metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt2)
+
+				return metrics
+			}(),
+		},
+		{
+			name: "double_gauge",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["metric_name:single"] = float64Ptr(13.13)
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				md := buildDefaultMetricsData(nanos)
+				metricPt := pdata.NewMetric()
+				metricPt.InitEmpty()
+				metricPt.SetDataType(pdata.MetricDataTypeDoubleGauge)
+				metricPt.SetName("single")
+				metricPt.DoubleGauge().InitEmpty()
+				doublePt := pdata.NewDoubleDataPoint()
+				doublePt.InitEmpty()
+				doublePt.SetValue(13.13)
+				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				metricPt.DoubleGauge().DataPoints().Append(doublePt)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
+				return md
+			}(),
+		},
+		{
+			name: "int_counter_pointer",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				return pt
+			}(),
+			wantMetricsData: buildDefaultMetricsData(nanos),
+		},
+		{
+			name: "int_counter",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["metric_name:single"] = int64(13)
+				return pt
+			}(),
+			wantMetricsData: buildDefaultMetricsData(nanos),
+		},
+		{
+			name: "double_counter",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["metric_name:single"] = float64Ptr(13.13)
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				md := buildDefaultMetricsData(nanos)
+				metricPt := pdata.NewMetric()
+				metricPt.InitEmpty()
+				metricPt.SetDataType(pdata.MetricDataTypeDoubleGauge)
+				metricPt.SetName("single")
+				metricPt.DoubleGauge().InitEmpty()
+				doublePt := pdata.NewDoubleDataPoint()
+				doublePt.InitEmpty()
+				doublePt.SetValue(13.13)
+				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				metricPt.DoubleGauge().DataPoints().Append(doublePt)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
+				return md
+			}(),
+		},
+
+		{
+			name: "double_counter_as_int",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["metric_name:single"] = float64Ptr(13)
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				md := buildDefaultMetricsData(nanos)
+				metricPt := pdata.NewMetric()
+				metricPt.InitEmpty()
+				metricPt.SetDataType(pdata.MetricDataTypeIntGauge)
+				metricPt.SetName("single")
+				metricPt.IntGauge().InitEmpty()
+				intPt := pdata.NewIntDataPoint()
+				intPt.InitEmpty()
+				intPt.SetValue(13)
+				intPt.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				metricPt.IntGauge().DataPoints().Append(intPt)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
+				return md
+			}(),
+		},
+		{
+			name: "double_counter_as_string",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["metric_name:single"] = strPtr("13.13")
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				md := buildDefaultMetricsData(nanos)
+				metricPt := pdata.NewMetric()
+				metricPt.InitEmpty()
+				metricPt.SetDataType(pdata.MetricDataTypeDoubleGauge)
+				metricPt.SetName("single")
+				metricPt.DoubleGauge().InitEmpty()
+				doublePt := pdata.NewDoubleDataPoint()
+				doublePt.InitEmpty()
+				doublePt.SetValue(13.13)
+				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
+				metricPt.DoubleGauge().DataPoints().Append(doublePt)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
+				return md
+			}(),
+		},
+		{
+			name: "zero_timestamp",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Time = 0
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				return buildDefaultMetricsData(0)
+			}(),
+		},
+		{
+			name: "empty_dimension_value",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["k0"] = ""
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				md := buildDefaultMetricsData(nanos)
+				value, _ := md.ResourceMetrics().At(0).Resource().Attributes().Get("k0")
+				value.SetStringVal("")
+				return md
+			}(),
+		},
+		{
+			name: "invalid_point",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["metric_name:single"] = "foo"
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				return pdata.NewMetrics()
+			}(),
+			wantDroppedTimeseries: 1,
+		},
+		{
+			name: "cannot_convert_string",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				value := "foo"
+				pt.Fields["metric_name:single"] = &value
+				return pt
+			}(),
+			wantMetricsData: func() pdata.Metrics {
+				return pdata.NewMetrics()
+			}(),
+			wantDroppedTimeseries: 1,
+		},
+		{
+			name: "nil_dimension_ignored",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				pt.Fields["k4"] = nil
+				pt.Fields["k5"] = nil
+				pt.Fields["k6"] = nil
+				return pt
+			}(),
+			wantMetricsData: buildDefaultMetricsData(nanos),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md, numDroppedTimeseries := SplunkHecToMetricsData(zap.NewNop(), []*splunk.Event{tt.splunkDataPoint}, func(resource pdata.Resource) {})
+			assert.Equal(t, tt.wantDroppedTimeseries, numDroppedTimeseries)
+			assert.Equal(t, tt.wantMetricsData, md)
+		})
+	}
+}
+
+func buildDefaultMetricsData(time int64) pdata.Metrics {
+	metrics := pdata.NewMetrics()
+	resourceMetrics := pdata.NewResourceMetrics()
+	resourceMetrics.InitEmpty()
+	metrics.ResourceMetrics().Append(resourceMetrics)
+	resourceMetrics.Resource().InitEmpty()
+	resourceMetrics.Resource().Attributes().InsertString("k0", "v0")
+	resourceMetrics.Resource().Attributes().InsertString("k1", "v1")
+	resourceMetrics.Resource().Attributes().InsertString("k2", "v2")
+
+	ilm := pdata.NewInstrumentationLibraryMetrics()
+	ilm.InitEmpty()
+	metricPt := pdata.NewMetric()
+	metricPt.InitEmpty()
+	metricPt.SetDataType(pdata.MetricDataTypeIntGauge)
+	metricPt.SetName("single")
+	metricPt.IntGauge().InitEmpty()
+	intPt := pdata.NewIntDataPoint()
+	intPt.InitEmpty()
+	intPt.SetValue(13)
+	intPt.SetTimestamp(pdata.TimestampUnixNano(time))
+	metricPt.IntGauge().DataPoints().Append(intPt)
+	ilm.Metrics().Append(metricPt)
+	resourceMetrics.InstrumentationLibraryMetrics().Append(ilm)
+	return metrics
+}
+
+func strPtr(s string) *string {
+	l := s
+	return &l
+}
+
+func int64Ptr(i int64) *int64 {
+	l := i
+	return &l
+}
+
+func float64Ptr(f float64) *float64 {
+	l := f
+	return &l
+}

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -175,34 +175,6 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 				return md
 			}(),
 		},
-
-		{
-			name: "double_counter_as_int",
-			splunkDataPoint: func() *splunk.Event {
-				pt := buildDefaultSplunkDataPt()
-				pt.Fields["metric_name:single"] = float64Ptr(13)
-				return pt
-			}(),
-			wantMetricsData: func() pdata.Metrics {
-				md := buildDefaultMetricsData(nanos)
-				metricPt := pdata.NewMetric()
-				metricPt.InitEmpty()
-				metricPt.SetDataType(pdata.MetricDataTypeIntGauge)
-				metricPt.SetName("single")
-				metricPt.IntGauge().InitEmpty()
-				intPt := pdata.NewIntDataPoint()
-				intPt.InitEmpty()
-				intPt.SetValue(13)
-				intPt.SetTimestamp(pdata.TimestampUnixNano(nanos))
-				intPt.LabelsMap().Insert("k0", "v0")
-				intPt.LabelsMap().Insert("k1", "v1")
-				intPt.LabelsMap().Insert("k2", "v2")
-				metricPt.IntGauge().DataPoints().Append(intPt)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
-				return md
-			}(),
-		},
 		{
 			name: "double_counter_as_string_pointer",
 			splunkDataPoint: func() *splunk.Event {
@@ -230,7 +202,6 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 				return md
 			}(),
 		},
-
 		{
 			name: "double_counter_as_string",
 			splunkDataPoint: func() *splunk.Event {


### PR DESCRIPTION
**Description:**
Adds the ability for Splunk HEC to ingest metrics.
This is a follow up to #1268 which adds the ability to ingest logs.
This replaces #846, with less code involved.

**Testing:**
Unit tests.

**Documentation:**
None