### PR TITLE
Enable resource attributes to metric label conversion option

### DIFF
--- a/exporter/awsemfexporter/README.md
+++ b/exporter/awsemfexporter/README.md
@@ -23,8 +23,9 @@ The following exporter configuration parameters are supported.
 | `region`          | Send Structured Logs to AWS CloudWatch in a specific region. If this field is not present in config, environment variable "AWS_REGION" can then be used to set region.| determined by metadata |
 | `role_arn`        | IAM role to upload segments to a different account.                    |         |
 | `max_retries`     | Maximum number of retries before abandoning an attempt to post data.   |    1    |
-| `dimension_rollup_option`| DimensionRollupOption is the option for metrics dimension rollup. Three options are available. |"ZeroAndSingleDimensionRollup" (Enable both zero dimension rollup and single dimension rollup)|
-
+| `dimension_rollup_option`| DimensionRollupOption is the option for metrics dimension rollup. Three options are available. |"ZeroAndSingleDimensionRollup" (Enable both zero dimension rollup and single dimension rollup)| 
+| `resource_to_telemetry_conversion` | "resource_to_telemetry_conversion" is the option for converting resource attributes to telemetry attributes. It has only one config onption- `enabled`. For metrics, if `enabled=true`, all the resource attributes will be converted to metric labels by default. See `Resource Attributes to Metric Labels` section below for examples. | `enabled=false` | 
+ 
 
 ## AWS Credential Configuration
 
@@ -33,3 +34,18 @@ This exporter follows default credential resolution for the
 
 Follow the [guidelines](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html) for the 
 credential configuration.
+
+
+## Configuration Examples
+
+
+### Resource Attributes to Metric Labels
+`resource_to_telemetry_conversion`  option can be enabled to convert all the resource attributes to metric labels. By default, this option is disabled. Users need to set `enabled=true` to opt-in. See the config example below.
+
+```yaml
+exporters:
+    awsemf:
+        region: 'us-west-2'
+        resource_to_telemetry_conversion:
+            enabled: true
+```

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -16,6 +16,7 @@ package awsemfexporter
 
 import (
 	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
 )
 
@@ -54,6 +55,11 @@ type Config struct {
 	// "SingleDimensionRollupOnly" - Enable single dimension rollup
 	// "NoDimensionRollup" - No dimension rollup (only keep original metrics which contain all dimensions)
 	DimensionRollupOption string `mapstructure:"dimension_rollup_option"`
+
+	// ResourceToTelemetrySettings is the option for converting resource attrihutes to telemetry attributes.
+	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.
+	// If enabled, all the resource attributes will be converted to metric labels by default.
+	exporterhelper.ResourceToTelemetrySettings `mapstructure:"resource_to_telemetry_conversion"`
 
 	// logger is the Logger used for writing error/warning logs
 	logger *zap.Logger

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -38,7 +39,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Exporters), 2)
+	assert.Equal(t, 3, len(cfg.Exporters))
 
 	r0 := cfg.Exporters["awsemf"]
 	assert.Equal(t, r0, factory.CreateDefaultConfig())
@@ -57,5 +58,22 @@ func TestLoadConfig(t *testing.T) {
 			Region:                "us-west-2",
 			RoleARN:               "arn:aws:iam::123456789:role/monitoring-EKS-NodeInstanceRole",
 			DimensionRollupOption: "ZeroAndSingleDimensionRollup",
+		})
+
+	r2 := cfg.Exporters["awsemf/resource_attr_to_label"].(*Config)
+	assert.Equal(t, r2,
+		&Config{
+			ExporterSettings:            configmodels.ExporterSettings{TypeVal: configmodels.Type(typeStr), NameVal: "awsemf/resource_attr_to_label"},
+			LogGroupName:                "",
+			LogStreamName:               "",
+			Endpoint:                    "",
+			RequestTimeoutSeconds:       30,
+			MaxRetries:                  1,
+			NoVerifySSL:                 false,
+			ProxyAddress:                "",
+			Region:                      "",
+			RoleARN:                     "",
+			DimensionRollupOption:       "ZeroAndSingleDimensionRollup",
+			ResourceToTelemetrySettings: exporterhelper.ResourceToTelemetrySettings{Enabled: true},
 		})
 }

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -250,3 +250,19 @@ func TestWrapErrorIfBadRequest(t *testing.T) {
 	err = wrapErrorIfBadRequest(&awsErr)
 	assert.False(t, consumererror.IsPermanent(err))
 }
+
+// This test verifies that if func New() returns an error then NewEmfExporter()
+// will do so.
+func TestNewEmfExporterWithoutConfig(t *testing.T) {
+	factory := NewFactory()
+	expCfg := factory.CreateDefaultConfig().(*Config)
+	env := stashEnv()
+	defer popEnv(env)
+	os.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
+
+	assert.Nil(t, expCfg.logger)
+	exp, err := NewEmfExporter(expCfg, component.ExporterCreateParams{Logger: zap.NewNop()})
+	assert.NotNil(t, err)
+	assert.Nil(t, exp)
+	assert.NotNil(t, expCfg.logger)
+}

--- a/exporter/awsemfexporter/factory.go
+++ b/exporter/awsemfexporter/factory.go
@@ -64,5 +64,5 @@ func createMetricsExporter(_ context.Context,
 
 	expCfg := config.(*Config)
 
-	return New(expCfg, params)
+	return NewEmfExporter(expCfg, params)
 }

--- a/exporter/awsemfexporter/testdata/config.yaml
+++ b/exporter/awsemfexporter/testdata/config.yaml
@@ -9,6 +9,9 @@ exporters:
   awsemf/1:
     region: 'us-west-2'
     role_arn: "arn:aws:iam::123456789:role/monitoring-EKS-NodeInstanceRole"
+  awsemf/resource_attr_to_label:
+    resource_to_telemetry_conversion:
+      enabled: true
 
 service:
   pipelines:


### PR DESCRIPTION
**Description:** 
Recently a PR [2060](https://github.com/open-telemetry/opentelemetry-collector/pull/2060) was merged in the core `opentelemetry-collector` repo for converting resource attributes to metric labels. This was added as a utility option in the `exporterhelper` module so that any exporter can easily opt-in. We need to enable this settings for `awsemf` exporter so that customer can enable it if they want.

This is a required option for AWS ECS Container Metrics customers.

This change introduces a new function for creating the `componenet.MetricsExporter` which utilizes the `exporterhelper` module with `resource_to_telemetry_conversion` option as well as our pre-existing `New()` function.

**Link to tracking Issue:** 
#1551 

**Testing:** 
It passes all the existing unit tests.
Added new unit tests for testing the new changes.
Manually tested for e2e experience.

**Documentation:** 
README updated.