### PR TITLE
[datadog exporter] Remove option to change the namespace prefix

### DIFF
--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -54,10 +54,6 @@ func (api *APIConfig) GetCensoredKey() string {
 
 // MetricsConfig defines the metrics exporter specific configuration options
 type MetricsConfig struct {
-	// Namespace is the namespace under which the metrics are sent
-	// By default metrics are not namespaced
-	Namespace string `mapstructure:"namespace"`
-
 	// Buckets states whether to report buckets from distribution metrics
 	Buckets bool `mapstructure:"report_buckets"`
 
@@ -137,11 +133,6 @@ func (c *Config) OnceMetadata() *sync.Once {
 
 // Sanitize tries to sanitize a given configuration
 func (c *Config) Sanitize() error {
-	// Add '.' at the end of namespace
-	if c.Metrics.Namespace != "" && !strings.HasSuffix(c.Metrics.Namespace, ".") {
-		c.Metrics.Namespace = c.Metrics.Namespace + "."
-	}
-
 	if c.TagsConfig.Env == "" {
 		c.TagsConfig.Env = "none"
 	}

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -52,12 +52,6 @@ exporters:
     ## Metric exporter specific configuration.
     #
     # metrics:
-      ## @param namespace - string - optional
-      ## The namespace with which to prefix all metrics.
-      ## By default metrics are not namespaced.
-      #
-      # namespace: ""
-
       ## @param report_buckets - boolean - optional - default: false
       ## Whether to report bucket counts for distribution metric types.
       ## Enabling this will increase the number of custom metrics.

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -90,7 +90,6 @@ func TestLoadConfig(t *testing.T) {
 		},
 
 		Metrics: config.MetricsConfig{
-			Namespace: "opentelemetry.",
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: "https://api.datadoghq.eu",
 			},

--- a/exporter/datadogexporter/metrics/utils_test.go
+++ b/exporter/datadogexporter/metrics/utils_test.go
@@ -42,31 +42,13 @@ func TestNewGauge(t *testing.T) {
 	assert.Equal(t, []string{"tag:value"}, metric.Tags)
 }
 
-func TestRunningMetric(t *testing.T) {
+func TestDefaultMetrics(t *testing.T) {
 	logger := zap.NewNop()
 	cfg := &config.Config{}
 
-	ms := RunningMetric("metrics", uint64(2e9), logger, cfg)
+	ms := DefaultMetrics("metrics", uint64(2e9))
+	ProcessMetrics(ms, logger, cfg)
 
-	assert.Equal(t, "otel.datadog_exporter.metrics.running", *ms[0].Metric)
-	// Assert metrics list length (should be 1)
-	assert.Equal(t, 1, len(ms))
-	// Assert timestamp
-	assert.Equal(t, 2.0, *ms[0].Points[0][0])
-	// Assert value (should always be 1.0)
-	assert.Equal(t, 1.0, *ms[0].Points[0][1])
-
-	// Test that the namespace set in config does not get used: the running
-	// metric needs to follow a specific format
-	cfg = &config.Config{
-		Metrics: config.MetricsConfig{
-			Namespace: "test.",
-		},
-	}
-
-	ms = RunningMetric("metrics", uint64(2e9), logger, cfg)
-
-	// Check that the namespace isn't used
 	assert.Equal(t, "otel.datadog_exporter.metrics.running", *ms[0].Metric)
 	// Assert metrics list length (should be 1)
 	assert.Equal(t, 1, len(ms))
@@ -98,7 +80,7 @@ func TestAddHostname(t *testing.T) {
 
 	ms[0].Host = &hostname
 
-	AddHostname(ms, logger, cfg)
+	addHostname(ms, logger, cfg)
 
 	// Check that all hostnames are set to the config's hostname
 	assert.Equal(t, "thishost", *ms[0].Host)
@@ -116,7 +98,7 @@ func TestAddHostname(t *testing.T) {
 
 	ms[0].Host = &hostname
 
-	AddHostname(ms, logger, cfg)
+	addHostname(ms, logger, cfg)
 
 	// Check that the already set host remains set
 	assert.Equal(t, "thathost", *ms[0].Host)
@@ -128,7 +110,7 @@ func TestAddNamespace(t *testing.T) {
 		NewGauge("test.metric2", 0, 2.0, []string{}),
 	}
 
-	AddNamespace(ms, "namespace.")
+	addNamespace(ms, "namespace")
 
 	assert.Equal(t, "namespace.test.metric", *ms[0].Metric)
 	assert.Equal(t, "namespace.test.metric2", *ms[1].Metric)

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -68,7 +68,6 @@ func TestProcessMetrics(t *testing.T) {
 			Tags:     []string{"key:val"},
 		},
 		Metrics: config.MetricsConfig{
-			Namespace: "test.",
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: server.URL,
 			},
@@ -90,10 +89,10 @@ func TestProcessMetrics(t *testing.T) {
 		),
 	}
 
-	exp.processMetrics(ms)
+	metrics.ProcessMetrics(ms, exp.logger, exp.cfg)
 
 	assert.Equal(t, "test-host", *ms[0].Host)
-	assert.Equal(t, "test.metric_name", *ms[0].Metric)
+	assert.Equal(t, "otel.metric_name", *ms[0].Metric)
 	assert.ElementsMatch(t,
 		[]string{"key2:val2"},
 		ms[0].Tags,

--- a/exporter/datadogexporter/testdata/config.yaml
+++ b/exporter/datadogexporter/testdata/config.yaml
@@ -18,9 +18,6 @@ exporters:
       key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       site: datadoghq.eu
 
-    metrics:
-      namespace: opentelemetry
-
     traces:
       sample_rate: 1
 

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -119,8 +119,10 @@ func (exp *traceExporter) pushTraceData(
 		})
 	}
 
-	ms := metrics.RunningMetric("traces", uint64(pushTime), exp.logger, exp.cfg)
-	exp.client.PostMetrics(ms)
+	ms := metrics.DefaultMetrics("traces", uint64(pushTime))
+
+	metrics.ProcessMetrics(ms, exp.logger, exp.cfg)
+	_ = exp.client.PostMetrics(ms)
 
 	return len(aggregatedTraces), nil
 }


### PR DESCRIPTION
**Description:**
Removes the config option "namespace" and hardcodes "otel" instead, which
is what the Datadog backend expects.

Additionally, stops treating the 'running' metric as a special case that
didn't use the configured namespace and makes it be processed like a
regular metric.

**Testing:** 

Updated tests.
