### PR TITLE
Exporter/Datadog: add version tag extract

### DIFF
--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -216,25 +216,27 @@ func spanToDatadogSpan(s pdata.Span,
 	datadogTags map[string]string,
 	cfg *config.Config,
 ) (*pb.Span, error) {
+
+	tags := aggregateSpanTags(s, datadogTags)
+
 	// otel specification resource service.name takes precedence
 	// and configuration DD_ENV as fallback if it exists
 	if serviceName == "" && cfg.Service != "" {
 		serviceName = cfg.Service
 	}
 
-	version := cfg.Version
-	tags := aggregateSpanTags(s, datadogTags)
-
-	// if no version tag exists, set it if provided via config
-	if version != "" {
-		if tagVersion := tags[versionTag]; tagVersion == "" {
-			tags[versionTag] = version
-		}
-	}
-
 	//  canonical resource attribute version should override others if it exists
 	if rsTagVersion := tags[conventions.AttributeServiceVersion]; rsTagVersion != "" {
 		tags[versionTag] = rsTagVersion
+	} else {
+		version := cfg.Version
+
+		// if no version tag exists, set it if provided via config
+		if version != "" {
+			if tagVersion := tags[versionTag]; tagVersion == "" {
+				tags[versionTag] = version
+			}
+		}
 	}
 
 	// get tracestate as just a general tag

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -41,7 +41,6 @@ type codeDetails struct {
 
 const (
 	keySamplingPriority string = "_sampling_priority_v1"
-	rsVersionTag        string = "service.version"
 	versionTag          string = "version"
 	oldILNameTag        string = "otel.instrumentation_library.name"
 	currentILNameTag    string = "otel.library.name"
@@ -234,7 +233,7 @@ func spanToDatadogSpan(s pdata.Span,
 	}
 
 	//  canonical resource attribute version should override others if it exists
-	if rsTagVersion := tags[conventions.AttributeVersionName]; rsTagVersion != "" {
+	if rsTagVersion := tags[conventions.AttributeServiceVersion]; rsTagVersion != "" {
 		tags[versionTag] = rsTagVersion
 	}
 

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -41,6 +41,7 @@ type codeDetails struct {
 
 const (
 	keySamplingPriority string = "_sampling_priority_v1"
+	rsVersionTag        string = "service.version"
 	versionTag          string = "version"
 	oldILNameTag        string = "otel.instrumentation_library.name"
 	currentILNameTag    string = "otel.library.name"
@@ -230,6 +231,11 @@ func spanToDatadogSpan(s pdata.Span,
 		if tagVersion := tags[versionTag]; tagVersion == "" {
 			tags[versionTag] = version
 		}
+	}
+
+	//  canonical resource attribute version should override others if it exists
+	if rsTagVersion := tags[conventions.AttributeVersionName]; rsTagVersion != "" {
+		tags[versionTag] = rsTagVersion
 	}
 
 	// get tracestate as just a general tag

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -289,7 +289,7 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 	// ensure that env gives resource deployment.environment priority
 	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
 
-	assert.Equal(t, 12, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 14, len(datadogPayload.Traces[0].Spans[0].Meta))
 }
 
 // ensure that the datadog span uses the configured unified service tags
@@ -338,7 +338,7 @@ func TestTracesTranslationConfig(t *testing.T) {
 	// ensure that version gives resource service.version priority
 	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
 
-	assert.Equal(t, 13, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 14, len(datadogPayload.Traces[0].Spans[0].Meta))
 }
 
 // ensure that the translation returns early if no resource instrumentation library spans

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -264,7 +264,13 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, true, true)
 
 	// translate mocks to datadog traces
-	datadogPayload, err := resourceSpansToDatadogSpans(rs, hostname, &config.Config{})
+	cfg := config.Config{
+		TagsConfig: config.TagsConfig{
+			Version: "v1",
+		},
+	}
+
+	datadogPayload, err := resourceSpansToDatadogSpans(rs, hostname, &cfg)
 
 	if err != nil {
 		t.Fatalf("Failed to convert from pdata ResourceSpans to pb.TracePayload: %v", err)
@@ -286,7 +292,7 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 	// ensure that env gives resource deployment.environment priority
 	assert.Equal(t, "test-env", datadogPayload.Env)
 
-	// ensure that env gives resource deployment.environment priority
+	// ensure that version gives resource service.version priority
 	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
 
 	assert.Equal(t, 14, len(datadogPayload.Traces[0].Spans[0].Meta))

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -95,6 +95,7 @@ func NewResourceSpansData(mockTraceID [16]byte, mockSpanID [8]byte, mockParentSp
 			"namespace":              pdata.NewAttributeValueString("kube-system"),
 			"service.name":           pdata.NewAttributeValueString("test-resource-service-name"),
 			"deployment.environment": pdata.NewAttributeValueString("test-env"),
+			"service.version":        pdata.NewAttributeValueString("test-version"),
 		}).CopyTo(resource.Attributes())
 
 	} else {
@@ -284,6 +285,10 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 
 	// ensure that env gives resource deployment.environment priority
 	assert.Equal(t, "test-env", datadogPayload.Env)
+
+	// ensure that env gives resource deployment.environment priority
+	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
+
 	assert.Equal(t, 12, len(datadogPayload.Traces[0].Spans[0].Meta))
 }
 
@@ -329,8 +334,11 @@ func TestTracesTranslationConfig(t *testing.T) {
 
 	// ensure that env gives resource deployment.environment priority
 	assert.Equal(t, "test-env", datadogPayload.Env)
+
+	// ensure that version gives resource service.version priority
+	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
+
 	assert.Equal(t, 13, len(datadogPayload.Traces[0].Spans[0].Meta))
-	assert.Equal(t, "v1", datadogPayload.Traces[0].Spans[0].Meta["version"])
 }
 
 // ensure that the translation returns early if no resource instrumentation library spans


### PR DESCRIPTION
**Description:**

This PR Adds logic to datadog trace translation to account for [`service.version` tag defined in semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/a2758014f408f64ff84728918d671ee3fdab2225/specification/resource/semantic_conventions/README.md#service)

**Testing:** Updated Unit Tests

**Documentation:** resource `service.version` is documented throughout OpenTelemetry Community as the appropriate way to add version attributes. We should support this within Datadog.