### PR TITLE
[exporter/datadogexporter]: add tag normalization util method 

### DIFF
--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -449,18 +449,18 @@ func getDatadogSpanName(s pdata.Span, datadogTags map[string]string) string {
 	// The spec has changed over time and, depending on the original exporter, IL Name could represented a few different ways
 	// so we try to account for all permutations
 	if ilnOtlp, okOtlp := datadogTags[tracetranslator.TagInstrumentationName]; okOtlp {
-		return utils.NormalizeTag(fmt.Sprintf("%s.%s", ilnOtlp, s.Kind()))
+		return utils.NormalizeSpanName(fmt.Sprintf("%s.%s", ilnOtlp, s.Kind()))
 	}
 
 	if ilnOtelCur, okOtelCur := datadogTags[currentILNameTag]; okOtelCur {
-		return utils.NormalizeTag(fmt.Sprintf("%s.%s", ilnOtelCur, s.Kind()))
+		return utils.NormalizeSpanName(fmt.Sprintf("%s.%s", ilnOtelCur, s.Kind()))
 	}
 
 	if ilnOtelOld, okOtelOld := datadogTags[oldILNameTag]; okOtelOld {
-		return utils.NormalizeTag(fmt.Sprintf("%s.%s", ilnOtelOld, s.Kind()))
+		return utils.NormalizeSpanName(fmt.Sprintf("%s.%s", ilnOtelOld, s.Kind()))
 	}
 
-	return utils.NormalizeTag(fmt.Sprintf("%s.%s", "opentelemetry", s.Kind()))
+	return utils.NormalizeSpanName(fmt.Sprintf("%s.%s", "opentelemetry", s.Kind()))
 }
 
 func getDatadogResourceName(s pdata.Span, datadogTags map[string]string) string {

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/utils"
 )
 
 // codeDetails specifies information about a trace status code.
@@ -448,18 +449,18 @@ func getDatadogSpanName(s pdata.Span, datadogTags map[string]string) string {
 	// The spec has changed over time and, depending on the original exporter, IL Name could represented a few different ways
 	// so we try to account for all permutations
 	if ilnOtlp, okOtlp := datadogTags[tracetranslator.TagInstrumentationName]; okOtlp {
-		return strings.ReplaceAll(fmt.Sprintf("%s.%s", ilnOtlp, s.Kind()), "::", "_")
+		return utils.NormalizeTag(fmt.Sprintf("%s.%s", ilnOtlp, s.Kind()))
 	}
 
 	if ilnOtelCur, okOtelCur := datadogTags[currentILNameTag]; okOtelCur {
-		return strings.ReplaceAll(fmt.Sprintf("%s.%s", ilnOtelCur, s.Kind()), "::", "_")
+		return utils.NormalizeTag(fmt.Sprintf("%s.%s", ilnOtelCur, s.Kind()))
 	}
 
 	if ilnOtelOld, okOtelOld := datadogTags[oldILNameTag]; okOtelOld {
-		return strings.ReplaceAll(fmt.Sprintf("%s.%s", ilnOtelOld, s.Kind()), "::", "_")
+		return utils.NormalizeTag(fmt.Sprintf("%s.%s", ilnOtelOld, s.Kind()))
 	}
 
-	return strings.ReplaceAll(fmt.Sprintf("%s.%s", "opentelemetry", s.Kind()), "::", "_")
+	return utils.NormalizeTag(fmt.Sprintf("%s.%s", "opentelemetry", s.Kind()))
 }
 
 func getDatadogResourceName(s pdata.Span, datadogTags map[string]string) string {

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -16,6 +16,7 @@ package datadogexporter
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -227,7 +228,7 @@ func TestBasicTracesTranslation(t *testing.T) {
 	assert.Equal(t, "End-To-End Here", datadogPayload.Traces[0].Spans[0].Resource)
 
 	// ensure that span.name defaults to string representing instrumentation library if present
-	assert.Equal(t, fmt.Sprintf("%s.%s", datadogPayload.Traces[0].Spans[0].Meta[tracetranslator.TagInstrumentationName], pdata.SpanKindSERVER), datadogPayload.Traces[0].Spans[0].Name)
+	assert.Equal(t, strings.ToLower(fmt.Sprintf("%s.%s", datadogPayload.Traces[0].Spans[0].Meta[tracetranslator.TagInstrumentationName], pdata.SpanKindSERVER)), datadogPayload.Traces[0].Spans[0].Name)
 
 	// ensure that span.type is based on otlp span.kind
 	assert.Equal(t, "web", datadogPayload.Traces[0].Spans[0].Type)
@@ -410,15 +411,21 @@ func TestSpanNameTranslation(t *testing.T) {
 		"otel.library.name": "current_value",
 	}
 
+	ddIlTagsUnusual := map[string]string{
+		"otel.library.name": "@unusual/\\::value",
+	}
+
 	spanNameIl := getDatadogSpanName(span, ddIlTags)
 	spanNameDefault := getDatadogSpanName(span, ddNoIlTags)
 	spanNameOld := getDatadogSpanName(span, ddIlTagsOld)
 	spanNameCur := getDatadogSpanName(span, ddIlTagsCur)
+	spanNameUnusual := getDatadogSpanName(span, ddIlTagsUnusual)
 
-	assert.Equal(t, fmt.Sprintf("%s.%s", "il_name", pdata.SpanKindSERVER), spanNameIl)
-	assert.Equal(t, fmt.Sprintf("%s.%s", "opentelemetry", pdata.SpanKindSERVER), spanNameDefault)
-	assert.Equal(t, fmt.Sprintf("%s.%s", "old_value", pdata.SpanKindSERVER), spanNameOld)
-	assert.Equal(t, fmt.Sprintf("%s.%s", "current_value", pdata.SpanKindSERVER), spanNameCur)
+	assert.Equal(t, strings.ToLower(fmt.Sprintf("%s.%s", "il_name", pdata.SpanKindSERVER)), spanNameIl)
+	assert.Equal(t, strings.ToLower(fmt.Sprintf("%s.%s", "opentelemetry", pdata.SpanKindSERVER)), spanNameDefault)
+	assert.Equal(t, strings.ToLower(fmt.Sprintf("%s.%s", "old_value", pdata.SpanKindSERVER)), spanNameOld)
+	assert.Equal(t, strings.ToLower(fmt.Sprintf("%s.%s", "current_value", pdata.SpanKindSERVER)), spanNameCur)
+	assert.Equal(t, strings.ToLower(fmt.Sprintf("%s.%s", "unusual_value", pdata.SpanKindSERVER)), spanNameUnusual)
 }
 
 // ensure that the datadog span type gets mapped from span kind

--- a/exporter/datadogexporter/utils/tags.go
+++ b/exporter/datadogexporter/utils/tags.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"strings"
+	"unicode"
+)
+
+// constants for tags
+const (
+	// maximums for tag string lengths
+	MaxTagLength = 200
+)
+
+// NormalizeTag returns a cleaned up, normalized tags. If the tag can't be normalized
+// it will return the empty string. Here are the rules:
+//
+// 	1. Convert to all lowercase unicode string
+// 	2. Convert bad characters to underscores
+// 	3. Dedupe contiguous underscores
+// 	4. Remove leading non-alpha chars except `:`
+// 	5. Truncate to MaxTagLength (200) characters
+// 	6. Strip trailing underscores
+//
+//  Needs to stay in sync with:
+//
+// 	https://docs.datadoghq.com/getting_started/tagging/#defining-tags
+//
+func NormalizeTag(tag string) string {
+	// unless you just throw out unicode, this is already as fast as it gets
+	bufSize := len(tag)
+	if bufSize > MaxTagLength {
+		bufSize = MaxTagLength // Limit size of allocation
+	}
+	var buf strings.Builder
+	buf.Grow(bufSize)
+
+	lastWasUnderscore := false
+
+	for i, c := range tag {
+		// Bail early if the tag contains a lot of non-letter/digit characters.
+		// Let us assume if a tag is test🍣🍣[.,...], it's unlikely to be properly formated tag.
+		// Max tag length matches backend constraint.
+		if i > 2*MaxTagLength {
+			break
+		}
+		// fast path for len check
+		if buf.Len() >= MaxTagLength {
+			break
+		}
+		// fast path for ascii alphabetic chars
+		switch {
+		case c >= 'a' && c <= 'z':
+			buf.WriteRune(c)
+			lastWasUnderscore = false
+			continue
+		case c >= 'A' && c <= 'Z':
+			c -= 'A' - 'a'
+			buf.WriteRune(c)
+			lastWasUnderscore = false
+			continue
+		}
+
+		c = unicode.ToLower(c)
+		switch {
+		// handle always valid cases
+		case unicode.IsLetter(c):
+			buf.WriteRune(c)
+			lastWasUnderscore = false
+		// skip any characters that can't start the string
+		case buf.Len() == 0:
+			continue
+		// handle valid characters that can't start the string.
+		case unicode.IsDigit(c) || c == '.' || c == '-':
+			buf.WriteRune(c)
+			lastWasUnderscore = false
+		// convert anything else to underscores (including underscores), but only allow one in a row.
+		case !lastWasUnderscore:
+			buf.WriteRune('_')
+			lastWasUnderscore = true
+		}
+	}
+
+	s := buf.String()
+
+	// strip trailing underscores
+	if lastWasUnderscore {
+		return s[:len(s)-1]
+	}
+
+	return s
+}

--- a/exporter/datadogexporter/utils/trace_helpers.go
+++ b/exporter/datadogexporter/utils/trace_helpers.go
@@ -26,18 +26,14 @@ const (
 )
 
 // NormalizeSpanName returns a cleaned up, normalized span name. Span names are used to formulate tags,
-// and they also are used throughout the UI to connect metrics and traces. Here are the rules:
+// and they also are used throughout the UI to connect metrics and traces. This helper function will:
 //
 // 	1. Convert to all lowercase unicode string
 // 	2. Convert bad characters to underscores
 // 	3. Dedupe contiguous underscores
-// 	4. Remove leading non-alpha chars except `:`
+// 	4. Remove leading non-alpha chars
 // 	5. Truncate to MaxTagLength (200) characters
 // 	6. Strip trailing underscores
-//
-//  Needs to stay in sync with:
-//
-// 	https://docs.datadoghq.com/getting_started/tagging/#defining-tags
 //
 func NormalizeSpanName(tag string) string {
 	// unless you just throw out unicode, this is already as fast as it gets

--- a/exporter/datadogexporter/utils/trace_helpers.go
+++ b/exporter/datadogexporter/utils/trace_helpers.go
@@ -21,7 +21,7 @@ import (
 
 // constants for tags
 const (
-	// maximums for tag string lengths
+	// maximum for tag string lengths
 	MaxTagLength = 200
 )
 

--- a/exporter/datadogexporter/utils/trace_helpers.go
+++ b/exporter/datadogexporter/utils/trace_helpers.go
@@ -25,8 +25,8 @@ const (
 	MaxTagLength = 200
 )
 
-// NormalizeTag returns a cleaned up, normalized tags. If the tag can't be normalized
-// it will return the empty string. Here are the rules:
+// NormalizeSpanName returns a cleaned up, normalized span name. Span names are used to formulate tags,
+// and they also are used throughout the UI to connect metrics and traces. Here are the rules:
 //
 // 	1. Convert to all lowercase unicode string
 // 	2. Convert bad characters to underscores
@@ -39,7 +39,7 @@ const (
 //
 // 	https://docs.datadoghq.com/getting_started/tagging/#defining-tags
 //
-func NormalizeTag(tag string) string {
+func NormalizeSpanName(tag string) string {
 	// unless you just throw out unicode, this is already as fast as it gets
 	bufSize := len(tag)
 	if bufSize > MaxTagLength {


### PR DESCRIPTION

**Description:** <Describe what has changed.>
This PR Adds a Tag Normalization helper method to the Datadog Trace exporter, which uses the `span name` in some of it's metric and stats naming+tags, so as to fit the constraints documented in public documentation https://docs.datadoghq.com/getting_started/tagging/#defining-tags

**Testing:**
Updated unit tests

cc @mx-psi 