### PR TITLE
Expose tail sampling processor metrics

### DIFF
--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -16,6 +16,7 @@ package tailsamplingprocessor
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"go.opencensus.io/stats/view"
@@ -31,10 +32,14 @@ const (
 	typeStr = "tail_sampling"
 )
 
+var onceMetrics sync.Once
+
 // NewFactory returns a new factory for the Tail Sampling processor.
 func NewFactory() component.ProcessorFactory {
-	// TODO: this is hardcoding the metrics level and skips error handling
-	_ = view.Register(SamplingProcessorMetricViews(configtelemetry.LevelNormal)...)
+	onceMetrics.Do(func() {
+		// TODO: this is hardcoding the metrics level and skips error handling
+		_ = view.Register(SamplingProcessorMetricViews(configtelemetry.LevelNormal)...)
+	})
 
 	return processorhelper.NewFactory(
 		typeStr,

--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"time"
 
+	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 )
@@ -31,6 +33,9 @@ const (
 
 // NewFactory returns a new factory for the Tail Sampling processor.
 func NewFactory() component.ProcessorFactory {
+	// TODO: this is hardcoding the metrics level and skips error handling
+	_ = view.Register(SamplingProcessorMetricViews(configtelemetry.LevelNormal)...)
+
 	return processorhelper.NewFactory(
 		typeStr,
 		createDefaultConfig,

--- a/processor/tailsamplingprocessor/metrics.go
+++ b/processor/tailsamplingprocessor/metrics.go
@@ -43,6 +43,11 @@ var (
 	statTracesOnMemoryGauge     = stats.Int64("sampling_traces_on_memory", "Tracks the number of traces current on memory", stats.UnitDimensionless)
 )
 
+func init() {
+	// TODO: this is hardcoding the metrics level and skips error handling
+	_ = view.Register(SamplingProcessorMetricViews(configtelemetry.LevelNormal)...)
+}
+
 // SamplingProcessorMetricViews return the metrics views according to given telemetry level.
 func SamplingProcessorMetricViews(level configtelemetry.Level) []*view.View {
 	if level == configtelemetry.LevelNone {

--- a/processor/tailsamplingprocessor/metrics.go
+++ b/processor/tailsamplingprocessor/metrics.go
@@ -43,11 +43,6 @@ var (
 	statTracesOnMemoryGauge     = stats.Int64("sampling_traces_on_memory", "Tracks the number of traces current on memory", stats.UnitDimensionless)
 )
 
-func init() {
-	// TODO: this is hardcoding the metrics level and skips error handling
-	_ = view.Register(SamplingProcessorMetricViews(configtelemetry.LevelNormal)...)
-}
-
 // SamplingProcessorMetricViews return the metrics views according to given telemetry level.
 func SamplingProcessorMetricViews(level configtelemetry.Level) []*view.View {
 	if level == configtelemetry.LevelNone {


### PR DESCRIPTION
**Description:** 

Tail sampling processor is not exposing metrics after moving to _-contrib_ repo. This fixes that
