### PR TITLE
Add more @elastic folks to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@ exporter/awsxrayexporter/                @kbrockhoff @anuraaga
 exporter/azuremonitorexporter/           @pcwiese
 exporter/carbonexporter/                 @pjanotti
 exporter/datadogexporter/                @KSerrania @ericmustin @mx-psi
-exporter/elasticexporter/                @axw
+exporter/elasticexporter/                @axw @simitt @jalvz
 exporter/honeycombexporter/              @paulosman @lizthegrey
 exporter/jaegerthrifthttpexporter/       @jpkrohling @pavolloffay
 exporter/kinesisexporter/                @owais


### PR DESCRIPTION
In answer to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1304#issuecomment-712529326 add two more codeowners for the Elastic exporter.