### PR TITLE
Enable stale PR action

### DIFF
--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -1,0 +1,16 @@
+name: "Close stale pull requests"
+on:
+  schedule:
+    - cron: "12 5 * * *" # arbitrary time not to DDOS GitHub
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
+          close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
+          days-before-stale: 7
+          days-before-close: 7


### PR DESCRIPTION
To help reviewers and authors remember to make progress on PR
this action will mark PRs as stale after inactivity of 7 days
and will close the PR after 7 more days of inactivity.
