### PR TITLE
Revert "Fix flaky test - increase file lifespan in rotation tests"

### DIFF
--- a/receiver/stanzareceiver/README.md
+++ b/receiver/stanzareceiver/README.md
@@ -35,6 +35,7 @@ It can also be easily configured to tail and parse any structured or unstructure
 - [timestamp](https://github.com/observIQ/stanza/blob/master/docs/types/timestamp.md) parsing is available as a block within all parser operators, and also as a standalone operator. Many common timestamp layouts are supported.
 - [severity](https://github.com/observIQ/stanza/blob/master/docs/types/severity.md) parsing is available as a block within all parser operators, and also as a standalone operator. Stanza uses a flexible severity representation which is automatically interpreted by the stanza receiver.
 
+
 ## Example - Tailing a simple json file
 
 Receiver Configuration


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#1384

Windows tests are still broken, and blocks development.