### PR TITLE
AWSEMFExporter - Only calculate metric rate for cumulative counter. Avoid doing SingleDImensionRollup for metrics with only one dimension.

### DIFF
--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -274,10 +274,16 @@ func buildCWMetricFromDP(dp interface{}, pmd *pdata.Metric, namespace string, me
 		// Put a fake but identical metric value here in order to add metric name into fieldsPairs
 		// since calculateRate() needs metric name as one of metric identifiers
 		fieldsPairs[pmd.Name()] = int64(FakeMetricValue)
-		metricVal = calculateRate(fieldsPairs, metric.Value(), timestamp)
+		metricVal = metric.Value()
+		if needsCalculateRate(pmd) {
+			metricVal = calculateRate(fieldsPairs, metric.Value(), timestamp)
+		}
 	case pdata.DoubleDataPoint:
 		fieldsPairs[pmd.Name()] = float64(FakeMetricValue)
-		metricVal = calculateRate(fieldsPairs, metric.Value(), timestamp)
+		metricVal = metric.Value()
+		if needsCalculateRate(pmd) {
+			metricVal = calculateRate(fieldsPairs, metric.Value(), timestamp)
+		}
 	}
 	if metricVal == nil {
 		return nil
@@ -428,10 +434,26 @@ func dimensionRollup(dimensionRollupOption string, originalDimensionSlice []stri
 	}
 	if dimensionRollupOption == ZeroAndSingleDimensionRollup || dimensionRollupOption == SingleDimensionRollupOnly {
 		//"One" dimension rollup
-		for _, dimensionKey := range originalDimensionSlice {
-			rollupDimensionArray = append(rollupDimensionArray, append(dimensionZero, dimensionKey))
+		if len(originalDimensionSlice) > 1 {
+			for _, dimensionKey := range originalDimensionSlice {
+				rollupDimensionArray = append(rollupDimensionArray, append(dimensionZero, dimensionKey))
+			}
 		}
 	}
 
 	return rollupDimensionArray
+}
+
+func needsCalculateRate(pmd *pdata.Metric) bool {
+	switch pmd.DataType() {
+	case pdata.MetricDataTypeIntSum:
+		if pmd.IntSum().AggregationTemporality() == pdata.AggregationTemporalityCumulative {
+			return true
+		}
+	case pdata.MetricDataTypeDoubleSum:
+		if pmd.DoubleSum().AggregationTemporality() == pdata.AggregationTemporalityCumulative {
+			return true
+		}
+	}
+	return false
 }

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -447,11 +447,11 @@ func dimensionRollup(dimensionRollupOption string, originalDimensionSlice []stri
 func needsCalculateRate(pmd *pdata.Metric) bool {
 	switch pmd.DataType() {
 	case pdata.MetricDataTypeIntSum:
-		if pmd.IntSum().AggregationTemporality() == pdata.AggregationTemporalityCumulative {
+		if !pmd.IntSum().IsNil() && pmd.IntSum().AggregationTemporality() == pdata.AggregationTemporalityCumulative {
 			return true
 		}
 	case pdata.MetricDataTypeDoubleSum:
-		if pmd.DoubleSum().AggregationTemporality() == pdata.AggregationTemporalityCumulative {
+		if !pmd.DoubleSum().IsNil() && pmd.DoubleSum().AggregationTemporality() == pdata.AggregationTemporalityCumulative {
 			return true
 		}
 	}


### PR DESCRIPTION
**Description:** 
1. Make change on the metric rate calculation logic. Only calculate metric rate for cumulative counter.
2. Do not do SingleDImensionRollup for metrics with only one dimension in order to avoid duplicate metrics.

**Testing:** 
```
make all
make unit-tests-with-cover
```
**Documentation:** 
1. Remove rate calculation for Gauge and Histogram data because It is not meaningful to calculate the rate for those data types.
2. Do not do SingleDImensionRollup for metrics with only one dimension because those metrics have only one dimension by default. Otherwise, it will generate duplicate metrics with single dimension.