### PR TITLE
update the xray receiver to emit all kind's language's eception

### DIFF
--- a/receiver/awsxrayreceiver/internal/translator/sdk.go
+++ b/receiver/awsxrayreceiver/internal/translator/sdk.go
@@ -29,19 +29,12 @@ func addSdkToResource(seg *awsxray.Segment, attrs *pdata.AttributeMap) {
 		addString(xr.SDKVersion, conventions.AttributeTelemetrySDKVersion, attrs)
 		if xr.SDK != nil {
 			attrs.UpsertString(conventions.AttributeTelemetrySDKName, *xr.SDK)
-			if seg.Cause != nil && len(seg.Cause.Exceptions) > 0 {
-				// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c615d2db351929b99e46f7b427f39c12afe15b54/exporter/awsxrayexporter/translator/cause.go#L150
-				// x-ray exporter only supports Java stack trace for now
-				// TODO: Update this once the exporter is more flexible
-				attrs.UpsertString(conventions.AttributeTelemetrySDKLanguage, "java")
-			} else {
-				// sample *xr.SDK: "X-Ray for Go"
-				sep := "for "
-				sdkStr := *xr.SDK
-				i := strings.Index(sdkStr, sep)
-				if i != -1 {
-					attrs.UpsertString(conventions.AttributeTelemetrySDKLanguage, sdkStr[i+len(sep):])
-				}
+			// sample *xr.SDK: "X-Ray for Go"
+			sep := "for "
+			sdkStr := *xr.SDK
+			i := strings.Index(sdkStr, sep)
+			if i != -1 {
+				attrs.UpsertString(conventions.AttributeTelemetrySDKLanguage, sdkStr[i+len(sep):])
 			}
 		}
 	}

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -139,7 +139,7 @@ func TestTranslation(t *testing.T) {
 					*seg.AWS.XRay.SDKVersion)
 				attrs[conventions.AttributeTelemetrySDKName] = pdata.NewAttributeValueString(
 					*seg.AWS.XRay.SDK)
-				attrs[conventions.AttributeTelemetrySDKLanguage] = pdata.NewAttributeValueString("java")
+				attrs[conventions.AttributeTelemetrySDKLanguage] = pdata.NewAttributeValueString("Go")
 
 				return attrs
 			},


### PR DESCRIPTION
**Description:** 
Xray-receiver used to mark the AttributeTelemetrySDKLanguage with "java" for all the spans with exceptions, because the xray-exporter doesn't deal with other language. This pr will update the xray receiver to generate the right AttributeTelemetrySDKLanguage attribute.

**Testing:** Unite test.