### PR TITLE
Correct breaking integration test job change

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -17,7 +17,7 @@ ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort 
 GOTEST_OPT?= -race -timeout 30s
 GOTEST_INTEGRATION_OPT?= -race -timeout 60s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
-GOTEST_INTEGRATION_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
+GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOTEST=go test
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)

--- a/receiver/jmxreceiver/go.mod
+++ b/receiver/jmxreceiver/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxmetricreceiver
+module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
 
 go 1.14
 

--- a/receiver/jmxreceiver/integration_test.go
+++ b/receiver/jmxreceiver/integration_test.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"runtime"
 	"testing"
 	"time"
 
@@ -219,16 +218,11 @@ func (suite *JMXIntegrationSuite) TestJMXMetricViaOTLPReceiverIntegration() {
 		require.Nil(t, (*otlpReceiver).Shutdown(context.Background()))
 	}()
 
-	otlp := "localhost"
-	if runtime.GOOS == "darwin" {
-		otlp = "host.docker.internal"
-	}
-
 	config := &config{
 		JARPath:      suite.JARPath,
 		ServiceURL:   fmt.Sprintf("service:jmx:rmi:///jndi/rmi://%v:7199/jmxrmi", hostname),
 		Exporter:     "otlp",
-		OTLPEndpoint: fmt.Sprintf("%v:%v", otlp, port),
+		OTLPEndpoint: fmt.Sprintf("localhost:%v", port),
 		GroovyScript: path.Join(".", "testdata", "script.groovy"),
 		Username:     "cassandra",
 		Password:     "cassandra",
@@ -322,7 +316,6 @@ func (suite *JMXIntegrationSuite) TestJMXMetricViaPrometheusReceiverIntegration(
 	}()
 
 	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
-	require.NoError(t, receiver.Ready())
 
 	require.Eventually(t, func() bool {
 		metrics := consumer.AllMetrics()

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxmetricreceiver/subprocess"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver/subprocess"
 )
 
 var _ component.MetricsReceiver = (*jmxMetricReceiver)(nil)


### PR DESCRIPTION
**Description:**
These changes revert an invalid make target change that has silenced integration runs introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1207. 

Also continue the JMX Receiver renaming from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1357 to include the module name and include required  integration test correction and darwin improvement that was missed due to partial rename progress.

**Testing:**

Includes test update to unblock now functioning integration task.