### PR TITLE
[awsemfexporter] Add check for unhandled metric data types

### DIFF
--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -15,6 +15,7 @@
 package awsemfexporter
 
 import (
+	"go.uber.org/zap"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
@@ -53,4 +54,7 @@ type Config struct {
 	// "SingleDimensionRollupOnly" - Enable single dimension rollup
 	// "NoDimensionRollup" - No dimension rollup (only keep original metrics which contain all dimensions)
 	DimensionRollupOption string `mapstructure:"dimension_rollup_option"`
+
+	// logger is the Logger used for writing error/warning logs
+	logger *zap.Logger
 }

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -15,8 +15,8 @@
 package awsemfexporter
 
 import (
-	"go.uber.org/zap"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.uber.org/zap"
 )
 
 // Config defines configuration for AWS EMF exporter.

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -53,8 +53,11 @@ func New(
 	}
 
 	logger := params.Logger
+	expConfig := config.(*Config)
+	expConfig.logger = logger
+
 	// create AWS session
-	awsConfig, session, err := GetAWSConfigSession(logger, &Conn{}, config.(*Config))
+	awsConfig, session, err := GetAWSConfigSession(logger, &Conn{}, expConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -77,11 +77,10 @@ func New(
 
 func (emf *emfExporter) pushMetricsData(_ context.Context, md pdata.Metrics) (droppedTimeSeries int, err error) {
 	expConfig := emf.config.(*Config)
-	dimensionRollupOption := expConfig.DimensionRollupOption
 	logGroup := "/metrics/default"
 	logStream := fmt.Sprintf("otel-stream-%s", emf.collectorID)
 	// override log group if customer has specified Resource Attributes service.name or service.namespace
-	putLogEvents, totalDroppedMetrics, namespace := generateLogEventFromMetric(md, dimensionRollupOption, expConfig.Namespace)
+	putLogEvents, totalDroppedMetrics, namespace := generateLogEventFromMetric(md, expConfig)
 	if namespace != "" {
 		logGroup = fmt.Sprintf("/metrics/%s", namespace)
 	}
@@ -169,7 +168,8 @@ func (emf *emfExporter) Start(ctx context.Context, host component.Host) error {
 	return nil
 }
 
-func generateLogEventFromMetric(metric pdata.Metrics, dimensionRollupOption string, namespace string) ([]*LogEvent, int, string) {
+func generateLogEventFromMetric(metric pdata.Metrics, config *Config) ([]*LogEvent, int, string) {
+	namespace := config.Namespace
 	rms := metric.ResourceMetrics()
 	cwMetricLists := []*CWMetrics{}
 	var cwm []*CWMetrics
@@ -180,7 +180,7 @@ func generateLogEventFromMetric(metric pdata.Metrics, dimensionRollupOption stri
 		if rm.IsNil() {
 			continue
 		}
-		cwm, totalDroppedMetrics = TranslateOtToCWMetric(&rm, dimensionRollupOption, namespace)
+		cwm, totalDroppedMetrics = TranslateOtToCWMetric(&rm, config)
 		if len(cwm) > 0 && len(cwm[0].Measurements) > 0 {
 			namespace = cwm[0].Measurements[0].Namespace
 		}

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -229,9 +229,11 @@ func TestNewExporterWithoutConfig(t *testing.T) {
 	defer popEnv(env)
 	os.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 
+	assert.Nil(t, expCfg.logger)
 	exp, err := New(expCfg, component.ExporterCreateParams{Logger: zap.NewNop()})
 	assert.NotNil(t, err)
 	assert.Nil(t, exp)
+	assert.NotNil(t, expCfg.logger)
 }
 
 func TestNewExporterWithoutSession(t *testing.T) {

--- a/exporter/awsemfexporter/factory.go
+++ b/exporter/awsemfexporter/factory.go
@@ -53,6 +53,7 @@ func createDefaultConfig() configmodels.Exporter {
 		Region:                "",
 		RoleARN:               "",
 		DimensionRollupOption: "ZeroAndSingleDimensionRollup",
+		logger:                nil,
 	}
 }
 

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -118,9 +118,10 @@ func (dps DoubleHistogramDataPointSlice) At(i int) DataPoint {
 }
 
 // TranslateOtToCWMetric converts OT metrics to CloudWatch Metric format
-func TranslateOtToCWMetric(rm *pdata.ResourceMetrics, dimensionRollupOption string, namespace string) ([]*CWMetrics, int) {
+func TranslateOtToCWMetric(rm *pdata.ResourceMetrics, config *Config) ([]*CWMetrics, int) {
 	var cwMetricList []*CWMetrics
 	totalDroppedMetrics := 0
+	namespace := config.Namespace
 	var instrumentationLibName string
 
 	if len(namespace) == 0 && !rm.Resource().IsNil() {
@@ -158,7 +159,7 @@ func TranslateOtToCWMetric(rm *pdata.ResourceMetrics, dimensionRollupOption stri
 				totalDroppedMetrics++
 				continue
 			}
-			cwMetrics := getCWMetrics(&metric, namespace, instrumentationLibName, dimensionRollupOption)
+			cwMetrics := getCWMetrics(&metric, namespace, instrumentationLibName, config)
 			cwMetricList = append(cwMetricList, cwMetrics...)
 		}
 	}
@@ -192,7 +193,7 @@ func TranslateCWMetricToEMF(cwMetricLists []*CWMetrics) []*LogEvent {
 }
 
 // Translates OTLP Metric to list of CW Metrics
-func getCWMetrics(metric *pdata.Metric, namespace string, instrumentationLibName string, dimensionRollupOption string) []*CWMetrics {
+func getCWMetrics(metric *pdata.Metric, namespace string, instrumentationLibName string, config *Config) []*CWMetrics {
 	var result []*CWMetrics
 	var dps DataPoints
 
@@ -225,7 +226,7 @@ func getCWMetrics(metric *pdata.Metric, namespace string, instrumentationLibName
 		if dp.IsNil() {
 			continue
 		}
-		cwMetric := buildCWMetric(dp, metric, namespace, metricSlice, instrumentationLibName, dimensionRollupOption)
+		cwMetric := buildCWMetric(dp, metric, namespace, metricSlice, instrumentationLibName, config.DimensionRollupOption)
 		if cwMetric != nil {
 			result = append(result, cwMetric)
 		}

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -31,6 +31,9 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 	"go.opentelemetry.io/collector/translator/internaldata"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // Asserts whether dimension sets are equal (i.e. has same sets of dimensions)
@@ -781,6 +784,42 @@ func TestGetCWMetrics(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Unhandled metric type", func (t *testing.T) {
+		metric := pdata.NewMetric()
+		metric.InitEmpty()
+		metric.SetName("foo")
+		metric.SetUnit("Count")
+		metric.SetDataType(pdata.MetricDataTypeIntHistogram)
+
+		obs, logs := observer.New(zap.WarnLevel)
+		config := &Config{
+			DimensionRollupOption: "",
+			logger: zap.New(obs),
+		}
+
+		cwMetrics := getCWMetrics(&metric, namespace, instrumentationLibName, config)
+		assert.Nil(t, cwMetrics)
+
+		// Test output warning logs
+		expectedLogs := []observer.LoggedEntry{
+			{
+				Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Unhandled metric data type."},
+				Context: []zapcore.Field{
+					zap.String("DataType", "IntHistogram"),
+					zap.String("Name", "foo"),
+					zap.String("Unit", "Count"),
+				},
+			},
+		}
+		assert.Equal(t, 1, logs.Len())
+		assert.Equal(t, expectedLogs, logs.AllUntimed())
+	})
+
+	t.Run("Nil metric", func (t *testing.T) {
+		cwMetrics := getCWMetrics(nil, namespace, instrumentationLibName, config)
+		assert.Nil(t, cwMetrics)
+	})
 }
 
 func TestBuildCWMetric(t *testing.T) {

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -53,14 +53,17 @@ func assertDimsEqual(t *testing.T, expected, actual [][]string) {
 }
 
 func TestTranslateOtToCWMetricWithInstrLibrary(t *testing.T) {
-
+	config := &Config{
+		Namespace:             "",
+		DimensionRollupOption: ZeroAndSingleDimensionRollup,
+	}
 	md := createMetricTestData()
 	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
 	ilms := rm.InstrumentationLibraryMetrics()
 	ilm := ilms.At(0)
 	ilm.InstrumentationLibrary().InitEmpty()
 	ilm.InstrumentationLibrary().SetName("cloudwatch-lib")
-	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, config)
 	assert.Equal(t, 1, totalDroppedMetrics)
 	assert.NotNil(t, cwm)
 	assert.Equal(t, 5, len(cwm))
@@ -91,10 +94,13 @@ func TestTranslateOtToCWMetricWithInstrLibrary(t *testing.T) {
 }
 
 func TestTranslateOtToCWMetricWithoutInstrLibrary(t *testing.T) {
-
+	config := &Config{
+		Namespace:             "",
+		DimensionRollupOption: ZeroAndSingleDimensionRollup,
+	}
 	md := createMetricTestData()
 	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, config)
 	assert.Equal(t, 1, totalDroppedMetrics)
 	assert.NotNil(t, cwm)
 	assert.Equal(t, 5, len(cwm))
@@ -127,6 +133,10 @@ func TestTranslateOtToCWMetricWithoutInstrLibrary(t *testing.T) {
 }
 
 func TestTranslateOtToCWMetricWithNameSpace(t *testing.T) {
+	config := &Config{
+		Namespace:             "",
+		DimensionRollupOption: ZeroAndSingleDimensionRollup,
+	}
 	md := consumerdata.MetricsData{
 		Node: &commonpb.Node{
 			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
@@ -139,7 +149,7 @@ func TestTranslateOtToCWMetricWithNameSpace(t *testing.T) {
 		Metrics: []*metricspb.Metric{},
 	}
 	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+	cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, config)
 	assert.Equal(t, 0, totalDroppedMetrics)
 	assert.Nil(t, cwm)
 	assert.Equal(t, 0, len(cwm))
@@ -231,7 +241,7 @@ func TestTranslateOtToCWMetricWithNameSpace(t *testing.T) {
 		},
 	}
 	rm = internaldata.OCToMetrics(md).ResourceMetrics().At(0)
-	cwm, totalDroppedMetrics = TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+	cwm, totalDroppedMetrics = TranslateOtToCWMetric(&rm, config)
 	assert.Equal(t, 0, totalDroppedMetrics)
 	assert.NotNil(t, cwm)
 	assert.Equal(t, 1, len(cwm))
@@ -269,6 +279,9 @@ func TestGetCWMetrics(t *testing.T) {
 	namespace := "Namespace"
 	OTelLib := "OTelLib"
 	instrumentationLibName := "InstrLibName"
+	config := &Config{
+		DimensionRollupOption: "",
+	}
 
 	testCases := []struct {
 		testName string
@@ -756,7 +769,7 @@ func TestGetCWMetrics(t *testing.T) {
 			assert.Equal(t, 1, metrics.Len())
 			metric := metrics.At(0)
 
-			cwMetrics := getCWMetrics(&metric, namespace, instrumentationLibName, "")
+			cwMetrics := getCWMetrics(&metric, namespace, instrumentationLibName, config)
 			assert.Equal(t, len(tc.expected), len(cwMetrics))
 
 			for i, expected := range tc.expected {
@@ -1400,20 +1413,28 @@ func BenchmarkTranslateOtToCWMetricWithInstrLibrary(b *testing.B) {
 	ilm := ilms.At(0)
 	ilm.InstrumentationLibrary().InitEmpty()
 	ilm.InstrumentationLibrary().SetName("cloudwatch-lib")
+	config := &Config{
+		Namespace:             "",
+		DimensionRollupOption: ZeroAndSingleDimensionRollup,
+	}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+		TranslateOtToCWMetric(&rm, config)
 	}
 }
 
 func BenchmarkTranslateOtToCWMetricWithoutInstrLibrary(b *testing.B) {
 	md := createMetricTestData()
 	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
+	config := &Config{
+		Namespace:             "",
+		DimensionRollupOption: ZeroAndSingleDimensionRollup,
+	}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+		TranslateOtToCWMetric(&rm, config)
 	}
 }
 
@@ -1430,10 +1451,14 @@ func BenchmarkTranslateOtToCWMetricWithNamespace(b *testing.B) {
 		Metrics: []*metricspb.Metric{},
 	}
 	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
+	config := &Config{
+		Namespace:             "",
+		DimensionRollupOption: ZeroAndSingleDimensionRollup,
+	}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		TranslateOtToCWMetric(&rm, ZeroAndSingleDimensionRollup, "")
+		TranslateOtToCWMetric(&rm, config)
 	}
 }
 

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -785,7 +785,7 @@ func TestGetCWMetrics(t *testing.T) {
 		})
 	}
 
-	t.Run("Unhandled metric type", func (t *testing.T) {
+	t.Run("Unhandled metric type", func(t *testing.T) {
 		metric := pdata.NewMetric()
 		metric.InitEmpty()
 		metric.SetName("foo")
@@ -793,18 +793,18 @@ func TestGetCWMetrics(t *testing.T) {
 		metric.SetDataType(pdata.MetricDataTypeIntHistogram)
 
 		obs, logs := observer.New(zap.WarnLevel)
-		config := &Config{
+		obsConfig := &Config{
 			DimensionRollupOption: "",
-			logger: zap.New(obs),
+			logger:                zap.New(obs),
 		}
 
-		cwMetrics := getCWMetrics(&metric, namespace, instrumentationLibName, config)
+		cwMetrics := getCWMetrics(&metric, namespace, instrumentationLibName, obsConfig)
 		assert.Nil(t, cwMetrics)
 
 		// Test output warning logs
 		expectedLogs := []observer.LoggedEntry{
 			{
-				Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Unhandled metric data type."},
+				Entry: zapcore.Entry{Level: zap.WarnLevel, Message: "Unhandled metric data type."},
 				Context: []zapcore.Field{
 					zap.String("DataType", "IntHistogram"),
 					zap.String("Name", "foo"),
@@ -816,7 +816,7 @@ func TestGetCWMetrics(t *testing.T) {
 		assert.Equal(t, expectedLogs, logs.AllUntimed())
 	})
 
-	t.Run("Nil metric", func (t *testing.T) {
+	t.Run("Nil metric", func(t *testing.T) {
 		cwMetrics := getCWMetrics(nil, namespace, instrumentationLibName, config)
 		assert.Nil(t, cwMetrics)
 	})


### PR DESCRIPTION
**Description:**
There is an edge case where the incoming metric might not fit one of the following `pdata` data types:
1. `MetricDataTypeIntGauge`
2. `MetricDataTypeDoubleGauge`
3. `MetricDataTypeIntSum`
4. `MetricDataTypeDoubleSum`
5. `MetricDataTypeDoubleHistogram`

In that case, there will be a nil pointer reference error. To fix this bug, this PR checks for any unhandled metric data types and logs out a warning message instead of panicking. With this change, we will now get the following warning messages for unhandled data types:
```
2020-11-04T20:48:41.812Z        WARN    awsemfexporter@v0.13.1-0.20201102154212-c742efac0db4/metric_translator.go:224  Unhandled metric data type.      {"component_kind": "exporter", "component_type": "awsemf", "component_name": "awsemf", "DataType": "None", "Name": "latency", "Unit": "ms"}
2020-11-04T20:48:42.812Z        WARN    awsemfexporter@v0.13.1-0.20201102154212-c742efac0db4/metric_translator.go:224  Unhandled metric data type.      {"component_kind": "exporter", "component_type": "awsemf", "component_name": "awsemf", "DataType": "None", "Name": "processedSpans", "Unit": "1"}
```

Additionally, a `logger` was added to the `Config` struct as a private field for access by functions to log out warning messages.

**Testing:**
Unit tests were added and ran successfully.