### PR TITLE
Change default behaviour of Windows perf counters receiver 2

### DIFF
--- a/receiver/windowsperfcountersreceiver/README.md
+++ b/receiver/windowsperfcountersreceiver/README.md
@@ -14,6 +14,11 @@ counter path, i.e.
 - `Memory\Committed Bytes`
 - `Processor\% Processor Time`, with a datapoint for each `Instance` label = (`_Total`, `1`, `2`, `3`, ... )
 
+If one of the specified performance counters cannot be loaded on startup, a
+warning will be printed, but the application will not fail fast. It is expected
+that some performance counters may not exist on some systems due to different OS
+configuration.
+
 ## Configuration
 
 The collection interval and the list of performance counters to be scraped can

--- a/receiver/windowsperfcountersreceiver/factory_windows.go
+++ b/receiver/windowsperfcountersreceiver/factory_windows.go
@@ -33,7 +33,7 @@ func createMetricsReceiver(
 	consumer consumer.MetricsConsumer,
 ) (component.MetricsReceiver, error) {
 	oCfg := cfg.(*Config)
-	scraper, err := newScraper(oCfg)
+	scraper, err := newScraper(oCfg, params.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
@@ -76,7 +76,7 @@ func (s *scraper) initialize(ctx context.Context) error {
 
 	// log a warning if some counters cannot be loaded, but do not crash the app
 	if len(errors) > 0 {
-		s.logger.Warn("error initializing counters", zap.Error(componenterror.CombineErrors(errors)))
+		s.logger.Warn("some performance counters could not be initialized", zap.Error(componenterror.CombineErrors(errors)))
 	}
 
 	return nil

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
@@ -23,6 +23,7 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver/internal/pdh"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver/internal/third_party/telegraf/win_perf_counters"
@@ -42,15 +43,16 @@ type PerfCounterScraper interface {
 // scraper is the type that scrapes various host metrics.
 type scraper struct {
 	cfg      *Config
+	logger   *zap.Logger
 	counters []PerfCounterScraper
 }
 
-func newScraper(cfg *Config) (*scraper, error) {
+func newScraper(cfg *Config, logger *zap.Logger) (*scraper, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
 
-	s := &scraper{cfg: cfg}
+	s := &scraper{cfg: cfg, logger: logger}
 	return s, nil
 }
 
@@ -64,7 +66,7 @@ func (s *scraper) initialize(ctx context.Context) error {
 
 				c, err := pdh.NewPerfCounter(counterPath, true)
 				if err != nil {
-					errors = append(errors, fmt.Errorf("error initializing counter %v: %w", counterPath, err))
+					errors = append(errors, fmt.Errorf("counter %v: %w", counterPath, err))
 				} else {
 					s.counters = append(s.counters, c)
 				}
@@ -72,7 +74,12 @@ func (s *scraper) initialize(ctx context.Context) error {
 		}
 	}
 
-	return componenterror.CombineErrors(errors)
+	// log a warning if some counters cannot be loaded, but do not crash the app
+	if len(errors) > 0 {
+		s.logger.Warn("error initializing counters", zap.Error(componenterror.CombineErrors(errors)))
+	}
+
+	return nil
 }
 
 func counterPath(object, instance, counterName string) string {

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -117,7 +117,7 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 				},
 				ScraperControllerSettings: receiverhelper.ScraperControllerSettings{CollectionInterval: time.Minute},
 			},
-			initializeMessage: "error initializing counters",
+			initializeMessage: "some performance counters could not be initialized",
 			initializeErr:     "counter \\Invalid Object\\Invalid Counter: The specified object was not found on the computer.\r\n",
 		},
 		{

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -25,6 +25,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver/internal/third_party/telegraf/win_perf_counters"
 )
@@ -64,11 +67,12 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 		name string
 		cfg  *Config
 
-		newErr          string
-		mockCounterPath string
-		initializeErr   string
-		scrapeErr       error
-		closeErr        error
+		newErr            string
+		mockCounterPath   string
+		initializeMessage string
+		initializeErr     string
+		scrapeErr         error
+		closeErr          error
 
 		expectedMetrics []expectedMetric
 	}
@@ -113,7 +117,8 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 				},
 				ScraperControllerSettings: receiverhelper.ScraperControllerSettings{CollectionInterval: time.Minute},
 			},
-			initializeErr: "error initializing counter \\Invalid Object\\Invalid Counter: The specified object was not found on the computer.\r\n",
+			initializeMessage: "error initializing counters",
+			initializeErr:     "counter \\Invalid Object\\Invalid Counter: The specified object was not found on the computer.\r\n",
 		},
 		{
 			name:      "ScrapeError",
@@ -132,15 +137,24 @@ func Test_WindowsPerfCounterScraper(t *testing.T) {
 			if cfg == nil {
 				cfg = defaultConfig
 			}
-			scraper, err := newScraper(cfg)
+
+			core, obs := observer.New(zapcore.WarnLevel)
+			logger := zap.New(core)
+			scraper, err := newScraper(cfg, logger)
 			if test.newErr != "" {
-				assert.EqualError(t, err, test.newErr)
+				require.EqualError(t, err, test.newErr)
 				return
 			}
 
 			err = scraper.initialize(context.Background())
+			require.NoError(t, err)
 			if test.initializeErr != "" {
-				assert.EqualError(t, err, test.initializeErr)
+				require.Equal(t, 1, obs.Len())
+				log := obs.All()[0]
+				assert.Equal(t, log.Level, zapcore.WarnLevel)
+				assert.Equal(t, test.initializeMessage, log.Message)
+				assert.Equal(t, "error", log.Context[0].Key)
+				assert.EqualError(t, log.Context[0].Interface.(error), test.initializeErr)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
Change the default behaviour of the Windows perf counters receiver to log a warning if perf counters cannot be loaded on startup instead of crashing. See the justification in README.