### PR TITLE
fix: dns resolver won't do periodic checks

### DIFF
--- a/exporter/loadbalancingexporter/resolver_dns.go
+++ b/exporter/loadbalancingexporter/resolver_dns.go
@@ -95,15 +95,18 @@ func (r *dnsResolver) shutdown(ctx context.Context) error {
 
 func (r *dnsResolver) periodicallyResolve() {
 	ticker := time.NewTicker(r.resInterval)
-	select {
-	case <-ticker.C:
-		ctx, cancel := context.WithTimeout(context.Background(), r.resTimeout)
-		if _, err := r.resolve(ctx); err != nil {
-			r.logger.Warn("failed to resolve", zap.Error(err))
+
+	for {
+		select {
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), r.resTimeout)
+			if _, err := r.resolve(ctx); err != nil {
+				r.logger.Warn("failed to resolve", zap.Error(err))
+			}
+			cancel()
+		case <-r.stopCh:
+			return
 		}
-		cancel()
-	case <-r.stopCh:
-		return
 	}
 }
 

--- a/exporter/loadbalancingexporter/resolver_dns_test.go
+++ b/exporter/loadbalancingexporter/resolver_dns_test.go
@@ -155,18 +155,30 @@ func TestPeriodicallyResolve(t *testing.T) {
 
 	counter := 0
 	resolve := [][]net.IPAddr{
-		{{IP: net.IPv4(127, 0, 0, 1)}}, {
+		{
+			{IP: net.IPv4(127, 0, 0, 1)},
+		}, {
 			{IP: net.IPv4(127, 0, 0, 1)},
 			{IP: net.IPv4(127, 0, 0, 2)},
+		}, {
+			{IP: net.IPv4(127, 0, 0, 1)},
+			{IP: net.IPv4(127, 0, 0, 2)},
+			{IP: net.IPv4(127, 0, 0, 3)},
 		},
 	}
 	res.resolver = &mockDNSResolver{
 		onLookupIPAddr: func(context.Context, string) ([]net.IPAddr, error) {
-			counter++
-
-			// for subsequent calls, return the second result
-			if counter >= 2 {
+			defer func() {
+				counter++
+			}()
+			// for second call, return the second result
+			if counter == 2 {
 				return resolve[1], nil
+			}
+			// for subsequent calls, return the last result, because we need more two periodic results
+			// to confirm that it works as expected.
+			if counter >= 3 {
+				return resolve[2], nil
 			}
 
 			// for the first call, return the first result
@@ -181,16 +193,16 @@ func TestPeriodicallyResolve(t *testing.T) {
 	})
 
 	// test
-	wg.Add(2)
+	wg.Add(3)
 	res.start(context.Background())
 	defer res.shutdown(context.Background())
 
-	// wait for two resolutions: from the start, and one periodic
+	// wait for three resolutions: from the start, and two periodic resolutions
 	wg.Wait()
 
 	// verify
-	assert.GreaterOrEqual(t, 2, counter)
-	assert.Len(t, res.endpoints, 2)
+	assert.GreaterOrEqual(t, counter, 3)
+	assert.Len(t, res.endpoints, 3)
 }
 
 func TestPeriodicallyResolveFailure(t *testing.T) {


### PR DESCRIPTION
**Description:**

Please refer to the issue, just fix a very little bug in `periodicallyResolve` in loadbalancing exporter

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1677

**Testing:**

I update the `TestPeriodicallyResolve` to have it test at least two dns changes.

**Documentation:**

None