### PR TITLE
tests: increase TestTrace10kSPS memory limits

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -56,7 +56,7 @@ func TestTrace10kSPS(t *testing.T) {
 			datareceivers.NewSapmDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 40,
-				ExpectedMaxRAM: 80,
+				ExpectedMaxRAM: 85,
 			},
 		},
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
since the work discussed in this PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1159 a few weeks ago, the `TestTrace10kSPS` `SAPM` test has been flaking pretty regularly on ci builds by a few mb. 

This PR resolves this flakiness by increasing the mem limits on this test to 85, which is in line with the approach taken here, and should be tight enough still that any further increase is noticed: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1183
