### PR TITLE
AWSEMFExporter - Add collector version to EMF exporter user agent

### DIFF
--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -64,7 +64,7 @@ func New(
 	}
 
 	// create CWLogs client with aws session config
-	svcStructuredLog := NewCloudWatchLogsClient(logger, awsConfig, session)
+	svcStructuredLog := NewCloudWatchLogsClient(logger, awsConfig, params.ApplicationStartInfo, session)
 	collectorIdentifier, _ := uuid.NewRandom()
 
 	// Initialize metric declarations and filter out invalid ones

--- a/exporter/awsemfexporter/pusher.go
+++ b/exporter/awsemfexporter/pusher.go
@@ -232,7 +232,7 @@ func (p *pusher) pushLogEventBatch(req interface{}) error {
 		return err
 	}
 
-	p.logger.Debug("logpusher: publish log events successfully.",
+	p.logger.Info("logpusher: publish log events successfully.",
 		zap.Int("NumOfLogEvents", len(putLogEventsInput.LogEvents)),
 		zap.Float64("LogEventsSize", float64(logEventBatch.byteTotal)/float64(1024)),
 		zap.Int64("Time", time.Since(startTime).Nanoseconds()/int64(time.Millisecond)))


### PR DESCRIPTION
**Description:** 
Add collector version to EMF exporter user agent
Similar implementation as in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1730. To provide support to customers using the otel collector, we need some more telemetry data from the collector. Adding the collector version to user agent is the first simple step.

**Testing:**
Unit tests