### PR TITLE
[awsemfexporter] Implement metric filtering and dimension setting

### DIFF
--- a/exporter/awsemfexporter/README.md
+++ b/exporter/awsemfexporter/README.md
@@ -25,7 +25,15 @@ The following exporter configuration parameters are supported.
 | `max_retries`     | Maximum number of retries before abandoning an attempt to post data.   |    1    |
 | `dimension_rollup_option`| DimensionRollupOption is the option for metrics dimension rollup. Three options are available. |"ZeroAndSingleDimensionRollup" (Enable both zero dimension rollup and single dimension rollup)| 
 | `resource_to_telemetry_conversion` | "resource_to_telemetry_conversion" is the option for converting resource attributes to telemetry attributes. It has only one config onption- `enabled`. For metrics, if `enabled=true`, all the resource attributes will be converted to metric labels by default. See `Resource Attributes to Metric Labels` section below for examples. | `enabled=false` | 
- 
+| [`metric_declarations`](#metric_declaration) | List of rules for filtering exported metrics and their dimensions. |    [ ]   |
+
+### <metric_declaration>
+A metric_declaration section characterizes a rule to be used to set dimensions for exported metrics, filtered by the incoming metrics' metric names.
+| Name              | Description                                                            | Default |
+| :---------------- | :--------------------------------------------------------------------- | ------- |
+| `dimensions`      | List of dimension sets to be exported.                                 |  [[ ]]   |
+| `metric_name_selectors` | List of regex strings to filter metric names by.                 |   [ ]    |
+
 
 ## AWS Credential Configuration
 

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -55,6 +55,8 @@ type Config struct {
 	// "SingleDimensionRollupOnly" - Enable single dimension rollup
 	// "NoDimensionRollup" - No dimension rollup (only keep original metrics which contain all dimensions)
 	DimensionRollupOption string `mapstructure:"dimension_rollup_option"`
+	// MetricDeclarations is a list of rules to be used to set dimensions for exported metrics.
+	MetricDeclarations []*MetricDeclaration `mapstructure:"metric_declarations"`
 
 	// ResourceToTelemetrySettings is the option for converting resource attrihutes to telemetry attributes.
 	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -58,6 +58,7 @@ func TestLoadConfig(t *testing.T) {
 			Region:                "us-west-2",
 			RoleARN:               "arn:aws:iam::123456789:role/monitoring-EKS-NodeInstanceRole",
 			DimensionRollupOption: "ZeroAndSingleDimensionRollup",
+			MetricDeclarations:    []*MetricDeclaration{},
 		})
 
 	r2 := cfg.Exporters["awsemf/resource_attr_to_label"].(*Config)

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -76,5 +76,6 @@ func TestLoadConfig(t *testing.T) {
 			RoleARN:                     "",
 			DimensionRollupOption:       "ZeroAndSingleDimensionRollup",
 			ResourceToTelemetrySettings: exporterhelper.ResourceToTelemetrySettings{Enabled: true},
+			MetricDeclarations:          []*MetricDeclaration{},
 		})
 }

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -67,6 +67,19 @@ func New(
 	svcStructuredLog := NewCloudWatchLogsClient(logger, awsConfig, session)
 	collectorIdentifier, _ := uuid.NewRandom()
 
+	// Initialize metric declarations and filter out invalid ones
+	emfConfig := config.(*Config)
+	validDeclarations := make([]*MetricDeclaration, 0, len(emfConfig.MetricDeclarations))
+	for _, declaration := range emfConfig.MetricDeclarations {
+		err := declaration.Init(logger)
+		if err != nil {
+			logger.Warn("Dropped metric declaration. Error: " + err.Error())
+		} else {
+			validDeclarations = append(validDeclarations, declaration)
+		}
+	}
+	emfConfig.MetricDeclarations = validDeclarations
+
 	emfExporter := &emfExporter{
 		svcStructuredLog: svcStructuredLog,
 		config:           config,
@@ -212,7 +225,7 @@ func generateLogEventFromMetric(metric pdata.Metrics, config *Config) ([]*LogEve
 		cwMetricLists = append(cwMetricLists, cwm...)
 	}
 
-	return TranslateCWMetricToEMF(cwMetricLists), totalDroppedMetrics, namespace
+	return TranslateCWMetricToEMF(cwMetricLists, config.logger), totalDroppedMetrics, namespace
 }
 
 func wrapErrorIfBadRequest(err *error) error {

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -73,7 +73,7 @@ func New(
 	for _, declaration := range emfConfig.MetricDeclarations {
 		err := declaration.Init(logger)
 		if err != nil {
-			logger.Warn("Dropped metric declaration. Error: " + err.Error())
+			logger.Warn("Dropped metric declaration. Error: " + err.Error() + ".")
 		} else {
 			validDeclarations = append(validDeclarations, declaration)
 		}

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -69,7 +69,7 @@ func New(
 
 	// Initialize metric declarations and filter out invalid ones
 	emfConfig := config.(*Config)
-	validDeclarations := make([]*MetricDeclaration, 0, len(emfConfig.MetricDeclarations))
+	var validDeclarations []*MetricDeclaration
 	for _, declaration := range emfConfig.MetricDeclarations {
 		err := declaration.Init(logger)
 		if err != nil {

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -281,7 +281,7 @@ func TestNewExporterWithMetricDeclarations(t *testing.T) {
 	// Test output warning logs
 	expectedLogs := []observer.LoggedEntry{
 		{
-			Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Dropped metric declaration. Error: Invalid metric declaration: no metric name selectors defined."},
+			Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Dropped metric declaration. Error: invalid metric declaration: no metric name selectors defined."},
 			Context: []zapcore.Field{},
 		},
 		{

--- a/exporter/awsemfexporter/factory.go
+++ b/exporter/awsemfexporter/factory.go
@@ -53,6 +53,7 @@ func createDefaultConfig() configmodels.Exporter {
 		Region:                "",
 		RoleARN:               "",
 		DimensionRollupOption: "ZeroAndSingleDimensionRollup",
+		MetricDeclarations:    make([]*MetricDeclaration, 0),
 		logger:                nil,
 	}
 }

--- a/exporter/awsemfexporter/metric_declaration.go
+++ b/exporter/awsemfexporter/metric_declaration.go
@@ -1,0 +1,111 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsemfexporter
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+// MetricDeclaration characterizes a rule to be used to set dimensions for certain
+// incoming metrics, filtered by their metric names.
+type MetricDeclaration struct {
+	// Dimensions is a list of dimension sets (which are lists of dimension names) to be
+	// included in exported metrics. If the metric does not contain any of the specified
+	// dimensions, the metric would be dropped (will only show up in logs).
+	Dimensions [][]string `mapstructure:"dimensions"`
+	// MetricNameSelectors is a list of regex strings to be matched against metric names
+	// to determine which metrics should be included with this metric declaration rule.
+	MetricNameSelectors []string `mapstructure:"metric_name_selectors"`
+
+	// metricRegexList is a list of compiled regexes for metric name selectors.
+	metricRegexList []*regexp.Regexp
+}
+
+// Init initializes the MetricDeclaration struct. Performs validation and compiles
+// regex strings.
+func (m *MetricDeclaration) Init(logger *zap.Logger) (err error) {
+	// Return error if no metric name selectors are defined
+	if len(m.MetricNameSelectors) == 0 {
+		return errors.New("Invalid metric declaration: no metric name selectors defined.")
+	}
+
+	// Filter out dimension sets with more than 10 elements
+	validDims := make([][]string, 0, len(m.Dimensions))
+	for _, dimSet := range m.Dimensions {
+		if len(dimSet) <= 10 {
+			validDims = append(validDims, dimSet)
+		} else {
+			logger.Warn("Dropped dimension set: > 10 dimensions specified.", zap.String("dimensions", strings.Join(dimSet, ",")))
+		}
+	}
+	m.Dimensions = validDims
+
+	m.metricRegexList = make([]*regexp.Regexp, len(m.MetricNameSelectors))
+	for i, selector := range m.MetricNameSelectors {
+		m.metricRegexList[i] = regexp.MustCompile(selector)
+	}
+	return
+}
+
+// Matches returns true if the given OTLP Metric's name matches any of the Metric
+// Declaration's metric name selectors.
+func (m *MetricDeclaration) Matches(metric *pdata.Metric) bool {
+	for _, regex := range m.metricRegexList {
+		if regex.MatchString(metric.Name()) {
+			return true
+		}
+	}
+	return false
+}
+
+// ExtractDimensions extracts dimensions within the MetricDeclaration that only
+// contains labels found in `labels`.
+func (m *MetricDeclaration) ExtractDimensions(labels map[string]string) (dimensions [][]string) {
+	for _, dimensionSet := range m.Dimensions {
+		if len(dimensionSet) == 0 {
+			continue
+		}
+		includeSet := true
+		for _, dim := range dimensionSet {
+			if _, ok := labels[dim]; !ok {
+				includeSet = false
+				break
+			}
+		}
+		if includeSet {
+			dimensions = append(dimensions, dimensionSet)
+		}
+	}
+	return
+}
+
+// processMetricDeclarations processes a list of MetricDeclarations and returns a
+// list of dimensions that matches the given `metric`.
+func processMetricDeclarations(metricDeclarations []*MetricDeclaration, metric *pdata.Metric, labels map[string]string) (dimensionsList [][][]string) {
+	for _, m := range metricDeclarations {
+		if m.Matches(metric) {
+			dimensions := m.ExtractDimensions(labels)
+			if len(dimensions) > 0 {
+				dimensionsList = append(dimensionsList, dimensions)
+			}
+		}
+	}
+	return
+}

--- a/exporter/awsemfexporter/metric_declaration.go
+++ b/exporter/awsemfexporter/metric_declaration.go
@@ -52,7 +52,7 @@ func dedupDimensionSet(dimensions []string) (deduped []string, hasDuplicate bool
 	}
 	deduped = make([]string, len(seen))
 	idx := 0
-	for dim, _ := range seen {
+	for dim := range seen {
 		deduped[idx] = dim
 		idx++
 	}
@@ -64,7 +64,7 @@ func dedupDimensionSet(dimensions []string) (deduped []string, hasDuplicate bool
 func (m *MetricDeclaration) Init(logger *zap.Logger) (err error) {
 	// Return error if no metric name selectors are defined
 	if len(m.MetricNameSelectors) == 0 {
-		return errors.New("Invalid metric declaration: no metric name selectors defined.")
+		return errors.New("invalid metric declaration: no metric name selectors defined")
 	}
 
 	// Filter out duplicate dimension sets and those with more than 10 elements
@@ -78,22 +78,22 @@ func (m *MetricDeclaration) Init(logger *zap.Logger) (err error) {
 		}
 
 		// Dedup dimensions within dimension set
-		dimSet, hasDuplicate := dedupDimensionSet(dimSet)
+		dedupedDims, hasDuplicate := dedupDimensionSet(dimSet)
 		if hasDuplicate {
 			logger.Warn("Removed duplicates from dimension set.", zap.String("dimensions", concatenatedDims))
 		}
 
 		// Sort dimensions
-		sort.Strings(dimSet)
+		sort.Strings(dedupedDims)
 
 		// Dedup dimension sets
-		key := strings.Join(dimSet, ",")
+		key := strings.Join(dedupedDims, ",")
 		if _, ok := seen[key]; ok {
 			logger.Warn("Dropped dimension set: duplicated dimension set.", zap.String("dimensions", concatenatedDims))
 			continue
 		}
 		seen[key] = true
-		validDims = append(validDims, dimSet)
+		validDims = append(validDims, dedupedDims)
 	}
 	m.Dimensions = validDims
 

--- a/exporter/awsemfexporter/metric_declaration_test.go
+++ b/exporter/awsemfexporter/metric_declaration_test.go
@@ -1,0 +1,288 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsemfexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestInit(t *testing.T) {
+	m := &MetricDeclaration{
+		MetricNameSelectors: []string{"a", "b", "aa"},
+	}
+	logger := zap.NewNop()
+	err := m.Init(logger)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(m.metricRegexList))
+
+	m = &MetricDeclaration{
+		Dimensions: [][]string{
+			{"foo"},
+			{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+		},
+		MetricNameSelectors: []string{"a.*", "b$", "aa+"},
+	}
+	err = m.Init(logger)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(m.metricRegexList))
+	assert.Equal(t, 2, len(m.Dimensions))
+
+	// Test removal of dimension sets with more than 10 elements
+	m = &MetricDeclaration{
+		Dimensions: [][]string{
+			{"foo"},
+			{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"},
+		},
+		MetricNameSelectors: []string{"a.*", "b$", "aa+"},
+	}
+	obs, logs := observer.New(zap.WarnLevel)
+	logger = zap.New(obs)
+	err = m.Init(logger)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(m.metricRegexList))
+	assert.Equal(t, 1, len(m.Dimensions))
+	// Check logged warning message
+	expectedLogs := []observer.LoggedEntry{{
+		Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Dropped dimension set: > 10 dimensions specified."},
+		Context: []zapcore.Field{zap.String("dimensions", "a,b,c,d,e,f,g,h,i,j,k")},
+	}}
+	assert.Equal(t, 1, logs.Len())
+	assert.Equal(t, expectedLogs, logs.AllUntimed())
+
+	// Test invalid metric declaration
+	m = &MetricDeclaration{}
+	err = m.Init(logger)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "Invalid metric declaration: no metric name selectors defined.")
+}
+
+func TestMatches(t *testing.T) {
+	m := &MetricDeclaration{
+		MetricNameSelectors: []string{"^a+$", "^b.*$", "^ac+a$"},
+	}
+	logger := zap.NewNop()
+	err := m.Init(logger)
+	assert.Nil(t, err)
+
+	metric := pdata.NewMetric()
+	metric.InitEmpty()
+	metric.SetName("a")
+	assert.True(t, m.Matches(&metric))
+
+	metric.SetName("aa")
+	assert.True(t, m.Matches(&metric))
+
+	metric.SetName("aaaa")
+	assert.True(t, m.Matches(&metric))
+
+	metric.SetName("aaab")
+	assert.False(t, m.Matches(&metric))
+
+	metric.SetName("b")
+	assert.True(t, m.Matches(&metric))
+
+	metric.SetName("ba")
+	assert.True(t, m.Matches(&metric))
+
+	metric.SetName("c")
+	assert.False(t, m.Matches(&metric))
+
+	metric.SetName("aca")
+	assert.True(t, m.Matches(&metric))
+
+	metric.SetName("accca")
+	assert.True(t, m.Matches(&metric))
+}
+
+func TestExtractDimensions(t *testing.T) {
+	testCases := []struct {
+		testName            string
+		dimensions          [][]string
+		labels              map[string]string
+		extractedDimensions [][]string
+	}{
+		{
+			"matches single dimension set exactly",
+			[][]string{{"a", "b"}},
+			map[string]string{
+				"a": "foo",
+				"b": "bar",
+			},
+			[][]string{{"a", "b"}},
+		},
+		{
+			"matches subset of single dimension set",
+			[][]string{{"a"}},
+			map[string]string{
+				"a": "foo",
+				"b": "bar",
+			},
+			[][]string{{"a"}},
+		},
+		{
+			"does not match single dimension set",
+			[][]string{{"a", "b"}},
+			map[string]string{
+				"b": "bar",
+			},
+			nil,
+		},
+		{
+			"matches multiple dimension sets",
+			[][]string{{"a", "b"}, {"a"}},
+			map[string]string{
+				"a": "foo",
+				"b": "bar",
+			},
+			[][]string{{"a", "b"}, {"a"}},
+		},
+		{
+			"matches one of multiple dimension sets",
+			[][]string{{"a", "b"}, {"a"}},
+			map[string]string{
+				"a": "foo",
+			},
+			[][]string{{"a"}},
+		},
+		{
+			"no dimensions",
+			[][]string{},
+			map[string]string{
+				"a": "foo",
+			},
+			nil,
+		},
+		{
+			"empty dimension set",
+			[][]string{{}},
+			map[string]string{
+				"a": "foo",
+			},
+			nil,
+		},
+	}
+	logger := zap.NewNop()
+
+	for _, tc := range testCases {
+		m := MetricDeclaration{
+			Dimensions:          tc.dimensions,
+			MetricNameSelectors: []string{"foo"},
+		}
+		t.Run(tc.testName, func(t *testing.T) {
+			err := m.Init(logger)
+			assert.Nil(t, err)
+			dimensions := m.ExtractDimensions(tc.labels)
+			assertDimsEqual(t, tc.extractedDimensions, dimensions)
+		})
+	}
+}
+
+func TestProcessMetricDeclarations(t *testing.T) {
+	metricDeclarations := []*MetricDeclaration{
+		{
+			Dimensions:          [][]string{{"dim1", "dim2"}},
+			MetricNameSelectors: []string{"a", "b"},
+		},
+		{
+			Dimensions:          [][]string{{"dim1"}},
+			MetricNameSelectors: []string{"aa", "b"},
+		},
+		{
+			Dimensions:          [][]string{{"dim1", "dim2"}, {"dim1"}},
+			MetricNameSelectors: []string{"a"},
+		},
+	}
+	logger := zap.NewNop()
+	for _, m := range metricDeclarations {
+		err := m.Init(logger)
+		assert.Nil(t, err)
+	}
+	testCases := []struct {
+		testName       string
+		metricName     string
+		labels         map[string]string
+		dimensionsList [][][]string
+	}{
+		{
+			"Matching multiple dimensions 1",
+			"a",
+			map[string]string{
+				"dim1": "foo",
+				"dim2": "bar",
+			},
+			[][][]string{
+				{{"dim1", "dim2"}},
+				{{"dim1", "dim2"}, {"dim1"}},
+			},
+		},
+		{
+			"Matching multiple dimensions 2",
+			"b",
+			map[string]string{
+				"dim1": "foo",
+				"dim2": "bar",
+			},
+			[][][]string{
+				{{"dim1", "dim2"}},
+				{{"dim1"}},
+			},
+		},
+		{
+			"Match single dimension set",
+			"a",
+			map[string]string{
+				"dim1": "foo",
+			},
+			[][][]string{
+				{{"dim1"}},
+			},
+		},
+		{
+			"No matching dimension set",
+			"a",
+			map[string]string{
+				"dim2": "bar",
+			},
+			nil,
+		},
+		{
+			"No matching metric name",
+			"c",
+			map[string]string{
+				"dim1": "foo",
+			},
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		metric := pdata.NewMetric()
+		metric.InitEmpty()
+		metric.SetName(tc.metricName)
+		t.Run(tc.testName, func(t *testing.T) {
+			dimensionsList := processMetricDeclarations(metricDeclarations, &metric, tc.labels)
+			assert.Equal(t, len(tc.dimensionsList), len(dimensionsList))
+			for i, dimensions := range dimensionsList {
+				assertDimsEqual(t, tc.dimensionsList[i], dimensions)
+			}
+		})
+	}
+}

--- a/exporter/awsemfexporter/metric_declaration_test.go
+++ b/exporter/awsemfexporter/metric_declaration_test.go
@@ -59,8 +59,8 @@ func TestInit(t *testing.T) {
 			MetricNameSelectors: []string{"a.*", "b$", "aa+"},
 		}
 		obs, logs := observer.New(zap.WarnLevel)
-		logger := zap.New(obs)
-		err := m.Init(logger)
+		obsLogger := zap.New(obs)
+		err := m.Init(obsLogger)
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(m.metricRegexList))
 		assert.Equal(t, 1, len(m.Dimensions))
@@ -84,8 +84,8 @@ func TestInit(t *testing.T) {
 			MetricNameSelectors: []string{"a.*", "b$", "aa+"},
 		}
 		obs, logs := observer.New(zap.WarnLevel)
-		logger := zap.New(obs)
-		err := m.Init(logger)
+		obsLogger := zap.New(obs)
+		err := m.Init(obsLogger)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(m.Dimensions))
 		assert.Equal(t, []string{"a", "b", "c"}, m.Dimensions[0])
@@ -109,7 +109,7 @@ func TestInit(t *testing.T) {
 		m := &MetricDeclaration{}
 		err := m.Init(logger)
 		assert.NotNil(t, err)
-		assert.EqualError(t, err, "Invalid metric declaration: no metric name selectors defined.")
+		assert.EqualError(t, err, "invalid metric declaration: no metric name selectors defined")
 	})
 }
 

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -267,7 +267,7 @@ func buildCWMetric(dp DataPoint, pmd *pdata.Metric, namespace string, metricSlic
 	// `fields` contains metric and dimensions key/value pairs
 	fields := make(map[string]interface{}, labelsMap.Len()+2)
 	idx := 0
-	labelsMap.ForEach(func(k string, v string) {
+	labelsMap.ForEach(func(k, v string) {
 		fields[k] = v
 		labels[k] = v
 		labelsSlice[idx] = k

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -203,8 +203,6 @@ func TranslateCWMetricToEMF(cwMetricLists []*CWMetrics, logger *zap.Logger) []*L
 
 // getCWMetrics translates OTLP Metric to a list of CW Metrics
 func getCWMetrics(metric *pdata.Metric, namespace string, instrumentationLibName string, config *Config) (cwMetrics []*CWMetrics) {
-	var dps DataPoints
-
 	if metric == nil {
 		return
 	}
@@ -217,6 +215,7 @@ func getCWMetrics(metric *pdata.Metric, namespace string, instrumentationLibName
 	metricSlice := []map[string]string{metricMeasure}
 
 	// Retrieve data points
+	var dps DataPoints
 	switch metric.DataType() {
 	case pdata.MetricDataTypeIntGauge:
 		dps = IntDataPointSlice{metric.IntGauge().DataPoints()}

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -15,6 +15,7 @@
 package awsemfexporter
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"sort"
 	"strings"
@@ -255,6 +256,110 @@ func TestTranslateOtToCWMetricWithNameSpace(t *testing.T) {
 	assert.Equal(t, "myServiceNS", met.Measurements[0].Namespace)
 }
 
+func TestTranslateOtToCWMetricWithFiltering(t *testing.T) {
+	md := consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
+		},
+		Resource: &resourcepb.Resource{
+			Labels: map[string]string{
+				conventions.AttributeServiceName:      "myServiceName",
+				conventions.AttributeServiceNamespace: "myServiceNS",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan", HasValue: true},
+							{Value: "false", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rm := internaldata.OCToMetrics(md).ResourceMetrics().At(0)
+	ilm := rm.InstrumentationLibraryMetrics().At(0)
+	ilm.InstrumentationLibrary().InitEmpty()
+	ilm.InstrumentationLibrary().SetName("cloudwatch-lib")
+
+	testCases := []struct {
+		testName            string
+		metricNameSelectors []string
+		dimensions       	[][]string
+		numMeasurements		int
+	}{
+		{
+			"With match",
+			[]string{"spanCounter"},
+			[][]string{
+				{"spanName", "isItAnError"},
+				{OTellibDimensionKey, "spanName"},
+				{OTellibDimensionKey, "isItAnError"},
+				{OTellibDimensionKey},
+			},
+			1,
+		},
+		{
+			"No match",
+			[]string{"invalid"},
+			nil,
+			0,
+		},
+	}
+	logger := zap.NewNop()
+
+	for _, tc := range testCases {
+		m := MetricDeclaration{
+			Dimensions: [][]string{{"isItAnError", "spanName"}},
+			MetricNameSelectors: tc.metricNameSelectors,
+		}
+		config := &Config{
+			Namespace: "",
+			DimensionRollupOption: ZeroAndSingleDimensionRollup,
+			MetricDeclarations: []*MetricDeclaration{&m},
+		}
+		t.Run(tc.testName, func(t *testing.T) {
+			err := m.Init(logger)
+			assert.Nil(t, err)
+			cwm, totalDroppedMetrics := TranslateOtToCWMetric(&rm, config)
+			assert.Equal(t, 0, totalDroppedMetrics)
+			assert.Equal(t, 1, len(cwm))
+			assert.NotNil(t, cwm)
+
+			assert.Equal(t, tc.numMeasurements, len(cwm[0].Measurements))
+
+			if tc.numMeasurements > 0 {
+				dimensions := cwm[0].Measurements[0].Dimensions
+				assertDimsEqual(t, tc.dimensions, dimensions)
+			}
+		})
+	}
+}
+
 func TestTranslateCWMetricToEMF(t *testing.T) {
 	cwMeasurement := CwMeasurement{
 		Namespace:  "test-emf",
@@ -275,9 +380,39 @@ func TestTranslateCWMetricToEMF(t *testing.T) {
 		Fields:       fields,
 		Measurements: []CwMeasurement{cwMeasurement},
 	}
-	inputLogEvent := TranslateCWMetricToEMF([]*CWMetrics{met})
+	logger := zap.NewNop()
+	inputLogEvent := TranslateCWMetricToEMF([]*CWMetrics{met}, logger)
 
 	assert.Equal(t, readFromFile("testdata/testTranslateCWMetricToEMF.json"), *inputLogEvent[0].InputLogEvent.Message, "Expect to be equal")
+}
+
+func TestTranslateCWMetricToEMFNoMeasurements(t *testing.T) {
+	timestamp := int64(1596151098037)
+	fields := make(map[string]interface{})
+	fields["OTelLib"] = "cloudwatch-otel"
+	fields["spanName"] = "test"
+	fields["spanCounter"] = 0
+
+	met := &CWMetrics{
+		Timestamp:    timestamp,
+		Fields:       fields,
+		Measurements: nil,
+	}
+	obs, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(obs)
+	inputLogEvent := TranslateCWMetricToEMF([]*CWMetrics{met}, logger)
+	expected := "{\"OTelLib\":\"cloudwatch-otel\",\"spanCounter\":0,\"spanName\":\"test\"}"
+
+	assert.Equal(t, expected, *inputLogEvent[0].InputLogEvent.Message)
+
+	// Check logged warning message
+	fieldsStr, _ := json.Marshal(fields)
+	expectedLogs := []observer.LoggedEntry{{
+		Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Dropped metric due to no matching metric declarations"},
+		Context: []zapcore.Field{zap.String("labels", string(fieldsStr))},
+	}}
+	assert.Equal(t, 1, logs.Len())
+	assert.Equal(t, expectedLogs, logs.AllUntimed())
 }
 
 func TestGetCWMetrics(t *testing.T) {
@@ -827,7 +962,11 @@ func TestGetCWMetrics(t *testing.T) {
 func TestBuildCWMetric(t *testing.T) {
 	namespace := "Namespace"
 	instrLibName := "InstrLibName"
-	OTelLib := "OTelLib"
+	OTelLib := OTellibDimensionKey
+	config := &Config{
+		Namespace:             "",
+		DimensionRollupOption: "",
+	}
 	metricSlice := []map[string]string{
 		{
 			"Name": "foo",
@@ -847,7 +986,7 @@ func TestBuildCWMetric(t *testing.T) {
 		})
 		dp.SetValue(int64(-17))
 
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, "")
+		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
 
 		assert.NotNil(t, cwMetric)
 		assert.Equal(t, 1, len(cwMetric.Measurements))
@@ -874,7 +1013,7 @@ func TestBuildCWMetric(t *testing.T) {
 		})
 		dp.SetValue(0.3)
 
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, "")
+		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
 
 		assert.NotNil(t, cwMetric)
 		assert.Equal(t, 1, len(cwMetric.Measurements))
@@ -903,7 +1042,7 @@ func TestBuildCWMetric(t *testing.T) {
 		})
 		dp.SetValue(int64(-17))
 
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, "")
+		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
 
 		assert.NotNil(t, cwMetric)
 		assert.Equal(t, 1, len(cwMetric.Measurements))
@@ -932,7 +1071,7 @@ func TestBuildCWMetric(t *testing.T) {
 		})
 		dp.SetValue(0.3)
 
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, "")
+		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
 
 		assert.NotNil(t, cwMetric)
 		assert.Equal(t, 1, len(cwMetric.Measurements))
@@ -962,7 +1101,7 @@ func TestBuildCWMetric(t *testing.T) {
 		dp.SetBucketCounts([]uint64{1, 2, 3})
 		dp.SetExplicitBounds([]float64{1, 2, 3})
 
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, "")
+		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
 
 		assert.NotNil(t, cwMetric)
 		assert.Equal(t, 1, len(cwMetric.Measurements))
@@ -990,40 +1129,69 @@ func TestBuildCWMetric(t *testing.T) {
 		dp := pdata.NewIntHistogramDataPoint()
 		dp.InitEmpty()
 
-		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, "")
+		cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrLibName, config)
 		assert.Nil(t, cwMetric)
 	})
-}
 
-func TestCreateDimensions(t *testing.T) {
-	OTelLib := "OTelLib"
+	// Test rollup options and labels
 	testCases := []struct {
-		testName string
-		labels   map[string]string
-		dims     [][]string
+		testName 				string
+		labels 					map[string]string
+		dimensionRollupOption 	string
+		expectedDims 			[][]string
 	}{
 		{
-			"single label",
+			"Single label w/ no rollup",
 			map[string]string{"a": "foo"},
+			"",
 			[][]string{
 				{"a", OTelLib},
+			},
+		},
+		{
+			"Single label w/ single rollup",
+			map[string]string{"a": "foo"},
+			SingleDimensionRollupOnly,
+			[][]string{
+				{"a", OTelLib},
+				{OTelLib, "a"},
+			},
+		},
+		{
+			"Single label w/ zero + single rollup",
+			map[string]string{"a": "foo"},
+			ZeroAndSingleDimensionRollup,
+			[][]string{
+				{"a", OTelLib},
+				{OTelLib, "a"},
 				{OTelLib},
 			},
 		},
 		{
-			"multiple labels",
-			map[string]string{"a": "foo", "b": "bar"},
+			"Multiple label w/ no rollup",
+			map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "car",
+			},
+			"",
 			[][]string{
-				{"a", "b", OTelLib},
-				{OTelLib},
+				{"a", "b", "c", OTelLib},
+			},
+		},
+		{
+			"Multiple label w/ rollup",
+			map[string]string{
+				"a": "foo",
+				"b": "bar",
+				"c": "car",
+			},
+			ZeroAndSingleDimensionRollup,
+			[][]string{
+				{"a", "b", "c", OTelLib},
 				{OTelLib, "a"},
 				{OTelLib, "b"},
-			},
-		},
-		{
-			"no labels",
-			map[string]string{},
-			[][]string{
+				{OTelLib, "c"},
 				{OTelLib},
 			},
 		},
@@ -1034,20 +1202,376 @@ func TestCreateDimensions(t *testing.T) {
 			dp := pdata.NewIntDataPoint()
 			dp.InitEmpty()
 			dp.LabelsMap().InitFromMap(tc.labels)
-			dimensions, fields := createDimensions(dp, OTelLib, ZeroAndSingleDimensionRollup)
+			dp.SetValue(int64(-17))
+			config = &Config{
+				Namespace:             namespace,
+				DimensionRollupOption: tc.dimensionRollupOption,
+			}
 
-			assertDimsEqual(t, tc.dims, dimensions)
-
-			expectedFields := make(map[string]interface{})
+			expectedFields := map[string]interface{}{
+				OTellibDimensionKey: OTelLib,
+				"foo":               int64(-17),
+			}
 			for k, v := range tc.labels {
 				expectedFields[k] = v
 			}
-			expectedFields[OTellibDimensionKey] = OTelLib
 
-			assert.Equal(t, expectedFields, fields)
+			cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, OTelLib, config)
+
+			// Check fields
+			assert.Equal(t, expectedFields, cwMetric.Fields)
+
+			// Check CW measurement
+			assert.Equal(t, 1, len(cwMetric.Measurements))
+			cwMeasurement := cwMetric.Measurements[0]
+			assert.Equal(t, namespace, cwMeasurement.Namespace)
+			assert.Equal(t, metricSlice, cwMeasurement.Metrics)
+			assertDimsEqual(t, tc.expectedDims, cwMeasurement.Dimensions)
 		})
 	}
+}
 
+func TestBuildCWMetricWithMetricDeclarations(t *testing.T) {
+	namespace := "Namespace"
+	OTelLib := OTellibDimensionKey
+	instrumentationLibName := "cloudwatch-otel"
+	metricName := "metric1"
+	metricValue := int64(-17)
+	metric := pdata.NewMetric()
+	metric.InitEmpty()
+	metric.SetName(metricName)
+	metricSlice := []map[string]string{{"Name": metricName}}
+	testCases := []struct {
+		testName 				string
+		labels 					map[string]string
+		metricDeclarations 		[]*MetricDeclaration
+		dimensionRollupOption 	string
+		expectedDims 			[][][]string
+	}{
+		{
+			"Single label w/ no rollup",
+			map[string]string{"a": "foo"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			[][][]string{{{"a"}}},
+		},
+		{
+			"Single label + OTelLib w/ no rollup",
+			map[string]string{"a": "foo"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", OTelLib}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			[][][]string{{{"a", OTelLib}}},
+		},
+		{
+			"Single label w/ single rollup",
+			map[string]string{"a": "foo"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			SingleDimensionRollupOnly,
+			[][][]string{{{"a"}, {"a", OTelLib}}},
+		},
+		{
+			"Single label w/ zero/single rollup",
+			map[string]string{"a": "foo"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			ZeroAndSingleDimensionRollup,
+			[][][]string{{{"a"}, {"a", OTelLib}, {OTelLib}}},
+		},
+		{
+			"No matching metric name",
+			map[string]string{"a": "foo"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a"}},
+					MetricNameSelectors: []string{"invalid"},
+				},
+			},
+			"",
+			nil,
+		},
+		{
+			"multiple labels w/ no rollup",
+			map[string]string{"a": "foo", "b": "bar"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			[][][]string{{{"a"}}},
+		},
+		{
+			"multiple labels w/ rollup",
+			map[string]string{"a": "foo", "b": "bar"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			ZeroAndSingleDimensionRollup,
+			[][][]string{{
+				{"a"},
+				{OTelLib, "a"},
+				{OTelLib, "b"},
+				{OTelLib},
+			}},
+		},
+		{
+			"multiple labels + multiple dimensions w/ no rollup",
+			map[string]string{"a": "foo", "b": "bar"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			[][][]string{{{"a", "b"}, {"b"}}},
+		},
+		{
+			"multiple labels + multiple dimensions + OTelLib w/ no rollup",
+			map[string]string{"a": "foo", "b": "bar"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "b"}, {"b", OTelLib}, {OTelLib}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			[][][]string{{{"a", "b"}, {"b", OTelLib}, {OTelLib}}},
+		},
+		{
+			"multiple labels + multiple dimensions w/ rollup",
+			map[string]string{"a": "foo", "b": "bar"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			ZeroAndSingleDimensionRollup,
+			[][][]string{{
+				{"a", "b"},
+				{"b"},
+				{OTelLib, "a"},
+				{OTelLib, "b"},
+				{OTelLib},
+			}},
+		},
+		{
+			"multiple labels, multiple dimensions w/ invalid dimension",
+			map[string]string{"a": "foo", "b": "bar"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "b", "c"}, {"b"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			ZeroAndSingleDimensionRollup,
+			[][][]string{{
+				{"b"},
+				{OTelLib, "a"},
+				{OTelLib, "b"},
+				{OTelLib},
+			}},
+		},
+		{
+			"multiple labels, multiple dimensions w/ missing dimension",
+			map[string]string{"a": "foo", "b": "bar", "c": "car"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			ZeroAndSingleDimensionRollup,
+			[][][]string{{
+				{"a", "b"},
+				{"b"},
+				{OTelLib, "a"},
+				{OTelLib, "b"},
+				{OTelLib, "c"},
+				{OTelLib},
+			}},
+		},
+		{
+			"multiple metric declarations w/ no rollup",
+			map[string]string{"a": "foo", "b": "bar", "c": "car"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					MetricNameSelectors: []string{metricName},
+				},
+				{
+					Dimensions: [][]string{{"a", "c"}, {"b"}, {"c"}},
+					MetricNameSelectors: []string{metricName},
+				},
+				{
+					Dimensions: [][]string{{"a", "d"}, {"b", "c"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			[][][]string{
+				{{"a", "b"}, {"b"}},
+				{{"a", "c"}, {"b"}, {"c"}},
+				{{"b", "c"}},
+			},
+		},
+		{
+			"multiple metric declarations w/ rollup",
+			map[string]string{"a": "foo", "b": "bar", "c": "car"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					MetricNameSelectors: []string{metricName},
+				},
+				{
+					Dimensions: [][]string{{"a", "c"}, {"b"}, {"c"}},
+					MetricNameSelectors: []string{metricName},
+				},
+				{
+					Dimensions: [][]string{{"a", "d"}, {"b", "c"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			ZeroAndSingleDimensionRollup,
+			[][][]string{
+				{
+					{"a", "b"},
+					{"b"},
+					{OTelLib, "a"},
+					{OTelLib, "b"},
+					{OTelLib, "c"},
+					{OTelLib},
+				},
+				{
+					{"a", "c"},
+					{"b"},
+					{"c"},
+					{OTelLib, "a"},
+					{OTelLib, "b"},
+					{OTelLib, "c"},
+					{OTelLib},
+				},
+				{
+					{"b", "c"},
+					{OTelLib, "a"},
+					{OTelLib, "b"},
+					{OTelLib, "c"},
+					{OTelLib},
+				},
+			},
+		},
+		{
+			"remove measurements with no dimensions",
+			map[string]string{"a": "foo", "b": "bar", "c": "car"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "b"}, {"b"}},
+					MetricNameSelectors: []string{metricName},
+				},
+				{
+					Dimensions: [][]string{{"a", "d"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			[][][]string{
+				{{"a", "b"}, {"b"}},
+			},
+		},
+		{
+			"multiple declarations w/ no dimensions",
+			map[string]string{"a": "foo", "b": "bar", "c": "car"},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "e"}, {"d"}},
+					MetricNameSelectors: []string{metricName},
+				},
+				{
+					Dimensions: [][]string{{"a", "d"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			"",
+			nil,
+		},
+		{
+			"no labels",
+			map[string]string{},
+			[]*MetricDeclaration{
+				{
+					Dimensions: [][]string{{"a", "b", "c"}, {"b"}},
+					MetricNameSelectors: []string{metricName},
+				},
+			},
+			ZeroAndSingleDimensionRollup,
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			dp := pdata.NewIntDataPoint()
+			dp.InitEmpty()
+			dp.LabelsMap().InitFromMap(tc.labels)
+			dp.SetValue(metricValue)
+			config := &Config{
+				Namespace: namespace,
+				DimensionRollupOption: tc.dimensionRollupOption,
+				MetricDeclarations: tc.metricDeclarations,
+			}
+			logger := zap.NewNop()
+			for _, m := range tc.metricDeclarations {
+				err := m.Init(logger)
+				assert.Nil(t, err)
+			}
+
+			expectedFields := map[string]interface{}{
+				OTellibDimensionKey: instrumentationLibName,
+				metricName: int64(-17),
+			}
+			for k, v := range tc.labels {
+				expectedFields[k] = v
+			}
+
+			cwMetric := buildCWMetric(dp, &metric, namespace, metricSlice, instrumentationLibName, config)
+			
+			// Check fields
+			assert.Equal(t, expectedFields, cwMetric.Fields)
+
+			// Check CW measurement
+			assert.Equal(t, len(tc.expectedDims), len(cwMetric.Measurements))
+			for i, dimensions := range tc.expectedDims {
+				cwMeasurement := cwMetric.Measurements[i]
+				assert.Equal(t, namespace, cwMeasurement.Namespace)
+				assert.Equal(t, metricSlice, cwMeasurement.Metrics)
+				assertDimsEqual(t, dimensions, cwMeasurement.Dimensions)
+			}
+		})
+	}
 }
 
 func TestCalculateRate(t *testing.T) {
@@ -1523,10 +2047,11 @@ func BenchmarkTranslateCWMetricToEMF(b *testing.B) {
 		Fields:       fields,
 		Measurements: []CwMeasurement{cwMeasurement},
 	}
+	logger := zap.NewNop()
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		TranslateCWMetricToEMF([]*CWMetrics{met})
+		TranslateCWMetricToEMF([]*CWMetrics{met}, logger)
 	}
 }
 

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -37,6 +37,245 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+func readFromFile(filename string) string {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+	str := string(data)
+	return str
+}
+
+func createMetricTestData() consumerdata.MetricsData {
+	return consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
+		},
+		Resource: &resourcepb.Resource{
+			Labels: map[string]string{
+				conventions.AttributeServiceName:      "myServiceName",
+				conventions.AttributeServiceNamespace: "myServiceNS",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan", HasValue: true},
+							{Value: "false", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanGaugeCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_GAUGE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan", HasValue: true},
+							{Value: "false", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanDoubleCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan", HasValue: true},
+							{Value: "false", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_DoubleValue{
+									DoubleValue: 0.1,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanGaugeDoubleCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan", HasValue: true},
+							{Value: "false", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_DoubleValue{
+									DoubleValue: 0.1,
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanTimer",
+					Description: "How long the spans take",
+					Unit:        "Seconds",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_DistributionValue{
+									DistributionValue: &metricspb.DistributionValue{
+										Sum:   15.0,
+										Count: 5,
+										BucketOptions: &metricspb.DistributionValue_BucketOptions{
+											Type: &metricspb.DistributionValue_BucketOptions_Explicit_{
+												Explicit: &metricspb.DistributionValue_BucketOptions_Explicit{
+													Bounds: []float64{0, 10},
+												},
+											},
+										},
+										Buckets: []*metricspb.DistributionValue_Bucket{
+											{
+												Count: 0,
+											},
+											{
+												Count: 4,
+											},
+											{
+												Count: 1,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanTimer",
+					Description: "How long the spans take",
+					Unit:        "Seconds",
+					Type:        metricspb.MetricDescriptor_SUMMARY,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan"},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_SummaryValue{
+									SummaryValue: &metricspb.SummaryValue{
+										Sum: &wrappers.DoubleValue{
+											Value: 15.0,
+										},
+										Count: &wrappers.Int64Value{
+											Value: 5,
+										},
+										Snapshot: &metricspb.SummaryValue_Snapshot{
+											PercentileValues: []*metricspb.SummaryValue_Snapshot_ValueAtPercentile{{
+												Percentile: 0,
+												Value:      1,
+											},
+												{
+													Percentile: 100,
+													Value:      5,
+												}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // Asserts whether dimension sets are equal (i.e. has same sets of dimensions)
 func assertDimsEqual(t *testing.T, expected, actual [][]string) {
 	// Convert to string for easier sorting
@@ -1750,245 +1989,6 @@ func TestDimensionRollup(t *testing.T) {
 			rolledUp := dimensionRollup(tc.dimensionRollupOption, tc.dims, tc.instrumentationLibName)
 			assert.Equal(t, tc.expected, rolledUp)
 		})
-	}
-}
-
-func readFromFile(filename string) string {
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		panic(err)
-	}
-	str := string(data)
-	return str
-}
-
-func createMetricTestData() consumerdata.MetricsData {
-	return consumerdata.MetricsData{
-		Node: &commonpb.Node{
-			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
-		},
-		Resource: &resourcepb.Resource{
-			Labels: map[string]string{
-				conventions.AttributeServiceName:      "myServiceName",
-				conventions.AttributeServiceNamespace: "myServiceNS",
-			},
-		},
-		Metrics: []*metricspb.Metric{
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan", HasValue: true},
-							{Value: "false", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 100,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanGaugeCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_GAUGE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan", HasValue: true},
-							{Value: "false", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 100,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanDoubleCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan", HasValue: true},
-							{Value: "false", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 100,
-								},
-								Value: &metricspb.Point_DoubleValue{
-									DoubleValue: 0.1,
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanGaugeDoubleCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_GAUGE_DOUBLE,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan", HasValue: true},
-							{Value: "false", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 100,
-								},
-								Value: &metricspb.Point_DoubleValue{
-									DoubleValue: 0.1,
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanTimer",
-					Description: "How long the spans take",
-					Unit:        "Seconds",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan", HasValue: true},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 100,
-								},
-								Value: &metricspb.Point_DistributionValue{
-									DistributionValue: &metricspb.DistributionValue{
-										Sum:   15.0,
-										Count: 5,
-										BucketOptions: &metricspb.DistributionValue_BucketOptions{
-											Type: &metricspb.DistributionValue_BucketOptions_Explicit_{
-												Explicit: &metricspb.DistributionValue_BucketOptions_Explicit{
-													Bounds: []float64{0, 10},
-												},
-											},
-										},
-										Buckets: []*metricspb.DistributionValue_Bucket{
-											{
-												Count: 0,
-											},
-											{
-												Count: 4,
-											},
-											{
-												Count: 1,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanTimer",
-					Description: "How long the spans take",
-					Unit:        "Seconds",
-					Type:        metricspb.MetricDescriptor_SUMMARY,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-					},
-				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan"},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 100,
-								},
-								Value: &metricspb.Point_SummaryValue{
-									SummaryValue: &metricspb.SummaryValue{
-										Sum: &wrappers.DoubleValue{
-											Value: 15.0,
-										},
-										Count: &wrappers.Int64Value{
-											Value: 5,
-										},
-										Snapshot: &metricspb.SummaryValue_Snapshot{
-											PercentileValues: []*metricspb.SummaryValue_Snapshot_ValueAtPercentile{{
-												Percentile: 0,
-												Value:      1,
-											},
-												{
-													Percentile: 100,
-													Value:      5,
-												}},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 }
 

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -1935,14 +1935,14 @@ func TestDimensionRollup(t *testing.T) {
 			SingleDimensionRollupOnly,
 			[]string{"a"},
 			noInstrumentationLibraryName,
-			nil,
+			[][]string{{"a"}},
 		},
 		{
 			"single dim w/ instrumentation library name and only one label",
 			SingleDimensionRollupOnly,
 			[]string{"a"},
 			"cloudwatch-otel",
-			nil,
+			[][]string{{OTellibDimensionKey, "a"}},
 		},
 		{
 			"zero + single dim w/o instrumentation library name",


### PR DESCRIPTION
## Description
### Problem
Currently, the EMF Exporter does not provide any configuration for defining the dimensions for exported metrics or which metrics should be exported. All incoming metrics are exported with their label set as the exported dimension. A few problems arise, including:
1. Unwanted metrics/dimensions resulting in increased cost for the customer
2. CloudWatch metrics can only support at max 10 dimensions. By exporting all labels, some metrics will have a dimension set of more than 10 dimensions.

### Solution
This PR solves both issues by defining a new `metric_declarations` (optional) attribute that allows the user to define the dimensions for exported metrics and filter by metric names. Specifically, the `metric_declarations` is a list of `metric_declaration`s with the following API spec:

**<metric_declaration>**
Each metric declaration characterizes a rule to be used to set dimensions for certain incoming metrics, filtered by their metric names. 
```yaml
# List of dimension sets (which are lists of dimension names) to be included
# in exported metrics. If the metric does not contain any of the specified
# dimensions, the metric would be dropped (will only show up in logs).
dimensions: [ - [ - <string> ] ]

# List of regex strings to be matched against metric names to determine which
# metrics should be included with this metric declaration rule.
metric_name_selectors: [ - <string> ]
```

**Example config**
```yaml
exporters:
  awsemf:
    log_group_name: 'awscollector-test'
    region: 'us-west-2'
    log_stream_name: metric-declarations
    dimension_rollup_option: 'NoDimensionRollup'
    metric_declarations:
    - dimensions: [['Service', 'Namespace'], ['pod_name', 'container_name']]
      metric_name_selectors:
      - '^go_memstats_alloc_bytes_total$'
    - dimensions: [['app_kubernetes_io_component', 'Namespace'], ['app_kubernetes_io_name'], ['Invalid', 'Namespace']]
      metric_name_selectors:
      - '^go_goroutines$'
    - dimensions: [['Namespace', 'Service', 'Namespace']]
      metric_name_selectors:
      - '^go_mem.+$'
```

Note that the `metric_declarations` attribute is optional. If this section is left out of the config file, the exporter defaults to exporting all labels as a dimension set, as is done currently. Each incoming metric is matched against each metric declaration rule. If it matches at least one of the `metric_name_selectors`, the corresponding rule is applied. Each dimension set specified by the rule is applied to the exported metric if and only if the metric has all the dimensions in that dimension set.

All of the dimension sets across all metric declarations are aggregated together and applied to the metric. In other words, if a metric matches multiple rules, all valid dimensions specified by those rules will be put into a single list of dimension sets. Additionally, any rolled-up dimensions are also added to this set. De-duplication is applied across the final list of dimension sets.

**De-duplication functionality**
We also help the user perform de-duplication of dimensions. 2 dimension sets are considered duplicate if they contain the same set of unique dimensions (order is irrelevant). There are 3 cases for duplicated dimensions:
1. Within a single dimension set, i.e. `['dim1', 'dim2', 'dim1']` -> `['dim1', 'dim2']`
2. Within a single metric declaration rule, i.e. `[['dim1', 'dim2'], ['dim2',  'dim1']]` -> `[['dim1', 'dim2']]`
3. Across metric declarations, i.e. if a metric matches multiple metric declaration rules. In this case, case 2 is applied since we aggregate all dimension sets into 1 list.

## Documentation
The documentation for the AWS EMF Exporter was updated to include the new `metric_declarations` attribute and its API spec.

## Testing
- Unit tests were added for each new function and ran successfully
- Manual E2E testing was done and logs/metrics were successfully exported to CloudWatch backend. Specifically, given the config defined above, we got the following CloudWatch logs:

1. 1 matching rule (w/ 1 unmatched dimension), `go_goroutines`:
```json
{
    "Namespace": "eks-aoc",
    "Service": "my-nginx-ingress-nginx-controller-metrics",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "metric-declarations",
                "Dimensions": [
                    [
                        "Namespace",
                        "app_kubernetes_io_component"
                    ],
                    [
                        "app_kubernetes_io_name"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "go_goroutines",
                        "Unit": ""
                    }
                ]
            }
        ],
        "Timestamp": 1604431600752
    },
    "app_kubernetes_io_component": "controller",
    "app_kubernetes_io_instance": "my-nginx",
    "app_kubernetes_io_managed_by": "Helm",
    "app_kubernetes_io_name": "ingress-nginx",
    "app_kubernetes_io_version": "0.40.2",
    "container_name": "controller",
    "go_goroutines": 93,
    "helm_sh_chart": "ingress-nginx-3.7.1",
    "kubernetes_node": "ip-192-168-69-5.us-west-2.compute.internal",
    "pod_name": "my-nginx-ingress-nginx-controller-77d5fd6977-mlc8k"
}
```

2. 1 matching rule (w/ dedup), `go_memstats_alloc_bytes`:
```json
{
    "Namespace": "eks-aoc",
    "Service": "my-nginx-ingress-nginx-controller-metrics",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "metric-declarations",
                "Dimensions": [
                    [
                        "Namespace",
                        "Service"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "go_memstats_alloc_bytes",
                        "Unit": "By"
                    }
                ]
            }
        ],
        "Timestamp": 1604431600752
    },
    "app_kubernetes_io_component": "controller",
    "app_kubernetes_io_instance": "my-nginx",
    "app_kubernetes_io_managed_by": "Helm",
    "app_kubernetes_io_name": "ingress-nginx",
    "app_kubernetes_io_version": "0.40.2",
    "container_name": "controller",
    "go_memstats_alloc_bytes": 6938768,
    "helm_sh_chart": "ingress-nginx-3.7.1",
    "kubernetes_node": "ip-192-168-69-5.us-west-2.compute.internal",
    "pod_name": "my-nginx-ingress-nginx-controller-77d5fd6977-mlc8k"
}
```
3. 2 matching rules w/ dedup), `go_memstats_alloc_bytes_total`:
```json
{
    "Namespace": "eks-aoc",
    "Service": "my-nginx-ingress-nginx-controller-metrics",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "metric-declarations",
                "Dimensions": [
                    [
                        "Namespace",
                        "Service"
                    ],
                    [
                        "container_name",
                        "pod_name"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "go_memstats_alloc_bytes_total",
                        "Unit": ""
                    }
                ]
            }
        ],
        "Timestamp": 1604431600752
    },
    "app_kubernetes_io_component": "controller",
    "app_kubernetes_io_instance": "my-nginx",
    "app_kubernetes_io_managed_by": "Helm",
    "app_kubernetes_io_name": "ingress-nginx",
    "app_kubernetes_io_version": "0.40.2",
    "container_name": "controller",
    "go_memstats_alloc_bytes_total": 0,
    "helm_sh_chart": "ingress-nginx-3.7.1",
    "kubernetes_node": "ip-192-168-69-5.us-west-2.compute.internal",
    "pod_name": "my-nginx-ingress-nginx-controller-77d5fd6977-mlc8k"
}
```
4. No matching rule, `go_info`:
```json
{
    "Namespace": "eks-aoc",
    "Service": "my-nginx-ingress-nginx-controller-metrics",
    "app_kubernetes_io_component": "controller",
    "app_kubernetes_io_instance": "my-nginx",
    "app_kubernetes_io_managed_by": "Helm",
    "app_kubernetes_io_name": "ingress-nginx",
    "app_kubernetes_io_version": "0.40.2",
    "container_name": "controller",
    "go_info": 1,
    "helm_sh_chart": "ingress-nginx-3.7.1",
    "kubernetes_node": "ip-192-168-69-5.us-west-2.compute.internal",
    "pod_name": "my-nginx-ingress-nginx-controller-77d5fd6977-mlc8k",
    "version": "go1.15.2"
}
```