### PR TITLE
Add timer support for statsD receiver

### DIFF
--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -47,9 +47,10 @@ General format is:
 
 `<name>:<value>|g|@<sample-rate>|#<tag1-key>:<tag1-value>`
 
-<!-- ### Timer/Histogram
+### Timer
 
-`<name>:<value>|<ms/h>|@<sample-rate>|#<tag1-key>:<tag1-value>` -->
+`<name>:<value>|ms|@<sample-rate>|#<tag1-key>:<tag1-value>`
+
 
 ## Testing
 


### PR DESCRIPTION
**Description:** 
Add the timer support for statsD receiver.
We plant to transfer timer type to Double_Gauge and add the unit to "ms" so that it can be distinguished with gauge metrics type
**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/290
**Testing:** 
Added unit tests