### PR TITLE
elasticexporter: ensure span name is limited

### DIFF
--- a/exporter/elasticexporter/internal/translator/elastic/traces.go
+++ b/exporter/elasticexporter/internal/translator/elastic/traces.go
@@ -45,7 +45,7 @@ func EncodeSpan(otlpSpan pdata.Span, otlpLibrary pdata.InstrumentationLibrary, w
 	endTime := time.Unix(0, int64(otlpSpan.EndTime())).UTC()
 	durationMillis := endTime.Sub(startTime).Seconds() * 1000
 
-	name := otlpSpan.Name()
+	name := truncate(otlpSpan.Name())
 	var transactionContext transactionContext
 	if root || otlpSpan.Kind() == pdata.SpanKindSERVER {
 		transaction := model.Transaction{


### PR DESCRIPTION
**Description:**

Ensure span names are no longer than 1024 runes, per the Elastic APM protocol's requirements. Span names longer than this will be truncated to 1024 runes.

There will be usability issues with such long span names. Ideally the span name would be shortened, e.g. by having the instrumentation summarise the database statement (as done in Elastic APM agents), or something more specific such as having instrumentation aware of the Postgres JDBC driver's `PgDatabaseMetaData#getTables` method, naming the span after that rather than the SQL that ensues.

**Link to tracking Issue:**

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1269

**Testing:**

Unit test added.