### PR TITLE
Exporter/Datadog: improve trace exporter performance

### DIFF
--- a/exporter/datadogexporter/model.go
+++ b/exporter/datadogexporter/model.go
@@ -77,14 +77,13 @@ func GetAnalyzedSpans(sps []*pb.Span) []*pb.Span {
 
 // Compute Sublayers updates a spans metrics with relevant metadata so that it's duration and breakdown between different services can
 // be accurately displayed in the Datadog UI
-func ComputeSublayerMetrics(t pb.Trace) {
+func ComputeSublayerMetrics(calculator *stats.SublayerCalculator, t pb.Trace) {
 	root := traceutil.GetRoot(t)
 	traceutil.ComputeTopLevel(t)
 
 	subtraces := stats.ExtractSubtraces(t, root)
 	sublayers := make(map[*pb.Span][]stats.SublayerValue)
 	for _, subtrace := range subtraces {
-		calculator := stats.NewSublayerCalculator()
 		subtraceSublayers := calculator.ComputeSublayers(subtrace.Trace)
 		sublayers[subtrace.Root] = subtraceSublayers
 		stats.SetSublayersOnSpan(subtrace.Root, subtraceSublayers)

--- a/exporter/datadogexporter/stats.go
+++ b/exporter/datadogexporter/stats.go
@@ -31,10 +31,9 @@ func ComputeAPMStats(tracePayload *pb.TracePayload, pushTime int64) *stats.Paylo
 	statsRawBuckets := make(map[int64]*stats.RawBucket)
 
 	bucketTS := pushTime - statsBucketDuration
-
+	calculator := stats.NewSublayerCalculator()
 	for _, trace := range tracePayload.Traces {
 		spans := GetAnalyzedSpans(trace.Spans)
-		calculator := stats.NewSublayerCalculator()
 		sublayers := calculator.ComputeSublayers(trace.Spans)
 		for _, span := range spans {
 

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/config/configdefs"
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/exportable/stats"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
@@ -93,10 +94,11 @@ func (exp *traceExporter) pushTraceData(
 	td pdata.Traces,
 ) (int, error) {
 
+	calculator := stats.NewSublayerCalculator()
 	// convert traces to datadog traces and group trace payloads by env
 	// we largely apply the same logic as the serverless implementation, simplified a bit
 	// https://github.com/DataDog/datadog-serverless-functions/blob/f5c3aedfec5ba223b11b76a4239fcbf35ec7d045/aws/logs_monitoring/trace_forwarder/cmd/trace/main.go#L61-L83
-	ddTraces, err := ConvertToDatadogTd(td, exp.cfg)
+	ddTraces, err := ConvertToDatadogTd(td, calculator, exp.cfg)
 
 	if err != nil {
 		exp.logger.Info("failed to convert traces", zap.Error(err))

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/exportable/stats"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
@@ -41,7 +42,7 @@ const (
 )
 
 // converts Traces into an array of datadog trace payloads grouped by env
-func ConvertToDatadogTd(td pdata.Traces, cfg *config.Config) ([]*pb.TracePayload, error) {
+func ConvertToDatadogTd(td pdata.Traces, calculator *stats.SublayerCalculator, cfg *config.Config) ([]*pb.TracePayload, error) {
 	// TODO:
 	// do we apply other global tags, like version+service, to every span or only root spans of a service
 	// should globalTags['service'] take precedence over a trace's resource.service.name? I don't believe so, need to confirm
@@ -63,7 +64,7 @@ func ConvertToDatadogTd(td pdata.Traces, cfg *config.Config) ([]*pb.TracePayload
 			hostname = resHostname
 		}
 
-		payload, err := resourceSpansToDatadogSpans(rs, hostname, cfg)
+		payload, err := resourceSpansToDatadogSpans(rs, calculator, hostname, cfg)
 		if err != nil {
 			return traces, err
 		}
@@ -102,7 +103,7 @@ func AggregateTracePayloadsByEnv(tracePayloads []*pb.TracePayload) []*pb.TracePa
 }
 
 // converts a Trace's resource spans into a trace payload
-func resourceSpansToDatadogSpans(rs pdata.ResourceSpans, hostname string, cfg *config.Config) (pb.TracePayload, error) {
+func resourceSpansToDatadogSpans(rs pdata.ResourceSpans, calculator *stats.SublayerCalculator, hostname string, cfg *config.Config) (pb.TracePayload, error) {
 	// get env tag
 	env := cfg.Env
 
@@ -172,7 +173,7 @@ func resourceSpansToDatadogSpans(rs pdata.ResourceSpans, hostname string, cfg *c
 		// calculates span metrics for representing direction and timing among it's different services for display in
 		// service overview graphs
 		// see: https://github.com/DataDog/datadog-agent/blob/f69a7d35330c563e9cad4c5b8865a357a87cd0dc/pkg/trace/stats/sublayers.go#L204
-		ComputeSublayerMetrics(apiTrace.Spans)
+		ComputeSublayerMetrics(calculator, apiTrace.Spans)
 		payload.Transactions = append(payload.Transactions, top...)
 		payload.Traces = append(payload.Traces, apiTrace)
 	}

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/exportable/stats"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
@@ -129,8 +130,9 @@ func NewResourceSpansData(mockTraceID [16]byte, mockSpanID [8]byte, mockParentSp
 func TestConvertToDatadogTd(t *testing.T) {
 	traces := pdata.NewTraces()
 	traces.ResourceSpans().Resize(1)
+	calculator := stats.NewSublayerCalculator()
 
-	outputTraces, err := ConvertToDatadogTd(traces, &config.Config{})
+	outputTraces, err := ConvertToDatadogTd(traces, calculator, &config.Config{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(outputTraces))
@@ -138,14 +140,16 @@ func TestConvertToDatadogTd(t *testing.T) {
 
 func TestConvertToDatadogTdNoResourceSpans(t *testing.T) {
 	traces := pdata.NewTraces()
+	calculator := stats.NewSublayerCalculator()
 
-	outputTraces, err := ConvertToDatadogTd(traces, &config.Config{})
+	outputTraces, err := ConvertToDatadogTd(traces, calculator, &config.Config{})
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(outputTraces))
 }
 
 func TestObfuscation(t *testing.T) {
+	calculator := stats.NewSublayerCalculator()
 	resource := pdata.NewResource()
 	resource.Attributes().InitFromMap(map[string]pdata.AttributeValue{
 		"service.name": pdata.NewAttributeValueString("sure"),
@@ -172,7 +176,7 @@ func TestObfuscation(t *testing.T) {
 	ilss.Spans().Resize(1)
 	span.CopyTo(ilss.Spans().At(0))
 
-	outputTraces, err := ConvertToDatadogTd(traces, &config.Config{})
+	outputTraces, err := ConvertToDatadogTd(traces, calculator, &config.Config{})
 
 	assert.NoError(t, err)
 
@@ -187,6 +191,7 @@ func TestObfuscation(t *testing.T) {
 
 func TestBasicTracesTranslation(t *testing.T) {
 	hostname := "testhostname"
+	calculator := stats.NewSublayerCalculator()
 
 	// generate mock trace, span and parent span ids
 	mockTraceID := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
@@ -198,7 +203,7 @@ func TestBasicTracesTranslation(t *testing.T) {
 	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeUnset, false)
 
 	// translate mocks to datadog traces
-	datadogPayload, err := resourceSpansToDatadogSpans(rs, hostname, &config.Config{})
+	datadogPayload, err := resourceSpansToDatadogSpans(rs, calculator, hostname, &config.Config{})
 
 	if err != nil {
 		t.Fatalf("Failed to convert from pdata ResourceSpans to pb.TracePayload: %v", err)
@@ -253,6 +258,7 @@ func TestBasicTracesTranslation(t *testing.T) {
 
 func TestTracesTranslationErrorsAndResource(t *testing.T) {
 	hostname := "testhostname"
+	calculator := stats.NewSublayerCalculator()
 
 	// generate mock trace, span and parent span ids
 	mockTraceID := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
@@ -270,7 +276,7 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 		},
 	}
 
-	datadogPayload, err := resourceSpansToDatadogSpans(rs, hostname, &cfg)
+	datadogPayload, err := resourceSpansToDatadogSpans(rs, calculator, hostname, &cfg)
 
 	if err != nil {
 		t.Fatalf("Failed to convert from pdata ResourceSpans to pb.TracePayload: %v", err)
@@ -303,6 +309,7 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 
 func TestTracesTranslationOkStatus(t *testing.T) {
 	hostname := "testhostname"
+	calculator := stats.NewSublayerCalculator()
 
 	// generate mock trace, span and parent span ids
 	mockTraceID := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
@@ -320,7 +327,7 @@ func TestTracesTranslationOkStatus(t *testing.T) {
 		},
 	}
 
-	datadogPayload, err := resourceSpansToDatadogSpans(rs, hostname, &cfg)
+	datadogPayload, err := resourceSpansToDatadogSpans(rs, calculator, hostname, &cfg)
 
 	if err != nil {
 		t.Fatalf("Failed to convert from pdata ResourceSpans to pb.TracePayload: %v", err)
@@ -354,6 +361,7 @@ func TestTracesTranslationOkStatus(t *testing.T) {
 // ensure that the datadog span uses the configured unified service tags
 func TestTracesTranslationConfig(t *testing.T) {
 	hostname := "testhostname"
+	calculator := stats.NewSublayerCalculator()
 
 	// generate mock trace, span and parent span ids
 	mockTraceID := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
@@ -372,7 +380,7 @@ func TestTracesTranslationConfig(t *testing.T) {
 	}
 
 	// translate mocks to datadog traces
-	datadogPayload, err := resourceSpansToDatadogSpans(rs, hostname, &cfg)
+	datadogPayload, err := resourceSpansToDatadogSpans(rs, calculator, hostname, &cfg)
 
 	if err != nil {
 		t.Fatalf("Failed to convert from pdata ResourceSpans to pb.TracePayload: %v", err)
@@ -403,6 +411,7 @@ func TestTracesTranslationConfig(t *testing.T) {
 // ensure that the translation returns early if no resource instrumentation library spans
 func TestTracesTranslationNoIls(t *testing.T) {
 	hostname := "testhostname"
+	calculator := stats.NewSublayerCalculator()
 
 	rs := pdata.NewResourceSpans()
 	rs.InitEmpty()
@@ -415,7 +424,7 @@ func TestTracesTranslationNoIls(t *testing.T) {
 	}
 
 	// translate mocks to datadog traces
-	datadogPayload, err := resourceSpansToDatadogSpans(rs, hostname, &cfg)
+	datadogPayload, err := resourceSpansToDatadogSpans(rs, calculator, hostname, &cfg)
 
 	if err != nil {
 		t.Fatalf("Failed to convert from pdata ResourceSpans to pb.TracePayload: %v", err)


### PR DESCRIPTION
**Description:** 

The cpu and memory usage of the tracer under heavy load is higher than where we'd like it to be, after investigating some profiles we found some areas where we could improve performance by re-using some components for generating statistics and improving trace translation logic

**Testing:** <Describe what testing was performed and which tests were added.>

Updated Unit tests

