### PR TITLE
fix: hostname passed to dnsResolver should not contain port

### DIFF
--- a/exporter/loadbalancingexporter/exporter.go
+++ b/exporter/loadbalancingexporter/exporter.go
@@ -120,7 +120,7 @@ func (e *exporterImp) Start(ctx context.Context, host component.Host) error {
 }
 
 func (e *exporterImp) onBackendChanges(resolved []string) {
-	resolved = sort.StringSlice(resolved)
+	resolved = sort.StringSlice(endpointsWithPort(resolved))
 	newRing := newHashRing(resolved)
 
 	if !newRing.equal(e.ring) {
@@ -140,8 +140,6 @@ func (e *exporterImp) onBackendChanges(resolved []string) {
 
 func (e *exporterImp) addMissingExporters(ctx context.Context, endpoints []string) {
 	for _, endpoint := range endpoints {
-		endpoint = endpointWithPort(endpoint)
-
 		if _, exists := e.exporters[endpoint]; !exists {
 			cfg := e.buildExporterConfig(endpoint)
 			exp, err := e.exporterFactory.CreateTracesExporter(ctx, e.templateCreateParams, &cfg)
@@ -257,4 +255,11 @@ func endpointWithPort(endpoint string) string {
 		endpoint = fmt.Sprintf("%s:%s", endpoint, defaultPort)
 	}
 	return endpoint
+}
+
+func endpointsWithPort(endpoints []string) (ret []string) {
+	for _, endpoint := range endpoints {
+		ret = append(ret, endpointWithPort(endpoint))
+	}
+	return
 }

--- a/exporter/loadbalancingexporter/exporter_test.go
+++ b/exporter/loadbalancingexporter/exporter_test.go
@@ -219,11 +219,11 @@ func TestConsumeTraces(t *testing.T) {
 	require.NoError(t, err)
 
 	// pre-load an exporter here, so that we don't use the actual OTLP exporter
-	p.exporters["endpoint-1"] = &componenttest.ExampleExporterConsumer{}
+	p.exporters[endpointWithPort("endpoint-1")] = &componenttest.ExampleExporterConsumer{}
 	p.res = &mockResolver{
 		triggerCallbacks: true,
 		onResolve: func(ctx context.Context) ([]string, error) {
-			return []string{"endpoint-1"}, nil
+			return []string{endpointWithPort("endpoint-1")}, nil
 		},
 	}
 
@@ -301,11 +301,11 @@ func TestAddMissingExporters(t *testing.T) {
 		return &componenttest.ExampleExporterConsumer{}, nil
 	}))
 
-	p.exporters["endpoint-1:55680"] = &componenttest.ExampleExporterConsumer{}
+	p.exporters[endpointWithPort("endpoint-1")] = &componenttest.ExampleExporterConsumer{}
 	resolved := []string{"endpoint-1", "endpoint-2"}
 
 	// test
-	p.addMissingExporters(context.Background(), resolved)
+	p.addMissingExporters(context.Background(), endpointsWithPort(resolved))
 
 	// verify
 	assert.Len(t, p.exporters, 2)
@@ -450,7 +450,7 @@ func TestBatchWithTwoTraces(t *testing.T) {
 	require.NoError(t, err)
 
 	sink := &componenttest.ExampleExporterConsumer{}
-	p.exporters["endpoint-1"] = sink
+	p.exporters[endpointWithPort("endpoint-1")] = sink
 
 	first := simpleTraces()
 	second := simpleTraceWithID(pdata.NewTraceID([16]byte{2, 3, 4, 5}))

--- a/exporter/loadbalancingexporter/exporter_test.go
+++ b/exporter/loadbalancingexporter/exporter_test.go
@@ -382,6 +382,26 @@ func TestEndpointWithPort(t *testing.T) {
 	}
 }
 
+func TestEndpointWithPorts(t *testing.T) {
+	for _, tt := range []struct {
+		input    []string
+		expected []string
+	}{
+		{
+			[]string{
+				"endpoint-1",
+				"endpoint-1:55690",
+			},
+			[]string{
+				"endpoint-1:55680",
+				"endpoint-1:55690",
+			},
+		},
+	} {
+		assert.Equal(t, tt.expected, endpointsWithPort(tt.input))
+	}
+}
+
 func TestBuildExporterConfig(t *testing.T) {
 	// prepare
 	factories, err := componenttest.ExampleComponents()

--- a/exporter/loadbalancingexporter/resolver_dns.go
+++ b/exporter/loadbalancingexporter/resolver_dns.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -114,7 +115,7 @@ func (r *dnsResolver) resolve(ctx context.Context) ([]string, error) {
 	// the context to use for all metrics in this function
 	mCtx, _ := tag.New(ctx, tag.Upsert(tag.MustNewKey("resolver"), "dns"))
 
-	addrs, err := r.resolver.LookupIPAddr(ctx, r.hostname)
+	addrs, err := r.resolver.LookupIPAddr(ctx, trimPort(r.hostname))
 	if err != nil {
 		failedCtx, _ := tag.New(mCtx, tag.Upsert(tag.MustNewKey("success"), "false"))
 		stats.Record(failedCtx, mNumResolutions.M(1))
@@ -177,4 +178,11 @@ func equalStringSlice(source, candidate []string) bool {
 	}
 
 	return true
+}
+
+func trimPort(hostname string) string {
+	if strings.Contains(hostname, ":") {
+		return strings.Split(hostname, ":")[0]
+	}
+	return hostname
 }

--- a/exporter/loadbalancingexporter/resolver_dns_test.go
+++ b/exporter/loadbalancingexporter/resolver_dns_test.go
@@ -259,6 +259,23 @@ func TestShutdownClearsCallbacks(t *testing.T) {
 	assert.Len(t, res.onChangeCallbacks, 1)
 }
 
+func TestTrimPort(t *testing.T) {
+	for _, tt := range []struct {
+		input, expected string
+	}{
+		{
+			"hostname-1:55681",
+			"hostname-1",
+		},
+		{
+			"hostname-1",
+			"hostname-1",
+		},
+	} {
+		assert.Equal(t, tt.expected, trimPort(tt.input))
+	}
+}
+
 var _ netResolver = (*mockDNSResolver)(nil)
 
 type mockDNSResolver struct {


### PR DESCRIPTION
**Description:**
1. dns resolver (net.Resolver) takes a hostname as input param. the hostname should not contains port. but if we use the following config:

```yaml
exporters:
  loadbalancing:
    protocol:
      otlp:
        insecure: true
        timeout: 1s
    resolver:
      dns:
        hostname: otelcol:55680
```

net.Resolver will complain about it.

2. `addMissingExporters` use hostnames with port but `removeExtraExporters` use hostnames without port, which cause the added exporters to be removed immediately.

**Link to tracking Issue:**
none. I can open one if needed.

**Testing:**
just basic tests for simple functions

**Documentation:**
none