### PR TITLE
[ecs-metrics-receiver] extract cluster name from ARN and rename some constants

### DIFF
--- a/receiver/awsecscontainermetricsreceiver/README.md
+++ b/receiver/awsecscontainermetricsreceiver/README.md
@@ -35,7 +35,7 @@ Task Level Metrics | Container Level Metrics | Unit
 ecs.task.memory.usage | container.memory.usage | Bytes
 ecs.task.memory.usage.max | container.memory.usage.max | Bytes
 ecs.task.memory.usage.limit | container.memory.usage.limit | Bytes
-ecs.task.memory.reserved | Bcontainer.memory.reserved | Megabytes
+ecs.task.memory.reserved | container.memory.reserved | Megabytes
 ecs.task.memory.utilized | container.memory.utilized | Megabytes
 ecs.task.cpu.usage.total | container.cpu.usage.total | Nanoseconds
 ecs.task.cpu.usage.kernelmode | container.cpu.usage.kernelmode | Nanoseconds

--- a/receiver/awsecscontainermetricsreceiver/README.md
+++ b/receiver/awsecscontainermetricsreceiver/README.md
@@ -64,16 +64,16 @@ ecs.task.storage.write_bytes | container.storage.write_bytes | Bytes
 Metrics emitted by this receiver comes with a set of resource attributes. These resource attributes can be converted to metrics labels using appropriate processors/exporters (See `Full Configuration Examples` section below). Finally, these metrics labels can be set as metrics dimensions while exporting to desired destinations. Check the following table to see available resource attributes for Task and Container level metrics. Container level metrics have three additional attributes than task level metrics.
 
 Resource Attributes for Task Level Metrics | Resource Attributes for Container Level Metrics
------------- | -------------
-ecs.cluster | ecs.cluster
-ecs.task-definition-family | ecs.task-definition-family
-ecs.task-arn | ecs.task-arn
-ecs.task-id | ecs.task-id
-ecs.task-definition-version | ecs.task-definition-version
-ecs.service | ecs.service
+-------------------- | -----------------------------
+aws.ecs.cluster.name | aws.ecs.cluster.name
+aws.ecs.task.family  | aws.ecs.task.family
+aws.ecs.task.arn     | aws.ecs.task.arn
+aws.ecs.task.id      | aws.ecs.task.id
+aws.ecs.task.version | aws.ecs.task.version
+aws.ecs.service.name | aws.ecs.service.name
 &nbsp; | container.name
 &nbsp; | container.id
-&nbsp; | ecs.docker-name 
+&nbsp; | aws.ecs.docker.name 
 
 ## Full Configuration Examples
 This receiver emits 52 unique metrics. Customer may not want to send all of them to destinations. This section will show full configuration files for filtering and transforming existing metrics with different processors/exporters. 

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/constant.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/constant.go
@@ -15,20 +15,19 @@
 package awsecscontainermetrics
 
 const (
-	AttributeECSDockerName   = "ecs.docker-name"
-	AttributeECSCluster      = "ecs.cluster"
-	AttributeECSTaskARN      = "ecs.task-arn"
-	AttributeECSTaskID       = "ecs.task-id"
-	AttributeECSTaskFamily   = "ecs.task-definition-family"
-	AttributeECSTaskRevesion = "ecs.task-definition-version"
-	AttributeECSServiceName  = "ecs.service"
+	AttributeECSDockerName   = "aws.ecs.docker.name"
+	AttributeECSCluster      = "aws.ecs.cluster.name"
+	AttributeECSTaskARN      = "aws.ecs.task.arn"
+	AttributeECSTaskID       = "aws.ecs.task.id"
+	AttributeECSTaskFamily   = "aws.ecs.task.family"
+	AttributeECSTaskRevesion = "aws.ecs.task.version"
+	AttributeECSServiceName  = "aws.ecs.service.name"
 
 	CPUsInVCpu = 1024
 	BytesInMiB = 1024 * 1024
 
-	TaskPrefix         = "ecs.task."
-	ContainerPrefix    = "container."
-	MetricResourceType = "aoc.ecs"
+	TaskPrefix      = "ecs.task."
+	ContainerPrefix = "container."
 
 	EndpointEnvKey   = "ECS_CONTAINER_METADATA_URI_V4"
 	TaskStatsPath    = "/task/stats"

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/resource.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/resource.go
@@ -32,9 +32,9 @@ func containerResource(cm ContainerMetadata) pdata.Resource {
 
 func taskResource(tm TaskMetadata) pdata.Resource {
 	resource := pdata.NewResource()
-	resource.Attributes().UpsertString(AttributeECSCluster, tm.Cluster)
+	resource.Attributes().UpsertString(AttributeECSCluster, getResourceFromARN(tm.Cluster))
 	resource.Attributes().UpsertString(AttributeECSTaskARN, tm.TaskARN)
-	resource.Attributes().UpsertString(AttributeECSTaskID, getTaskIDFromARN(tm.TaskARN))
+	resource.Attributes().UpsertString(AttributeECSTaskID, getResourceFromARN(tm.TaskARN))
 	resource.Attributes().UpsertString(AttributeECSTaskFamily, tm.Family)
 	resource.Attributes().UpsertString(AttributeECSTaskRevesion, tm.Revision)
 	resource.Attributes().UpsertString(AttributeECSServiceName, "undefined")
@@ -42,9 +42,9 @@ func taskResource(tm TaskMetadata) pdata.Resource {
 	return resource
 }
 
-func getTaskIDFromARN(arn string) string {
+func getResourceFromARN(arn string) string {
 	if arn == "" || !strings.HasPrefix(arn, "arn:aws") {
-		return ""
+		return arn
 	}
 	splits := strings.Split(arn, "/")
 

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/resource_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/resource_test.go
@@ -68,6 +68,30 @@ func TestTaskResource(t *testing.T) {
 	verifyAttributeMap(t, expected, attrMap)
 }
 
+func TestTaskResourceWithClusterARN(t *testing.T) {
+	tm := TaskMetadata{
+		Cluster:  "arn:aws:ecs:us-west-2:803860917211:cluster/main-cluster",
+		TaskARN:  "arn:aws:some-value/001",
+		Family:   "task-def-family-1",
+		Revision: "v1.2",
+	}
+	r := taskResource(tm)
+	require.NotNil(t, r)
+
+	attrMap := r.Attributes()
+	require.EqualValues(t, 6, attrMap.Len())
+
+	expected := map[string]string{
+		AttributeECSCluster:      "main-cluster",
+		AttributeECSTaskARN:      "arn:aws:some-value/001",
+		AttributeECSTaskID:       "001",
+		AttributeECSTaskFamily:   "task-def-family-1",
+		AttributeECSTaskRevesion: "v1.2",
+	}
+
+	verifyAttributeMap(t, expected, attrMap)
+}
+
 func verifyAttributeMap(t *testing.T, expected map[string]string, found pdata.AttributeMap) {
 	for key, val := range expected {
 		attributeVal, found := found.Get(key)

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/resource_test.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/resource_test.go
@@ -77,12 +77,12 @@ func verifyAttributeMap(t *testing.T, expected map[string]string, found pdata.At
 	}
 }
 func TestGetTaskIDFromARN(t *testing.T) {
-	id := getTaskIDFromARN("arn:aws:something/001")
+	id := getResourceFromARN("arn:aws:something/001")
 	require.EqualValues(t, "001", id)
 
-	id = getTaskIDFromARN("not-arn:aws:something/001")
-	require.LessOrEqual(t, 0, len(id))
+	id = getResourceFromARN("not-arn:aws:something/001")
+	require.EqualValues(t, "not-arn:aws:something/001", id)
 
-	id = getTaskIDFromARN("")
+	id = getResourceFromARN("")
 	require.LessOrEqual(t, 0, len(id))
 }


### PR DESCRIPTION
Metadata received from Fargate gives us ClusterARN instead of ClusterName. So, This change extracts the ClusterName if we receive a ClusterARN. It utilizes our existing func (renamed it). 

Also, renamed some resource names matching with semantic conventions. Once semantic convention for AWS PR is merged, we can easily change them without introducing any customer facing changes. 