### PR TITLE
Change default behaviour of Windows perf counters receiver 1

### DIFF
--- a/receiver/windowsperfcountersreceiver/internal/pdh/pdh.go
+++ b/receiver/windowsperfcountersreceiver/internal/pdh/pdh.go
@@ -85,10 +85,19 @@ func (pc *PerfCounter) ScrapeData() ([]win_perf_counters.CounterValue, error) {
 }
 
 func removeTotalIfMultipleValues(vals []win_perf_counters.CounterValue) []win_perf_counters.CounterValue {
-	if len(vals) <= 1 {
+	if len(vals) == 0 {
 		return vals
 	}
 
+	if len(vals) == 1 {
+		// if there is only one item & the instance name is "_Total", clear the instance name
+		if vals[0].InstanceName == totalInstanceName {
+			vals[0].InstanceName = ""
+		}
+		return vals
+	}
+
+	// if there is more than one item, remove an item that has the instance name "_Total"
 	for i, val := range vals {
 		if val.InstanceName == totalInstanceName {
 			return removeItemAt(vals, i)

--- a/receiver/windowsperfcountersreceiver/internal/pdh/pdh_test.go
+++ b/receiver/windowsperfcountersreceiver/internal/pdh/pdh_test.go
@@ -80,12 +80,50 @@ func TestPerfCounter_Close(t *testing.T) {
 }
 
 func TestPerfCounter_ScrapeData(t *testing.T) {
-	pc, err := NewPerfCounter(`\Memory\Committed Bytes`, false)
-	require.NoError(t, err)
+	type testCase struct {
+		name           string
+		path           string
+		assertExpected func(t *testing.T, data []win_perf_counters.CounterValue)
+	}
 
-	performanceCounters, err := pc.ScrapeData()
-	require.NoError(t, err, "Failed to scrape data: %v", err)
+	testCases := []testCase{
+		{
+			name: "no instances",
+			path: `\Memory\Committed Bytes`,
+			assertExpected: func(t *testing.T, data []win_perf_counters.CounterValue) {
+				assert.Equal(t, 1, len(data))
+				assert.Empty(t, data[0].InstanceName)
+			},
+		},
+		{
+			name: "total instance",
+			path: `\LogicalDisk(_Total)\Free Megabytes`,
+			assertExpected: func(t *testing.T, data []win_perf_counters.CounterValue) {
+				assert.Equal(t, 1, len(data))
+				assert.Empty(t, data[0].InstanceName)
+			},
+		},
+		{
+			name: "all instances",
+			path: `\LogicalDisk(*)\Free Megabytes`,
+			assertExpected: func(t *testing.T, data []win_perf_counters.CounterValue) {
+				assert.GreaterOrEqual(t, len(data), 1)
+				for _, d := range data {
+					assert.NotEmpty(t, d.InstanceName)
+				}
+			},
+		},
+	}
 
-	assert.Equal(t, 1, len(performanceCounters))
-	assert.NotNil(t, 1, performanceCounters[0])
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			pc, err := NewPerfCounter(test.path, false)
+			require.NoError(t, err)
+
+			data, err := pc.ScrapeData()
+			require.NoError(t, err, "Failed to scrape data: %v", err)
+
+			test.assertExpected(t, data)
+		})
+	}
 }

--- a/receiver/windowsperfcountersreceiver/internal/pdh/pdh_test.go
+++ b/receiver/windowsperfcountersreceiver/internal/pdh/pdh_test.go
@@ -91,7 +91,7 @@ func TestPerfCounter_ScrapeData(t *testing.T) {
 			name: "no instances",
 			path: `\Memory\Committed Bytes`,
 			assertExpected: func(t *testing.T, data []win_perf_counters.CounterValue) {
-				assert.Equal(t, 1, len(data))
+				assert.Len(t, data, 1)
 				assert.Empty(t, data[0].InstanceName)
 			},
 		},


### PR DESCRIPTION
Change the default behaviour of the Windows perf counters receiver to not set the "instance" label to "_Total" if only total is requested