### PR TITLE
Add combine action

### DIFF
--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -14,21 +14,23 @@ a batch of metrics**. It does not do any aggregation across batches, so it is
 not suitable for aggregating metrics from multiple sources (e.g. multiple nodes
 or clients).
 
-| Operation                                                         | Example (based on metric `system.cpu.usage`)                                                    |
-|-------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| Rename metrics                                                    | Rename to `system.cpu.usage_time`                                                               |
-| Add labels                                                        | Add new label `identifier` with value `1` to all points                                         |
-| Rename label keys                                                 | Rename label `state` to `cpu_state`                                                             |
-| Rename label values                                               | For label `state`, rename value `idle` to `-`                                                   |
-| Delete data points based on label values                          | Delete all points where label `state` has value `idle`                                          |
-| Toggle the data type of scalar metrics between `int` and `double` | Change from `int` data points to `double` data points                                           |
-| Aggregate across label sets by sum, mean, min, or max             | Retain only the label `state`, sum all points with the same value for this label                |
-| Aggregate across label values by sum, mean, min, or max           | For label `state`, sum points where the value is `user` or `system` into `used = user + system` |
+| Operation                     | Example (based on metric `system.cpu.usage`)                                                    |
+|-------------------------------|-------------------------------------------------------------------------------------------------|
+| Rename metrics                | Rename to `system.cpu.usage_time`                                                               |
+| Add labels                    | Add new label `identifier` with value `1` to all points                                         |
+| Rename label keys             | Rename label `state` to `cpu_state`                                                             |
+| Rename label values           | For label `state`, rename value `idle` to `-`                                                   |
+| Delete data points            | Delete all points where label `state` has value `idle`                                          |
+| Toggle data type              | Change from `int` data points to `double` data points                                           |
+| Aggregate across label sets   | Retain only the label `state`, average all points with the same value for this label            |
+| Aggregate across label values | For label `state`, sum points where the value is `user` or `system` into `used = user + system` |
 
 In addition to the above:
 
 - Operations can be applied to one or more metrics using a `strict` or `regexp`
   filter
+- Metrics can be updated in place or on an inserted copy
+- A set of matching metrics can be combined into a single metric
 - When renaming metrics, capturing groups from the `regexp` filter will be
   expanded
 - When adding or updating a label value, `{{version}}` will be replaced with
@@ -48,10 +50,12 @@ transforms:
   - include: <metric_name>
     # match_type specifies whether the include name should be used as a strict match or regexp match, default = strict
     match_type: {strict, regexp}
-    # action specifies if the operations are performed on the metric in place, or on an inserted clone
-    action: {update, insert}
+    # action specifies if the operations are performed on a metric in place, on an inserted clone, or if the matched metrics should be combined
+    action: {update, insert, combine}
     # new_name specifies the updated name of the metric; if action is insert, new_name is required
     new_name: <new_metric_name_inserted>
+    # aggregation_type defines how combined data points will be aggregated; if action is combine, aggregation_type is required
+    aggregation_type: {sum, mean, min, max}
     # operations contain a list of operations that will be performed on the selected metrics
     operations:
         # action defines the type of operation that will be performed, see examples below for more details
@@ -68,7 +72,7 @@ transforms:
         label_value: <label_value>
         # label_set contains a list of labels that will remain after aggregation; if action is aggregate_labels, label_set is required
         label_set: [labels...]
-        # aggregation_type defines how excluded labels will be aggregated; if action is aggregate_labels or aggregate_label_values, aggregation_type is required
+        # aggregation_type defines how data points will be aggregated; if action is aggregate_labels or aggregate_label_values, aggregation_type is required
         aggregation_type: {sum, mean, min, max}
         # value_actions contain a list of operations that will be performed on the selected label
         value_actions:
@@ -209,4 +213,19 @@ operations:
     aggregated_values: [ slab_reclaimable, slab_unreclaimable ]
     new_value: slab 
     aggregation_type: sum
+```
+
+### Combine metrics
+```yaml
+# convert a set of metrics for each http_method into a single metric with an http_method label, i.e.
+#
+# Web Service (*)/Total DELETE Requests     iis.requests{http_method=DELETE}
+# Web Service (*)/Total GET Requests     >  iis.requests{http_method=GET}
+# Web Service (*)/Total POST Requests       iis.requests{http_method=POST}
+metric_names: ^Web Service \(\*\)/Total (?P<http_method>.*) Requests$
+match_type: regexp
+action: combine
+new_name: iis.requests
+operations:
+  ...
 ```

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -34,6 +34,9 @@ const (
 	// NewNameFieldName is the mapstructure field name for NewName field
 	NewNameFieldName = "new_name"
 
+	// AggregationTypeFieldName is the mapstructure field name for AggregationType field
+	AggregationTypeFieldName = "aggregation_type"
+
 	// LabelFieldName is the mapstructure field name for Label field
 	LabelFieldName = "label"
 
@@ -43,16 +46,6 @@ const (
 	// NewValueFieldName is the mapstructure field name for NewValue field
 	NewValueFieldName = "new_value"
 )
-
-const (
-	// StrictMatchType is the FilterType for filtering by exact string matches.
-	StrictMatchType = "strict"
-
-	// RegexpMatchType is the FilterType for filtering by regexp string matches.
-	RegexpMatchType = "regexp"
-)
-
-var MatchTypes = []string{StrictMatchType, RegexpMatchType}
 
 // Config defines configuration for Resource processor.
 type Config struct {
@@ -93,7 +86,7 @@ type FilterConfig struct {
 	Include string `mapstructure:"include"`
 
 	// MatchType determines how the Include string is matched: <strict|regexp>.
-	MatchType string `mapstructure:"match_type"`
+	MatchType MatchType `mapstructure:"match_type"`
 }
 
 // Operation defines the specific operation performed on the selected metrics.
@@ -139,12 +132,6 @@ type ValueAction struct {
 // ConfigAction is the enum to capture the two types of actions to perform on a metric.
 type ConfigAction string
 
-// OperationAction is the enum to capture the thress types of actions to perform for an operation.
-type OperationAction string
-
-// AggregationType os the enum to capture the three types of aggregation for the aggregation operation.
-type AggregationType string
-
 const (
 	// Insert adds a new metric to the batch with a new name.
 	Insert ConfigAction = "insert"
@@ -154,10 +141,24 @@ const (
 
 	// Combine combines multiple metrics into a single metric.
 	Combine ConfigAction = "combine"
+)
 
-	// ToggleScalarDataType changes the data type from int64 to double, or vice-versa
-	ToggleScalarDataType OperationAction = "toggle_scalar_data_type"
+var Actions = []ConfigAction{Insert, Update, Combine}
 
+func (ca ConfigAction) isValid() bool {
+	for _, configAction := range Actions {
+		if ca == configAction {
+			return true
+		}
+	}
+
+	return false
+}
+
+// OperationAction is the enum to capture the thress types of actions to perform for an operation.
+type OperationAction string
+
+const (
 	// AddLabel adds a new label to an existing metric.
 	AddLabel OperationAction = "add_label"
 
@@ -167,6 +168,9 @@ const (
 	// DeleteLabelValue deletes a label value by also removing all the points associated with this label value
 	DeleteLabelValue OperationAction = "delete_label_value"
 
+	// ToggleScalarDataType changes the data type from int64 to double, or vice-versa
+	ToggleScalarDataType OperationAction = "toggle_scalar_data_type"
+
 	// AggregateLabels aggregates away all labels other than the ones in Operation.LabelSet
 	// by the method indicated by Operation.AggregationType.
 	AggregateLabels OperationAction = "aggregate_labels"
@@ -174,18 +178,68 @@ const (
 	// AggregateLabelValues aggregates away the values in Operation.AggregatedValues
 	// by the method indicated by Operation.AggregationType.
 	AggregateLabelValues OperationAction = "aggregate_label_values"
+)
+
+var OperationActions = []OperationAction{AddLabel, UpdateLabel, DeleteLabelValue, ToggleScalarDataType, AggregateLabels, AggregateLabelValues}
+
+func (oa OperationAction) isValid() bool {
+	for _, operationAction := range OperationActions {
+		if oa == operationAction {
+			return true
+		}
+	}
+
+	return false
+}
+
+// AggregationType is the enum to capture the three types of aggregation for the aggregation operation.
+type AggregationType string
+
+const (
+	// Sum indicates taking the sum of the aggregated data.
+	Sum AggregationType = "sum"
 
 	// Mean indicates taking the mean of the aggregated data.
 	Mean AggregationType = "mean"
 
-	// Max indicates taking the max of the aggregated data.
-	Max AggregationType = "max"
-
-	// Sum indicates taking the sum of the aggregated data.
-	Sum AggregationType = "sum"
-
 	// Min indicates taking the minimum of the aggregated data.
 	Min AggregationType = "min"
+
+	// Max indicates taking the max of the aggregated data.
+	Max AggregationType = "max"
 )
 
-var Actions = []ConfigAction{Insert, Update, Combine}
+var AggregationTypes = []AggregationType{Sum, Mean, Min, Max}
+
+func (at AggregationType) isValid() bool {
+	for _, aggregationType := range AggregationTypes {
+		if at == aggregationType {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MatchType is the enum to capture the two types of matching metric(s) that should have operations applied to them.
+type MatchType string
+
+const (
+	// StrictMatchType is the FilterType for filtering by exact string matches.
+	StrictMatchType MatchType = "strict"
+
+	// RegexpMatchType is the FilterType for filtering by regexp string matches.
+	RegexpMatchType MatchType = "regexp"
+)
+
+var MatchTypes = []MatchType{StrictMatchType, RegexpMatchType}
+
+func (mt MatchType) isValid() bool {
+	for _, matchType := range MatchTypes {
+		if mt == matchType {
+			return true
+		}
+	}
+
+	return false
+}

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -80,6 +80,10 @@ type Transform struct {
 	// REQUIRED only if Action is INSERT.
 	NewName string `mapstructure:"new_name"`
 
+	// AggregationType specifies how to aggregate.
+	// REQUIRED only if Action is COMBINE.
+	AggregationType AggregationType `mapstructure:"aggregation_type"`
+
 	// Operations contains a list of operations that will be performed on the selected metric.
 	Operations []Operation `mapstructure:"operations"`
 }
@@ -148,6 +152,9 @@ const (
 	// Update updates an existing metric.
 	Update ConfigAction = "update"
 
+	// Combine combines multiple metrics into a single metric.
+	Combine ConfigAction = "combine"
+
 	// ToggleScalarDataType changes the data type from int64 to double, or vice-versa
 	ToggleScalarDataType OperationAction = "toggle_scalar_data_type"
 
@@ -180,3 +187,5 @@ const (
 	// Min indicates taking the minimum of the aggregated data.
 	Min AggregationType = "min"
 )
+
+var Actions = []ConfigAction{Insert, Update, Combine}

--- a/processor/metricstransformprocessor/config_test.go
+++ b/processor/metricstransformprocessor/config_test.go
@@ -25,40 +25,8 @@ import (
 	"go.opentelemetry.io/collector/config/configtest"
 )
 
-var (
-	testDataOperations = []Operation{
-		{
-			Action:   UpdateLabel,
-			Label:    "label",
-			NewLabel: "new_label",
-			ValueActions: []ValueAction{
-				{
-					Value:    "current_label_value",
-					NewValue: "new_label_value",
-				},
-			},
-		},
-		{
-			Action: AggregateLabels,
-			LabelSet: []string{
-				"label1",
-				"label2",
-			},
-			AggregationType: Sum,
-		},
-		{
-			Action: AggregateLabelValues,
-			Label:  "label",
-			AggregatedValues: []string{
-				"value1",
-				"value2",
-			},
-			NewValue:        "new_value",
-			AggregationType: Sum,
-		},
-	}
-
-	tests = []struct {
+func TestLoadingFullConfig(t *testing.T) {
+	tests := []struct {
 		configFile string
 		filterName string
 		expCfg     *Config
@@ -68,43 +36,95 @@ var (
 			filterName: "metricstransform",
 			expCfg: &Config{
 				ProcessorSettings: configmodels.ProcessorSettings{
+					TypeVal: "metricstransform",
 					NameVal: "metricstransform",
-					TypeVal: typeStr,
 				},
 				Transforms: []Transform{
 					{
 						MetricIncludeFilter: FilterConfig{
-							Include: "old_name",
+							Include:   "name",
+							MatchType: "",
 						},
-						Action:     Update,
-						NewName:    "new_name",
-						Operations: testDataOperations,
+						Action:  "update",
+						NewName: "new_name",
 					},
 				},
 			},
 		},
 		{
 			configFile: "config_full.yaml",
-			filterName: "metricstransform/addlabel",
+			filterName: "metricstransform/multiple",
 			expCfg: &Config{
 				ProcessorSettings: configmodels.ProcessorSettings{
-					NameVal: "metricstransform/addlabel",
-					TypeVal: typeStr,
+					TypeVal: "metricstransform",
+					NameVal: "metricstransform/multiple",
 				},
 				Transforms: []Transform{
 					{
 						MetricIncludeFilter: FilterConfig{
-							Include:   "some_name",
-							MatchType: "regexp",
+							Include:   "name1",
+							MatchType: "strict",
 						},
-						Action: Update,
+						Action:  "insert",
+						NewName: "new_name",
 						Operations: []Operation{
 							{
-								Action:   AddLabel,
-								NewLabel: "mylabel",
-								NewValue: "myvalue",
+								Action:   "add_label",
+								NewLabel: "my_label",
+								NewValue: "my_value",
 							},
 						},
+					},
+					{
+						MetricIncludeFilter: FilterConfig{
+							Include:   "name2",
+							MatchType: "",
+						},
+						Action: "update",
+						Operations: []Operation{
+							{
+								Action:   "update_label",
+								Label:    "label",
+								NewLabel: "new_label_key",
+								ValueActions: []ValueAction{
+									{Value: "label1", NewValue: "new_label1"},
+								},
+							},
+							{
+								Action:          "aggregate_labels",
+								LabelSet:        []string{"new_label1", "label2"},
+								AggregationType: "sum",
+							},
+							{
+								Action:           "aggregate_label_values",
+								Label:            "new_label1",
+								AggregationType:  "sum",
+								AggregatedValues: []string{"value1", "value2"},
+								NewValue:         "new_value",
+							},
+						},
+					},
+					{
+						MetricIncludeFilter: FilterConfig{
+							Include:   "name3",
+							MatchType: "strict",
+						},
+						Action: "update",
+						Operations: []Operation{
+							{
+								Action:     "delete_label_value",
+								Label:      "my_label",
+								LabelValue: "delete_me",
+							},
+						},
+					},
+					{
+						MetricIncludeFilter: FilterConfig{
+							Include:   "^regexp (?P<my_label>.*)$",
+							MatchType: "regexp",
+						},
+						Action:  "combine",
+						NewName: "combined_metric_name",
 					},
 				},
 			},
@@ -127,10 +147,7 @@ var (
 			},
 		},
 	}
-)
 
-// TestLoadingFullConfig tests loading testdata/config_full.yaml.
-func TestLoadingFullConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.filterName, func(t *testing.T) {
 

--- a/processor/metricstransformprocessor/datapoint_aggregation.go
+++ b/processor/metricstransformprocessor/datapoint_aggregation.go
@@ -49,6 +49,15 @@ func (mtp *metricsTransformProcessor) mergeTimeseries(groupedTimeseries map[stri
 	return newTimeSeriesList
 }
 
+// sortTimeseries performs an in place sort of a list of timeseries by start timestamp
+// Returns the sorted timeseries
+func (mtp *metricsTransformProcessor) sortTimeseries(timeseries []*metricspb.TimeSeries) []*metricspb.TimeSeries {
+	sort.Slice(timeseries, func(i, j int) bool {
+		return mtp.compareTimestamps(timeseries[i].StartTimestamp, timeseries[j].StartTimestamp)
+	})
+	return timeseries
+}
+
 // groupPointsByTimestamp groups points by timestamp
 // Returns a map of grouped points and the minimum start timestamp
 func (mtp *metricsTransformProcessor) groupPointsByTimestamp(timeseries []*metricspb.TimeSeries) (map[int64][]*metricspb.Point, *timestamppb.Timestamp) {

--- a/processor/metricstransformprocessor/datapoint_aggregation.go
+++ b/processor/metricstransformprocessor/datapoint_aggregation.go
@@ -51,11 +51,10 @@ func (mtp *metricsTransformProcessor) mergeTimeseries(groupedTimeseries map[stri
 
 // sortTimeseries performs an in place sort of a list of timeseries by start timestamp
 // Returns the sorted timeseries
-func (mtp *metricsTransformProcessor) sortTimeseries(timeseries []*metricspb.TimeSeries) []*metricspb.TimeSeries {
+func (mtp *metricsTransformProcessor) sortTimeseries(timeseries []*metricspb.TimeSeries) {
 	sort.Slice(timeseries, func(i, j int) bool {
 		return mtp.compareTimestamps(timeseries[i].StartTimestamp, timeseries[j].StartTimestamp)
 	})
-	return timeseries
 }
 
 // groupPointsByTimestamp groups points by timestamp

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -82,18 +82,8 @@ func validateConfiguration(config *Config) error {
 			return fmt.Errorf("cannot supply both %q and %q, use %q with %q match type", IncludeFieldName, MetricNameFieldName, IncludeFieldName, StrictMatchType)
 		}
 
-		if transform.MetricIncludeFilter.MatchType != "" {
-			var validMatchType bool
-			for _, matchType := range MatchTypes {
-				if transform.MetricIncludeFilter.MatchType == matchType {
-					validMatchType = true
-					break
-				}
-			}
-
-			if !validMatchType {
-				return fmt.Errorf("%q must be in %q", MatchTypeFieldName, MatchTypes)
-			}
+		if transform.MetricIncludeFilter.MatchType != "" && !transform.MetricIncludeFilter.MatchType.isValid() {
+			return fmt.Errorf("%q must be in %q", MatchTypeFieldName, MatchTypes)
 		}
 
 		if transform.MetricIncludeFilter.MatchType == RegexpMatchType {
@@ -103,15 +93,7 @@ func validateConfiguration(config *Config) error {
 			}
 		}
 
-		var validAction bool
-		for _, action := range Actions {
-			if transform.Action == action {
-				validAction = true
-				break
-			}
-		}
-
-		if !validAction {
+		if !transform.Action.isValid() {
 			return fmt.Errorf("%q must be in %q", ActionFieldName, Actions)
 		}
 
@@ -119,15 +101,27 @@ func validateConfiguration(config *Config) error {
 			return fmt.Errorf("missing required field %q while %q is %v", NewNameFieldName, ActionFieldName, Insert)
 		}
 
+		if transform.AggregationType != "" && !transform.AggregationType.isValid() {
+			return fmt.Errorf("%q must be in %q", AggregationTypeFieldName, AggregationTypes)
+		}
+
 		for i, op := range transform.Operations {
+			if !op.Action.isValid() {
+				return fmt.Errorf("operation %v: %q must be in %q", i+1, ActionFieldName, OperationActions)
+			}
+
 			if op.Action == UpdateLabel && op.Label == "" {
-				return fmt.Errorf("missing required field %q while %q is %v in the %vth operation", LabelFieldName, ActionFieldName, UpdateLabel, i)
+				return fmt.Errorf("operation %v: missing required field %q while %q is %v", i+1, LabelFieldName, ActionFieldName, UpdateLabel)
 			}
 			if op.Action == AddLabel && op.NewLabel == "" {
-				return fmt.Errorf("missing required field %q while %q is %v in the %vth operation", NewLabelFieldName, ActionFieldName, AddLabel, i)
+				return fmt.Errorf("operation %v: missing required field %q while %q is %v", i+1, NewLabelFieldName, ActionFieldName, AddLabel)
 			}
 			if op.Action == AddLabel && op.NewValue == "" {
-				return fmt.Errorf("missing required field %q while %q is %v in the %vth operation", NewValueFieldName, ActionFieldName, AddLabel, i)
+				return fmt.Errorf("operation %v: missing required field %q while %q is %v", i+1, NewValueFieldName, ActionFieldName, AddLabel)
+			}
+
+			if op.AggregationType != "" && !op.AggregationType.isValid() {
+				return fmt.Errorf("operation %v: %q must be in %q", i+1, AggregationTypeFieldName, AggregationTypes)
 			}
 		}
 	}

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -103,8 +103,16 @@ func validateConfiguration(config *Config) error {
 			}
 		}
 
-		if transform.Action != Update && transform.Action != Insert {
-			return fmt.Errorf("unsupported %q: %v, the supported actions are %q and %q", ActionFieldName, transform.Action, Insert, Update)
+		var validAction bool
+		for _, action := range Actions {
+			if transform.Action == action {
+				validAction = true
+				break
+			}
+		}
+
+		if !validAction {
+			return fmt.Errorf("%q must be in %q", ActionFieldName, Actions)
 		}
 
 		if transform.Action == Insert && transform.NewName == "" {
@@ -144,6 +152,7 @@ func buildHelperConfig(config *Config, version string) []internalTransform {
 			MetricIncludeFilter: createFilter(t.MetricIncludeFilter),
 			Action:              t.Action,
 			NewName:             t.NewName,
+			AggregationType:     t.AggregationType,
 			Operations:          make([]internalOperation, len(t.Operations)),
 		}
 

--- a/processor/metricstransformprocessor/factory_test.go
+++ b/processor/metricstransformprocessor/factory_test.go
@@ -87,12 +87,27 @@ func TestCreateProcessors(t *testing.T) {
 		{
 			configName:   "config_invalid_label.yaml",
 			succeed:      false,
-			errorMessage: fmt.Sprintf("missing required field %q while %q is %v in the %vth operation", LabelFieldName, ActionFieldName, UpdateLabel, 0),
+			errorMessage: fmt.Sprintf("operation %v: missing required field %q while %q is %v", 1, LabelFieldName, ActionFieldName, UpdateLabel),
 		},
 		{
 			configName:   "config_invalid_regexp.yaml",
 			succeed:      false,
 			errorMessage: fmt.Sprintf("%q, error parsing regexp: missing closing ]: `[\\da`", IncludeFieldName),
+		},
+		{
+			configName:   "config_invalid_aggregationtype.yaml",
+			succeed:      false,
+			errorMessage: fmt.Sprintf("%q must be in %q", AggregationTypeFieldName, AggregationTypes),
+		},
+		{
+			configName:   "config_invalid_operation_action.yaml",
+			succeed:      false,
+			errorMessage: fmt.Sprintf("operation %v: %q must be in %q", 1, ActionFieldName, OperationActions),
+		},
+		{
+			configName:   "config_invalid_operation_aggregationtype.yaml",
+			succeed:      false,
+			errorMessage: fmt.Sprintf("operation %v: %q must be in %q", 1, AggregationTypeFieldName, AggregationTypes),
 		},
 	}
 
@@ -148,7 +163,7 @@ func TestFactory_validateConfiguration(t *testing.T) {
 		},
 	}
 	err := validateConfiguration(&v1)
-	assert.Equal(t, "missing required field \"new_label\" while \"action\" is add_label in the 0th operation", err.Error())
+	assert.Equal(t, "operation 1: missing required field \"new_label\" while \"action\" is add_label", err.Error())
 
 	v2 := Config{
 		Transforms: []Transform{
@@ -166,7 +181,7 @@ func TestFactory_validateConfiguration(t *testing.T) {
 	}
 
 	err = validateConfiguration(&v2)
-	assert.Equal(t, "missing required field \"new_value\" while \"action\" is add_label in the 0th operation", err.Error())
+	assert.Equal(t, "operation 1: missing required field \"new_value\" while \"action\" is add_label", err.Error())
 }
 
 func TestCreateProcessorsFilledData(t *testing.T) {

--- a/processor/metricstransformprocessor/factory_test.go
+++ b/processor/metricstransformprocessor/factory_test.go
@@ -67,7 +67,7 @@ func TestCreateProcessors(t *testing.T) {
 		{
 			configName:   "config_invalid_action.yaml",
 			succeed:      false,
-			errorMessage: fmt.Sprintf("unsupported %q: %v, the supported actions are %q and %q", ActionFieldName, "invalid", Insert, Update),
+			errorMessage: fmt.Sprintf("%q must be in %q", ActionFieldName, Actions),
 		},
 		{
 			configName:   "config_invalid_include.yaml",

--- a/processor/metricstransformprocessor/metrics_testcase_builder_test.go
+++ b/processor/metricstransformprocessor/metrics_testcase_builder_test.go
@@ -81,6 +81,12 @@ func (b builder) setDataType(dataType metricspb.MetricDescriptor_Type) builder {
 	return b
 }
 
+// setUnit sets the unit of this metric
+func (b builder) setUnit(unit string) builder {
+	b.metric.MetricDescriptor.Unit = unit
+	return b
+}
+
 // addInt64Point adds a int64 point to the tidx-th timseries
 func (b builder) addInt64Point(tidx int, val int64, timestampVal int64) builder {
 	point := &metricspb.Point{

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -254,7 +254,9 @@ func (mtp *metricsTransformProcessor) combine(matchedMetrics []*match, transform
 
 	groupedTimeseries := mtp.groupTimeseries(allTimeseries, len(combinedMetric.MetricDescriptor.LabelKeys))
 	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, transform.AggregationType, combinedMetric.MetricDescriptor.Type)
-	combinedMetric.Timeseries = mtp.sortTimeseries(aggregatedTimeseries)
+
+	mtp.sortTimeseries(aggregatedTimeseries)
+	combinedMetric.Timeseries = aggregatedTimeseries
 
 	return combinedMetric
 }

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -16,7 +16,9 @@ package metricstransformprocessor
 
 import (
 	"context"
+	"fmt"
 	"regexp"
+	"strconv"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
@@ -39,6 +41,7 @@ type internalTransform struct {
 	MetricIncludeFilter internalFilter
 	Action              ConfigAction
 	NewName             string
+	AggregationType     AggregationType
 	Operations          []internalOperation
 }
 
@@ -51,6 +54,7 @@ type internalOperation struct {
 
 type internalFilter interface {
 	getMatches(toMatch metricNameMapping) []*match
+	getSubexpNames() []string
 }
 
 type match struct {
@@ -75,6 +79,10 @@ func (f internalFilterStrict) getMatches(toMatch metricNameMapping) []*match {
 	return nil
 }
 
+func (f internalFilterStrict) getSubexpNames() []string {
+	return nil
+}
+
 type internalFilterRegexp struct {
 	include *regexp.Regexp
 }
@@ -89,6 +97,10 @@ func (f internalFilterRegexp) getMatches(toMatch metricNameMapping) []*match {
 		}
 	}
 	return matches
+}
+
+func (f internalFilterRegexp) getSubexpNames() []string {
+	return f.include.SubexpNames()
 }
 
 type metricNameMapping map[string][]*metricspb.Metric
@@ -134,6 +146,20 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 		for _, transform := range mtp.transforms {
 			matchedMetrics := transform.MetricIncludeFilter.getMatches(nameToMetricMapping)
 
+			if transform.Action == Combine && len(matchedMetrics) > 0 {
+				if err := mtp.canBeCombined(matchedMetrics); err != nil {
+					// TODO: report via trace / metric instead
+					mtp.logger.Warn(err.Error())
+					continue
+				}
+
+				combined := mtp.combine(matchedMetrics, transform)
+				data.Metrics = mtp.removeMatchedMetricsAndAppendCombined(data.Metrics, matchedMetrics, combined)
+
+				// set matchedMetrics to the combined metric so that any additional operations are performed on the combined metric
+				matchedMetrics = []*match{{metric: combined}}
+			}
+
 			for _, match := range matchedMetrics {
 				metricName := match.metric.MetricDescriptor.Name
 
@@ -155,6 +181,101 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 	}
 
 	return internaldata.OCSliceToMetrics(mds), nil
+}
+
+// canBeCombined returns true if all the provided metrics share the same type, unit, and labels
+func (mtp *metricsTransformProcessor) canBeCombined(matchedMetrics []*match) error {
+	if len(matchedMetrics) <= 1 {
+		return nil
+	}
+
+	firstMetricDescriptor := matchedMetrics[0].metric.MetricDescriptor
+	firstMetricLabelKeys := make(map[string]struct{}, len(firstMetricDescriptor.LabelKeys))
+	for _, label := range firstMetricDescriptor.LabelKeys {
+		firstMetricLabelKeys[label.Key] = struct{}{}
+	}
+
+	for i := 1; i < len(matchedMetrics); i++ {
+		metric := matchedMetrics[i].metric
+		if metric.MetricDescriptor.Type != firstMetricDescriptor.Type {
+			return fmt.Errorf("metrics cannot be combined as they are of different types: %v (%v) and %v (%v)", firstMetricDescriptor.Name, firstMetricDescriptor.Type, metric.MetricDescriptor.Name, metric.MetricDescriptor.Type)
+		}
+		if metric.MetricDescriptor.Unit != firstMetricDescriptor.Unit {
+			return fmt.Errorf("metrics cannot be combined as they have different units: %v (%v) and %v (%v)", firstMetricDescriptor.Name, firstMetricDescriptor.Unit, metric.MetricDescriptor.Name, metric.MetricDescriptor.Unit)
+		}
+
+		if len(metric.MetricDescriptor.LabelKeys) != len(firstMetricLabelKeys) {
+			return fmt.Errorf("metrics cannot be combined as they have different labels: %v (%v) and %v (%v)", firstMetricDescriptor.Name, firstMetricDescriptor.LabelKeys, metric.MetricDescriptor.Name, metric.MetricDescriptor.LabelKeys)
+		}
+
+		for _, label := range metric.MetricDescriptor.LabelKeys {
+			if _, ok := firstMetricLabelKeys[label.Key]; !ok {
+				return fmt.Errorf("metrics cannot be combined as they have different labels: %v (%v) and %v (%v)", firstMetricDescriptor.Name, firstMetricDescriptor.LabelKeys, metric.MetricDescriptor.Name, metric.MetricDescriptor.LabelKeys)
+			}
+		}
+	}
+
+	return nil
+}
+
+// combine combines the metrics based on the supplied filter.
+func (mtp *metricsTransformProcessor) combine(matchedMetrics []*match, transform internalTransform) *metricspb.Metric {
+	// create combined metric with relevant name & descriptor
+	combinedMetric := &metricspb.Metric{}
+	combinedMetric.MetricDescriptor = proto.Clone(matchedMetrics[0].metric.MetricDescriptor).(*metricspb.MetricDescriptor)
+	combinedMetric.MetricDescriptor.Name = transform.NewName
+	combinedMetric.MetricDescriptor.Description = ""
+
+	// append label keys based on the transform filter's named capturing groups
+	subexprNames := transform.MetricIncludeFilter.getSubexpNames()
+	for i := 1; i < len(subexprNames); i++ {
+		// if the subexpression is not named, use regexp notation, e.g. $1
+		name := subexprNames[i]
+		if name == "" {
+			name = "$" + strconv.Itoa(i)
+		}
+
+		combinedMetric.MetricDescriptor.LabelKeys = append(combinedMetric.MetricDescriptor.LabelKeys, &metricspb.LabelKey{Key: name})
+	}
+
+	// combine timeseries from all metrics, using the specified AggregationType if data points need to be merged
+	var allTimeseries []*metricspb.TimeSeries
+	for _, match := range matchedMetrics {
+		for _, ts := range match.metric.Timeseries {
+			// append label values based on regex submatches
+			for i := 1; i < len(match.submatches)/2; i++ {
+				submatch := match.metric.MetricDescriptor.Name[match.submatches[2*i]:match.submatches[2*i+1]]
+				ts.LabelValues = append(ts.LabelValues, &metricspb.LabelValue{Value: submatch, HasValue: (submatch != "")})
+			}
+
+			allTimeseries = append(allTimeseries, match.metric.Timeseries...)
+		}
+	}
+
+	groupedTimeseries := mtp.groupTimeseries(allTimeseries, len(combinedMetric.MetricDescriptor.LabelKeys))
+	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, transform.AggregationType, combinedMetric.MetricDescriptor.Type)
+	combinedMetric.Timeseries = mtp.sortTimeseries(aggregatedTimeseries)
+
+	return combinedMetric
+}
+
+// removeMatchedMetricsAndAppendCombined removes the set of matched metrics from metrics and appends the combined metric at the end.
+func (mtp *metricsTransformProcessor) removeMatchedMetricsAndAppendCombined(metrics []*metricspb.Metric, matchedMetrics []*match, combined *metricspb.Metric) []*metricspb.Metric {
+	filteredMetrics := make([]*metricspb.Metric, 0, len(metrics)-len(matchedMetrics))
+	for _, metric := range metrics {
+		var matched bool
+		for _, match := range matchedMetrics {
+			if match.metric == metric {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			filteredMetrics = append(filteredMetrics, metric)
+		}
+	}
+
+	return append(filteredMetrics, combined)
 }
 
 // update updates the metric content based on operations indicated in transform.

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -851,6 +851,371 @@ var (
 					build(),
 			},
 		},
+		// COMBINE
+		{
+			name: "combine",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^(metric)(?P<namedsubmatch>[12])$")},
+					Action:              Combine,
+					NewName:             "new",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(2, nil).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+				metricBuilder().setName("new").
+					setLabels([]string{"$1", "namedsubmatch"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"metric", "1"}).addInt64Point(0, 1, 1).
+					addTimeseries(2, []string{"metric", "2"}).addInt64Point(1, 2, 1).
+					build(),
+			},
+		},
+		{
+			name: "combine_no_matches",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^X(metric)(?P<namedsubmatch>[12])$")},
+					Action:              Combine,
+					NewName:             "new",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(2, nil).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(2, nil).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+		},
+		{
+			name: "combine_single_match",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^(metric)(?P<namedsubmatch>[1])$")},
+					Action:              Combine,
+					NewName:             "new",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(2, nil).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(2, nil).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+				metricBuilder().setName("new").
+					setLabels([]string{"$1", "namedsubmatch"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"metric", "1"}).addInt64Point(0, 1, 1).
+					build(),
+			},
+		},
+		{
+			name: "combine_aggregate",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+					Action:              Combine,
+					NewName:             "new",
+					AggregationType:     Sum,
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+				metricBuilder().setName("new").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+		},
+		{
+			name: "combine_with_operations",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^(metric)(?P<namedsubmatch>[12])$")},
+					Action:              Combine,
+					NewName:             "new",
+					Operations: []internalOperation{
+						{
+							configOperation: Operation{
+								Action:   AddLabel,
+								NewLabel: "new_label",
+								NewValue: "new_label_value",
+							},
+						},
+						{
+							configOperation: Operation{
+								Action:          AggregateLabels,
+								AggregationType: Sum,
+								LabelSet:        []string{"$1", "new_label"},
+							},
+							labelSetMap: map[string]bool{"$1": true, "new_label": true},
+						},
+					},
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+				metricBuilder().setName("new").
+					setLabels([]string{"$1", "new_label"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"metric", "new_label_value"}).addInt64Point(0, 3, 1).
+					build(),
+			},
+		},
+		{
+			name: "combine_error_type",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+					Action:              Combine,
+					NewName:             "new",
+					AggregationType:     Sum,
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
+					addTimeseries(1, nil).addDoublePoint(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
+					addTimeseries(1, nil).addDoublePoint(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+		},
+		{
+			name: "combine_error_units",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+					Action:              Combine,
+					NewName:             "new",
+					AggregationType:     Sum,
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).setUnit("ms").
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).setUnit("s").
+					addTimeseries(1, nil).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).setUnit("ms").
+					addTimeseries(1, nil).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).setUnit("s").
+					addTimeseries(1, nil).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+		},
+		{
+			name: "combine_error_labels1",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+					Action:              Combine,
+					NewName:             "new",
+					AggregationType:     Sum,
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"a", "b"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"1", "2"}).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setLabels([]string{"a", "b", "c"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"1", "2", "3"}).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"a", "b"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"1", "2"}).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setLabels([]string{"a", "b", "c"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"1", "2", "3"}).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+		},
+		{
+			name: "combine_error_labels2",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+					Action:              Combine,
+					NewName:             "new",
+					AggregationType:     Sum,
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"a", "b"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"1", "2"}).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setLabels([]string{"a", "c"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"1", "3"}).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"a", "b"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"1", "2"}).addInt64Point(0, 1, 1).
+					build(),
+				metricBuilder().setName("metric2").
+					setLabels([]string{"a", "c"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"1", "3"}).addInt64Point(0, 2, 1).
+					build(),
+				metricBuilder().setName("metric3").
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(3, nil).addInt64Point(0, 3, 1).
+					build(),
+			},
+		},
 		// Toggle Data Type
 		{
 			name: "metric_toggle_scalar_data_type_int64_to_double",

--- a/processor/metricstransformprocessor/operation_aggregate_label_values.go
+++ b/processor/metricstransformprocessor/operation_aggregate_label_values.go
@@ -16,7 +16,6 @@ package metricstransformprocessor
 
 import (
 	"fmt"
-	"sort"
 	"strconv"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
@@ -24,7 +23,6 @@ import (
 
 // aggregateLabelValuesOp aggregates points that have the label values specified in aggregated_values
 func (mtp *metricsTransformProcessor) aggregateLabelValuesOp(metric *metricspb.Metric, mtpOp internalOperation) {
-	op := mtpOp.configOperation
 	var operationLabelIdx int
 	for idx, label := range metric.MetricDescriptor.LabelKeys {
 		if label.Key == mtpOp.configOperation.Label {
@@ -32,13 +30,12 @@ func (mtp *metricsTransformProcessor) aggregateLabelValuesOp(metric *metricspb.M
 			break
 		}
 	}
-	groupedTimeseries, unchangedTimeseries := mtp.groupTimeseriesByNewLabelValue(metric, operationLabelIdx, op.NewValue, mtpOp.aggregatedValuesSet)
-	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, op.AggregationType, metric.MetricDescriptor.Type)
+
+	groupedTimeseries, unchangedTimeseries := mtp.groupTimeseriesByNewLabelValue(metric, operationLabelIdx, mtpOp.configOperation.NewValue, mtpOp.aggregatedValuesSet)
+	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, mtpOp.configOperation.AggregationType, metric.MetricDescriptor.Type)
 	aggregatedTimeseries = append(aggregatedTimeseries, unchangedTimeseries...)
-	sort.Slice(aggregatedTimeseries, func(i, j int) bool {
-		return mtp.compareTimestamps(aggregatedTimeseries[i].StartTimestamp, aggregatedTimeseries[j].StartTimestamp)
-	})
-	metric.Timeseries = aggregatedTimeseries
+
+	metric.Timeseries = mtp.sortTimeseries(aggregatedTimeseries)
 }
 
 // groupTimeseriesByNewLabelValue groups all timeseries in the metric that will be aggregated together based on the entire label values after replacing the aggregatedValues by newValue.

--- a/processor/metricstransformprocessor/operation_aggregate_label_values.go
+++ b/processor/metricstransformprocessor/operation_aggregate_label_values.go
@@ -35,7 +35,8 @@ func (mtp *metricsTransformProcessor) aggregateLabelValuesOp(metric *metricspb.M
 	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, mtpOp.configOperation.AggregationType, metric.MetricDescriptor.Type)
 	aggregatedTimeseries = append(aggregatedTimeseries, unchangedTimeseries...)
 
-	metric.Timeseries = mtp.sortTimeseries(aggregatedTimeseries)
+	mtp.sortTimeseries(aggregatedTimeseries)
+	metric.Timeseries = aggregatedTimeseries
 }
 
 // groupTimeseriesByNewLabelValue groups all timeseries in the metric that will be aggregated together based on the entire label values after replacing the aggregatedValues by newValue.

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -16,7 +16,6 @@ package metricstransformprocessor
 
 import (
 	"fmt"
-	"sort"
 	"strconv"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
@@ -24,25 +23,30 @@ import (
 
 // aggregateLabelsOp aggregates points that have the labels excluded in label_set
 func (mtp *metricsTransformProcessor) aggregateLabelsOp(metric *metricspb.Metric, mtpOp internalOperation) {
-	op := mtpOp.configOperation
-	labelSet := mtpOp.labelSetMap
-	labelIdxs, labels := mtp.getLabelIdxs(metric, labelSet)
-	groupedTimeseries := mtp.groupTimeseriesByLabelSet(metric, labelIdxs)
+	labelIdxs, labels := mtp.getLabelIdxs(metric, mtpOp.labelSetMap)
+	groupedTimeseries := mtp.groupTimeseriesByLabelSet(metric.Timeseries, labelIdxs)
+	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, mtpOp.configOperation.AggregationType, metric.MetricDescriptor.Type)
 
-	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, op.AggregationType, metric.MetricDescriptor.Type)
-	sort.Slice(aggregatedTimeseries, func(i, j int) bool {
-		return mtp.compareTimestamps(aggregatedTimeseries[i].StartTimestamp, aggregatedTimeseries[j].StartTimestamp)
-	})
-	metric.Timeseries = aggregatedTimeseries
 	metric.MetricDescriptor.LabelKeys = labels
+	metric.Timeseries = mtp.sortTimeseries(aggregatedTimeseries)
 }
 
-// groupTimeseriesByLabelSet groups all timeseries in the metric that will be aggregated together based on the selected labels' values indicated by labelIdxs.
+// groupTimeseries groups all the provided timeseries that will be aggregated together based on all the label values.
 // Returns a map of grouped timeseries and the corresponding selected labels
-func (mtp *metricsTransformProcessor) groupTimeseriesByLabelSet(metric *metricspb.Metric, labelIdxs []int) map[string]*timeseriesAndLabelValues {
+func (mtp *metricsTransformProcessor) groupTimeseries(timeseries []*metricspb.TimeSeries, labelCount int) map[string]*timeseriesAndLabelValues {
+	labelIdxs := make([]int, labelCount)
+	for i := 0; i < labelCount; i++ {
+		labelIdxs[i] = i
+	}
+	return mtp.groupTimeseriesByLabelSet(timeseries, labelIdxs)
+}
+
+// groupTimeseriesByLabelSet groups all the provided timeseries that will be aggregated together based on the selected label values as indicated by labelIdxs.
+// Returns a map of grouped timeseries and the corresponding selected labels
+func (mtp *metricsTransformProcessor) groupTimeseriesByLabelSet(timeseries []*metricspb.TimeSeries, labelIdxs []int) map[string]*timeseriesAndLabelValues {
 	// key is a composite of the label values as a single string
 	groupedTimeseries := make(map[string]*timeseriesAndLabelValues)
-	for _, timeseries := range metric.Timeseries {
+	for _, timeseries := range timeseries {
 		key, newLabelValues := mtp.selectedLabelsAsKey(labelIdxs, timeseries)
 		if timeseries.StartTimestamp != nil {
 			key += strconv.FormatInt(timeseries.StartTimestamp.Seconds, 10)

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -28,7 +28,9 @@ func (mtp *metricsTransformProcessor) aggregateLabelsOp(metric *metricspb.Metric
 	aggregatedTimeseries := mtp.mergeTimeseries(groupedTimeseries, mtpOp.configOperation.AggregationType, metric.MetricDescriptor.Type)
 
 	metric.MetricDescriptor.LabelKeys = labels
-	metric.Timeseries = mtp.sortTimeseries(aggregatedTimeseries)
+
+	mtp.sortTimeseries(aggregatedTimeseries)
+	metric.Timeseries = aggregatedTimeseries
 }
 
 // groupTimeseries groups all the provided timeseries that will be aggregated together based on all the label values.

--- a/processor/metricstransformprocessor/testdata/config_full.yaml
+++ b/processor/metricstransformprocessor/testdata/config_full.yaml
@@ -1,47 +1,65 @@
 receivers:
-    examplereceiver:
+  examplereceiver:
 
 processors:
-    metricstransform:
-        transforms:
-            - include: old_name
-              action: update
-              new_name: new_name
-              operations:
-                - action: update_label
-                  label: label
-                  new_label: new_label
-                  value_actions:
-                    - value: current_label_value
-                      new_value: new_label_value
-                - action: aggregate_labels
-                  label_set: [label1, label2]
-                  aggregation_type: sum
-                - action: aggregate_label_values
-                  label: label
-                  aggregated_values: [value1,  value2]
-                  new_value: new_value
-                  aggregation_type: sum
-    metricstransform/addlabel:
-      transforms:
-        - include: some_name
-          match_type: regexp
-          action: update
-          operations:
-            - action: add_label
-              new_label: mylabel
-              new_value: myvalue
+  metricstransform:
+    transforms:
+      - include: name
+        action: update
+        new_name: new_name
+
+  metricstransform/multiple:
+    transforms:
+      - include: name1
+        match_type: strict
+        action: insert
+        new_name: new_name
+        operations:
+          - action: add_label
+            new_label: my_label
+            new_value: my_value
+
+      - include: name2
+        action: update
+        operations:
+          - action: update_label
+            label: label
+            new_label: new_label_key
+            value_actions:
+              - value: label1
+                new_value: new_label1
+          - action: aggregate_labels
+            label_set: [new_label1, label2]
+            aggregation_type: sum
+          - action: aggregate_label_values
+            label: new_label1
+            aggregated_values: [value1, value2]
+            new_value: new_value
+            aggregation_type: sum
+
+      - include: name3
+        match_type: strict
+        action: update
+        operations:
+          - action: delete_label_value
+            label: my_label
+            label_value: delete_me
+
+      - include: ^regexp (?P<my_label>.*)$
+        match_type: regexp
+        action: combine
+        new_name: combined_metric_name
 
 exporters:
-    exampleexporter:
+  exampleexporter:
 
 service:
-    pipelines:
-        traces:
-            receivers: [examplereceiver]
-            processors: [metricstransform]
-            exporters: [exampleexporter]
-        metrics:
-            receivers: [examplereceiver]
-            processors: [metricstransform]
-            exporters: [exampleexporter]
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [metricstransform]
+      exporters: [exampleexporter]
+    metrics:
+      receivers: [examplereceiver]
+      processors: [metricstransform]
+      exporters: [exampleexporter]

--- a/processor/metricstransformprocessor/testdata/config_invalid_aggregationtype.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_aggregationtype.yaml
@@ -1,0 +1,24 @@
+receivers:
+    examplereceiver:
+
+processors:
+    metricstransform:
+        transforms:
+          - include: old_name
+            action: combine
+            new_name: new_name
+            aggregation_type: invalid
+
+exporters:
+    exampleexporter:
+
+service:
+    pipelines:
+        traces:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]
+        metrics:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]

--- a/processor/metricstransformprocessor/testdata/config_invalid_operation_action.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_operation_action.yaml
@@ -1,0 +1,24 @@
+receivers:
+    examplereceiver:
+
+processors:
+    metricstransform:
+        transforms:
+          - include: old_name
+            action: update
+            operations:
+                - action: invalid
+
+exporters:
+    exampleexporter:
+
+service:
+    pipelines:
+        traces:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]
+        metrics:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]

--- a/processor/metricstransformprocessor/testdata/config_invalid_operation_aggregationtype.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_operation_aggregationtype.yaml
@@ -1,0 +1,25 @@
+receivers:
+    examplereceiver:
+
+processors:
+    metricstransform:
+        transforms:
+          - include: old_name
+            action: update
+            operations:
+              - action: aggregate_labels
+                aggregation_type: invalid
+
+exporters:
+    exampleexporter:
+
+service:
+    pipelines:
+        traces:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]
+        metrics:
+            receivers: [examplereceiver]
+            processors: [metricstransform]
+            exporters: [exampleexporter]


### PR DESCRIPTION
**Description:**

Add a "combine" action to the Metrics Transform processor:

- Validates that all metrics to be combined have the same type, unit, and labelset
- Re-uses the existing data point aggregation functions to merge data points from different metrics
- Automatically appends labels extracted from the regexp filter to data points

See README & added test cases for more details.

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1088