### PR TITLE
Add sample rate support for counter, transfer gauge to double and tra…

### DIFF
--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -167,20 +167,12 @@ func buildPoint(parsedMetric *statsDMetric) (*metricspb.Point, error) {
 
 	switch parsedMetric.statsdMetricType {
 	case "c":
-		return buildGaugeOrCounterPoint(parsedMetric, now, func(parsedMetric *statsDMetric, isDouble bool) {
-			if isDouble {
-				parsedMetric.metricType = metricspb.MetricDescriptor_CUMULATIVE_DOUBLE
-				return
-			}
+		return buildCounterPoint(parsedMetric, now, func(parsedMetric *statsDMetric) {
 			parsedMetric.metricType = metricspb.MetricDescriptor_CUMULATIVE_INT64
 		})
 	case "g":
-		return buildGaugeOrCounterPoint(parsedMetric, now, func(parsedMetric *statsDMetric, isDouble bool) {
-			if isDouble {
-				parsedMetric.metricType = metricspb.MetricDescriptor_GAUGE_DOUBLE
-				return
-			}
-			parsedMetric.metricType = metricspb.MetricDescriptor_GAUGE_INT64
+		return buildGaugePoint(parsedMetric, now, func(parsedMetric *statsDMetric) {
+			parsedMetric.metricType = metricspb.MetricDescriptor_GAUGE_DOUBLE
 		})
 	case "ms":
 		return buildTimerPoint(parsedMetric, now, func(parsedMetric *statsDMetric) {
@@ -191,33 +183,44 @@ func buildPoint(parsedMetric *statsDMetric) (*metricspb.Point, error) {
 	return nil, fmt.Errorf("unhandled metric type: %s", parsedMetric.statsdMetricType)
 }
 
-func buildGaugeOrCounterPoint(parsedMetric *statsDMetric, now *timestamppb.Timestamp,
-	metricTypeSetter func(parsedMetric *statsDMetric, isDouble bool)) (*metricspb.Point, error) {
+func buildCounterPoint(parsedMetric *statsDMetric, now *timestamppb.Timestamp,
+	metricTypeSetter func(parsedMetric *statsDMetric)) (*metricspb.Point, error) {
 	var point *metricspb.Point
-	var isDouble bool
+	var i int64
 
-	i, err := strconv.ParseInt(parsedMetric.value, 10, 64)
+	f, err := strconv.ParseFloat(parsedMetric.value, 64)
 	if err != nil {
-		f, err := strconv.ParseFloat(parsedMetric.value, 64)
-		if err != nil {
-			return nil, fmt.Errorf("parse metric value string: %s", parsedMetric.value)
-		}
-		point = &metricspb.Point{
-			Timestamp: now,
-			Value: &metricspb.Point_DoubleValue{
-				DoubleValue: f,
-			},
-		}
-		isDouble = true
-	} else {
-		point = &metricspb.Point{
-			Timestamp: now,
-			Value: &metricspb.Point_Int64Value{
-				Int64Value: i,
-			},
-		}
+		return nil, fmt.Errorf("counter: parse metric value string: %s", parsedMetric.value)
 	}
-	metricTypeSetter(parsedMetric, isDouble)
+	i = int64(f)
+	if 0 < parsedMetric.sampleRate && parsedMetric.sampleRate < 1 {
+		i = int64(f / parsedMetric.sampleRate)
+	}
+	point = &metricspb.Point{
+		Timestamp: now,
+		Value: &metricspb.Point_Int64Value{
+			Int64Value: i,
+		},
+	}
+	metricTypeSetter(parsedMetric)
+	return point, nil
+}
+
+func buildGaugePoint(parsedMetric *statsDMetric, now *timestamppb.Timestamp,
+	metricTypeSetter func(parsedMetric *statsDMetric)) (*metricspb.Point, error) {
+	var point *metricspb.Point
+
+	f, err := strconv.ParseFloat(parsedMetric.value, 64)
+	if err != nil {
+		return nil, fmt.Errorf("gauge: parse metric value string: %s", parsedMetric.value)
+	}
+	point = &metricspb.Point{
+		Timestamp: now,
+		Value: &metricspb.Point_DoubleValue{
+			DoubleValue: f,
+		},
+	}
+	metricTypeSetter(parsedMetric)
 	return point, nil
 }
 


### PR DESCRIPTION
…nsfer counter to int only.

**Description:** 
- Add sample rate support for counter
 If we receive `counterName:10|c|@0.1`, we will transfer the value to `10/0.1 = 100` to the following process
- Transfer gauge to double only
After discussion, we plan to transfer gauge to double only no matter what we receive
`gaugeName:86|g` will be transferred to 86.0 as Double_Gauge only
- Transfer counter to int only
After discussion, we plan to transfer counter to int only no matter what we receive
`counterName:86|c` will be transferred to 86 as Int only

**Link to tracking Issue:** 
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/290

**Testing:** 
- Added unit tests
