### PR TITLE
Filter only for the main tag the integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ workflows:
       - integration-tests:
           filters:
             tags:
-              only: /.*/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
       - build-package:
           name: deb-package
           package_type: deb


### PR DESCRIPTION
Right now when we add the release tags ~40 tags, they will trigger builds for all of them which are duplicated, and we want to trigger the build only for the main tag.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>