### PR TITLE
Use OTLP Metrics type instead of OpenCensus type [aws-ecs-container-metrics-receiver]

### DIFF
--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/accumulator_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/accumulator_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 func TestGetMetricsData(t *testing.T) {
@@ -101,11 +101,12 @@ func TestGetMetricsData(t *testing.T) {
 	cstats := make(map[string]ContainerStats)
 	cstats["001"] = containerStats
 
-	var mds []*consumerdata.MetricsData
+	var md []pdata.Metrics
+
 	acc := metricDataAccumulator{
-		md: mds,
+		mds: md,
 	}
 
 	acc.getMetricsData(cstats, tm)
-	require.Less(t, 0, len(acc.md))
+	require.Less(t, 0, len(acc.mds))
 }

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/metrics.go
@@ -15,12 +15,13 @@
 package awsecscontainermetrics
 
 import (
-	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
-func MetricsData(containerStatsMap map[string]ContainerStats, metadata TaskMetadata) []*consumerdata.MetricsData {
+// MetricsData generates OTLP metrics from endpoint raw data
+func MetricsData(containerStatsMap map[string]ContainerStats, metadata TaskMetadata) []pdata.Metrics {
 	acc := &metricDataAccumulator{}
 	acc.getMetricsData(containerStatsMap, metadata)
 
-	return acc.md
+	return acc.mds
 }

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/resource.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/resource.go
@@ -22,32 +22,27 @@ import (
 )
 
 func containerResource(cm ContainerMetadata) pdata.Resource {
-	attributes := map[string]pdata.AttributeValue{}
+	resource := pdata.NewResource()
+	resource.InitEmpty()
 
-	attributes[conventions.AttributeContainerName] = pdata.NewAttributeValueString(cm.ContainerName)
-	attributes[conventions.AttributeContainerID] = pdata.NewAttributeValueString(cm.DockerID)
-	attributes[AttributeECSDockerName] = pdata.NewAttributeValueString(cm.DockerName)
+	resource.Attributes().UpsertString(conventions.AttributeContainerName, cm.ContainerName)
+	resource.Attributes().UpsertString(conventions.AttributeContainerID, cm.DockerID)
+	resource.Attributes().UpsertString(AttributeECSDockerName, cm.DockerName)
 
-	return createResourceWithAttributes(attributes)
+	return resource
 }
 
 func taskResource(tm TaskMetadata) pdata.Resource {
-	attributes := map[string]pdata.AttributeValue{}
-
-	attributes[AttributeECSCluster] = pdata.NewAttributeValueString(tm.Cluster)
-	attributes[AttributeECSTaskARN] = pdata.NewAttributeValueString(tm.TaskARN)
-	attributes[AttributeECSTaskID] = pdata.NewAttributeValueString(getTaskIDFromARN(tm.TaskARN))
-	attributes[AttributeECSTaskFamily] = pdata.NewAttributeValueString(tm.Family)
-	attributes[AttributeECSTaskRevesion] = pdata.NewAttributeValueString(tm.Revision)
-	attributes[AttributeECSServiceName] = pdata.NewAttributeValueString("undefined")
-
-	return createResourceWithAttributes(attributes)
-}
-
-func createResourceWithAttributes(attributes map[string]pdata.AttributeValue) pdata.Resource {
 	resource := pdata.NewResource()
 	resource.InitEmpty()
-	resource.Attributes().InitFromMap(attributes)
+
+	resource.Attributes().UpsertString(AttributeECSCluster, tm.Cluster)
+	resource.Attributes().UpsertString(AttributeECSTaskARN, tm.TaskARN)
+	resource.Attributes().UpsertString(AttributeECSTaskID, getTaskIDFromARN(tm.TaskARN))
+	resource.Attributes().UpsertString(AttributeECSTaskFamily, tm.Family)
+	resource.Attributes().UpsertString(AttributeECSTaskRevesion, tm.Revision)
+	resource.Attributes().UpsertString(AttributeECSServiceName, "undefined")
+
 	return resource
 }
 

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/translator.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/translator.go
@@ -15,108 +15,122 @@
 package awsecscontainermetrics
 
 import (
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"github.com/golang/protobuf/ptypes/timestamp"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
-func convertToOCMetrics(prefix string, m ECSMetrics, labelKeys []*metricspb.LabelKey, labelValues []*metricspb.LabelValue, timestamp *timestamp.Timestamp) []*metricspb.Metric {
+func convertToOTLPMetrics(prefix string, m ECSMetrics, r pdata.Resource, timestamp pdata.TimestampUnixNano) pdata.ResourceMetricsSlice {
+	rms := pdata.NewResourceMetricsSlice()
 
-	return applyTimestamp([]*metricspb.Metric{
-		intGauge(prefix+AttributeMemoryUsage, UnitBytes, &m.MemoryUsage, labelKeys, labelValues),
-		intGauge(prefix+AttributeMemoryMaxUsage, UnitBytes, &m.MemoryMaxUsage, labelKeys, labelValues),
-		intGauge(prefix+AttributeMemoryLimit, UnitBytes, &m.MemoryLimit, labelKeys, labelValues),
-		intGauge(prefix+AttributeMemoryUtilized, UnitMegaBytes, &m.MemoryUtilized, labelKeys, labelValues),
-		intGauge(prefix+AttributeMemoryReserved, UnitMegaBytes, &m.MemoryReserved, labelKeys, labelValues),
+	rms.Resize(1)
 
-		intCumulative(prefix+AttributeCPUTotalUsage, UnitNanoSecond, &m.CPUTotalUsage, labelKeys, labelValues),
-		intCumulative(prefix+AttributeCPUKernelModeUsage, UnitNanoSecond, &m.CPUUsageInKernelmode, labelKeys, labelValues),
-		intCumulative(prefix+AttributeCPUUserModeUsage, UnitNanoSecond, &m.CPUUsageInUserMode, labelKeys, labelValues),
-		intGauge(prefix+AttributeCPUCores, UnitCount, &m.NumOfCPUCores, labelKeys, labelValues),
-		intGauge(prefix+AttributeCPUOnlines, UnitCount, &m.CPUOnlineCpus, labelKeys, labelValues),
-		intCumulative(prefix+AttributeCPUSystemUsage, UnitNanoSecond, &m.SystemCPUUsage, labelKeys, labelValues),
-		doubleGauge(prefix+AttributeCPUUtilized, UnitPercent, &m.CPUUtilized, labelKeys, labelValues),
-		doubleGauge(prefix+AttributeCPUReserved, UnitVCpu, &m.CPUReserved, labelKeys, labelValues),
-		doubleGauge(prefix+AttributeCPUUsageInVCPU, UnitVCpu, &m.CPUUsageInVCPU, labelKeys, labelValues),
+	rm := rms.At(0)
+	rm.InitEmpty()
 
-		doubleGauge(prefix+AttributeNetworkRateRx, UnitBytesPerSec, &m.NetworkRateRxBytesPerSecond, labelKeys, labelValues),
-		doubleGauge(prefix+AttributeNetworkRateTx, UnitBytesPerSec, &m.NetworkRateTxBytesPerSecond, labelKeys, labelValues),
+	rm.Resource().InitEmpty()
+	r.CopyTo(rm.Resource())
 
-		intCumulative(prefix+AttributeNetworkRxBytes, UnitBytes, &m.NetworkRxBytes, labelKeys, labelValues),
-		intCumulative(prefix+AttributeNetworkRxPackets, UnitCount, &m.NetworkRxPackets, labelKeys, labelValues),
-		intCumulative(prefix+AttributeNetworkRxErrors, UnitCount, &m.NetworkRxErrors, labelKeys, labelValues),
-		intCumulative(prefix+AttributeNetworkRxDropped, UnitCount, &m.NetworkRxDropped, labelKeys, labelValues),
-		intCumulative(prefix+AttributeNetworkTxBytes, UnitBytes, &m.NetworkTxBytes, labelKeys, labelValues),
-		intCumulative(prefix+AttributeNetworkTxPackets, UnitCount, &m.NetworkTxPackets, labelKeys, labelValues),
-		intCumulative(prefix+AttributeNetworkTxErrors, UnitCount, &m.NetworkTxErrors, labelKeys, labelValues),
-		intCumulative(prefix+AttributeNetworkTxDropped, UnitCount, &m.NetworkTxDropped, labelKeys, labelValues),
+	ilms := rm.InstrumentationLibraryMetrics()
 
-		intCumulative(prefix+AttributeStorageRead, UnitBytes, &m.StorageReadBytes, labelKeys, labelValues),
-		intCumulative(prefix+AttributeStorageWrite, UnitBytes, &m.StorageWriteBytes, labelKeys, labelValues),
-	}, timestamp)
+	ilms.Append(intGauge(prefix+AttributeMemoryUsage, UnitBytes, int64(m.MemoryUsage), timestamp))
+	ilms.Append(intGauge(prefix+AttributeMemoryMaxUsage, UnitBytes, int64(m.MemoryMaxUsage), timestamp))
+	ilms.Append(intGauge(prefix+AttributeMemoryLimit, UnitBytes, int64(m.MemoryLimit), timestamp))
+	ilms.Append(intGauge(prefix+AttributeMemoryUtilized, UnitMegaBytes, int64(m.MemoryUtilized), timestamp))
+	ilms.Append(intGauge(prefix+AttributeMemoryReserved, UnitMegaBytes, int64(m.MemoryReserved), timestamp))
+
+	ilms.Append(intSum(prefix+AttributeCPUTotalUsage, UnitNanoSecond, int64(m.CPUTotalUsage), timestamp))
+	ilms.Append(intSum(prefix+AttributeCPUKernelModeUsage, UnitNanoSecond, int64(m.CPUUsageInKernelmode), timestamp))
+	ilms.Append(intSum(prefix+AttributeCPUUserModeUsage, UnitNanoSecond, int64(m.CPUUsageInUserMode), timestamp))
+	ilms.Append(intGauge(prefix+AttributeCPUCores, UnitCount, int64(m.NumOfCPUCores), timestamp))
+	ilms.Append(intGauge(prefix+AttributeCPUOnlines, UnitCount, int64(m.CPUOnlineCpus), timestamp))
+	ilms.Append(intSum(prefix+AttributeCPUSystemUsage, UnitNanoSecond, int64(m.SystemCPUUsage), timestamp))
+	ilms.Append(doubleGauge(prefix+AttributeCPUUtilized, UnitPercent, float64(m.CPUUtilized), timestamp))
+	ilms.Append(doubleGauge(prefix+AttributeCPUReserved, UnitVCpu, float64(m.CPUReserved), timestamp))
+	ilms.Append(doubleGauge(prefix+AttributeCPUUsageInVCPU, UnitVCpu, float64(m.CPUUsageInVCPU), timestamp))
+
+	ilms.Append(doubleGauge(prefix+AttributeNetworkRateRx, UnitBytesPerSec, float64(m.NetworkRateRxBytesPerSecond), timestamp))
+	ilms.Append(doubleGauge(prefix+AttributeNetworkRateTx, UnitBytesPerSec, float64(m.NetworkRateTxBytesPerSecond), timestamp))
+
+	ilms.Append(intSum(prefix+AttributeNetworkRxBytes, UnitBytes, int64(m.NetworkRxBytes), timestamp))
+	ilms.Append(intSum(prefix+AttributeNetworkRxPackets, UnitCount, int64(m.NetworkRxPackets), timestamp))
+	ilms.Append(intSum(prefix+AttributeNetworkRxErrors, UnitCount, int64(m.NetworkRxErrors), timestamp))
+	ilms.Append(intSum(prefix+AttributeNetworkRxDropped, UnitCount, int64(m.NetworkRxDropped), timestamp))
+	ilms.Append(intSum(prefix+AttributeNetworkTxBytes, UnitBytes, int64(m.NetworkTxBytes), timestamp))
+	ilms.Append(intSum(prefix+AttributeNetworkTxPackets, UnitCount, int64(m.NetworkTxPackets), timestamp))
+	ilms.Append(intSum(prefix+AttributeNetworkTxErrors, UnitCount, int64(m.NetworkTxErrors), timestamp))
+	ilms.Append(intSum(prefix+AttributeNetworkTxDropped, UnitCount, int64(m.NetworkTxDropped), timestamp))
+
+	ilms.Append(intSum(prefix+AttributeStorageRead, UnitBytes, int64(m.StorageReadBytes), timestamp))
+	ilms.Append(intSum(prefix+AttributeStorageWrite, UnitBytes, int64(m.StorageWriteBytes), timestamp))
+
+	return rms
 }
 
-func intGauge(metricName string, unit string, value *uint64, labelKeys []*metricspb.LabelKey, labelValues []*metricspb.LabelValue) *metricspb.Metric {
-	if value == nil {
-		return nil
-	}
-	return &metricspb.Metric{
-		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name:      metricName,
-			Unit:      unit,
-			Type:      metricspb.MetricDescriptor_GAUGE_INT64,
-			LabelKeys: labelKeys,
-		},
-		Timeseries: []*metricspb.TimeSeries{{
-			LabelValues: labelValues,
-			Points: []*metricspb.Point{{
-				Value: &metricspb.Point_Int64Value{
-					Int64Value: int64(*value),
-				},
-			}},
-		}},
-	}
+func intGauge(metricName string, unit string, value int64, ts pdata.TimestampUnixNano) pdata.InstrumentationLibraryMetrics {
+	ilm := pdata.NewInstrumentationLibraryMetrics()
+
+	metric := initMetric(ilm, metricName, unit)
+
+	metric.SetDataType(pdata.MetricDataTypeIntGauge)
+	intGauge := metric.IntGauge()
+	intGauge.InitEmpty()
+
+	updateIntDataPoint(intGauge.DataPoints(), value, ts)
+
+	return ilm
 }
 
-func doubleGauge(metricName string, unit string, value *float64, labelKeys []*metricspb.LabelKey, labelValues []*metricspb.LabelValue) *metricspb.Metric {
-	if value == nil {
-		return nil
-	}
-	return &metricspb.Metric{
-		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name:      metricName,
-			Unit:      unit,
-			Type:      metricspb.MetricDescriptor_GAUGE_DOUBLE,
-			LabelKeys: labelKeys,
-		},
-		Timeseries: []*metricspb.TimeSeries{{
-			LabelValues: labelValues,
-			Points: []*metricspb.Point{{
-				Value: &metricspb.Point_DoubleValue{
-					DoubleValue: *value,
-				},
-			}},
-		}},
-	}
+func intSum(metricName string, unit string, value int64, ts pdata.TimestampUnixNano) pdata.InstrumentationLibraryMetrics {
+	ilm := pdata.NewInstrumentationLibraryMetrics()
+
+	metric := initMetric(ilm, metricName, unit)
+
+	metric.SetDataType(pdata.MetricDataTypeIntSum)
+	intSum := metric.IntSum()
+	intSum.InitEmpty()
+	intSum.SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
+
+	updateIntDataPoint(intSum.DataPoints(), value, ts)
+
+	return ilm
 }
 
-func intCumulative(metricName string, unit string, value *uint64, labelKeys []*metricspb.LabelKey, labelValues []*metricspb.LabelValue) *metricspb.Metric {
-	if value == nil {
-		return nil
-	}
-	return &metricspb.Metric{
-		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name:      metricName,
-			Unit:      unit,
-			Type:      metricspb.MetricDescriptor_CUMULATIVE_INT64,
-			LabelKeys: labelKeys,
-		},
-		Timeseries: []*metricspb.TimeSeries{{
-			LabelValues: labelValues,
-			Points: []*metricspb.Point{{
-				Value: &metricspb.Point_Int64Value{
-					Int64Value: int64(*value),
-				},
-			}},
-		}},
-	}
+func doubleGauge(metricName string, unit string, value float64, ts pdata.TimestampUnixNano) pdata.InstrumentationLibraryMetrics {
+	ilm := pdata.NewInstrumentationLibraryMetrics()
+
+	metric := initMetric(ilm, metricName, unit)
+
+	metric.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	doubleGauge := metric.DoubleGauge()
+	doubleGauge.InitEmpty()
+	dataPoints := doubleGauge.DataPoints()
+	dataPoints.Resize(1)
+	dataPoint := dataPoints.At(0)
+
+	dataPoint.InitEmpty()
+	dataPoint.SetValue(value)
+	dataPoint.SetTimestamp(ts)
+
+	return ilm
+}
+
+func updateIntDataPoint(dataPoints pdata.IntDataPointSlice, value int64, ts pdata.TimestampUnixNano) {
+	dataPoints.Resize(1)
+	dataPoint := dataPoints.At(0)
+
+	dataPoint.InitEmpty()
+	dataPoint.SetValue(value)
+	dataPoint.SetTimestamp(ts)
+}
+
+func initMetric(ilm pdata.InstrumentationLibraryMetrics, name, unit string) pdata.Metric {
+	ilm.InitEmpty()
+
+	ilm.Metrics().Resize(1)
+	metric := ilm.Metrics().At(0)
+
+	metric.InitEmpty()
+	metric.SetName(name)
+	metric.SetUnit(unit)
+
+	return metric
 }

--- a/receiver/awsecscontainermetricsreceiver/factory_test.go
+++ b/receiver/awsecscontainermetricsreceiver/factory_test.go
@@ -35,6 +35,8 @@ func TestValidConfig(t *testing.T) {
 }
 
 func TestCreateMetricsReceiver(t *testing.T) {
+	os.Unsetenv(awsecscontainermetrics.EndpointEnvKey)
+
 	metricsReceiver, err := createMetricsReceiver(
 		context.Background(),
 		component.ReceiverCreateParams{Logger: zap.NewNop()},

--- a/receiver/awsecscontainermetricsreceiver/receiver.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/obsreport"
-	"go.opentelemetry.io/collector/translator/internaldata"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics"
@@ -97,8 +96,7 @@ func (aecmr *awsEcsContainerMetricsReceiver) collectDataFromEndpoint(ctx context
 	// TODO: report self metrics using obsreport
 	mds := awsecscontainermetrics.MetricsData(stats, metadata)
 	for _, md := range mds {
-		metrics := internaldata.OCToMetrics(*md)
-		err = aecmr.nextConsumer.ConsumeMetrics(ctx, metrics)
+		err = aecmr.nextConsumer.ConsumeMetrics(ctx, md)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description:** 
Use `pdata.Metrics` instead of OpenCensus metric types. 
This change replaces all the uses of OpenCensus metric types with OTLP metric type (`pdata.Metrics`) and updates the unit tests.

**Link to tracking Issue:** 
#1122 

**Testing:** 
Updated previous unit test.
Manually tested with `logging` exporter for e2e experience.