### PR TITLE
Set options.UserAgent so that the OpenCensus exporter does not overri…

### DIFF
--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -77,8 +77,8 @@ func generateClientOptions(cfg *Config) ([]option.ClientOption, error) {
 	}
 	if cfg.Endpoint != "" {
 		if cfg.UseInsecure {
-			// option.WithGRPCConn option takes precedent over all other supplied options so need to provide
-			// user agent here as well, for both exporters
+			// option.WithGRPCConn option takes precedent over all other supplied options so the
+			// following user agent will be used by both exporters if we reach this branch
 			var dialOpts []grpc.DialOption
 			if cfg.UserAgent != "" {
 				dialOpts = append(dialOpts, grpc.WithUserAgent(cfg.UserAgent))

--- a/exporter/stackdriverexporter/stackdriver.go
+++ b/exporter/stackdriverexporter/stackdriver.go
@@ -71,12 +71,14 @@ func setVersionInUserAgent(cfg *Config, version string) {
 
 func generateClientOptions(cfg *Config) ([]option.ClientOption, error) {
 	var copts []option.ClientOption
+	// option.WithUserAgent is used by the Trace exporter, but not the Metric exporter (see comment below)
 	if cfg.UserAgent != "" {
 		copts = append(copts, option.WithUserAgent(cfg.UserAgent))
 	}
 	if cfg.Endpoint != "" {
 		if cfg.UseInsecure {
-			// WithGRPCConn option takes precedent over all other supplied options so need to provide user agent here as well
+			// option.WithGRPCConn option takes precedent over all other supplied options so need to provide
+			// user agent here as well, for both exporters
 			var dialOpts []grpc.DialOption
 			if cfg.UserAgent != "" {
 				dialOpts = append(dialOpts, grpc.WithUserAgent(cfg.UserAgent))
@@ -206,6 +208,7 @@ func newStackdriverMetricsExporter(cfg *Config, params component.ExporterCreateP
 		Timeout: cfg.Timeout,
 	}
 
+	// note options.UserAgent overrides the option.WithUserAgent client option in the Metric exporter
 	if cfg.UserAgent != "" {
 		options.UserAgent = cfg.UserAgent
 	}


### PR DESCRIPTION
Fixes a bug where the configured `UserAgent` was being overridden in the Stackdriver OpenCensus exporter. The setup here is a bit complex so I described in detail below.

The OpenCensus exporter allows the client to fully control the gRPC client by passing in a list of `[]option.ClientOption`. The configuration options available are:

1. Provide a list of `[]option.ClientOption` to configure the client. This can include:
    1. `option.WithUserAgent(...)`
    1. `option.WithGRPCConn(grpc.Dial(cfg.Endpoint, grpc.WithUserAgent(...), grpc.WithInsecure()))`
1. Provide a string `UserAgent`

If configuring an insecure local gRPC connection for testing, the code uses `1ii`, which requires the UserAgent to be set explicitly as part of the grpc dial options (as `WithGRPCConn` option takes precedent over all other supplied options).

If configuring anything else, the user can currently specify the UserAgent via `option.WithUserAgent(...)` (`1i`) or directly via the `UserAgent` string (`2`). The problem with approach `1i` is that the exporter has no way to inspect the provided options; it doesn't know if the UserAgent string is already set and so will override the value. It would be nice if there was an `option.AppendUserAgent` function but I haven't found anything like that. If using approach `2`, the exporter will not override the user agent value.

This is a bit confusing (multiple ways to configure the same thing) and we should consider if there's a way to make this cleaner.

**Testing:** There is a unit test for `1ii`. I'm unable to add a test to correctly validate `2` since it's dependent on not configuring a local endpoint.