### PR TITLE
Replace traceKey with traceID

### DIFF
--- a/processor/groupbytraceprocessor/ring_buffer.go
+++ b/processor/groupbytraceprocessor/ring_buffer.go
@@ -21,7 +21,7 @@ type ringBuffer struct {
 	index     int
 	size      int
 	ids       []pdata.TraceID
-	idToIndex map[string]int // key is traceID as string, value is the index on the 'ids' slice
+	idToIndex map[pdata.TraceID]int // key is traceID, value is the index on the 'ids' slice
 }
 
 func newRingBuffer(size int) *ringBuffer {
@@ -29,7 +29,7 @@ func newRingBuffer(size int) *ringBuffer {
 		index:     -1, // the first span to be received will be placed at position '0'
 		size:      size,
 		ids:       make([]pdata.TraceID, size),
-		idToIndex: make(map[string]int),
+		idToIndex: make(map[pdata.TraceID]int),
 	}
 }
 
@@ -47,24 +47,23 @@ func (r *ringBuffer) put(traceID pdata.TraceID) pdata.TraceID {
 
 	// place the traceID in memory
 	r.ids[r.index] = traceID
-	r.idToIndex[traceID.HexString()] = r.index
+	r.idToIndex[traceID] = r.index
 
 	return evicted
 }
 
 func (r *ringBuffer) contains(traceID pdata.TraceID) bool {
-	_, found := r.idToIndex[traceID.HexString()]
+	_, found := r.idToIndex[traceID]
 	return found
 }
 
 func (r *ringBuffer) delete(traceID pdata.TraceID) bool {
-	sTraceID := traceID.HexString()
-	index, found := r.idToIndex[sTraceID]
+	index, found := r.idToIndex[traceID]
 	if !found {
 		return false
 	}
 
-	delete(r.idToIndex, sTraceID)
+	delete(r.idToIndex, traceID)
 	r.ids[index] = pdata.InvalidTraceID()
 	return true
 }

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -45,10 +45,6 @@ type Policy struct {
 	ctx context.Context
 }
 
-// traceKey is defined since sync.Map requires a comparable type, isolating it on its own
-// type to help track usage.
-type traceKey [16]byte
-
 // tailSamplingSpanProcessor handles the incoming trace data and uses the given sampling
 // policy to sample traces.
 type tailSamplingSpanProcessor struct {
@@ -61,7 +57,7 @@ type tailSamplingSpanProcessor struct {
 	idToTrace       sync.Map
 	policyTicker    tTicker
 	decisionBatcher idbatcher.Batcher
-	deleteChan      chan traceKey
+	deleteChan      chan pdata.TraceID
 	numTracesOnMap  uint64
 }
 
@@ -112,7 +108,7 @@ func newTraceProcessor(logger *zap.Logger, nextConsumer consumer.TracesConsumer,
 	}
 
 	tsp.policyTicker = &policyTicker{onTick: tsp.samplingPolicyOnTick}
-	tsp.deleteChan = make(chan traceKey, cfg.NumTraces)
+	tsp.deleteChan = make(chan pdata.TraceID, cfg.NumTraces)
 
 	return tsp, nil
 }
@@ -147,7 +143,7 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() {
 	batchLen := len(batch)
 	tsp.logger.Debug("Sampling Policy Evaluation ticked")
 	for _, id := range batch {
-		d, ok := tsp.idToTrace.Load(traceKey(id.Bytes()))
+		d, ok := tsp.idToTrace.Load(id)
 		if !ok {
 			metrics.idNotFoundOnMapCount++
 			continue
@@ -257,8 +253,8 @@ func (tsp *tailSamplingSpanProcessor) ConsumeTraces(ctx context.Context, td pdat
 	return nil
 }
 
-func (tsp *tailSamplingSpanProcessor) groupSpansByTraceKey(resourceSpans pdata.ResourceSpans) map[traceKey][]*pdata.Span {
-	idToSpans := make(map[traceKey][]*pdata.Span)
+func (tsp *tailSamplingSpanProcessor) groupSpansByTraceKey(resourceSpans pdata.ResourceSpans) map[pdata.TraceID][]*pdata.Span {
+	idToSpans := make(map[pdata.TraceID][]*pdata.Span)
 	ilss := resourceSpans.InstrumentationLibrarySpans()
 	for j := 0; j < ilss.Len(); j++ {
 		ils := ilss.At(j)
@@ -268,11 +264,8 @@ func (tsp *tailSamplingSpanProcessor) groupSpansByTraceKey(resourceSpans pdata.R
 		spansLen := ils.Spans().Len()
 		for k := 0; k < spansLen; k++ {
 			span := ils.Spans().At(k)
-			tk := traceKey(span.TraceID().Bytes())
-			if len(tk) != 16 {
-				tsp.logger.Warn("Span without valid TraceId")
-			}
-			idToSpans[tk] = append(idToSpans[tk], &span)
+			key := span.TraceID()
+			idToSpans[key] = append(idToSpans[key], &span)
 		}
 	}
 	return idToSpans
@@ -301,7 +294,7 @@ func (tsp *tailSamplingSpanProcessor) processTraces(resourceSpans pdata.Resource
 			atomic.AddInt64(&actualData.SpanCount, lenSpans)
 		} else {
 			newTraceIDs++
-			tsp.decisionBatcher.AddToCurrentBatch(pdata.NewTraceID(id))
+			tsp.decisionBatcher.AddToCurrentBatch(id)
 			atomic.AddUint64(&tsp.numTracesOnMap, 1)
 			postDeletion := false
 			currTime := time.Now()
@@ -377,7 +370,7 @@ func (tsp *tailSamplingSpanProcessor) Shutdown(context.Context) error {
 	return nil
 }
 
-func (tsp *tailSamplingSpanProcessor) dropTrace(traceID traceKey, deletionTime time.Time) {
+func (tsp *tailSamplingSpanProcessor) dropTrace(traceID pdata.TraceID, deletionTime time.Time) {
 	var trace *sampling.TraceData
 	if d, ok := tsp.idToTrace.Load(traceID); ok {
 		trace = d.(*sampling.TraceData)

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -53,7 +53,7 @@ func TestSequentialTraceArrival(t *testing.T) {
 	}
 
 	for i := range traceIds {
-		d, ok := tsp.idToTrace.Load(traceKey(traceIds[i].Bytes()))
+		d, ok := tsp.idToTrace.Load(traceIds[i])
 		require.True(t, ok, "Missing expected traceId")
 		v := d.(*sampling.TraceData)
 		require.Equal(t, int64(i+1), v.SpanCount, "Incorrect number of spans for entry %d", i)
@@ -88,7 +88,7 @@ func TestConcurrentTraceArrival(t *testing.T) {
 	wg.Wait()
 
 	for i := range traceIds {
-		d, ok := tsp.idToTrace.Load(traceKey(traceIds[i].Bytes()))
+		d, ok := tsp.idToTrace.Load(traceIds[i])
 		require.True(t, ok, "Missing expected traceId")
 		v := d.(*sampling.TraceData)
 		require.Equal(t, int64(i+1)*2, v.SpanCount, "Incorrect number of spans for entry %d", i)
@@ -112,7 +112,7 @@ func TestSequentialTraceMapSize(t *testing.T) {
 
 	// On sequential insertion it is possible to know exactly which traces should be still on the map.
 	for i := 0; i < len(traceIds)-maxSize; i++ {
-		_, ok := tsp.idToTrace.Load(traceKey(traceIds[i].Bytes()))
+		_, ok := tsp.idToTrace.Load(traceIds[i])
 		require.False(t, ok, "Found unexpected traceId[%d] still on map (id: %v)", i, traceIds[i])
 	}
 }
@@ -164,7 +164,7 @@ func TestSamplingPolicyTypicalPath(t *testing.T) {
 		logger:          zap.NewNop(),
 		decisionBatcher: newSyncIDBatcher(decisionWaitSeconds),
 		policies:        []*Policy{{Name: "mock-policy", Evaluator: mpe, ctx: context.TODO()}},
-		deleteChan:      make(chan traceKey, maxSize),
+		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
 	}
 
@@ -227,7 +227,7 @@ func TestSamplingMultiplePolicies(t *testing.T) {
 			{
 				Name: "policy-2", Evaluator: mpe2, ctx: context.TODO(),
 			}},
-		deleteChan:   make(chan traceKey, maxSize),
+		deleteChan:   make(chan pdata.TraceID, maxSize),
 		policyTicker: mtt,
 	}
 
@@ -286,7 +286,7 @@ func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
 		logger:          zap.NewNop(),
 		decisionBatcher: newSyncIDBatcher(decisionWaitSeconds),
 		policies:        []*Policy{{Name: "mock-policy", Evaluator: mpe, ctx: context.TODO()}},
-		deleteChan:      make(chan traceKey, maxSize),
+		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
 	}
 
@@ -345,7 +345,7 @@ func TestMultipleBatchesAreCombinedIntoOne(t *testing.T) {
 		logger:          zap.NewNop(),
 		decisionBatcher: newSyncIDBatcher(decisionWaitSeconds),
 		policies:        []*Policy{{Name: "mock-policy", Evaluator: mpe, ctx: context.TODO()}},
-		deleteChan:      make(chan traceKey, maxSize),
+		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
 	}
 


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

Description: replaced the map keys using custom types/strings for traceIDs to use pdata.TraceID instead.

Link to tracking Issue: Closes #1541
