### PR TITLE
Add timer support for statsD receiver

### DIFF
--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -47,9 +47,10 @@ General format is:
 
 `<name>:<value>|g|@<sample-rate>|#<tag1-key>:<tag1-value>`
 
-<!-- ### Timer/Histogram
+### Timer
 
-`<name>:<value>|<ms/h>|@<sample-rate>|#<tag1-key>:<tag1-value>` -->
+`<name>:<value>|ms|@<sample-rate>|#<tag1-key>:<tag1-value>`
+
 
 ## Testing
 

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -31,7 +31,7 @@ var (
 )
 
 func getSupportedTypes() []string {
-	return []string{"c", "g"}
+	return []string{"c", "g", "ms"}
 }
 
 // StatsDParser supports the Parse method for parsing StatsD messages with Tags.
@@ -41,6 +41,7 @@ type statsDMetric struct {
 	name             string
 	value            string
 	statsdMetricType string
+	unit             string
 	metricType       metricspb.MetricDescriptor_Type
 	sampleRate       float64
 	labelKeys        []*metricspb.LabelKey
@@ -128,7 +129,13 @@ func parseMessageToMetric(line string) (*statsDMetric, error) {
 			return nil, fmt.Errorf("unrecognized message part: %s", part)
 		}
 	}
-
+	//fmt.Println("name: " + result.name)
+	//fmt.Println("value: " + result.value)
+	//fmt.Println("statsdMetricType: " + result.statsdMetricType)
+	//fmt.Println("metricsType: " + result.metricType.String())
+	//fmt.Println("samplerate: " + fmt.Sprintf("%f", result.sampleRate))
+	//fmt.Printf("labelkeys: %q\n", result.labelKeys)
+	//fmt.Printf("labelvalues: %q\n", result.labelValues)
 	return result, nil
 }
 
@@ -147,6 +154,7 @@ func buildMetric(metric *statsDMetric, point *metricspb.Point) *metricspb.Metric
 			Name:      metric.name,
 			Type:      metric.metricType,
 			LabelKeys: metric.labelKeys,
+			Unit:      metric.unit,
 		},
 		Timeseries: []*metricspb.TimeSeries{
 			{
@@ -181,6 +189,11 @@ func buildPoint(parsedMetric *statsDMetric) (*metricspb.Point, error) {
 			}
 			parsedMetric.metricType = metricspb.MetricDescriptor_GAUGE_INT64
 		})
+	case "ms":
+		return buildTimerPoint(parsedMetric, now, func(parsedMetric *statsDMetric) {
+			// we may need to change the transferred type in the future
+			parsedMetric.metricType = metricspb.MetricDescriptor_GAUGE_DOUBLE
+		})
 	}
 
 	return nil, fmt.Errorf("unhandled metric type: %s", parsedMetric.statsdMetricType)
@@ -213,5 +226,22 @@ func buildGaugeOrCounterPoint(parsedMetric *statsDMetric, now *timestamppb.Times
 		}
 	}
 	metricTypeSetter(parsedMetric, isDouble)
+	return point, nil
+}
+
+func buildTimerPoint(parsedMetric *statsDMetric, now *timestamppb.Timestamp, metricTypeSetter func(parsedMetric *statsDMetric)) (*metricspb.Point, error) {
+	var point *metricspb.Point
+	parsedMetric.unit = "ms"
+	f, err := strconv.ParseFloat(parsedMetric.value, 64)
+	if err != nil {
+		return nil, fmt.Errorf("timer: parse metric value string: %s", parsedMetric.value)
+	}
+	point = &metricspb.Point{
+		Timestamp: now,
+		Value: &metricspb.Point_DoubleValue{
+			DoubleValue: f,
+		},
+	}
+	metricTypeSetter(parsedMetric)
 	return point, nil
 }

--- a/receiver/statsdreceiver/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser_test.go
@@ -67,6 +67,7 @@ func Test_StatsDParser_Parse(t *testing.T) {
 				metricspb.MetricDescriptor_CUMULATIVE_INT64,
 				nil,
 				nil,
+				"",
 				&metricspb.Point{
 					Timestamp: &timestamppb.Timestamp{
 						Seconds: 0,
@@ -83,6 +84,7 @@ func Test_StatsDParser_Parse(t *testing.T) {
 				metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
 				nil,
 				nil,
+				"",
 				&metricspb.Point{
 					Timestamp: &timestamppb.Timestamp{
 						Seconds: 0,
@@ -118,6 +120,7 @@ func Test_StatsDParser_Parse(t *testing.T) {
 						HasValue: true,
 					},
 				},
+				"",
 				&metricspb.Point{
 					Timestamp: &timestamppb.Timestamp{
 						Seconds: 0,
@@ -143,6 +146,7 @@ func Test_StatsDParser_Parse(t *testing.T) {
 						HasValue: true,
 					},
 				},
+				"",
 				&metricspb.Point{
 					Timestamp: &timestamppb.Timestamp{
 						Seconds: 0,
@@ -168,6 +172,7 @@ func Test_StatsDParser_Parse(t *testing.T) {
 						HasValue: true,
 					},
 				},
+				"",
 				&metricspb.Point{
 					Timestamp: &timestamppb.Timestamp{
 						Seconds: 0,
@@ -176,6 +181,54 @@ func Test_StatsDParser_Parse(t *testing.T) {
 						Int64Value: 42,
 					},
 				}),
+		},
+		{
+			name:  "timer metric with sample rate",
+			input: "test.timer:42.3|ms|@0.1",
+			wantMetric: testMetric("test.timer",
+				metricspb.MetricDescriptor_GAUGE_DOUBLE,
+				nil,
+				nil,
+				"ms",
+				&metricspb.Point{
+					Timestamp: &timestamppb.Timestamp{
+						Seconds: 0,
+					},
+					Value: &metricspb.Point_DoubleValue{
+						DoubleValue: 42.3,
+					},
+				}),
+		},
+		{
+			name:  "timer metric with sample rate and tag",
+			input: "test.timer:42|ms|@0.1|#key:value",
+			wantMetric: testMetric("test.timer",
+				metricspb.MetricDescriptor_GAUGE_DOUBLE,
+				[]*metricspb.LabelKey{
+					{
+						Key: "key",
+					},
+				},
+				[]*metricspb.LabelValue{
+					{
+						Value:    "value",
+						HasValue: true,
+					},
+				},
+				"ms",
+				&metricspb.Point{
+					Timestamp: &timestamppb.Timestamp{
+						Seconds: 0,
+					},
+					Value: &metricspb.Point_DoubleValue{
+						DoubleValue: 42,
+					},
+				}),
+		},
+		{
+			name:  "timer: invalid metric value",
+			input: "test.metric:invalidValue|ms",
+			err:   errors.New("timer: parse metric value string: invalidValue"),
 		},
 		{
 			name:  "invalid sample rate value",
@@ -214,12 +267,14 @@ func testMetric(metricName string,
 	metricType metricspb.MetricDescriptor_Type,
 	lableKeys []*metricspb.LabelKey,
 	labelValues []*metricspb.LabelValue,
+	unit string,
 	point *metricspb.Point) *metricspb.Metric {
 	return &metricspb.Metric{
 		MetricDescriptor: &metricspb.MetricDescriptor{
 			Name:      metricName,
 			Type:      metricType,
 			LabelKeys: lableKeys,
+			Unit:      unit,
 		},
 		Timeseries: []*metricspb.TimeSeries{
 			{


### PR DESCRIPTION
**Description:** 
Add the timer support for statsD receiver.
We plant to transfer timer type to Double_Gauge and add the unit to "ms" so that it can be distinguished with gauge metrics type
**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/290
**Testing:** 
Added unit tests