### PR TITLE
[datadogexporter] Further improvements to traces exporter performance

### DIFF
--- a/exporter/datadogexporter/stats.go
+++ b/exporter/datadogexporter/stats.go
@@ -26,12 +26,11 @@ const (
 )
 
 // ComputeAPMStats calculates the stats that should be submitted to APM about a given trace
-func ComputeAPMStats(tracePayload *pb.TracePayload, pushTime int64) *stats.Payload {
+func ComputeAPMStats(tracePayload *pb.TracePayload, calculator *stats.SublayerCalculator, pushTime int64) *stats.Payload {
 
 	statsRawBuckets := make(map[int64]*stats.RawBucket)
 
 	bucketTS := pushTime - statsBucketDuration
-	calculator := stats.NewSublayerCalculator()
 	for _, trace := range tracePayload.Traces {
 		spans := GetAnalyzedSpans(trace.Spans)
 		sublayers := calculator.ComputeSublayers(trace.Spans)

--- a/exporter/datadogexporter/trace_connection.go
+++ b/exporter/datadogexporter/trace_connection.go
@@ -39,6 +39,7 @@ type traceEdgeConnection struct {
 	traceURL           string
 	statsURL           string
 	apiKey             string
+	client             *http.Client
 	startInfo          component.ApplicationStartInfo
 	InsecureSkipVerify bool
 }
@@ -56,6 +57,7 @@ func CreateTraceEdgeConnection(rootURL, apiKey string, startInfo component.Appli
 		statsURL:  rootURL + "/api/v0.2/stats",
 		startInfo: startInfo,
 		apiKey:    apiKey,
+		client:    utils.NewHTTPClient(traceEdgeTimeout),
 	}
 }
 
@@ -155,8 +157,7 @@ func (con *traceEdgeConnection) sendPayloadToTraceEdge(ctx context.Context, apiK
 	utils.SetDDHeaders(req.Header, con.startInfo, apiKey)
 	utils.SetExtraHeaders(req.Header, payload.Headers)
 
-	client := utils.NewHTTPClient(traceEdgeTimeout)
-	resp, err := client.Do(req)
+	resp, err := con.client.Do(req)
 
 	if err != nil {
 		// in this case, the payload and client are malformed in some way, so we should not retry


### PR DESCRIPTION
**Description:**

- Predefine map capacity wherever possible
- Use a single HTTP client for all trace edge connections
- Use a single sublayer calculator for all APM stats calculations (one per `pushTraceData` since it is not thread-safe otherwise)

**Link to tracking Issue:** aws-observability/aws-otel-collector#179

**Testing:** 

- Updated unit tests
- Tested in an end to end environment
