### PR TITLE
Add AWS ECS and EKS attributes to aws xray receiver.

### DIFF
--- a/internal/awsxray/testdata/awsValidAwsFields.txt
+++ b/internal/awsxray/testdata/awsValidAwsFields.txt
@@ -22,7 +22,9 @@
             "sdk": "X-Ray for Go"
         },
         "ecs": {
-            "container": "containerId1234"
+            "container": "containerId1234",
+            "container_id": "d8453812a556",
+            "availability_zone": "us-west-2c"
         },
         "ec2": {
             "availability_zone": "us-west-2c",

--- a/internal/awsxray/testdata/serverSample.txt
+++ b/internal/awsxray/testdata/serverSample.txt
@@ -20,6 +20,11 @@
         "xray": {
             "sdk_version": "1.1.0",
             "sdk": "X-Ray for Go"
+        },
+        "eks": {
+            "cluster_name": "containerName",
+            "pod": "podname",
+            "container_id": "d8453812a556"
         }
     },
     "service": {

--- a/internal/awsxray/tracesegment_test.go
+++ b/internal/awsxray/tracesegment_test.go
@@ -527,6 +527,11 @@ var rawExpectedSegmentForInstrumentedServer = Segment{
 			SDKVersion: String("1.1.0"),
 			SDK:        String("X-Ray for Go"),
 		},
+		EKS: &EKSMetadata{
+			String("containerName"),
+			String("podname"),
+			String("d8453812a556"),
+		},
 	},
 	Service: &ServiceData{
 		CompilerVersion: String("go1.14.6"),

--- a/receiver/awsxrayreceiver/internal/translator/aws.go
+++ b/receiver/awsxrayreceiver/internal/translator/aws.go
@@ -46,6 +46,8 @@ func addAWSToResource(aws *awsxray.AWSData, attrs *pdata.AttributeMap) {
 
 	if ecs := aws.ECS; ecs != nil {
 		addString(ecs.ContainerName, conventions.AttributeContainerName, attrs)
+		addString(ecs.AvailabilityZone, conventions.AttributeCloudZone, attrs)
+		addString(ecs.ContainerID, conventions.AttributeContainerID, attrs)
 	}
 
 	if bs := aws.Beanstalk; bs != nil {
@@ -54,6 +56,13 @@ func addAWSToResource(aws *awsxray.AWSData, attrs *pdata.AttributeMap) {
 			attrs.UpsertString(conventions.AttributeServiceInstance, strconv.FormatInt(*bs.DeploymentID, 10))
 		}
 		addString(bs.VersionLabel, conventions.AttributeServiceVersion, attrs)
+	}
+
+	if eks := aws.EKS; eks != nil {
+		addString(eks.ContainerID, conventions.AttributeContainerID, attrs)
+		addString(eks.ClusterName, conventions.AttributeK8sCluster, attrs)
+		addString(eks.Pod, conventions.AttributeK8sPod, attrs)
+
 	}
 }
 

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -94,6 +94,12 @@ func TestTranslation(t *testing.T) {
 				attrs[conventions.AttributeTelemetrySDKName] = pdata.NewAttributeValueString(
 					*seg.AWS.XRay.SDK)
 				attrs[conventions.AttributeTelemetrySDKLanguage] = pdata.NewAttributeValueString("Go")
+				attrs[conventions.AttributeK8sCluster] = pdata.NewAttributeValueString(
+					*seg.AWS.EKS.ClusterName)
+				attrs[conventions.AttributeK8sPod] = pdata.NewAttributeValueString(
+					*seg.AWS.EKS.Pod)
+				attrs[conventions.AttributeContainerID] = pdata.NewAttributeValueString(
+					*seg.AWS.EKS.ContainerID)
 				return attrs
 			},
 			propsPerSpan: func(_ string, _ *testing.T, seg *awsxray.Segment) []perSpanProperties {
@@ -597,6 +603,10 @@ func TestTranslation(t *testing.T) {
 					*seg.AWS.EC2.AmiID)
 				attrs[conventions.AttributeContainerName] = pdata.NewAttributeValueString(
 					*seg.AWS.ECS.ContainerName)
+				attrs[conventions.AttributeContainerID] = pdata.NewAttributeValueString(
+					*seg.AWS.ECS.ContainerID)
+				attrs[conventions.AttributeCloudZone] = pdata.NewAttributeValueString(
+					*seg.AWS.ECS.AvailabilityZone)
 				attrs[conventions.AttributeServiceNamespace] = pdata.NewAttributeValueString(
 					*seg.AWS.Beanstalk.Environment)
 				attrs[conventions.AttributeServiceInstance] = pdata.NewAttributeValueString(


### PR DESCRIPTION
**Description:**  Add ECS and EKS attributes, and add test data in the template to do the unit test for the translation of these attributes.

**Testing:** Unit tests.
