### PR TITLE
awsecscontainermetrics: Set task/container metadata as metric labels

### DIFF
--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/label.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/label.go
@@ -1,0 +1,61 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecscontainermetrics
+
+import (
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"go.opentelemetry.io/collector/translator/conventions"
+)
+
+func containerLabelKeysAndValues(cm ContainerMetadata) ([]*metricspb.LabelKey, []*metricspb.LabelValue) {
+	labelKeys := make([]*metricspb.LabelKey, 0, 3)
+	labelValues := make([]*metricspb.LabelValue, 0, 3)
+
+	labelKeys = append(labelKeys, &metricspb.LabelKey{Key: conventions.AttributeContainerName})
+	labelValues = append(labelValues, &metricspb.LabelValue{Value: cm.ContainerName, HasValue: true})
+
+	labelKeys = append(labelKeys, &metricspb.LabelKey{Key: conventions.AttributeContainerID})
+	labelValues = append(labelValues, &metricspb.LabelValue{Value: cm.DockerID, HasValue: true})
+
+	labelKeys = append(labelKeys, &metricspb.LabelKey{Key: AttributeECSDockerName})
+	labelValues = append(labelValues, &metricspb.LabelValue{Value: cm.DockerName, HasValue: true})
+
+	return labelKeys, labelValues
+}
+
+func taskLabelKeysAndValues(tm TaskMetadata) ([]*metricspb.LabelKey, []*metricspb.LabelValue) {
+	labelKeys := make([]*metricspb.LabelKey, 0, 6)
+	labelValues := make([]*metricspb.LabelValue, 0, 6)
+
+	labelKeys = append(labelKeys, &metricspb.LabelKey{Key: AttributeECSCluster})
+	labelValues = append(labelValues, &metricspb.LabelValue{Value: tm.Cluster, HasValue: true})
+
+	labelKeys = append(labelKeys, &metricspb.LabelKey{Key: AttributeECSTaskARN})
+	labelValues = append(labelValues, &metricspb.LabelValue{Value: tm.TaskARN, HasValue: true})
+
+	labelKeys = append(labelKeys, &metricspb.LabelKey{Key: AttributeECSTaskID})
+	labelValues = append(labelValues, &metricspb.LabelValue{Value: getTaskIDFromARN(tm.TaskARN), HasValue: true})
+
+	labelKeys = append(labelKeys, &metricspb.LabelKey{Key: AttributeECSTaskFamily})
+	labelValues = append(labelValues, &metricspb.LabelValue{Value: tm.Family, HasValue: true})
+
+	labelKeys = append(labelKeys, &metricspb.LabelKey{Key: AttributeECSTaskRevesion})
+	labelValues = append(labelValues, &metricspb.LabelValue{Value: tm.Revision, HasValue: true})
+
+	labelKeys = append(labelKeys, &metricspb.LabelKey{Key: AttributeECSServiceName})
+	labelValues = append(labelValues, &metricspb.LabelValue{Value: "undefined", HasValue: true})
+
+	return labelKeys, labelValues
+}

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/label_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/label_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsecscontainermetrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerLabelKeysAndValues(t *testing.T) {
+	cm := ContainerMetadata{
+		ContainerName: "container-1",
+		DockerID:      "001",
+		DockerName:    "docker-container-1",
+	}
+	k, v := containerLabelKeysAndValues(cm)
+	require.EqualValues(t, 3, len(k))
+	require.EqualValues(t, 3, len(v))
+}
+
+func TestTaskLabelKeysAndValues(t *testing.T) {
+	tm := TaskMetadata{
+		Cluster:  "cluster-1",
+		TaskARN:  "arn:aws:some-value/001",
+		Family:   "task-def-family-1",
+		Revision: "task-def-version",
+	}
+	k, v := taskLabelKeysAndValues(tm)
+	require.EqualValues(t, 6, len(k))
+	require.EqualValues(t, 6, len(v))
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Earlier we decided to add task and container metadata as resource attributes. However, CloudWatch `awsemf` exporter reads dimensions only from metric labels. As this exporter is a major target for `awsecscontainermetrics` receiver, we need to add these metadata as metric labels. I discussed this in our OTel Metric SIG meeting. We also discussed internally and agreed to add them as metric labels as well.

**Link to tracking Issue:** 
#1281 

**Testing:** 
Unit test added.
