### PR TITLE
[resourcedetectionprocessor] Add EC2 hostname attribute

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -31,6 +31,7 @@ to read resource information from the [GCE metadata server](https://cloud.google
     * cloud.zone
     * host.id
     * host.image.id
+    * host.name
     * host.type
 
 ## Configuration

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
@@ -56,6 +56,11 @@ func (d *Detector) Detect(ctx context.Context) (pdata.Resource, error) {
 		return res, err
 	}
 
+	hostname, err := d.provider.hostname(ctx)
+	if err != nil {
+		return res, err
+	}
+
 	attr := res.Attributes()
 	attr.InsertString(conventions.AttributeCloudProvider, cloud.ProviderAWS)
 	attr.InsertString(conventions.AttributeCloudRegion, meta.Region)
@@ -64,6 +69,7 @@ func (d *Detector) Detect(ctx context.Context) (pdata.Resource, error) {
 	attr.InsertString(conventions.AttributeHostID, meta.InstanceID)
 	attr.InsertString(conventions.AttributeHostImageID, meta.ImageID)
 	attr.InsertString(conventions.AttributeHostType, meta.InstanceType)
+	attr.InsertString(conventions.AttributeHostName, hostname)
 
 	return res, nil
 }

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
@@ -16,6 +16,7 @@ package ec2
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -53,12 +54,12 @@ func (d *Detector) Detect(ctx context.Context) (pdata.Resource, error) {
 
 	meta, err := d.provider.get(ctx)
 	if err != nil {
-		return res, err
+		return res, fmt.Errorf("failed getting identity document: %w", err)
 	}
 
 	hostname, err := d.provider.hostname(ctx)
 	if err != nil {
-		return res, err
+		return res, fmt.Errorf("failed getting hostname: %w", err)
 	}
 
 	attr := res.Attributes()

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 type mockMetadata struct {
-	retIdDoc    ec2metadata.EC2InstanceIdentityDocument
-	retErrIdDoc error
+	retIDDoc    ec2metadata.EC2InstanceIdentityDocument
+	retErrIDDoc error
 
 	retHostname    string
 	retErrHostname error
@@ -44,10 +44,10 @@ func (mm mockMetadata) available(ctx context.Context) bool {
 }
 
 func (mm mockMetadata) get(ctx context.Context) (ec2metadata.EC2InstanceIdentityDocument, error) {
-	if mm.retErrIdDoc != nil {
-		return ec2metadata.EC2InstanceIdentityDocument{}, mm.retErrIdDoc
+	if mm.retErrIDDoc != nil {
+		return ec2metadata.EC2InstanceIdentityDocument{}, mm.retErrIDDoc
 	}
-	return mm.retIdDoc, nil
+	return mm.retIDDoc, nil
 }
 
 func (mm mockMetadata) hostname(ctx context.Context) (string, error) {
@@ -80,7 +80,7 @@ func TestDetector_Detect(t *testing.T) {
 		{
 			name: "success",
 			fields: fields{provider: &mockMetadata{
-				retIdDoc: ec2metadata.EC2InstanceIdentityDocument{
+				retIDDoc: ec2metadata.EC2InstanceIdentityDocument{
 					Region:           "us-west-2",
 					AccountID:        "account1234",
 					AvailabilityZone: "us-west-2a",
@@ -108,8 +108,8 @@ func TestDetector_Detect(t *testing.T) {
 		{
 			name: "endpoint not available",
 			fields: fields{provider: &mockMetadata{
-				retIdDoc:    ec2metadata.EC2InstanceIdentityDocument{},
-				retErrIdDoc: errors.New("should not be called"),
+				retIDDoc:    ec2metadata.EC2InstanceIdentityDocument{},
+				retErrIDDoc: errors.New("should not be called"),
 				isAvailable: false,
 			}},
 			args: args{ctx: context.Background()},
@@ -122,8 +122,8 @@ func TestDetector_Detect(t *testing.T) {
 		{
 			name: "get fails",
 			fields: fields{provider: &mockMetadata{
-				retIdDoc:    ec2metadata.EC2InstanceIdentityDocument{},
-				retErrIdDoc: errors.New("get failed"),
+				retIDDoc:    ec2metadata.EC2InstanceIdentityDocument{},
+				retErrIDDoc: errors.New("get failed"),
 				isAvailable: true,
 			}},
 			args: args{ctx: context.Background()},
@@ -136,7 +136,7 @@ func TestDetector_Detect(t *testing.T) {
 		{
 			name: "hostname fails",
 			fields: fields{provider: &mockMetadata{
-				retIdDoc:       ec2metadata.EC2InstanceIdentityDocument{},
+				retIDDoc:       ec2metadata.EC2InstanceIdentityDocument{},
 				retHostname:    "",
 				retErrHostname: errors.New("hostname failed"),
 				isAvailable:    true,

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -28,8 +28,12 @@ import (
 )
 
 type mockMetadata struct {
-	ret         ec2metadata.EC2InstanceIdentityDocument
-	returnErr   error
+	retIdDoc    ec2metadata.EC2InstanceIdentityDocument
+	retErrIdDoc error
+
+	retHostname    string
+	retErrHostname error
+
 	isAvailable bool
 }
 
@@ -40,10 +44,17 @@ func (mm mockMetadata) available(ctx context.Context) bool {
 }
 
 func (mm mockMetadata) get(ctx context.Context) (ec2metadata.EC2InstanceIdentityDocument, error) {
-	if mm.returnErr != nil {
-		return ec2metadata.EC2InstanceIdentityDocument{}, mm.returnErr
+	if mm.retErrIdDoc != nil {
+		return ec2metadata.EC2InstanceIdentityDocument{}, mm.retErrIdDoc
 	}
-	return mm.ret, nil
+	return mm.retIdDoc, nil
+}
+
+func (mm mockMetadata) hostname(ctx context.Context) (string, error) {
+	if mm.retErrHostname != nil {
+		return "", mm.retErrHostname
+	}
+	return mm.retHostname, nil
 }
 
 func TestNewDetector(t *testing.T) {
@@ -68,14 +79,16 @@ func TestDetector_Detect(t *testing.T) {
 	}{
 		{
 			name: "success",
-			fields: fields{provider: &mockMetadata{ret: ec2metadata.EC2InstanceIdentityDocument{
-				Region:           "us-west-2",
-				AccountID:        "account1234",
-				AvailabilityZone: "us-west-2a",
-				InstanceID:       "i-abcd1234",
-				ImageID:          "abcdef",
-				InstanceType:     "c4.xlarge",
-			},
+			fields: fields{provider: &mockMetadata{
+				retIdDoc: ec2metadata.EC2InstanceIdentityDocument{
+					Region:           "us-west-2",
+					AccountID:        "account1234",
+					AvailabilityZone: "us-west-2a",
+					InstanceID:       "i-abcd1234",
+					ImageID:          "abcdef",
+					InstanceType:     "c4.xlarge",
+				},
+				retHostname: "example-hostname",
 				isAvailable: true}},
 			args: args{ctx: context.Background()},
 			want: func() pdata.Resource {
@@ -89,13 +102,14 @@ func TestDetector_Detect(t *testing.T) {
 				attr.InsertString("host.id", "i-abcd1234")
 				attr.InsertString("host.image.id", "abcdef")
 				attr.InsertString("host.type", "c4.xlarge")
+				attr.InsertString("host.name", "example-hostname")
 				return res
 			}()},
 		{
 			name: "endpoint not available",
 			fields: fields{provider: &mockMetadata{
-				ret:         ec2metadata.EC2InstanceIdentityDocument{},
-				returnErr:   errors.New("should not be called"),
+				retIdDoc:    ec2metadata.EC2InstanceIdentityDocument{},
+				retErrIdDoc: errors.New("should not be called"),
 				isAvailable: false,
 			}},
 			args: args{ctx: context.Background()},
@@ -108,9 +122,24 @@ func TestDetector_Detect(t *testing.T) {
 		{
 			name: "get fails",
 			fields: fields{provider: &mockMetadata{
-				ret:         ec2metadata.EC2InstanceIdentityDocument{},
-				returnErr:   errors.New("get failed"),
+				retIdDoc:    ec2metadata.EC2InstanceIdentityDocument{},
+				retErrIdDoc: errors.New("get failed"),
 				isAvailable: true,
+			}},
+			args: args{ctx: context.Background()},
+			want: func() pdata.Resource {
+				res := pdata.NewResource()
+				res.InitEmpty()
+				return res
+			}(),
+			wantErr: true},
+		{
+			name: "hostname fails",
+			fields: fields{provider: &mockMetadata{
+				retIdDoc:       ec2metadata.EC2InstanceIdentityDocument{},
+				retHostname:    "",
+				retErrHostname: errors.New("hostname failed"),
+				isAvailable:    true,
 			}},
 			args: args{ctx: context.Background()},
 			want: func() pdata.Resource {

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/metadata.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/metadata.go
@@ -22,5 +22,6 @@ import (
 
 type ec2MetadataProvider interface {
 	get(ctx context.Context) (ec2metadata.EC2InstanceIdentityDocument, error)
+	hostname(ctx context.Context) (string, error)
 	available(ctx context.Context) bool
 }

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/metadata_ec2.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/metadata_ec2.go
@@ -32,6 +32,11 @@ func (md *ec2MetadataImpl) available(ctx context.Context) bool {
 	return meta.AvailableWithContext(ctx)
 }
 
+func (md *ec2MetadataImpl) hostname(ctx context.Context) (string, error) {
+	meta := ec2metadata.New(md.sess)
+	return meta.GetMetadataWithContext(ctx, "hostname")
+}
+
 func (md *ec2MetadataImpl) get(ctx context.Context) (ec2metadata.EC2InstanceIdentityDocument, error) {
 	meta := ec2metadata.New(md.sess)
 	return meta.GetInstanceIdentityDocumentWithContext(ctx)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adds EC2 fully qualified host name to the information gathered by the EC2 resource detector.
The information I query from EC2 metadata is documented [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-categories.html) as 
> The private IPv4 DNS hostname of the instance. In cases where multiple network interfaces are present, this refers to the eth0 device (the device for which the device number is 0).

I associate this information to the `host.name` key, [defined in the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/host.md) as
> Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.

**Link to tracking Issue:** n/a

**Testing:** I amended the unit tests to include this new function. I tested on an EC2 instance that the information was retrieved correctly.

**Documentation:** Added the new resource to the README list.