### PR TITLE
Add sort of endpoints in static resolver

### DIFF
--- a/exporter/loadbalancingexporter/resolver_static.go
+++ b/exporter/loadbalancingexporter/resolver_static.go
@@ -17,6 +17,7 @@ package loadbalancingexporter
 import (
 	"context"
 	"errors"
+	"sort"
 	"sync"
 
 	"go.opencensus.io/stats"
@@ -38,8 +39,15 @@ func newStaticResolver(endpoints []string) (*staticResolver, error) {
 		return nil, errNoEndpoints
 	}
 
+	// make sure we won't change the provided slice
+	endpointsCopy := make([]string, len(endpoints))
+	copy(endpointsCopy, endpoints)
+
+	// sort is a guarantee that the order of endpoints doesn't matter
+	sort.Strings(endpointsCopy)
+
 	return &staticResolver{
-		endpoints: endpoints,
+		endpoints: endpointsCopy,
 	}, nil
 }
 

--- a/exporter/loadbalancingexporter/resolver_static_test.go
+++ b/exporter/loadbalancingexporter/resolver_static_test.go
@@ -24,8 +24,8 @@ import (
 
 func TestInitialResolution(t *testing.T) {
 	// prepare
-	expected := []string{"endpoint-1", "endpoint-2"}
-	res, err := newStaticResolver(expected)
+	provided := []string{"endpoint-2", "endpoint-1"}
+	res, err := newStaticResolver(provided)
 	require.NoError(t, err)
 
 	// test
@@ -37,6 +37,7 @@ func TestInitialResolution(t *testing.T) {
 	defer res.shutdown(context.Background())
 
 	// verify
+	expected := []string{"endpoint-1", "endpoint-2"}
 	assert.Equal(t, expected, resolved)
 }
 


### PR DESCRIPTION
**Description:**
The sort guarantees that the order of hosts in config doesn't matter

**Testing:**
Changed one test