### PR TITLE
SignalFx Exporter: Convert to pdata.Metrics

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -30,7 +30,9 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/translator/internaldata"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -275,7 +277,7 @@ func TestDefaultTranslationRules(t *testing.T) {
 	data := testMetricsData()
 
 	c := translation.NewMetricsConverter(zap.NewNop(), tr)
-	translated, _ := c.MetricDataToSignalFxV2(data, nil)
+	translated, _ := c.MetricDataToSignalFxV2(data)
 	require.NotNil(t, translated)
 
 	metrics := make(map[string][]*sfxpb.DataPoint)
@@ -339,7 +341,7 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.True(t, ok, "container_memory_major_page_faults not found")
 }
 
-func testMetricsData() []consumerdata.MetricsData {
+func testMetricsData() pdata.ResourceMetrics {
 	md := consumerdata.MetricsData{
 		Metrics: []*metricspb.Metric{
 			{
@@ -782,7 +784,7 @@ func testMetricsData() []consumerdata.MetricsData {
 			},
 		},
 	}
-	return []consumerdata.MetricsData{md}
+	return internaldata.OCSliceToMetrics([]consumerdata.MetricsData{md}).ResourceMetrics().At(0)
 }
 
 func TestDefaultDiskTranslations(t *testing.T) {

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/gogo/protobuf v1.3.1
-	github.com/golang/protobuf v1.4.3
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.0.0-00010101000000-000000000000
 	github.com/shirou/gopsutil v2.20.9+incompatible
@@ -16,6 +16,8 @@ require (
 	go.uber.org/zap v1.16.0
 	google.golang.org/protobuf v1.25.0
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk => ../../internal/splunk
 

--- a/exporter/signalfxexporter/go.sum
+++ b/exporter/signalfxexporter/go.sum
@@ -177,6 +177,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/containerd v1.3.4 h1:3o0smo5SKY7H6AJCmJhsnCjR2/V2T8VmiHt7seN2/kI=
 github.com/containerd/containerd v1.3.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.3.6 h1:SMfcKoQyWhaRsYq7290ioC6XFcHDNcHvcEMjF6ORpac=
+github.com/containerd/containerd v1.3.6/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -1516,6 +1518,7 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9 h1:f+/+gfZ/tfaHBXXiv1gWRmCej6wlX3mLY4bnLpI99wk=

--- a/exporter/signalfxexporter/translation/converter_test.go
+++ b/exporter/signalfxexporter/translation/converter_test.go
@@ -20,350 +20,558 @@ import (
 	"testing"
 	"time"
 
-	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/consumer/consumerdata"
-	"go.opentelemetry.io/collector/testutil/metricstestutil"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testing/util"
 )
 
 func Test_MetricDataToSignalFxV2(t *testing.T) {
 	logger := zap.NewNop()
 
-	keys := []string{"k0", "k1"}
-	values := []string{"v0", "v1"}
+	labelMap := map[string]string{
+		"k0": "v0",
+		"k1": "v1",
+	}
+	labels := pdata.NewStringMap()
+	labels.InitFromMap(labelMap)
 
 	unixSecs := int64(1574092046)
 	unixNSecs := int64(11 * time.Millisecond)
-	tsUnix := time.Unix(unixSecs, unixNSecs)
+	ts := pdata.TimestampUnixNano(time.Unix(unixSecs, unixNSecs).UnixNano())
 	tsMSecs := unixSecs*1e3 + unixNSecs/1e6
 
 	doubleVal := 1234.5678
-	doublePt := metricstestutil.Double(tsUnix, doubleVal)
+	doublePt := pdata.NewDoubleDataPoint()
+	doublePt.InitEmpty()
+	doublePt.SetTimestamp(ts)
+	doublePt.SetValue(doubleVal)
+	doublePtWithLabels := pdata.NewDoubleDataPoint()
+	doublePt.CopyTo(doublePtWithLabels)
+	labels.CopyTo(doublePtWithLabels.LabelsMap())
+
 	int64Val := int64(123)
-	int64Pt := &metricspb.Point{
-		Timestamp: metricstestutil.Timestamp(tsUnix),
-		Value:     &metricspb.Point_Int64Value{Int64Value: int64Val},
-	}
+	int64Pt := pdata.NewIntDataPoint()
+	int64Pt.InitEmpty()
+	int64Pt.SetTimestamp(ts)
+	int64Pt.SetValue(int64Val)
+	int64PtWithLabels := pdata.NewIntDataPoint()
+	int64Pt.CopyTo(int64PtWithLabels)
+	labels.CopyTo(int64PtWithLabels.LabelsMap())
 
-	distributionBounds := []float64{1, 2, 4}
-	distributionCounts := []int64{4, 2, 3, 7}
-	distributionTimeSeries := metricstestutil.Timeseries(
-		tsUnix,
-		values,
-		metricstestutil.DistPt(tsUnix, distributionBounds, distributionCounts))
+	histBounds := []float64{1, 2, 4}
+	histCounts := []uint64{4, 2, 3, 7}
+	histDP := pdata.NewIntHistogramDataPoint()
+	histDP.InitEmpty()
+	histDP.SetTimestamp(ts)
+	histDP.SetCount(16)
+	histDP.SetSum(100)
+	histDP.SetExplicitBounds(histBounds)
+	histDP.SetBucketCounts(histCounts)
+	labels.CopyTo(histDP.LabelsMap())
 
-	distributionValueNoBuckets := metricspb.DistributionValue{
-		Count: 2,
-		Sum:   10,
-	}
-	distributionNoBuckets := metricstestutil.Timeseries(
-		tsUnix,
-		values,
-		&metricspb.Point{
-			Timestamp: metricstestutil.Timestamp(tsUnix),
-			Value:     &metricspb.Point_DistributionValue{DistributionValue: &distributionValueNoBuckets},
-		},
-	)
+	doubleHistDP := pdata.NewDoubleHistogramDataPoint()
+	doubleHistDP.InitEmpty()
+	doubleHistDP.SetTimestamp(ts)
+	doubleHistDP.SetCount(16)
+	doubleHistDP.SetSum(100.0)
+	doubleHistDP.SetExplicitBounds(histBounds)
+	doubleHistDP.SetBucketCounts(histCounts)
+	labels.CopyTo(doubleHistDP.LabelsMap())
 
-	summaryTimeSeries := metricstestutil.Timeseries(
-		tsUnix,
-		values,
-		metricstestutil.SummPt(
-			tsUnix,
-			11,
-			111,
-			[]float64{90, 95, 99, 99.9},
-			[]float64{100, 6, 4, 1}))
-
-	summaryValueNoQuantiles := metricspb.SummaryValue{
-		Sum:   &wrapperspb.DoubleValue{Value: 111},
-		Count: &wrapperspb.Int64Value{Value: 11},
-	}
-	summaryNoQuantiles := metricstestutil.Timeseries(
-		tsUnix,
-		values,
-		&metricspb.Point{
-			Timestamp: metricstestutil.Timestamp(tsUnix),
-			Value:     &metricspb.Point_SummaryValue{SummaryValue: &summaryValueNoQuantiles},
-		},
-	)
+	histDPNoBuckets := pdata.NewIntHistogramDataPoint()
+	histDPNoBuckets.InitEmpty()
+	histDPNoBuckets.SetCount(2)
+	histDPNoBuckets.SetSum(10)
+	histDPNoBuckets.SetTimestamp(ts)
+	labels.CopyTo(histDPNoBuckets.LabelsMap())
 
 	tests := []struct {
 		name                     string
-		metricsDataFn            func() []consumerdata.MetricsData
+		metricsDataFn            func() pdata.ResourceMetrics
 		wantSfxDataPoints        []*sfxpb.DataPoint
 		wantNumDroppedTimeseries int
 	}{
 		{
 			name: "nil_node_nil_resources_no_dims",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Metrics: []*metricspb.Metric{
-							metricstestutil.Gauge("gauge_double_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, doublePt)),
-							metricstestutil.GaugeInt("gauge_int_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, int64Pt)),
-							metricstestutil.Cumulative("cumulative_double_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, doublePt)),
-							metricstestutil.CumulativeInt("cumulative_int_with_dims", nil, metricstestutil.Timeseries(tsUnix, nil, int64Pt)),
-						},
-					},
+			metricsDataFn: func() pdata.ResourceMetrics {
+				out := pdata.NewResourceMetrics()
+				out.InitEmpty()
+
+				out.InstrumentationLibraryMetrics().Resize(1)
+				ilm := out.InstrumentationLibraryMetrics().At(0)
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+					m.DoubleGauge().InitEmpty()
+					m.DoubleGauge().DataPoints().Append(doublePt)
+					ilm.Metrics().Append(m)
 				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_int_with_dims")
+					m.SetDataType(pdata.MetricDataTypeIntGauge)
+					m.IntGauge().InitEmpty()
+					m.IntGauge().DataPoints().Append(int64Pt)
+					ilm.Metrics().Append(m)
+				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("cumulative_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleSum)
+					m.DoubleSum().InitEmpty()
+					m.DoubleSum().SetIsMonotonic(true)
+					m.DoubleSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
+					m.DoubleSum().DataPoints().Append(doublePt)
+					ilm.Metrics().Append(m)
+				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("cumulative_int_with_dims")
+					m.SetDataType(pdata.MetricDataTypeIntSum)
+					m.IntSum().InitEmpty()
+					m.IntSum().SetIsMonotonic(true)
+					m.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
+					m.IntSum().DataPoints().Append(int64Pt)
+					ilm.Metrics().Append(m)
+				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("delta_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleSum)
+					m.DoubleSum().InitEmpty()
+					m.DoubleSum().SetIsMonotonic(true)
+					m.DoubleSum().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
+					m.DoubleSum().DataPoints().Append(doublePt)
+					ilm.Metrics().Append(m)
+				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("delta_int_with_dims")
+					m.SetDataType(pdata.MetricDataTypeIntSum)
+					m.IntSum().InitEmpty()
+					m.IntSum().SetIsMonotonic(true)
+					m.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
+					m.IntSum().DataPoints().Append(int64Pt)
+					ilm.Metrics().Append(m)
+				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_sum_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleSum)
+					m.DoubleSum().InitEmpty()
+					m.DoubleSum().SetIsMonotonic(false)
+					m.DoubleSum().DataPoints().Append(doublePt)
+					ilm.Metrics().Append(m)
+				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_sum_int_with_dims")
+					m.SetDataType(pdata.MetricDataTypeIntSum)
+					m.IntSum().InitEmpty()
+					m.IntSum().SetIsMonotonic(false)
+					m.IntSum().DataPoints().Append(int64Pt)
+					ilm.Metrics().Append(m)
+				}
+
+				return out
 			},
 			wantSfxDataPoints: []*sfxpb.DataPoint{
-				doubleSFxDataPoint("gauge_double_with_dims", tsMSecs, &sfxMetricTypeGauge, []string{}, []string{}, doubleVal),
-				int64SFxDataPoint("gauge_int_with_dims", tsMSecs, &sfxMetricTypeGauge, []string{}, []string{}, int64Val),
-				doubleSFxDataPoint("cumulative_double_with_dims", tsMSecs, &sfxMetricTypeCumulativeCounter, []string{}, []string{}, doubleVal),
-				int64SFxDataPoint("cumulative_int_with_dims", tsMSecs, &sfxMetricTypeCumulativeCounter, []string{}, []string{}, int64Val),
+				doubleSFxDataPoint("gauge_double_with_dims", tsMSecs, &sfxMetricTypeGauge, nil, doubleVal),
+				int64SFxDataPoint("gauge_int_with_dims", tsMSecs, &sfxMetricTypeGauge, nil, int64Val),
+				doubleSFxDataPoint("cumulative_double_with_dims", tsMSecs, &sfxMetricTypeCumulativeCounter, nil, doubleVal),
+				int64SFxDataPoint("cumulative_int_with_dims", tsMSecs, &sfxMetricTypeCumulativeCounter, nil, int64Val),
+				doubleSFxDataPoint("delta_double_with_dims", tsMSecs, &sfxMetricTypeCounter, nil, doubleVal),
+				int64SFxDataPoint("delta_int_with_dims", tsMSecs, &sfxMetricTypeCounter, nil, int64Val),
+				doubleSFxDataPoint("gauge_sum_double_with_dims", tsMSecs, &sfxMetricTypeGauge, nil, doubleVal),
+				int64SFxDataPoint("gauge_sum_int_with_dims", tsMSecs, &sfxMetricTypeGauge, nil, int64Val),
 			},
 		},
 		{
 			name: "nil_node_and_resources_with_dims",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Metrics: []*metricspb.Metric{
-							metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-							metricstestutil.GaugeInt("gauge_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
-							metricstestutil.Cumulative("cumulative_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-							metricstestutil.CumulativeInt("cumulative_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
-						},
-					},
+			metricsDataFn: func() pdata.ResourceMetrics {
+				out := pdata.NewResourceMetrics()
+				out.InitEmpty()
+
+				out.InstrumentationLibraryMetrics().Resize(1)
+				ilm := out.InstrumentationLibraryMetrics().At(0)
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+					m.DoubleGauge().InitEmpty()
+					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
+					ilm.Metrics().Append(m)
 				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_int_with_dims")
+					m.SetDataType(pdata.MetricDataTypeIntGauge)
+					m.IntGauge().InitEmpty()
+					m.IntGauge().DataPoints().Append(int64PtWithLabels)
+					ilm.Metrics().Append(m)
+				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("cumulative_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleSum)
+					m.DoubleSum().InitEmpty()
+					m.DoubleSum().SetIsMonotonic(true)
+					m.DoubleSum().DataPoints().Append(doublePtWithLabels)
+					ilm.Metrics().Append(m)
+				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("cumulative_int_with_dims")
+					m.SetDataType(pdata.MetricDataTypeIntSum)
+					m.IntSum().InitEmpty()
+					m.IntSum().SetIsMonotonic(true)
+					m.IntSum().DataPoints().Append(int64PtWithLabels)
+					ilm.Metrics().Append(m)
+				}
+
+				return out
 			},
 			wantSfxDataPoints: []*sfxpb.DataPoint{
-				doubleSFxDataPoint("gauge_double_with_dims", tsMSecs, &sfxMetricTypeGauge, keys, values, doubleVal),
-				int64SFxDataPoint("gauge_int_with_dims", tsMSecs, &sfxMetricTypeGauge, keys, values, int64Val),
-				doubleSFxDataPoint("cumulative_double_with_dims", tsMSecs, &sfxMetricTypeCumulativeCounter, keys, values, doubleVal),
-				int64SFxDataPoint("cumulative_int_with_dims", tsMSecs, &sfxMetricTypeCumulativeCounter, keys, values, int64Val),
+				doubleSFxDataPoint("gauge_double_with_dims", tsMSecs, &sfxMetricTypeGauge, labelMap, doubleVal),
+				int64SFxDataPoint("gauge_int_with_dims", tsMSecs, &sfxMetricTypeGauge, labelMap, int64Val),
+				doubleSFxDataPoint("cumulative_double_with_dims", tsMSecs, &sfxMetricTypeCumulativeCounter, labelMap, doubleVal),
+				int64SFxDataPoint("cumulative_int_with_dims", tsMSecs, &sfxMetricTypeCumulativeCounter, labelMap, int64Val),
 			},
 		},
 		{
 			name: "with_node_resources_dims",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Node: &commonpb.Node{
-							Attributes: map[string]string{
-								"k/n0": "vn0",
-								"k/n1": "vn1",
-							},
-						},
-						Resource: &resourcepb.Resource{
-							Labels: map[string]string{
-								"k/r0": "vr0",
-								"k/r1": "vr1",
-							},
-						},
-						Metrics: []*metricspb.Metric{
-							metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-							metricstestutil.GaugeInt("gauge_int_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, int64Pt)),
-						},
-					},
+			metricsDataFn: func() pdata.ResourceMetrics {
+				out := pdata.NewResourceMetrics()
+				out.InitEmpty()
+
+				res := out.Resource()
+				res.Attributes().InsertString("k/r0", "vr0")
+				res.Attributes().InsertString("k/r1", "vr1")
+				res.Attributes().InsertString("k/n0", "vn0")
+				res.Attributes().InsertString("k/n1", "vn1")
+
+				out.InstrumentationLibraryMetrics().Resize(1)
+				ilm := out.InstrumentationLibraryMetrics().At(0)
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+					m.DoubleGauge().InitEmpty()
+					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
+					ilm.Metrics().Append(m)
 				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_int_with_dims")
+					m.SetDataType(pdata.MetricDataTypeIntGauge)
+					m.IntGauge().InitEmpty()
+					m.IntGauge().DataPoints().Append(int64PtWithLabels)
+					ilm.Metrics().Append(m)
+				}
+
+				return out
 			},
 			wantSfxDataPoints: []*sfxpb.DataPoint{
 				doubleSFxDataPoint(
 					"gauge_double_with_dims",
 					tsMSecs,
 					&sfxMetricTypeGauge,
-					append([]string{"k_n0", "k_n1", "k_r0", "k_r1"}, keys...),
-					append([]string{"vn0", "vn1", "vr0", "vr1"}, values...),
+					util.MergeStringMaps(map[string]string{
+						"k_n0": "vn0",
+						"k_n1": "vn1",
+						"k_r0": "vr0",
+						"k_r1": "vr1",
+					}, labelMap),
 					doubleVal),
 				int64SFxDataPoint(
 					"gauge_int_with_dims",
 					tsMSecs,
 					&sfxMetricTypeGauge,
-					append([]string{"k_n0", "k_n1", "k_r0", "k_r1"}, keys...),
-					append([]string{"vn0", "vn1", "vr0", "vr1"}, values...),
+					util.MergeStringMaps(map[string]string{
+						"k_n0": "vn0",
+						"k_n1": "vn1",
+						"k_r0": "vr0",
+						"k_r1": "vr1",
+					}, labelMap),
 					int64Val),
 			},
 		},
 		{
 			name: "with_resources_cloud_partial_aws_dim",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Resource: &resourcepb.Resource{
-							Labels: map[string]string{
-								"k/r0":             "vr0",
-								"k/r1":             "vr1",
-								"cloud.provider":   conventions.AttributeCloudProviderAWS,
-								"cloud.account.id": "efgh",
-								"cloud.region":     "us-east",
-							},
-						},
-						Metrics: []*metricspb.Metric{
-							metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-						},
-					},
+			metricsDataFn: func() pdata.ResourceMetrics {
+				out := pdata.NewResourceMetrics()
+				out.InitEmpty()
+
+				res := out.Resource()
+				res.Attributes().InsertString("k/r0", "vr0")
+				res.Attributes().InsertString("k/r1", "vr1")
+				res.Attributes().InsertString("cloud.provider", conventions.AttributeCloudProviderAWS)
+				res.Attributes().InsertString("cloud.account.id", "efgh")
+				res.Attributes().InsertString("cloud.region", "us-east")
+
+				out.InstrumentationLibraryMetrics().Resize(1)
+				ilm := out.InstrumentationLibraryMetrics().At(0)
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+					m.DoubleGauge().InitEmpty()
+					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
+					ilm.Metrics().Append(m)
 				}
+
+				return out
 			},
 			wantSfxDataPoints: []*sfxpb.DataPoint{
 				doubleSFxDataPoint(
 					"gauge_double_with_dims",
 					tsMSecs,
 					&sfxMetricTypeGauge,
-					append([]string{"cloud_account_id", "cloud_provider", "cloud_region", "k_r0", "k_r1"}, keys...),
-					append([]string{"efgh", conventions.AttributeCloudProviderAWS, "us-east", "vr0", "vr1"}, values...),
+					util.MergeStringMaps(labelMap, map[string]string{
+						"cloud_account_id": "efgh",
+						"cloud_provider":   conventions.AttributeCloudProviderAWS,
+						"cloud_region":     "us-east",
+						"k_r0":             "vr0",
+						"k_r1":             "vr1",
+					}),
 					doubleVal),
 			},
 		},
 		{
 			name: "with_resources_cloud_aws_dim",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Resource: &resourcepb.Resource{
-							Labels: map[string]string{
-								"k/r0":             "vr0",
-								"k/r1":             "vr1",
-								"cloud.provider":   conventions.AttributeCloudProviderAWS,
-								"cloud.account.id": "efgh",
-								"cloud.region":     "us-east",
-								"host.id":          "abcd",
-							},
-						},
-						Metrics: []*metricspb.Metric{
-							metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-						},
-					},
+			metricsDataFn: func() pdata.ResourceMetrics {
+				out := pdata.NewResourceMetrics()
+				out.InitEmpty()
+
+				res := out.Resource()
+				res.Attributes().InsertString("k/r0", "vr0")
+				res.Attributes().InsertString("k/r1", "vr1")
+				res.Attributes().InsertString("cloud.provider", conventions.AttributeCloudProviderAWS)
+				res.Attributes().InsertString("cloud.account.id", "efgh")
+				res.Attributes().InsertString("cloud.region", "us-east")
+				res.Attributes().InsertString("host.id", "abcd")
+
+				out.InstrumentationLibraryMetrics().Resize(1)
+				ilm := out.InstrumentationLibraryMetrics().At(0)
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+					m.DoubleGauge().InitEmpty()
+					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
+					ilm.Metrics().Append(m)
 				}
+
+				return out
 			},
 			wantSfxDataPoints: []*sfxpb.DataPoint{
 				doubleSFxDataPoint(
 					"gauge_double_with_dims",
 					tsMSecs,
 					&sfxMetricTypeGauge,
-					append([]string{"AWSUniqueId", "k_r0", "k_r1"}, keys...),
-					append([]string{"abcd_us-east_efgh", "vr0", "vr1"}, values...),
+					util.MergeStringMaps(labelMap, map[string]string{
+						"AWSUniqueId": "abcd_us-east_efgh",
+						"k_r0":        "vr0",
+						"k_r1":        "vr1",
+					}),
 					doubleVal),
 			},
 		},
 		{
 			name: "with_resources_cloud_gcp_dim_partial",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Resource: &resourcepb.Resource{
-							Labels: map[string]string{
-								"k/r0":           "vr0",
-								"k/r1":           "vr1",
-								"cloud.provider": conventions.AttributeCloudProviderGCP,
-								"host.id":        "abcd",
-							},
-						},
-						Metrics: []*metricspb.Metric{
-							metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-						},
-					},
+			metricsDataFn: func() pdata.ResourceMetrics {
+				out := pdata.NewResourceMetrics()
+				out.InitEmpty()
+
+				res := out.Resource()
+				res.Attributes().InsertString("k/r0", "vr0")
+				res.Attributes().InsertString("k/r1", "vr1")
+				res.Attributes().InsertString("cloud.provider", conventions.AttributeCloudProviderGCP)
+				res.Attributes().InsertString("host.id", "abcd")
+
+				out.InstrumentationLibraryMetrics().Resize(1)
+				ilm := out.InstrumentationLibraryMetrics().At(0)
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+					m.DoubleGauge().InitEmpty()
+					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
+					ilm.Metrics().Append(m)
 				}
+
+				return out
 			},
 			wantSfxDataPoints: []*sfxpb.DataPoint{
 				doubleSFxDataPoint(
 					"gauge_double_with_dims",
 					tsMSecs,
 					&sfxMetricTypeGauge,
-					append([]string{"cloud_provider", "host_id", "k_r0", "k_r1"}, keys...),
-					append([]string{conventions.AttributeCloudProviderGCP, "abcd", "vr0", "vr1"}, values...),
+					util.MergeStringMaps(labelMap, map[string]string{
+						"host_id":        "abcd",
+						"cloud_provider": conventions.AttributeCloudProviderGCP,
+						"k_r0":           "vr0",
+						"k_r1":           "vr1",
+					}),
 					doubleVal),
 			},
 		},
 		{
 			name: "with_resources_cloud_gcp_dim",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Resource: &resourcepb.Resource{
-							Labels: map[string]string{
-								"k/r0":             "vr0",
-								"k/r1":             "vr1",
-								"cloud.provider":   conventions.AttributeCloudProviderGCP,
-								"cloud.account.id": "efgh",
-								"host.id":          "abcd",
-							},
-						},
-						Metrics: []*metricspb.Metric{
-							metricstestutil.Gauge("gauge_double_with_dims", keys, metricstestutil.Timeseries(tsUnix, values, doublePt)),
-						},
-					},
+			metricsDataFn: func() pdata.ResourceMetrics {
+				out := pdata.NewResourceMetrics()
+				out.InitEmpty()
+
+				res := out.Resource()
+				res.Attributes().InsertString("k/r0", "vr0")
+				res.Attributes().InsertString("k/r1", "vr1")
+				res.Attributes().InsertString("cloud.provider", conventions.AttributeCloudProviderGCP)
+				res.Attributes().InsertString("host.id", "abcd")
+				res.Attributes().InsertString("cloud.account.id", "efgh")
+
+				out.InstrumentationLibraryMetrics().Resize(1)
+				ilm := out.InstrumentationLibraryMetrics().At(0)
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("gauge_double_with_dims")
+					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+					m.DoubleGauge().InitEmpty()
+					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
+					ilm.Metrics().Append(m)
 				}
+
+				return out
 			},
 			wantSfxDataPoints: []*sfxpb.DataPoint{
 				doubleSFxDataPoint(
 					"gauge_double_with_dims",
 					tsMSecs,
 					&sfxMetricTypeGauge,
-					append([]string{"gcp_id", "k_r0", "k_r1"}, keys...),
-					append([]string{"efgh_abcd", "vr0", "vr1"}, values...),
+					util.MergeStringMaps(labelMap, map[string]string{
+						"gcp_id": "efgh_abcd",
+						"k_r0":   "vr0",
+						"k_r1":   "vr1",
+					}),
 					doubleVal),
 			},
 		},
 		{
-			name: "distributions",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Metrics: []*metricspb.Metric{
-							metricstestutil.GaugeDist("gauge_distrib", keys, distributionTimeSeries),
-							metricstestutil.CumulativeDist("cumulative_distrib", keys, distributionTimeSeries),
-						},
-					},
+			name: "histograms",
+			metricsDataFn: func() pdata.ResourceMetrics {
+				out := pdata.NewResourceMetrics()
+				out.InitEmpty()
+
+				out.InstrumentationLibraryMetrics().Resize(1)
+				ilm := out.InstrumentationLibraryMetrics().At(0)
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("int_histo")
+					m.SetDataType(pdata.MetricDataTypeIntHistogram)
+					m.IntHistogram().InitEmpty()
+					m.IntHistogram().DataPoints().Append(histDP)
+					ilm.Metrics().Append(m)
 				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("double_histo")
+					m.SetDataType(pdata.MetricDataTypeDoubleHistogram)
+					m.DoubleHistogram().InitEmpty()
+					m.DoubleHistogram().DataPoints().Append(doubleHistDP)
+					ilm.Metrics().Append(m)
+				}
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("int_delta_histo")
+					m.SetDataType(pdata.MetricDataTypeIntHistogram)
+					m.IntHistogram().InitEmpty()
+					m.IntHistogram().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
+					m.IntHistogram().DataPoints().Append(histDP)
+					ilm.Metrics().Append(m)
+				}
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("double_delta_histo")
+					m.SetDataType(pdata.MetricDataTypeDoubleHistogram)
+					m.DoubleHistogram().InitEmpty()
+					m.DoubleHistogram().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
+					m.DoubleHistogram().DataPoints().Append(doubleHistDP)
+					ilm.Metrics().Append(m)
+				}
+
+				return out
 			},
-			wantSfxDataPoints: append(
-				expectedFromDistribution("gauge_distrib", tsMSecs, keys, values, distributionTimeSeries),
-				expectedFromDistribution("cumulative_distrib", tsMSecs, keys, values, distributionTimeSeries)...),
+			wantSfxDataPoints: mergeDPs(
+				expectedFromIntHistogram("int_histo", tsMSecs, labelMap, histDP, false),
+				expectedFromDoubleHistogram("double_histo", tsMSecs, labelMap, doubleHistDP, false),
+				expectedFromIntHistogram("int_delta_histo", tsMSecs, labelMap, histDP, true),
+				expectedFromDoubleHistogram("double_delta_histo", tsMSecs, labelMap, doubleHistDP, true),
+			),
 		},
 		{
 			name: "distribution_no_buckets",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Metrics: []*metricspb.Metric{
-							metricstestutil.GaugeDist("invalid_distrib", keys, distributionNoBuckets),
-						},
-					},
+			metricsDataFn: func() pdata.ResourceMetrics {
+				out := pdata.NewResourceMetrics()
+				out.InitEmpty()
+
+				out.InstrumentationLibraryMetrics().Resize(1)
+				ilm := out.InstrumentationLibraryMetrics().At(0)
+
+				{
+					m := pdata.NewMetric()
+					m.InitEmpty()
+					m.SetName("no_bucket_histo")
+					m.SetDataType(pdata.MetricDataTypeIntHistogram)
+					m.IntHistogram().InitEmpty()
+					m.IntHistogram().DataPoints().Append(histDPNoBuckets)
+					ilm.Metrics().Append(m)
 				}
+
+				return out
 			},
-			wantSfxDataPoints: expectedFromDistribution("invalid_distrib", tsMSecs, keys, values, distributionNoBuckets),
-		},
-		{
-			name: "summary",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Metrics: []*metricspb.Metric{
-							metricstestutil.Summary("summary", keys, summaryTimeSeries),
-						},
-					},
-				}
-			},
-			wantSfxDataPoints: expectedFromSummary("summary", tsMSecs, keys, values, summaryTimeSeries),
-		},
-		{
-			name: "summary_no_quantiles",
-			metricsDataFn: func() []consumerdata.MetricsData {
-				return []consumerdata.MetricsData{
-					{
-						Metrics: []*metricspb.Metric{
-							metricstestutil.Summary("summary_no_quantiles", keys, summaryNoQuantiles),
-						},
-					},
-				}
-			},
-			wantSfxDataPoints: expectedFromSummary("summary_no_quantiles", tsMSecs, keys, values, summaryNoQuantiles),
+			wantSfxDataPoints: expectedFromIntHistogram("no_bucket_histo", tsMSecs, labelMap, histDPNoBuckets, false),
 		},
 	}
 	c := NewMetricsConverter(logger, nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSfxDataPoints, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(tt.metricsDataFn(), nil)
+			gotSfxDataPoints, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(tt.metricsDataFn())
 			assert.Equal(t, tt.wantNumDroppedTimeseries, gotNumDroppedTimeSeries)
 			// Sort SFx dimensions since they are built from maps and the order
 			// of those is not deterministic.
@@ -385,28 +593,17 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 	}, 1)
 	require.NoError(t, err)
 
-	md := []consumerdata.MetricsData{
-		{
-			Node: &commonpb.Node{
-				Attributes: map[string]string{"old.dim": "val1"},
-			},
-			Metrics: []*metricspb.Metric{
-				{
-					MetricDescriptor: &metricspb.MetricDescriptor{
-						Name: "metric1",
-						Type: metricspb.MetricDescriptor_GAUGE_INT64,
-					},
-					Timeseries: []*metricspb.TimeSeries{
-						{
-							Points: []*metricspb.Point{
-								{Value: &metricspb.Point_Int64Value{Int64Value: 123}},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	md := pdata.NewMetric()
+	md.InitEmpty()
+	md.SetDataType(pdata.MetricDataTypeIntGauge)
+	md.IntGauge().InitEmpty()
+	md.IntGauge().DataPoints().Resize(1)
+	md.SetName("metric1")
+	dp := md.IntGauge().DataPoints().At(0)
+	dp.SetValue(123)
+	dp.LabelsMap().InitFromMap(map[string]string{
+		"old.dim": "val1",
+	})
 
 	gaugeType := sfxpb.MetricType_GAUGE
 	expected := []*sfxpb.DataPoint{
@@ -425,7 +622,7 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 		},
 	}
 	c := NewMetricsConverter(zap.NewNop(), translator)
-	got, dropped := c.MetricDataToSignalFxV2(md, nil)
+	got, dropped := c.MetricDataToSignalFxV2(wrapMetric(md))
 
 	assert.EqualValues(t, 0, dropped)
 	assert.EqualValues(t, expected, got)
@@ -446,8 +643,7 @@ func doubleSFxDataPoint(
 	metric string,
 	ts int64,
 	metricType *sfxpb.MetricType,
-	keys []string,
-	values []string,
+	dims map[string]string,
 	val float64,
 ) *sfxpb.DataPoint {
 	return &sfxpb.DataPoint{
@@ -455,7 +651,7 @@ func doubleSFxDataPoint(
 		Timestamp:  ts,
 		Value:      sfxpb.Datum{DoubleValue: &val},
 		MetricType: metricType,
-		Dimensions: sfxDimensions(keys, values),
+		Dimensions: sfxDimensions(dims),
 	}
 }
 
@@ -463,8 +659,7 @@ func int64SFxDataPoint(
 	metric string,
 	ts int64,
 	metricType *sfxpb.MetricType,
-	keys []string,
-	values []string,
+	dims map[string]string,
 	val int64,
 ) *sfxpb.DataPoint {
 	return &sfxpb.DataPoint{
@@ -472,136 +667,112 @@ func int64SFxDataPoint(
 		Timestamp:  ts,
 		Value:      sfxpb.Datum{IntValue: &val},
 		MetricType: metricType,
-		Dimensions: sfxDimensions(keys, values),
+		Dimensions: sfxDimensions(dims),
 	}
 }
 
-func sfxDimensions(keys, values []string) []*sfxpb.Dimension {
-	if len(keys) != len(values) {
-		panic("keys and values do not match")
-	}
-
-	if keys == nil && values == nil {
-		return nil
-	}
-
-	sfxDims := make([]*sfxpb.Dimension, len(keys))
-	for i := 0; i < len(keys); i++ {
-		sfxDims[i] = &sfxpb.Dimension{
-			Key:   keys[i],
-			Value: values[i],
-		}
+func sfxDimensions(m map[string]string) []*sfxpb.Dimension {
+	sfxDims := make([]*sfxpb.Dimension, 0, len(m))
+	for k, v := range m {
+		sfxDims = append(sfxDims, &sfxpb.Dimension{
+			Key:   k,
+			Value: v,
+		})
 	}
 
 	return sfxDims
 }
 
-func expectedFromDistribution(
+func expectedFromIntHistogram(
 	metricName string,
 	ts int64,
-	keys []string,
-	values []string,
-	distributionTimeSeries *metricspb.TimeSeries,
+	dims map[string]string,
+	histDP pdata.IntHistogramDataPoint,
+	isDelta bool,
 ) []*sfxpb.DataPoint {
-	distributionValue := distributionTimeSeries.Points[0].GetDistributionValue()
+	buckets := histDP.BucketCounts()
 
-	// Two additional data points: one for count and one for sum.
-	const extraDataPoints = 2
-	dps := make([]*sfxpb.DataPoint, 0, len(distributionValue.Buckets)+extraDataPoints)
+	dps := make([]*sfxpb.DataPoint, 0)
+
+	typ := &sfxMetricTypeCumulativeCounter
+	if isDelta {
+		typ = &sfxMetricTypeCounter
+	}
 
 	dps = append(dps,
-		int64SFxDataPoint(metricName+"_count", ts, &sfxMetricTypeCumulativeCounter, keys, values,
-			distributionValue.Count),
-		doubleSFxDataPoint(metricName, ts, &sfxMetricTypeCumulativeCounter, keys, values,
-			distributionValue.Sum))
+		int64SFxDataPoint(metricName+"_count", ts, typ, dims,
+			int64(histDP.Count())),
+		int64SFxDataPoint(metricName, ts, typ, dims,
+			histDP.Sum()))
 
-	explicitBuckets := distributionValue.BucketOptions.GetExplicit()
-	if explicitBuckets == nil {
+	explicitBounds := histDP.ExplicitBounds()
+	if explicitBounds == nil {
 		return dps
 	}
-	for i := 0; i < len(explicitBuckets.Bounds); i++ {
+	for i := 0; i < len(explicitBounds); i++ {
+		dimsCopy := util.CloneStringMap(dims)
+		dimsCopy[upperBoundDimensionKey] = float64ToDimValue(explicitBounds[i])
 		dps = append(dps,
-			int64SFxDataPoint(metricName+"_bucket", ts, &sfxMetricTypeCumulativeCounter,
-				append(keys, upperBoundDimensionKey),
-				append(values, float64ToDimValue(explicitBuckets.Bounds[i])),
-				distributionValue.Buckets[i].Count))
+			int64SFxDataPoint(metricName+"_bucket", ts,
+				typ, dimsCopy,
+				int64(buckets[i])))
 	}
+	dimsCopy := util.CloneStringMap(dims)
+	dimsCopy[upperBoundDimensionKey] = float64ToDimValue(math.Inf(1))
 	dps = append(dps,
-		int64SFxDataPoint(metricName+"_bucket", ts, &sfxMetricTypeCumulativeCounter,
-			append(keys, upperBoundDimensionKey),
-			append(values, float64ToDimValue(math.Inf(1))),
-			distributionValue.Buckets[len(distributionValue.Buckets)-1].Count))
+		int64SFxDataPoint(metricName+"_bucket", ts, typ,
+			dimsCopy,
+			int64(buckets[len(buckets)-1])))
 	return dps
 }
 
-func expectedFromSummary(
+func expectedFromDoubleHistogram(
 	metricName string,
 	ts int64,
-	keys []string,
-	values []string,
-	summaryTimeSeries *metricspb.TimeSeries,
+	dims map[string]string,
+	histDP pdata.DoubleHistogramDataPoint,
+	isDelta bool,
 ) []*sfxpb.DataPoint {
-	summaryValue := summaryTimeSeries.Points[0].GetSummaryValue()
+	buckets := histDP.BucketCounts()
 
-	dps := []*sfxpb.DataPoint{}
+	dps := make([]*sfxpb.DataPoint, 0)
 
-	dps = append(dps,
-		int64SFxDataPoint(metricName+"_count", ts, &sfxMetricTypeCumulativeCounter, keys, values,
-			summaryValue.Count.Value),
-		doubleSFxDataPoint(metricName, ts, &sfxMetricTypeCumulativeCounter, keys, values,
-			summaryValue.Sum.Value))
-
-	percentiles := summaryValue.Snapshot.GetPercentileValues()
-	for _, percentile := range percentiles {
-		dps = append(dps,
-			doubleSFxDataPoint(metricName+"_quantile", ts, &sfxMetricTypeGauge,
-				append(keys, quantileDimensionKey),
-				append(values, float64ToDimValue(percentile.Percentile)),
-				percentile.Value))
+	typ := &sfxMetricTypeCumulativeCounter
+	if isDelta {
+		typ = &sfxMetricTypeCounter
 	}
 
+	dps = append(dps,
+		int64SFxDataPoint(metricName+"_count", ts, typ, dims,
+			int64(histDP.Count())),
+		doubleSFxDataPoint(metricName, ts, typ, dims,
+			histDP.Sum()))
+
+	explicitBounds := histDP.ExplicitBounds()
+	if explicitBounds == nil {
+		return dps
+	}
+	for i := 0; i < len(explicitBounds); i++ {
+		dimsCopy := util.CloneStringMap(dims)
+		dimsCopy[upperBoundDimensionKey] = float64ToDimValue(explicitBounds[i])
+		dps = append(dps,
+			int64SFxDataPoint(metricName+"_bucket", ts,
+				typ, dimsCopy,
+				int64(buckets[i])))
+	}
+	dimsCopy := util.CloneStringMap(dims)
+	dimsCopy[upperBoundDimensionKey] = float64ToDimValue(math.Inf(1))
+	dps = append(dps,
+		int64SFxDataPoint(metricName+"_bucket", ts, typ,
+			dimsCopy,
+			int64(buckets[len(buckets)-1])))
 	return dps
 }
 
-func Test_InvalidPoint_NoValue(t *testing.T) {
-	logger := zap.NewNop()
-	unixSecs := int64(1574092046)
-	unixNSecs := int64(11 * time.Millisecond)
-	tsUnix := time.Unix(unixSecs, unixNSecs)
-	keys := []string{"k0", "k1"}
-	values := []string{"v0", "v1"}
-
-	point := &metricspb.Point{Timestamp: metricstestutil.Timestamp(tsUnix), Value: nil}
-	metricData := []consumerdata.MetricsData{
-		{
-			Metrics: []*metricspb.Metric{
-				metricstestutil.Gauge("gauge", keys, metricstestutil.Timeseries(
-					tsUnix,
-					values,
-					point)),
-			},
-		},
+func mergeDPs(dps ...[]*sfxpb.DataPoint) []*sfxpb.DataPoint {
+	var out []*sfxpb.DataPoint
+	for i := range dps {
+		out = append(out, dps[i]...)
 	}
-	c := NewMetricsConverter(logger, nil)
-	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData, nil)
-	assert.Equal(t, 1, gotNumDroppedTimeSeries)
-}
-
-func Test_InvalidMetric(t *testing.T) {
-	logger := zap.NewNop()
-	metricData := []consumerdata.MetricsData{
-		{
-			Metrics: []*metricspb.Metric{
-				nil,
-				{
-					MetricDescriptor: nil,
-					Timeseries:       []*metricspb.TimeSeries{nil},
-				},
-			},
-		},
-	}
-	c := NewMetricsConverter(logger, nil)
-	_, gotNumDroppedTimeSeries := c.MetricDataToSignalFxV2(metricData, nil)
-	// Only 1 timeseries is dropped because the nil metric does not have any timeseries.
-	assert.Equal(t, 1, gotNumDroppedTimeSeries)
+	return out
 }

--- a/internal/common/testing/util/maps.go
+++ b/internal/common/testing/util/maps.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package util
 
 // MergeStringMaps merges n maps with a later map's keys overriding earlier maps.
 func MergeStringMaps(maps ...map[string]string) map[string]string {

--- a/internal/common/testing/util/maps_test.go
+++ b/internal/common/testing/util/maps_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package util
 
 import (
 	"testing"

--- a/receiver/k8sclusterreceiver/collection/containers.go
+++ b/receiver/k8sclusterreceiver/collection/containers.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/translator/conventions"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testing/util"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/utils"
 )
 
@@ -142,7 +143,7 @@ func getResourceForContainer(labels map[string]string) *resourcepb.Resource {
 func getAllContainerLabels(cs corev1.ContainerStatus,
 	dims map[string]string) map[string]string {
 
-	out := utils.CloneStringMap(dims)
+	out := util.CloneStringMap(dims)
 
 	out[conventions.AttributeContainerID] = utils.StripContainerID(cs.ContainerID)
 	out[conventions.AttributeK8sContainer] = cs.Name

--- a/receiver/k8sclusterreceiver/collection/metadata.go
+++ b/receiver/k8sclusterreceiver/collection/metadata.go
@@ -21,7 +21,7 @@ import (
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/utils"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testing/util"
 )
 
 const (
@@ -47,7 +47,7 @@ type KubernetesMetadata struct {
 // live on v1.ObjectMeta.
 func getGenericMetadata(om *v1.ObjectMeta, resourceType string) *KubernetesMetadata {
 	rType := strings.ToLower(resourceType)
-	metadata := utils.MergeStringMaps(map[string]string{}, om.Labels)
+	metadata := util.MergeStringMaps(map[string]string{}, om.Labels)
 
 	metadata[k8sKeyWorkLoadKind] = resourceType
 	metadata[k8sKeyWorkLoadName] = om.Name

--- a/receiver/k8sclusterreceiver/collection/nodes.go
+++ b/receiver/k8sclusterreceiver/collection/nodes.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/translator/conventions"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testing/util"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/utils"
 )
 
@@ -93,7 +94,7 @@ func nodeConditionValue(node *corev1.Node, condType corev1.NodeConditionType) in
 }
 
 func getMetadataForNode(node *corev1.Node) map[ResourceID]*KubernetesMetadata {
-	metadata := utils.MergeStringMaps(map[string]string{}, node.Labels)
+	metadata := util.MergeStringMaps(map[string]string{}, node.Labels)
 
 	metadata[k8sKeyNodeName] = node.Name
 	metadata[nodeCreationTime] = node.GetCreationTimestamp().Format(time.RFC3339)

--- a/receiver/k8sclusterreceiver/collection/pods.go
+++ b/receiver/k8sclusterreceiver/collection/pods.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testing/util"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/utils"
 )
 
@@ -139,7 +140,7 @@ func phaseToInt(phase corev1.PodPhase) int32 {
 
 // getMetadataForPod returns all metadata associated with the pod.
 func getMetadataForPod(pod *corev1.Pod, mc *metadataStore, logger *zap.Logger) map[ResourceID]*KubernetesMetadata {
-	metadata := utils.MergeStringMaps(map[string]string{}, pod.Labels)
+	metadata := util.MergeStringMaps(map[string]string{}, pod.Labels)
 
 	metadata[podCreationTime] = pod.CreationTimestamp.Format(time.RFC3339)
 
@@ -156,19 +157,19 @@ func getMetadataForPod(pod *corev1.Pod, mc *metadataStore, logger *zap.Logger) m
 	}
 
 	if mc.services != nil {
-		metadata = utils.MergeStringMaps(metadata,
+		metadata = util.MergeStringMaps(metadata,
 			getPodServiceTags(pod, mc.services),
 		)
 	}
 
 	if mc.jobs != nil {
-		metadata = utils.MergeStringMaps(metadata,
+		metadata = util.MergeStringMaps(metadata,
 			collectPodJobProperties(pod, mc.jobs, logger),
 		)
 	}
 
 	if mc.replicaSets != nil {
-		metadata = utils.MergeStringMaps(metadata,
+		metadata = util.MergeStringMaps(metadata,
 			collectPodReplicaSetProperties(pod, mc.replicaSets, logger),
 		)
 	}

--- a/receiver/k8sclusterreceiver/collection/pods_test.go
+++ b/receiver/k8sclusterreceiver/collection/pods_test.go
@@ -30,8 +30,8 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testing/util"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/testutils"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/utils"
 )
 
 func TestPodAndContainerMetrics(t *testing.T) {
@@ -217,7 +217,7 @@ var commonPodMetadata = map[string]string{
 }
 
 var allPodMetadata = func(metadata map[string]string) map[string]string {
-	out := utils.MergeStringMaps(metadata, commonPodMetadata)
+	out := util.MergeStringMaps(metadata, commonPodMetadata)
 	return out
 }
 

--- a/receiver/k8sclusterreceiver/go.mod
+++ b/receiver/k8sclusterreceiver/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/iancoleman/strcase v0.0.0-20171129010253-3de563c3dc08
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.14.1-0.20201110213227-d322a4161b8d
@@ -15,5 +16,7 @@ require (
 	k8s.io/apimachinery v0.19.3
 	k8s.io/client-go v0.19.3
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig => ../../internal/k8sconfig

--- a/receiver/k8sclusterreceiver/go.sum
+++ b/receiver/k8sclusterreceiver/go.sum
@@ -150,6 +150,7 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/containerd v1.3.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.3.6/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -1412,6 +1413,7 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9/go.mod h1:5j1uub0jRGhRiSghIlrThmBUgcgLXOVJQ/l1getT4uo=

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -3,7 +3,6 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signal
 go 1.14
 
 require (
-	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.0.0-00010101000000-000000000000
@@ -12,10 +11,11 @@ require (
 	go.opencensus.io v0.22.5
 	go.opentelemetry.io/collector v0.14.1-0.20201110213227-d322a4161b8d
 	go.uber.org/zap v1.16.0
-	google.golang.org/protobuf v1.25.0
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig => ../../internal/k8sconfig
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver => ../../receiver/k8sclusterreceiver
 

--- a/receiver/signalfxreceiver/go.sum
+++ b/receiver/signalfxreceiver/go.sum
@@ -177,6 +177,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/containerd v1.3.4 h1:3o0smo5SKY7H6AJCmJhsnCjR2/V2T8VmiHt7seN2/kI=
 github.com/containerd/containerd v1.3.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.3.6 h1:SMfcKoQyWhaRsYq7290ioC6XFcHDNcHvcEMjF6ORpac=
+github.com/containerd/containerd v1.3.6/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -1516,6 +1518,7 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9 h1:f+/+gfZ/tfaHBXXiv1gWRmCej6wlX3mLY4bnLpI99wk=

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -23,6 +23,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signa
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig => ../internal/k8sconfig
 
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../internal/common
+
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk => ../internal/splunk
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver => ../receiver/carbonreceiver

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -180,6 +180,7 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/containerd v1.3.4 h1:3o0smo5SKY7H6AJCmJhsnCjR2/V2T8VmiHt7seN2/kI=
 github.com/containerd/containerd v1.3.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.3.6/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -1526,6 +1527,7 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc/examples v0.0.0-20200728065043-dfc0c05b2da9/go.mod h1:5j1uub0jRGhRiSghIlrThmBUgcgLXOVJQ/l1getT4uo=


### PR DESCRIPTION
This converts almost everything in this exporter to fully use native
OTLP data structures instead of the old OpenCensus models.  There is one
test fixture that still uses OC due to the sheer size of it, but it is
relatively simple data so the conversion is not complex.