### PR TITLE
Temporarily remove dmitryax from PR facilitators

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -12,7 +12,6 @@ assigneeGroups:
   approvers_maintainers:
     - anuraaga
     - bogdandrutu
-    - dmitryax
     - james-bebbington
     - jrcamp
     - jpkrohling


### PR DESCRIPTION
dmitryax will be unavailable for a while, removing him from the list of PR facilitators.
