### PR TITLE
[datadogexporter] Add option to only send metadata

### DIFF
--- a/exporter/datadogexporter/config/config_test.go
+++ b/exporter/datadogexporter/config/config_test.go
@@ -68,6 +68,16 @@ func TestAPIKeyUnset(t *testing.T) {
 	assert.Equal(t, err, errUnsetAPIKey)
 }
 
+func TestNoMetadata(t *testing.T) {
+	cfg := Config{
+		OnlyMetadata: true,
+		SendMetadata: false,
+	}
+
+	err := cfg.Sanitize()
+	assert.Equal(t, err, errNoMetadata)
+}
+
 func TestCensorAPIKey(t *testing.T) {
 	cfg := APIConfig{
 		Key: "ddog_32_characters_long_api_key1",

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -32,6 +32,11 @@ exporters:
     #
     # tags: []
 
+    ## @param only_metadata - boolean - optional - default: false
+    ## Whether to send only metadata. This is useful for agent-collector
+    ## setups, so that metadata about a host is sent to the backend even
+    ## when telemetry data is reported via a different host.
+
     ## @param api - custom object - required.
     ## Specific API configuration.
     #


### PR DESCRIPTION
**Description:** 

- Add option to only send metadata, for agent-collector setups

**Link to tracking Issue:** n/a
**Testing:** Amended unit tests, tested in end-to-end environment
**Documentation:** Added option in the sample configuration files
