### PR TITLE
Update honeycomb exporter to use internal data format

### DIFF
--- a/exporter/honeycombexporter/factory.go
+++ b/exporter/honeycombexporter/factory.go
@@ -55,5 +55,14 @@ func createTraceExporter(
 	cfg configmodels.Exporter,
 ) (component.TracesExporter, error) {
 	eCfg := cfg.(*Config)
-	return newHoneycombTraceExporter(eCfg, params.Logger)
+	exporter, err := newHoneycombTraceExporter(eCfg, params.Logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return exporterhelper.NewTraceExporter(
+		cfg,
+		params.Logger,
+		exporter.pushTraceData,
+		exporterhelper.WithShutdown(exporter.Shutdown))
 }

--- a/exporter/honeycombexporter/honeycomb.go
+++ b/exporter/honeycombexporter/honeycomb.go
@@ -119,21 +119,21 @@ func (e *honeycombExporter) pushTraceData(ctx context.Context, td pdata.Traces) 
 
 	rs := td.ResourceSpans()
 	for i := 0; i < rs.Len(); i++ {
-		rs_span := rs.At(i)
-		if rs_span.IsNil() {
+		rsSpan := rs.At(i)
+		if rsSpan.IsNil() {
 			continue
 		}
 
 		// Extract Resource attributes, they will be added to every span.
-		resourceAttrs := spanAttributesToMap(rs_span.Resource().Attributes())
+		resourceAttrs := spanAttributesToMap(rsSpan.Resource().Attributes())
 
-		ils := rs_span.InstrumentationLibrarySpans()
+		ils := rsSpan.InstrumentationLibrarySpans()
 		for j := 0; j < ils.Len(); j++ {
-			ils_span := ils.At(j)
-			if ils_span.IsNil() {
+			ilsSpan := ils.At(j)
+			if ilsSpan.IsNil() {
 				continue
 			}
-			spans := ils_span.Spans()
+			spans := ilsSpan.Spans()
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
 				if span.IsNil() {
@@ -197,11 +197,10 @@ func getSpanKind(kind pdata.SpanKind) string {
 		return "consumer"
 	case pdata.SpanKindINTERNAL:
 		return "internal"
-	default:
-		fallthrough
 	case pdata.SpanKindUNSPECIFIED:
+		fallthrough
+	default:
 		return "unspecified"
-
 	}
 }
 

--- a/exporter/honeycombexporter/honeycomb.go
+++ b/exporter/honeycombexporter/honeycomb.go
@@ -16,18 +16,14 @@ package honeycombexporter
 
 import (
 	"context"
-	"strings"
 	"time"
 
-	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/honeycombio/libhoney-go"
 	"github.com/honeycombio/libhoney-go/transmission"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
-	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.opentelemetry.io/collector/translator/internaldata"
 	"go.uber.org/zap"
 )
 
@@ -46,13 +42,12 @@ type honeycombExporter struct {
 
 // event represents a honeycomb event.
 type event struct {
-	ID              string  `json:"trace.span_id"`
-	TraceID         string  `json:"trace.trace_id"`
-	ParentID        string  `json:"trace.parent_id,omitempty"`
-	Name            string  `json:"name"`
-	Status          string  `json:"response.status_code,omitempty"`
-	HasRemoteParent bool    `json:"has_remote_parent"`
-	DurationMilli   float64 `json:"duration_ms"`
+	ID            string  `json:"trace.span_id"`
+	TraceID       string  `json:"trace.trace_id"`
+	ParentID      string  `json:"trace.parent_id,omitempty"`
+	Name          string  `json:"name"`
+	Status        string  `json:"response.status_code,omitempty"`
+	DurationMilli float64 `json:"duration_ms"`
 }
 
 // spanEvent represents an event attached to a specific span.¬
@@ -68,17 +63,12 @@ type spanEvent struct {
 // TraceID and ParentID are used to identify the span with which the trace is associated
 // We are modeling Links for now as child spans rather than properties of the event.
 type link struct {
-	TraceID        string      `json:"trace.trace_id"`
-	ParentID       string      `json:"trace.parent_id,omitempty"`
-	LinkTraceID    string      `json:"trace.link.trace_id"`
-	LinkSpanID     string      `json:"trace.link.span_id"`
-	AnnotationType string      `json:"meta.annotation_type"`
-	RefType        spanRefType `json:"ref_type,omitempty"`
+	TraceID        string `json:"trace.trace_id"`
+	ParentID       string `json:"trace.parent_id,omitempty"`
+	LinkTraceID    string `json:"trace.link.trace_id"`
+	LinkSpanID     string `json:"trace.link.span_id"`
+	AnnotationType string `json:"meta.annotation_type"`
 }
-
-// spanRefType defines the relationship a Link has to a trace or a span. It can
-// either be a child of, or a follows from relationship.
-type spanRefType int64
 
 // newHoneycombTraceExporter creates and returns a new honeycombExporter. It
 // wraps the exporter in the component.TraceExporterOld helper method.
@@ -127,70 +117,67 @@ func (e *honeycombExporter) pushTraceData(ctx context.Context, td pdata.Traces) 
 	go e.RunErrorLogger(ctx, libhoney.TxResponses())
 	defer cancel()
 
-	octds := internaldata.TraceDataToOC(td)
-	for _, octd := range octds {
-
-		// Extract Node and Resource attributes, labels and other information.
-		// Because these exist on the TraceData, they will be added to every span.
-		traceLevelFields := getTraceLevelFields(octd.Node, octd.Resource, octd.SourceFormat)
-		addTraceLevelFields := func(ev *libhoney.Event, tlf map[string]interface{}) {
-			for k, v := range tlf {
-				ev.AddField(k, v)
-			}
+	rs := td.ResourceSpans()
+	for i := 0; i < rs.Len(); i++ {
+		rs_span := rs.At(i)
+		if rs_span.IsNil() {
+			continue
 		}
 
-		for _, span := range octd.Spans {
-			ev := e.builder.NewEvent()
+		// Extract Resource attributes, they will be added to every span.
+		resourceAttrs := spanAttributesToMap(rs_span.Resource().Attributes())
 
-			tlf := traceLevelFields
-			// If Resource present need to recalculate traceLevelFields
-			if span.Resource != nil {
-				tlf = getTraceLevelFields(octd.Node, span.Resource, octd.SourceFormat)
+		ils := rs_span.InstrumentationLibrarySpans()
+		for j := 0; j < ils.Len(); j++ {
+			ils_span := ils.At(j)
+			if ils_span.IsNil() {
+				continue
 			}
-			addTraceLevelFields(ev, tlf)
-
-			if len(span.GetParentSpanId()) == 0 || hasRemoteParent(span) {
-				if octd.Node != nil {
-					for k, v := range octd.Node.Attributes {
-						ev.AddField(k, v)
-					}
+			spans := ils_span.Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				if span.IsNil() {
+					continue
 				}
-			}
 
-			if attrs := spanAttributesToMap(span.GetAttributes()); attrs != nil {
-				for k, v := range attrs {
+				ev := e.builder.NewEvent()
+
+				for k, v := range resourceAttrs {
 					ev.AddField(k, v)
 				}
 
-				e.addSampleRate(ev, attrs)
-			}
+				if attrs := spanAttributesToMap(span.Attributes()); attrs != nil {
+					for k, v := range attrs {
+						ev.AddField(k, v)
+					}
 
-			ev.Timestamp = timestampToTime(span.GetStartTime())
-			startTime := timestampToTime(span.GetStartTime())
-			endTime := timestampToTime(span.GetEndTime())
+					e.addSampleRate(ev, attrs)
+				}
 
-			ev.Add(event{
-				ID:              getHoneycombSpanID(span.GetSpanId()),
-				TraceID:         getHoneycombTraceID(span.GetTraceId()),
-				ParentID:        getHoneycombSpanID(span.GetParentSpanId()),
-				Name:            truncatableStringAsString(span.GetName()),
-				DurationMilli:   float64(endTime.Sub(startTime)) / float64(time.Millisecond),
-				HasRemoteParent: hasRemoteParent(span),
-			})
+				ev.Timestamp = timestampToTime(span.StartTime())
+				startTime := timestampToTime(span.StartTime())
+				endTime := timestampToTime(span.EndTime())
 
-			e.sendMessageEvents(octd, span, tlf)
-			e.sendSpanLinks(span)
+				ev.Add(event{
+					ID:            getHoneycombSpanID(span.SpanID()),
+					TraceID:       getHoneycombTraceID(span.TraceID()),
+					ParentID:      getHoneycombSpanID(span.ParentSpanID()),
+					Name:          span.Name(),
+					DurationMilli: float64(endTime.Sub(startTime)) / float64(time.Millisecond),
+				})
 
-			ev.AddField("span_kind", strings.ToLower(span.Kind.String()))
-			ev.AddField("status.code", getStatusCode(span.Status))
-			ev.AddField("status.message", getStatusMessage(span.Status))
-			ev.AddField("has_remote_parent", !span.GetSameProcessAsParentSpan().GetValue())
-			ev.AddField("child_span_count", span.GetChildSpanCount())
+				e.sendMessageEvents(span, resourceAttrs)
+				e.sendSpanLinks(span)
 
-			if err := ev.SendPresampled(); err != nil {
-				errs = append(errs, err)
-			} else {
-				goodSpans++
+				ev.AddField("span_kind", getSpanKind(span.Kind()))
+				ev.AddField("status.code", getStatusCode(span.Status()))
+				ev.AddField("status.message", getStatusMessage(span.Status()))
+
+				if err := ev.SendPresampled(); err != nil {
+					errs = append(errs, err)
+				} else {
+					goodSpans++
+				}
 			}
 		}
 	}
@@ -198,26 +185,43 @@ func (e *honeycombExporter) pushTraceData(ctx context.Context, td pdata.Traces) 
 	return td.SpanCount() - goodSpans, componenterror.CombineErrors(errs)
 }
 
+func getSpanKind(kind pdata.SpanKind) string {
+	switch kind {
+	case pdata.SpanKindCLIENT:
+		return "client"
+	case pdata.SpanKindSERVER:
+		return "server"
+	case pdata.SpanKindPRODUCER:
+		return "producer"
+	case pdata.SpanKindCONSUMER:
+		return "consumer"
+	case pdata.SpanKindINTERNAL:
+		return "internal"
+	default:
+		fallthrough
+	case pdata.SpanKindUNSPECIFIED:
+		return "unspecified"
+
+	}
+}
+
 // sendSpanLinks gets the list of links associated with this span and sends them as
 // separate events to Honeycomb, with a span type "link".
-func (e *honeycombExporter) sendSpanLinks(span *tracepb.Span) {
-	links := span.GetLinks()
+func (e *honeycombExporter) sendSpanLinks(span pdata.Span) {
+	links := span.Links()
 
-	if links == nil {
-		return
-	}
+	for i := 0; i < links.Len(); i++ {
+		l := links.At(i)
 
-	for _, l := range links.GetLink() {
 		ev := e.builder.NewEvent()
 		ev.Add(link{
-			TraceID:        getHoneycombTraceID(span.GetTraceId()),
-			ParentID:       getHoneycombSpanID(span.GetSpanId()),
-			LinkTraceID:    getHoneycombTraceID(l.GetTraceId()),
-			LinkSpanID:     getHoneycombSpanID(l.GetSpanId()),
+			TraceID:        getHoneycombTraceID(span.TraceID()),
+			ParentID:       getHoneycombSpanID(span.SpanID()),
+			LinkTraceID:    getHoneycombTraceID(l.TraceID()),
+			LinkSpanID:     getHoneycombSpanID(l.SpanID()),
 			AnnotationType: "link",
-			RefType:        spanRefType(l.GetType()),
 		})
-		attrs := spanAttributesToMap(l.GetAttributes())
+		attrs := spanAttributesToMap(l.Attributes())
 		for k, v := range attrs {
 			ev.AddField(k, v)
 		}
@@ -231,34 +235,22 @@ func (e *honeycombExporter) sendSpanLinks(span *tracepb.Span) {
 
 // sendMessageEvents gets the list of timeevents from the span and sends them as
 // separate events to Honeycomb, with a span type "span_event".
-func (e *honeycombExporter) sendMessageEvents(td consumerdata.TraceData, span *tracepb.Span, traceFields map[string]interface{}) {
-	timeEvents := span.GetTimeEvents()
-	if timeEvents == nil {
-		return
-	}
+func (e *honeycombExporter) sendMessageEvents(span pdata.Span, resourceAttrs map[string]interface{}) {
+	timeEvents := span.Events()
 
-	for _, event := range timeEvents.TimeEvent {
-		annotation := event.GetAnnotation()
-		if annotation == nil {
-			continue
-		}
+	for i := 0; i < timeEvents.Len(); i++ {
+		event := timeEvents.At(i)
 
-		ts := timestampToTime(event.GetTime())
-		name := annotation.GetDescription().GetValue()
-		attrs := spanAttributesToMap(annotation.GetAttributes())
+		ts := timestampToTime(event.Timestamp())
+		name := event.Name()
+		attrs := spanAttributesToMap(event.Attributes())
 
 		// treat trace level fields as underlays with same keyed span attributes taking precedence.
 		ev := e.builder.NewEvent()
-		for k, v := range traceFields {
+		for k, v := range resourceAttrs {
 			ev.AddField(k, v)
 		}
-		if len(span.GetParentSpanId()) == 0 || hasRemoteParent(span) {
-			if td.Node != nil {
-				for k, v := range td.Node.Attributes {
-					ev.AddField(k, v)
-				}
-			}
-		}
+
 		for k, v := range attrs {
 			ev.AddField(k, v)
 		}
@@ -267,9 +259,9 @@ func (e *honeycombExporter) sendMessageEvents(td consumerdata.TraceData, span *t
 		ev.Timestamp = ts
 		ev.Add(spanEvent{
 			Name:           name,
-			TraceID:        getHoneycombTraceID(span.GetTraceId()),
-			ParentID:       getHoneycombSpanID(span.GetSpanId()),
-			ParentName:     truncatableStringAsString(span.GetName()),
+			TraceID:        getHoneycombTraceID(span.TraceID()),
+			ParentID:       getHoneycombSpanID(span.SpanID()),
+			ParentName:     span.Name(),
 			AnnotationType: "span_event",
 		})
 		if err := ev.SendPresampled(); err != nil {

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -24,24 +24,21 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/zapcore"
-
-	"go.uber.org/zap/zaptest/observer"
-
-	"github.com/honeycombio/libhoney-go/transmission"
-
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/google/go-cmp/cmp"
+	"github.com/honeycombio/libhoney-go/transmission"
 	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/internaldata"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -661,3 +661,10 @@ func TestRunErrorLogger_OnError(t *testing.T) {
 	assert.Equal(t, 1, logs.Len())
 	assert.Equal(t, expectedLogs, logs.AllUntimed())
 }
+
+func TestDebugUsesDebugLogger(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Debug = true
+	_, err := newHoneycombTraceExporter(cfg, zap.NewNop())
+	require.NoError(t, err)
+}

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -209,11 +209,9 @@ func TestExporter(t *testing.T) {
 		{
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      false,
 				"name":                                   "client",
-				"service_name":                           "test_service",
+				"service.name":                           "test_service",
 				"span_kind":                              "client",
-				"source_format":                          "otlp_trace",
 				"status.code":                            float64(0),
 				"status.message":                         "OK",
 				"trace.parent_id":                        "0200000000000000",
@@ -228,11 +226,9 @@ func TestExporter(t *testing.T) {
 		{
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      true,
 				"name":                                   "server",
-				"service_name":                           "test_service",
+				"service.name":                           "test_service",
 				"span_kind":                              "server",
-				"source_format":                          "otlp_trace",
 				"status.code":                            float64(0),
 				"status.message":                         "OK",
 				"trace.parent_id":                        "0300000000000000",
@@ -252,8 +248,7 @@ func TestExporter(t *testing.T) {
 				"meta.annotation_type":    "span_event",
 				"name":                    "Some Description",
 				"opencensus.resourcetype": "override",
-				"service_name":            "test_service",
-				"source_format":           "otlp_trace",
+				"service.name":            "test_service",
 				"trace.parent_id":         "0200000000000000",
 				"trace.parent_name":       "root",
 				"trace.trace_id":          "01000000000000000000000000000000",
@@ -262,10 +257,8 @@ func TestExporter(t *testing.T) {
 		{
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      false,
 				"name":                                   "root",
-				"service_name":                           "test_service",
-				"source_format":                          "otlp_trace",
+				"service.name":                           "test_service",
 				"span_attr_name":                         "Span Attribute",
 				"span_kind":                              "server",
 				"status.code":                            float64(0),
@@ -354,10 +347,8 @@ func TestSampleRateAttribute(t *testing.T) {
 		{
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      false,
 				"hc.sample.rate":                         float64(13),
 				"name":                                   "root",
-				"source_format":                          "otlp_trace",
 				"span_kind":                              "server",
 				"status.code":                            float64(0),
 				"status.message":                         "OK",
@@ -370,9 +361,7 @@ func TestSampleRateAttribute(t *testing.T) {
 		{
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      false,
 				"name":                                   "root",
-				"source_format":                          "otlp_trace",
 				"span_kind":                              "server",
 				"status.code":                            float64(0),
 				"status.message":                         "OK",
@@ -385,10 +374,8 @@ func TestSampleRateAttribute(t *testing.T) {
 		{
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      false,
 				"hc.sample.rate":                         "wrong_type",
 				"name":                                   "root",
-				"source_format":                          "otlp_trace",
 				"span_kind":                              "server",
 				"status.code":                            float64(0),
 				"status.message":                         "OK",
@@ -424,9 +411,7 @@ func TestEmptyNode(t *testing.T) {
 		{
 			Data: map[string]interface{}{
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      false,
 				"name":                                   "root",
-				"source_format":                          "otlp_trace",
 				"span_kind":                              "server",
 				"status.code":                            float64(0),
 				"status.message":                         "OK",
@@ -464,9 +449,7 @@ func TestNode(t *testing.T) {
 			expected: map[string]interface{}{
 				"B":                                      "C",
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      false,
 				"name":                                   "root",
-				"source_format":                          "otlp_trace",
 				"span_kind":                              "server",
 				"status.code":                            float64(0),
 				"status.message":                         "OK",
@@ -474,10 +457,10 @@ func TestNode(t *testing.T) {
 				"trace.trace_id":                         "01000000000000000000000000000000",
 				"opencensus.resourcetype":                "container",
 				"opencensus.same_process_as_parent_span": true,
-				"opencensus.start_timestamp":             "2020-09-08T20:15:12Z",
-				"process.hostname":                       "my-host",
-				"process.pid":                            float64(123),
-				"service_name":                           "test_service",
+				"opencensus.starttime":                   "2020-09-08T20:15:12Z",
+				"host.name":                              "my-host",
+				"opencensus.pid":                         float64(123),
+				"service.name":                           "test_service",
 			},
 		},
 		{
@@ -488,9 +471,7 @@ func TestNode(t *testing.T) {
 			expected: map[string]interface{}{
 				"B":                                      "C",
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      false,
 				"name":                                   "root",
-				"source_format":                          "otlp_trace",
 				"span_kind":                              "server",
 				"status.code":                            float64(0),
 				"status.message":                         "OK",
@@ -498,8 +479,8 @@ func TestNode(t *testing.T) {
 				"trace.trace_id":                         "01000000000000000000000000000000",
 				"opencensus.resourcetype":                "container",
 				"opencensus.same_process_as_parent_span": true,
-				"process.hostname":                       "my-host",
-				"service_name":                           "test_service",
+				"host.name":                              "my-host",
+				"service.name":                           "test_service",
 			},
 		},
 		{
@@ -508,9 +489,7 @@ func TestNode(t *testing.T) {
 			expected: map[string]interface{}{
 				"B":                                      "C",
 				"duration_ms":                            float64(0),
-				"has_remote_parent":                      false,
 				"name":                                   "root",
-				"source_format":                          "otlp_trace",
 				"span_kind":                              "server",
 				"status.code":                            float64(0),
 				"status.message":                         "OK",
@@ -518,7 +497,7 @@ func TestNode(t *testing.T) {
 				"trace.trace_id":                         "01000000000000000000000000000000",
 				"opencensus.resourcetype":                "container",
 				"opencensus.same_process_as_parent_span": true,
-				"service_name":                           "test_service",
+				"service.name":                           "test_service",
 			},
 		},
 	}

--- a/exporter/honeycombexporter/ids_test.go
+++ b/exporter/honeycombexporter/ids_test.go
@@ -15,51 +15,33 @@
 package honeycombexporter
 
 import (
-	"encoding/hex"
 	"reflect"
 	"testing"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 func TestGetHoneycombTraceID(t *testing.T) {
 	tests := []struct {
 		name    string
-		traceID string
+		traceID pdata.TraceID
 		want    string
 	}{
 		{
-			name:    "64-bit traceID",
-			traceID: "cbe4decd12429177",
-			want:    "cbe4decd12429177",
-		},
-		{
 			name:    "128-bit zero-padded traceID",
-			traceID: "0000000000000000cbe4decd12429177",
+			traceID: pdata.NewTraceID([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 203, 228, 222, 205, 18, 66, 145, 119}),
 			want:    "cbe4decd12429177",
 		},
 		{
 			name:    "128-bit non-zero-padded traceID",
-			traceID: "f23b42eac289a0fdcde48fcbe3ab1a32",
+			traceID: pdata.NewTraceID([16]byte{242, 59, 66, 234, 194, 137, 160, 253, 205, 228, 143, 203, 227, 171, 26, 50}),
 			want:    "f23b42eac289a0fdcde48fcbe3ab1a32",
-		},
-		{
-			name:    "Non-hex traceID",
-			traceID: "foobar1",
-			want:    "666f6f62617231",
-		},
-		{
-			name:    "Longer non-hex traceID",
-			traceID: "foobarbaz",
-			want:    "666f6f6261726261",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			traceID, err := hex.DecodeString(tt.traceID)
-			if err != nil {
-				traceID = []byte(tt.traceID)
-			}
-			got := getHoneycombTraceID(traceID)
+			got := getHoneycombTraceID(tt.traceID)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getHoneycombTraceID:\n\tgot:  %#v\n\twant: %#v", got, tt.want)
 			}

--- a/exporter/honeycombexporter/translator.go
+++ b/exporter/honeycombexporter/translator.go
@@ -17,146 +17,55 @@ package honeycombexporter
 import (
 	"time"
 
-	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"go.opentelemetry.io/collector/consumer/pdata"
+
 	"google.golang.org/grpc/codes"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // spanAttributesToMap converts an opencensus proto Span_Attributes object into a map
 // of strings to generic types usable for sending events to honeycomb.
-func spanAttributesToMap(spanAttrs *tracepb.Span_Attributes) map[string]interface{} {
-	var attrs map[string]interface{}
+func spanAttributesToMap(spanAttrs pdata.AttributeMap) map[string]interface{} {
+	var attrs = make(map[string]interface{}, spanAttrs.Len())
 
-	if spanAttrs == nil {
-		return attrs
-	}
-
-	attrMap := spanAttrs.GetAttributeMap()
-	if attrMap == nil {
-		return attrs
-	}
-
-	attrs = make(map[string]interface{}, len(attrMap))
-
-	for key, attributeValue := range attrMap {
-		switch val := attributeValue.Value.(type) {
-		case *tracepb.AttributeValue_StringValue:
-			attrs[key] = attributeValueAsString(attributeValue)
-		case *tracepb.AttributeValue_BoolValue:
-			attrs[key] = val.BoolValue
-		case *tracepb.AttributeValue_IntValue:
-			attrs[key] = val.IntValue
-		case *tracepb.AttributeValue_DoubleValue:
-			attrs[key] = val.DoubleValue
+	spanAttrs.ForEach(func(key string, value pdata.AttributeValue) {
+		switch value.Type() {
+		case pdata.AttributeValueSTRING:
+			attrs[key] = value.StringVal()
+		case pdata.AttributeValueBOOL:
+			attrs[key] = value.BoolVal()
+		case pdata.AttributeValueINT:
+			attrs[key] = value.IntVal()
+		case pdata.AttributeValueDOUBLE:
+			attrs[key] = value.DoubleVal()
 		}
-	}
+	})
+
 	return attrs
 }
 
-// hasRemoteParent returns true if the this span is a child of a span in a different process.
-func hasRemoteParent(span *tracepb.Span) bool {
-	if sameProcess := span.GetSameProcessAsParentSpan(); sameProcess != nil {
-		return !sameProcess.Value
-	}
-	return false
-}
-
 // timestampToTime converts a protobuf timestamp into a time.Time.
-func timestampToTime(ts *timestamppb.Timestamp) (t time.Time) {
-	if ts == nil {
+func timestampToTime(ts pdata.TimestampUnixNano) (t time.Time) {
+	if ts == 0 {
 		return
 	}
-	return time.Unix(ts.Seconds, int64(ts.Nanos)).UTC()
+	return time.Unix(0, int64(ts)).UTC()
 }
 
 // getStatusCode returns the status code
-func getStatusCode(status *tracepb.Status) int32 {
-	if status != nil {
-		return int32(codes.Code(status.Code))
+func getStatusCode(status pdata.SpanStatus) int32 {
+	if !status.IsNil() {
+		return int32(status.Code())
 	}
-
 	return int32(codes.OK)
 }
 
 // getStatusMessage returns the status message as a string
-func getStatusMessage(status *tracepb.Status) string {
-	if status != nil {
-		if len(status.GetMessage()) > 0 {
-			return status.GetMessage()
+func getStatusMessage(status pdata.SpanStatus) string {
+	if !status.IsNil() {
+		if len(status.Message()) > 0 {
+			return status.Message()
 		}
 	}
 
 	return codes.OK.String()
-}
-
-// getTraceLevelfFields extracts the node and resource fields from TraceData that
-// should be added as underlays on every span in a trace.
-func getTraceLevelFields(node *commonpb.Node, resource *resourcepb.Resource, sourceFormat string) map[string]interface{} {
-	fields := make(map[string]interface{})
-
-	// we want to get the service_name and some opencensus fields that are set when
-	// run as an agent from the node.
-	nodeFields := func(node *commonpb.Node, fields map[string]interface{}) {
-		if node == nil {
-			return
-		}
-		if node.ServiceInfo != nil {
-			fields["service_name"] = node.ServiceInfo.Name
-		}
-		if process := node.GetIdentifier(); process != nil {
-			if len(process.HostName) != 0 {
-				fields["process.hostname"] = process.HostName
-			}
-			if process.Pid != 0 {
-				fields["process.pid"] = process.Pid
-			}
-
-			startTime := timestampToTime(process.StartTimestamp)
-			if startTime != (time.Time{}) {
-				fields["opencensus.start_timestamp"] = startTime
-			}
-		}
-	}
-
-	// all resource labels should be applied as trace level fields
-	resourceFields := func(resource *resourcepb.Resource, fields map[string]interface{}) {
-		if resource == nil {
-			return
-		}
-		resourceType := resource.GetType()
-		if resourceType != "" {
-			fields["opencensus.resourcetype"] = resourceType
-		}
-		for k, v := range resource.GetLabels() {
-			fields[k] = v
-		}
-	}
-
-	nodeFields(node, fields)
-	resourceFields(resource, fields)
-
-	if sourceFormat := sourceFormat; len(sourceFormat) > 0 {
-		fields["source_format"] = sourceFormat
-	}
-
-	return fields
-}
-
-// attributeValueAsString converts a opencensus proto AttributeValue object into a string
-func attributeValueAsString(val *tracepb.AttributeValue) string {
-	if wrapper := val.GetStringValue(); wrapper != nil {
-		return wrapper.GetValue()
-	}
-
-	return ""
-}
-
-// truncatableStringAsString just returns the value part as a string. "" if s is nil
-func truncatableStringAsString(s *tracepb.TruncatableString) string {
-	if s != nil {
-		return s.GetValue()
-	}
-	return ""
 }

--- a/exporter/honeycombexporter/translator.go
+++ b/exporter/honeycombexporter/translator.go
@@ -18,8 +18,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-
-	"google.golang.org/grpc/codes"
 )
 
 // spanAttributesToMap converts an opencensus proto Span_Attributes object into a map
@@ -56,7 +54,7 @@ func getStatusCode(status pdata.SpanStatus) int32 {
 	if !status.IsNil() {
 		return int32(status.Code())
 	}
-	return int32(codes.OK)
+	return int32(pdata.StatusCodeOk)
 }
 
 // getStatusMessage returns the status message as a string
@@ -67,5 +65,5 @@ func getStatusMessage(status pdata.SpanStatus) string {
 		}
 	}
 
-	return codes.OK.String()
+	return pdata.StatusCodeOk.String()
 }

--- a/exporter/honeycombexporter/translator_test.go
+++ b/exporter/honeycombexporter/translator_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer/pdata"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -80,4 +81,29 @@ func TestTimestampToTime(t *testing.T) {
 	if !t2.Equal(nowTime) {
 		t.Errorf("Expected %+v, Got %+v\n", t2, nowTime)
 	}
+}
+
+func TestStatusCode(t *testing.T) {
+	status := pdata.NewSpanStatus()
+	assert.Equal(t, int32(pdata.StatusCodeOk), getStatusCode(status), "uninitialized")
+
+	status.InitEmpty()
+	assert.Equal(t, int32(pdata.StatusCodeUnset), getStatusCode(status), "empty")
+
+	status.SetCode(pdata.StatusCodeError)
+	assert.Equal(t, int32(pdata.StatusCodeError), getStatusCode(status), "error")
+
+	status.SetCode(pdata.StatusCodeOk)
+	assert.Equal(t, int32(pdata.StatusCodeOk), getStatusCode(status), "ok")
+}
+
+func TestStatusMessage(t *testing.T) {
+	status := pdata.NewSpanStatus()
+	assert.Equal(t, "STATUS_CODE_OK", getStatusMessage(status), "uninitialized")
+
+	status.InitEmpty()
+	assert.Equal(t, "STATUS_CODE_OK", getStatusMessage(status), "empty")
+
+	status.SetMessage("custom message")
+	assert.Equal(t, "custom message", getStatusMessage(status), "custom")
 }

--- a/exporter/honeycombexporter/translator_test.go
+++ b/exporter/honeycombexporter/translator_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer/pdata"
-
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 


### PR DESCRIPTION
**Description:** 
Update honeycomb exporter to use internal data format. The data produced by the exported now mirrors the open telemetry format more accurately. 

This has several breaking changes to the events produced by the exporter. Please let me know if any of these are particularly problematic

- service_name -> service.name
- process.hostname -> host.name
- process.pid -> opencensus.pid (for census users)
- opencensus.start_timestamp -> opencensus.starttime
- has_remote_parent was removed
- child_span_count was removed
- source_format was removed
- reftype from links was removed

New features
- other span_kinds are now supported (consumer, producer, internal)

@MikeGoldsmith @paulosman 