### PR TITLE
[exporters/signalfx_correlation] Add ability to translate host dimension

### DIFF
--- a/exporter/signalfxcorrelationexporter/config.go
+++ b/exporter/signalfxcorrelationexporter/config.go
@@ -38,6 +38,10 @@ type Config struct {
 
 	// AccessToken is the authentication token provided by SignalFx.
 	AccessToken string `mapstructure:"access_token"`
+
+	// HostTranslations is a map where the key is the host attribute name to rename to the value.
+	// TODO: Remove once translations are removed from signalfx exporter.
+	HostTranslations map[string]string `mapstructure:"host_translations"`
 }
 
 func (c *Config) validate() error {

--- a/exporter/signalfxcorrelationexporter/config_test.go
+++ b/exporter/signalfxcorrelationexporter/config_test.go
@@ -65,6 +65,9 @@ func TestLoadConfig(t *testing.T) {
 				RetryDelay:      30 * time.Second,
 				CleanupInterval: 1 * time.Minute,
 			},
+			HostTranslations: map[string]string{
+				"host.name": "host",
+			},
 		})
 }
 

--- a/exporter/signalfxcorrelationexporter/correlation.go
+++ b/exporter/signalfxcorrelationexporter/correlation.go
@@ -110,12 +110,19 @@ func (cor *Tracker) AddSpans(ctx context.Context, traces pdata.Traces) {
 			return
 		}
 
+		hostDimension := string(hostID.Key)
+
+		// Translate host dimension (e.g. from host.name to host depending on configuration).
+		if newHostDimension, ok := cor.cfg.HostTranslations[string(hostID.Key)]; ok {
+			hostDimension = newHostDimension
+		}
+
 		cor.traceTracker = tracetracker.New(
 			newZapShim(cor.params.Logger),
 			cor.cfg.StaleServiceTimeout,
 			cor.correlation,
 			map[string]string{
-				string(hostID.Key): hostID.ID,
+				hostDimension: hostID.ID,
 			},
 			false,
 			nil,

--- a/exporter/signalfxcorrelationexporter/correlation_test.go
+++ b/exporter/signalfxcorrelationexporter/correlation_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestTrackerAddSpans(t *testing.T) {
 	tracker := NewTracker(
-		&Config{},
+		createDefaultConfig().(*Config),
 		component.ExporterCreateParams{
 			Logger: zap.NewNop(),
 		},

--- a/exporter/signalfxcorrelationexporter/factory.go
+++ b/exporter/signalfxcorrelationexporter/factory.go
@@ -47,6 +47,9 @@ func createDefaultConfig() configmodels.Exporter {
 			NameVal: typeStr,
 		},
 		StaleServiceTimeout: 5 * time.Minute,
+		HostTranslations: map[string]string{
+			conventions.AttributeHostName: "host",
+		},
 		SyncAttributes: map[string]string{
 			conventions.AttributeK8sPodUID:   conventions.AttributeK8sPodUID,
 			conventions.AttributeContainerID: conventions.AttributeContainerID,


### PR DESCRIPTION
If we're exporting using dimension `host` instead of `host.name` need to use
the same in the correlation exporter. This will be removed once translations
are removed from the metrics exporter.