### PR TITLE
exporter/datadog: Issue 1684 fix, update status code handling

### DIFF
--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -17,11 +17,9 @@ package datadogexporter
 import (
 	"encoding/hex"
 	"fmt"
-	"net/http"
 	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/pb"
-	"go.opencensus.io/trace"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
@@ -33,40 +31,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/utils"
 )
 
-// codeDetails specifies information about a trace status code.
-type codeDetails struct {
-	message string // status message
-	status  int    // corresponding HTTP status code
-}
-
 const (
 	keySamplingPriority string = "_sampling_priority_v1"
 	versionTag          string = "version"
 	oldILNameTag        string = "otel.instrumentation_library.name"
 	currentILNameTag    string = "otel.library.name"
 )
-
-// statusCodes maps (*trace.SpanData).Status.Code to their message and http status code. See:
-// https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto.
-var statusCodes = map[int32]codeDetails{
-	trace.StatusCodeOK:                 {message: "OK", status: http.StatusOK},
-	trace.StatusCodeCancelled:          {message: "CANCELLED", status: 499},
-	trace.StatusCodeUnknown:            {message: "UNKNOWN", status: http.StatusInternalServerError},
-	trace.StatusCodeInvalidArgument:    {message: "INVALID_ARGUMENT", status: http.StatusBadRequest},
-	trace.StatusCodeDeadlineExceeded:   {message: "DEADLINE_EXCEEDED", status: http.StatusGatewayTimeout},
-	trace.StatusCodeNotFound:           {message: "NOT_FOUND", status: http.StatusNotFound},
-	trace.StatusCodeAlreadyExists:      {message: "ALREADY_EXISTS", status: http.StatusConflict},
-	trace.StatusCodePermissionDenied:   {message: "PERMISSION_DENIED", status: http.StatusForbidden},
-	trace.StatusCodeResourceExhausted:  {message: "RESOURCE_EXHAUSTED", status: http.StatusTooManyRequests},
-	trace.StatusCodeFailedPrecondition: {message: "FAILED_PRECONDITION", status: http.StatusBadRequest},
-	trace.StatusCodeAborted:            {message: "ABORTED", status: http.StatusConflict},
-	trace.StatusCodeOutOfRange:         {message: "OUT_OF_RANGE", status: http.StatusBadRequest},
-	trace.StatusCodeUnimplemented:      {message: "UNIMPLEMENTED", status: http.StatusNotImplemented},
-	trace.StatusCodeInternal:           {message: "INTERNAL", status: http.StatusInternalServerError},
-	trace.StatusCodeUnavailable:        {message: "UNAVAILABLE", status: http.StatusServiceUnavailable},
-	trace.StatusCodeDataLoss:           {message: "DATA_LOSS", status: http.StatusNotImplemented},
-	trace.StatusCodeUnauthenticated:    {message: "UNAUTHENTICATED", status: http.StatusUnauthorized},
-}
 
 // converts Traces into an array of datadog trace payloads grouped by env
 func ConvertToDatadogTd(td pdata.Traces, cfg *config.Config) ([]*pb.TracePayload, error) {
@@ -287,7 +257,7 @@ func spanToDatadogSpan(s pdata.Span,
 
 		if isError > 0 {
 			tags[ext.ErrorType] = "ERR_CODE_" + strconv.FormatInt(int64(status.Code()), 10)
-			
+
 			// try to add a message if possible
 			if status.Message() != "" {
 				tags[ext.ErrorMsg] = status.Message()
@@ -300,15 +270,15 @@ func spanToDatadogSpan(s pdata.Span,
 		if tags[conventions.AttributeHTTPStatusCode] != "" {
 			httpStatusCode, err := strconv.ParseInt(tags[conventions.AttributeHTTPStatusCode], 10, 64)
 			if err == nil {
-				 // for 500 type, always mark as errror
+				// for 500 type, always mark as errror
 				if httpStatusCode >= 500 {
 					span.Error = int32(1)
-				// for 400 type, mark as errror if it is an http client
+					// for 400 type, mark as errror if it is an http client
 				} else if s.Kind() == pdata.SpanKindCLIENT && httpStatusCode >= 400 {
 					span.Error = int32(1)
 				}
 			}
-		}	
+		}
 	}
 
 	// Set Attributes as Tags

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -59,7 +59,7 @@ func NewResourceSpansData(mockTraceID [16]byte, mockSpanID [8]byte, mockParentSp
 	status.InitEmpty()
 
 	if shouldErr {
-		status.SetCode(13)
+		status.SetCode(pdata.StatusCodeError)
 		status.SetMessage("This is not a drill!")
 	} else {
 		status.SetCode(0)
@@ -230,7 +230,7 @@ func TestBasicTracesTranslation(t *testing.T) {
 	assert.Equal(t, "web", datadogPayload.Traces[0].Spans[0].Type)
 
 	// ensure that span.meta and span.metrics pick up attibutes, instrumentation ibrary and resource attribs
-	assert.Equal(t, 9, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 8, len(datadogPayload.Traces[0].Spans[0].Meta))
 	assert.Equal(t, 1, len(datadogPayload.Traces[0].Spans[0].Metrics))
 
 	// ensure that span error is based on otlp span status
@@ -291,7 +291,7 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 	// ensure that version gives resource service.version priority
 	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
 
-	assert.Equal(t, 14, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 13, len(datadogPayload.Traces[0].Spans[0].Meta))
 }
 
 // ensure that the datadog span uses the configured unified service tags
@@ -340,7 +340,7 @@ func TestTracesTranslationConfig(t *testing.T) {
 	// ensure that version gives resource service.version priority
 	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
 
-	assert.Equal(t, 14, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 13, len(datadogPayload.Traces[0].Spans[0].Meta))
 }
 
 // ensure that the translation returns early if no resource instrumentation library spans

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
 )
 
-func NewResourceSpansData(mockTraceID [16]byte, mockSpanID [8]byte, mockParentSpanID [8]byte, shouldErr bool, resourceEnvAndService bool) pdata.ResourceSpans {
+func NewResourceSpansData(mockTraceID [16]byte, mockSpanID [8]byte, mockParentSpanID [8]byte, statusCode pdata.StatusCode, resourceEnvAndService bool) pdata.ResourceSpans {
 	// The goal of this test is to ensure that each span in
 	// pdata.ResourceSpans is transformed to its *trace.SpanData correctly!
 
@@ -58,11 +58,11 @@ func NewResourceSpansData(mockTraceID [16]byte, mockSpanID [8]byte, mockParentSp
 	status := pdata.NewSpanStatus()
 	status.InitEmpty()
 
-	if shouldErr {
+	if statusCode == pdata.StatusCodeError {
 		status.SetCode(pdata.StatusCodeError)
 		status.SetMessage("This is not a drill!")
 	} else {
-		status.SetCode(0)
+		status.SetCode(statusCode)
 	}
 
 	status.CopyTo(span.Status())
@@ -87,7 +87,7 @@ func NewResourceSpansData(mockTraceID [16]byte, mockSpanID [8]byte, mockParentSp
 		"agent":      pdata.NewAttributeValueString("ocagent"),
 	}
 
-	if shouldErr {
+	if statusCode == pdata.StatusCodeError {
 		attribs["http.status_code"] = pdata.NewAttributeValueString("501")
 	}
 
@@ -197,7 +197,7 @@ func TestBasicTracesTranslation(t *testing.T) {
 
 	// create mock resource span data
 	// set shouldError and resourceServiceandEnv to false to test defaut behavior
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, false, false)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeUnset, false)
 
 	// translate mocks to datadog traces
 	datadogPayload, err := resourceSpansToDatadogSpans(rs, hostname, &config.Config{})
@@ -263,7 +263,57 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 
 	// create mock resource span data
 	// toggle on errors and custom service naming to test edge case code paths
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, true, true)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true)
+
+	// translate mocks to datadog traces
+	cfg := config.Config{
+		TagsConfig: config.TagsConfig{
+			Version: "v1",
+		},
+	}
+
+	datadogPayload, err := resourceSpansToDatadogSpans(rs, hostname, &cfg)
+
+	if err != nil {
+		t.Fatalf("Failed to convert from pdata ResourceSpans to pb.TracePayload: %v", err)
+	}
+
+	// ensure we return the correct type
+	assert.IsType(t, pb.TracePayload{}, datadogPayload)
+
+	// ensure hostname arg is respected
+	assert.Equal(t, hostname, datadogPayload.HostName)
+	assert.Equal(t, 1, len(datadogPayload.Traces))
+
+	// ensure that span error is based on otlp span status
+	assert.Equal(t, int32(1), datadogPayload.Traces[0].Spans[0].Error)
+
+	// ensure that span status code is set
+	assert.Equal(t, "501", datadogPayload.Traces[0].Spans[0].Meta["http.status_code"])
+
+	// ensure that span service name gives resource service.name priority
+	assert.Equal(t, "test-resource-service-name", datadogPayload.Traces[0].Spans[0].Service)
+
+	// ensure that env gives resource deployment.environment priority
+	assert.Equal(t, "test-env", datadogPayload.Env)
+
+	// ensure that version gives resource service.version priority
+	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
+
+	assert.Equal(t, 14, len(datadogPayload.Traces[0].Spans[0].Meta))
+}
+
+func TestTracesTranslationOkStatus(t *testing.T) {
+	hostname := "testhostname"
+
+	// generate mock trace, span and parent span ids
+	mockTraceID := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
+	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
+	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
+
+	// create mock resource span data
+	// toggle on errors and custom service naming to test edge case code paths
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true)
 
 	// translate mocks to datadog traces
 	cfg := config.Config{
@@ -314,7 +364,7 @@ func TestTracesTranslationConfig(t *testing.T) {
 
 	// create mock resource span data
 	// toggle on errors and custom service naming to test edge case code paths
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, true, true)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeUnset, true)
 
 	cfg := config.Config{
 		TagsConfig: config.TagsConfig{
@@ -337,11 +387,8 @@ func TestTracesTranslationConfig(t *testing.T) {
 	assert.Equal(t, hostname, datadogPayload.HostName)
 	assert.Equal(t, 1, len(datadogPayload.Traces))
 
-	// ensure that span error is based on otlp span status
-	assert.Equal(t, int32(1), datadogPayload.Traces[0].Spans[0].Error)
-
-	// ensure that span status code is set
-	assert.Equal(t, "501", datadogPayload.Traces[0].Spans[0].Meta["http.status_code"])
+	// ensure that span error is based on otlp span status, unset should not error
+	assert.Equal(t, int32(0), datadogPayload.Traces[0].Spans[0].Error)
 
 	// ensure that span service name gives resource service.name priority
 	assert.Equal(t, "test-resource-service-name", datadogPayload.Traces[0].Spans[0].Service)
@@ -352,7 +399,7 @@ func TestTracesTranslationConfig(t *testing.T) {
 	// ensure that version gives resource service.version priority
 	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
 
-	assert.Equal(t, 14, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 11, len(datadogPayload.Traces[0].Spans[0].Meta))
 }
 
 // ensure that the translation returns early if no resource instrumentation library spans


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This PR addresses the status code handling issue described in this open issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1684

There were recently some changes made to Span Status Code, and while otel-collector-contrib exporters were updated to reflect those changes here https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1489, the datadog exporter was not included as it was only recently added to the repository. This PR brings the datadog exporter up to date with how Span Status Code's are handled by Otel and generally simplifies the logic of setting a DatadogSpan `error`.

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1684

**Testing:** Beside updating the unit tests, I reproduced the issue highlighted in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1684 using the latest otel-collector-contrib and opentelemetry-go, and then confirmed that the above change resolves the issue.