### PR TITLE
Fix nits in usage of pdata

### DIFF
--- a/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
@@ -28,14 +28,10 @@ import (
 
 func createSimpleLogData(numberOfLogs int) pdata.Logs {
 	logs := pdata.NewLogs()
-	rl := pdata.NewResourceLogs()
-	rl2 := pdata.NewResourceLogs()
-	logs.ResourceLogs().Append(rl)
-	logs.ResourceLogs().Append(rl2)
-	ill := pdata.NewInstrumentationLibraryLogs()
-	ill2 := pdata.NewInstrumentationLibraryLogs()
-	rl.InstrumentationLibraryLogs().Append(ill)
-	rl.InstrumentationLibraryLogs().Append(ill2)
+	logs.ResourceLogs().Resize(2)
+	rl := logs.ResourceLogs().At(0)
+	rl.InstrumentationLibraryLogs().Resize(2)
+	ill := rl.InstrumentationLibraryLogs().At(0)
 
 	for i := 0; i < numberOfLogs; i++ {
 		ts := pdata.TimestampUnixNano(int64(i) * time.Millisecond.Nanoseconds())

--- a/exporter/alibabacloudlogserviceexporter/logsdata_to_logservice_test.go
+++ b/exporter/alibabacloudlogserviceexporter/logsdata_to_logservice_test.go
@@ -48,17 +48,15 @@ func getComplexAttributeValueMap() pdata.AttributeValue {
 
 func createLogData(numberOfLogs int) pdata.Logs {
 	logs := pdata.NewLogs()
-	rl := pdata.NewResourceLogs()
+	logs.ResourceLogs().Resize(2)
+	rl := logs.ResourceLogs().At(0)
 	rl.Resource().Attributes().InsertString("resouceKey", "resourceValue")
 	rl.Resource().Attributes().InsertString(conventions.AttributeServiceName, "test-log-service-exporter")
 	rl.Resource().Attributes().InsertString(conventions.AttributeHostName, "test-host")
-	logs.ResourceLogs().Append(rl)
-	rl2 := pdata.NewResourceLogs()
-	logs.ResourceLogs().Append(rl2)
-	ill := pdata.NewInstrumentationLibraryLogs()
+	rl.InstrumentationLibraryLogs().Resize(1)
+	ill := rl.InstrumentationLibraryLogs().At(0)
 	ill.InstrumentationLibrary().SetName("collector")
 	ill.InstrumentationLibrary().SetVersion("v0.1.0")
-	rl.InstrumentationLibraryLogs().Append(ill)
 
 	for i := 0; i < numberOfLogs; i++ {
 		ts := pdata.TimestampUnixNano(int64(i) * time.Millisecond.Nanoseconds())

--- a/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
@@ -34,16 +34,15 @@ func TestNewTraceExporter(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, got)
 
-	traceData := pdata.NewTraces()
-	spanData := pdata.NewResourceSpans()
-	spans := pdata.NewInstrumentationLibrarySpans()
-	span := pdata.NewSpan()
-	spans.Spans().Append(span)
-	spanData.InstrumentationLibrarySpans().Append(spans)
-	traceData.ResourceSpans().Append(spanData)
+	traces := pdata.NewTraces()
+	traces.ResourceSpans().Resize(1)
+	rs := traces.ResourceSpans().At(0)
+	rs.InstrumentationLibrarySpans().Resize(1)
+	ils := rs.InstrumentationLibrarySpans().At(0)
+	ils.Spans().Resize(1)
 
 	// This will put trace data to send buffer and return success.
-	err = got.ConsumeTraces(context.Background(), traceData)
+	err = got.ConsumeTraces(context.Background(), traces)
 	assert.Error(t, err)
 	assert.Nil(t, got.Shutdown(context.Background()))
 }

--- a/exporter/awsxrayexporter/translator/aws_test.go
+++ b/exporter/awsxrayexporter/translator/aws_test.go
@@ -366,8 +366,9 @@ func TestLogGroups(t *testing.T) {
 	resource := pdata.NewResource()
 	lg := pdata.NewAttributeValueArray()
 	ava := lg.ArrayVal()
-	ava.Append(pdata.NewAttributeValueString("group1"))
-	ava.Append(pdata.NewAttributeValueString("group2"))
+	ava.Resize(2)
+	ava.At(0).SetStringVal("group1")
+	ava.At(1).SetStringVal("group2")
 
 	resource.Attributes().Insert(awsLogGroupNames, lg)
 
@@ -396,8 +397,9 @@ func TestLogGroupsFromArns(t *testing.T) {
 	resource := pdata.NewResource()
 	lga := pdata.NewAttributeValueArray()
 	ava := lga.ArrayVal()
-	ava.Append(pdata.NewAttributeValueString(group1))
-	ava.Append(pdata.NewAttributeValueString(group2))
+	ava.Resize(2)
+	ava.At(0).SetStringVal(group1)
+	ava.At(1).SetStringVal(group2)
 
 	resource.Attributes().Insert(awsLogGroupArns, lga)
 

--- a/exporter/azuremonitorexporter/traceiteration_test.go
+++ b/exporter/azuremonitorexporter/traceiteration_test.go
@@ -42,20 +42,7 @@ func TestTraceDataIterationNoResourceSpans(t *testing.T) {
 }
 
 // Tests the iteration logic over a pdata.Traces type when a ResourceSpans is nil
-func TestTraceDataIterationResourceSpansIsNil(t *testing.T) {
-	traces := pdata.NewTraces()
-	resourceSpans := pdata.NewResourceSpans()
-	traces.ResourceSpans().Append(resourceSpans)
-
-	visitor := getMockVisitor(true)
-
-	Accept(traces, visitor)
-
-	visitor.AssertNumberOfCalls(t, "visit", 0)
-}
-
-// Tests the iteration logic over a pdata.Traces type when a Resource is nil
-func TestTraceDataIterationResourceIsNil(t *testing.T) {
+func TestTraceDataIterationResourceSpansIsEmpty(t *testing.T) {
 	traces := pdata.NewTraces()
 	traces.ResourceSpans().Resize(1)
 

--- a/exporter/signalfxcorrelationexporter/correlation_test.go
+++ b/exporter/signalfxcorrelationexporter/correlation_test.go
@@ -33,10 +33,10 @@ func TestTrackerAddSpans(t *testing.T) {
 	)
 
 	traces := pdata.NewTraces()
-	spans := pdata.NewResourceSpans()
-	attr := spans.Resource().Attributes()
+	traces.ResourceSpans().Resize(1)
+	rs := traces.ResourceSpans().At(0)
+	attr := rs.Resource().Attributes()
 	attr.InsertString("host.name", "localhost")
-	traces.ResourceSpans().Append(spans)
 
 	// Add empty first, should ignore.
 	tracker.AddSpans(context.Background(), pdata.NewTraces())

--- a/exporter/signalfxcorrelationexporter/spanshims_test.go
+++ b/exporter/signalfxcorrelationexporter/spanshims_test.go
@@ -24,10 +24,9 @@ import (
 
 func TestSpanShimList(t *testing.T) {
 	spans := pdata.NewResourceSpansSlice()
-	s1 := pdata.NewResourceSpans()
-	s2 := pdata.NewResourceSpans()
-	spans.Append(s1)
-	spans.Append(s2)
+	spans.Resize(2)
+	s1 := spans.At(0)
+	s2 := spans.At(1)
 	wrapped := spanListWrap{spans}
 	assert.Equal(t, 2, wrapped.Len())
 	assert.Equal(t, spanWrap{s1}, wrapped.At(0))

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -111,15 +111,13 @@ func TestConsumeMetrics(t *testing.T) {
 
 	m.SetName("test_gauge")
 	m.SetDataType(pdata.MetricDataTypeDoubleGauge)
-
-	dp := pdata.NewDoubleDataPoint()
+	m.DoubleGauge().DataPoints().Resize(1)
+	dp := m.DoubleGauge().DataPoints().At(0)
 	dp.LabelsMap().InitFromMap(map[string]string{
 		"k0": "v0",
 		"k1": "v1",
 	})
 	dp.SetValue(123)
-
-	m.DoubleGauge().DataPoints().Append(dp)
 
 	tests := []struct {
 		name                 string
@@ -250,14 +248,13 @@ func TestConsumeMetricsWithAccessTokenPassthrough(t *testing.T) {
 		m.SetName("test_gauge")
 		m.SetDataType(pdata.MetricDataTypeDoubleGauge)
 
-		dp := pdata.NewDoubleDataPoint()
+		m.DoubleGauge().DataPoints().Resize(1)
+		dp := m.DoubleGauge().DataPoints().At(0)
 		dp.LabelsMap().InitFromMap(map[string]string{
 			"k0": "v0",
 			"k1": "v1",
 		})
 		dp.SetValue(123)
-
-		m.DoubleGauge().DataPoints().Append(dp)
 		return out
 	}
 
@@ -320,15 +317,13 @@ func TestConsumeMetricsWithAccessTokenPassthrough(t *testing.T) {
 
 				m.SetName("test_gauge")
 				m.SetDataType(pdata.MetricDataTypeDoubleGauge)
-
-				dp := pdata.NewDoubleDataPoint()
+				m.DoubleGauge().DataPoints().Resize(1)
+				dp := m.DoubleGauge().DataPoints().At(0)
 				dp.LabelsMap().InitFromMap(map[string]string{
 					"k0": "v0",
 					"k1": "v1",
 				})
 				dp.SetValue(123)
-
-				m.DoubleGauge().DataPoints().Append(dp)
 
 				return out
 			}(),
@@ -476,8 +471,11 @@ func TestNewEventExporter(t *testing.T) {
 }
 
 func makeSampleResourceLogs() pdata.Logs {
-	logSlice := pdata.NewLogSlice()
+	out := pdata.NewLogs()
+	out.ResourceLogs().Resize(1)
+	out.ResourceLogs().At(0).InstrumentationLibraryLogs().Resize(1)
 
+	logSlice := out.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).Logs()
 	logSlice.Resize(1)
 	l := logSlice.At(0)
 
@@ -504,11 +502,6 @@ func makeSampleResourceLogs() pdata.Logs {
 	attrs.Insert("com.splunk.signalfx.event_category", pdata.NewAttributeValueInt(int64(sfxpb.EventCategory_USER_DEFINED)))
 
 	l.Attributes().Sort()
-
-	out := pdata.NewLogs()
-	out.ResourceLogs().Resize(1)
-	out.ResourceLogs().At(0).InstrumentationLibraryLogs().Resize(1)
-	logSlice.MoveAndAppendTo(out.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).Logs())
 
 	return out
 }

--- a/exporter/signalfxexporter/translation/converter_test.go
+++ b/exporter/signalfxexporter/translation/converter_test.go
@@ -96,72 +96,65 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 				out := pdata.NewResourceMetrics()
 				out.InstrumentationLibraryMetrics().Resize(1)
 				ilm := out.InstrumentationLibraryMetrics().At(0)
+				ilm.Metrics().Resize(8)
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(0)
 					m.SetName("gauge_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
 					m.DoubleGauge().DataPoints().Append(doublePt)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(1)
 					m.SetName("gauge_int_with_dims")
 					m.SetDataType(pdata.MetricDataTypeIntGauge)
 					m.IntGauge().DataPoints().Append(int64Pt)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(2)
 					m.SetName("cumulative_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleSum)
 					m.DoubleSum().SetIsMonotonic(true)
 					m.DoubleSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 					m.DoubleSum().DataPoints().Append(doublePt)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(3)
 					m.SetName("cumulative_int_with_dims")
 					m.SetDataType(pdata.MetricDataTypeIntSum)
 					m.IntSum().SetIsMonotonic(true)
 					m.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 					m.IntSum().DataPoints().Append(int64Pt)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(4)
 					m.SetName("delta_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleSum)
 					m.DoubleSum().SetIsMonotonic(true)
 					m.DoubleSum().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
 					m.DoubleSum().DataPoints().Append(doublePt)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(5)
 					m.SetName("delta_int_with_dims")
 					m.SetDataType(pdata.MetricDataTypeIntSum)
 					m.IntSum().SetIsMonotonic(true)
 					m.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
 					m.IntSum().DataPoints().Append(int64Pt)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(6)
 					m.SetName("gauge_sum_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleSum)
 					m.DoubleSum().SetIsMonotonic(false)
 					m.DoubleSum().DataPoints().Append(doublePt)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(7)
 					m.SetName("gauge_sum_int_with_dims")
 					m.SetDataType(pdata.MetricDataTypeIntSum)
 					m.IntSum().SetIsMonotonic(false)
 					m.IntSum().DataPoints().Append(int64Pt)
-					ilm.Metrics().Append(m)
 				}
 
 				return out
@@ -183,36 +176,33 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 				out := pdata.NewResourceMetrics()
 				out.InstrumentationLibraryMetrics().Resize(1)
 				ilm := out.InstrumentationLibraryMetrics().At(0)
+				ilm.Metrics().Resize(4)
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(0)
 					m.SetName("gauge_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
 					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(1)
 					m.SetName("gauge_int_with_dims")
 					m.SetDataType(pdata.MetricDataTypeIntGauge)
 					m.IntGauge().DataPoints().Append(int64PtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(2)
 					m.SetName("cumulative_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleSum)
 					m.DoubleSum().SetIsMonotonic(true)
 					m.DoubleSum().DataPoints().Append(doublePtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(3)
 					m.SetName("cumulative_int_with_dims")
 					m.SetDataType(pdata.MetricDataTypeIntSum)
 					m.IntSum().SetIsMonotonic(true)
 					m.IntSum().DataPoints().Append(int64PtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 
 				return out
@@ -236,20 +226,19 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 
 				out.InstrumentationLibraryMetrics().Resize(1)
 				ilm := out.InstrumentationLibraryMetrics().At(0)
+				ilm.Metrics().Resize(2)
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(0)
 					m.SetName("gauge_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
 					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(1)
 					m.SetName("gauge_int_with_dims")
 					m.SetDataType(pdata.MetricDataTypeIntGauge)
 					m.IntGauge().DataPoints().Append(int64PtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 
 				return out
@@ -292,13 +281,13 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 
 				out.InstrumentationLibraryMetrics().Resize(1)
 				ilm := out.InstrumentationLibraryMetrics().At(0)
+				ilm.Metrics().Resize(1)
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(0)
 					m.SetName("gauge_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
 					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 
 				return out
@@ -332,13 +321,13 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 
 				out.InstrumentationLibraryMetrics().Resize(1)
 				ilm := out.InstrumentationLibraryMetrics().At(0)
+				ilm.Metrics().Resize(1)
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(0)
 					m.SetName("gauge_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
 					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 
 				return out
@@ -368,13 +357,13 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 
 				out.InstrumentationLibraryMetrics().Resize(1)
 				ilm := out.InstrumentationLibraryMetrics().At(0)
+				ilm.Metrics().Resize(1)
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(0)
 					m.SetName("gauge_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
 					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 
 				return out
@@ -406,13 +395,13 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 
 				out.InstrumentationLibraryMetrics().Resize(1)
 				ilm := out.InstrumentationLibraryMetrics().At(0)
+				ilm.Metrics().Resize(1)
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(0)
 					m.SetName("gauge_double_with_dims")
 					m.SetDataType(pdata.MetricDataTypeDoubleGauge)
 					m.DoubleGauge().DataPoints().Append(doublePtWithLabels)
-					ilm.Metrics().Append(m)
 				}
 
 				return out
@@ -436,37 +425,34 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 				out := pdata.NewResourceMetrics()
 				out.InstrumentationLibraryMetrics().Resize(1)
 				ilm := out.InstrumentationLibraryMetrics().At(0)
+				ilm.Metrics().Resize(4)
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(0)
 					m.SetName("int_histo")
 					m.SetDataType(pdata.MetricDataTypeIntHistogram)
 					m.IntHistogram().DataPoints().Append(histDP)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(1)
 					m.SetName("double_histo")
 					m.SetDataType(pdata.MetricDataTypeDoubleHistogram)
 					m.DoubleHistogram().DataPoints().Append(doubleHistDP)
-					ilm.Metrics().Append(m)
 				}
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(2)
 					m.SetName("int_delta_histo")
 					m.SetDataType(pdata.MetricDataTypeIntHistogram)
 					m.IntHistogram().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
 					m.IntHistogram().DataPoints().Append(histDP)
-					ilm.Metrics().Append(m)
 				}
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(3)
 					m.SetName("double_delta_histo")
 					m.SetDataType(pdata.MetricDataTypeDoubleHistogram)
 					m.DoubleHistogram().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
 					m.DoubleHistogram().DataPoints().Append(doubleHistDP)
-					ilm.Metrics().Append(m)
 				}
 
 				return out
@@ -484,13 +470,13 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 				out := pdata.NewResourceMetrics()
 				out.InstrumentationLibraryMetrics().Resize(1)
 				ilm := out.InstrumentationLibraryMetrics().At(0)
+				ilm.Metrics().Resize(1)
 
 				{
-					m := pdata.NewMetric()
+					m := ilm.Metrics().At(0)
 					m.SetName("no_bucket_histo")
 					m.SetDataType(pdata.MetricDataTypeIntHistogram)
 					m.IntHistogram().DataPoints().Append(histDPNoBuckets)
-					ilm.Metrics().Append(m)
 				}
 
 				return out

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -2602,7 +2602,6 @@ func indexPts(pts []*sfxpb.DataPoint) map[string][]*sfxpb.DataPoint {
 func doubleMD(secondsDelta int64, valueDelta float64) pdata.ResourceMetrics {
 	md := baseMD()
 	md.SetDataType(pdata.MetricDataTypeDoubleSum)
-
 	ms := md.DoubleSum()
 	ms.DataPoints().Append(dblTS("cpu0", "user", secondsDelta, 100, valueDelta))
 	ms.DataPoints().Append(dblTS("cpu0", "system", secondsDelta, 200, valueDelta))

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -69,13 +69,14 @@ func createMetricsData(numberOfDataPoints int) pdata.Metrics {
 
 func createTraceData(numberOfTraces int) pdata.Traces {
 	traces := pdata.NewTraces()
-	rs := pdata.NewResourceSpans()
-	traces.ResourceSpans().Append(rs)
-	ils := pdata.NewInstrumentationLibrarySpans()
-	rs.InstrumentationLibrarySpans().Append(ils)
+	traces.ResourceSpans().Resize(1)
+	rs := traces.ResourceSpans().At(0)
 	rs.Resource().Attributes().InsertString("resource", "R1")
+	rs.InstrumentationLibrarySpans().Resize(1)
+	ils := rs.InstrumentationLibrarySpans().At(0)
+	ils.Spans().Resize(numberOfTraces)
 	for i := 0; i < numberOfTraces; i++ {
-		span := pdata.NewSpan()
+		span := ils.Spans().At(i)
 		span.SetName("root")
 		span.SetStartTime(pdata.TimestampUnixNano((i + 1) * 1e9))
 		span.SetEndTime(pdata.TimestampUnixNano((i + 2) * 1e9))
@@ -89,7 +90,6 @@ func createTraceData(numberOfTraces int) pdata.Traces {
 			span.Status().SetMessage("ok")
 
 		}
-		ils.Spans().Append(span)
 	}
 
 	return traces
@@ -97,10 +97,10 @@ func createTraceData(numberOfTraces int) pdata.Traces {
 
 func createLogData(numberOfLogs int) pdata.Logs {
 	logs := pdata.NewLogs()
-	rl := pdata.NewResourceLogs()
-	logs.ResourceLogs().Append(rl)
-	ill := pdata.NewInstrumentationLibraryLogs()
-	rl.InstrumentationLibraryLogs().Append(ill)
+	logs.ResourceLogs().Resize(1)
+	rl := logs.ResourceLogs().At(0)
+	rl.InstrumentationLibraryLogs().Resize(1)
+	ill := rl.InstrumentationLibraryLogs().At(0)
 
 	for i := 0; i < numberOfLogs; i++ {
 		ts := pdata.TimestampUnixNano(int64(i) * time.Millisecond.Nanoseconds())

--- a/exporter/splunkhecexporter/exporter_test.go
+++ b/exporter/splunkhecexporter/exporter_test.go
@@ -193,16 +193,16 @@ func generateLargeBatch(t *testing.T) consumerdata.MetricsData {
 	return md
 }
 
-func generateLargeLogsBatch(t *testing.T) pdata.Logs {
+func generateLargeLogsBatch() pdata.Logs {
 	logs := pdata.NewLogs()
-	rl := pdata.NewResourceLogs()
-	logs.ResourceLogs().Append(rl)
-	ill := pdata.NewInstrumentationLibraryLogs()
-	rl.InstrumentationLibraryLogs().Append(ill)
-
+	logs.ResourceLogs().Resize(1)
+	rl := logs.ResourceLogs().At(0)
+	rl.InstrumentationLibraryLogs().Resize(1)
+	ill := rl.InstrumentationLibraryLogs().At(0)
+	ill.Logs().Resize(65000)
 	ts := pdata.TimestampUnixNano(123)
 	for i := 0; i < 65000; i++ {
-		logRecord := pdata.NewLogRecord()
+		logRecord := ill.Logs().At(i)
 		logRecord.Body().SetStringVal("mylog")
 		logRecord.Attributes().InsertString(conventions.AttributeServiceName, "myapp")
 		logRecord.Attributes().InsertString(splunk.SourcetypeLabel, "myapp-type")
@@ -268,7 +268,7 @@ func TestConsumeLogsData(t *testing.T) {
 		},
 		{
 			name:             "large_batch",
-			ld:               generateLargeLogsBatch(t),
+			ld:               generateLargeLogsBatch(),
 			reqTestFunc:      nil,
 			httpResponseCode: http.StatusAccepted,
 		},

--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -268,10 +268,10 @@ func Test_logDataToSplunk(t *testing.T) {
 
 func makeLog(record pdata.LogRecord) pdata.Logs {
 	logs := pdata.NewLogs()
-	rl := pdata.NewResourceLogs()
-	logs.ResourceLogs().Append(rl)
-	ill := pdata.NewInstrumentationLibraryLogs()
-	rl.InstrumentationLibraryLogs().Append(ill)
+	logs.ResourceLogs().Resize(1)
+	rl := logs.ResourceLogs().At(0)
+	rl.InstrumentationLibraryLogs().Resize(1)
+	ill := rl.InstrumentationLibraryLogs().At(0)
 	ill.Logs().Append(record)
 	return logs
 }
@@ -301,18 +301,16 @@ func Test_nilLogs(t *testing.T) {
 
 func Test_nilResourceLogs(t *testing.T) {
 	logs := pdata.NewLogs()
-	resourceLog := pdata.NewResourceLogs()
-	logs.ResourceLogs().Append(resourceLog)
+	logs.ResourceLogs().Resize(1)
 	events := logDataToSplunk(zap.NewNop(), logs, &Config{})
 	assert.Equal(t, 0, len(events))
 }
 
 func Test_nilInstrumentationLogs(t *testing.T) {
 	logs := pdata.NewLogs()
-	resourceLog := pdata.NewResourceLogs()
-	logs.ResourceLogs().Append(resourceLog)
-	ils := pdata.NewInstrumentationLibraryLogs()
-	resourceLog.InstrumentationLibraryLogs().Append(ils)
+	logs.ResourceLogs().Resize(1)
+	resourceLog := logs.ResourceLogs().At(0)
+	resourceLog.InstrumentationLibraryLogs().Resize(1)
 	events := logDataToSplunk(zap.NewNop(), logs, &Config{})
 	assert.Equal(t, 0, len(events))
 }

--- a/exporter/stackdriverexporter/spandata_test.go
+++ b/exporter/stackdriverexporter/spandata_test.go
@@ -37,8 +37,17 @@ func TestPDataResourceSpansToOTSpanData_endToEnd(t *testing.T) {
 	pdataStartTime := pdata.TimestampUnixNano(startTime.UnixNano())
 
 	rs := pdata.NewResourceSpans()
-
-	span := pdata.NewSpan()
+	resource := rs.Resource()
+	resource.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"namespace": pdata.NewAttributeValueString("kube-system"),
+	})
+	ilss := rs.InstrumentationLibrarySpans()
+	ilss.Resize(1)
+	il := ilss.At(0).InstrumentationLibrary()
+	il.SetName("test_il_name")
+	il.SetVersion("test_il_version")
+	ilss.At(0).Spans().Resize(1)
+	span := ilss.At(0).Spans().At(0)
 	traceID := pdata.NewTraceID([16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F})
 	spanID := pdata.NewSpanID([8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8})
 	parentSpanID := pdata.NewSpanID([8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8})
@@ -50,13 +59,12 @@ func TestPDataResourceSpansToOTSpanData_endToEnd(t *testing.T) {
 	span.SetStartTime(pdataStartTime)
 	span.SetEndTime(pdataEndTime)
 
-	status := pdata.NewSpanStatus()
+	status := span.Status()
 	status.InitEmpty()
 	status.SetCode(pdata.StatusCodeError)
 	status.SetMessage("This is not a drill!")
-	status.CopyTo(span.Status())
 
-	events := pdata.NewSpanEventSlice()
+	events := span.Events()
 	events.Resize(2)
 
 	events.At(0).SetTimestamp(pdataStartTime)
@@ -64,44 +72,23 @@ func TestPDataResourceSpansToOTSpanData_endToEnd(t *testing.T) {
 
 	events.At(1).SetTimestamp(pdataEndTime)
 	events.At(1).SetName("end")
-	pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
+	events.At(1).Attributes().InitFromMap(map[string]pdata.AttributeValue{
 		"flag": pdata.NewAttributeValueBool(false),
-	}).CopyTo(events.At(1).Attributes())
-	events.MoveAndAppendTo(span.Events())
+	})
 
-	links := pdata.NewSpanLinkSlice()
+	links := span.Links()
 	links.Resize(2)
 	links.At(0).SetTraceID(pdata.NewTraceID([16]byte{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF}))
 	links.At(0).SetSpanID(pdata.NewSpanID([8]byte{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7}))
 	links.At(1).SetTraceID(pdata.NewTraceID([16]byte{0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF}))
 	links.At(1).SetSpanID(pdata.NewSpanID([8]byte{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7}))
-	links.MoveAndAppendTo(span.Links())
 
-	pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
+	span.Attributes().InitFromMap(map[string]pdata.AttributeValue{
 		"cache_hit":  pdata.NewAttributeValueBool(true),
 		"timeout_ns": pdata.NewAttributeValueInt(12e9),
 		"ping_count": pdata.NewAttributeValueInt(25),
 		"agent":      pdata.NewAttributeValueString("ocagent"),
-	}).CopyTo(span.Attributes())
-
-	resource := pdata.NewResource()
-	pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
-		"namespace": pdata.NewAttributeValueString("kube-system"),
-	}).CopyTo(resource.Attributes())
-	resource.CopyTo(rs.Resource())
-
-	il := pdata.NewInstrumentationLibrary()
-	il.SetName("test_il_name")
-	il.SetVersion("test_il_version")
-
-	spans := pdata.NewSpanSlice()
-	spans.Append(span)
-
-	ilss := pdata.NewInstrumentationLibrarySpansSlice()
-	ilss.Resize(1)
-	il.CopyTo(ilss.At(0).InstrumentationLibrary())
-	spans.MoveAndAppendTo(ilss.At(0).Spans())
-	ilss.CopyTo(rs.InstrumentationLibrarySpans())
+	})
 
 	gotOTSpanData, err := pdataResourceSpansToOTSpanData(rs)
 	if err != nil {

--- a/pkg/batchpertrace/batchpertrace_test.go
+++ b/pkg/batchpertrace/batchpertrace_test.go
@@ -23,7 +23,9 @@ import (
 
 func TestSplitDifferentTracesIntoDifferentBatches(t *testing.T) {
 	// we have 1 ResourceSpans with 1 ILS and two traceIDs, resulting in two batches
-	rs := pdata.NewResourceSpans()
+	inBatch := pdata.NewTraces()
+	inBatch.ResourceSpans().Resize(1)
+	rs := inBatch.ResourceSpans().At(0)
 	rs.InstrumentationLibrarySpans().Resize(1)
 
 	// the first ILS has two spans
@@ -37,9 +39,6 @@ func TestSplitDifferentTracesIntoDifferentBatches(t *testing.T) {
 	secondSpan := ils.Spans().At(1)
 	secondSpan.SetName("first-batch-second-span")
 	secondSpan.SetTraceID(pdata.NewTraceID([16]byte{2, 3, 4, 5}))
-
-	inBatch := pdata.NewTraces()
-	inBatch.ResourceSpans().Append(rs)
 
 	// test
 	out := Split(inBatch)

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -245,8 +245,9 @@ func TestAttributesToMap(t *testing.T) {
 
 	ava := pdata.NewAttributeValueArray()
 	arrayAttr := ava.ArrayVal()
-	arrayAttr.Append(pdata.NewAttributeValueString("inner"))
-	arrayAttr.Append(pdata.NewAttributeValueInt(42))
+	arrayAttr.Resize(2)
+	arrayAttr.At(0).SetStringVal("inner")
+	arrayAttr.At(1).SetIntVal(42)
 	attr.Insert("array", ava)
 
 	assert.Equal(t, m, AttributesToMap(attr))

--- a/processor/resourcedetectionprocessor/internal/testutils.go
+++ b/processor/resourcedetectionprocessor/internal/testutils.go
@@ -18,14 +18,19 @@ import "go.opentelemetry.io/collector/consumer/pdata"
 
 func NewResource(mp map[string]interface{}) pdata.Resource {
 	res := pdata.NewResource()
-	NewAttributeMap(mp).CopyTo(res.Attributes())
+	attr := res.Attributes()
+	fillAttributeMap(mp, attr)
 	return res
 }
 
 func NewAttributeMap(mp map[string]interface{}) pdata.AttributeMap {
 	attr := pdata.NewAttributeMap()
-	attr.InitEmptyWithCapacity(len(mp))
+	fillAttributeMap(mp, attr)
+	return attr
+}
 
+func fillAttributeMap(mp map[string]interface{}, attr pdata.AttributeMap) {
+	attr.InitEmptyWithCapacity(len(mp))
 	for k, v := range mp {
 		switch t := v.(type) {
 		case bool:
@@ -38,6 +43,4 @@ func NewAttributeMap(mp map[string]interface{}) pdata.AttributeMap {
 			attr.Insert(k, pdata.NewAttributeValueString(t))
 		}
 	}
-
-	return attr
 }

--- a/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/translator.go
+++ b/receiver/awsecscontainermetricsreceiver/awsecscontainermetrics/translator.go
@@ -20,10 +20,9 @@ import (
 
 func convertToOTLPMetrics(prefix string, m ECSMetrics, r pdata.Resource, timestamp pdata.TimestampUnixNano) pdata.ResourceMetricsSlice {
 	rms := pdata.NewResourceMetricsSlice()
-
 	rms.Resize(1)
-
 	rm := rms.At(0)
+
 	r.CopyTo(rm.Resource())
 
 	ilms := rm.InstrumentationLibraryMetrics()

--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -306,23 +306,19 @@ func (r *sfxReceiver) handleEventReq(resp http.ResponseWriter, req *http.Request
 		return
 	}
 
-	logSlice := signalFxV2EventsToLogRecords(r.logger, msg.Events)
-
 	ld := pdata.NewLogs()
 	rls := ld.ResourceLogs()
 	rls.Resize(1)
 	rl := rls.At(0)
-	resource := rl.Resource()
 
 	ills := rl.InstrumentationLibraryLogs()
 	ills.Resize(1)
 	ill := ills.At(0)
-
-	logSlice.MoveAndAppendTo(ill.Logs())
+	signalFxV2EventsToLogRecords(msg.Events, ill.Logs())
 
 	if r.config.AccessTokenPassthrough {
 		if accessToken := req.Header.Get(splunk.SFxAccessTokenHeader); accessToken != "" {
-			resource.Attributes().InsertString(splunk.SFxAccessTokenLabel, accessToken)
+			rl.Resource().Attributes().InsertString(splunk.SFxAccessTokenLabel, accessToken)
 		}
 	}
 

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -135,38 +135,35 @@ func Test_signalfxeceiver_EndToEnd(t *testing.T) {
 
 	rm.InstrumentationLibraryMetrics().Resize(1)
 	ilm := rm.InstrumentationLibraryMetrics().At(0)
+	ilm.Metrics().Resize(4)
 
 	{
-		m := pdata.NewMetric()
+		m := ilm.Metrics().At(0)
 		m.SetName("gauge_double_with_dims")
 		m.SetDataType(pdata.MetricDataTypeDoubleGauge)
 		m.DoubleGauge().DataPoints().Append(doublePt)
-		ilm.Metrics().Append(m)
 	}
 	{
-		m := pdata.NewMetric()
+		m := ilm.Metrics().At(1)
 		m.SetName("gauge_int_with_dims")
 		m.SetDataType(pdata.MetricDataTypeIntGauge)
 		m.IntGauge().DataPoints().Append(int64Pt)
-		ilm.Metrics().Append(m)
 	}
 	{
-		m := pdata.NewMetric()
+		m := ilm.Metrics().At(2)
 		m.SetName("cumulative_double_with_dims")
 		m.SetDataType(pdata.MetricDataTypeDoubleSum)
 		m.DoubleSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 		m.DoubleSum().SetIsMonotonic(true)
 		m.DoubleSum().DataPoints().Append(doublePt)
-		ilm.Metrics().Append(m)
 	}
 	{
-		m := pdata.NewMetric()
+		m := ilm.Metrics().At(3)
 		m.SetName("cumulative_int_with_dims")
 		m.SetDataType(pdata.MetricDataTypeIntSum)
 		m.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 		m.IntSum().SetIsMonotonic(true)
 		m.IntSum().DataPoints().Append(int64Pt)
-		ilm.Metrics().Append(m)
 	}
 
 	expCfg := &signalfxexporter.Config{

--- a/receiver/signalfxreceiver/signalfxv2_event_to_logdata.go
+++ b/receiver/signalfxreceiver/signalfxv2_event_to_logdata.go
@@ -17,7 +17,6 @@ package signalfxreceiver
 import (
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
@@ -25,11 +24,7 @@ import (
 // signalFxV2ToMetricsData converts SignalFx event proto data points to
 // pdata.LogSlice. Returning the converted data and the number of dropped log
 // records.
-func signalFxV2EventsToLogRecords(
-	logger *zap.Logger,
-	events []*sfxpb.Event,
-) pdata.LogSlice {
-	lrs := pdata.NewLogSlice()
+func signalFxV2EventsToLogRecords(events []*sfxpb.Event, lrs pdata.LogSlice) {
 	lrs.Resize(len(events))
 
 	for i, event := range events {
@@ -84,6 +79,4 @@ func signalFxV2EventsToLogRecords(
 			attrs.Insert(splunk.SFxEventPropertiesKey, propMapVal)
 		}
 	}
-
-	return lrs
 }

--- a/receiver/signalfxreceiver/signalfxv2_event_to_logdata_test.go
+++ b/receiver/signalfxreceiver/signalfxv2_event_to_logdata_test.go
@@ -23,7 +23,6 @@ import (
 	sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.uber.org/zap"
 )
 
 func TestSignalFxV2EventsToLogData(t *testing.T) {
@@ -109,7 +108,8 @@ func TestSignalFxV2EventsToLogData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lrs := signalFxV2EventsToLogRecords(zap.NewNop(), tt.sfxEvents)
+			lrs := pdata.NewLogSlice()
+			signalFxV2EventsToLogRecords(tt.sfxEvents, lrs)
 			for i := 0; i < lrs.Len(); i++ {
 				lrs.At(i).Attributes().Sort()
 			}

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -412,22 +412,23 @@ func Test_splunkhecReceiver_TLS(t *testing.T) {
 	require.False(t, receivedError)
 	t.Log("Event Reception Started")
 
+	logs := pdata.NewLogs()
+	logs.ResourceLogs().Resize(1)
+	rl := logs.ResourceLogs().At(0)
+	rl.InstrumentationLibraryLogs().Resize(1)
+	ill := rl.InstrumentationLibraryLogs().At(0)
+	ill.Logs().Resize(1)
+	lr := ill.Logs().At(0)
+
 	now := time.Now()
 	msecInt64 := now.UnixNano() / 1e6
 	sec := float64(msecInt64) / 1e3
-	lr := pdata.NewLogRecord()
 	lr.SetTimestamp(pdata.TimestampUnixNano(int64(sec * 1e9)))
 	lr.SetName("custom:sourcetype")
 
 	lr.Body().SetStringVal("foo")
-	logs := pdata.NewLogs()
-	rl := pdata.NewResourceLogs()
 	lr.Attributes().InsertString("com.splunk.sourcetype", "custom:sourcetype")
 	lr.Attributes().InsertString("com.splunk.index", "myindex")
-	ill := pdata.NewInstrumentationLibraryLogs()
-	ill.Logs().Append(lr)
-	rl.InstrumentationLibraryLogs().Append(ill)
-	logs.ResourceLogs().Append(rl)
 	want := logs
 
 	t.Log("Sending Splunk HEC data Request")

--- a/receiver/splunkhecreceiver/splunk_to_logdata.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata.go
@@ -35,8 +35,8 @@ func SplunkHecToLogData(logger *zap.Logger, events []*splunk.Event, resourceCust
 	rls := ld.ResourceLogs()
 	rls.Resize(1)
 	rl := rls.At(0)
-	ill := pdata.NewInstrumentationLibraryLogs()
-	rl.InstrumentationLibraryLogs().Append(ill)
+	rl.InstrumentationLibraryLogs().Resize(1)
+	ill := rl.InstrumentationLibraryLogs().At(0)
 	for _, event := range events {
 		logRecord := pdata.NewLogRecord()
 

--- a/receiver/splunkhecreceiver/splunk_to_logdata_test.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata_test.go
@@ -90,8 +90,9 @@ func Test_SplunkHecToLogData(t *testing.T) {
 				logsSlice := createLogsSlice("value", nanoseconds)
 				arrVal := pdata.NewAttributeValueArray()
 				arr := arrVal.ArrayVal()
-				arr.Append(pdata.NewAttributeValueString("foo"))
-				arr.Append(pdata.NewAttributeValueString("bar"))
+				arr.Resize(2)
+				arr.At(0).SetStringVal("foo")
+				arr.At(1).SetStringVal("bar")
 				arrVal.CopyTo(logsSlice.At(0).InstrumentationLibraryLogs().At(0).Logs().At(0).Body())
 				return logsSlice
 			}(),
@@ -114,9 +115,10 @@ func Test_SplunkHecToLogData(t *testing.T) {
 				logsSlice := createLogsSlice("value", nanoseconds)
 				foosArr := pdata.NewAttributeValueArray()
 				foos := foosArr.ArrayVal()
-				foos.Append(pdata.NewAttributeValueString("foo"))
-				foos.Append(pdata.NewAttributeValueString("bar"))
-				foos.Append(pdata.NewAttributeValueString("foobar"))
+				foos.Resize(3)
+				foos.At(0).SetStringVal("foo")
+				foos.At(1).SetStringVal("bar")
+				foos.At(2).SetStringVal("foobar")
 
 				attVal := pdata.NewAttributeValueMap()
 				attMap := attVal.MapVal()
@@ -213,10 +215,11 @@ func Test_ConvertAttributeValueMap(t *testing.T) {
 func Test_ConvertAttributeValueArray(t *testing.T) {
 	value, err := convertInterfaceToAttributeValue(zap.NewNop(), []interface{}{"foo"})
 	assert.NoError(t, err)
-	arr := pdata.NewAttributeValueArray()
-	arrValue := arr.ArrayVal()
-	arrValue.Append(pdata.NewAttributeValueString("foo"))
-	assert.Equal(t, arr, value)
+	arrValue := pdata.NewAttributeValueArray()
+	arr := arrValue.ArrayVal()
+	arr.Resize(1)
+	arr.At(0).SetStringVal("foo")
+	assert.Equal(t, arrValue, value)
 }
 
 func Test_ConvertAttributeValueInvalid(t *testing.T) {

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -70,30 +70,30 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 			}(),
 			wantMetricsData: func() pdata.Metrics {
 				metrics := buildDefaultMetricsData(nanos)
+				mts := metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+				mts.Resize(3)
 
-				metricPt := pdata.NewMetric()
+				metricPt := mts.At(1)
 				metricPt.SetDataType(pdata.MetricDataTypeIntGauge)
 				metricPt.SetName("yetanother")
-				intPt := pdata.NewIntDataPoint()
+				metricPt.IntGauge().DataPoints().Resize(1)
+				intPt := metricPt.IntGauge().DataPoints().At(0)
 				intPt.SetValue(14)
 				intPt.SetTimestamp(pdata.TimestampUnixNano(nanos))
 				intPt.LabelsMap().Insert("k0", "v0")
 				intPt.LabelsMap().Insert("k1", "v1")
 				intPt.LabelsMap().Insert("k2", "v2")
-				metricPt.IntGauge().DataPoints().Append(intPt)
-				metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
 
-				metricPt2 := pdata.NewMetric()
+				metricPt2 := mts.At(2)
 				metricPt2.SetDataType(pdata.MetricDataTypeIntGauge)
 				metricPt2.SetName("yetanotherandanother")
-				intPt2 := pdata.NewIntDataPoint()
+				metricPt2.IntGauge().DataPoints().Resize(1)
+				intPt2 := metricPt2.IntGauge().DataPoints().At(0)
 				intPt2.SetValue(15)
 				intPt2.SetTimestamp(pdata.TimestampUnixNano(nanos))
 				intPt2.LabelsMap().Insert("k0", "v0")
 				intPt2.LabelsMap().Insert("k1", "v1")
 				intPt2.LabelsMap().Insert("k2", "v2")
-				metricPt2.IntGauge().DataPoints().Append(intPt2)
-				metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt2)
 
 				return metrics
 			}(),
@@ -107,18 +107,18 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 			}(),
 			wantMetricsData: func() pdata.Metrics {
 				md := buildDefaultMetricsData(nanos)
-				metricPt := pdata.NewMetric()
+				mts := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+				mts.Resize(1)
+				metricPt := mts.At(0)
 				metricPt.SetDataType(pdata.MetricDataTypeDoubleGauge)
 				metricPt.SetName("single")
-				doublePt := pdata.NewDoubleDataPoint()
+				metricPt.DoubleGauge().DataPoints().Resize(1)
+				doublePt := metricPt.DoubleGauge().DataPoints().At(0)
 				doublePt.SetValue(13.13)
 				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
 				doublePt.LabelsMap().Insert("k0", "v0")
 				doublePt.LabelsMap().Insert("k1", "v1")
 				doublePt.LabelsMap().Insert("k2", "v2")
-				metricPt.DoubleGauge().DataPoints().Append(doublePt)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
 				return md
 			}(),
 		},
@@ -148,18 +148,18 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 			}(),
 			wantMetricsData: func() pdata.Metrics {
 				md := buildDefaultMetricsData(nanos)
-				metricPt := pdata.NewMetric()
+				mts := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+				mts.Resize(1)
+				metricPt := mts.At(0)
 				metricPt.SetDataType(pdata.MetricDataTypeDoubleGauge)
 				metricPt.SetName("single")
-				doublePt := pdata.NewDoubleDataPoint()
+				metricPt.DoubleGauge().DataPoints().Resize(1)
+				doublePt := metricPt.DoubleGauge().DataPoints().At(0)
 				doublePt.SetValue(13.13)
 				doublePt.LabelsMap().Insert("k0", "v0")
 				doublePt.LabelsMap().Insert("k1", "v1")
 				doublePt.LabelsMap().Insert("k2", "v2")
 				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
-				metricPt.DoubleGauge().DataPoints().Append(doublePt)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
 				return md
 			}(),
 		},
@@ -172,18 +172,18 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 			}(),
 			wantMetricsData: func() pdata.Metrics {
 				md := buildDefaultMetricsData(nanos)
-				metricPt := pdata.NewMetric()
+				mts := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+				mts.Resize(1)
+				metricPt := mts.At(0)
 				metricPt.SetDataType(pdata.MetricDataTypeDoubleGauge)
 				metricPt.SetName("single")
-				doublePt := pdata.NewDoubleDataPoint()
+				metricPt.DoubleGauge().DataPoints().Resize(1)
+				doublePt := metricPt.DoubleGauge().DataPoints().At(0)
 				doublePt.SetValue(13.13)
 				doublePt.LabelsMap().Insert("k0", "v0")
 				doublePt.LabelsMap().Insert("k1", "v1")
 				doublePt.LabelsMap().Insert("k2", "v2")
 				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
-				metricPt.DoubleGauge().DataPoints().Append(doublePt)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
 				return md
 			}(),
 		},
@@ -196,18 +196,18 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 			}(),
 			wantMetricsData: func() pdata.Metrics {
 				md := buildDefaultMetricsData(nanos)
-				metricPt := pdata.NewMetric()
+				mts := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+				mts.Resize(1)
+				metricPt := mts.At(0)
 				metricPt.SetDataType(pdata.MetricDataTypeDoubleGauge)
 				metricPt.SetName("single")
-				doublePt := pdata.NewDoubleDataPoint()
+				metricPt.DoubleGauge().DataPoints().Resize(1)
+				doublePt := metricPt.DoubleGauge().DataPoints().At(0)
 				doublePt.SetValue(13.13)
 				doublePt.LabelsMap().Insert("k0", "v0")
 				doublePt.LabelsMap().Insert("k1", "v1")
 				doublePt.LabelsMap().Insert("k2", "v2")
 				doublePt.SetTimestamp(pdata.TimestampUnixNano(nanos))
-				metricPt.DoubleGauge().DataPoints().Append(doublePt)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Resize(0)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Append(metricPt)
 				return md
 			}(),
 		},
@@ -284,27 +284,27 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 
 func buildDefaultMetricsData(time int64) pdata.Metrics {
 	metrics := pdata.NewMetrics()
-	resourceMetrics := pdata.NewResourceMetrics()
-	metrics.ResourceMetrics().Append(resourceMetrics)
+	metrics.ResourceMetrics().Resize(1)
+	resourceMetrics := metrics.ResourceMetrics().At(0)
 	attrs := resourceMetrics.Resource().Attributes()
 	attrs.InsertString("host.name", "localhost")
 	attrs.InsertString("service.name", "source")
 	attrs.InsertString("com.splunk.sourcetype", "sourcetype")
 	attrs.InsertString("com.splunk.index", "index")
 
-	ilm := pdata.NewInstrumentationLibraryMetrics()
-	metricPt := pdata.NewMetric()
+	resourceMetrics.InstrumentationLibraryMetrics().Resize(1)
+	ilm := resourceMetrics.InstrumentationLibraryMetrics().At(0)
+	ilm.Metrics().Resize(1)
+	metricPt := ilm.Metrics().At(0)
 	metricPt.SetDataType(pdata.MetricDataTypeIntGauge)
 	metricPt.SetName("single")
-	intPt := pdata.NewIntDataPoint()
+	metricPt.IntGauge().DataPoints().Resize(1)
+	intPt := metricPt.IntGauge().DataPoints().At(0)
 	intPt.SetValue(13)
 	intPt.LabelsMap().Insert("k0", "v0")
 	intPt.LabelsMap().Insert("k1", "v1")
 	intPt.LabelsMap().Insert("k2", "v2")
 	intPt.SetTimestamp(pdata.TimestampUnixNano(time))
-	metricPt.IntGauge().DataPoints().Append(intPt)
-	ilm.Metrics().Append(metricPt)
-	resourceMetrics.InstrumentationLibraryMetrics().Append(ilm)
 	return metrics
 }
 


### PR DESCRIPTION
`pdata` structs are intended to be constructed from top to bottom, and it should be rarely
the case where it is necessary to use functions like Append/CopyTo/MoveAndAppendTo.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
