### PR TITLE
[signalfxexporter] Split incoming data requests by access token before enqueuing

### DIFF
--- a/exporter/signalfxexporter/eventclient.go
+++ b/exporter/signalfxexporter/eventclient.go
@@ -128,8 +128,6 @@ func (s *sfxEventClient) retrieveAccessToken(rl pdata.ResourceLogs) string {
 	}
 	attrs := rl.Resource().Attributes()
 	if accessToken, ok := attrs.Get(splunk.SFxAccessTokenLabel); ok && accessToken.Type() == pdata.AttributeValueSTRING {
-		// Drop internally passed access token in all cases
-		attrs.Delete(splunk.SFxAccessTokenLabel)
 		return accessToken.StringVal()
 	}
 	return ""

--- a/exporter/signalfxexporter/eventclient.go
+++ b/exporter/signalfxexporter/eventclient.go
@@ -39,27 +39,30 @@ type sfxEventClient struct {
 	accessTokenPassthrough bool
 }
 
-func (s *sfxEventClient) pushResourceLogs(
-	ctx context.Context,
-	rls pdata.ResourceLogs,
-) (int, error) {
-	accessToken := s.retrieveAccessToken(rls)
+func (s *sfxEventClient) pushLogsData(ctx context.Context, ld pdata.Logs) (int, error) {
+	rls := ld.ResourceLogs()
+	if rls.Len() == 0 {
+		return 0, nil
+	}
+
+	accessToken := s.retrieveAccessToken(rls.At(0))
 
 	var sfxEvents []*sfxpb.Event
 	numDroppedLogRecords := 0
 
-	ills := rls.InstrumentationLibraryLogs()
-	for j := 0; j < ills.Len(); j++ {
-		ill := ills.At(j)
-
-		events, dropped := translation.LogSliceToSignalFxV2(s.logger, ill.Logs())
-		sfxEvents = append(sfxEvents, events...)
-		numDroppedLogRecords += dropped
+	for i := 0; i < rls.Len(); i++ {
+		ills := rls.At(0).InstrumentationLibraryLogs()
+		for j := 0; j < ills.Len(); j++ {
+			ill := ills.At(j)
+			events, dropped := translation.LogSliceToSignalFxV2(s.logger, ill.Logs())
+			sfxEvents = append(sfxEvents, events...)
+			numDroppedLogRecords += dropped
+		}
 	}
 
 	body, compressed, err := s.encodeBody(sfxEvents)
 	if err != nil {
-		return countRecords(rls), consumererror.Permanent(err)
+		return ld.LogRecordCount(), consumererror.Permanent(err)
 	}
 
 	eventURL := *s.ingestURL
@@ -68,7 +71,7 @@ func (s *sfxEventClient) pushResourceLogs(
 	}
 	req, err := http.NewRequestWithContext(ctx, "POST", eventURL.String(), body)
 	if err != nil {
-		return countRecords(rls), consumererror.Permanent(err)
+		return ld.LogRecordCount(), consumererror.Permanent(err)
 	}
 
 	for k, v := range s.headers {
@@ -85,7 +88,7 @@ func (s *sfxEventClient) pushResourceLogs(
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return countRecords(rls), err
+		return ld.LogRecordCount(), err
 	}
 
 	defer func() {
@@ -102,7 +105,7 @@ func (s *sfxEventClient) pushResourceLogs(
 			http.StatusText(resp.StatusCode),
 			req.URL,
 			body)
-		return countRecords(rls), err
+		return ld.LogRecordCount(), err
 	}
 
 	return numDroppedLogRecords, nil
@@ -130,15 +133,4 @@ func (s *sfxEventClient) retrieveAccessToken(rl pdata.ResourceLogs) string {
 		return accessToken.StringVal()
 	}
 	return ""
-}
-
-func countRecords(rs pdata.ResourceLogs) int {
-	logCount := 0
-
-	ill := rs.InstrumentationLibraryLogs()
-	for i := 0; i < ill.Len(); i++ {
-		logs := ill.At(i)
-		logCount += logs.Logs().Len()
-	}
-	return logCount
 }

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -34,6 +35,18 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/translation"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/collection"
 )
+
+// TODO: Find a place for this to be shared.
+type baseMetricsExporter struct {
+	component.Component
+	consumer.MetricsConsumer
+}
+
+// TODO: Find a place for this to be shared.
+type baseLogsExporter struct {
+	component.Component
+	consumer.LogsConsumer
+}
 
 type signalfMetadataExporter struct {
 	component.MetricsExporter

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -27,7 +27,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/dimensions"
@@ -61,7 +60,7 @@ type signalfxExporter struct {
 	logger             *zap.Logger
 	pushMetricsData    func(ctx context.Context, md pdata.Metrics) (droppedTimeSeries int, err error)
 	pushMetadata       func(metadata []*collection.MetadataUpdate) error
-	pushResourceLogs   func(ctx context.Context, ld pdata.ResourceLogs) (droppedLogRecords int, err error)
+	pushLogsData       func(ctx context.Context, ld pdata.Logs) (droppedLogRecords int, err error)
 	hostMetadataSyncer *hostmetadata.Syncer
 }
 
@@ -173,8 +172,8 @@ func newEventExporter(config *Config, logger *zap.Logger) (*signalfxExporter, er
 	}
 
 	return &signalfxExporter{
-		logger:           logger,
-		pushResourceLogs: eventClient.pushResourceLogs,
+		logger:       logger,
+		pushLogsData: eventClient.pushLogsData,
 	}, nil
 }
 
@@ -187,14 +186,5 @@ func (se *signalfxExporter) pushMetrics(ctx context.Context, md pdata.Metrics) (
 }
 
 func (se *signalfxExporter) pushLogs(ctx context.Context, ld pdata.Logs) (int, error) {
-	var numDroppedRecords int
-	var err error
-	rls := ld.ResourceLogs()
-	for i := 0; i < rls.Len(); i++ {
-		dropped, thisErr := se.pushResourceLogs(ctx, rls.At(i))
-		numDroppedRecords += dropped
-		err = multierr.Append(err, thisErr)
-	}
-
-	return numDroppedRecords, err
+	return se.pushLogsData(ctx, ld)
 }

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.0.0-00010101000000-000000000000
 	github.com/shirou/gopsutil v3.20.10+incompatible
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.2
@@ -22,5 +23,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/commo
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk => ../../internal/splunk
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig => ../../internal/k8sconfig
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr => ../../pkg/batchperresourceattr
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver => ../../receiver/k8sclusterreceiver

--- a/exporter/signalfxexporter/translation/converter.go
+++ b/exporter/signalfxexporter/translation/converter.go
@@ -26,6 +26,8 @@ import (
 	"go.opentelemetry.io/collector/translator/conventions"
 	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
 // Some fields on SignalFx protobuf are pointers, in order to reduce
@@ -425,6 +427,11 @@ func resourceAttributesToDimensions(resourceAttr pdata.AttributeMap) []*sfxpb.Di
 	}
 
 	resourceAttr.ForEach(func(k string, val pdata.AttributeValue) {
+		// Never send the SignalFX token
+		if k == splunk.SFxAccessTokenLabel {
+			return
+		}
+
 		if !filter(k) {
 			return
 		}

--- a/go.mod
+++ b/go.mod
@@ -125,6 +125,10 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/obse
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver => ./extension/observer/k8sobserver
 
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr => ./pkg/batchperresourceattr
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpertrace => ./pkg/batchpertrace
+
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver => ./receiver/awsecscontainermetricsreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver => ./receiver/awsxrayreceiver
@@ -163,13 +167,11 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxre
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver => ./receiver/zookeeperreceiver
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpertrace => ./pkg/batchpertrace
-
-replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor => ./processor/groupbytraceprocessor
-
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stanzareceiver => ./receiver/stanzareceiver/
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver => ./receiver/memcachedreceiver
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor => ./processor/groupbytraceprocessor
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor => ./processor/k8sprocessor/
 

--- a/pkg/batchperresourceattr/go.mod
+++ b/pkg/batchperresourceattr/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpertrace
+module github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr
 
 go 1.14
 

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -13,12 +13,15 @@ require (
 	go.uber.org/zap v1.16.0
 )
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig => ../../internal/k8sconfig
+replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter => ../../exporter/signalfxexporter
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver => ../../receiver/k8sclusterreceiver
-
-replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter => ../../exporter/signalfxexporter
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig => ../../internal/k8sconfig
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk => ../../internal/splunk
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr => ../../pkg/batchperresourceattr
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver => ../../receiver/k8sclusterreceiver
+

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -27,6 +27,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/commo
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk => ../internal/splunk
 
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr => ../../pkg/batchperresourceattr
+
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver => ../receiver/carbonreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver => ../receiver/k8sclusterreceiver

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -27,7 +27,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/commo
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk => ../internal/splunk
 
-replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr => ../../pkg/batchperresourceattr
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr => ../pkg/batchperresourceattr
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver => ../receiver/carbonreceiver
 


### PR DESCRIPTION
Fixes a possible memory corruption caused by the fact that the previous logic was deleting an element from the resource attributes, and the data could be shared between different exporters (exporters are not allowed to manipulate data).

Updates #1495

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
