### PR TITLE
sapmexporter: make span source attribute and destination dimension names configurable

### DIFF
--- a/exporter/sapmexporter/README.md
+++ b/exporter/sapmexporter/README.md
@@ -36,9 +36,10 @@ during final translation.  Intended to be used in tandem with identical configur
   - `max_requests` (default = 20): Max HTTP requests to be made in parallel.
   - `max_buffered` (default = 10,000): Max number of correlation updates that can be buffered before updates are dropped.
   - `max_retries` (default = 2): Max number of retries that will be made for failed correlation updates.
-  - `log_updates` (default = false): Whether or not to log correlation updates to dimensions (at DEBUG level).
+  - `log_updates` (default = false): Whether or not to log correlation updates to dimensions (at `DEBUG` level).
   - `retry_delay` (default = 30 seconds): How long to wait between retries.
   - `cleanup_interval` (default = 1 minute): How frequently to purge duplicate requests.
+  - `sync_attributes` (default = `{"k8s.pod.uid": "k8s.pod.uid", "container.id": "container.id"}`) Map containing key of the attribute to read from spans to sync to dimensions specified as the value.
 
 In addition, this exporter offers queued retry which is enabled by default.
 Information about queued retry configuration parameters can be found

--- a/exporter/sapmexporter/config.go
+++ b/exporter/sapmexporter/config.go
@@ -42,6 +42,8 @@ type CorrelationConfig struct {
 	// How long to wait after a trace span's service name is last seen before
 	// uncorrelating that service.
 	StaleServiceTimeout time.Duration `mapstructure:"stale_service_timeout"`
+	// SyncAttributes is a key of the span attribute name to sync to the dimension as the value.
+	SyncAttributes map[string]string `mapstructure:"sync_attributes"`
 }
 
 // Config defines configuration for SAPM exporter.

--- a/exporter/sapmexporter/config_test.go
+++ b/exporter/sapmexporter/config_test.go
@@ -76,6 +76,10 @@ func TestLoadConfig(t *testing.T) {
 			Correlation: CorrelationConfig{
 				Enabled:             false,
 				StaleServiceTimeout: 5 * time.Minute,
+				SyncAttributes: map[string]string{
+					"k8s.pod.uid":  "k8s.pod.uid",
+					"container.id": "container.id",
+				},
 				Config: correlations.Config{
 					MaxRequests:     20,
 					MaxBuffered:     10_000,

--- a/exporter/sapmexporter/correlation.go
+++ b/exporter/sapmexporter/correlation.go
@@ -119,8 +119,7 @@ func (cor *Tracker) AddSpans(ctx context.Context, traces pdata.Traces) {
 			},
 			false,
 			nil,
-			// TODO: Followup PR to use translated dimension names.
-			tracetracker.DefaultDimsToSyncSource)
+			cor.cfg.Correlation.SyncAttributes)
 		cor.Start()
 	})
 

--- a/exporter/sapmexporter/factory.go
+++ b/exporter/sapmexporter/factory.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/translator/conventions"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/splunk"
 )
@@ -55,6 +56,10 @@ func createDefaultConfig() configmodels.Exporter {
 		Correlation: CorrelationConfig{
 			Enabled:             false,
 			StaleServiceTimeout: 5 * time.Minute,
+			SyncAttributes: map[string]string{
+				conventions.AttributeK8sPodUID:   conventions.AttributeK8sPodUID,
+				conventions.AttributeContainerID: conventions.AttributeContainerID,
+			},
 			Config: correlations.Config{
 				MaxRequests:     20,
 				MaxBuffered:     10_000,

--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.0.0-00010101000000-000000000000
 	github.com/signalfx/sapm-proto v0.6.2
-	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201009143858-d25fd073fb56
+	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201015185032-52a4f97df2a4
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.12.1-0.20201012183541-526f34200197
 	go.uber.org/zap v1.16.0

--- a/exporter/sapmexporter/go.sum
+++ b/exporter/sapmexporter/go.sum
@@ -1027,6 +1027,8 @@ github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201005151249-ce1a2e0a25e7 h1
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201005151249-ce1a2e0a25e7/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201009143858-d25fd073fb56 h1:XYBr6vxBtAufUs72S5LYkjCmCB7QM4kvX2jwufGCqhg=
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201009143858-d25fd073fb56/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
+github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201015185032-52a4f97df2a4 h1:NpsZqpjpM3c0YokW6ozSF+VktmkOUIni3YQkCytHeto=
+github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201015185032-52a4f97df2a4/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=

--- a/go.sum
+++ b/go.sum
@@ -1227,6 +1227,8 @@ github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201005151249-ce1a2e0a25e7 h1
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201005151249-ce1a2e0a25e7/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201009143858-d25fd073fb56 h1:XYBr6vxBtAufUs72S5LYkjCmCB7QM4kvX2jwufGCqhg=
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201009143858-d25fd073fb56/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
+github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201015185032-52a4f97df2a4 h1:NpsZqpjpM3c0YokW6ozSF+VktmkOUIni3YQkCytHeto=
+github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201015185032-52a4f97df2a4/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
If dimension names are being translated in the signalfxexporter then the map values
should be set to the signalfx names. Ideally we can sync to OT dimension names
with translation being done on the backend (the default).