### PR TITLE
[datadogexporter] Support resource conventions for hostnames

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -21,6 +21,7 @@ datadog:
  ```
 
 The hostname, environment, service and version can be set in the configuration for unified service tagging.
+The exporter will try to retrieve a hostname following the OpenTelemetry semantic conventions if there is one available.
 
 See the sample configuration file under the `example` folder for other available options.
 

--- a/exporter/datadogexporter/metadata/ec2/ec2.go
+++ b/exporter/datadogexporter/metadata/ec2/ec2.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
 )
 
@@ -77,4 +79,19 @@ func (hi *HostInfo) GetHostname(logger *zap.Logger) string {
 	}
 
 	return hi.EC2Hostname
+}
+
+// HostnameFromAttributes gets a valid hostname from labels
+// if available
+func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
+	hostName, ok := attrs.Get(conventions.AttributeHostName)
+	if ok && !isDefaultHostname(hostName.StringVal()) {
+		return hostName.StringVal(), true
+	}
+
+	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
+		return hostID.StringVal(), true
+	}
+
+	return "", false
 }

--- a/exporter/datadogexporter/metadata/ec2/ec2_test.go
+++ b/exporter/datadogexporter/metadata/ec2/ec2_test.go
@@ -17,7 +17,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/testutils"
 )
 
 const (
@@ -49,4 +52,15 @@ func TestGetHostname(t *testing.T) {
 		EC2Hostname: customHost,
 	}
 	assert.Equal(t, customHost, hostInfo.GetHostname(logger))
+}
+
+func TestHostnameFromAttributes(t *testing.T) {
+	attrs := testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+		conventions.AttributeHostID:        testInstanceID,
+		conventions.AttributeHostName:      testIP,
+	})
+	hostname, ok := HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testInstanceID)
 }

--- a/exporter/datadogexporter/testutils/test_utils.go
+++ b/exporter/datadogexporter/testutils/test_utils.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 // DatadogServerMock mocks a Datadog backend server
@@ -54,4 +56,17 @@ func metricsEndpoint(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	w.Write(resJSON)
+}
+
+// NewAttributeMap creates a new attribute map (string only)
+// from a Go map
+func NewAttributeMap(mp map[string]string) pdata.AttributeMap {
+	attrs := pdata.NewAttributeMap()
+	attrs.InitEmptyWithCapacity(len(mp))
+
+	for k, v := range mp {
+		attrs.Insert(k, pdata.NewAttributeValueString(v))
+	}
+
+	return attrs
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The resource attributes of metrics and traces are now checked to see if there are any of `host.id`, `host.name` or `container.id` to get a suitable hostname (see [resource semantic conventions here](https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions)). This hostname has preference over the one retrieved automatically. This allows

- using the exporter in an agent-collector setup, where each agent sets the correct attributes for later processing
- being compatible with other Collector components that set these attributes, like the resource detection processor.

**Link to tracking Issue:** n/a
**Testing:** Added unit tests. Tested in an end to end environment
**Documentation:** Stated support for semantic conventions on the README. Documented public functions.