### PR TITLE
Change the User-Agent content order for xray and emf exporter

### DIFF
--- a/exporter/awsemfexporter/cwlog_client.go
+++ b/exporter/awsemfexporter/cwlog_client.go
@@ -182,8 +182,19 @@ func (client *cloudWatchLogClient) CreateStream(logGroup, streamName *string) (t
 }
 
 func newCollectorUserAgentHandler(startInfo component.ApplicationStartInfo) request.NamedHandler {
+	ua := fmt.Sprintf("%s/%s (%s)", collectorDistribution, startInfo.Version, startInfo.GitHash)
 	return request.NamedHandler{
 		Name: "otel.collector.UserAgentHandler",
-		Fn:   request.MakeAddToUserAgentHandler(collectorDistribution, startInfo.Version, startInfo.GitHash),
+		Fn: func(r *request.Request) {
+			prependToUserAgent(r, ua)
+		},
 	}
+}
+
+func prependToUserAgent(request *request.Request, ua string) {
+	curUA := request.HTTPRequest.UserAgent()
+	if len(curUA) > 0 {
+		ua = ua + " " + curUA
+	}
+	request.HTTPRequest.Header.Set("User-Agent", ua)
 }


### PR DESCRIPTION
**Description:** 
Change the User-Agent content order for awsxrayexporter and awsemfexporter so that we can process this data for our dashboard.

**Related PRs:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1730
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1778

**Testing:** 
Unit tests