### PR TITLE
Add codeowners to ensure components are assigned to the appropriate reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,50 @@
 #
 
 * @open-telemetry/collector-contrib-approvers
+
+exporter/alibabacloudlogserviceexporter/ @shabicheng
+exporter/awsemfexporter/                 @anuraaga @shaochengwang @mxiamxia
+exporter/awsxrayexporter/                @kbrockhoff @anuraaga
+exporter/azuremonitorexporter/           @pcwiese
+exporter/carbonexporter/                 @pjanotti
+exporter/datadogexporter/                @KSerrania @ericmustin @mx-psi
+exporter/elasticexporter/                @axw
+exporter/honeycombexporter/              @paulosman @lizthegrey
+exporter/jaegerthrifthttpexporter/       @jpkrohling @pavolloffay
+exporter/kinesisexporter/                @owais
+exporter/logzioexporter/                 @yyyogev
+exporter/newrelicexporter/               @MrAlias
+exporter/sapmexporter/                   @owais @dmitryax
+exporter/sentryexporter/                 @AbhiPrasad
+exporter/signalfxexporter/               @pmcollins @asuresh4
+exporter/splunkhecexporter/              @atoulme
+exporter/stackdriverexporter/            @nilebox @james-bebbington
+
+extension/httpforwarder/                 @asuresh4
+extension/jmxmetrics/                    @rmfitzpatrick
+extension/observer/                      @asuresh4 @jrcamp
+
+processor/k8sprocessor/                  @owais @dmitryax @pmm-sumo
+processor/metricstransformprocessor/     @james-bebbington
+processor/resourcedetectionprocessor/    @jrcamp @pmm-sumo @anuraaga @james-bebbington
+processor/routing/                       @jpkrohling
+
+receiver/awsecscontainermetricsreceiver/ @kbrockhoff @anuraaga
+receiver/awsxrayreceiver/                @kbrockhoff @anuraaga
+receiver/carbonreceiver/                 @pjanotti
+receiver/collectdreceiver/               @owais
+receiver/dockerstatsreceiver/            @rmfitzpatrick
+receiver/k8sclusterreceiver/             @asuresh4
+receiver/kubeletstatsreceiver/           @pmcollins @asuresh4
+receiver/prometheusexecreceiver/         @keitwb @james-bebbington
+receiver/receivercreator/                @jrcamp
+receiver/redisreceiver/                  @pmcollins @jrcamp
+receiver/sapmreceiver/                   @owais
+receiver/signalfxreceiver/               @pjanotti @asuresh4
+receiver/simpleprometheusreceiver/       @asuresh4
+receiver/splunkhecreceiver/              @atoulme @keitwb
+receiver/stanzareceiver/                 @djaglowski
+receiver/statsdreceiver/                 @keitwb @jmacd
+receiver/wavefrontreceiver/              @pjanotti
+receiver/windowsperfcountersreceiver/    @james-bebbington
+


### PR DESCRIPTION
This is the initial list extracted from README.
