### PR TITLE
Pass processor params to the detectors

### DIFF
--- a/processor/resourcedetectionprocessor/factory.go
+++ b/processor/resourcedetectionprocessor/factory.go
@@ -24,7 +24,6 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor/processorhelper"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2"
@@ -98,7 +97,7 @@ func (f *factory) createTraceProcessor(
 	cfg configmodels.Processor,
 	nextConsumer consumer.TracesConsumer,
 ) (component.TracesProcessor, error) {
-	rdp, err := f.getResourceDetectionProcessor(params.Logger, cfg)
+	rdp, err := f.getResourceDetectionProcessor(params, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +116,7 @@ func (f *factory) createMetricsProcessor(
 	cfg configmodels.Processor,
 	nextConsumer consumer.MetricsConsumer,
 ) (component.MetricsProcessor, error) {
-	rdp, err := f.getResourceDetectionProcessor(params.Logger, cfg)
+	rdp, err := f.getResourceDetectionProcessor(params, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +135,7 @@ func (f *factory) createLogsProcessor(
 	cfg configmodels.Processor,
 	nextConsumer consumer.LogsConsumer,
 ) (component.LogsProcessor, error) {
-	rdp, err := f.getResourceDetectionProcessor(params.Logger, cfg)
+	rdp, err := f.getResourceDetectionProcessor(params, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -150,12 +149,12 @@ func (f *factory) createLogsProcessor(
 }
 
 func (f *factory) getResourceDetectionProcessor(
-	logger *zap.Logger,
+	params component.ProcessorCreateParams,
 	cfg configmodels.Processor,
 ) (*resourceDetectionProcessor, error) {
 	oCfg := cfg.(*Config)
 
-	provider, err := f.getResourceProvider(logger, cfg.Name(), oCfg.Timeout, oCfg.Detectors)
+	provider, err := f.getResourceProvider(params, cfg.Name(), oCfg.Timeout, oCfg.Detectors)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +166,7 @@ func (f *factory) getResourceDetectionProcessor(
 }
 
 func (f *factory) getResourceProvider(
-	logger *zap.Logger,
+	params component.ProcessorCreateParams,
 	processorName string,
 	timeout time.Duration,
 	configuredDetectors []string,
@@ -184,7 +183,7 @@ func (f *factory) getResourceProvider(
 		detectorTypes = append(detectorTypes, internal.DetectorType(strings.TrimSpace(key)))
 	}
 
-	provider, err := f.resourceProviderFactory.CreateResourceProvider(logger, timeout, detectorTypes...)
+	provider, err := f.resourceProviderFactory.CreateResourceProvider(params, timeout, detectorTypes...)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/session"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 
@@ -35,7 +36,7 @@ type Detector struct {
 	metadataProvider metadataProvider
 }
 
-func NewDetector() (internal.Detector, error) {
+func NewDetector(component.ProcessorCreateParams) (internal.Detector, error) {
 	sess, err := session.NewSession()
 	if err != nil {
 		return nil, err

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
@@ -58,7 +60,7 @@ func (mm mockMetadata) hostname(ctx context.Context) (string, error) {
 }
 
 func TestNewDetector(t *testing.T) {
-	detector, err := NewDetector()
+	detector, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
 	assert.NotNil(t, detector)
 	assert.NoError(t, err)
 }

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 
@@ -40,8 +41,8 @@ type Detector struct {
 	provider ecsMetadataProvider
 }
 
-func NewDetector() (internal.Detector, error) {
-	return &Detector{provider: &ecsMetadataProviderImpl{client: &http.Client{}}}, nil
+func NewDetector(params component.ProcessorCreateParams) (internal.Detector, error) {
+	return &Detector{provider: &ecsMetadataProviderImpl{logger: params.Logger, client: &http.Client{}}}, nil
 }
 
 // Records metadata retrieved from the ECS Task Metadata Endpoint (TMDE) as resource attributes

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
@@ -50,13 +52,13 @@ func (md *mockMetaDataProvider) fetchTaskMetaData(tmde string) (*TaskMetaData, e
 	return tmd, nil
 }
 
-func (md *mockMetaDataProvider) fetchContainerMetaData(tmde string) (*Container, error) {
+func (md *mockMetaDataProvider) fetchContainerMetaData(string) (*Container, error) {
 	c := createTestContainer(md.isV4)
 	return &c, nil
 }
 
 func Test_ecsNewDetector(t *testing.T) {
-	d, err := NewDetector()
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
 
 	assert.NotNil(t, d)
 	assert.Nil(t, err)
@@ -64,7 +66,7 @@ func Test_ecsNewDetector(t *testing.T) {
 
 func Test_detectorReturnsIfNoEnvVars(t *testing.T) {
 	os.Clearenv()
-	d, _ := NewDetector()
+	d, _ := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
 	res, err := d.Detect(context.TODO())
 
 	assert.Nil(t, err)

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/metadata_ecs_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/metadata_ecs_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 const (
@@ -52,7 +53,7 @@ type mockClient struct {
 	retErr   bool
 }
 
-func (mc *mockClient) Do(req *http.Request) (*http.Response, error) {
+func (mc *mockClient) Do(*http.Request) (*http.Response, error) {
 	if mc.retErr {
 		return nil, errors.New("fake error")
 	}
@@ -65,7 +66,7 @@ func (mc *mockClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 func Test_ecsMetadata_fetchTask(t *testing.T) {
-	md := ecsMetadataProviderImpl{client: &mockClient{response: taskMeta, retErr: false}}
+	md := ecsMetadataProviderImpl{logger: zap.NewNop(), client: &mockClient{response: taskMeta, retErr: false}}
 	fetchResp, err := md.fetchTaskMetaData("url")
 
 	assert.Nil(t, err)
@@ -78,7 +79,7 @@ func Test_ecsMetadata_fetchTask(t *testing.T) {
 }
 
 func Test_ecsMetadata_fetchContainer(t *testing.T) {
-	md := ecsMetadataProviderImpl{client: &mockClient{response: containerMeta, retErr: false}}
+	md := ecsMetadataProviderImpl{logger: zap.NewNop(), client: &mockClient{response: containerMeta, retErr: false}}
 	fetchResp, err := md.fetchContainerMetaData("url")
 
 	assert.Nil(t, err)
@@ -93,7 +94,7 @@ func Test_ecsMetadata_fetchContainer(t *testing.T) {
 }
 
 func Test_ecsMetadata_returnsError(t *testing.T) {
-	md := ecsMetadataProviderImpl{client: &mockClient{response: "{}", retErr: true}}
+	md := ecsMetadataProviderImpl{logger: zap.NewNop(), client: &mockClient{response: "{}", retErr: true}}
 	fetchResp, err := md.fetchContainerMetaData("url")
 
 	assert.Nil(t, fetchResp)

--- a/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk.go
+++ b/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"strconv"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 
@@ -45,7 +46,7 @@ type EbMetaData struct {
 	VersionLabel    string `json:"version_label"`
 }
 
-func NewDetector() (internal.Detector, error) {
+func NewDetector(component.ProcessorCreateParams) (internal.Detector, error) {
 	return &Detector{fs: &ebFileSystem{}}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk_test.go
@@ -23,7 +23,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
@@ -51,7 +53,7 @@ func (mfs *mockFileSystem) IsWindows() bool {
 }
 
 func Test_newDetector(t *testing.T) {
-	d, err := NewDetector()
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
 
 	assert.Nil(t, err)
 	assert.NotNil(t, d)

--- a/processor/resourcedetectionprocessor/internal/env/env.go
+++ b/processor/resourcedetectionprocessor/internal/env/env.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strings"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
@@ -40,7 +41,7 @@ var _ internal.Detector = (*Detector)(nil)
 
 type Detector struct{}
 
-func NewDetector() (internal.Detector, error) {
+func NewDetector(component.ProcessorCreateParams) (internal.Detector, error) {
 	return &Detector{}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/env/env_test.go
+++ b/processor/resourcedetectionprocessor/internal/env/env_test.go
@@ -21,13 +21,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
 
 func TestNewDetector(t *testing.T) {
-	d, err := NewDetector()
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
 	assert.NotNil(t, d)
 	assert.NoError(t, err)
 }

--- a/processor/resourcedetectionprocessor/internal/gcp/gce/gce.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gce/gce.go
@@ -19,6 +19,7 @@ package gce // import "cloud.google.com/go/compute/metadata"
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
@@ -36,7 +37,7 @@ type Detector struct {
 	metadata gceMetadata
 }
 
-func NewDetector() (internal.Detector, error) {
+func NewDetector(component.ProcessorCreateParams) (internal.Detector, error) {
 	return &Detector{metadata: &gceMetadataImpl{}}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/gcp/gce/gce_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gce/gce_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/translator/conventions"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
@@ -66,7 +68,7 @@ func (m *mockMetadata) Get(suffix string) (string, error) {
 }
 
 func TestNewDetector(t *testing.T) {
-	d, err := NewDetector()
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
 	assert.NotNil(t, d)
 	assert.NoError(t, err)
 }

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 )
@@ -32,7 +33,7 @@ type Detector interface {
 	Detect(ctx context.Context) (pdata.Resource, error)
 }
 
-type DetectorFactory func() (Detector, error)
+type DetectorFactory func(component.ProcessorCreateParams) (Detector, error)
 
 type ResourceProviderFactory struct {
 	// detectors holds all possible detector types.
@@ -43,17 +44,20 @@ func NewProviderFactory(detectors map[DetectorType]DetectorFactory) *ResourcePro
 	return &ResourceProviderFactory{detectors: detectors}
 }
 
-func (f *ResourceProviderFactory) CreateResourceProvider(logger *zap.Logger, timeout time.Duration, detectorTypes ...DetectorType) (*ResourceProvider, error) {
-	detectors, err := f.getDetectors(detectorTypes)
+func (f *ResourceProviderFactory) CreateResourceProvider(
+	params component.ProcessorCreateParams,
+	timeout time.Duration,
+	detectorTypes ...DetectorType) (*ResourceProvider, error) {
+	detectors, err := f.getDetectors(params, detectorTypes)
 	if err != nil {
 		return nil, err
 	}
 
-	provider := NewResourceProvider(logger, timeout, detectors...)
+	provider := NewResourceProvider(params.Logger, timeout, detectors...)
 	return provider, nil
 }
 
-func (f *ResourceProviderFactory) getDetectors(detectorTypes []DetectorType) ([]Detector, error) {
+func (f *ResourceProviderFactory) getDetectors(params component.ProcessorCreateParams, detectorTypes []DetectorType) ([]Detector, error) {
 	detectors := make([]Detector, 0, len(detectorTypes))
 	for _, detectorType := range detectorTypes {
 		detectorFactory, ok := f.detectors[detectorType]
@@ -61,7 +65,7 @@ func (f *ResourceProviderFactory) getDetectors(detectorTypes []DetectorType) ([]
 			return nil, fmt.Errorf("invalid detector key: %v", detectorType)
 		}
 
-		detector, err := detectorFactory()
+		detector, err := detectorFactory(params)
 		if err != nil {
 			return nil, fmt.Errorf("failed creating detector type %q: %w", detectorType, err)
 		}

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 
@@ -37,7 +38,7 @@ type Detector struct {
 }
 
 // NewDetector creates a new system metadata detector
-func NewDetector() (internal.Detector, error) {
+func NewDetector(component.ProcessorCreateParams) (internal.Detector, error) {
 	return &Detector{provider: &systemMetadataImpl{}}, nil
 }
 

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/translator/conventions"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
@@ -42,7 +44,7 @@ func (m *mockMetadata) OSType() (string, error) {
 }
 
 func TestNewDetector(t *testing.T) {
-	d, err := NewDetector()
+	d, err := NewDetector(component.ProcessorCreateParams{Logger: zap.NewNop()})
 	require.NoError(t, err)
 	assert.NotNil(t, d)
 }

--- a/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
+++ b/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
@@ -162,7 +162,7 @@ func TestResourceProcessor(t *testing.T) {
 			md1 := &MockDetector{}
 			md1.On("Detect").Return(tt.detectedResource, tt.detectedError)
 			factory.resourceProviderFactory = internal.NewProviderFactory(
-				map[internal.DetectorType]internal.DetectorFactory{"mock": func() (internal.Detector, error) {
+				map[internal.DetectorType]internal.DetectorFactory{"mock": func(component.ProcessorCreateParams) (internal.Detector, error) {
 					return md1, nil
 				}})
 


### PR DESCRIPTION
Fix ecs detector to not use the default golang logger.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1645
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1586

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>