### PR TITLE
Batching logic for same label set metrics

### DIFF
--- a/exporter/awsemfexporter/factory.go
+++ b/exporter/awsemfexporter/factory.go
@@ -60,7 +60,6 @@ func createDefaultConfig() configmodels.Exporter {
 func createMetricsExporter(_ context.Context,
 	params component.ExporterCreateParams,
 	config configmodels.Exporter) (component.MetricsExporter, error) {
-	fmt.Println("HELLO WORLD")
 	expCfg := config.(*Config)
 
 	return New(expCfg, params)

--- a/exporter/awsemfexporter/factory.go
+++ b/exporter/awsemfexporter/factory.go
@@ -16,7 +16,7 @@ package awsemfexporter
 
 import (
 	"context"
-
+	"fmt"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -60,7 +60,7 @@ func createDefaultConfig() configmodels.Exporter {
 func createMetricsExporter(_ context.Context,
 	params component.ExporterCreateParams,
 	config configmodels.Exporter) (component.MetricsExporter, error) {
-
+	fmt.Println("HELLO WORLD")
 	expCfg := config.(*Config)
 
 	return New(expCfg, params)


### PR DESCRIPTION
**Description:**
This PR implements the necessary functionality to batch metrics with exact same label sets. Specifically, this PR accomplishes the following:

1. Create a new `GroupedMetric` struct in the metric_translator file which defines the measurements and stats for CW metrics.
2. Implement new function called batchCWMetrics which group CW Metrics with same label sets together and store them in `groupedCWMetricMap`. This will check the key in map for new incoming CW metrics, and create a new <k,v> pair if does not exists. Otherwise, it will update `groupedCWMetricMap` with new metric name(s).
3. Set new parameters (within `TranslateOtToCWMetric` function) to include the `GroupedCWMetricMap` which will be used to keep track of any new metrics that share same set of labels
4. Ensure that newly defined `TranslateBatchedMetricToEMF` function convert batched metrics correctly to EMF logs on corresponding CloudWatch log group/stream.
5. Verify timestamp of nginx metric scraped in one shot sharing same timestamp.

**Testing:** 
This code change has been tested with unit tests and in a sample environment using an NGINX server on EKS with these settings in `config.yaml` 
```
exporters:
  logging:
    loglevel: debug
  awsemf:
    log_group_name: 'awscollector-test'
    region: 'us-west-2'
    log_stream_name: metric-declarations
    dimension_rollup_option: 'NoDimensionRollup'

service:
  pipelines:
    metrics:
      receivers: [prometheus]
      exporters: [awsemf, logging]

  extensions: [health_check, pprof, zpages]
```

Before, the CW logs look like this:
```
{
    "Namespace": "kube-system",
    "OTLib": "Undefined",
    "Service": "kube-dns",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "kubernetes-service-endpoints",
                "Dimensions": [
                    [
                        "Namespace",
                        "Service",
                        "container_name",
                        "eks_amazonaws_com_component",
                        "k8s_app",
                        "kubernetes_io_cluster_service",
                        "kubernetes_io_name",
                        "kubernetes_node",
                        "pod_name",
                        "OTLib"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "go_goroutines",
                        "Unit": ""
                    }
                ]
            }
        ],
        "Timestamp": 1603352885414
    },
    "container_name": "coredns",
    "eks_amazonaws_com_component": "kube-dns",
    "go_goroutines": 0,
    "k8s_app": "kube-dns",
    "kubernetes_io_cluster_service": "true",
    "kubernetes_io_name": "CoreDNS",
    "kubernetes_node": "ip-192-168-43-221.us-west-2.compute.internal",
    "pod_name": "coredns-5946c5d67c-txp4b"
}
```
And after batching, the newly exported CW logs:
```
{
    "Dimensions": {
        "Namespace": "kube-system",
        "OTLib": "Undefined",
        "Service": "kube-dns",
        "container_name": "coredns",
        "eks_amazonaws_com_component": "kube-dns",
        "k8s_app": "kube-dns",
        "kubernetes_io_cluster_service": "true",
        "kubernetes_io_name": "CoreDNS",
        "kubernetes_node": "ip-192-168-43-221.us-west-2.compute.internal",
        "pod_name": "coredns-5946c5d67c-txp4b"
    },
    "Metrics": {
        "coredns_health_request_duration_seconds": {
            "Max": 8.192,
            "Min": 0.00025,
            "Count": 3300,
            "Sum": 1.0383265599980405
        },
        "coredns_panic_count_total": 0.016666666666666666,
        "go_goroutines": 0,
        "go_memstats_alloc_bytes": 0,
        "go_memstats_alloc_bytes_total": 0,
        "go_memstats_buck_hash_sys_bytes": 0,
        "go_memstats_frees_total": 0,
        "go_memstats_gc_cpu_fraction": 0,
        "go_memstats_gc_sys_bytes": 0,
        "go_memstats_heap_alloc_bytes": 0,
        "go_memstats_heap_idle_bytes": 0,
        "go_memstats_heap_inuse_bytes": 0,
        "go_memstats_heap_objects": 0,
        "go_memstats_heap_released_bytes": 0,
        "go_memstats_heap_sys_bytes": 0,
        "go_memstats_last_gc_time_seconds": 0,
        "go_memstats_lookups_total": 0,
        "go_memstats_mallocs_total": 0,
        "go_memstats_mcache_inuse_bytes": 0,
        "go_memstats_mcache_sys_bytes": 0,
        "go_memstats_mspan_inuse_bytes": 0,
        "go_memstats_mspan_sys_bytes": 0,
        "go_memstats_next_gc_bytes": 0,
        "go_memstats_other_sys_bytes": 0,
        "go_memstats_stack_inuse_bytes": 0,
        "go_memstats_stack_sys_bytes": 0,
        "go_memstats_sys_bytes": 0,
        "go_threads": 0,
        "process_cpu_seconds_total": 0,
        "process_max_fds": 0,
        "process_open_fds": 0,
        "process_resident_memory_bytes": 0,
        "process_start_time_seconds": 0,
        "process_virtual_memory_bytes": 0,
        "process_virtual_memory_max_bytes": 0
    },
    "Namespace": "kubernetes-service-endpoints",
    "Timestamp": 1603396018630
}
```

**Documentation**
Nothing in README has been updated as no changes were made to configurations or rules for exported metrics.