### PR TITLE
[awsemf-exporter] add placeholder support in logGroup and logStream config

### DIFF
--- a/exporter/awsemfexporter/README.md
+++ b/exporter/awsemfexporter/README.md
@@ -14,8 +14,8 @@ The following exporter configuration parameters are supported.
 
 | Name              | Description                                                            | Default |
 | :---------------- | :--------------------------------------------------------------------- | ------- |
-| `log_group_name`  | Customized log group name                                              |"/metrics/default"|
-| `log_stream_name` | Customized log stream name                                             |"otel-stream"|
+| `log_group_name`  | Customized log group name which supports `{{ClusterName}}` and `{{TaskId}}` placeholders. One valid example is `/aws/metrics/{{ClusterName}}`. It will search for `ClusterName` (or `aws.ecs.cluster.name`) resource attribute in the metrics data and replace with the actual cluster name. If none of them are found in the resource attribute map, `{{ClusterName}}` will be replaced by `undefined`. Similar way, for the `{{TaskId}}`, it searches for `TaskId` (or `aws.ecs.task.id`) key in the resource attribute map.                                           |"/metrics/default"|
+| `log_stream_name` | Customized log stream name which supports `{{TaskId}}` and `{{ClusterName}}` placeholders. One valid example is `{{TaskId}}`. It will search for `TaskId` (or `aws.ecs.task.id`) resource attribute in the metrics data and replace with the actual task id. If none of them are found in the resource attribute map, `{{TaskId}}` will be replaced by `undefined`. Similar way, for the `{{ClusterName}}`, it searches for `ClusterName` (or `aws.ecs.cluster.name`) key in the resource attribute map.                                             |"otel-stream"|
 | `namespace`       | Customized CloudWatch metrics namespace                                | "default" |
 | `endpoint`        | Optionally override the default CloudWatch service endpoint.           |         |
 | `no_verify_ssl`   | Enable or disable TLS certificate verification.                        | false   |

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -135,14 +135,263 @@ func TestConsumeMetricsWithLogGroupStreamConfig(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, exp)
 
-	mdata := consumerdata.MetricsData{}
+	mdata := consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			ServiceInfo: &commonpb.ServiceInfo{Name: "test-emf"},
+			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
+		},
+		Resource: &resourcepb.Resource{
+			Labels: map[string]string{
+				"resource": "R1",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan"},
+							{Value: "false"},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	md := internaldata.OCToMetrics(mdata)
 	require.NoError(t, exp.Start(ctx, nil))
-	require.NoError(t, exp.ConsumeMetrics(ctx, md))
+	require.Error(t, exp.ConsumeMetrics(ctx, md))
 	require.NoError(t, exp.Shutdown(ctx))
 	streamToPusherMap, ok := exp.(*emfExporter).groupStreamToPusherMap["test-logGroupName"]
 	assert.True(t, ok)
 	pusher, ok := streamToPusherMap["test-logStreamName"]
+	assert.True(t, ok)
+	assert.NotNil(t, pusher)
+}
+
+func TestConsumeMetricsWithLogGroupStreamValidPlaceholder(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	factory := NewFactory()
+	expCfg := factory.CreateDefaultConfig().(*Config)
+	expCfg.Region = "us-west-2"
+	expCfg.MaxRetries = defaultRetryCount
+	expCfg.LogGroupName = "/aws/ecs/containerinsights/{{ClusterName}}/performance"
+	expCfg.LogStreamName = "{{TaskId}}"
+	exp, err := New(expCfg, component.ExporterCreateParams{Logger: zap.NewNop()})
+	assert.Nil(t, err)
+	assert.NotNil(t, exp)
+
+	mdata := consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			ServiceInfo: &commonpb.ServiceInfo{Name: "test-emf"},
+			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
+		},
+		Resource: &resourcepb.Resource{
+			Labels: map[string]string{
+				"aws.ecs.cluster.name": "test-cluster-name",
+				"aws.ecs.task.id":      "test-task-id",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan"},
+							{Value: "false"},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	md := internaldata.OCToMetrics(mdata)
+	require.NoError(t, exp.Start(ctx, nil))
+	require.Error(t, exp.ConsumeMetrics(ctx, md))
+	require.NoError(t, exp.Shutdown(ctx))
+	streamToPusherMap, ok := exp.(*emfExporter).groupStreamToPusherMap["/aws/ecs/containerinsights/test-cluster-name/performance"]
+	assert.True(t, ok)
+	pusher, ok := streamToPusherMap["test-task-id"]
+	assert.True(t, ok)
+	assert.NotNil(t, pusher)
+}
+
+func TestConsumeMetricsWithOnlyLogStreamPlaceholder(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	factory := NewFactory()
+	expCfg := factory.CreateDefaultConfig().(*Config)
+	expCfg.Region = "us-west-2"
+	expCfg.MaxRetries = defaultRetryCount
+	expCfg.LogGroupName = "test-logGroupName"
+	expCfg.LogStreamName = "{{TaskId}}"
+	exp, err := New(expCfg, component.ExporterCreateParams{Logger: zap.NewNop()})
+	assert.Nil(t, err)
+	assert.NotNil(t, exp)
+
+	mdata := consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			ServiceInfo: &commonpb.ServiceInfo{Name: "test-emf"},
+			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
+		},
+		Resource: &resourcepb.Resource{
+			Labels: map[string]string{
+				"aws.ecs.cluster.name": "test-cluster-name",
+				"aws.ecs.task.id":      "test-task-id",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan"},
+							{Value: "false"},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	md := internaldata.OCToMetrics(mdata)
+	require.NoError(t, exp.Start(ctx, nil))
+	require.Error(t, exp.ConsumeMetrics(ctx, md))
+	require.NoError(t, exp.Shutdown(ctx))
+	streamToPusherMap, ok := exp.(*emfExporter).groupStreamToPusherMap["test-logGroupName"]
+	assert.True(t, ok)
+	pusher, ok := streamToPusherMap["test-task-id"]
+	assert.True(t, ok)
+	assert.NotNil(t, pusher)
+}
+
+func TestConsumeMetricsWithWrongPlaceholder(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	factory := NewFactory()
+	expCfg := factory.CreateDefaultConfig().(*Config)
+	expCfg.Region = "us-west-2"
+	expCfg.MaxRetries = defaultRetryCount
+	expCfg.LogGroupName = "test-logGroupName"
+	expCfg.LogStreamName = "{{WorngKey}}"
+	exp, err := New(expCfg, component.ExporterCreateParams{Logger: zap.NewNop()})
+	assert.Nil(t, err)
+	assert.NotNil(t, exp)
+
+	mdata := consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			ServiceInfo: &commonpb.ServiceInfo{Name: "test-emf"},
+			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
+		},
+		Resource: &resourcepb.Resource{
+			Labels: map[string]string{
+				"aws.ecs.cluster.name": "test-cluster-name",
+				"aws.ecs.task.id":      "test-task-id",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan"},
+							{Value: "false"},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 100,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	md := internaldata.OCToMetrics(mdata)
+	require.NoError(t, exp.Start(ctx, nil))
+	require.Error(t, exp.ConsumeMetrics(ctx, md))
+	require.NoError(t, exp.Shutdown(ctx))
+	streamToPusherMap, ok := exp.(*emfExporter).groupStreamToPusherMap["test-logGroupName"]
+	assert.True(t, ok)
+	pusher, ok := streamToPusherMap["{{WorngKey}}"]
 	assert.True(t, ok)
 	assert.NotNil(t, pusher)
 }

--- a/exporter/awsemfexporter/util.go
+++ b/exporter/awsemfexporter/util.go
@@ -1,0 +1,49 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsemfexporter
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+const (
+	AttributeCluster   = "ecs.cluster"
+	AttributeECSTaskID = "ecs.task-id"
+)
+
+func replacePatterns(s string, attrMap pdata.AttributeMap, logger *zap.Logger) string {
+	s = replacePatternWithResource(s, AttributeCluster, attrMap, logger)
+	s = replacePatternWithResource(s, AttributeECSTaskID, attrMap, logger)
+	return s
+}
+
+func replacePatternWithResource(s, patternKey string, attrMap pdata.AttributeMap, logger *zap.Logger) string {
+	pattern := "{{" + patternKey + "}}"
+	if strings.Contains(s, pattern) {
+		value, ok := attrMap.Get(patternKey)
+		if ok {
+			if !value.IsNil() {
+				stringVal := value.StringVal()
+				s = strings.ReplaceAll(s, pattern, stringVal)
+			}
+		} else {
+			logger.Error("No resource attribute found for pattern " + pattern)
+		}
+	}
+	return s
+}

--- a/exporter/awsemfexporter/util_test.go
+++ b/exporter/awsemfexporter/util_test.go
@@ -1,0 +1,113 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awsemfexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+func TestReplacePatternValidTaskId(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "{{TaskId}}"
+
+	attrMap := pdata.NewAttributeMap()
+	attrMap.InitEmptyWithCapacity(2)
+
+	attrMap.UpsertString("aws.ecs.cluster.name", "test-cluster-name")
+	attrMap.UpsertString("aws.ecs.task.id", "test-task-id")
+
+	s := replacePatterns(input, attrMap, logger)
+
+	assert.Equal(t, "test-task-id", s)
+}
+
+func TestReplacePatternValidClusterName(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{{ClusterName}}/performance"
+
+	attrMap := pdata.NewAttributeMap()
+	attrMap.InitEmptyWithCapacity(2)
+
+	attrMap.UpsertString("aws.ecs.cluster.name", "test-cluster-name")
+	attrMap.UpsertString("aws.ecs.task.id", "test-task-id")
+
+	s := replacePatterns(input, attrMap, logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/test-cluster-name/performance", s)
+}
+
+func TestReplacePatternMissingAttribute(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{{ClusterName}}/performance"
+
+	attrMap := pdata.NewAttributeMap()
+	attrMap.InitEmptyWithCapacity(1)
+
+	attrMap.UpsertString("aws.ecs.task.id", "test-task-id")
+
+	s := replacePatterns(input, attrMap, logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/undefined/performance", s)
+}
+
+func TestReplacePatternAttrPlaceholderClusterName(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{{ClusterName}}/performance"
+
+	attrMap := pdata.NewAttributeMap()
+	attrMap.InitEmptyWithCapacity(1)
+
+	attrMap.UpsertString("ClusterName", "test-cluster-name")
+
+	s := replacePatterns(input, attrMap, logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/test-cluster-name/performance", s)
+}
+
+func TestReplacePatternWrongKey(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{{WrongKey}}/performance"
+
+	attrMap := pdata.NewAttributeMap()
+	attrMap.InitEmptyWithCapacity(1)
+
+	attrMap.UpsertString("ClusterName", "test-task-id")
+
+	s := replacePatterns(input, attrMap, logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/{{WrongKey}}/performance", s)
+}
+
+func TestReplacePatternNilAttrValue(t *testing.T) {
+	logger := zap.NewNop()
+
+	input := "/aws/ecs/containerinsights/{{ClusterName}}/performance"
+
+	attrMap := pdata.NewAttributeMap()
+	attrMap.InsertNull("ClusterName")
+
+	s := replacePatterns(input, attrMap, logger)
+
+	assert.Equal(t, "/aws/ecs/containerinsights/undefined/performance", s)
+}


### PR DESCRIPTION
This change adds support for placeholders in `logGroup` and `logStream` name. The expected pattern is `{{resource_attribute_key}}`. If the key is not found in the resource attribute map, it will be replaced by `undefined` (also, will print an error message).
```yaml
awsemf:
        region: 'us-west-2'
        log_group_name: "/aws/metrics/{{ClusterName}}"
        log_stream_name: "{{TaskId}}"
```

Key Facts:
1. Right now, it only looks for two attributes `{{ClusterName}}` and `{{TaskId}}`. We can easily add new attributes and support more configuration options.
2. In future, if we see a need for generic, we can update our `replacePatterns()` func with regex support without introducing customer facing changes. Because of performance issue, we are not considering it until we see a strong need. Discussed with Min offline.

***Testing***
[1] Added unit tests
[2] Manually tested for e2e experience

***Documentation***
Updated README