### PR TITLE
[statsdreceiver]add aggregation for StatsD receiver

### DIFF
--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -15,7 +15,7 @@ The following settings are required:
 
 The Following settings are optional:
 
-- `aggregation_interval: 70s`(default value is 60s): The aggregation time that the receiver aggregates the metrics
+- `aggregation_interval: 70s`(default value is 60s): The aggregation time that the receiver aggregates the metrics (similar to the flush interval in StatsD server)
 
 Example:
 
@@ -32,7 +32,7 @@ with detailed sample configurations [here](./testdata/config.yaml).
 
 ## Aggregation
 
-In this new revision. Aggregation is done in statsD receiver. The default aggregation interval is 60s. The receiver only aggregates the metrics with the same metric name, metric type, label keys and label values. After each aggregation interval, the receiver will send all metrics(after aggregation) in this aggregation interval to the following workflow.
+Aggregation is done in statsD receiver. The default aggregation interval is 60s. The receiver only aggregates the metrics with the same metric name, metric type, label keys and label values. After each aggregation interval, the receiver will send all metrics (after aggregation) in this aggregation interval to the following workflow.
 
 It supports:
 

--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -1,6 +1,6 @@
 # StatsD Receiver
 
-StatsD receiver for ingesting StatsD messages into the OpenTelemetry Collector.
+StatsD receiver for ingesting StatsD messages(https://github.com/statsd/statsd/blob/master/docs/metric_types.md) into the OpenTelemetry Collector.
 
 Supported pipeline types: metrics
 
@@ -36,7 +36,7 @@ Aggregation is done in statsD receiver. The default aggregation interval is 60s.
 
 It supports:
 
-Gauge:
+Gauge(transferred to double):
 - statsdTestMetric1:500|g|#mykey:myvalue
 statsdTestMetric1:400|g|#mykey:myvalue
 (get the latest value: 400)
@@ -45,7 +45,7 @@ statsdTestMetric1:+2|g|#mykey:myvalue
 statsdTestMetric1:-1|g|#mykey:myvalue
 (get the value after calculation: 501)
 
-Counter:
+Counter(transferred to int):
 - statsdTestMetric1:3000|c|#mykey:myvalue
 statsdTestMetric1:4000|c|#mykey:myvalue
 (get the value after incrementation: 7000)
@@ -68,7 +68,9 @@ it supports sample rate
 
 `<name>:<value>|g|@<sample-rate>|#<tag1-key>:<tag1-value>`
 
+### Timer
 
+TODO: add support for timer
 
 ## Testing
 

--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -15,6 +15,8 @@
 package statsdreceiver
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/confignet"
 )
@@ -23,4 +25,5 @@ import (
 type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 	NetAddr                       confignet.NetAddr `mapstructure:",squash"`
+	AggregationInterval           time.Duration     `mapstructure:"aggregation_interval"`
 }

--- a/receiver/statsdreceiver/config_test.go
+++ b/receiver/statsdreceiver/config_test.go
@@ -17,6 +17,7 @@ package statsdreceiver
 import (
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,5 +55,6 @@ func TestLoadConfig(t *testing.T) {
 			Endpoint:  "localhost:12345",
 			Transport: "custom_transport",
 		},
+		AggregationInterval: 70 * time.Second,
 	}, r1)
 }

--- a/receiver/statsdreceiver/factory.go
+++ b/receiver/statsdreceiver/factory.go
@@ -16,6 +16,7 @@ package statsdreceiver
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -26,9 +27,10 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr             = "statsd"
-	defaultBindEndpoint = "localhost:8125"
-	defaultTransport    = "udp"
+	typeStr                    = "statsd"
+	defaultBindEndpoint        = "localhost:8125"
+	defaultTransport           = "udp"
+	defaultAggregationInterval = 60 * time.Second
 )
 
 // NewFactory creates a factory for the StatsD receiver.
@@ -50,6 +52,7 @@ func createDefaultConfig() configmodels.Receiver {
 			Endpoint:  defaultBindEndpoint,
 			Transport: defaultTransport,
 		},
+		AggregationInterval: defaultAggregationInterval,
 	}
 }
 

--- a/receiver/statsdreceiver/factory_test.go
+++ b/receiver/statsdreceiver/factory_test.go
@@ -41,3 +41,15 @@ func TestCreateReceiver(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 }
+
+func TestCreateMetricsReceiverWithNilConsumer(t *testing.T) {
+	receiver, err := createMetricsReceiver(
+		context.Background(),
+		component.ReceiverCreateParams{Logger: zap.NewNop()},
+		createDefaultConfig(),
+		nil,
+	)
+
+	assert.Error(t, err, "nil consumer")
+	assert.Nil(t, receiver)
+}

--- a/receiver/statsdreceiver/go.mod
+++ b/receiver/statsdreceiver/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	go.opencensus.io v0.22.5
 	go.opentelemetry.io/collector v0.16.1-0.20201207152538-326931de8c32
+	go.opentelemetry.io/otel v0.13.0
 	go.uber.org/zap v1.16.0
 	google.golang.org/protobuf v1.25.0
 )

--- a/receiver/statsdreceiver/protocol/parser.go
+++ b/receiver/statsdreceiver/protocol/parser.go
@@ -20,5 +20,7 @@ import (
 
 // Parser is something that can map input StatsD strings to OTLP Metric representations.
 type Parser interface {
-	Parse(in string) (*metricspb.Metric, error)
+	Initialize() error
+	GetMetrics() []*metricspb.Metric
+	Aggregate(line string) error
 }

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -22,11 +22,9 @@ import (
 	"time"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"go.opentelemetry.io/otel/label"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-var gauges map[string]*metricspb.Metric
-var counters map[string]*metricspb.Metric
 
 var (
 	errEmptyMetricName  = errors.New("empty metric name")
@@ -38,26 +36,33 @@ func getSupportedTypes() []string {
 }
 
 // StatsDParser supports the Parse method for parsing StatsD messages with Tags.
-type StatsDParser struct{}
+type StatsDParser struct {
+	gauges   map[statsDMetricdescription]*metricspb.Metric
+	counters map[statsDMetricdescription]*metricspb.Metric
+}
 
 type statsDMetric struct {
+	description statsDMetricdescription
+	value       string
+	intvalue    int64
+	floatvalue  float64
+	addition    bool
+	unit        string
+	metricType  metricspb.MetricDescriptor_Type
+	sampleRate  float64
+	labelKeys   []*metricspb.LabelKey
+	labelValues []*metricspb.LabelValue
+}
+
+type statsDMetricdescription struct {
 	name             string
-	value            string
-	intvalue         int64
-	floatvalue       float64
-	hash             string
-	addition         bool
 	statsdMetricType string
-	unit             string
-	metricType       metricspb.MetricDescriptor_Type
-	sampleRate       float64
-	labelKeys        []*metricspb.LabelKey
-	labelValues      []*metricspb.LabelValue
+	labels           label.Distinct
 }
 
 func (p *StatsDParser) Initialize() error {
-	gauges = make(map[string]*metricspb.Metric)
-	counters = make(map[string]*metricspb.Metric)
+	p.gauges = make(map[statsDMetricdescription]*metricspb.Metric)
+	p.counters = make(map[statsDMetricdescription]*metricspb.Metric)
 	return nil
 }
 
@@ -65,16 +70,16 @@ func (p *StatsDParser) Initialize() error {
 func (p *StatsDParser) GetMetrics() []*metricspb.Metric {
 	var metrics []*metricspb.Metric
 
-	for _, metric := range gauges {
+	for _, metric := range p.gauges {
 		metrics = append(metrics, metric)
 	}
 
-	for _, metric := range counters {
+	for _, metric := range p.counters {
 		metrics = append(metrics, metric)
 	}
 
-	gauges = make(map[string]*metricspb.Metric)
-	counters = make(map[string]*metricspb.Metric)
+	p.gauges = make(map[statsDMetricdescription]*metricspb.Metric)
+	p.counters = make(map[statsDMetricdescription]*metricspb.Metric)
 
 	return metrics
 }
@@ -89,68 +94,68 @@ func (p *StatsDParser) Aggregate(line string) error {
 	if err != nil {
 		return err
 	}
-	switch parsedMetric.statsdMetricType {
+	switch parsedMetric.description.statsdMetricType {
 	case "g":
-		_, ok := gauges[parsedMetric.hash]
+		_, ok := p.gauges[parsedMetric.description]
 		if !ok {
 			metricPoint := buildPoint(parsedMetric)
-			gauges[parsedMetric.hash] = buildMetric(parsedMetric, metricPoint)
+			p.gauges[parsedMetric.description] = buildMetric(parsedMetric, metricPoint)
 		} else {
 			if parsedMetric.addition {
-				savedValue := gauges[parsedMetric.hash].GetTimeseries()[0].Points[0].GetDoubleValue()
+				savedValue := p.gauges[parsedMetric.description].GetTimeseries()[0].Points[0].GetDoubleValue()
 				parsedMetric.floatvalue = parsedMetric.floatvalue + savedValue
 				metricPoint := buildPoint(parsedMetric)
-				gauges[parsedMetric.hash] = buildMetric(parsedMetric, metricPoint)
+				p.gauges[parsedMetric.description] = buildMetric(parsedMetric, metricPoint)
 			} else {
 				metricPoint := buildPoint(parsedMetric)
-				gauges[parsedMetric.hash] = buildMetric(parsedMetric, metricPoint)
+				p.gauges[parsedMetric.description] = buildMetric(parsedMetric, metricPoint)
 			}
 		}
 
 	case "c":
-		_, ok := counters[parsedMetric.hash]
+		_, ok := p.counters[parsedMetric.description]
 		if !ok {
 			metricPoint := buildPoint(parsedMetric)
-			counters[parsedMetric.hash] = buildMetric(parsedMetric, metricPoint)
+			p.counters[parsedMetric.description] = buildMetric(parsedMetric, metricPoint)
 		} else {
-			savedValue := counters[parsedMetric.hash].GetTimeseries()[0].Points[0].GetInt64Value()
+			savedValue := p.counters[parsedMetric.description].GetTimeseries()[0].Points[0].GetInt64Value()
 			parsedMetric.intvalue = parsedMetric.intvalue + savedValue
 			metricPoint := buildPoint(parsedMetric)
-			counters[parsedMetric.hash] = buildMetric(parsedMetric, metricPoint)
+			p.counters[parsedMetric.description] = buildMetric(parsedMetric, metricPoint)
 		}
 	}
 
 	return nil
 }
 
-func parseMessageToMetric(line string) (*statsDMetric, error) {
-	result := &statsDMetric{}
+func parseMessageToMetric(line string) (statsDMetric, error) {
+	result := statsDMetric{}
 
 	parts := strings.Split(line, "|")
 	if len(parts) < 2 {
-		return nil, fmt.Errorf("invalid message format: %s", line)
+		return result, fmt.Errorf("invalid message format: %s", line)
 	}
 
 	separatorIndex := strings.IndexByte(parts[0], ':')
 	if separatorIndex < 0 {
-		return nil, fmt.Errorf("invalid <name>:<value> format: %s", parts[0])
+		return result, fmt.Errorf("invalid <name>:<value> format: %s", parts[0])
 	}
 
-	result.name = parts[0][0:separatorIndex]
-	if result.name == "" {
-		return nil, errEmptyMetricName
+	result.description.name = parts[0][0:separatorIndex]
+	if result.description.name == "" {
+		return result, errEmptyMetricName
 	}
 	result.value = parts[0][separatorIndex+1:]
 	if result.value == "" {
-		return nil, errEmptyMetricValue
+		return result, errEmptyMetricValue
 	}
 	if strings.HasPrefix(result.value, "-") || strings.HasPrefix(result.value, "+") {
 		result.addition = true
 	}
 
-	result.statsdMetricType = parts[1]
-	if !contains(getSupportedTypes(), result.statsdMetricType) {
-		return nil, fmt.Errorf("unsupported metric type: %s", result.statsdMetricType)
+	result.description.statsdMetricType = parts[1]
+	if !contains(getSupportedTypes(), result.description.statsdMetricType) {
+		return result, fmt.Errorf("unsupported metric type: %s", result.description.statsdMetricType)
 	}
 
 	additionalParts := parts[2:]
@@ -161,7 +166,7 @@ func parseMessageToMetric(line string) (*statsDMetric, error) {
 
 			f, err := strconv.ParseFloat(sampleRateStr, 64)
 			if err != nil {
-				return nil, fmt.Errorf("parse sample rate: %s", sampleRateStr)
+				return result, fmt.Errorf("parse sample rate: %s", sampleRateStr)
 			}
 
 			result.sampleRate = f
@@ -173,34 +178,39 @@ func parseMessageToMetric(line string) (*statsDMetric, error) {
 			result.labelKeys = make([]*metricspb.LabelKey, 0, len(tagSets))
 			result.labelValues = make([]*metricspb.LabelValue, 0, len(tagSets))
 
+			var kvs []label.KeyValue
+			var sortable label.Sortable
 			for _, tagSet := range tagSets {
 				tagParts := strings.Split(tagSet, ":")
 				if len(tagParts) != 2 {
-					return nil, fmt.Errorf("invalid tag format: %s", tagParts)
+					return result, fmt.Errorf("invalid tag format: %s", tagParts)
 				}
 				result.labelKeys = append(result.labelKeys, &metricspb.LabelKey{Key: tagParts[0]})
 				result.labelValues = append(result.labelValues, &metricspb.LabelValue{
 					Value:    tagParts[1],
 					HasValue: true,
 				})
+				kvs = append(kvs, label.String(tagParts[0], tagParts[1]))
 			}
+			set := label.NewSetWithSortable(kvs, &sortable)
+			result.description.labels = set.Equivalent()
 		} else {
-			return nil, fmt.Errorf("unrecognized message part: %s", part)
+			return result, fmt.Errorf("unrecognized message part: %s", part)
 		}
 	}
 
-	switch result.statsdMetricType {
+	switch result.description.statsdMetricType {
 	case "g":
 		f, err := strconv.ParseFloat(result.value, 64)
 		if err != nil {
-			return nil, fmt.Errorf("gauge: parse metric value string: %s", result.value)
+			return result, fmt.Errorf("gauge: parse metric value string: %s", result.value)
 		}
 		result.floatvalue = f
 		result.metricType = metricspb.MetricDescriptor_GAUGE_DOUBLE
 	case "c":
 		f, err := strconv.ParseFloat(result.value, 64)
 		if err != nil {
-			return nil, fmt.Errorf("counter: parse metric value string: %s", result.value)
+			return result, fmt.Errorf("counter: parse metric value string: %s", result.value)
 		}
 		i := int64(f)
 		if 0 < result.sampleRate && result.sampleRate < 1 {
@@ -210,13 +220,6 @@ func parseMessageToMetric(line string) (*statsDMetric, error) {
 		result.metricType = metricspb.MetricDescriptor_GAUGE_INT64
 	}
 
-	var tg []string
-	for n, k := range result.labelKeys {
-		if result.labelValues[n].HasValue {
-			tg = append(tg, k.Key+"="+result.labelValues[n].Value)
-		}
-	}
-	result.hash = result.name + strings.Join(tg, "")
 	return result, nil
 }
 
@@ -229,10 +232,10 @@ func contains(slice []string, element string) bool {
 	return false
 }
 
-func buildMetric(metric *statsDMetric, point *metricspb.Point) *metricspb.Metric {
+func buildMetric(metric statsDMetric, point *metricspb.Point) *metricspb.Metric {
 	return &metricspb.Metric{
 		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name:      metric.name,
+			Name:      metric.description.name,
 			Type:      metric.metricType,
 			LabelKeys: metric.labelKeys,
 			Unit:      metric.unit,
@@ -248,12 +251,12 @@ func buildMetric(metric *statsDMetric, point *metricspb.Point) *metricspb.Metric
 	}
 }
 
-func buildPoint(parsedMetric *statsDMetric) *metricspb.Point {
+func buildPoint(parsedMetric statsDMetric) *metricspb.Point {
 	now := &timestamppb.Timestamp{
 		Seconds: timeNowFunc(),
 	}
 
-	switch parsedMetric.statsdMetricType {
+	switch parsedMetric.description.statsdMetricType {
 	case "c":
 		return buildCounterPoint(parsedMetric, now)
 	case "g":
@@ -263,7 +266,7 @@ func buildPoint(parsedMetric *statsDMetric) *metricspb.Point {
 	return nil
 }
 
-func buildCounterPoint(parsedMetric *statsDMetric, now *timestamppb.Timestamp) *metricspb.Point {
+func buildCounterPoint(parsedMetric statsDMetric, now *timestamppb.Timestamp) *metricspb.Point {
 	point := &metricspb.Point{
 		Timestamp: now,
 		Value: &metricspb.Point_Int64Value{
@@ -273,7 +276,7 @@ func buildCounterPoint(parsedMetric *statsDMetric, now *timestamppb.Timestamp) *
 	return point
 }
 
-func buildGaugePoint(parsedMetric *statsDMetric, now *timestamppb.Timestamp) *metricspb.Point {
+func buildGaugePoint(parsedMetric statsDMetric, now *timestamppb.Timestamp) *metricspb.Point {
 	point := &metricspb.Point{
 		Timestamp: now,
 		Value: &metricspb.Point_DoubleValue{

--- a/receiver/statsdreceiver/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser_test.go
@@ -23,15 +23,12 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func Test_StatsDParser_Parse(t *testing.T) {
-	timeNowFunc = func() int64 {
-		return 0
-	}
+func Test_ParseMessageToMetric(t *testing.T) {
 
 	tests := []struct {
 		name       string
 		input      string
-		wantMetric *metricspb.Metric
+		wantMetric *statsDMetric
 		err        error
 	}{
 		{
@@ -55,207 +52,6 @@ func Test_StatsDParser_Parse(t *testing.T) {
 			err:   errors.New("empty metric value"),
 		},
 		{
-			name:  "integer counter",
-			input: "test.metric:42|c",
-			wantMetric: testMetric("test.metric",
-				metricspb.MetricDescriptor_CUMULATIVE_INT64,
-				nil,
-				nil,
-				"",
-				&metricspb.Point{
-					Timestamp: &timestamppb.Timestamp{
-						Seconds: 0,
-					},
-					Value: &metricspb.Point_Int64Value{
-						Int64Value: 42,
-					},
-				}),
-		},
-		{
-			name:  "float counter",
-			input: "test.metric:42.0|c",
-			wantMetric: testMetric("test.metric",
-				metricspb.MetricDescriptor_CUMULATIVE_INT64,
-				nil,
-				nil,
-				"",
-				&metricspb.Point{
-					Timestamp: &timestamppb.Timestamp{
-						Seconds: 0,
-					},
-					Value: &metricspb.Point_Int64Value{
-						Int64Value: 42,
-					},
-				}),
-		},
-		{
-			name:  "invalid  counter metric value",
-			input: "test.metric:42.abc|c",
-			err:   errors.New("counter: parse metric value string: 42.abc"),
-		},
-		{
-			name:  "unhandled metric type",
-			input: "test.metric:42|unhandled_type",
-			err:   errors.New("unsupported metric type: unhandled_type"),
-		},
-		{
-			name:  "counter metric with sample rate and tags",
-			input: "test.metric:42|c|@0.1|#key:value",
-			wantMetric: testMetric("test.metric",
-				metricspb.MetricDescriptor_CUMULATIVE_INT64,
-				[]*metricspb.LabelKey{
-					{
-						Key: "key",
-					},
-				},
-				[]*metricspb.LabelValue{
-					{
-						Value:    "value",
-						HasValue: true,
-					},
-				},
-				"",
-				&metricspb.Point{
-					Timestamp: &timestamppb.Timestamp{
-						Seconds: 0,
-					},
-					Value: &metricspb.Point_Int64Value{
-						Int64Value: 420,
-					},
-				}),
-		},
-		{
-			name:  "counter metric with sample rate(not divisible) and tags",
-			input: "test.metric:42|c|@0.8|#key:value",
-			wantMetric: testMetric("test.metric",
-				metricspb.MetricDescriptor_CUMULATIVE_INT64,
-				[]*metricspb.LabelKey{
-					{
-						Key: "key",
-					},
-				},
-				[]*metricspb.LabelValue{
-					{
-						Value:    "value",
-						HasValue: true,
-					},
-				},
-				"",
-				&metricspb.Point{
-					Timestamp: &timestamppb.Timestamp{
-						Seconds: 0,
-					},
-					Value: &metricspb.Point_Int64Value{
-						Int64Value: 52,
-					},
-				}),
-		},
-		{
-			name:  "double gauge metric",
-			input: "test.gauge:42.0|g|@0.1|#key:value",
-			wantMetric: testMetric("test.gauge",
-				metricspb.MetricDescriptor_GAUGE_DOUBLE,
-				[]*metricspb.LabelKey{
-					{
-						Key: "key",
-					},
-				},
-				[]*metricspb.LabelValue{
-					{
-						Value:    "value",
-						HasValue: true,
-					},
-				},
-				"",
-				&metricspb.Point{
-					Timestamp: &timestamppb.Timestamp{
-						Seconds: 0,
-					},
-					Value: &metricspb.Point_DoubleValue{
-						DoubleValue: 42,
-					},
-				}),
-		},
-		{
-			name:  "int gauge metric",
-			input: "test.gauge:42|g|@0.1|#key:value",
-			wantMetric: testMetric("test.gauge",
-				metricspb.MetricDescriptor_GAUGE_DOUBLE,
-				[]*metricspb.LabelKey{
-					{
-						Key: "key",
-					},
-				},
-				[]*metricspb.LabelValue{
-					{
-						Value:    "value",
-						HasValue: true,
-					},
-				},
-				"",
-				&metricspb.Point{
-					Timestamp: &timestamppb.Timestamp{
-						Seconds: 0,
-					},
-					Value: &metricspb.Point_DoubleValue{
-						DoubleValue: 42,
-					},
-				}),
-		},
-		{
-			name:  "gauge: invalid metric value",
-			input: "test.metric:invalidValue|g",
-			err:   errors.New("gauge: parse metric value string: invalidValue"),
-		},
-		{
-			name:  "timer metric with sample rate",
-			input: "test.timer:42.3|ms|@0.1",
-			wantMetric: testMetric("test.timer",
-				metricspb.MetricDescriptor_GAUGE_DOUBLE,
-				nil,
-				nil,
-				"ms",
-				&metricspb.Point{
-					Timestamp: &timestamppb.Timestamp{
-						Seconds: 0,
-					},
-					Value: &metricspb.Point_DoubleValue{
-						DoubleValue: 42.3,
-					},
-				}),
-		},
-		{
-			name:  "timer metric with sample rate and tag",
-			input: "test.timer:42|ms|@0.1|#key:value",
-			wantMetric: testMetric("test.timer",
-				metricspb.MetricDescriptor_GAUGE_DOUBLE,
-				[]*metricspb.LabelKey{
-					{
-						Key: "key",
-					},
-				},
-				[]*metricspb.LabelValue{
-					{
-						Value:    "value",
-						HasValue: true,
-					},
-				},
-				"ms",
-				&metricspb.Point{
-					Timestamp: &timestamppb.Timestamp{
-						Seconds: 0,
-					},
-					Value: &metricspb.Point_DoubleValue{
-						DoubleValue: 42,
-					},
-				}),
-		},
-		{
-			name:  "timer: invalid metric value",
-			input: "test.metric:invalidValue|ms",
-			err:   errors.New("timer: failed to parse metric value to float: invalidValue"),
-		},
-		{
 			name:  "invalid sample rate value",
 			input: "test.metric:42|c|@1.0a",
 			err:   errors.New("parse sample rate: 1.0a"),
@@ -270,19 +66,759 @@ func Test_StatsDParser_Parse(t *testing.T) {
 			input: "test.metric:42|c|$extra",
 			err:   errors.New("unrecognized message part: $extra"),
 		},
+		{
+			name:  "integer counter",
+			input: "test.metric:42|c",
+			wantMetric: testStatsDMetric("test.metric",
+				"42",
+				42,
+				0,
+				"test.metric",
+				false,
+				"c",
+				"", 1, 0, nil, nil),
+		},
+		{
+			name:  "invalid  counter metric value",
+			input: "test.metric:42.abc|c",
+			err:   errors.New("counter: parse metric value string: 42.abc"),
+		},
+		{
+			name:  "unhandled metric type",
+			input: "test.metric:42|unhandled_type",
+			err:   errors.New("unsupported metric type: unhandled_type"),
+		},
+		{
+			name:  "counter metric with sample rate and tag",
+			input: "test.metric:42|c|@0.1|#key:value",
+			wantMetric: testStatsDMetric("test.metric",
+				"42",
+				420,
+				0,
+				"test.metrickey=value",
+				false,
+				"c",
+				"",
+				1,
+				0.1,
+				[]*metricspb.LabelKey{
+					{
+						Key: "key",
+					},
+				},
+				[]*metricspb.LabelValue{
+					{
+						Value:    "value",
+						HasValue: true,
+					},
+				}),
+		},
+		{
+			name:  "counter metric with sample rate(not divisible) and tag",
+			input: "test.metric:42|c|@0.8|#key:value",
+			wantMetric: testStatsDMetric("test.metric",
+				"42",
+				52,
+				0,
+				"test.metrickey=value",
+				false,
+				"c",
+				"",
+				1,
+				0.8,
+				[]*metricspb.LabelKey{
+					{
+						Key: "key",
+					},
+				},
+				[]*metricspb.LabelValue{
+					{
+						Value:    "value",
+						HasValue: true,
+					},
+				}),
+		},
+		{
+			name:  "counter metric with sample rate(not divisible) and two tags",
+			input: "test.metric:42|c|@0.8|#key:value,key2:value2",
+			wantMetric: testStatsDMetric("test.metric",
+				"42",
+				52,
+				0,
+				"test.metrickey=valuekey2=value2",
+				false,
+				"c",
+				"",
+				1,
+				0.8,
+				[]*metricspb.LabelKey{
+					{
+						Key: "key",
+					},
+					{
+						Key: "key2",
+					},
+				},
+				[]*metricspb.LabelValue{
+					{
+						Value:    "value",
+						HasValue: true,
+					},
+					{
+						Value:    "value2",
+						HasValue: true,
+					},
+				}),
+		},
+		{
+			name:  "double gauge",
+			input: "test.metric:42.0|g",
+			wantMetric: testStatsDMetric("test.metric",
+				"42.0",
+				0,
+				42,
+				"test.metric",
+				false,
+				"g",
+				"", 2, 0, nil, nil),
+		},
+		{
+			name:  "int gauge",
+			input: "test.metric:42|g",
+			wantMetric: testStatsDMetric("test.metric",
+				"42",
+				0,
+				42,
+				"test.metric",
+				false,
+				"g",
+				"", 2, 0, nil, nil),
+		},
+		{
+			name:  "invalid gauge metric value",
+			input: "test.metric:42.abc|g",
+			err:   errors.New("gauge: parse metric value string: 42.abc"),
+		},
+		{
+			name:  "gauge metric with sample rate and tag",
+			input: "test.metric:11|g|@0.1|#key:value",
+			wantMetric: testStatsDMetric("test.metric",
+				"11",
+				0,
+				11,
+				"test.metrickey=value",
+				false,
+				"g",
+				"",
+				2,
+				0.1,
+				[]*metricspb.LabelKey{
+					{
+						Key: "key",
+					},
+				},
+				[]*metricspb.LabelValue{
+					{
+						Value:    "value",
+						HasValue: true,
+					},
+				}),
+		},
+		{
+			name:  "gauge metric with sample rate and two tags",
+			input: "test.metric:11|g|@0.8|#key:value,key2:value2",
+			wantMetric: testStatsDMetric("test.metric",
+				"11",
+				0,
+				11,
+				"test.metrickey=valuekey2=value2",
+				false,
+				"g",
+				"",
+				2,
+				0.8,
+				[]*metricspb.LabelKey{
+					{
+						Key: "key",
+					},
+					{
+						Key: "key2",
+					},
+				},
+				[]*metricspb.LabelValue{
+					{
+						Value:    "value",
+						HasValue: true,
+					},
+					{
+						Value:    "value2",
+						HasValue: true,
+					},
+				}),
+		},
+		{
+			name:  "double gauge plus",
+			input: "test.metric:+42.0|g",
+			wantMetric: testStatsDMetric("test.metric",
+				"+42.0",
+				0,
+				42,
+				"test.metric",
+				true,
+				"g",
+				"", 2, 0, nil, nil),
+		},
+		{
+			name:  "double gauge minus",
+			input: "test.metric:-42.0|g",
+			wantMetric: testStatsDMetric("test.metric",
+				"-42.0",
+				0,
+				-42,
+				"test.metric",
+				true,
+				"g",
+				"", 2, 0, nil, nil),
+		},
+		{
+			name:  "int gauge plus",
+			input: "test.metric:+42|g",
+			wantMetric: testStatsDMetric("test.metric",
+				"+42",
+				0,
+				42,
+				"test.metric",
+				true,
+				"g",
+				"", 2, 0, nil, nil),
+		},
+		{
+			name:  "int gauge minus",
+			input: "test.metric:-42|g",
+			wantMetric: testStatsDMetric("test.metric",
+				"-42",
+				0,
+				-42,
+				"test.metric",
+				true,
+				"g",
+				"", 2, 0, nil, nil),
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &StatsDParser{}
 
-			got, err := p.Parse(tt.input)
+			got, err := parseMessageToMetric(tt.input)
 
 			if tt.err != nil {
-				assert.Equal(t, err, tt.err)
+				assert.Equal(t, tt.err, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, got, tt.wantMetric)
+				assert.Equal(t, tt.wantMetric, got)
+			}
+		})
+	}
+}
+
+func testStatsDMetric(name string,
+	value string, intValue int64,
+	floatValue float64, hash string,
+	addition bool, statsdMetricType string,
+	unit string, metricType metricspb.MetricDescriptor_Type,
+	sampleRate float64, labelKeys []*metricspb.LabelKey,
+	labelValue []*metricspb.LabelValue) *statsDMetric {
+	return &statsDMetric{
+		name:             name,
+		value:            value,
+		intvalue:         intValue,
+		floatvalue:       floatValue,
+		hash:             hash,
+		addition:         addition,
+		statsdMetricType: statsdMetricType,
+		unit:             unit,
+		metricType:       metricType,
+		sampleRate:       sampleRate,
+		labelKeys:        labelKeys,
+		labelValues:      labelValue,
+	}
+}
+
+func NewTestInitialization() {
+	gauges = make(map[string]*metricspb.Metric)
+	counters = make(map[string]*metricspb.Metric)
+}
+
+func TestStatsDParser_Aggregate(t *testing.T) {
+	timeNowFunc = func() int64 {
+		return 0
+	}
+
+	tests := []struct {
+		name             string
+		input            []string
+		expectedGauges   map[string]*metricspb.Metric
+		expectedCounters map[string]*metricspb.Metric
+		err              error
+	}{
+		{
+			name: "parsedMetric error: empty metric value",
+			input: []string{
+				"test.metric:|c",
+			},
+			err: errors.New("empty metric value"),
+		},
+		{
+			name: "parsedMetric error: empty metric name",
+			input: []string{
+				":42|c",
+			},
+			err: errors.New("empty metric name"),
+		},
+		{
+			name: "gauge plus",
+			input: []string{
+				"statsdTestMetric1:1|g|#mykey:myvalue",
+				"statsdTestMetric2:2|g|#mykey:myvalue",
+				"statsdTestMetric1:+1|g|#mykey:myvalue",
+				"statsdTestMetric1:+100|g|#mykey:myvalue",
+				"statsdTestMetric1:+10000|g|#mykey:myvalue",
+				"statsdTestMetric2:+5|g|#mykey:myvalue",
+				"statsdTestMetric2:+500|g|#mykey:myvalue",
+			},
+			expectedGauges: map[string]*metricspb.Metric{
+				"statsdTestMetric1mykey=myvalue": testMetric("statsdTestMetric1",
+					metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: 10102,
+						},
+					}),
+				"statsdTestMetric2mykey=myvalue": testMetric("statsdTestMetric2",
+					metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: 507,
+						},
+					}),
+			},
+			expectedCounters: map[string]*metricspb.Metric{},
+		},
+		{
+			name: "gauge minus",
+			input: []string{
+				"statsdTestMetric1:5000|g|#mykey:myvalue",
+				"statsdTestMetric2:10|g|#mykey:myvalue",
+				"statsdTestMetric1:-1|g|#mykey:myvalue",
+				"statsdTestMetric2:-5|g|#mykey:myvalue",
+				"statsdTestMetric1:-1|g|#mykey:myvalue",
+				"statsdTestMetric1:-1|g|#mykey:myvalue",
+				"statsdTestMetric1:-10|g|#mykey:myvalue",
+				"statsdTestMetric1:-1|g|#mykey:myvalue",
+				"statsdTestMetric1:-100|g|#mykey:myvalue",
+				"statsdTestMetric1:-1|g|#mykey:myvalue",
+			},
+			expectedGauges: map[string]*metricspb.Metric{
+				"statsdTestMetric1mykey=myvalue": testMetric("statsdTestMetric1",
+					metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: 4885,
+						},
+					}),
+				"statsdTestMetric2mykey=myvalue": testMetric("statsdTestMetric2",
+					metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: 5,
+						},
+					}),
+			},
+			expectedCounters: map[string]*metricspb.Metric{},
+		},
+		{
+			name: "gauge plus and minus",
+			input: []string{
+				"statsdTestMetric1:5000|g|#mykey:myvalue",
+				"statsdTestMetric1:4000|g|#mykey:myvalue",
+				"statsdTestMetric1:+500|g|#mykey:myvalue",
+				"statsdTestMetric1:-400|g|#mykey:myvalue",
+				"statsdTestMetric1:+2|g|#mykey:myvalue",
+				"statsdTestMetric1:-1|g|#mykey:myvalue",
+				"statsdTestMetric2:365|g|#mykey:myvalue",
+				"statsdTestMetric2:+300|g|#mykey:myvalue",
+				"statsdTestMetric2:-200|g|#mykey:myvalue",
+				"statsdTestMetric2:200|g|#mykey:myvalue",
+			},
+			expectedGauges: map[string]*metricspb.Metric{
+				"statsdTestMetric1mykey=myvalue": testMetric("statsdTestMetric1",
+					metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: 4101,
+						},
+					}),
+				"statsdTestMetric2mykey=myvalue": testMetric("statsdTestMetric2",
+					metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: 200,
+						},
+					}),
+			},
+			expectedCounters: map[string]*metricspb.Metric{},
+		},
+		{
+			name: "counter with increment and sample rate",
+			input: []string{
+				"statsdTestMetric1:3000|c|#mykey:myvalue",
+				"statsdTestMetric1:4000|c|#mykey:myvalue",
+				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
+				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
+			},
+			expectedGauges: map[string]*metricspb.Metric{},
+			expectedCounters: map[string]*metricspb.Metric{
+				"statsdTestMetric1mykey=myvalue": testMetric("statsdTestMetric1",
+					metricspb.MetricDescriptor_GAUGE_INT64,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_Int64Value{
+							Int64Value: 7000,
+						},
+					}),
+				"statsdTestMetric2mykey=myvalue": testMetric("statsdTestMetric2",
+					metricspb.MetricDescriptor_GAUGE_INT64,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_Int64Value{
+							Int64Value: 50,
+						},
+					}),
+			},
+		},
+		{
+			name: "counter and gauge: one gauge and two counters",
+			input: []string{
+				"statsdTestMetric1:3000|c|#mykey:myvalue",
+				"statsdTestMetric1:500|g|#mykey:myvalue",
+				"statsdTestMetric1:400|g|#mykey:myvalue",
+				"statsdTestMetric1:+20|g|#mykey:myvalue",
+				"statsdTestMetric1:4000|c|#mykey:myvalue",
+				"statsdTestMetric1:-1|g|#mykey:myvalue",
+				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
+				"statsdTestMetric1:+2|g|#mykey:myvalue",
+				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
+			},
+			expectedGauges: map[string]*metricspb.Metric{
+				"statsdTestMetric1mykey=myvalue": testMetric("statsdTestMetric1",
+					metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: 421,
+						},
+					}),
+			},
+			expectedCounters: map[string]*metricspb.Metric{
+				"statsdTestMetric1mykey=myvalue": testMetric("statsdTestMetric1",
+					metricspb.MetricDescriptor_GAUGE_INT64,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_Int64Value{
+							Int64Value: 7000,
+						},
+					}),
+				"statsdTestMetric2mykey=myvalue": testMetric("statsdTestMetric2",
+					metricspb.MetricDescriptor_GAUGE_INT64,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_Int64Value{
+							Int64Value: 50,
+						},
+					}),
+			},
+		},
+		{
+			name: "counter and gauge: 2 gauges and 2 counters",
+			input: []string{
+				"statsdTestMetric1:500|g|#mykey:myvalue",
+				"statsdTestMetric1:400|g|#mykey:myvalue1",
+				"statsdTestMetric1:300|g|#mykey:myvalue",
+				"statsdTestMetric1:-1|g|#mykey:myvalue1",
+				"statsdTestMetric1:+20|g|#mykey:myvalue",
+				"statsdTestMetric1:-1|g|#mykey:myvalue",
+				"statsdTestMetric1:20|c|@0.1|#mykey:myvalue",
+				"statsdTestMetric2:50|c|#mykey:myvalue",
+				"statsdTestMetric1:15|c|#mykey:myvalue",
+				"statsdTestMetric2:5|c|@0.2|#mykey:myvalue",
+			},
+			expectedGauges: map[string]*metricspb.Metric{
+				"statsdTestMetric1mykey=myvalue": testMetric("statsdTestMetric1",
+					metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: 319,
+						},
+					}),
+				"statsdTestMetric1mykey=myvalue1": testMetric("statsdTestMetric1",
+					metricspb.MetricDescriptor_GAUGE_DOUBLE,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue1",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_DoubleValue{
+							DoubleValue: 399,
+						},
+					}),
+			},
+			expectedCounters: map[string]*metricspb.Metric{
+				"statsdTestMetric1mykey=myvalue": testMetric("statsdTestMetric1",
+					metricspb.MetricDescriptor_GAUGE_INT64,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_Int64Value{
+							Int64Value: 215,
+						},
+					}),
+				"statsdTestMetric2mykey=myvalue": testMetric("statsdTestMetric2",
+					metricspb.MetricDescriptor_GAUGE_INT64,
+					[]*metricspb.LabelKey{
+						{
+							Key: "mykey",
+						},
+					},
+					[]*metricspb.LabelValue{
+						{
+							Value:    "myvalue",
+							HasValue: true,
+						},
+					},
+					"",
+					&metricspb.Point{
+						Timestamp: &timestamppb.Timestamp{
+							Seconds: 0,
+						},
+						Value: &metricspb.Point_Int64Value{
+							Int64Value: 75,
+						},
+					}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			NewTestInitialization()
+			var err error
+			for _, line := range tt.input {
+				p := &StatsDParser{}
+				err = p.Aggregate(line)
+			}
+			if tt.err != nil {
+				assert.Equal(t, tt.err, err)
+			} else {
+				assert.Equal(t, tt.expectedGauges, gauges)
+				assert.Equal(t, tt.expectedCounters, counters)
 			}
 		})
 	}
@@ -310,4 +846,102 @@ func testMetric(metricName string,
 			},
 		},
 	}
+}
+
+func Test_contains(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []string
+		element  string
+		expected bool
+	}{
+		{
+			name: "contain 1",
+			slice: []string{
+				"m",
+				"g",
+			},
+			element:  "m",
+			expected: true,
+		},
+		{
+			name: "contain 2",
+			slice: []string{
+				"m",
+				"g",
+			},
+			element:  "g",
+			expected: true,
+		},
+		{
+			name: "does not contain",
+			slice: []string{
+				"m",
+				"g",
+			},
+			element:  "t",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			answer := contains(tt.slice, tt.element)
+			assert.Equal(t, tt.expected, answer)
+		})
+	}
+}
+
+func TestStatsDParser_Initialize(t *testing.T) {
+	p := &StatsDParser{}
+	p.Initialize()
+	gauges["test"] = &metricspb.Metric{}
+	counters["test"] = &metricspb.Metric{}
+	assert.Equal(t, 1, len(gauges))
+	assert.Equal(t, 1, len(counters))
+}
+
+func TestStatsDParser_GetMetrics(t *testing.T) {
+	p := &StatsDParser{}
+	p.Initialize()
+	gauges["testGauge1"] = testMetric("testGauge1",
+		metricspb.MetricDescriptor_GAUGE_DOUBLE,
+		nil,
+		nil,
+		"",
+		&metricspb.Point{
+			Timestamp: &timestamppb.Timestamp{
+				Seconds: 0,
+			},
+			Value: &metricspb.Point_DoubleValue{
+				DoubleValue: 1,
+			},
+		})
+	gauges["testGauge2"] = testMetric("testGauge2",
+		metricspb.MetricDescriptor_GAUGE_DOUBLE,
+		nil,
+		nil,
+		"",
+		&metricspb.Point{
+			Timestamp: &timestamppb.Timestamp{
+				Seconds: 0,
+			},
+			Value: &metricspb.Point_DoubleValue{
+				DoubleValue: 2,
+			},
+		})
+	counters["testCounter1"] = testMetric("testCounter1",
+		metricspb.MetricDescriptor_GAUGE_INT64,
+		nil,
+		nil,
+		"",
+		&metricspb.Point{
+			Timestamp: &timestamppb.Timestamp{
+				Seconds: 0,
+			},
+			Value: &metricspb.Point_Int64Value{
+				Int64Value: 1,
+			},
+		})
+	metrics := p.GetMetrics()
+	assert.Equal(t, 3, len(metrics))
 }

--- a/receiver/statsdreceiver/testdata/config.yaml
+++ b/receiver/statsdreceiver/testdata/config.yaml
@@ -3,6 +3,7 @@ receivers:
   statsd/receiver_settings:
     endpoint: "localhost:12345"
     transport: "custom_transport"
+    aggregation_interval: 70s
 
 processors:
   exampleprocessor:

--- a/receiver/statsdreceiver/transport/server.go
+++ b/receiver/statsdreceiver/transport/server.go
@@ -37,6 +37,7 @@ type Server interface {
 		p protocol.Parser,
 		mc consumer.MetricsConsumer,
 		r Reporter,
+		transferChan chan<- string,
 	) error
 
 	// Close stops any running ListenAndServe, however, it waits for any


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- add aggregation for StatsD receiver, support metrics types: gauge and counter
- We finally agree to add aggregation in StatsD receiver (now the default aggregation interval is 60s). 
- Every each interval, the receiver will send the aggregated metrics to the next workflow:

Gauge:
- statsdTestMetric1:500|g|#mykey:myvalue
statsdTestMetric1:400|g|#mykey:myvalue
(get the latest value: 400)
- statsdTestMetric1:500|g|#mykey:myvalue
statsdTestMetric1:+2|g|#mykey:myvalue
statsdTestMetric1:-1|g|#mykey:myvalue
(get the value after calculation: 501)

Counter:
- statsdTestMetric1:3000|c|#mykey:myvalue
statsdTestMetric1:4000|c|#mykey:myvalue
(get the value after incrementation: 7000)
- statsdTestMetric1:3000|c|#mykey:myvalue
statsdTestMetric1:20|c|@0.8|#mykey:myvalue
(get the value after incrementation with sample rate: 3000+20/0.8=3025)

**Testing:** 
- Added unit tests

**Documentation:** 
- You can check the readme for detail