### PR TITLE
[loadbalancingexporter]Allow specifying port when using DNS resolver

### DIFF
--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -17,6 +17,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `otlp` property configures the template used for building the OTLP exporter. Refer to the OTLP Exporter documentation for information on which options are available. Note that the `endpoint` property should not be set and will be overridden by this exporter with the backend endpoint.
 * The `resolver` accepts either a `static` node, or a `dns`. If both are specified, `dns` takes precedence.
 * The `hostname` property inside a `dns` node specifies the hostname to query in order to obtain the list of IP addresses.
+* The `dns` node also accepts an optional property `port` to specify which port should be used to export the traces for the IP addresses resolved from `hostname`. If `port` is not specified, the default port 55680 is used.
 
 
 Simple example

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -17,7 +17,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `otlp` property configures the template used for building the OTLP exporter. Refer to the OTLP Exporter documentation for information on which options are available. Note that the `endpoint` property should not be set and will be overridden by this exporter with the backend endpoint.
 * The `resolver` accepts either a `static` node, or a `dns`. If both are specified, `dns` takes precedence.
 * The `hostname` property inside a `dns` node specifies the hostname to query in order to obtain the list of IP addresses.
-* The `dns` node also accepts an optional property `port` to specify which port should be used to export the traces for the IP addresses resolved from `hostname`. If `port` is not specified, the default port 55680 is used.
+* The `dns` node also accepts an optional property `port` to specify the port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 55680 is used.
 
 
 Simple example

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -45,4 +45,5 @@ type StaticResolver struct {
 // DNSResolver defines the configuration for the DNS resolver
 type DNSResolver struct {
 	Hostname string `mapstructure:"hostname"`
+	Port     string `mapstructure:"port"`
 }

--- a/exporter/loadbalancingexporter/exporter.go
+++ b/exporter/loadbalancingexporter/exporter.go
@@ -88,7 +88,7 @@ func newExporter(params component.ExporterCreateParams, cfg configmodels.Exporte
 		dnsLogger := params.Logger.With(zap.String("resolver", "dns"))
 
 		var err error
-		res, err = newDNSResolver(dnsLogger, oCfg.Resolver.DNS.Hostname)
+		res, err = newDNSResolver(dnsLogger, oCfg.Resolver.DNS.Hostname, oCfg.Resolver.DNS.Port)
 		if err != nil {
 			return nil, err
 		}

--- a/exporter/loadbalancingexporter/resolver_dns.go
+++ b/exporter/loadbalancingexporter/resolver_dns.go
@@ -41,6 +41,7 @@ type dnsResolver struct {
 	logger *zap.Logger
 
 	hostname    string
+	port        string
 	resolver    netResolver
 	resInterval time.Duration
 	resTimeout  time.Duration
@@ -58,7 +59,7 @@ type netResolver interface {
 	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
 }
 
-func newDNSResolver(logger *zap.Logger, hostname string) (*dnsResolver, error) {
+func newDNSResolver(logger *zap.Logger, hostname string, port string) (*dnsResolver, error) {
 	if len(hostname) == 0 {
 		return nil, errNoHostname
 	}
@@ -66,6 +67,7 @@ func newDNSResolver(logger *zap.Logger, hostname string) (*dnsResolver, error) {
 	return &dnsResolver{
 		logger:      logger,
 		hostname:    hostname,
+		port:        port,
 		resolver:    &net.Resolver{},
 		resInterval: defaultResInterval,
 		resTimeout:  defaultResTimeout,
@@ -134,6 +136,12 @@ func (r *dnsResolver) resolve(ctx context.Context) ([]string, error) {
 			// it's an IPv6 address
 			backend = fmt.Sprintf("[%s]", ip.String())
 		}
+
+		// if a port is specified in the configuration, add it
+		if r.port != "" {
+			backend = fmt.Sprintf("%s:%s", backend, r.port)
+		}
+
 		backends = append(backends, backend)
 	}
 

--- a/exporter/loadbalancingexporter/testdata/config.yaml
+++ b/exporter/loadbalancingexporter/testdata/config.yaml
@@ -14,7 +14,7 @@ exporters:
     resolver:
       static:
         hostnames:
-        - endpoint-1 # assumes 55678 as the default port
+        - endpoint-1 # assumes 55680 as the default port
         - endpoint-2:55678
   loadbalancing/2:
     protocol:
@@ -23,7 +23,16 @@ exporters:
     # how to get the list of backends: DNS
     resolver:
       dns:
+        hostname: service-1 # assumes 55680 as the default port for the resolved IP addresses
+  loadbalancing/3:
+    protocol:
+      otlp:
+
+    # how to get the list of backends: DNS
+    resolver:
+      dns:
         hostname: service-1
+        port: 55690
 
 service:
   pipelines:


### PR DESCRIPTION
Description:
Adding a feature to allow specifying a port when using DNS resolver is used in the loadbalancing exporter. Previously the port always defaulted to 55680 with no ability to specify a different port.

Link to tracking Issue:
Closes #1648

Testing:
This code change was tested using new unit tests included in this PR.

Documentation:
README has been updated with the usage of the `port` field. Also the sample config.yaml has been updated showing the new optional configuration for port when using DNS resolver.