### PR TITLE
Fix TestPeriodicMetrics test

### DIFF
--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -320,7 +320,12 @@ func TestEventShutdown(t *testing.T) {
 func TestPeriodicMetrics(t *testing.T) {
 	// prepare
 	views := MetricViews()
+
+	// ensure that we are starting with a clean state
+	view.Unregister(views...)
 	view.Register(views...)
+
+	// try to be nice with the next consumer (test)
 	defer view.Unregister(views...)
 
 	logger, err := zap.NewDevelopment()


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

**Description:** Fixes the TestPeriodicMetrics test from the groupbytrace processor by ensuring that the views used during the test are clean.
Before this PR, the test would fail all the time when running multiple times in the same process:

```
$ go test . -count 100 "^TestPeriodicMetrics$" | grep Messages | sort | uniq -c 
     99         	Messages:   	gauge exists already but shouldn't
```

After this PR, the test didn't fail after 100 attempts:
```
$ go test . -count 100 "^TestPeriodicMetrics$" | grep Messages | sort | uniq -c 
```

**Link to tracking Issue:** Closes open-telemetry/opentelemetry-collector#1927

**Testing:** n/a

**Documentation:** n/a
