### PR TITLE
Enable back test for groupbytrace processor

### DIFF
--- a/processor/groupbytraceprocessor/processor_test.go
+++ b/processor/groupbytraceprocessor/processor_test.go
@@ -635,10 +635,6 @@ func TestSplitByTraceWithNilTraceID(t *testing.T) {
 }
 
 func TestErrorOnProcessResourceSpansContinuesProcessing(t *testing.T) {
-	// Skip it, this is failing on Windows. Bug submitted:
-	// https://github.com/open-telemetry/opentelemetry-collector/issues/1923
-	t.SkipNow()
-
 	// prepare
 	config := Config{
 		WaitDuration: time.Second, // we are not waiting for this whole time


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

**Description:** The test TestErrorOnProcessResourceSpansContinuesProcessing was disabled as part of open-telemetry/opentelemetry-collector#1923. Turns out, the test failure wasn't because of this test, but rather, because of TestPeriodicMetrics.
This PR enables this test back.

**Link to tracking Issue:** Closes open-telemetry/opentelemetry-collector#1923

**Testing:** n/a

**Documentation:** n/a
