### PR TITLE
Add metric filter option to metrics transform processor

### DIFF
--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -1,94 +1,134 @@
 # Metrics Transform Processor
+
 Supported pipeline types: metrics
-- This ONLY supports renames/aggregations **within individual metrics**. It does not do any aggregation across batches, so it is not suitable for aggregating metrics from multiple sources (e.g. multiple nodes or clients). At this point, it is only for aggregating metrics from a single source that groups its metrics for a particular time period into a single batch (e.g. host metrics from the VM the collector is running on).
-- Rename Collisions will result in a no operation on the metrics data
-  - e.g. If want to rename a metric or label to `new_name` while there is already a metric or label called `new_name`, this operation will not take any effect. There will also be an error logged
 
 ## Description
-The metrics transform processor can be used to rename metrics, labels, or label values. It can also be used to perform aggregations on metrics across labels or label values.
 
-## Capabilities
-- Rename metrics (e.g. rename `cpu/usage` to `cpu/usage_time`)
-- Rename labels (e.g. rename `cpu` to `core`)
-- Rename label values (e.g. rename `done` to `complete`)
-- Aggregate across label sets (e.g. only want the label `usage`, but don’t care about the labels `core`, and `cpu`)
-  - Aggregation_type: sum, mean, max
-- Aggregate across label values (e.g. want `memory{slab}`, but don’t care about `memory{slab_reclaimable}` & `memory{slab_unreclaimable}`)
-  - Aggregation_type: sum, mean, max
-- Add label to an existing metric
-- When adding or updating a label value, specify `{{version}}` to include the application version number
+The metrics transform processor can be used to rename metrics, and add, rename or delete label keys and values. It can also be used to perform aggregations on metrics across labels or label values. The complete list of supported operations that can be applied to one or more metrics is provided in the below table.
+
+:information_source: This processor only supports renames/aggregations **within a batch of metrics**. It does not do any aggregation across batches, so it is not suitable for aggregating metrics from multiple sources (e.g. multiple nodes or clients).
+
+| Operation | Example |
+| --- | --- |
+| Rename metrics | Rename `system.cpu.usage` to `system.cpu.usage_time` |
+| Add labels | For metric `system.cpu.usage`, add new label `identifier` with value `1` to all data points |
+| Rename label keys | For metric `system.cpu.usage`, rename label `state` to `cpu_state` |
+| Rename label values | For metric `system.cpu.usage`, label `state`, rename label value `idle` to `-` |
+| Delete label values | For metric `system.cpu.usage`, delete all data points where label `state` has value `idle` |
+| Toggle the data type of scalar metrics between `int` and `double` | For metric `system.cpu.usage`, change from `int` data points to `double` data points |
+| Aggregate across label sets by sum, mean, min, or max | For metric `system.cpu.usage`, retain the label `state`, but aggregate away the label `cpu` |
+| Aggregate across label values by sum, mean, min, or max | For metric `system.cpu.usage`, label `state`, calculate `used = sum{user + system}` |
+
+In addition to the above, when adding or updating a label value, specify `{{version}}` to include the application version number
 
 ## Configuration
+
+Configuration is specified through a list of transformations and operations. Transformations and operations will be applied to all metrics in order so that later transformations or operations may reference the result of previous transformations or operations.
+
 ```yaml
 # transforms is a list of transformations with each element transforming a metric selected by metric name
 transforms:
-  # name is used to match with the metric to operate on. This implementation doesn’t utilize the filtermetric’s MatchProperties struct because it doesn’t match well with what I need at this phase. All is needed for this processor at this stage is a single name string that can be used to match with selected metrics. The list of metric names and the match type in the filtermetric’s MatchProperties struct are unnecessary. Also, based on the issue about improving filtering configuration, it seems like this struct is subject to be slightly modified.
-  - metric_name: <current_metric_name>
-
-  # action specifies if the operations are performed on the current copy of the metric or on a newly created metric that will be inserted
+    # include specifies the metric name used to determine which metric(s) to operate on
+  - include: <metric_name>
+    # match_type specifies whether the include name should be used as a strict match or regexp match, default = strict
+    match_type: {strict, regexp}
+    # action specifies if the operations are performed on the metric in place, or on an inserted clone
     action: {update, insert}
-
-  # new_name is used to rename metrics (e.g. rename cpu/usage to cpu/usage_time) if action is insert, new_name is required
+    # new_name specifies the updated name of the metric; if action is insert, new_name is required
     new_name: <new_metric_name_inserted>
-
-  # operations contain a list of operations that will be performed on the selected metrics. Each operation block is a key-value pair, where the key can be any arbitrary string set by the users for readability, and the value is a struct with fields required for operations. The action field is important for the processor to identify exactly which operation to perform 
+    # operations contain a list of operations that will be performed on the selected metrics
     operations:
-
-    # update_label action can be used to update the name of a label or the values of this label (e.g. rename label `cpu` to `core`)
-    - action: update_label
-      label: <current_label1>
-      new_label: <new_label>
-      value_actions:
-      - value: <current_label_value>
-        new_value: <new_label_value>
-
-    # aggregate_labels action aggregates metrics across labels (e.g. only want the label `usage`, but don’t care about the labels `core`, and `cpu`)
-    - action: aggregate_labels
-    # label_set contains a list of labels that will remain after the aggregation. The excluded labels will be aggregated by the way specified by aggregation_type.
-      label_set: [labels...]
-      aggregation_type: {sum, mean, max}
-
-    # aggregate_label_values action aggregates labels across label values (e.g. want memory{slab}, but don’t care about memory{slab_reclaimable} & memory{slab_unreclaimable})
-    - action: aggregate_label_values
-      label: <label>
-    # aggregated_values contains a list of label values that will be aggregated by the way specified by aggregation_type into new_value. The excluded label values will remain.
-      aggregated_values: [values...]
-      new_value: <new_value> 
-      aggregation_type: {sum, mean, max}
+        # update_label action can be used to update the name of a label or the values of this label
+      - action: {add_label, update_label, delete_label_value, toggle_scalar_data_type, aggregate_labels, aggregate_label_values}
+        # label specifies the label to operate on
+        label: <label>
+        # new_label specifies the updated name of the label; if action is add_label, new_label is required
+        new_label: <new_label>
+        # aggregated_values contains a list of label values that will be aggregated; if action is aggregate_label_values, aggregated_values is required
+        aggregated_values: [values...]
+        # new_label specifies the updated name of the label value; if action is add_label or aggregate_label_values, new_value is required
+        new_value: <new_value>
+        # label_set contains a list of labels that will remain after aggregation; if action is aggregate_labels, label_set is required
+        label_set: [labels...]
+        # aggregation_type defines how excluded labels will be aggregated
+        aggregation_type: {sum, mean, max}
+        # value_actions contain a list of operations that will be performed on the selected label
+        value_actions:
+            # value specifies the value to operate on
+          - value: <current_label_value>
+            # new_value specifies the updated value
+            new_value: <new_label_value>
 ```
 
 ## Examples
 
-### Insert New Metric
+### Create a new metric from an existing metric
 ```yaml
 # create host.cpu.utilization from host.cpu.usage
-metric_name: host.cpu.usage
+include: host.cpu.usage
 action: insert
 new_name: host.cpu.utilization
 operations:
   ...
 ```
 
-### Rename Metric
+### Rename metric
 ```yaml
-# rename system.cpu.usage to cpu/usage_time
-metric_name: system.cpu.usage
+# rename system.cpu.usage to system.cpu.usage_time
+include: system.cpu.usage
 action: update
-new_name: cpu/usage_time
+new_name: system.cpu.usage_time
 ```
 
-### Rename Labels
+### Add a label
 ```yaml
-# rename the label cpu to core
+# for system.cpu.usage_time, add label `version` with value `opentelemetry collector vX.Y.Z` to all points
+include: system.cpu.usage
+action: update
+operations:
+  - action: add_label
+    new_label: version
+    new_value: opentelemetry collector {{version}}
+```
+
+### Add a label to multiple metrics
+```yaml
+# for all system metrics, add label `version` with value `opentelemetry collector vX.Y.Z` to all points
+include: ^system\.
+match_type: regexp
+action: update
+operations:
+  - action: add_label
+    new_label: version
+    new_value: opentelemetry collector {{version}}
+```
+
+### Rename labels
+```yaml
+# for system.cpu.usage_time, rename the label state to cpu_state
+include: system.cpu.usage
+action: update
 operations:
   - action: update_label
-    label: cpu
-    new_label: core
+    label: state
+    new_label: cpu_state
 ```
 
-### Rename Label Values
+### Rename labels for multiple metrics
+```yaml
+# for all system.cpu metrics, rename the label state to cpu_state
+include: ^system\.cpu\.
+action: update
+operations:
+  - action: update_label
+    label: state
+    new_label: cpu_state
+```
+
+### Rename label values
 ```yaml
 # rename the label value slab_reclaimable to sreclaimable, slab_unreclaimable to sunreclaimable
+...
 operations:
   - action: update_label
     label: state
@@ -99,47 +139,7 @@ operations:
         new_value: sunreclaimable
 ```
 
-### Aggregate Labels
-```yaml
-# aggregate away everything but `state` using summation
-...
-operations:
-  - action: aggregate_labels
-    label_set: [ state ]
-    aggregation_type: sum
-```
-
-### Aggregate Label Values
-```yaml
-# combine slab_reclaimable & slab_unreclaimable by summation
-...
-operations:
-  - action: aggregate_label_values
-    label: state
-    aggregated_values: [ slab_reclaimable, slab_unreclaimable ]
-    new_value: slab 
-    aggregation_type: sum
-```
-
-### Add a label to an existing metric
-```yaml
-...
-# add label `version` with value `opentelemetry collector vX.Y.Z` to all points
-operations:
-  - action: add_label
-    new_label: version
-    new_value: opentelemetry collector {{version}}
-```
-
-### Toggle Datatype
-```yaml
-# toggle the datatype for the metric system.cpu.usage
-...
-operation:
-  - action: toggle_scalar_data_type
-```
-
-### Delete Label Value
+### Delete label value
 ```yaml
 # delete the label value 'value' of the label 'label'
 ...
@@ -147,4 +147,34 @@ operation:
   - action: delete_label_value
     label: label
     label_value: value
+```
+
+### Toggle datatype
+```yaml
+# toggle the datatype for a metric
+...
+operation:
+  - action: toggle_scalar_data_type
+```
+
+### Aggregate labels
+```yaml
+# aggregate away all labels except `state` using summation
+...
+operations:
+  - action: aggregate_labels
+    label_set: [ state ]
+    aggregation_type: sum
+```
+
+### Aggregate label values
+```yaml
+# aggregate data points with state label value slab_reclaimable & slab_unreclaimable using summation
+...
+operations:
+  - action: aggregate_label_values
+    label: state
+    aggregated_values: [ slab_reclaimable, slab_unreclaimable ]
+    new_value: slab 
+    aggregation_type: sum
 ```

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -14,9 +14,17 @@
 
 package metricstransformprocessor
 
-import "go.opentelemetry.io/collector/config/configmodels"
+import (
+	"go.opentelemetry.io/collector/config/configmodels"
+)
 
 const (
+	// IncludeFieldName is the mapstructure field name for Include field
+	IncludeFieldName = "include"
+
+	// MatchTypeFieldName is the mapstructure field name for MatchType field
+	MatchTypeFieldName = "match_type"
+
 	// MetricNameFieldName is the mapstructure field name for MetricName field
 	MetricNameFieldName = "metric_name"
 
@@ -36,6 +44,16 @@ const (
 	NewValueFieldName = "new_value"
 )
 
+const (
+	// StrictMatchType is the FilterType for filtering by exact string matches.
+	StrictMatchType = "strict"
+
+	// RegexpMatchType is the FilterType for filtering by regexp string matches.
+	RegexpMatchType = "regexp"
+)
+
+var MatchTypes = []string{StrictMatchType, RegexpMatchType}
+
 // Config defines configuration for Resource processor.
 type Config struct {
 	configmodels.ProcessorSettings `mapstructure:",squash"`
@@ -46,8 +64,12 @@ type Config struct {
 
 // Transform defines the transformation applied to the specific metric
 type Transform struct {
-	// MetricName is used to select the metric to operate on.
+	// MetricIncludeFilter is used to select the metric(s) to operate on.
 	// REQUIRED
+	MetricIncludeFilter FilterConfig `mapstructure:",squash"`
+
+	// MetricName is used to select the metric to operate on.
+	// DEPRECATED
 	MetricName string `mapstructure:"metric_name"`
 
 	// Action specifies the action performed on the matched metric.
@@ -60,6 +82,14 @@ type Transform struct {
 
 	// Operations contains a list of operations that will be performed on the selected metric.
 	Operations []Operation `mapstructure:"operations"`
+}
+
+type FilterConfig struct {
+	// Include specifies the metric(s) to operate on.
+	Include string `mapstructure:"include"`
+
+	// MatchType determines how the Include string is matched: <strict|regexp>.
+	MatchType string `mapstructure:"match_type"`
 }
 
 // Operation defines the specific operation performed on the selected metrics.
@@ -127,6 +157,9 @@ const (
 	// UpdateLabel applies name changes to label and/or label values.
 	UpdateLabel OperationAction = "update_label"
 
+	// DeleteLabelValue deletes a label value by also removing all the points associated with this label value
+	DeleteLabelValue OperationAction = "delete_label_value"
+
 	// AggregateLabels aggregates away all labels other than the ones in Operation.LabelSet
 	// by the method indicated by Operation.AggregationType.
 	AggregateLabels OperationAction = "aggregate_labels"
@@ -134,9 +167,6 @@ const (
 	// AggregateLabelValues aggregates away the values in Operation.AggregatedValues
 	// by the method indicated by Operation.AggregationType.
 	AggregateLabelValues OperationAction = "aggregate_label_values"
-
-	// DeleteLabelValue deletes a label value by also removing all the points associated with this label value
-	DeleteLabelValue OperationAction = "delete_label_value"
 
 	// Mean indicates taking the mean of the aggregated data.
 	Mean AggregationType = "mean"

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -69,7 +69,7 @@ type Transform struct {
 	MetricIncludeFilter FilterConfig `mapstructure:",squash"`
 
 	// MetricName is used to select the metric to operate on.
-	// DEPRECATED
+	// DEPRECATED. Use MetricIncludeFilter instead.
 	MetricName string `mapstructure:"metric_name"`
 
 	// Action specifies the action performed on the matched metric.

--- a/processor/metricstransformprocessor/config_test.go
+++ b/processor/metricstransformprocessor/config_test.go
@@ -59,10 +59,12 @@ var (
 	}
 
 	tests = []struct {
+		configFile string
 		filterName string
 		expCfg     *Config
 	}{
 		{
+			configFile: "config_full.yaml",
 			filterName: "metricstransform",
 			expCfg: &Config{
 				ProcessorSettings: configmodels.ProcessorSettings{
@@ -82,6 +84,7 @@ var (
 			},
 		},
 		{
+			configFile: "config_full.yaml",
 			filterName: "metricstransform/addlabel",
 			expCfg: &Config{
 				ProcessorSettings: configmodels.ProcessorSettings{
@@ -106,23 +109,40 @@ var (
 				},
 			},
 		},
+		{
+			configFile: "config_deprecated.yaml",
+			filterName: "metricstransform",
+			expCfg: &Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					NameVal: "metricstransform",
+					TypeVal: typeStr,
+				},
+				Transforms: []Transform{
+					{
+						MetricName: "old_name",
+						Action:     Update,
+						NewName:    "new_name",
+					},
+				},
+			},
+		},
 	}
 )
 
 // TestLoadingFullConfig tests loading testdata/config_full.yaml.
 func TestLoadingFullConfig(t *testing.T) {
-	factories, err := componenttest.ExampleComponents()
-	assert.NoError(t, err)
-
-	factory := NewFactory()
-	factories.Processors[configmodels.Type(typeStr)] = factory
-	config, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config_full.yaml"), factories)
-
-	assert.NoError(t, err)
-	require.NotNil(t, config)
-
 	for _, test := range tests {
 		t.Run(test.filterName, func(t *testing.T) {
+
+			factories, err := componenttest.ExampleComponents()
+			assert.NoError(t, err)
+
+			factory := NewFactory()
+			factories.Processors[configmodels.Type(typeStr)] = factory
+			config, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", test.configFile), factories)
+			assert.NoError(t, err)
+			require.NotNil(t, config)
+
 			cfg := config.Processors[test.filterName]
 			assert.Equal(t, test.expCfg, cfg)
 		})

--- a/processor/metricstransformprocessor/config_test.go
+++ b/processor/metricstransformprocessor/config_test.go
@@ -71,7 +71,9 @@ var (
 				},
 				Transforms: []Transform{
 					{
-						MetricName: "old_name",
+						MetricIncludeFilter: FilterConfig{
+							Include: "old_name",
+						},
 						Action:     Update,
 						NewName:    "new_name",
 						Operations: testDataOperations,
@@ -88,8 +90,11 @@ var (
 				},
 				Transforms: []Transform{
 					{
-						MetricName: "some_name",
-						Action:     Update,
+						MetricIncludeFilter: FilterConfig{
+							Include:   "some_name",
+							MatchType: "regexp",
+						},
+						Action: Update,
 						Operations: []Operation{
 							{
 								Action:   AddLabel,

--- a/processor/metricstransformprocessor/factory_test.go
+++ b/processor/metricstransformprocessor/factory_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configcheck"
@@ -89,6 +88,11 @@ func TestCreateProcessors(t *testing.T) {
 			configName:   "config_invalid_label.yaml",
 			succeed:      false,
 			errorMessage: fmt.Sprintf("missing required field %q while %q is %v in the %vth operation", LabelFieldName, ActionFieldName, UpdateLabel, 0),
+		},
+		{
+			configName:   "config_invalid_regexp.yaml",
+			succeed:      false,
+			errorMessage: fmt.Sprintf("%q, error parsing regexp: missing closing ]: `[\\da`", IncludeFieldName),
 		},
 	}
 
@@ -263,8 +267,7 @@ func TestCreateProcessorsFilledData(t *testing.T) {
 		},
 	}
 
-	internalTransforms, err := buildHelperConfig(oCfg, "v0.0.1")
-	require.NoError(t, err)
+	internalTransforms := buildHelperConfig(oCfg, "v0.0.1")
 
 	for i, expTr := range expData {
 		mtpT := internalTransforms[i]

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -28,43 +28,18 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+type metricsTransformProcessor struct {
+	transforms []internalTransform
+	logger     *zap.Logger
+}
+
+var _ processorhelper.MProcessor = (*metricsTransformProcessor)(nil)
+
 type internalTransform struct {
 	MetricIncludeFilter internalFilter
 	Action              ConfigAction
 	NewName             string
 	Operations          []internalOperation
-}
-
-type internalFilter interface {
-	getMatches(toMatch metricNameMapping) []*metricspb.Metric
-}
-
-type internalFilterStrict struct {
-	include string
-}
-
-func (f internalFilterStrict) getMatches(toMatch metricNameMapping) []*metricspb.Metric {
-	if metrics, ok := toMatch[f.include]; ok {
-		return metrics
-	}
-
-	return nil
-}
-
-type internalFilterRegexp struct {
-	include *regexp.Regexp
-}
-
-func (f internalFilterRegexp) getMatches(toMatch metricNameMapping) []*metricspb.Metric {
-	const capExpectedMatches = 10
-
-	matches := make([]*metricspb.Metric, 0, capExpectedMatches)
-	for name, metrics := range toMatch {
-		if matched := f.include.MatchString(name); matched {
-			matches = append(matches, metrics...)
-		}
-	}
-	return matches
 }
 
 type internalOperation struct {
@@ -74,12 +49,47 @@ type internalOperation struct {
 	aggregatedValuesSet map[string]bool
 }
 
-type metricsTransformProcessor struct {
-	transforms []internalTransform
-	logger     *zap.Logger
+type internalFilter interface {
+	getMatches(toMatch metricNameMapping) []*match
 }
 
-var _ processorhelper.MProcessor = (*metricsTransformProcessor)(nil)
+type match struct {
+	metric     *metricspb.Metric
+	pattern    *regexp.Regexp
+	submatches []int
+}
+
+type internalFilterStrict struct {
+	include string
+}
+
+func (f internalFilterStrict) getMatches(toMatch metricNameMapping) []*match {
+	if metrics, ok := toMatch[f.include]; ok {
+		matches := make([]*match, len(metrics))
+		for i, metric := range metrics {
+			matches[i] = &match{metric: metric}
+		}
+		return matches
+	}
+
+	return nil
+}
+
+type internalFilterRegexp struct {
+	include *regexp.Regexp
+}
+
+func (f internalFilterRegexp) getMatches(toMatch metricNameMapping) []*match {
+	matches := make([]*match, 0, 10)
+	for name, metrics := range toMatch {
+		if submatches := f.include.FindStringSubmatchIndex(name); submatches != nil {
+			for _, metric := range metrics {
+				matches = append(matches, &match{metric: metric, pattern: f.include, submatches: submatches})
+			}
+		}
+	}
+	return matches
+}
 
 type metricNameMapping map[string][]*metricspb.Metric
 
@@ -123,21 +133,22 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 		nameToMetricMapping := newMetricNameMapping(data)
 		for _, transform := range mtp.transforms {
 			matchedMetrics := transform.MetricIncludeFilter.getMatches(nameToMetricMapping)
-			for _, metric := range matchedMetrics {
-				metricName := metric.MetricDescriptor.Name
+
+			for _, match := range matchedMetrics {
+				metricName := match.metric.MetricDescriptor.Name
 
 				if transform.Action == Insert {
-					metric = proto.Clone(metric).(*metricspb.Metric)
-					data.Metrics = append(data.Metrics, metric)
+					match.metric = proto.Clone(match.metric).(*metricspb.Metric)
+					data.Metrics = append(data.Metrics, match.metric)
 				}
 
-				mtp.update(metric, transform)
+				mtp.update(match, transform)
 
 				if transform.NewName != "" {
 					if transform.Action == Update {
-						nameToMetricMapping.remove(metricName, metric)
+						nameToMetricMapping.remove(metricName, match.metric)
 					}
-					nameToMetricMapping.add(metric.MetricDescriptor.Name, metric)
+					nameToMetricMapping.add(match.metric.MetricDescriptor.Name, match.metric)
 				}
 			}
 		}
@@ -147,25 +158,29 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 }
 
 // update updates the metric content based on operations indicated in transform.
-func (mtp *metricsTransformProcessor) update(metric *metricspb.Metric, transform internalTransform) {
+func (mtp *metricsTransformProcessor) update(match *match, transform internalTransform) {
 	if transform.NewName != "" {
-		metric.MetricDescriptor.Name = transform.NewName
+		if match.pattern == nil {
+			match.metric.MetricDescriptor.Name = transform.NewName
+		} else {
+			match.metric.MetricDescriptor.Name = string(match.pattern.ExpandString([]byte{}, transform.NewName, match.metric.MetricDescriptor.Name, match.submatches))
+		}
 	}
 
 	for _, op := range transform.Operations {
 		switch op.configOperation.Action {
 		case UpdateLabel:
-			mtp.updateLabelOp(metric, op)
+			mtp.updateLabelOp(match.metric, op)
 		case AggregateLabels:
-			mtp.aggregateLabelsOp(metric, op)
+			mtp.aggregateLabelsOp(match.metric, op)
 		case AggregateLabelValues:
-			mtp.aggregateLabelValuesOp(metric, op)
+			mtp.aggregateLabelValuesOp(match.metric, op)
 		case ToggleScalarDataType:
-			mtp.ToggleScalarDataType(metric)
+			mtp.ToggleScalarDataType(match.metric)
 		case AddLabel:
-			mtp.addLabelOp(metric, op)
+			mtp.addLabelOp(match.metric, op)
 		case DeleteLabelValue:
-			mtp.deleteLabelValueOp(metric, op)
+			mtp.deleteLabelValueOp(match.metric, op)
 		}
 	}
 }

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -161,9 +161,9 @@ func BenchmarkMetricsTransformProcessorRenameMetrics(b *testing.B) {
 
 	transforms := []internalTransform{
 		{
-			MetricName: "metric1",
-			Action:     Insert,
-			NewName:    "new/metric1",
+			MetricIncludeFilter: internalFilterStrict{include: "metric"},
+			Action:              Insert,
+			NewName:             "new/metric1",
 		},
 	}
 

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -80,14 +80,14 @@ var (
 			name: "metric_names_update_chained",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^(metric)(?P<namedsubmatch>[12])$")},
 					Action:              Update,
-					NewName:             "new/metric1",
+					NewName:             "new/$1/$namedsubmatch",
 				},
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "new/metric1"},
+					MetricIncludeFilter: internalFilterStrict{include: "new/metric/1"},
 					Action:              Update,
-					NewName:             "new/metric2",
+					NewName:             "new/new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -99,9 +99,9 @@ var (
 					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
 			},
 			out: []*metricspb.Metric{
-				metricBuilder().setName("new/metric2").
+				metricBuilder().setName("new/new/metric1").
 					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-				metricBuilder().setName("new/metric2").
+				metricBuilder().setName("new/metric/2").
 					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
 				metricBuilder().setName("metric3").
 					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -15,6 +15,8 @@
 package metricstransformprocessor
 
 import (
+	"regexp"
+
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 )
 
@@ -33,9 +35,9 @@ var (
 			name: "metric_name_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
-					NewName:    "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
+					NewName:             "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -48,17 +50,17 @@ var (
 			},
 		},
 		{
-			name: "metric_name_update_multiple",
+			name: "metric_name_update_chained",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
-					NewName:    "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
+					NewName:             "new/metric1",
 				},
 				{
-					MetricName: "metric2",
-					Action:     Update,
-					NewName:    "new/metric2",
+					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+					Action:              Update,
+					NewName:             "new/metric2",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -75,12 +77,43 @@ var (
 			},
 		},
 		{
+			name: "metric_names_update_chained",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+					Action:              Update,
+					NewName:             "new/metric1",
+				},
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "new/metric1"},
+					Action:              Update,
+					NewName:             "new/metric2",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("new/metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+				metricBuilder().setName("new/metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+			},
+		},
+		{
 			name: "metric_name_update_nonexist",
 			transforms: []internalTransform{
 				{
-					MetricName: "nonexist",
-					Action:     Update,
-					NewName:    "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "nonexist"},
+					Action:              Update,
+					NewName:             "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -96,8 +129,8 @@ var (
 			name: "metric_label_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -128,8 +161,8 @@ var (
 			name: "metric_label_value_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -166,8 +199,8 @@ var (
 			name: "metric_label_aggregation_sum_int_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -203,8 +236,8 @@ var (
 			name: "metric_label_aggregation_mean_int_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -239,8 +272,8 @@ var (
 			name: "metric_label_aggregation_max_int_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -276,8 +309,8 @@ var (
 			name: "metric_label_aggregation_min_int_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -315,8 +348,8 @@ var (
 			name: "metric_label_aggregation_sum_double_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -352,8 +385,8 @@ var (
 			name: "metric_label_aggregation_mean_double_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -387,8 +420,8 @@ var (
 			name: "metric_label_aggregation_max_double_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -423,8 +456,8 @@ var (
 			name: "metric_label_aggregation_min_double_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -457,8 +490,8 @@ var (
 			name: "metric_label_values_aggregation_sum_int_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -504,8 +537,8 @@ var (
 			name: "metric_label_values_aggregation_sum_distribution_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -541,8 +574,8 @@ var (
 			name: "metric_label_values_aggregation_not_sum_distribution_update",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -575,9 +608,9 @@ var (
 			name: "metric_name_insert",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Insert,
-					NewName:    "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Insert,
+					NewName:             "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -595,14 +628,14 @@ var (
 			name: "metric_name_insert_multiple",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Insert,
-					NewName:    "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Insert,
+					NewName:             "new/metric1",
 				},
 				{
-					MetricName: "metric2",
-					Action:     Insert,
-					NewName:    "new/metric2",
+					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+					Action:              Insert,
+					NewName:             "new/metric2",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -620,9 +653,9 @@ var (
 			name: "metric_label_update_with_metric_insert",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Insert,
-					NewName:    "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Insert,
+					NewName:             "new/metric1",
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -658,9 +691,9 @@ var (
 			name: "metric_label_value_update_with_metric_insert",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Insert,
-					NewName:    "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Insert,
+					NewName:             "new/metric1",
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -706,8 +739,8 @@ var (
 			name: "metric_label_aggregation_sum_int_insert",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Insert,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Insert,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -749,8 +782,8 @@ var (
 			name: "metric_label_values_aggregation_sum_int_insert",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Insert,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Insert,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -785,8 +818,8 @@ var (
 			name: "metric_labels_aggregation_sum_distribution_insert",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Insert,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Insert,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -823,8 +856,8 @@ var (
 			name: "metric_toggle_scalar_data_type_int64_to_double",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -834,8 +867,8 @@ var (
 					},
 				},
 				{
-					MetricName: "metric2",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -858,8 +891,8 @@ var (
 			name: "metric_toggle_scalar_data_type_double_to_int64",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -869,8 +902,8 @@ var (
 					},
 				},
 				{
-					MetricName: "metric2",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -897,8 +930,8 @@ var (
 			name: "metric_toggle_scalar_data_type_no_effect",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -922,8 +955,8 @@ var (
 			name: "update existing metric by adding a new label when there are no labels",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -954,8 +987,8 @@ var (
 			name: "update existing metric by adding a new label when there are labels",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -986,8 +1019,8 @@ var (
 			name: "update existing metric by adding a label that is duplicated in the list",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric1",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -1018,8 +1051,8 @@ var (
 			name: "update_does_not_happen_because_target_metric_doesn't_exist",
 			transforms: []internalTransform{
 				{
-					MetricName: "mymetric",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "mymetric"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{
@@ -1051,8 +1084,8 @@ var (
 			name: "delete_a_label_value",
 			transforms: []internalTransform{
 				{
-					MetricName: "metric",
-					Action:     Update,
+					MetricIncludeFilter: internalFilterStrict{include: "metric"},
+					Action:              Update,
 					Operations: []internalOperation{
 						{
 							configOperation: Operation{

--- a/processor/metricstransformprocessor/testdata/config_deprecated.yaml
+++ b/processor/metricstransformprocessor/testdata/config_deprecated.yaml
@@ -1,0 +1,23 @@
+receivers:
+  examplereceiver:
+
+processors:
+  metricstransform:
+      transforms:
+        - metric_name: old_name
+          action: update
+          new_name: new_name
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+      traces:
+          receivers: [examplereceiver]
+          processors: [metricstransform]
+          exporters: [exampleexporter]
+      metrics:
+          receivers: [examplereceiver]
+          processors: [metricstransform]
+          exporters: [exampleexporter]

--- a/processor/metricstransformprocessor/testdata/config_full.yaml
+++ b/processor/metricstransformprocessor/testdata/config_full.yaml
@@ -31,7 +31,6 @@ processors:
             - action: add_label
               new_label: mylabel
               new_value: myvalue
-            
 
 exporters:
     exampleexporter:

--- a/processor/metricstransformprocessor/testdata/config_full.yaml
+++ b/processor/metricstransformprocessor/testdata/config_full.yaml
@@ -4,7 +4,7 @@ receivers:
 processors:
     metricstransform:
         transforms:
-            - metric_name: old_name
+            - include: old_name
               action: update
               new_name: new_name
               operations:
@@ -24,7 +24,8 @@ processors:
                   aggregation_type: sum
     metricstransform/addlabel:
       transforms:
-        - metric_name: some_name
+        - include: some_name
+          match_type: regexp
           action: update
           operations:
             - action: add_label

--- a/processor/metricstransformprocessor/testdata/config_invalid_action.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_action.yaml
@@ -4,9 +4,8 @@ receivers:
 processors:
     metricstransform:
         transforms:
-          - metric_name: old_name
+          - include: old_name
             action: invalid # invalid action type
-            
 
 exporters:
     exampleexporter:

--- a/processor/metricstransformprocessor/testdata/config_invalid_include.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_include.yaml
@@ -1,0 +1,21 @@
+receivers:
+    examplereceiver:
+
+processors:
+    metricstransform:
+        transforms:
+            - action: update
+
+exporters:
+    exampleexporter:
+
+service:
+    pipelines:
+        traces:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]
+        metrics:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]

--- a/processor/metricstransformprocessor/testdata/config_invalid_include_and_metricname.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_include_and_metricname.yaml
@@ -4,8 +4,8 @@ receivers:
 processors:
     metricstransform:
         transforms:
-            - metric_name: name1
-              include: name2
+            - include: name1
+              metric_name: name2
               action: update
 
 exporters:

--- a/processor/metricstransformprocessor/testdata/config_invalid_include_and_metricname.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_include_and_metricname.yaml
@@ -1,0 +1,23 @@
+receivers:
+    examplereceiver:
+
+processors:
+    metricstransform:
+        transforms:
+            - metric_name: name1
+              include: name2
+              action: update
+
+exporters:
+    exampleexporter:
+
+service:
+    pipelines:
+        traces:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]
+        metrics:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]

--- a/processor/metricstransformprocessor/testdata/config_invalid_label.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_label.yaml
@@ -4,7 +4,7 @@ receivers:
 processors:
     metricstransform:
         transforms:
-            - metric_name: old_name
+            - include: old_name
               action: update
               operations:
                 - action: update_label # missing label key

--- a/processor/metricstransformprocessor/testdata/config_invalid_matchtype.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_matchtype.yaml
@@ -4,7 +4,8 @@ receivers:
 processors:
     metricstransform:
         transforms:
-            - metric_name: # missing metric name
+            - include: metric_name
+              match_type: invalid
               action: update
 
 exporters:

--- a/processor/metricstransformprocessor/testdata/config_invalid_regexp.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_regexp.yaml
@@ -4,8 +4,9 @@ receivers:
 processors:
     metricstransform:
         transforms:
-            - include: old_name
-              action: insert # missing new_name
+            - include: old[\da
+              match_type: regexp
+              action: update
 
 exporters:
     exampleexporter:


### PR DESCRIPTION
**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1088#issuecomment-706916609

**Description:**

Add a simple include filter option with `strict` or `regexp` match type so that transforms can be applied to a range of metrics. When using the `regexp` match type, `new_name` supports expansion.

This implementation is compatible with the config proposed [here](https://github.com/open-telemetry/opentelemetry-collector/issues/1081#issuecomment-707450870) so could be switched out for that implementation in the future if desired. Also retained the `metric_name` config option for backwards compatibility but removed references to this from the documentation.

Continues optimizing for the `strict` match case, i.e. retain `O(n) + O(t)` for `strict` matches where metric names are unique, at the cost of making `regexp` matching slightly slower. `regexp` matches will be `O(n) * O(t)`.

Also resolves an edge case where if multiple metrics have the same name only one of them would previously have been transformed.

**Documentation:**

Updated the documentation to specify how to use the `match_type` filter, and generally cleaned up the README to be more easily digested.