### PR TITLE
Update newrelicexporter to use pdata for traces

### DIFF
--- a/exporter/newrelicexporter/factory_test.go
+++ b/exporter/newrelicexporter/factory_test.go
@@ -50,3 +50,15 @@ func TestCreateExporter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, me, "failed to create metrics exporter")
 }
+
+func TestCreateTraceExporterError(t *testing.T) {
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+	_, err := createTraceExporter(context.Background(), params, nil)
+	assert.Error(t, err)
+}
+
+func TestCreateMetricsExporterError(t *testing.T) {
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+	_, err := createMetricsExporter(context.Background(), params, nil)
+	assert.Error(t, err)
+}

--- a/exporter/newrelicexporter/newrelic.go
+++ b/exporter/newrelicexporter/newrelic.go
@@ -106,16 +106,15 @@ func (e exporter) pushTraceData(ctx context.Context, td pdata.Traces) (int, erro
 
 				nrSpan, err := transform.Span(span)
 				if err != nil {
-					// Record the error and try export anyway to help debug.
 					errs = append(errs, err)
-				} else {
-					goodSpans++
+					continue
 				}
 
 				if err := e.harvester.RecordSpan(nrSpan); err != nil {
 					errs = append(errs, err)
 					continue
 				}
+				goodSpans++
 			}
 		}
 	}

--- a/exporter/newrelicexporter/newrelic.go
+++ b/exporter/newrelicexporter/newrelic.go
@@ -79,34 +79,44 @@ func newExporter(l *zap.Logger, c configmodels.Exporter) (*exporter, error) {
 }
 
 func (e exporter) pushTraceData(ctx context.Context, td pdata.Traces) (int, error) {
-	var errs []error
-	goodSpans := 0
+	var (
+		errs      []error
+		goodSpans int
+	)
 
-	octds := internaldata.TraceDataToOC(td)
-	for _, octd := range octds {
-
-		var srv string
-		if octd.Node != nil && octd.Node.ServiceInfo != nil {
-			srv = octd.Node.ServiceInfo.Name
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rspans := td.ResourceSpans().At(i)
+		if rspans.IsNil() {
+			continue
 		}
 
-		transform := &transformer{
-			ServiceName: srv,
-			Resource:    octd.Resource,
-		}
+		resource := rspans.Resource()
+		for j := 0; j < rspans.InstrumentationLibrarySpans().Len(); j++ {
+			ispans := rspans.InstrumentationLibrarySpans().At(j)
+			if ispans.IsNil() {
+				continue
+			}
 
-		for _, span := range octd.Spans {
-			nrSpan, err := transform.Span(span)
-			if err != nil {
-				errs = append(errs, err)
-				continue
+			transform := newTraceTransformer(resource, ispans.InstrumentationLibrary())
+			for k := 0; k < ispans.Spans().Len(); k++ {
+				span := ispans.Spans().At(k)
+				if span.IsNil() {
+					continue
+				}
+
+				nrSpan, err := transform.Span(span)
+				if err != nil {
+					// Record the error and try export anyway to help debug.
+					errs = append(errs, err)
+				} else {
+					goodSpans++
+				}
+
+				if err := e.harvester.RecordSpan(nrSpan); err != nil {
+					errs = append(errs, err)
+					continue
+				}
 			}
-			err = e.harvester.RecordSpan(nrSpan)
-			if err != nil {
-				errs = append(errs, err)
-				continue
-			}
-			goodSpans++
 		}
 	}
 
@@ -126,7 +136,7 @@ func (e exporter) pushMetricData(ctx context.Context, md pdata.Metrics) (int, er
 			srv = ocmd.Node.ServiceInfo.Name
 		}
 
-		transform := &transformer{
+		transform := &metricTransformer{
 			DeltaCalculator: e.deltaCalculator,
 			ServiceName:     srv,
 			Resource:        ocmd.Resource,

--- a/exporter/newrelicexporter/newrelic_test.go
+++ b/exporter/newrelicexporter/newrelic_test.go
@@ -97,12 +97,10 @@ func TestExportTraceDataMinimum(t *testing.T) {
 
 func TestExportTraceDataFullTrace(t *testing.T) {
 	td := consumerdata.TraceData{
-		Node: &commonpb.Node{
-			ServiceInfo: &commonpb.ServiceInfo{Name: "test-service"},
-		},
 		Resource: &resourcepb.Resource{
 			Labels: map[string]string{
-				"resource": "R1",
+				serviceNameKey: "test-service",
+				"resource":     "R1",
 			},
 		},
 		Spans: []*tracepb.Span{

--- a/exporter/newrelicexporter/newrelic_test.go
+++ b/exporter/newrelicexporter/newrelic_test.go
@@ -16,6 +16,7 @@ package newrelicexporter
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/internaldata"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -50,7 +52,7 @@ func TestLogWriter(t *testing.T) {
 	assert.Len(t, messages, 2)
 }
 
-func testTraceData(t *testing.T, expected []Span, td consumerdata.TraceData) {
+func runMock(ptrace pdata.Traces) (*Mock, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -63,10 +65,42 @@ func testTraceData(t *testing.T, expected []Span, td consumerdata.TraceData) {
 	c.APIKey, c.SpansURLOverride = "1", srv.URL
 	params := component.ExporterCreateParams{Logger: zap.NewNop()}
 	exp, err := f.CreateTracesExporter(context.Background(), params, c)
+	if err != nil {
+		return m, err
+	}
+	if err := exp.ConsumeTraces(ctx, ptrace); err != nil {
+		return m, err
+	}
+	if err := exp.Shutdown(ctx); err != nil {
+		return m, err
+	}
+	return m, nil
+}
+
+func testTraceData(t *testing.T, expected []Span, td consumerdata.TraceData) {
+	m, err := runMock(internaldata.OCToTraceData(td))
 	require.NoError(t, err)
-	require.NoError(t, exp.ConsumeTraces(ctx, internaldata.OCToTraceData(td)))
-	require.NoError(t, exp.Shutdown(ctx))
 	assert.Equal(t, expected, m.Spans())
+}
+
+func TestExportTracePartialData(t *testing.T) {
+	ptrace := internaldata.OCToTraceData(consumerdata.TraceData{
+		Spans: []*tracepb.Span{
+			{
+				SpanId: []byte{0, 0, 0, 0, 0, 0, 0, 1},
+				Name:   &tracepb.TruncatableString{Value: "no trace id"},
+			},
+			{
+				TraceId: []byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+				Name:    &tracepb.TruncatableString{Value: "no span id"},
+			},
+		},
+	})
+
+	_, err := runMock(ptrace)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), errInvalidSpanID.Error()))
+	assert.True(t, strings.Contains(err.Error(), errInvalidTraceID.Error()))
 }
 
 func TestExportTraceDataMinimum(t *testing.T) {

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -74,13 +74,15 @@ func newTraceTransformer(resource pdata.Resource, lib pdata.InstrumentationLibra
 }
 
 var (
-	emptySpan      telemetry.Span
-	emptySpanError = errors.New("empty span")
+	emptySpan         telemetry.Span
+	emptySpanErr      = errors.New("empty span")
+	invalidSpanIDErr  = errors.New("SpanID is invalid")
+	invalidTraceIDErr = errors.New("TraceID is invalid")
 )
 
 func (t *traceTransformer) Span(span pdata.Span) (telemetry.Span, error) {
 	if span.IsNil() {
-		return emptySpan, emptySpanError
+		return emptySpan, emptySpanErr
 	}
 
 	startTime := pdata.UnixNanoToTime(span.StartTime())
@@ -96,10 +98,10 @@ func (t *traceTransformer) Span(span pdata.Span) (telemetry.Span, error) {
 	}
 
 	if sp.ID == "" {
-		return sp, errors.New("SpanID is invalid")
+		return sp, invalidSpanIDErr
 	}
 	if sp.TraceID == "" {
-		return sp, errors.New("TraceID is invalid")
+		return sp, invalidTraceIDErr
 	}
 
 	return sp, nil

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -22,124 +22,141 @@ import (
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/newrelic/newrelic-telemetry-sdk-go/cumulative"
 	"github.com/newrelic/newrelic-telemetry-sdk-go/telemetry"
-	"go.opencensus.io/trace"
 	"go.opentelemetry.io/collector/component/componenterror"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
-	unitAttrKey         = "unit"
-	descriptionAttrKey  = "description"
-	collectorNameKey    = "collector.name"
-	collectorVersionKey = "collector.version"
-	serviceNameKey      = "service.name"
+	unitAttrKey          = "unit"
+	descriptionAttrKey   = "description"
+	collectorNameKey     = "collector.name"
+	collectorVersionKey  = "collector.version"
+	statusCodeKey        = "otel.status_code"
+	statusDescriptionKey = "otel.status_description"
+	spanKindKey          = "span.kind"
+	serviceNameKey       = "service.name"
 )
 
-type transformer struct {
+// TODO (MrAlias): unify this with the traceTransformer when the metric data
+// export moves to using pdata and away from the OC proto.
+type metricTransformer struct {
 	DeltaCalculator *cumulative.DeltaCalculator
 	ServiceName     string
 	Resource        *resourcepb.Resource
 }
 
-var (
-	emptySpan   telemetry.Span
-	emptySpanID trace.SpanID
-)
+type traceTransformer struct {
+	ServiceName        string
+	ResourceAttributes map[string]interface{}
+}
 
-func (t *transformer) Span(span *tracepb.Span) (telemetry.Span, error) {
-	if span == nil {
+func newTraceTransformer(resource pdata.Resource, lib pdata.InstrumentationLibrary) *traceTransformer {
+	t := &traceTransformer{
+		ServiceName: tracetranslator.ResourceNoServiceName,
+		ResourceAttributes: tracetranslator.AttributeMapToMap(
+			resource.Attributes(),
+		),
+	}
+	if resource.Attributes().Len() == 0 {
+		return t
+	}
+
+	var srv string
+	if sn, ok := t.ResourceAttributes[conventions.AttributeServiceName]; ok {
+		srv, ok = sn.(string)
+		if ok {
+			delete(t.ResourceAttributes, conventions.AttributeServiceName)
+		}
+	} else if fn, ok := t.ResourceAttributes[conventions.AttributeFaasName]; ok {
+		srv, _ = fn.(string)
+	} else if fn, ok := t.ResourceAttributes[conventions.AttributeK8sDeployment]; ok {
+		srv, _ = fn.(string)
+	} else if fn, ok := t.ResourceAttributes[conventions.AttributeProcessExecutableName]; ok {
+		srv, _ = fn.(string)
+	}
+	if srv != "" {
+		t.ServiceName = srv
+	}
+
+	return t
+}
+
+var emptySpan telemetry.Span
+
+func (t *traceTransformer) Span(span pdata.Span) (telemetry.Span, error) {
+	if span.IsNil() {
 		return emptySpan, errors.New("empty span")
 	}
 
-	startTime := t.Timestamp(span.StartTime)
-
-	var (
-		traceID          trace.TraceID
-		spanID, parentID trace.SpanID
-	)
-
-	copy(traceID[:], span.GetTraceId())
-	copy(spanID[:], span.GetSpanId())
-	copy(parentID[:], span.GetParentSpanId())
+	startTime := pdata.UnixNanoToTime(span.StartTime())
 	sp := telemetry.Span{
-		ID:          spanID.String(),
-		TraceID:     traceID.String(),
-		Name:        t.TruncatableString(span.GetName()),
+		// HexString validates the IDs, it will be an empty string if invalid.
+		ID:          span.SpanID().HexString(),
+		TraceID:     span.TraceID().HexString(),
+		ParentID:    span.ParentSpanID().HexString(),
+		Name:        span.Name(),
 		Timestamp:   startTime,
-		Duration:    t.Timestamp(span.EndTime).Sub(startTime),
+		Duration:    pdata.UnixNanoToTime(span.EndTime()).Sub(startTime),
 		ServiceName: t.ServiceName,
 		Attributes:  t.SpanAttributes(span),
 	}
 
-	if parentID != emptySpanID {
-		sp.ParentID = parentID.String()
+	if sp.ID == "" {
+		return sp, errors.New("SpanID is invalid")
+	}
+	if sp.TraceID == "" {
+		return sp, errors.New("TraceID is invalid")
 	}
 
 	return sp, nil
 }
 
-func (t *transformer) TruncatableString(ts *tracepb.TruncatableString) string {
-	if ts == nil {
-		return ""
+func (t *traceTransformer) SpanAttributes(span pdata.Span) map[string]interface{} {
+
+	length := 2 + len(t.ResourceAttributes) + span.Attributes().Len()
+
+	var hasStatusCode, hasStatusDesc bool
+	if s := span.Status(); !s.IsNil() {
+		if s.Code() != pdata.StatusCodeUnset {
+			hasStatusCode = true
+			length++
+			if s.Message() != "" {
+				hasStatusDesc = true
+				length++
+			}
+		}
 	}
-	return ts.Value
-}
 
-func (t *transformer) SpanAttributes(span *tracepb.Span) map[string]interface{} {
-
-	length := 2
-
-	isErr := span.Status != nil && span.Status.Code != 0
-	if isErr {
+	validSpanKind := span.Kind() != pdata.SpanKindUNSPECIFIED
+	if validSpanKind {
 		length++
-	}
-
-	if t.Resource != nil {
-		length += len(t.Resource.Labels)
-	}
-
-	if span.Attributes != nil {
-		length += len(span.Attributes.AttributeMap)
 	}
 
 	attrs := make(map[string]interface{}, length)
 
-	// Any existing error attribute will override this.
-	if isErr {
-		attrs["error"] = true
+	if hasStatusCode {
+		attrs[statusCodeKey] = int(span.Status().Code())
+	}
+	if hasStatusDesc {
+		attrs[statusDescriptionKey] = span.Status().Message()
 	}
 
 	// Add span kind if it is set
-	if span.Kind != tracepb.Span_SPAN_KIND_UNSPECIFIED {
-		attrs["span.kind"] = strings.ToLower(span.Kind.String())
+	if validSpanKind {
+		attrs[spanKindKey] = strings.ToLower(span.Kind().String())
 	}
 
-	if t.Resource != nil {
-		for k, v := range t.Resource.Labels {
-			attrs[k] = v
-		}
+	for k, v := range t.ResourceAttributes {
+		attrs[k] = v
 	}
 
-	if span.Attributes != nil {
-		for key, attr := range span.Attributes.AttributeMap {
-			if attr == nil || attr.Value == nil {
-				continue
-			}
-			// Default to skipping if unknown type.
-			switch v := attr.Value.(type) {
-			case *tracepb.AttributeValue_BoolValue:
-				attrs[key] = v.BoolValue
-			case *tracepb.AttributeValue_IntValue:
-				attrs[key] = v.IntValue
-			case *tracepb.AttributeValue_DoubleValue:
-				attrs[key] = v.DoubleValue
-			case *tracepb.AttributeValue_StringValue:
-				attrs[key] = t.TruncatableString(v.StringValue)
-			}
-		}
+	for k, v := range tracetranslator.AttributeMapToMap(span.Attributes()) {
+		attrs[k] = v
 	}
 
 	// Default attributes to tell New Relic about this collector.
@@ -150,14 +167,14 @@ func (t *transformer) SpanAttributes(span *tracepb.Span) map[string]interface{} 
 	return attrs
 }
 
-func (t *transformer) Timestamp(ts *timestamppb.Timestamp) time.Time {
+func (t *metricTransformer) Timestamp(ts *timestamppb.Timestamp) time.Time {
 	if ts == nil {
 		return time.Time{}
 	}
 	return time.Unix(ts.Seconds, int64(ts.Nanos))
 }
 
-func (t *transformer) Metric(metric *metricspb.Metric) ([]telemetry.Metric, error) {
+func (t *metricTransformer) Metric(metric *metricspb.Metric) ([]telemetry.Metric, error) {
 	if metric == nil || metric.MetricDescriptor == nil {
 		return nil, errors.New("empty metric")
 	}
@@ -201,7 +218,7 @@ func (t *transformer) Metric(metric *metricspb.Metric) ([]telemetry.Metric, erro
 	return metrics, componenterror.CombineErrors(errs)
 }
 
-func (t *transformer) MetricAttributes(metric *metricspb.Metric) map[string]interface{} {
+func (t *metricTransformer) MetricAttributes(metric *metricspb.Metric) map[string]interface{} {
 	length := 3
 
 	if t.Resource != nil {
@@ -241,7 +258,7 @@ func (t *transformer) MetricAttributes(metric *metricspb.Metric) map[string]inte
 	return attrs
 }
 
-func (t *transformer) MergeAttributes(base map[string]interface{}, lk []*metricspb.LabelKey, lv []*metricspb.LabelValue) (map[string]interface{}, error) {
+func (t *metricTransformer) MergeAttributes(base map[string]interface{}, lk []*metricspb.LabelKey, lv []*metricspb.LabelValue) (map[string]interface{}, error) {
 	if len(lk) != len(lv) {
 		return nil, fmt.Errorf("number of label keys (%d) different than label values (%d)", len(lk), len(lv))
 	}
@@ -260,7 +277,7 @@ func (t *transformer) MergeAttributes(base map[string]interface{}, lk []*metrics
 	return attrs, nil
 }
 
-func (t *transformer) Gauge(name string, attrs map[string]interface{}, point *metricspb.Point) telemetry.Metric {
+func (t *metricTransformer) Gauge(name string, attrs map[string]interface{}, point *metricspb.Point) telemetry.Metric {
 	now := time.Now()
 	if point.Timestamp != nil {
 		now = t.Timestamp(point.Timestamp)
@@ -282,7 +299,7 @@ func (t *transformer) Gauge(name string, attrs map[string]interface{}, point *me
 	return m
 }
 
-func (t *transformer) DeltaSummary(name string, attrs map[string]interface{}, start time.Time, point *metricspb.Point) telemetry.Metric {
+func (t *metricTransformer) DeltaSummary(name string, attrs map[string]interface{}, start time.Time, point *metricspb.Point) telemetry.Metric {
 	now := time.Now()
 	if point.Timestamp != nil {
 		now = t.Timestamp(point.Timestamp)
@@ -307,7 +324,7 @@ func (t *transformer) DeltaSummary(name string, attrs map[string]interface{}, st
 	return m
 }
 
-func (t *transformer) CumulativeCount(name string, attrs map[string]interface{}, start time.Time, point *metricspb.Point) telemetry.Metric {
+func (t *metricTransformer) CumulativeCount(name string, attrs map[string]interface{}, start time.Time, point *metricspb.Point) telemetry.Metric {
 	var value float64
 	switch t := point.Value.(type) {
 	case *metricspb.Point_Int64Value:
@@ -337,7 +354,7 @@ func (t *transformer) CumulativeCount(name string, attrs map[string]interface{},
 	return count
 }
 
-func (t *transformer) CumulativeSummary(name string, attrs map[string]interface{}, start time.Time, point *metricspb.Point) telemetry.Metric {
+func (t *metricTransformer) CumulativeSummary(name string, attrs map[string]interface{}, start time.Time, point *metricspb.Point) telemetry.Metric {
 	var sum, count float64
 	switch t := point.Value.(type) {
 	case *metricspb.Point_DistributionValue:

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -75,14 +75,14 @@ func newTraceTransformer(resource pdata.Resource, lib pdata.InstrumentationLibra
 
 var (
 	emptySpan         telemetry.Span
-	emptySpanErr      = errors.New("empty span")
-	invalidSpanIDErr  = errors.New("SpanID is invalid")
-	invalidTraceIDErr = errors.New("TraceID is invalid")
+	errEmptySpan      = errors.New("empty span")
+	errInvalidSpanID  = errors.New("SpanID is invalid")
+	errInvalidTraceID = errors.New("TraceID is invalid")
 )
 
 func (t *traceTransformer) Span(span pdata.Span) (telemetry.Span, error) {
 	if span.IsNil() {
-		return emptySpan, emptySpanErr
+		return emptySpan, errEmptySpan
 	}
 
 	startTime := pdata.UnixNanoToTime(span.StartTime())
@@ -98,10 +98,10 @@ func (t *traceTransformer) Span(span pdata.Span) (telemetry.Span, error) {
 	}
 
 	if sp.ID == "" {
-		return sp, invalidSpanIDErr
+		return sp, errInvalidSpanID
 	}
 	if sp.TraceID == "" {
-		return sp, invalidTraceIDErr
+		return sp, errInvalidTraceID
 	}
 
 	return sp, nil

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -251,9 +251,11 @@ func (t *metricTransformer) MetricAttributes(metric *metricspb.Metric) map[strin
 	return attrs
 }
 
+var errIncompatibleLabels = errors.New("label keys and values do not match")
+
 func (t *metricTransformer) MergeAttributes(base map[string]interface{}, lk []*metricspb.LabelKey, lv []*metricspb.LabelValue) (map[string]interface{}, error) {
 	if len(lk) != len(lv) {
-		return nil, fmt.Errorf("number of label keys (%d) different than label values (%d)", len(lk), len(lv))
+		return nil, fmt.Errorf("%w: number of label keys (%d) different than label values (%d)", errIncompatibleLabels, len(lk), len(lv))
 	}
 
 	attrs := make(map[string]interface{}, len(base)+len(lk))

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -32,14 +32,16 @@ import (
 )
 
 const (
-	unitAttrKey          = "unit"
-	descriptionAttrKey   = "description"
-	collectorNameKey     = "collector.name"
-	collectorVersionKey  = "collector.version"
-	statusCodeKey        = "otel.status_code"
-	statusDescriptionKey = "otel.status_description"
-	spanKindKey          = "span.kind"
-	serviceNameKey       = "service.name"
+	unitAttrKey               = "unit"
+	descriptionAttrKey        = "description"
+	collectorNameKey          = "collector.name"
+	collectorVersionKey       = "collector.version"
+	instrumentationNameKey    = "instrumentation.name"
+	instrumentationVersionKey = "instrumentation.version"
+	statusCodeKey             = "otel.status_code"
+	statusDescriptionKey      = "otel.status_description"
+	spanKindKey               = "span.kind"
+	serviceNameKey            = "service.name"
 )
 
 // TODO (MrAlias): unify this with the traceTransformer when the metric data
@@ -62,8 +64,14 @@ func newTraceTransformer(resource pdata.Resource, lib pdata.InstrumentationLibra
 			resource.Attributes(),
 		),
 	}
-	if resource.Attributes().Len() == 0 {
-		return t
+
+	if !lib.IsNil() {
+		if n := lib.Name(); n != nil {
+			t.ResourceAttributes[instrumentationNameKey] = n
+			if v := lib.Version(); v != nil {
+				t.ResourceAttributes[instrumentationVersionKey] = v
+			}
+		}
 	}
 
 	var srv string

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -79,7 +79,7 @@ func TestTransformSpan(t *testing.T) {
 		{
 			name:     "nil span",
 			spanFunc: pdata.NewSpan,
-			err:      emptySpanErr,
+			err:      errEmptySpan,
 			want:     emptySpan,
 		},
 		{
@@ -91,7 +91,7 @@ func TestTransformSpan(t *testing.T) {
 				s.SetName("invalid TraceID")
 				return s
 			},
-			err: invalidTraceIDErr,
+			err: errInvalidTraceID,
 			want: telemetry.Span{
 				ID:         "0000000000000001",
 				Name:       "invalid TraceID",
@@ -107,7 +107,7 @@ func TestTransformSpan(t *testing.T) {
 				s.SetName("invalid SpanID")
 				return s
 			},
-			err: invalidSpanIDErr,
+			err: errInvalidSpanID,
 			want: telemetry.Span{
 				TraceID:    "01010101010101010101010101010101",
 				Name:       "invalid SpanID",

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -33,6 +33,19 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+func TestNewTraceTransformerInstrumentation(t *testing.T) {
+	ilm := pdata.NewInstrumentationLibrary()
+	ilm.InitEmpty()
+	ilm.SetName("test name")
+	ilm.SetVersion("test version")
+
+	transform := newTraceTransformer(pdata.NewResource(), ilm)
+	require.Contains(t, transform.ResourceAttributes, instrumentationNameKey)
+	require.Contains(t, transform.ResourceAttributes, instrumentationVersionKey)
+	assert.Equal(t, transform.ResourceAttributes[instrumentationNameKey], "test name")
+	assert.Equal(t, transform.ResourceAttributes[instrumentationVersionKey], "test version")
+}
+
 func defaultAttrFunc(res map[string]interface{}) func(map[string]interface{}) map[string]interface{} {
 	return func(add map[string]interface{}) map[string]interface{} {
 		full := make(map[string]interface{}, 2+len(res)+len(add))

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -312,6 +312,15 @@ func TestTransformSpan(t *testing.T) {
 	}
 }
 
+func TestMergeAttributesIncompatibleLenghts(t *testing.T) {
+	transform := &metricTransformer{}
+	lk := make([]*metricspb.LabelKey, 2)
+	lv := make([]*metricspb.LabelValue, 3)
+	_, err := transform.MergeAttributes(nil, lk, lv)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errIncompatibleLabels))
+}
+
 func TestTransformEmptyMetric(t *testing.T) {
 	transform := &metricTransformer{}
 	_, err := transform.Metric(nil)

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -16,6 +16,7 @@ package newrelicexporter
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ func TestTransformEmptySpan(t *testing.T) {
 	transform := new(traceTransformer)
 	_, err := transform.Span(pdata.NewSpan())
 	assert.Error(t, err)
+	assert.True(t, errors.Is(err, emptySpanError))
 }
 
 func TestTransformSpan(t *testing.T) {


### PR DESCRIPTION
**Description:**  Update the newrelicexporter to use the `pdata` module instead of the OpenCensus proto for its tracing export pipeline. This includes updates to resource, instrumentation library, and status transformations to account for their form in the OTLP.

**Testing:** Unit tests have been updated to test the pdata data structures where possible.