### PR TITLE
SignalFx Receiver: Switch to pdata.Metrics

### DIFF
--- a/receiver/signalfxreceiver/signalfxv2_to_metricdata.go
+++ b/receiver/signalfxreceiver/signalfxv2_to_metricdata.go
@@ -17,214 +17,197 @@ package signalfxreceiver
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
-	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var (
 	errSFxNilDatum = errors.New("nil datum value for data-point")
 
-	errSFxUnexpectedInt64DatumType   = errors.New("datum value type of int64 is unexpected")
-	errSFxUnexpectedFloat64DatumType = errors.New("datum value type of float64 is unexpected")
-	errSFxUnexpectedStringDatumType  = errors.New("datum value type of string is unexpected")
-	errSFxStringDatumNotNumber       = errors.New("datum string cannot be parsed to a number")
-	errSFxNoDatumValue               = errors.New("no datum value present for data-point")
+	errSFxNoDatumValue = errors.New("no datum value present for data-point")
 )
 
-// signalFxV2ToMetricsData converts SignalFx proto data points to
-// consumerdata.MetricsData. Returning the converted data and the number of
-// dropped time series.
-func signalFxV2ToMetricsData(
+// signalFxV2ToMetrics converts SignalFx proto data points to pdata.Metrics.
+// Returning the converted data and the number of dropped data points.
+func signalFxV2ToMetrics(
 	logger *zap.Logger,
 	sfxDataPoints []*sfxpb.DataPoint,
-) (consumerdata.MetricsData, int) {
+) (pdata.Metrics, int) {
 
 	// TODO: not optimized at all, basically regenerating everything for each
 	// 	data point.
-	numDroppedTimeSeries := 0
-	md := consumerdata.MetricsData{}
-	metrics := make([]*metricspb.Metric, 0, len(sfxDataPoints))
+	numDroppedDataPoints := 0
+	md := pdata.NewMetrics()
+	md.ResourceMetrics().Resize(1)
+	rm := md.ResourceMetrics().At(0)
+	rm.InitEmpty()
+
+	rm.InstrumentationLibraryMetrics().Resize(1)
+	ilm := rm.InstrumentationLibraryMetrics().At(0)
+	ilm.InitEmpty()
+
+	metrics := ilm.Metrics()
+	metrics.Resize(len(sfxDataPoints))
+
+	i := 0
 	for _, sfxDataPoint := range sfxDataPoints {
 		if sfxDataPoint == nil {
 			// TODO: Log or metric for this odd ball?
 			continue
 		}
 
+		m := metrics.At(i)
 		// First check if the type is convertible and the data point is consistent.
-		metricType, err := convertType(sfxDataPoint)
+		err := fillInType(sfxDataPoint, m)
 		if err != nil {
-			numDroppedTimeSeries++
+			numDroppedDataPoints++
 			logger.Debug("SignalFx data-point type conversion error",
 				zap.Error(err),
 				zap.String("metric", sfxDataPoint.GetMetric()))
 			continue
 		}
-		point, err := buildPoint(sfxDataPoint, metricType)
+
+		m.SetName(sfxDataPoint.Metric)
+
+		switch m.DataType() {
+		case pdata.MetricDataTypeIntGauge:
+			err = fillIntDataPoint(sfxDataPoint, m.IntGauge().DataPoints())
+		case pdata.MetricDataTypeIntSum:
+			err = fillIntDataPoint(sfxDataPoint, m.IntSum().DataPoints())
+		case pdata.MetricDataTypeDoubleGauge:
+			err = fillDoubleDataPoint(sfxDataPoint, m.DoubleGauge().DataPoints())
+		case pdata.MetricDataTypeDoubleSum:
+			err = fillDoubleDataPoint(sfxDataPoint, m.DoubleSum().DataPoints())
+		}
+
 		if err != nil {
-			numDroppedTimeSeries++
+			numDroppedDataPoints++
 			logger.Debug("SignalFx data-point datum conversion error",
 				zap.Error(err),
 				zap.String("metric", sfxDataPoint.GetMetric()))
 			continue
 		}
 
-		labelKeys, labelValues := buildLabelKeysAndValues(sfxDataPoint.Dimensions)
-		descriptor := buildDescriptor(sfxDataPoint, labelKeys, metricType)
-		ts := &metricspb.TimeSeries{
-			// TODO: StartTimestamp can be set if each cumulative time series are
-			//  	tracked but right now it is not clear if it brings benefits.
-			//		Perhaps as an option so cost is "pay for play".
-			LabelValues: labelValues,
-			Points:      []*metricspb.Point{point},
-		}
-		metric := &metricspb.Metric{
-			MetricDescriptor: descriptor,
-			Timeseries:       []*metricspb.TimeSeries{ts},
-		}
-		metrics = append(metrics, metric)
+		i++
 	}
 
-	md.Metrics = metrics
-	return md, numDroppedTimeSeries
+	metrics.Resize(i)
+
+	return md, numDroppedDataPoints
 }
 
-func convertType(
+func fillInType(
 	sfxDataPoint *sfxpb.DataPoint,
-) (descType metricspb.MetricDescriptor_Type, err error) {
-
+	m pdata.Metric,
+) (err error) {
 	// Combine metric type with the actual data point type
 	sfxMetricType := sfxDataPoint.GetMetricType()
 	sfxDatum := sfxDataPoint.Value
-	if sfxDatum.IntValue == nil && sfxDatum.DoubleValue == nil && sfxDatum.StrValue == nil {
-		return metricspb.MetricDescriptor_UNSPECIFIED, errSFxNilDatum
+	if sfxDatum.IntValue == nil && sfxDatum.DoubleValue == nil {
+		return errSFxNilDatum
 	}
 
 	switch sfxMetricType {
 	case sfxpb.MetricType_GAUGE:
-		// Numerical: Periodic, instantaneous measurement of some state.
-		descType = metricspb.MetricDescriptor_GAUGE_DOUBLE
-		if sfxDatum.IntValue != nil {
-			descType = metricspb.MetricDescriptor_GAUGE_INT64
+		switch {
+		case sfxDatum.DoubleValue != nil:
+			// Numerical: Periodic, instantaneous measurement of some state.
+			m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+			m.DoubleGauge().InitEmpty()
+		case sfxDatum.IntValue != nil:
+			m.SetDataType(pdata.MetricDataTypeIntGauge)
+			m.IntGauge().InitEmpty()
+		default:
+			err = fmt.Errorf("non-numeric datapoint encountered")
 		}
 
-	case sfxpb.MetricType_COUNTER, sfxpb.MetricType_CUMULATIVE_COUNTER:
-		// COUNTER:  Count of occurrences. Generally non-negative integers.
-		// CUMULATIVE_COUNTER: Tracks a value that increases over time, where
-		// only the difference is important.
-		descType = metricspb.MetricDescriptor_CUMULATIVE_DOUBLE
-		if sfxDatum.IntValue != nil {
-			descType = metricspb.MetricDescriptor_CUMULATIVE_INT64
+	case sfxpb.MetricType_COUNTER:
+		switch {
+		case sfxDatum.DoubleValue != nil:
+			m.SetDataType(pdata.MetricDataTypeDoubleSum)
+			m.DoubleSum().InitEmpty()
+			m.DoubleSum().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
+			m.DoubleSum().SetIsMonotonic(true)
+		case sfxDatum.IntValue != nil:
+			m.SetDataType(pdata.MetricDataTypeIntSum)
+			m.IntSum().InitEmpty()
+			m.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
+			m.IntSum().SetIsMonotonic(true)
+		default:
+			err = fmt.Errorf("non-numeric datapoint encountered")
 		}
 
-	case sfxpb.MetricType_ENUM:
-		// String: Used for non-continuous quantities (that is, measurements where there is a fixed
-		// set of meaningful values). This is essentially a special case of gauge.
-		// Attempt to treat it as a numeric gauge.
-		descType = metricspb.MetricDescriptor_GAUGE_DOUBLE
-
+	case sfxpb.MetricType_CUMULATIVE_COUNTER:
+		switch {
+		case sfxDatum.DoubleValue != nil:
+			m.SetDataType(pdata.MetricDataTypeDoubleSum)
+			m.DoubleSum().InitEmpty()
+			m.DoubleSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
+			m.DoubleSum().SetIsMonotonic(true)
+		case sfxDatum.IntValue != nil:
+			m.SetDataType(pdata.MetricDataTypeIntSum)
+			m.IntSum().InitEmpty()
+			m.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
+			m.IntSum().SetIsMonotonic(true)
+		default:
+			err = fmt.Errorf("non-numeric datapoint encountered")
+		}
 	default:
 		err = fmt.Errorf("unknown data-point type (%d)", sfxMetricType)
 	}
 
-	return descType, err
+	return err
 }
 
-func buildPoint(
-	sfxDataPoint *sfxpb.DataPoint,
-	expectedMetricType metricspb.MetricDescriptor_Type,
-) (*metricspb.Point, error) {
-	if sfxDataPoint.Value.IntValue == nil && sfxDataPoint.Value.DoubleValue == nil && sfxDataPoint.Value.StrValue == nil {
-		return nil, errSFxNoDatumValue
+func fillIntDataPoint(sfxDataPoint *sfxpb.DataPoint, dps pdata.IntDataPointSlice) error {
+	if sfxDataPoint.Value.IntValue == nil {
+		return errSFxNoDatumValue
 	}
 
-	p := &metricspb.Point{
-		Timestamp: convertTimestamp(sfxDataPoint.GetTimestamp()),
-	}
+	dps.Resize(1)
+	dp := dps.At(0)
 
-	switch {
-	case sfxDataPoint.Value.IntValue != nil:
-		mismatch := expectedMetricType != metricspb.MetricDescriptor_CUMULATIVE_INT64 &&
-			expectedMetricType != metricspb.MetricDescriptor_GAUGE_INT64
-		if mismatch {
-			return nil, errSFxUnexpectedInt64DatumType
-		}
-		p.Value = &metricspb.Point_Int64Value{Int64Value: *sfxDataPoint.Value.IntValue}
+	dp.SetTimestamp(dpTimestamp(sfxDataPoint))
+	dp.SetValue(*sfxDataPoint.Value.IntValue)
+	fillInLabels(sfxDataPoint.Dimensions, dp.LabelsMap())
 
-	case sfxDataPoint.Value.DoubleValue != nil:
-		mismatch := expectedMetricType != metricspb.MetricDescriptor_CUMULATIVE_DOUBLE &&
-			expectedMetricType != metricspb.MetricDescriptor_GAUGE_DOUBLE
-		if mismatch {
-			return nil, errSFxUnexpectedFloat64DatumType
-		}
-		p.Value = &metricspb.Point_DoubleValue{DoubleValue: *sfxDataPoint.Value.DoubleValue}
-
-	case sfxDataPoint.Value.StrValue != nil:
-		if expectedMetricType != metricspb.MetricDescriptor_GAUGE_DOUBLE {
-			return nil, errSFxUnexpectedStringDatumType
-		}
-		dbl, err := strconv.ParseFloat(*sfxDataPoint.Value.StrValue, 64)
-		if err != nil {
-			return nil, errSFxStringDatumNotNumber
-		}
-		p.Value = &metricspb.Point_DoubleValue{DoubleValue: dbl}
-	}
-
-	return p, nil
+	return nil
 }
 
-func convertTimestamp(msec int64) *timestamppb.Timestamp {
-	if msec == 0 {
-		return nil
+func fillDoubleDataPoint(sfxDataPoint *sfxpb.DataPoint, dps pdata.DoubleDataPointSlice) error {
+	if sfxDataPoint.Value.DoubleValue == nil {
+		return errSFxNoDatumValue
 	}
 
-	ts := &timestamppb.Timestamp{
-		Seconds: msec / 1e3,
-		Nanos:   int32(msec%1e3) * 1e6,
-	}
-	return ts
+	dps.Resize(1)
+	dp := dps.At(0)
+
+	dp.SetTimestamp(dpTimestamp(sfxDataPoint))
+	dp.SetValue(*sfxDataPoint.Value.DoubleValue)
+	fillInLabels(sfxDataPoint.Dimensions, dp.LabelsMap())
+
+	return nil
+
 }
 
-func buildDescriptor(
-	sfxDataPoint *sfxpb.DataPoint,
-	labelKeys []*metricspb.LabelKey,
-	metricType metricspb.MetricDescriptor_Type,
-) *metricspb.MetricDescriptor {
-
-	// TODO: Evaluate performance impact with different datasets to see if it
-	//  is worth to cache these.
-	descriptor := &metricspb.MetricDescriptor{
-		Name: sfxDataPoint.GetMetric(),
-		// Description: no value to go here
-		// Unit:        no value to go here
-		Type:      metricType,
-		LabelKeys: labelKeys,
-	}
-
-	return descriptor
+func dpTimestamp(dp *sfxpb.DataPoint) pdata.TimestampUnixNano {
+	// Convert from SignalFx millis to pdata nanos
+	return pdata.TimestampUnixNano(dp.GetTimestamp() * 1e6)
 }
 
-func buildLabelKeysAndValues(
+func fillInLabels(
 	dimensions []*sfxpb.Dimension,
-) ([]*metricspb.LabelKey, []*metricspb.LabelValue) {
-	keys := make([]*metricspb.LabelKey, 0, len(dimensions))
-	values := make([]*metricspb.LabelValue, 0, len(dimensions))
+	labels pdata.StringMap,
+) {
+	labels.InitEmptyWithCapacity(len(dimensions))
+
 	for _, dim := range dimensions {
 		if dim == nil {
 			// TODO: Log or metric for this odd ball?
 			continue
 		}
-		lk := &metricspb.LabelKey{Key: dim.Key}
-		keys = append(keys, lk)
-
-		lv := &metricspb.LabelValue{}
-		lv.Value = dim.Value
-		lv.HasValue = true
-		values = append(values, lv)
+		labels.Insert(dim.Key, dim.Value)
 	}
-	return keys, values
 }


### PR DESCRIPTION
This excises all of the old OpenCensus model usage from the
signalfx receiver and replaces it with pdata structures.