### PR TITLE
[datadogexporter] Add resource attributes to tags conversion feature

### DIFF
--- a/exporter/datadogexporter/attributes/attributes.go
+++ b/exporter/datadogexporter/attributes/attributes.go
@@ -1,10 +1,23 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package attributes
 
 import (
-	"go.opentelemetry.io/collector/translator/conventions"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 )
-
 
 // TagsFromAttributes converts a selected list of attributes
 // to a tag list that can be added to metrics.

--- a/exporter/datadogexporter/attributes/attributes.go
+++ b/exporter/datadogexporter/attributes/attributes.go
@@ -25,9 +25,11 @@ func TagsFromAttributes(attrs pdata.AttributeMap) []string {
 	tags := make([]string, 0, attrs.Len())
 
 	var processAttributes processAttributes
+	var systemAttributes systemAttributes
 
 	attrs.ForEach(func(key string, value pdata.AttributeValue) {
 		switch key {
+		// Process attributes
 		case conventions.AttributeProcessExecutableName:
 			processAttributes.ExecutableName = value.StringVal()
 		case conventions.AttributeProcessExecutablePath:
@@ -40,10 +42,15 @@ func TagsFromAttributes(attrs pdata.AttributeMap) []string {
 			processAttributes.PID = value.IntVal()
 		case conventions.AttributeProcessOwner:
 			processAttributes.Owner = value.StringVal()
+
+		// System attributes
+		case conventions.AttributeOSType:
+			systemAttributes.OSType = value.StringVal()
 		}
 	})
 
-	tags = append(tags, processAttributes.extractProcessTags()...)
+	tags = append(tags, processAttributes.extractTags()...)
+	tags = append(tags, systemAttributes.extractTags()...)
 
 	return tags
 }

--- a/exporter/datadogexporter/attributes/attributes.go
+++ b/exporter/datadogexporter/attributes/attributes.go
@@ -1,0 +1,36 @@
+package attributes
+
+import (
+	"go.opentelemetry.io/collector/translator/conventions"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+
+// TagsFromAttributes converts a selected list of attributes
+// to a tag list that can be added to metrics.
+func TagsFromAttributes(attrs pdata.AttributeMap) []string {
+	tags := make([]string, 0, attrs.Len())
+
+	var processAttributes processAttributes
+
+	attrs.ForEach(func(key string, value pdata.AttributeValue) {
+		switch key {
+		case conventions.AttributeProcessExecutableName:
+			processAttributes.ExecutableName = value.StringVal()
+		case conventions.AttributeProcessExecutablePath:
+			processAttributes.ExecutablePath = value.StringVal()
+		case conventions.AttributeProcessCommand:
+			processAttributes.Command = value.StringVal()
+		case conventions.AttributeProcessCommandLine:
+			processAttributes.CommandLine = value.StringVal()
+		case conventions.AttributeProcessID:
+			processAttributes.PID = value.IntVal()
+		case conventions.AttributeProcessOwner:
+			processAttributes.Owner = value.StringVal()
+		}
+	})
+
+	tags = append(tags, processAttributes.extractProcessTags()...)
+
+	return tags
+}

--- a/exporter/datadogexporter/attributes/attributes_test.go
+++ b/exporter/datadogexporter/attributes/attributes_test.go
@@ -1,13 +1,26 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package attributes
 
 import (
-	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/translator/conventions"
-
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 )
 
 func TestTagsFromAttributes(t *testing.T) {
@@ -21,7 +34,6 @@ func TestTagsFromAttributes(t *testing.T) {
 	}
 	attrs := pdata.NewAttributeMap().InitFromMap(attributeMap)
 
-
 	assert.Equal(t, []string{
 		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, "otelcol"),
 	}, TagsFromAttributes(attrs))
@@ -29,7 +41,6 @@ func TestTagsFromAttributes(t *testing.T) {
 
 func TestTagsFromAttributesEmpty(t *testing.T) {
 	attrs := pdata.NewAttributeMap()
-
 
 	assert.Equal(t, []string{}, TagsFromAttributes(attrs))
 }

--- a/exporter/datadogexporter/attributes/attributes_test.go
+++ b/exporter/datadogexporter/attributes/attributes_test.go
@@ -31,11 +31,13 @@ func TestTagsFromAttributes(t *testing.T) {
 		conventions.AttributeProcessCommandLine:    pdata.NewAttributeValueString("cmd/otelcol --config=\"/path/to/config.yaml\""),
 		conventions.AttributeProcessID:             pdata.NewAttributeValueInt(1),
 		conventions.AttributeProcessOwner:          pdata.NewAttributeValueString("root"),
+		conventions.AttributeOSType:                pdata.NewAttributeValueString("LINUX"),
 	}
 	attrs := pdata.NewAttributeMap().InitFromMap(attributeMap)
 
 	assert.Equal(t, []string{
 		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, "otelcol"),
+		fmt.Sprintf("%s:%s", conventions.AttributeOSType, "LINUX"),
 	}, TagsFromAttributes(attrs))
 }
 

--- a/exporter/datadogexporter/attributes/attributes_test.go
+++ b/exporter/datadogexporter/attributes/attributes_test.go
@@ -1,0 +1,35 @@
+package attributes
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagsFromAttributes(t *testing.T) {
+	attributeMap := map[string]pdata.AttributeValue{
+		conventions.AttributeProcessExecutableName: pdata.NewAttributeValueString("otelcol"),
+		conventions.AttributeProcessExecutablePath: pdata.NewAttributeValueString("/usr/bin/cmd/otelcol"),
+		conventions.AttributeProcessCommand:        pdata.NewAttributeValueString("cmd/otelcol"),
+		conventions.AttributeProcessCommandLine:    pdata.NewAttributeValueString("cmd/otelcol --config=\"/path/to/config.yaml\""),
+		conventions.AttributeProcessID:             pdata.NewAttributeValueInt(1),
+		conventions.AttributeProcessOwner:          pdata.NewAttributeValueString("root"),
+	}
+	attrs := pdata.NewAttributeMap().InitFromMap(attributeMap)
+
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, "otelcol"),
+	}, TagsFromAttributes(attrs))
+}
+
+func TestTagsFromAttributesEmpty(t *testing.T) {
+	attrs := pdata.NewAttributeMap()
+
+
+	assert.Equal(t, []string{}, TagsFromAttributes(attrs))
+}

--- a/exporter/datadogexporter/attributes/process.go
+++ b/exporter/datadogexporter/attributes/process.go
@@ -1,11 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package attributes
 
 import (
-	"go.opentelemetry.io/collector/translator/conventions"
-
 	"fmt"
-)
 
+	"go.opentelemetry.io/collector/translator/conventions"
+)
 
 type processAttributes struct {
 	ExecutableName string

--- a/exporter/datadogexporter/attributes/process.go
+++ b/exporter/datadogexporter/attributes/process.go
@@ -35,9 +35,10 @@ func (pattrs *processAttributes) extractTags() []string {
 	// According to OTel conventions: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/process.md,
 	// a process can be defined by any of the 4 following attributes: process.executable.name, process.executable.path, process.command or process.command_line
 	// (process.command_args isn't in the current attribute conventions: https://github.com/open-telemetry/opentelemetry-collector/blob/ecb27f49d4e26ae42d82e6ea18d57b08e252452d/translator/conventions/opentelemetry.go#L58-L63)
-	// We go through them in order of preference (from most concise to less concise), and add the first available one as identifier.
-	// We don't add all of them to avoid increasing the number of tags unnecessarily.
+	// We go through them, and add the first available one as a tag to identify the process.
+	// We don't want to add all of them to avoid unnecessarily increasing the number of tags attached to a metric.
 
+	// TODO: check if this order should be changed.
 	if pattrs.ExecutableName != "" { // otelcol
 		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, pattrs.ExecutableName))
 	} else if pattrs.ExecutablePath != "" { // /usr/bin/cmd/otelcol

--- a/exporter/datadogexporter/attributes/process.go
+++ b/exporter/datadogexporter/attributes/process.go
@@ -1,0 +1,41 @@
+package attributes
+
+import (
+	"go.opentelemetry.io/collector/translator/conventions"
+
+	"fmt"
+)
+
+
+type processAttributes struct {
+	ExecutableName string
+	ExecutablePath string
+	Command        string
+	CommandLine    string
+	PID            int64
+	Owner          string
+}
+
+func (pattrs *processAttributes) extractProcessTags() []string {
+	tags := make([]string, 0, 1)
+
+	// According to OTel conventions: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/process.md,
+	// a process can be defined by any of the 4 following attributes: process.executable.name, process.executable.path, process.command or process.command_line
+	// (process.command_args isn't in the current attribute conventions: https://github.com/open-telemetry/opentelemetry-collector/blob/ecb27f49d4e26ae42d82e6ea18d57b08e252452d/translator/conventions/opentelemetry.go#L58-L63)
+	// We go through them in order of preference (from most concise to less concise), and add the first available one as identifier.
+	// We don't add all of them to avoid increasing the number of tags unnecessarily.
+
+	if pattrs.ExecutableName != "" { // otelcol
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, pattrs.ExecutableName))
+	} else if pattrs.ExecutablePath != "" { // /usr/bin/cmd/otelcol
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutablePath, pattrs.ExecutablePath))
+	} else if pattrs.Command != "" { // cmd/otelcol
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeProcessCommand, pattrs.Command))
+	} else if pattrs.CommandLine != "" { // cmd/otelcol --config="/path/to/config.yaml"
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeProcessCommandLine, pattrs.CommandLine))
+	}
+
+	// For now, we don't care about the process ID nor the process owner.
+
+	return tags
+}

--- a/exporter/datadogexporter/attributes/process.go
+++ b/exporter/datadogexporter/attributes/process.go
@@ -29,7 +29,7 @@ type processAttributes struct {
 	Owner          string
 }
 
-func (pattrs *processAttributes) extractProcessTags() []string {
+func (pattrs *processAttributes) extractTags() []string {
 	tags := make([]string, 0, 1)
 
 	// According to OTel conventions: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/process.md,

--- a/exporter/datadogexporter/attributes/process_test.go
+++ b/exporter/datadogexporter/attributes/process_test.go
@@ -1,12 +1,25 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package attributes
 
 import (
-	"go.opentelemetry.io/collector/translator/conventions"
-
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/translator/conventions"
 )
 
 func TestExtractProcessTags(t *testing.T) {

--- a/exporter/datadogexporter/attributes/process_test.go
+++ b/exporter/datadogexporter/attributes/process_test.go
@@ -1,0 +1,64 @@
+package attributes
+
+import (
+	"go.opentelemetry.io/collector/translator/conventions"
+
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractProcessTags(t *testing.T) {
+	pattrs := processAttributes{
+		ExecutableName: "otelcol",
+		ExecutablePath: "/usr/bin/cmd/otelcol",
+		Command:        "cmd/otelcol",
+		CommandLine:    "cmd/otelcol --config=\"/path/to/config.yaml\"",
+		PID:            1,
+		Owner:          "root",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, "otelcol"),
+	}, pattrs.extractProcessTags())
+
+	pattrs = processAttributes{
+		ExecutablePath: "/usr/bin/cmd/otelcol",
+		Command:        "cmd/otelcol",
+		CommandLine:    "cmd/otelcol --config=\"/path/to/config.yaml\"",
+		PID:            1,
+		Owner:          "root",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutablePath, "/usr/bin/cmd/otelcol"),
+	}, pattrs.extractProcessTags())
+
+	pattrs = processAttributes{
+		Command:     "cmd/otelcol",
+		CommandLine: "cmd/otelcol --config=\"/path/to/config.yaml\"",
+		PID:         1,
+		Owner:       "root",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessCommand, "cmd/otelcol"),
+	}, pattrs.extractProcessTags())
+
+	pattrs = processAttributes{
+		CommandLine: "cmd/otelcol --config=\"/path/to/config.yaml\"",
+		PID:         1,
+		Owner:       "root",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessCommandLine, "cmd/otelcol --config=\"/path/to/config.yaml\""),
+	}, pattrs.extractProcessTags())
+}
+
+func TestExtractProcessEmpty(t *testing.T) {
+	pattrs := processAttributes{}
+
+	assert.Equal(t, []string{}, pattrs.extractProcessTags())
+}

--- a/exporter/datadogexporter/attributes/process_test.go
+++ b/exporter/datadogexporter/attributes/process_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/translator/conventions"
 )
 
-func TestExtractProcessTags(t *testing.T) {
+func TestProcessExtractTags(t *testing.T) {
 	pattrs := processAttributes{
 		ExecutableName: "otelcol",
 		ExecutablePath: "/usr/bin/cmd/otelcol",
@@ -34,7 +34,7 @@ func TestExtractProcessTags(t *testing.T) {
 
 	assert.Equal(t, []string{
 		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, "otelcol"),
-	}, pattrs.extractProcessTags())
+	}, pattrs.extractTags())
 
 	pattrs = processAttributes{
 		ExecutablePath: "/usr/bin/cmd/otelcol",
@@ -46,7 +46,7 @@ func TestExtractProcessTags(t *testing.T) {
 
 	assert.Equal(t, []string{
 		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutablePath, "/usr/bin/cmd/otelcol"),
-	}, pattrs.extractProcessTags())
+	}, pattrs.extractTags())
 
 	pattrs = processAttributes{
 		Command:     "cmd/otelcol",
@@ -57,7 +57,7 @@ func TestExtractProcessTags(t *testing.T) {
 
 	assert.Equal(t, []string{
 		fmt.Sprintf("%s:%s", conventions.AttributeProcessCommand, "cmd/otelcol"),
-	}, pattrs.extractProcessTags())
+	}, pattrs.extractTags())
 
 	pattrs = processAttributes{
 		CommandLine: "cmd/otelcol --config=\"/path/to/config.yaml\"",
@@ -67,11 +67,11 @@ func TestExtractProcessTags(t *testing.T) {
 
 	assert.Equal(t, []string{
 		fmt.Sprintf("%s:%s", conventions.AttributeProcessCommandLine, "cmd/otelcol --config=\"/path/to/config.yaml\""),
-	}, pattrs.extractProcessTags())
+	}, pattrs.extractTags())
 }
 
-func TestExtractProcessEmpty(t *testing.T) {
+func TestProcessExtractTagsEmpty(t *testing.T) {
 	pattrs := processAttributes{}
 
-	assert.Equal(t, []string{}, pattrs.extractProcessTags())
+	assert.Equal(t, []string{}, pattrs.extractTags())
 }

--- a/exporter/datadogexporter/attributes/system.go
+++ b/exporter/datadogexporter/attributes/system.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/translator/conventions"
+)
+
+type systemAttributes struct {
+	OSType string
+}
+
+func (sattrs *systemAttributes) extractTags() []string {
+	tags := make([]string, 0, 1)
+
+	// Add OS type, eg. WINDOWS, LINUX, etc.
+	if sattrs.OSType != "" {
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeOSType, sattrs.OSType))
+	}
+
+	return tags
+}

--- a/exporter/datadogexporter/attributes/system_test.go
+++ b/exporter/datadogexporter/attributes/system_test.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/translator/conventions"
+)
+
+func TestSystemExtractTags(t *testing.T) {
+	sattrs := systemAttributes{
+		OSType: "WINDOWS",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeOSType, "WINDOWS"),
+	}, sattrs.extractTags())
+}
+
+func TestSystemExtractTagsEmpty(t *testing.T) {
+	sattrs := systemAttributes{}
+
+	assert.Equal(t, []string{}, sattrs.extractTags())
+}

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -65,8 +65,8 @@ type MetricsConfig struct {
 	ExporterConfig MetricsExporterConfig `mapstructure:",squash"`
 }
 
-// MetricsExporterConfig provides options for a user to customize the behavior of an
-// exporter
+// MetricsExporterConfig provides options for a user to customize the behavior of the
+// metrics exporter
 type MetricsExporterConfig struct {
 	// ResourceAttributesAsTags, if set to true, will use the exporterhelper feature to transform all
 	// resource attributes into metric labels, which are then converted into tags

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -61,6 +61,16 @@ type MetricsConfig struct {
 	// TCPAddr.Endpoint is the host of the Datadog intake server to send metrics to.
 	// If unset, the value is obtained from the Site.
 	confignet.TCPAddr `mapstructure:",squash"`
+
+	ExporterConfig MetricsExporterConfig `mapstructure:",squash"`
+}
+
+// MetricsExporterConfig provides options for a user to customize the behavior of an
+// exporter
+type MetricsExporterConfig struct {
+	// ResourceAttributesAsTags, if set to true, will use the exporterhelper feature to transform all
+	// resource attributes into metric labels, which are then converted into tags
+	ResourceAttributesAsTags bool `mapstructure:"resource_attributes_as_tags"`
 }
 
 // TracesConfig defines the traces exporter specific configuration options

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -70,8 +70,8 @@ exporters:
       # endpoint: https://api.datadoghq.com
 
       ## @param resource_attributes_as_tags - string - optional - default: false
-      ## Set to true to add all resource attributes of to the metric tags.
-      ## When set to false, only a small subset of resource attributes is converted
+      ## Set to true to add all resource attributes of a metric to its metric tags.
+      ## When set to false, only a small predefined subset of resource attributes is converted
       ## to metric tags.
       #
       # resource_attributes_as_tags: false

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -69,6 +69,13 @@ exporters:
       #
       # endpoint: https://api.datadoghq.com
 
+      ## @param resource_attributes_as_tags - string - optional - default: false
+      ## Set to true to add all resource attributes of to the metric tags.
+      ## When set to false, only a small subset of resource attributes is converted
+      ## to metric tags.
+      #
+      # resource_attributes_as_tags: false
+
     ## @param traces - custom object - optional
     ## Trace exporter specific configuration.
     #
@@ -85,7 +92,6 @@ exporters:
       ## If unset the value is obtained through the `site` parameter in the `api` section.
       #
       # endpoint: https://api.datadoghq.com
-      
 
 service:
   pipelines:

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -59,6 +59,9 @@ func createDefaultConfig() configmodels.Exporter {
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: "", // set during config sanitization
 			},
+			ExporterConfig: config.MetricsExporterConfig{
+				ResourceAttributesAsTags: false,
+			},
 		},
 
 		Traces: config.TracesConfig{
@@ -117,6 +120,9 @@ func createMetricsExporter(
 		exporterhelper.WithShutdown(func(context.Context) error {
 			cancel()
 			return nil
+		}),
+		exporterhelper.WithResourceToTelemetryConversion(exporterhelper.ResourceToTelemetrySettings{
+			Enabled: cfg.Metrics.ExporterConfig.ResourceAttributesAsTags,
 		}),
 	)
 }

--- a/exporter/datadogexporter/metrics_translator.go
+++ b/exporter/datadogexporter/metrics_translator.go
@@ -47,7 +47,7 @@ func mapIntMetrics(name string, slice pdata.IntDataPointSlice, attrTags []string
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
 		tags := getTags(p.LabelsMap())
-		tags = append(tags, attrTags...)	
+		tags = append(tags, attrTags...)
 		ms = append(ms, metrics.NewGauge(name, uint64(p.Timestamp()), float64(p.Value()), tags))
 	}
 	return ms

--- a/exporter/datadogexporter/metrics_translator.go
+++ b/exporter/datadogexporter/metrics_translator.go
@@ -148,7 +148,13 @@ func MapMetrics(logger *zap.Logger, cfg config.MetricsConfig, md pdata.Metrics) 
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
 
-		attributeTags := attributes.TagsFromAttributes(rm.Resource().Attributes())
+		var attributeTags []string
+
+		// Only fetch attribute tags if they're not already converted into labels.
+		// Otherwise some tags would be present twice in a metric's tag list.
+		if !cfg.ExporterConfig.ResourceAttributesAsTags {
+			attributeTags = attributes.TagsFromAttributes(rm.Resource().Attributes())
+		}
 
 		ilms := rm.InstrumentationLibraryMetrics()
 		for j := 0; j < ilms.Len(); j++ {

--- a/exporter/datadogexporter/metrics_translator.go
+++ b/exporter/datadogexporter/metrics_translator.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/attributes"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/metrics"
@@ -40,24 +41,28 @@ func getTags(labels pdata.StringMap) []string {
 }
 
 // mapIntMetrics maps int datapoints into Datadog metrics
-func mapIntMetrics(name string, slice pdata.IntDataPointSlice) []datadog.Metric {
+func mapIntMetrics(name string, slice pdata.IntDataPointSlice, attrTags []string) []datadog.Metric {
 	// Allocate assuming none are nil
 	ms := make([]datadog.Metric, 0, slice.Len())
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
-		ms = append(ms, metrics.NewGauge(name, uint64(p.Timestamp()), float64(p.Value()), getTags(p.LabelsMap())))
+		tags := getTags(p.LabelsMap())
+		tags = append(tags, attrTags...)	
+		ms = append(ms, metrics.NewGauge(name, uint64(p.Timestamp()), float64(p.Value()), tags))
 	}
 	return ms
 }
 
 // mapDoubleMetrics maps double datapoints into Datadog metrics
-func mapDoubleMetrics(name string, slice pdata.DoubleDataPointSlice) []datadog.Metric {
+func mapDoubleMetrics(name string, slice pdata.DoubleDataPointSlice, attrTags []string) []datadog.Metric {
 	// Allocate assuming none are nil
 	ms := make([]datadog.Metric, 0, slice.Len())
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
+		tags := getTags(p.LabelsMap())
+		tags = append(tags, attrTags...)
 		ms = append(ms,
-			metrics.NewGauge(name, uint64(p.Timestamp()), p.Value(), getTags(p.LabelsMap())),
+			metrics.NewGauge(name, uint64(p.Timestamp()), p.Value(), tags),
 		)
 	}
 	return ms
@@ -76,13 +81,14 @@ func mapDoubleMetrics(name string, slice pdata.DoubleDataPointSlice) []datadog.M
 // We follow a similar approach to our OpenCensus exporter:
 // we report sum and count by default; buckets count can also
 // be reported (opt-in), but bounds are ignored.
-func mapIntHistogramMetrics(name string, slice pdata.IntHistogramDataPointSlice, buckets bool) []datadog.Metric {
+func mapIntHistogramMetrics(name string, slice pdata.IntHistogramDataPointSlice, buckets bool, attrTags []string) []datadog.Metric {
 	// Allocate assuming none are nil and no buckets
 	ms := make([]datadog.Metric, 0, 2*slice.Len())
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
 		ts := uint64(p.Timestamp())
 		tags := getTags(p.LabelsMap())
+		tags = append(tags, attrTags...)
 
 		ms = append(ms,
 			metrics.NewGauge(fmt.Sprintf("%s.count", name), ts, float64(p.Count()), tags),
@@ -107,13 +113,14 @@ func mapIntHistogramMetrics(name string, slice pdata.IntHistogramDataPointSlice,
 // mapIntHistogramMetrics maps double histogram metrics slices to Datadog metrics
 //
 // see mapIntHistogramMetrics docs for further details.
-func mapDoubleHistogramMetrics(name string, slice pdata.DoubleHistogramDataPointSlice, buckets bool) []datadog.Metric {
+func mapDoubleHistogramMetrics(name string, slice pdata.DoubleHistogramDataPointSlice, buckets bool, attrTags []string) []datadog.Metric {
 	// Allocate assuming none are nil and no buckets
 	ms := make([]datadog.Metric, 0, 2*slice.Len())
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
 		ts := uint64(p.Timestamp())
 		tags := getTags(p.LabelsMap())
+		tags = append(tags, attrTags...)
 
 		ms = append(ms,
 			metrics.NewGauge(fmt.Sprintf("%s.count", name), ts, float64(p.Count()), tags),
@@ -140,6 +147,9 @@ func MapMetrics(logger *zap.Logger, cfg config.MetricsConfig, md pdata.Metrics) 
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
+
+		attributeTags := attributes.TagsFromAttributes(rm.Resource().Attributes())
+
 		ilms := rm.InstrumentationLibraryMetrics()
 		for j := 0; j < ilms.Len(); j++ {
 			ilm := ilms.At(j)
@@ -151,19 +161,19 @@ func MapMetrics(logger *zap.Logger, cfg config.MetricsConfig, md pdata.Metrics) 
 				case pdata.MetricDataTypeNone:
 					continue
 				case pdata.MetricDataTypeIntGauge:
-					datapoints = mapIntMetrics(md.Name(), md.IntGauge().DataPoints())
+					datapoints = mapIntMetrics(md.Name(), md.IntGauge().DataPoints(), attributeTags)
 				case pdata.MetricDataTypeDoubleGauge:
-					datapoints = mapDoubleMetrics(md.Name(), md.DoubleGauge().DataPoints())
+					datapoints = mapDoubleMetrics(md.Name(), md.DoubleGauge().DataPoints(), attributeTags)
 				case pdata.MetricDataTypeIntSum:
 					// Ignore aggregation temporality; report raw values
-					datapoints = mapIntMetrics(md.Name(), md.IntSum().DataPoints())
+					datapoints = mapIntMetrics(md.Name(), md.IntSum().DataPoints(), attributeTags)
 				case pdata.MetricDataTypeDoubleSum:
 					// Ignore aggregation temporality; report raw values
-					datapoints = mapDoubleMetrics(md.Name(), md.DoubleSum().DataPoints())
+					datapoints = mapDoubleMetrics(md.Name(), md.DoubleSum().DataPoints(), attributeTags)
 				case pdata.MetricDataTypeIntHistogram:
-					datapoints = mapIntHistogramMetrics(md.Name(), md.IntHistogram().DataPoints(), cfg.Buckets)
+					datapoints = mapIntHistogramMetrics(md.Name(), md.IntHistogram().DataPoints(), cfg.Buckets, attributeTags)
 				case pdata.MetricDataTypeDoubleHistogram:
-					datapoints = mapDoubleHistogramMetrics(md.Name(), md.DoubleHistogram().DataPoints(), cfg.Buckets)
+					datapoints = mapDoubleHistogramMetrics(md.Name(), md.DoubleHistogram().DataPoints(), cfg.Buckets, attributeTags)
 				}
 
 				// Try to get host from resource

--- a/exporter/datadogexporter/metrics_translator_test.go
+++ b/exporter/datadogexporter/metrics_translator_test.go
@@ -62,8 +62,14 @@ func TestMapIntMetrics(t *testing.T) {
 	point.SetTimestamp(pdata.TimestampUnixNano(ts))
 
 	assert.ElementsMatch(t,
-		mapIntMetrics("int64.test", slice),
+		mapIntMetrics("int64.test", slice, []string{}),
 		[]datadog.Metric{metrics.NewGauge("int64.test", uint64(ts), 17, []string{})},
+	)
+
+	// With attribute tags
+	assert.ElementsMatch(t,
+		mapIntMetrics("int64.test", slice, []string{"attribute_tag:attribute_value"}),
+		[]datadog.Metric{metrics.NewGauge("int64.test", uint64(ts), 17, []string{"attribute_tag:attribute_value"})},
 	)
 }
 
@@ -76,8 +82,14 @@ func TestMapDoubleMetrics(t *testing.T) {
 	point.SetTimestamp(pdata.TimestampUnixNano(ts))
 
 	assert.ElementsMatch(t,
-		mapDoubleMetrics("float64.test", slice),
+		mapDoubleMetrics("float64.test", slice, []string{}),
 		[]datadog.Metric{metrics.NewGauge("float64.test", uint64(ts), math.Pi, []string{})},
+	)
+
+	// With attribute tags
+	assert.ElementsMatch(t,
+		mapDoubleMetrics("float64.test", slice, []string{"attribute_tag:attribute_value"}),
+		[]datadog.Metric{metrics.NewGauge("float64.test", uint64(ts), math.Pi, []string{"attribute_tag:attribute_value"})},
 	)
 }
 
@@ -102,13 +114,34 @@ func TestMapIntHistogramMetrics(t *testing.T) {
 	}
 
 	assert.ElementsMatch(t,
-		mapIntHistogramMetrics("intHist.test", slice, false), // No buckets
+		mapIntHistogramMetrics("intHist.test", slice, false, []string{}), // No buckets
 		noBuckets,
 	)
 
 	assert.ElementsMatch(t,
-		mapIntHistogramMetrics("intHist.test", slice, true), // buckets
+		mapIntHistogramMetrics("intHist.test", slice, true, []string{}), // buckets
 		append(noBuckets, buckets...),
+	)
+
+	// With attribute tags
+	noBucketsAttributeTags := []datadog.Metric{
+		metrics.NewGauge("intHist.test.count", uint64(ts), 20, []string{"attribute_tag:attribute_value"}),
+		metrics.NewGauge("intHist.test.sum", uint64(ts), 200, []string{"attribute_tag:attribute_value"}),
+	}
+
+	bucketsAttributeTags := []datadog.Metric{
+		metrics.NewGauge("intHist.test.count_per_bucket", uint64(ts), 2, []string{"attribute_tag:attribute_value", "bucket_idx:0"}),
+		metrics.NewGauge("intHist.test.count_per_bucket", uint64(ts), 18, []string{"attribute_tag:attribute_value", "bucket_idx:1"}),
+	}
+
+	assert.ElementsMatch(t,
+		mapIntHistogramMetrics("intHist.test", slice, false, []string{"attribute_tag:attribute_value"}), // No buckets
+		noBucketsAttributeTags,
+	)
+
+	assert.ElementsMatch(t,
+		mapIntHistogramMetrics("intHist.test", slice, true, []string{"attribute_tag:attribute_value"}), // buckets
+		append(noBucketsAttributeTags, bucketsAttributeTags...),
 	)
 }
 
@@ -133,12 +166,33 @@ func TestMapDoubleHistogramMetrics(t *testing.T) {
 	}
 
 	assert.ElementsMatch(t,
-		mapDoubleHistogramMetrics("doubleHist.test", slice, false), // No buckets
+		mapDoubleHistogramMetrics("doubleHist.test", slice, false, []string{}), // No buckets
 		noBuckets,
 	)
 
 	assert.ElementsMatch(t,
-		mapDoubleHistogramMetrics("doubleHist.test", slice, true), // buckets
+		mapDoubleHistogramMetrics("doubleHist.test", slice, true, []string{}), // buckets
 		append(noBuckets, buckets...),
+	)
+
+	// With attribute tags
+	noBucketsAttributeTags := []datadog.Metric{
+		metrics.NewGauge("doubleHist.test.count", uint64(ts), 20, []string{"attribute_tag:attribute_value"}),
+		metrics.NewGauge("doubleHist.test.sum", uint64(ts), math.Pi, []string{"attribute_tag:attribute_value"}),
+	}
+
+	bucketsAttributeTags := []datadog.Metric{
+		metrics.NewGauge("doubleHist.test.count_per_bucket", uint64(ts), 2, []string{"attribute_tag:attribute_value", "bucket_idx:0"}),
+		metrics.NewGauge("doubleHist.test.count_per_bucket", uint64(ts), 18, []string{"attribute_tag:attribute_value", "bucket_idx:1"}),
+	}
+
+	assert.ElementsMatch(t,
+		mapDoubleHistogramMetrics("doubleHist.test", slice, false, []string{"attribute_tag:attribute_value"}), // No buckets
+		noBucketsAttributeTags,
+	)
+
+	assert.ElementsMatch(t,
+		mapDoubleHistogramMetrics("doubleHist.test", slice, true, []string{"attribute_tag:attribute_value"}), // buckets
+		append(noBucketsAttributeTags, bucketsAttributeTags...),
 	)
 }


### PR DESCRIPTION
**Description:** 

Makes the Datadog metric exporter automatically include some useful resource attributes as metric tags. For now, the attributes identifying a process and the OS type are automatically included. That list could change in the future if needed.

For instance, we detected that with the current logic (which ignored resource attributes), the `process.*` metrics sent by the `process` scrapper of the `hostmetrics` receiver weren't tagged with something that could identify the process, making these metrics less useful than they could be. This PR fixes that problem.

Moreover, a new option, `resource_attributes_as_tags`, has been added. When enabled, the `ResourceToTelemetryConversion` feature of `exporterhelper` is used to convert all resource attributes to labels (which are then converted to tags by the `MapMetrics` function). When this option is enabled, the above automatic inclusion is disabled (as its behaviour is already included in the `ResourceToTelemetryConversion`).

Users can leverage this option in conjunction with the [resource processor](https://github.com/open-telemetry/opentelemetry-collector/tree/master/processor/resourceprocessor) to customize the list of resource attributes that get translated into metric tags.

**Link to tracking Issue:** n/a

**Testing:** Unit tests were added for the attributes to tags logic.

Codecov complains because this PR modifies some lines that aren't tested, but the coverage of the component didn't really change (these lines were already not tested). We'll add tests for the `MapMetrics` function in a separate PR.

**Documentation:** The configuration example was updated to document the new `resource_attributes_as_tags` option of the metric exporter.