### PR TITLE
[SignalFx]: Disable retry on 400 and 401, retry with backoff on 429 and 503

### DIFF
--- a/exporter/signalfxexporter/dpclient.go
+++ b/exporter/signalfxexporter/dpclient.go
@@ -18,28 +18,22 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/translation"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
-
-const headerRetryAfter = "Retry-After"
 
 type sfxClientBase struct {
 	ingestURL *url.URL
@@ -138,35 +132,11 @@ func (s *sfxDPClient) pushMetricsDataForToken(ctx context.Context, sfxDataPoints
 	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
 
-	// SignalFx accepts all 2XX codes.
-	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
-		return 0, nil
+	err = splunk.HandleHTTPCode(resp)
+	if err != nil {
+		return len(sfxDataPoints), err
 	}
-
-	err = fmt.Errorf(
-		"HTTP %d %q",
-		resp.StatusCode,
-		http.StatusText(resp.StatusCode))
-
-	switch resp.StatusCode {
-	// Check for responses that may include "Retry-After" header.
-	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
-		// Fallback to 0 if the Retry-After header is not present. This will trigger the
-		// default backoff policy by our caller (retry handler).
-		retryAfter := 0
-		if val := resp.Header.Get(headerRetryAfter); val != "" {
-			if seconds, err2 := strconv.Atoi(val); err2 == nil {
-				retryAfter = seconds
-			}
-		}
-		// Indicate to our caller to pause for the specified number of seconds.
-		err = exporterhelper.NewThrottleRetry(err, time.Duration(retryAfter)*time.Second)
-	// Check for permanent errors.
-	case http.StatusBadRequest, http.StatusUnauthorized:
-		err = consumererror.Permanent(err)
-	}
-
-	return len(sfxDataPoints), err
+	return 0, nil
 }
 
 func buildHeaders(config *Config) map[string]string {

--- a/exporter/signalfxexporter/eventclient.go
+++ b/exporter/signalfxexporter/eventclient.go
@@ -16,7 +16,6 @@ package signalfxexporter
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -96,15 +95,8 @@ func (s *sfxEventClient) pushLogsData(ctx context.Context, ld pdata.Logs) (int, 
 		resp.Body.Close()
 	}()
 
-	// SignalFx accepts all 2XX codes.
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		body, _ := ioutil.ReadAll(resp.Body)
-		err = fmt.Errorf(
-			"HTTP %d %q for %q: %s",
-			resp.StatusCode,
-			http.StatusText(resp.StatusCode),
-			req.URL,
-			body)
+	err = splunk.HandleHTTPCode(resp)
+	if err != nil {
 		return ld.LogRecordCount(), err
 	}
 

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -33,17 +33,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-<<<<<<< HEAD
 	"go.opentelemetry.io/collector/component/componenttest"
-=======
 	"go.opentelemetry.io/collector/consumer/consumererror"
->>>>>>> 0006cef5 ([SignalFx]: Disable retry on 400 and 401, retry with backoff on 429 and 503)
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/dimensions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/translation"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/collection"
 )
 
@@ -185,7 +183,7 @@ func TestConsumeMetrics(t *testing.T) {
 				assert.Equal(t, "test", r.Header.Get("test_header_"))
 				if (tt.httpResponseCode == http.StatusTooManyRequests ||
 					tt.httpResponseCode == http.StatusServiceUnavailable) && tt.retryAfter != 0 {
-					w.Header().Add(headerRetryAfter, strconv.Itoa(tt.retryAfter))
+					w.Header().Add(splunk.HeaderRetryAfter, strconv.Itoa(tt.retryAfter))
 				}
 				w.WriteHeader(tt.httpResponseCode)
 			}))

--- a/internal/splunk/httprequest.go
+++ b/internal/splunk/httprequest.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunk
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+const HeaderRetryAfter = "Retry-After"
+
+// HandleHTTPCode handles an http response and returns the right type of error in case of a failure.
+func HandleHTTPCode(resp *http.Response) error {
+	// SignalFx accepts all 2XX codes.
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return nil
+	}
+
+	err := fmt.Errorf(
+		"HTTP %d %q",
+		resp.StatusCode,
+		http.StatusText(resp.StatusCode))
+
+	switch resp.StatusCode {
+	// Check for responses that may include "Retry-After" header.
+	case http.StatusTooManyRequests, http.StatusServiceUnavailable:
+		// Fallback to 0 if the Retry-After header is not present. This will trigger the
+		// default backoff policy by our caller (retry handler).
+		retryAfter := 0
+		if val := resp.Header.Get(HeaderRetryAfter); val != "" {
+			if seconds, err2 := strconv.Atoi(val); err2 == nil {
+				retryAfter = seconds
+			}
+		}
+		// Indicate to our caller to pause for the specified number of seconds.
+		err = exporterhelper.NewThrottleRetry(err, time.Duration(retryAfter)*time.Second)
+	// Check for permanent errors.
+	case http.StatusBadRequest, http.StatusUnauthorized:
+		err = consumererror.Permanent(err)
+	}
+
+	return err
+}

--- a/internal/splunk/httprequest_test.go
+++ b/internal/splunk/httprequest_test.go
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package splunk
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+func TestConsumeMetrics(t *testing.T) {
+	tests := []struct {
+		name             string
+		httpResponseCode int
+		retryAfter       int
+		wantErr          bool
+		wantPermanentErr bool
+		wantThrottleErr  bool
+	}{
+		{
+			name:             "response_forbidden",
+			httpResponseCode: http.StatusForbidden,
+			wantErr:          true,
+		},
+		{
+			name:             "response_bad_request",
+			httpResponseCode: http.StatusBadRequest,
+			wantPermanentErr: true,
+		},
+		{
+			name:             "response_throttle",
+			httpResponseCode: http.StatusTooManyRequests,
+			wantThrottleErr:  true,
+		},
+		{
+			name:             "response_throttle_with_header",
+			retryAfter:       123,
+			httpResponseCode: http.StatusServiceUnavailable,
+			wantThrottleErr:  true,
+		},
+		{
+			name:             "large_batch",
+			httpResponseCode: http.StatusAccepted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: tt.httpResponseCode,
+			}
+			if tt.retryAfter != 0 {
+				resp.Header = map[string][]string{
+					HeaderRetryAfter: {strconv.Itoa(tt.retryAfter)},
+				}
+			}
+
+			err := HandleHTTPCode(resp)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			if tt.wantPermanentErr {
+				assert.Error(t, err)
+				assert.True(t, consumererror.IsPermanent(err))
+				return
+			}
+
+			if tt.wantThrottleErr {
+				expected := fmt.Errorf("HTTP %d %q", tt.httpResponseCode, http.StatusText(tt.httpResponseCode))
+				expected = exporterhelper.NewThrottleRetry(expected, time.Duration(tt.retryAfter)*time.Second)
+				assert.EqualValues(t, expected, err)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1495

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
