### PR TITLE
Skip processing empty metrics slice in Stackdriver exporter

### DIFF
--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -242,6 +242,10 @@ func (me *metricsExporter) pushMetrics(ctx context.Context, m pdata.Metrics) (in
 
 	mds := internaldata.MetricsToOC(m)
 	for _, md := range mds {
+		if len(md.Metrics) == 0 {
+			continue
+		}
+
 		points := numPoints(md)
 		dropped, err := me.mexporter.PushMetricsProto(ctx, md.Node, md.Resource, md.Metrics)
 		recordPointCount(ctx, points-dropped, dropped, err)


### PR DESCRIPTION
**Description:**
Fixing a minor bug - skip empty metrics slice instead of returning an error.

The OpenCensus exporter code currently returns an error when it encounters empty metrics slice: https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/blob/59d068f8d8ff5b653916aa30cdc4e13c7f15d56e/metrics_proto.go#L53-L55

The easiest way to mitigate this issue is by adding a check to skip processing of empty slice.