### PR TITLE
jmx: Add endpoint config field

### DIFF
--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -26,7 +26,7 @@ Example configuration:
 receivers:
   jmx:
     jar_path: /opt/opentelemetry-java-contrib-jmx-metrics.jar
-    service_url: service:jmx:rmi:///jndi/rmi://<my-jmx-host>:<my-jmx-port>/jmxrmi
+    endpoint: my_jmx_host:12345
     target_system: jvm
     collection_interval: 10s
     # optional: the same as specifying OTLP receiver endpoint.
@@ -41,11 +41,13 @@ receivers:
 
 The path for the JMX Metric Gatherer uber JAR to run.
 
-### service_url
+### endpoint
+The [JMX Service URL](https://docs.oracle.com/javase/8/docs/api/javax/management/remote/JMXServiceURL.html) or host
+and port used to construct the Service URL the Metric Gatherer's JMX client should use. Value must be in the form of
+`service:jmx:<protocol>:<sap>` or `host:port`. Values in `host:port` form will be used to create a Service URL of
+`service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi`.
 
-The JMX Service URL the Metric Gatherer's JMX client should use.
-
-Corresponds to the `otel.jmx.service.url` property.
+When in or coerced to `service:jmx:<protocol>:<sap>` form, corresponds to the `otel.jmx.service.url` property.
 
 _Required._
 

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -27,8 +27,8 @@ type config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 	// The path for the JMX Metric Gatherer uber JAR (/opt/opentelemetry-java-contrib-jmx-metrics.jar by default).
 	JARPath string `mapstructure:"jar_path"`
-	// The target JMX service url.
-	ServiceURL string `mapstructure:"service_url"`
+	// The Service URL or host:port for the target coerced to one of form: service:jmx:rmi:///jndi/rmi://<host>:<port>/jmxrmi.
+	Endpoint string `mapstructure:"endpoint"`
 	// The target system for the metric gatherer whose built in groovy script to run.  Cannot be set with GroovyScript.
 	TargetSystem string `mapstructure:"target_system"`
 	// The script for the metric gatherer to run on the configured interval.  Cannot be set with TargetSystem.
@@ -72,8 +72,8 @@ type otlpExporterConfig struct {
 
 func (c *config) validate() error {
 	var missingFields []string
-	if c.ServiceURL == "" {
-		missingFields = append(missingFields, "`service_url`")
+	if c.Endpoint == "" {
+		missingFields = append(missingFields, "`endpoint`")
 	}
 	if c.TargetSystem == "" && c.GroovyScript == "" {
 		missingFields = append(missingFields, "`target_system` or `groovy_script`")

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -46,7 +46,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
 	err = r0.validate()
 	require.Error(t, err)
-	assert.Equal(t, "jmx missing required fields: `service_url`, `target_system` or `groovy_script`", err.Error())
+	assert.Equal(t, "jmx missing required fields: `endpoint`, `target_system` or `groovy_script`", err.Error())
 
 	r1 := cfg.Receivers["jmx/all"].(*config)
 	require.NoError(t, configcheck.ValidateConfig(r1))
@@ -58,7 +58,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "jmx/all",
 			},
 			JARPath:            "myjarpath",
-			ServiceURL:         "myserviceurl",
+			Endpoint:           "myendpoint:12345",
 			GroovyScript:       "mygroovyscriptpath",
 			CollectionInterval: 15 * time.Second,
 			Username:           "myusername",
@@ -82,13 +82,13 @@ func TestLoadConfig(t *testing.T) {
 			Realm:              "myrealm",
 		}, r1)
 
-	r2 := cfg.Receivers["jmx/missingservice"].(*config)
+	r2 := cfg.Receivers["jmx/missingendpoint"].(*config)
 	require.NoError(t, configcheck.ValidateConfig(r2))
 	assert.Equal(t,
 		&config{
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal: "jmx",
-				NameVal: "jmx/missingservice",
+				NameVal: "jmx/missingendpoint",
 			},
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
 			GroovyScript:       "mygroovyscriptpath",
@@ -102,7 +102,7 @@ func TestLoadConfig(t *testing.T) {
 		}, r2)
 	err = r2.validate()
 	require.Error(t, err)
-	assert.Equal(t, "jmx/missingservice missing required field: `service_url`", err.Error())
+	assert.Equal(t, "jmx/missingendpoint missing required field: `endpoint`", err.Error())
 
 	r3 := cfg.Receivers["jmx/missinggroovy"].(*config)
 	require.NoError(t, configcheck.ValidateConfig(r3))
@@ -113,7 +113,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "jmx/missinggroovy",
 			},
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
-			ServiceURL:         "myserviceurl",
+			Endpoint:           "service:jmx:rmi:///jndi/rmi://host:12345/jmxrmi",
 			CollectionInterval: 10 * time.Second,
 			OTLPExporterConfig: otlpExporterConfig{
 				Endpoint: "0.0.0.0:0",
@@ -135,7 +135,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "jmx/invalidinterval",
 			},
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
-			ServiceURL:         "myserviceurl",
+			Endpoint:           "myendpoint:23456",
 			GroovyScript:       "mygroovyscriptpath",
 			CollectionInterval: -100 * time.Millisecond,
 			OTLPExporterConfig: otlpExporterConfig{
@@ -158,7 +158,7 @@ func TestLoadConfig(t *testing.T) {
 				NameVal: "jmx/invalidotlptimeout",
 			},
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
-			ServiceURL:         "myserviceurl",
+			Endpoint:           "myendpoint:34567",
 			GroovyScript:       "mygroovyscriptpath",
 			CollectionInterval: 10 * time.Second,
 			OTLPExporterConfig: otlpExporterConfig{

--- a/receiver/jmxreceiver/factory_test.go
+++ b/receiver/jmxreceiver/factory_test.go
@@ -39,7 +39,7 @@ func TestWithInvalidConfig(t *testing.T) {
 		cfg, consumertest.NewMetricsNop(),
 	)
 	require.Error(t, err)
-	assert.Equal(t, "jmx missing required fields: `service_url`, `target_system` or `groovy_script`", err.Error())
+	assert.Equal(t, "jmx missing required fields: `endpoint`, `target_system` or `groovy_script`", err.Error())
 	require.Nil(t, r)
 }
 
@@ -48,7 +48,7 @@ func TestWithValidConfig(t *testing.T) {
 	assert.Equal(t, configmodels.Type("jmx"), f.Type())
 
 	cfg := f.CreateDefaultConfig()
-	cfg.(*config).ServiceURL = "myserviceurl"
+	cfg.(*config).Endpoint = "myendpoint:12345"
 	cfg.(*config).GroovyScript = "mygroovyscriptpath"
 
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}

--- a/receiver/jmxreceiver/integration_test.go
+++ b/receiver/jmxreceiver/integration_test.go
@@ -140,7 +140,7 @@ func (suite *JMXIntegrationSuite) TestJMXReceiverHappyPath() {
 
 	config := &config{
 		CollectionInterval: 100 * time.Millisecond,
-		ServiceURL:         fmt.Sprintf("service:jmx:rmi:///jndi/rmi://%v:7199/jmxrmi", hostname),
+		Endpoint:           fmt.Sprintf("%v:7199", hostname),
 		JARPath:            suite.JARPath,
 		GroovyScript:       path.Join(".", "testdata", "script.groovy"),
 		OTLPExporterConfig: otlpExporterConfig{
@@ -209,11 +209,11 @@ func (suite *JMXIntegrationSuite) TestJMXReceiverHappyPath() {
 	}, 30*time.Second, 100*time.Millisecond, getJavaStdout(receiver))
 }
 
-func TestJMXReceiverInvalidEndpointIntegration(t *testing.T) {
+func TestJMXReceiverInvalidOTLPEndpointIntegration(t *testing.T) {
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	config := &config{
 		CollectionInterval: 100 * time.Millisecond,
-		ServiceURL:         fmt.Sprintf("service:jmx:rmi:///jndi/rmi://localhost:7199/jmxrmi"),
+		Endpoint:           fmt.Sprintf("service:jmx:rmi:///jndi/rmi://localhost:7199/jmxrmi"),
 		JARPath:            "/notavalidpath",
 		GroovyScript:       path.Join(".", "testdata", "script.groovy"),
 		OTLPExporterConfig: otlpExporterConfig{

--- a/receiver/jmxreceiver/testdata/config.yaml
+++ b/receiver/jmxreceiver/testdata/config.yaml
@@ -2,7 +2,7 @@ receivers:
   jmx:
   jmx/all:
     jar_path: myjarpath
-    service_url: myserviceurl
+    endpoint: myendpoint:12345
     groovy_script: mygroovyscriptpath
     collection_interval: 15s
     username: myusername
@@ -20,16 +20,16 @@ receivers:
     truststore_password: mytruststorepassword
     remote_profile: myremoteprofile
     realm: myrealm
-  jmx/missingservice:
+  jmx/missingendpoint:
     groovy_script: mygroovyscriptpath
   jmx/missinggroovy:
-    service_url: myserviceurl
+    endpoint: service:jmx:rmi:///jndi/rmi://host:12345/jmxrmi
   jmx/invalidinterval:
-    service_url: myserviceurl
+    endpoint: myendpoint:23456
     groovy_script: mygroovyscriptpath
     collection_interval: -100ms
   jmx/invalidotlptimeout:
-    service_url: myserviceurl
+    endpoint: myendpoint:34567
     groovy_script: mygroovyscriptpath
     otlp:
       timeout: -100ms


### PR DESCRIPTION
**Description:**
 Adding a feature - These changes add standard receiver `endpoint` config support to the JMX Receiver.  The value will be used in creating a service url value.

**Testing:**

Updates existing suites.

**Documentation:**

Updates existing readme.