### PR TITLE
adding queue settings

### DIFF
--- a/exporter/sapmexporter/exporter.go
+++ b/exporter/sapmexporter/exporter.go
@@ -77,7 +77,11 @@ func newSAPMTraceExporter(cfg *Config, params component.ExporterCreateParams) (c
 	return exporterhelper.NewTraceExporter(
 		cfg,
 		se.pushTraceData,
-		exporterhelper.WithShutdown(se.Shutdown))
+		exporterhelper.WithShutdown(se.Shutdown),
+		exporterhelper.WithQueue(cfg.QueueSettings),
+		exporterhelper.WithRetry(cfg.RetrySettings),
+		exporterhelper.WithTimeout(cfg.TimeoutSettings),
+	)
 }
 
 // tracesByAccessToken takes a pdata.Traces struct and will iterate through its ResourceSpans' attributes,


### PR DESCRIPTION
sapm should use the new queue as the queue processor is deprecated.

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1389