### PR TITLE
jmxreceiver: address flake issues

### DIFF
--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -79,6 +79,12 @@ func (jmx *jmxMetricReceiver) Start(ctx context.Context, host component.Host) (e
 	if err != nil {
 		return err
 	}
+	go func() {
+		for range jmx.subprocess.Stdout {
+			// ensure stdout/stderr buffer is read from.
+			// these messages are already debug logged when captured.
+		}
+	}()
 
 	return jmx.subprocess.Start(context.Background())
 }

--- a/receiver/jmxreceiver/receiver_test.go
+++ b/receiver/jmxreceiver/receiver_test.go
@@ -199,7 +199,7 @@ func TestBuildOTLPReceiverInvalidEndpoints(t *testing.T) {
 		{
 			"invalid OTLPExporterConfig.Endpoint host with 0 port",
 			config{OTLPExporterConfig: otlpExporterConfig{Endpoint: ".:0"}},
-			"failed determining desired port from OTLPExporterConfig.Endpoint .:0: listen tcp: lookup .: no such host",
+			"failed determining desired port from OTLPExporterConfig.Endpoint .:0: listen tcp: lookup .:",
 		},
 	}
 	for _, test := range tests {
@@ -208,7 +208,7 @@ func TestBuildOTLPReceiverInvalidEndpoints(t *testing.T) {
 			jmxReceiver := newJMXMetricReceiver(params, &test.config, consumertest.NewMetricsNop())
 			otlpReceiver, err := jmxReceiver.buildOTLPReceiver()
 			require.Error(t, err)
-			require.EqualError(t, err, test.expectedErr)
+			require.Contains(t, err.Error(), test.expectedErr)
 			require.Nil(t, otlpReceiver)
 		})
 	}

--- a/receiver/jmxreceiver/subprocess/subprocess_test.go
+++ b/receiver/jmxreceiver/subprocess/subprocess_test.go
@@ -63,7 +63,7 @@ func TestShutdownTimeout(t *testing.T) {
 
 	elapsed := int64(time.Since(t0))
 	require.GreaterOrEqual(t, elapsed, int64(10*time.Millisecond))
-	require.GreaterOrEqual(t, int64(20*time.Millisecond), elapsed)
+	require.GreaterOrEqual(t, int64(1*time.Second), elapsed)
 }
 
 func TestPidAccessors(t *testing.T) {


### PR DESCRIPTION
**Description:**
Fixing a bug - these changes include a few minor improvements to the jmx receiver and associated tests:

1. set up a goroutine to read from the receiver's subprocesses' stdout/err channel to avoid it becoming filled.
1. match errors by substring to support running tests on more platforms (vm in this case)
1. bump the failure threshold for the `TestShutdownTimeout` test, as it appears the timer tick channel can be unreliable in timeliness.