### PR TITLE
Setting the tlsconfig InsecureSkipVerify using NoVerifySSL

### DIFF
--- a/exporter/awsxrayexporter/conn.go
+++ b/exporter/awsxrayexporter/conn.go
@@ -60,7 +60,7 @@ func newHTTPClient(logger *zap.Logger, maxIdle int, requestTimeout int, noVerify
 		zap.String("proxyAddr", proxyAddress),
 	)
 	tls := &tls.Config{
-		InsecureSkipVerify: false,
+		InsecureSkipVerify: noVerify,
 	}
 
 	finalProxyAddress := getProxyAddress(proxyAddress)


### PR DESCRIPTION
**Description:** Fixing a bug: currently the TLS config InsecureSkipVerify is default set to false, for which we already have a config variable in exporter config NoVerifySSL

**Testing:** Run all the unit test cases as well as the testbed to check if the collector is connecting correctly or not. 