### PR TITLE
Remove samplerate property from honeycomb exporter

### DIFF
--- a/exporter/honeycombexporter/config.go
+++ b/exporter/honeycombexporter/config.go
@@ -24,10 +24,6 @@ type Config struct {
 	Dataset string `mapstructure:"dataset"`
 	// API URL to use (defaults to https://api.honeycomb.io)
 	APIURL string `mapstructure:"api_url"`
-	// SampleRate is the rate at which to sample this event. Default is 1,
-	// meaning no sampling. If you want to send one event out of every 250
-	// times Send() is called, you would specify 250 here.
-	SampleRate uint `mapstructure:"sample_rate"`
 	// The name of an attribute that contains the sample_rate for each span.
 	// If the attribute is on the span, it takes precedence over the static sample_rate configuration
 	SampleRateAttribute string `mapstructure:"sample_rate_attribute"`

--- a/exporter/honeycombexporter/config.go
+++ b/exporter/honeycombexporter/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	Dataset string `mapstructure:"dataset"`
 	// API URL to use (defaults to https://api.honeycomb.io)
 	APIURL string `mapstructure:"api_url"`
+	// Deprecated - do not use. This will be removed in a future release.
+	SampleRate uint `mapstructure:"sample_rate"`
 	// The name of an attribute that contains the sample_rate for each span.
 	// If the attribute is on the span, it takes precedence over the static sample_rate configuration
 	SampleRateAttribute string `mapstructure:"sample_rate_attribute"`

--- a/exporter/honeycombexporter/config_test.go
+++ b/exporter/honeycombexporter/config_test.go
@@ -49,14 +49,12 @@ func TestLoadConfig(t *testing.T) {
 		APIKey:           "test-apikey",
 		Dataset:          "test-dataset",
 		APIURL:           "https://api.testhost.io",
-		SampleRate:       1,
 	})
 
 	r2 := cfg.Exporters["honeycomb/sample_rate"].(*Config)
 	assert.Equal(t, r2, &Config{
 		ExporterSettings:    configmodels.ExporterSettings{TypeVal: configmodels.Type(typeStr), NameVal: "honeycomb/sample_rate"},
 		APIURL:              "https://api.honeycomb.io",
-		SampleRate:          5,
 		SampleRateAttribute: "custom.sample_rate",
 	})
 }

--- a/exporter/honeycombexporter/config_test.go
+++ b/exporter/honeycombexporter/config_test.go
@@ -55,6 +55,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, r2, &Config{
 		ExporterSettings:    configmodels.ExporterSettings{TypeVal: configmodels.Type(typeStr), NameVal: "honeycomb/sample_rate"},
 		APIURL:              "https://api.honeycomb.io",
+		SampleRate:          5,
 		SampleRateAttribute: "custom.sample_rate",
 	})
 }

--- a/exporter/honeycombexporter/factory.go
+++ b/exporter/honeycombexporter/factory.go
@@ -44,7 +44,6 @@ func createDefaultConfig() configmodels.Exporter {
 		APIKey:              "",
 		Dataset:             "",
 		APIURL:              "https://api.honeycomb.io",
-		SampleRate:          1,
 		SampleRateAttribute: "",
 		Debug:               false,
 	}

--- a/exporter/honeycombexporter/honeycomb.go
+++ b/exporter/honeycombexporter/honeycomb.go
@@ -84,10 +84,9 @@ type spanRefType int64
 // wraps the exporter in the component.TraceExporterOld helper method.
 func newHoneycombTraceExporter(cfg *Config, logger *zap.Logger) (component.TracesExporter, error) {
 	libhoneyConfig := libhoney.Config{
-		WriteKey:   cfg.APIKey,
-		Dataset:    cfg.Dataset,
-		APIHost:    cfg.APIURL,
-		SampleRate: cfg.SampleRate,
+		WriteKey: cfg.APIKey,
+		Dataset:  cfg.Dataset,
+		APIHost:  cfg.APIURL,
 	}
 	userAgent := oTelCollectorUserAgentStr
 	libhoney.UserAgentAddition = userAgent

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -38,8 +38,7 @@ import (
 )
 
 type honeycombData struct {
-	Data       map[string]interface{} `json:"data"`
-	SampleRate int                    `json:"samplerate"`
+	Data map[string]interface{} `json:"data"`
 }
 
 func testingServer(callback func(data []honeycombData)) *httptest.Server {
@@ -93,7 +92,6 @@ func baseConfig() *Config {
 		APIKey:              "test",
 		Dataset:             "test",
 		Debug:               false,
-		SampleRate:          1,
 		SampleRateAttribute: "",
 	}
 }
@@ -348,14 +346,12 @@ func TestSampleRateAttribute(t *testing.T) {
 	}
 
 	cfg := baseConfig()
-	cfg.SampleRate = 2 // default sample rate
 	cfg.SampleRateAttribute = "hc.sample.rate"
 
 	got := testTraceExporter(internaldata.OCToTraceData(td), t, cfg)
 
 	want := []honeycombData{
 		{
-			SampleRate: 13,
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
 				"has_remote_parent":                      false,
@@ -372,7 +368,6 @@ func TestSampleRateAttribute(t *testing.T) {
 			},
 		},
 		{
-			SampleRate: 2,
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
 				"has_remote_parent":                      false,
@@ -388,7 +383,6 @@ func TestSampleRateAttribute(t *testing.T) {
 			},
 		},
 		{
-			SampleRate: 2,
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
 				"has_remote_parent":                      false,

--- a/exporter/honeycombexporter/testdata/config.yaml
+++ b/exporter/honeycombexporter/testdata/config.yaml
@@ -11,6 +11,7 @@ exporters:
     dataset: "test-dataset"
     api_url: "https://api.testhost.io"
   honeycomb/sample_rate:
+    sample_rate: 5 # deprecated but left to ensure existing configs do not break
     sample_rate_attribute: "custom.sample_rate"
 
 service:

--- a/exporter/honeycombexporter/testdata/config.yaml
+++ b/exporter/honeycombexporter/testdata/config.yaml
@@ -11,7 +11,6 @@ exporters:
     dataset: "test-dataset"
     api_url: "https://api.testhost.io"
   honeycomb/sample_rate:
-    sample_rate: 5
     sample_rate_attribute: "custom.sample_rate"
 
 service:


### PR DESCRIPTION
Sampling should not be performed as part of the export process. If sampling is wanted to be used, it should be done with a sampling span processor earlier in the collector pipeline.