### PR TITLE
[corrected PR] Make buffered channel to avoid goroutines leak in groupbytraceprocessor

### DIFF
--- a/processor/groupbytraceprocessor/event.go
+++ b/processor/groupbytraceprocessor/event.go
@@ -208,6 +208,7 @@ func (em *eventMachine) shutdown() {
 	em.closed = true
 	em.shutdownLock.Unlock()
 
+	done := make(chan struct{})
 	// we never return an error here
 	ok, _ := doWithTimeout(em.shutdownTimeout, func() error {
 		for {
@@ -215,8 +216,16 @@ func (em *eventMachine) shutdown() {
 				return nil
 			}
 			time.Sleep(100 * time.Millisecond)
+
+			// Do not leak goroutine
+			select {
+			case <-done:
+				return nil
+			default:
+			}
 		}
 	})
+	close(done)
 
 	if !ok {
 		em.logger.Info("forcing the shutdown of the event manager", zap.Int("pending-events", len(em.events)))
@@ -254,7 +263,7 @@ func (em *eventMachine) handleEventWithObservability(event string, do func() err
 // doWithTimeout wraps a function in a timeout, returning whether it succeeded before timing out.
 // If the function returns an error within the timeout, it's considered as succeeded and the error will be returned back to the caller.
 func doWithTimeout(timeout time.Duration, do func() error) (bool, error) {
-	done := make(chan error)
+	done := make(chan error, 1)
 	go func() {
 		done <- do()
 	}()

--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -389,6 +389,9 @@ func TestForceShutdown(t *testing.T) {
 
 	// verify
 	assert.True(t, duration > 20*time.Millisecond)
+
+	// wait for shutdown goroutine to end
+	time.Sleep(100 * time.Millisecond)
 }
 
 func TestDoWithTimeout(t *testing.T) {
@@ -396,13 +399,15 @@ func TestDoWithTimeout(t *testing.T) {
 	start := time.Now()
 
 	// test
-	doWithTimeout(10*time.Millisecond, func() error {
-		time.Sleep(20 * time.Second)
+	done := make(chan struct{})
+	doWithTimeout(5*time.Millisecond, func() error {
+		<-done
 		return nil
 	})
+	close(done)
 
 	// verify
-	assert.WithinDuration(t, start, time.Now(), 20*time.Millisecond)
+	assert.WithinDuration(t, start, time.Now(), 10*time.Millisecond)
 }
 
 func assertGauge(t *testing.T, expected int, gauge *stats.Int64Measure) {


### PR DESCRIPTION
Signed-off-by: Pavel Kositsyn <kositsyn.pa@phystech.edu>

Fixed the problem with EasyCLA
See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1505 for details