### PR TITLE
Add span events to New Relic exporter

### DIFF
--- a/exporter/newrelicexporter/go.mod
+++ b/exporter/newrelicexporter/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
-	github.com/newrelic/newrelic-telemetry-sdk-go v0.4.0
+	github.com/newrelic/newrelic-telemetry-sdk-go v0.5.0
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.14.1-0.20201117192738-131ff3e248b6
 	go.uber.org/zap v1.16.0

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -161,6 +161,7 @@ func (t *traceTransformer) SpanAttributes(span pdata.Span) map[string]interface{
 	return attrs
 }
 
+// SpanEvents transforms the recorded events of span into New Relic tracing events.
 func (t *traceTransformer) SpanEvents(span pdata.Span) []telemetry.Event {
 	length := span.Events().Len()
 	if length == 0 {
@@ -169,14 +170,13 @@ func (t *traceTransformer) SpanEvents(span pdata.Span) []telemetry.Event {
 
 	events := make([]telemetry.Event, length)
 
-	for i := 0; i < span.Events().Len(); i++ {
+	for i := 0; i < length; i++ {
 		event := span.Events().At(i)
-		evt := telemetry.Event{
+		events[i] = telemetry.Event{
 			EventType:  event.Name(),
 			Timestamp:  pdata.UnixNanoToTime(event.Timestamp()),
 			Attributes: tracetranslator.AttributeMapToMap(event.Attributes()),
 		}
-		events[i] = evt
 	}
 	return events
 }

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -327,7 +327,7 @@ func TestTransformSpan(t *testing.T) {
 				Name:       "with events",
 				Attributes: withDefaults(nil),
 				Events: []telemetry.Event{
-					telemetry.Event{
+					{
 						EventType:  "this is the event name",
 						Timestamp:  now.UTC(),
 						Attributes: map[string]interface{}{},

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -129,6 +129,7 @@ func TestTransformSpan(t *testing.T) {
 				TraceID:    "01010101010101010101010101010101",
 				Name:       "root",
 				Attributes: withDefaults(nil),
+				Events:     nil,
 			},
 		},
 		{
@@ -148,6 +149,7 @@ func TestTransformSpan(t *testing.T) {
 				Name:       "client",
 				ParentID:   "0000000000000001",
 				Attributes: withDefaults(nil),
+				Events:     nil,
 			},
 		},
 		{
@@ -174,6 +176,7 @@ func TestTransformSpan(t *testing.T) {
 				Attributes: withDefaults(map[string]interface{}{
 					statusCodeKey: "ERROR",
 				}),
+				Events: nil,
 			},
 		},
 		{
@@ -201,6 +204,7 @@ func TestTransformSpan(t *testing.T) {
 					statusCodeKey:        "ERROR",
 					statusDescriptionKey: "error message",
 				}),
+				Events: nil,
 			},
 		},
 		{
@@ -254,6 +258,7 @@ func TestTransformSpan(t *testing.T) {
 					"score":  99.8,
 					"user":   "alice",
 				}),
+				Events: nil,
 			},
 		},
 		{
@@ -275,6 +280,7 @@ func TestTransformSpan(t *testing.T) {
 				Timestamp:  now.UTC(),
 				Duration:   time.Second * 5,
 				Attributes: withDefaults(nil),
+				Events:     nil,
 			},
 		},
 		{
@@ -295,6 +301,38 @@ func TestTransformSpan(t *testing.T) {
 				Attributes: withDefaults(map[string]interface{}{
 					spanKindKey: "server",
 				}),
+				Events: nil,
+			},
+		},
+		{
+			name: "with events",
+			spanFunc: func() pdata.Span {
+				s := pdata.NewSpan()
+				s.InitEmpty()
+				s.SetTraceID(pdata.NewTraceID([...]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+				s.SetSpanID(pdata.NewSpanID([...]byte{0, 0, 0, 0, 0, 0, 0, 7}))
+				s.SetName("with events")
+
+				ev := pdata.NewSpanEventSlice()
+				ev.Resize(1)
+				event := ev.At(0)
+				event.SetName("this is the event name")
+				event.SetTimestamp(pdata.TimeToUnixNano(now))
+				s.Events().Append(event)
+				return s
+			},
+			want: telemetry.Span{
+				ID:         "0000000000000007",
+				TraceID:    "01010101010101010101010101010101",
+				Name:       "with events",
+				Attributes: withDefaults(nil),
+				Events: []telemetry.Event{
+					telemetry.Event{
+						EventType:  "this is the event name",
+						Timestamp:  now.UTC(),
+						Attributes: map[string]interface{}{},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
**Description:**
Adding a Feature: SpanEvent support in the New Relic exporter.

**Testing:** 
I've added unit tests that verify the struct is constructed the way we expect when given an OpenTelemetry Span that contains events. 
The underlying serialization is done by the New Relic Telemetry SDK, which has its own automated tests to verify the serialization.
I've also used a locally-build collector to verify that these structs are serialized and sent to New Relic correctly, and that the format matches our expectations. 
The output from the collector with debug logging enabled:
```
2020-11-19T17:10:07.482Z	info	newrelicexporter/newrelic.go:47	2020/11/19 17:10:07.457528 {"body-length":286,"event":"data post","url":"https://staging-trace-api.newrelic.com/trace/v1"}
	{"component_kind": "exporter", "component_type": "newrelic", "component_name": "newrelic"}
2020-11-19T17:10:07.563Z	debug	newrelicexporter/newrelic.go:47	2020/11/19 17:10:07.563437 {"data":[{"common":{},"spans":[{"id":"3e0f5885710776cd","trace.id":"3e0f5885710776cd3e0f5885710776cd","timestamp":1605748201371,"attributes":{"name":"post","duration.ms":508.068,"collector.name":"opentelemetry-collector","collector.version":"0.0.0","span.kind":"client","service.name":"service-1","net.host.ip":"127.0.0.1","net.host.port":8080},"events":[{"name":"cs","timestamp":1605748201371,"attributes":{}},{"name":"cr","timestamp":1605748201371,"attributes":{}}]},{"id":"3e0f5885710776de","trace.id":"3e0f5885710776cd3e0f5885710776cd","timestamp":1605748201371,"attributes":{"name":"service 2 span","parent.id":"3e0f5885710776cd","duration.ms":2.019,"net.host.ip":"127.0.0.1","net.host.port":8080,"collector.name":"opentelemetry-collector","collector.version":"0.0.0","span.kind":"client","service.name":"service-2"}}]}],"event":"uncompressed request body","url":"https://staging-trace-api.newrelic.com/trace/v1"}
	{"component_kind": "exporter", "component_type": "newrelic", "component_name": "newrelic"}
2020-11-19T17:10:09.217Z	info	newrelicexporter/newrelic.go:47	2020/11/19 17:10:09.217161 {"body":{"requestId":"f1f565fb-0001-b000-0000-0175e17c1e10"},"event":"data post response","status":202}
```
This format matches our ingest expectations. 