### PR TITLE
Small fixes to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,10 +14,6 @@
 
 * @open-telemetry/collector-contrib-approvers
 
-internal/awsxray/                @anuraaga @mxiamxia
-internal/k8sconfig/              @pmcollins @asuresh4
-internal/splunk/                 @pmcollins @asuresh4
-
 exporter/alibabacloudlogserviceexporter/ @shabicheng
 exporter/awsemfexporter/                 @anuraaga @shaochengwang @mxiamxia
 exporter/awsxrayexporter/                @kbrockhoff @anuraaga
@@ -28,6 +24,7 @@ exporter/elasticexporter/                @axw
 exporter/honeycombexporter/              @paulosman @lizthegrey
 exporter/jaegerthrifthttpexporter/       @jpkrohling @pavolloffay
 exporter/kinesisexporter/                @owais
+exporter/loadbalancingexporter/          @jpkrohling
 exporter/logzioexporter/                 @yyyogev
 exporter/newrelicexporter/               @MrAlias
 exporter/sapmexporter/                   @owais @dmitryax
@@ -37,13 +34,18 @@ exporter/splunkhecexporter/              @atoulme
 exporter/stackdriverexporter/            @nilebox @james-bebbington
 
 extension/httpforwarder/                 @asuresh4
-extension/jmxmetrics/                    @rmfitzpatrick
+extension/jmxmetricsextension/           @rmfitzpatrick
 extension/observer/                      @asuresh4 @jrcamp
 
+internal/awsxray/                        @anuraaga @mxiamxia
+internal/k8sconfig/                      @pmcollins @asuresh4
+internal/splunk/                         @pmcollins @asuresh4
+
+processor/groupbytraceprocessor/         @jpkrohling
 processor/k8sprocessor/                  @owais @dmitryax @pmm-sumo
 processor/metricstransformprocessor/     @james-bebbington
 processor/resourcedetectionprocessor/    @jrcamp @pmm-sumo @anuraaga @james-bebbington
-processor/routing/                       @jpkrohling
+processor/routingprocessor/              @jpkrohling
 
 receiver/awsecscontainermetricsreceiver/ @kbrockhoff @anuraaga
 receiver/awsxrayreceiver/                @kbrockhoff @anuraaga
@@ -64,3 +66,4 @@ receiver/statsdreceiver/                 @keitwb @jmacd
 receiver/wavefrontreceiver/              @pjanotti
 receiver/windowsperfcountersreceiver/    @james-bebbington
 
+tracegen/                                @jpkrohling


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

**Description:** This PR changes the CODEOWNERS in a couple of aspects:

1. Fixed the order of the directories, so that 'internal' comes after 'extension'
1. Fixed the name of a few components
1. Added missing components and directories

Verified with:

```
for component in exporter extension processor receiver; 
do 
  ls ${component}/ -1 > /tmp/${component}.txt
  grep ${component} .github/CODEOWNERS | awk -F\/ '{print $2}' > /tmp/${component}-codeowners.txt
  diff /tmp/${component}.txt /tmp/${component}-codeowners.txt
done
```

Result of the script before this PR:

```diff
11d10
< loadbalancingexporter
2c2
< jmxmetricsextension
---
> jmxmetrics
1d0
< groupbytraceprocessor
5c4
< routingprocessor
---
> routing
```

**Link to tracking Issue:** n/a

**Testing:** none

**Documentation:** n/a
