### PR TITLE
Fix the race condition issue for xray receiver

### DIFF
--- a/receiver/awsxrayreceiver/internal/udppoller/poller.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller.go
@@ -187,7 +187,6 @@ func (p *poller) poll() {
 				continue
 			}
 
-			buffer := make([]byte, pollerBufferSizeKB)
 			bufMessage := buffer[0:rlen]
 
 			header, body, err := tracesegment.SplitHeaderBody(bufMessage)

--- a/receiver/awsxrayreceiver/internal/udppoller/poller.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller.go
@@ -156,7 +156,6 @@ func (p *poller) read(buf *[]byte) (int, error) {
 
 func (p *poller) poll() {
 	defer p.wg.Done()
-	buffer := make([]byte, pollerBufferSizeKB)
 
 	var (
 		errRecv   *recvErr.ErrRecoverable
@@ -173,6 +172,7 @@ func (p *poller) poll() {
 				p.receiverInstanceName,
 				Transport,
 				obsreport.WithLongLivedCtx())
+			buffer := make([]byte, pollerBufferSizeKB)
 			bufPointer := &buffer
 			rlen, err := p.read(bufPointer)
 			if errors.As(err, &errIrrecv) {

--- a/receiver/awsxrayreceiver/internal/udppoller/poller.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller.go
@@ -156,7 +156,6 @@ func (p *poller) read(buf *[]byte) (int, error) {
 
 func (p *poller) poll() {
 	defer p.wg.Done()
-	buffer := make([]byte, pollerBufferSizeKB)
 
 	var (
 		errRecv   *recvErr.ErrRecoverable
@@ -187,6 +186,7 @@ func (p *poller) poll() {
 				continue
 			}
 
+			buffer := make([]byte, pollerBufferSizeKB)
 			bufMessage := buffer[0:rlen]
 
 			header, body, err := tracesegment.SplitHeaderBody(bufMessage)


### PR DESCRIPTION
**Description:** 
Aws xrayreceiver throws fatal errors when the input data load is intensive.  Solving the race condition issue.

**Link to tracking Issue:** 
https://github.com/aws-observability/aws-otel-collector/issues/92

**Testing:** 
Did the local test when the input data load to the receiver is intensive (1000 segments/s in my test), the receiver works well.