### PR TITLE
Add kind type to root span to fix the empty parentID problem

### DIFF
--- a/receiver/awsxrayreceiver/internal/translator/translator.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator.go
@@ -167,6 +167,10 @@ func populateSpan(
 		}
 	}
 
+	if parentID == nil{
+		span.SetKind(2)
+	}
+
 	// decode span id
 	spanIDBytes, err := decodeXRaySpanID(seg.ID)
 	if err != nil {


### PR DESCRIPTION
**Description:**

 Fixing the bug for xray receiver which didn't set the span kind type for root span

**Testing:**

 Did the local test, and checked the multi-span data in the aws xray console