### PR TITLE
[datadogexporter] Send otel.exporter running metric

### DIFF
--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -142,6 +142,9 @@ func TestCreateAPIMetricsExporter(t *testing.T) {
 }
 
 func TestCreateAPITracesExporter(t *testing.T) {
+	server := testutils.DatadogServerMock()
+	defer server.Close()
+
 	logger := zap.NewNop()
 
 	factories, err := componenttest.ExampleComponents()
@@ -153,6 +156,11 @@ func TestCreateAPITracesExporter(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
+
+	// Use the mock server for API key validation
+	c := (cfg.Exporters["datadog/api"]).(*config.Config)
+	c.Metrics.TCPAddr.Endpoint = server.URL
+	cfg.Exporters["datadog/api"] = c
 
 	ctx := context.Background()
 	exp, err := factory.CreateTraceExporter(

--- a/exporter/datadogexporter/metadata/host_test.go
+++ b/exporter/datadogexporter/metadata/host_test.go
@@ -30,6 +30,10 @@ func TestHost(t *testing.T) {
 
 	logger := zap.NewNop()
 
+	// Start with a fresh cache, the following test would fail
+	// if the cache key is already set.
+	cache.Cache.Delete(cache.CanonicalHostnameKey)
+
 	host := GetHost(logger, &config.Config{
 		TagsConfig: config.TagsConfig{Hostname: "test-host"},
 	})

--- a/exporter/datadogexporter/metrics/utils.go
+++ b/exporter/datadogexporter/metrics/utils.go
@@ -48,7 +48,7 @@ func NewGauge(name string, ts uint64, value float64, tags []string) datadog.Metr
 // RunningMetric creates a metric to report that an exporter is running
 func RunningMetric(exporterType string, timestamp uint64, logger *zap.Logger, cfg *config.Config) []datadog.Metric {
 	runningMetric := []datadog.Metric{
-		NewGauge(fmt.Sprintf("otel.exporter.%s.running", exporterType), timestamp, float64(1.0), []string{}),
+		NewGauge(fmt.Sprintf("otel.datadog_exporter.%s.running", exporterType), timestamp, float64(1.0), []string{}),
 	}
 
 	AddHostname(runningMetric, logger, cfg)

--- a/exporter/datadogexporter/metrics/utils.go
+++ b/exporter/datadogexporter/metrics/utils.go
@@ -56,7 +56,8 @@ func RunningMetric(exporterType string, timestamp uint64, logger *zap.Logger, cf
 	return runningMetric
 }
 
-// AddHostname adds the hostname to metrics
+// AddHostname adds an hostname to metrics, either using the hostname given
+// in the config, or retrieved from the host metadata
 func AddHostname(metrics []datadog.Metric, logger *zap.Logger, cfg *config.Config) {
 	overrideHostname := cfg.Hostname != ""
 
@@ -67,7 +68,7 @@ func AddHostname(metrics []datadog.Metric, logger *zap.Logger, cfg *config.Confi
 	}
 }
 
-// AddTags adds the given tags to all metrics
+// AddTags adds the given tags to all metrics in the provided list
 func AddTags(metrics []datadog.Metric, tags []string) {
 	for i := range metrics {
 		metrics[i].Tags = append(metrics[i].Tags, tags...)

--- a/exporter/datadogexporter/metrics/utils.go
+++ b/exporter/datadogexporter/metrics/utils.go
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/metadata"
+)
+
+const (
+	// Gauge is the Datadog Gauge metric type
+	Gauge string = "gauge"
+)
+
+// NewGauge creates a new Datadog Gauge metric given a name, a Unix nanoseconds timestamp
+// a value and a slice of tags
+func NewGauge(name string, ts uint64, value float64, tags []string) datadog.Metric {
+	// Transform UnixNano timestamp into Unix timestamp
+	// 1 second = 1e9 ns
+	timestamp := float64(ts / 1e9)
+
+	gauge := datadog.Metric{
+		Points: []datadog.DataPoint{[2]*float64{&timestamp, &value}},
+		Tags:   tags,
+	}
+	gauge.SetMetric(name)
+	gauge.SetType(Gauge)
+	return gauge
+}
+
+// RunningMetric creates a metric to report that an exporter is running
+func RunningMetric(exporterType string, timestamp uint64, logger *zap.Logger, cfg *config.Config) []datadog.Metric {
+	runningMetric := []datadog.Metric{
+		NewGauge(fmt.Sprintf("otel.exporter.%s.running", exporterType), timestamp, float64(1.0), []string{}),
+	}
+
+	AddHostname(runningMetric, logger, cfg)
+
+	return runningMetric
+}
+
+// AddHostname adds the hostname to metrics
+func AddHostname(metrics []datadog.Metric, logger *zap.Logger, cfg *config.Config) {
+	overrideHostname := cfg.Hostname != ""
+
+	for i := range metrics {
+		if overrideHostname || metrics[i].GetHost() == "" {
+			metrics[i].Host = metadata.GetHost(logger, cfg)
+		}
+	}
+}
+
+// AddTags adds the given tags to all metrics
+func AddTags(metrics []datadog.Metric, tags []string) {
+	for i := range metrics {
+		metrics[i].Tags = append(metrics[i].Tags, tags...)
+	}
+}
+
+// AddNamespace prepends all metric names with a given namespace
+func AddNamespace(metrics []datadog.Metric, namespace string) {
+	for i := range metrics {
+		newName := namespace + *metrics[i].Metric
+		metrics[i].Metric = &newName
+	}
+}

--- a/exporter/datadogexporter/metrics/utils_test.go
+++ b/exporter/datadogexporter/metrics/utils_test.go
@@ -48,7 +48,7 @@ func TestRunningMetric(t *testing.T) {
 
 	ms := RunningMetric("metrics", uint64(2e9), logger, cfg)
 
-	assert.Equal(t, "otel.exporter.metrics.running", *ms[0].Metric)
+	assert.Equal(t, "otel.datadog_exporter.metrics.running", *ms[0].Metric)
 	// Assert metrics list length (should be 1)
 	assert.Equal(t, 1, len(ms))
 	// Assert timestamp

--- a/exporter/datadogexporter/metrics/utils_test.go
+++ b/exporter/datadogexporter/metrics/utils_test.go
@@ -46,22 +46,24 @@ func TestRunningMetric(t *testing.T) {
 	logger := zap.NewNop()
 	cfg := &config.Config{}
 
-	ms := RunningMetric("metrics", 0, logger, cfg)
+	ms := RunningMetric("metrics", uint64(2e9), logger, cfg)
 
 	assert.Equal(t, "otel.exporter.metrics.running", *ms[0].Metric)
 	// Assert metrics list length (should be 1)
 	assert.Equal(t, 1, len(ms))
 	// Assert timestamp
-	assert.Equal(t, 0.0, *ms[0].Points[0][0])
+	assert.Equal(t, 2.0, *ms[0].Points[0][0])
 	// Assert value (should always be 1.0)
 	assert.Equal(t, 1.0, *ms[0].Points[0][1])
 }
 
 func TestAddHostname(t *testing.T) {
-	// With hostname in config
+	logger := zap.NewNop()
+
+	// Reset hostname cache
 	cache.Cache.Flush()
 
-	logger := zap.NewNop()
+	// With hostname in config
 	cfg := &config.Config{
 		TagsConfig: config.TagsConfig{
 			Hostname: "thishost",
@@ -83,9 +85,10 @@ func TestAddHostname(t *testing.T) {
 	assert.Equal(t, "thishost", *ms[0].Host)
 	assert.Equal(t, "thishost", *ms[1].Host)
 
-	// Without hostname in config
+	// Reset hostname cache
 	cache.Cache.Flush()
 
+	// Without hostname in config
 	cfg = &config.Config{}
 
 	ms = []datadog.Metric{

--- a/exporter/datadogexporter/metrics/utils_test.go
+++ b/exporter/datadogexporter/metrics/utils_test.go
@@ -55,6 +55,25 @@ func TestRunningMetric(t *testing.T) {
 	assert.Equal(t, 2.0, *ms[0].Points[0][0])
 	// Assert value (should always be 1.0)
 	assert.Equal(t, 1.0, *ms[0].Points[0][1])
+
+	// Test that the namespace set in config does not get used: the running
+	// metric needs to follow a specific format
+	cfg = &config.Config{
+		Metrics: config.MetricsConfig{
+			Namespace: "test.",
+		},
+	}
+
+	ms = RunningMetric("metrics", uint64(2e9), logger, cfg)
+
+	// Check that the namespace isn't used
+	assert.Equal(t, "otel.datadog_exporter.metrics.running", *ms[0].Metric)
+	// Assert metrics list length (should be 1)
+	assert.Equal(t, 1, len(ms))
+	// Assert timestamp
+	assert.Equal(t, 2.0, *ms[0].Points[0][0])
+	// Assert value (should always be 1.0)
+	assert.Equal(t, 1.0, *ms[0].Points[0][1])
 }
 
 func TestAddHostname(t *testing.T) {

--- a/exporter/datadogexporter/metrics/utils_test.go
+++ b/exporter/datadogexporter/metrics/utils_test.go
@@ -1,0 +1,125 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/utils/cache"
+)
+
+func TestNewGauge(t *testing.T) {
+	name := "test.metric"
+	ts := uint64(1e9)
+	value := 2.0
+	tags := []string{"tag:value"}
+
+	metric := NewGauge(name, ts, value, tags)
+
+	assert.Equal(t, "test.metric", *metric.Metric)
+	// Assert timestamp conversion from uint64 ns to float64 s
+	assert.Equal(t, 1.0, *metric.Points[0][0])
+	// Assert value
+	assert.Equal(t, 2.0, *metric.Points[0][1])
+	// Assert tags
+	assert.Equal(t, []string{"tag:value"}, metric.Tags)
+}
+
+func TestRunningMetric(t *testing.T) {
+	logger := zap.NewNop()
+	cfg := &config.Config{}
+
+	ms := RunningMetric("metrics", 0, logger, cfg)
+
+	assert.Equal(t, "otel.exporter.metrics.running", *ms[0].Metric)
+	// Assert metrics list length (should be 1)
+	assert.Equal(t, 1, len(ms))
+	// Assert timestamp
+	assert.Equal(t, 0.0, *ms[0].Points[0][0])
+	// Assert value (should always be 1.0)
+	assert.Equal(t, 1.0, *ms[0].Points[0][1])
+}
+
+func TestAddHostname(t *testing.T) {
+	// With hostname in config
+	cache.Cache.Flush()
+
+	logger := zap.NewNop()
+	cfg := &config.Config{
+		TagsConfig: config.TagsConfig{
+			Hostname: "thishost",
+		},
+	}
+
+	ms := []datadog.Metric{
+		NewGauge("test.metric", 0, 1.0, []string{}),
+		NewGauge("test.metric2", 0, 2.0, []string{}),
+	}
+
+	hostname := "thathost"
+
+	ms[0].Host = &hostname
+
+	AddHostname(ms, logger, cfg)
+
+	// Check that all hostnames are set to the config's hostname
+	assert.Equal(t, "thishost", *ms[0].Host)
+	assert.Equal(t, "thishost", *ms[1].Host)
+
+	// Without hostname in config
+	cache.Cache.Flush()
+
+	cfg = &config.Config{}
+
+	ms = []datadog.Metric{
+		NewGauge("test.metric", 0, 1.0, []string{}),
+	}
+
+	ms[0].Host = &hostname
+
+	AddHostname(ms, logger, cfg)
+
+	// Check that the already set host remains set
+	assert.Equal(t, "thathost", *ms[0].Host)
+}
+
+func TestAddNamespace(t *testing.T) {
+	ms := []datadog.Metric{
+		NewGauge("test.metric", 0, 1.0, []string{}),
+		NewGauge("test.metric2", 0, 2.0, []string{}),
+	}
+
+	AddNamespace(ms, "namespace.")
+
+	assert.Equal(t, "namespace.test.metric", *ms[0].Metric)
+	assert.Equal(t, "namespace.test.metric2", *ms[1].Metric)
+}
+
+func TestAddTags(t *testing.T) {
+	ms := []datadog.Metric{
+		NewGauge("test.metric", 0, 1.0, []string{}),
+		NewGauge("test.metric2", 0, 2.0, []string{"tag:value"}),
+	}
+
+	AddTags(ms, []string{"othertag:othervalue"})
+
+	assert.Equal(t, []string{"othertag:othervalue"}, ms[0].Tags)
+	assert.Equal(t, []string{"tag:value", "othertag:othervalue"}, ms[1].Tags)
+}

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -59,6 +59,8 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pdata.Metric
 	ms, droppedTimeSeries := MapMetrics(exp.logger, exp.cfg.Metrics, md)
 	exp.processMetrics(ms)
 
+	// The running metric is added after metrics are processed, as the running metric is already
+	// processed in a special way in RunningMetric (eg. no namespace is added)
 	pushTime := uint64(time.Now().UTC().UnixNano())
 	ms = append(ms, metrics.RunningMetric("metrics", pushTime, exp.logger, exp.cfg)...)
 

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -24,6 +24,7 @@ import (
 	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/testutils"
 )
 
@@ -79,8 +80,8 @@ func TestProcessMetrics(t *testing.T) {
 
 	require.NoError(t, err)
 
-	metrics := []datadog.Metric{
-		newGauge(
+	ms := []datadog.Metric{
+		metrics.NewGauge(
 			"metric_name",
 			0,
 			0,
@@ -88,13 +89,13 @@ func TestProcessMetrics(t *testing.T) {
 		),
 	}
 
-	exp.processMetrics(metrics)
+	exp.processMetrics(ms)
 
-	assert.Equal(t, "test-host", *metrics[0].Host)
-	assert.Equal(t, "test.metric_name", *metrics[0].Metric)
+	assert.Equal(t, "test-host", *ms[0].Host)
+	assert.Equal(t, "test.metric_name", *ms[0].Metric)
 	assert.ElementsMatch(t,
 		[]string{"key:val", "env:test_env", "key2:val2"},
-		metrics[0].Tags,
+		ms[0].Tags,
 	)
 
 }

--- a/exporter/datadogexporter/metrics_translator_test.go
+++ b/exporter/datadogexporter/metrics_translator_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"gopkg.in/zorkian/go-datadog-api.v2"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/metrics"
 )
 
 func TestMetricValue(t *testing.T) {
@@ -32,8 +34,8 @@ func TestMetricValue(t *testing.T) {
 		tags  []string = []string{"tool:opentelemetry", "version:0.1.0"}
 	)
 
-	metric := newGauge(name, ts, value, tags)
-	assert.Equal(t, Gauge, metric.GetType())
+	metric := metrics.NewGauge(name, ts, value, tags)
+	assert.Equal(t, metrics.Gauge, metric.GetType())
 	assert.Equal(t, tags, metric.Tags)
 }
 
@@ -66,7 +68,7 @@ func TestMapIntMetrics(t *testing.T) {
 
 	assert.ElementsMatch(t,
 		mapIntMetrics("int64.test", slice),
-		[]datadog.Metric{newGauge("int64.test", uint64(ts), 17, []string{})},
+		[]datadog.Metric{metrics.NewGauge("int64.test", uint64(ts), 17, []string{})},
 	)
 }
 
@@ -85,7 +87,7 @@ func TestMapDoubleMetrics(t *testing.T) {
 
 	assert.ElementsMatch(t,
 		mapDoubleMetrics("float64.test", slice),
-		[]datadog.Metric{newGauge("float64.test", uint64(ts), math.Pi, []string{})},
+		[]datadog.Metric{metrics.NewGauge("float64.test", uint64(ts), math.Pi, []string{})},
 	)
 }
 
@@ -105,13 +107,13 @@ func TestMapIntHistogramMetrics(t *testing.T) {
 	slice.Append(nilPoint)
 
 	noBuckets := []datadog.Metric{
-		newGauge("intHist.test.count", uint64(ts), 20, []string{}),
-		newGauge("intHist.test.sum", uint64(ts), 200, []string{}),
+		metrics.NewGauge("intHist.test.count", uint64(ts), 20, []string{}),
+		metrics.NewGauge("intHist.test.sum", uint64(ts), 200, []string{}),
 	}
 
 	buckets := []datadog.Metric{
-		newGauge("intHist.test.count_per_bucket", uint64(ts), 2, []string{"bucket_idx:0"}),
-		newGauge("intHist.test.count_per_bucket", uint64(ts), 18, []string{"bucket_idx:1"}),
+		metrics.NewGauge("intHist.test.count_per_bucket", uint64(ts), 2, []string{"bucket_idx:0"}),
+		metrics.NewGauge("intHist.test.count_per_bucket", uint64(ts), 18, []string{"bucket_idx:1"}),
 	}
 
 	assert.ElementsMatch(t,
@@ -141,13 +143,13 @@ func TestMapDoubleHistogramMetrics(t *testing.T) {
 	slice.Append(nilPoint)
 
 	noBuckets := []datadog.Metric{
-		newGauge("doubleHist.test.count", uint64(ts), 20, []string{}),
-		newGauge("doubleHist.test.sum", uint64(ts), math.Pi, []string{}),
+		metrics.NewGauge("doubleHist.test.count", uint64(ts), 20, []string{}),
+		metrics.NewGauge("doubleHist.test.sum", uint64(ts), math.Pi, []string{}),
 	}
 
 	buckets := []datadog.Metric{
-		newGauge("doubleHist.test.count_per_bucket", uint64(ts), 2, []string{"bucket_idx:0"}),
-		newGauge("doubleHist.test.count_per_bucket", uint64(ts), 18, []string{"bucket_idx:1"}),
+		metrics.NewGauge("doubleHist.test.count_per_bucket", uint64(ts), 2, []string{"bucket_idx:0"}),
+		metrics.NewGauge("doubleHist.test.count_per_bucket", uint64(ts), 18, []string{"bucket_idx:1"}),
 	}
 
 	assert.ElementsMatch(t,

--- a/exporter/datadogexporter/testutils/test_utils.go
+++ b/exporter/datadogexporter/testutils/test_utils.go
@@ -24,6 +24,7 @@ import (
 func DatadogServerMock() *httptest.Server {
 	handler := http.NewServeMux()
 	handler.HandleFunc("/api/v1/validate", validateAPIKeyEndpoint)
+	handler.HandleFunc("/api/v1/series", metricsEndpoint)
 
 	srv := httptest.NewServer(handler)
 
@@ -39,5 +40,18 @@ func validateAPIKeyEndpoint(w http.ResponseWriter, r *http.Request) {
 	resJSON, _ := json.Marshal(res)
 
 	w.Header().Set("Content-Type", "application/json")
+	w.Write(resJSON)
+}
+
+type metricsResponse struct {
+	Status string `json:"status"`
+}
+
+func metricsEndpoint(w http.ResponseWriter, r *http.Request) {
+	res := metricsResponse{Status: "ok"}
+	resJSON, _ := json.Marshal(res)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
 	w.Write(resJSON)
 }

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -23,8 +23,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/pb"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
+	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/metrics"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/utils"
 )
 
 type traceExporter struct {
@@ -32,6 +35,7 @@ type traceExporter struct {
 	cfg            *config.Config
 	edgeConnection TraceEdgeConnection
 	obfuscator     *obfuscate.Obfuscator
+	client         *datadog.Client
 	tags           []string
 }
 
@@ -54,6 +58,10 @@ var (
 )
 
 func newTraceExporter(logger *zap.Logger, cfg *config.Config) (*traceExporter, error) {
+	// client to send running metric to the backend & perform API key validation
+	client := utils.CreateClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
+	utils.ValidateAPIKey(logger, client)
+
 	// removes potentially sensitive info and PII, approach taken from serverless approach
 	// https://github.com/DataDog/datadog-serverless-functions/blob/11f170eac105d66be30f18eda09eca791bc0d31b/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go#L43
 	obfuscator := obfuscate.NewObfuscator(obfuscatorConfig)
@@ -112,6 +120,9 @@ func (exp *traceExporter) pushTraceData(
 			return nil
 		})
 	}
+
+	ms := metrics.RunningMetric("metrics", uint64(pushTime), exp.logger, exp.cfg)
+	exp.client.PostMetrics(ms)
 
 	return len(aggregatedTraces), nil
 }

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -73,6 +73,7 @@ func newTraceExporter(logger *zap.Logger, cfg *config.Config) (*traceExporter, e
 		cfg:            cfg,
 		edgeConnection: CreateTraceEdgeConnection(cfg.Traces.TCPAddr.Endpoint, cfg.API.Key),
 		obfuscator:     obfuscator,
+		client:         client,
 		tags:           tags,
 	}
 
@@ -121,7 +122,7 @@ func (exp *traceExporter) pushTraceData(
 		})
 	}
 
-	ms := metrics.RunningMetric("metrics", uint64(pushTime), exp.logger, exp.cfg)
+	ms := metrics.RunningMetric("traces", uint64(pushTime), exp.logger, exp.cfg)
 	exp.client.PostMetrics(ms)
 
 	return len(aggregatedTraces), nil

--- a/exporter/datadogexporter/utils/api.go
+++ b/exporter/datadogexporter/utils/api.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"go.uber.org/zap"
+	"gopkg.in/zorkian/go-datadog-api.v2"
+)
+
+// CreateClient creates a new Datadog client
+func CreateClient(APIKey string, endpoint string) *datadog.Client {
+	client := datadog.NewClient(APIKey, "")
+	client.SetBaseUrl(endpoint)
+
+	return client
+}
+
+// ValidateAPIKey checks that the provided client was given a correct API key.
+func ValidateAPIKey(logger *zap.Logger, client *datadog.Client) {
+	logger.Info("Validating API key.")
+	res, err := client.Validate()
+	if err != nil {
+		logger.Warn("Error while validating API key.", zap.Error(err))
+	}
+
+	if res {
+		logger.Info("API key validation successful.")
+	} else {
+		logger.Warn("API key validation failed.")
+	}
+}


### PR DESCRIPTION
**Description:**

Send an additional metric when an exporter is running: `otel.datadog_exporter.metrics.running` for the metrics exporter, `otel.datadog_exporter.traces.running` for the traces exporter.

This addition needed the trace exporter to be able to send metrics, therefore this PR adds a datadog go client to the trace exporter, and:
- the go client creation & API key validation were refactored in the `utils/api.go` file.
- utilities for metrics creation & population were moved to the `metrics/utils.go`file.
- tests for the new `metrics` package.

Other unit tests have been updated to match these changes.

**Link to tracking Issue:** n/a

**Testing:** 

Checked that both metrics are sent to the backend when exporters are enabled, using our E2E test environment.

**Documentation:** n/a