### PR TITLE
[datadog exporter] Move ProcessMetrics test to metrics package

### DIFF
--- a/exporter/datadogexporter/metrics/utils_test.go
+++ b/exporter/datadogexporter/metrics/utils_test.go
@@ -63,6 +63,9 @@ func TestDefaultMetrics(t *testing.T) {
 func TestProcessMetrics(t *testing.T) {
 	logger := zap.NewNop()
 
+	// Reset hostname cache
+	cache.Cache.Flush()
+
 	server := testutils.DatadogServerMock()
 	defer server.Close()
 

--- a/exporter/datadogexporter/metrics/utils_test.go
+++ b/exporter/datadogexporter/metrics/utils_test.go
@@ -18,12 +18,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/collector/config/confignet"
 	"go.uber.org/zap"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/testutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/utils/cache"
 )
 
@@ -66,23 +64,12 @@ func TestProcessMetrics(t *testing.T) {
 	// Reset hostname cache
 	cache.Cache.Flush()
 
-	server := testutils.DatadogServerMock()
-	defer server.Close()
-
 	cfg := &config.Config{
-		API: config.APIConfig{
-			Key: "ddog_32_characters_long_api_key1",
-		},
 		// Global tags should be ignored and sent as metadata
 		TagsConfig: config.TagsConfig{
 			Hostname: "test-host",
 			Env:      "test_env",
 			Tags:     []string{"key:val"},
-		},
-		Metrics: config.MetricsConfig{
-			TCPAddr: confignet.TCPAddr{
-				Endpoint: server.URL,
-			},
 		},
 	}
 	cfg.Sanitize()


### PR DESCRIPTION
**Description:**
After moving `ProcessMetrics` it makes sense to also move its test, as suggested in the comments of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1483

It also simplifies the test a bit since `ProcessMetrics` no longer needs a valid `metricsExporter` object, and adds a call to clear the cache, required since this test reads the hostname.

**Testing:**  Tests pass.