### PR TITLE
loadbalancingexporter: add Start for exporters

### DIFF
--- a/exporter/loadbalancingexporter/exporter.go
+++ b/exporter/loadbalancingexporter/exporter.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -122,7 +121,6 @@ func (e *exporterImp) Start(ctx context.Context, host component.Host) error {
 }
 
 func (e *exporterImp) onBackendChanges(resolved []string) {
-	sort.Strings(resolved)
 	newRing := newHashRing(resolved)
 
 	if !newRing.equal(e.ring) {

--- a/exporter/loadbalancingexporter/exporter.go
+++ b/exporter/loadbalancingexporter/exporter.go
@@ -50,7 +50,7 @@ var (
 type exporterImp struct {
 	logger *zap.Logger
 	config Config
-	host component.Host
+	host   component.Host
 
 	res  resolver
 	ring *hashRing

--- a/exporter/loadbalancingexporter/exporter.go
+++ b/exporter/loadbalancingexporter/exporter.go
@@ -50,6 +50,7 @@ var (
 type exporterImp struct {
 	logger *zap.Logger
 	config Config
+	host component.Host
 
 	res  resolver
 	ring *hashRing
@@ -112,6 +113,7 @@ func newExporter(params component.ExporterCreateParams, cfg configmodels.Exporte
 
 func (e *exporterImp) Start(ctx context.Context, host component.Host) error {
 	e.res.onChange(e.onBackendChanges)
+	e.host = host
 	if err := e.res.start(ctx); err != nil {
 		return err
 	}
@@ -120,7 +122,7 @@ func (e *exporterImp) Start(ctx context.Context, host component.Host) error {
 }
 
 func (e *exporterImp) onBackendChanges(resolved []string) {
-	resolved = sort.StringSlice(resolved)
+	sort.Strings(resolved)
 	newRing := newHashRing(resolved)
 
 	if !newRing.equal(e.ring) {
@@ -146,7 +148,11 @@ func (e *exporterImp) addMissingExporters(ctx context.Context, endpoints []strin
 			cfg := e.buildExporterConfig(endpoint)
 			exp, err := e.exporterFactory.CreateTracesExporter(ctx, e.templateCreateParams, &cfg)
 			if err != nil {
-				e.logger.Warn("failed to create new trace exporter for endpoint", zap.String("endpoint", endpoint))
+				e.logger.Error("failed to create new trace exporter for endpoint", zap.String("endpoint", endpoint), zap.Error(err))
+				continue
+			}
+			if err = exp.Start(ctx, e.host); err != nil {
+				e.logger.Error("failed to start new trace exporter for endpoint", zap.String("endpoint", endpoint), zap.Error(err))
 				continue
 			}
 			e.exporters[endpoint] = exp

--- a/exporter/loadbalancingexporter/exporter_test.go
+++ b/exporter/loadbalancingexporter/exporter_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"path"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -253,10 +254,12 @@ func TestOnBackendChanges(t *testing.T) {
 	require.Len(t, p.ring.items, defaultWeight)
 
 	// this should resolve to two endpoints
-	p.onBackendChanges([]string{"endpoint-1", "endpoint-2"})
+	endpoints := []string{"endpoint-2", "endpoint-1"}
+	p.onBackendChanges(endpoints)
 
 	// verify
 	assert.Len(t, p.ring.items, 2*defaultWeight)
+	assert.True(t, sort.IsSorted(sort.StringSlice(endpoints)))
 }
 
 func TestRemoveExtraExporters(t *testing.T) {

--- a/exporter/loadbalancingexporter/exporter_test.go
+++ b/exporter/loadbalancingexporter/exporter_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"path"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -254,12 +253,11 @@ func TestOnBackendChanges(t *testing.T) {
 	require.Len(t, p.ring.items, defaultWeight)
 
 	// this should resolve to two endpoints
-	endpoints := []string{"endpoint-2", "endpoint-1"}
+	endpoints := []string{"endpoint-1", "endpoint-2"}
 	p.onBackendChanges(endpoints)
 
 	// verify
 	assert.Len(t, p.ring.items, 2*defaultWeight)
-	assert.True(t, sort.IsSorted(sort.StringSlice(endpoints)))
 }
 
 func TestRemoveExtraExporters(t *testing.T) {


### PR DESCRIPTION
**Description:** 
Fixed a bug with not working loadbalancingexporter with retry queue. Also added sorting for endpoints on backend change (assume it is occasionally missing).

**Link to tracking Issue:** Fixes #1621 

**Testing:**
Added test for endpoints sort