### PR TITLE
groupbyattrsprocessor - part 2 - grouping logic (#1744)

### DIFF
--- a/processor/groupbyattrsprocessor/README.md
+++ b/processor/groupbyattrsprocessor/README.md
@@ -27,7 +27,7 @@ processors:
 
 Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using the processor.
 
-The `group_by_keys` property describes which attribute keys should be considered for grouping, if any of them is found
+The `keys` property describes which attribute keys should be considered for grouping, if any of them is found
 the grouping occurs.
 
 ## Metrics

--- a/processor/groupbyattrsprocessor/README.md
+++ b/processor/groupbyattrsprocessor/README.md
@@ -4,7 +4,9 @@ Supported pipeline types: traces, logs
 Status: in development
 
 This processor groups the records by provided attributes, extracting them from the 
-record to resource level. 
+record to resource level. When the grouped attribute key already exists at the resource-level,
+it's value is being overwritten with the record-level one. The processor also merges collections of records 
+under matching InstrumentationLibrary.
 
 Typical use-cases:
 

--- a/processor/groupbyattrsprocessor/attribute_groups.go
+++ b/processor/groupbyattrsprocessor/attribute_groups.go
@@ -1,0 +1,160 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package groupbyattrsprocessor
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+// attributeEntry keeps a grouping attributes and matching records
+type attributeEntry struct {
+	attrs         pdata.AttributeMap
+	resourceSpans pdata.ResourceSpans
+	resourceLogs  pdata.ResourceLogs
+}
+
+func instrumentationLibrariesEqual(il1, il2 pdata.InstrumentationLibrary) bool {
+	return il1.Name() == il2.Name() && il1.Version() == il2.Version()
+}
+
+// instrumentationLibrarySpans searches for a pdata.InstrumentationLibrarySpans instance matching
+// given InstrumentatonLibrary. If nothing is found, it creates a new one
+func (ae *attributeEntry) instrumentationLibrarySpans(library pdata.InstrumentationLibrary) pdata.InstrumentationLibrarySpans {
+	ilss := ae.resourceSpans.InstrumentationLibrarySpans()
+	for i := 0; i < ilss.Len(); i++ {
+		ill := ilss.At(i)
+		if instrumentationLibrariesEqual(ill.InstrumentationLibrary(), library) {
+			return ill
+		}
+	}
+
+	ilss.Resize(ilss.Len() + 1)
+	ils := ilss.At(ilss.Len() - 1)
+	library.CopyTo(ils.InstrumentationLibrary())
+	return ils
+}
+
+// instrumentationLibraryLogs searches for a pdata.InstrumentationLibraryLogs instance matching
+// given InstrumentatonLibrary. If nothing is found, it creates a new one
+func (ae *attributeEntry) instrumentationLibraryLogs(library pdata.InstrumentationLibrary) pdata.InstrumentationLibraryLogs {
+	ills := ae.resourceLogs.InstrumentationLibraryLogs()
+	for i := 0; i < ills.Len(); i++ {
+		ill := ills.At(i)
+		if instrumentationLibrariesEqual(ill.InstrumentationLibrary(), library) {
+			return ill
+		}
+	}
+
+	ills.Resize(ills.Len() + 1)
+	ill := ills.At(ills.Len() - 1)
+	library.CopyTo(ill.InstrumentationLibrary())
+	return ill
+}
+
+// attributeGroups keeps all found grouping attributes, together with the matching records
+type attributeGroups struct {
+	entries []attributeEntry
+}
+
+type logAttributeGroups struct {
+	attributeGroups
+}
+
+func newLogAttributeGroups() *logAttributeGroups {
+	return &logAttributeGroups{
+		attributeGroups{
+			entries: []attributeEntry{},
+		},
+	}
+}
+
+type spanAttributeGroups struct {
+	attributeGroups
+}
+
+func newSpanAttributeGroups() *spanAttributeGroups {
+	return &spanAttributeGroups{
+		attributeGroups{
+			entries: []attributeEntry{},
+		},
+	}
+}
+
+func (ag *attributeGroups) findAttr(attrs pdata.AttributeMap) *attributeEntry {
+	for i := 0; i < len(ag.entries); i++ {
+		if attributeMapsEqual(ag.entries[i].attrs, attrs) {
+			return &ag.entries[i]
+		}
+	}
+	return nil
+}
+
+func attributeMapsEqual(attrs1 pdata.AttributeMap, attrs2 pdata.AttributeMap) bool {
+	if attrs1.Len() != attrs2.Len() {
+		return false
+	}
+
+	matching := true
+
+	attrs1.ForEach(func(k1 string, v1 pdata.AttributeValue) {
+		if matching {
+			v2, found := attrs2.Get(k1)
+			if found {
+				if !v1.Equal(v2) {
+					matching = false
+				}
+			} else {
+				matching = false
+			}
+		}
+	})
+
+	return matching
+}
+
+// attributeEntry searches for an entry with matching attributes and returns it, if nothing is found, it is being created
+func (sag *spanAttributeGroups) attributeEntry(attrs pdata.AttributeMap, res pdata.Resource) attributeEntry {
+	entry := sag.findAttr(attrs)
+	if entry == nil {
+		entry = &attributeEntry{
+			attrs:         attrs,
+			resourceSpans: pdata.NewResourceSpans(),
+		}
+
+		res.CopyTo(entry.resourceSpans.Resource())
+		attrs.CopyTo(entry.resourceSpans.Resource().Attributes())
+
+		sag.entries = append(sag.entries, *entry)
+	}
+
+	return *entry
+}
+
+func (lag *logAttributeGroups) attributeEntry(attrs pdata.AttributeMap, res pdata.Resource) attributeEntry {
+	entry := lag.findAttr(attrs)
+	if entry == nil {
+		entry = &attributeEntry{
+			attrs:        attrs,
+			resourceLogs: pdata.NewResourceLogs(),
+		}
+
+		res.CopyTo(entry.resourceLogs.Resource())
+		attrs.CopyTo(entry.resourceLogs.Resource().Attributes())
+
+		lag.entries = append(lag.entries, *entry)
+	}
+
+	return *entry
+}

--- a/processor/groupbyattrsprocessor/attribute_groups_test.go
+++ b/processor/groupbyattrsprocessor/attribute_groups_test.go
@@ -1,0 +1,68 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package groupbyattrsprocessor
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func simpleResource() pdata.Resource {
+	rs := pdata.NewResource()
+	rs.Attributes().Insert("somekey1", pdata.NewAttributeValueString("some-string-value"))
+	rs.Attributes().Insert("somekey2", pdata.NewAttributeValueInt(123))
+	for i := 0; i < 10; i++ {
+		k := fmt.Sprint("random-", i)
+		v := fmt.Sprint("value-", rand.Intn(100))
+		rs.Attributes().Insert(k, pdata.NewAttributeValueString(v))
+	}
+	return rs
+}
+
+func randomAttributeMap() pdata.AttributeMap {
+	attrs := pdata.NewAttributeMap()
+	for i := 0; i < 10; i++ {
+		k := fmt.Sprint("key-", i)
+		v := fmt.Sprint("value-", rand.Intn(500000))
+		attrs.InsertString(k, v)
+	}
+	return attrs
+}
+
+func randomGroups(count int) []pdata.AttributeMap {
+	entries := make([]pdata.AttributeMap, count)
+	for i := 0; i < count; i++ {
+		entries[i] = randomAttributeMap()
+	}
+	return entries
+}
+
+var (
+	count    = 1000
+	groups   = randomGroups(count)
+	rs       = simpleResource()
+	lagAttrs = &logAttributeGroups{
+		attributeGroups{
+			entries: []attributeEntry{},
+		},
+	}
+)
+
+func BenchmarkAttrs(b *testing.B) {
+	lagAttrs.attributeEntry(groups[rand.Intn(count)], rs)
+}

--- a/processor/groupbyattrsprocessor/attribute_groups_test.go
+++ b/processor/groupbyattrsprocessor/attribute_groups_test.go
@@ -56,13 +56,9 @@ var (
 	count    = 1000
 	groups   = randomGroups(count)
 	rs       = simpleResource()
-	lagAttrs = &logAttributeGroups{
-		attributeGroups{
-			entries: []attributeEntry{},
-		},
-	}
+	lagAttrs = &logsGroupedByAttrs{}
 )
 
 func BenchmarkAttrs(b *testing.B) {
-	lagAttrs.attributeEntry(groups[rand.Intn(count)], rs)
+	lagAttrs.attributeGroup(groups[rand.Intn(count)], rs)
 }

--- a/processor/groupbyattrsprocessor/attribute_groups_test.go
+++ b/processor/groupbyattrsprocessor/attribute_groups_test.go
@@ -60,5 +60,5 @@ var (
 )
 
 func BenchmarkAttrs(b *testing.B) {
-	lagAttrs.attributeGroup(groups[rand.Intn(count)], rs)
+	lagAttrs.attributeGroup(rs, groups[rand.Intn(count)])
 }

--- a/processor/groupbyattrsprocessor/factory.go
+++ b/processor/groupbyattrsprocessor/factory.go
@@ -59,7 +59,7 @@ func createDefaultConfig() configmodels.Processor {
 	}
 }
 
-func createGroupByAttrsProcessor(logger *zap.Logger, attributes []string) (*groupbyattrsprocessor, error) {
+func createGroupByAttrsProcessor(logger *zap.Logger, attributes []string) (*groupByAttrsProcessor, error) {
 	var nonEmptyAttributes []string
 	presentAttributes := make(map[string]struct{})
 
@@ -79,7 +79,7 @@ func createGroupByAttrsProcessor(logger *zap.Logger, attributes []string) (*grou
 		return nil, errAtLeastOneAttributeNeeded
 	}
 
-	return &groupbyattrsprocessor{logger: logger, groupByKeys: nonEmptyAttributes}, nil
+	return &groupByAttrsProcessor{logger: logger, groupByKeys: nonEmptyAttributes}, nil
 }
 
 // createTraceProcessor creates a trace processor based on this config.

--- a/processor/groupbyattrsprocessor/processor.go
+++ b/processor/groupbyattrsprocessor/processor.go
@@ -28,13 +28,111 @@ type groupbyattrsprocessor struct {
 
 // ProcessTraces process traces and groups traces by attribute.
 func (gap *groupbyattrsprocessor) ProcessTraces(_ context.Context, td pdata.Traces) (pdata.Traces, error) {
-	// TODO
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		rs := rss.At(i)
+
+		extractedResourceSpans := newSpanAttributeGroups()
+
+		ilss := rs.InstrumentationLibrarySpans()
+		for j := 0; j < ilss.Len(); j++ {
+			ils := ilss.At(j)
+			for k := 0; k < ils.Spans().Len(); k++ {
+				span := ils.Spans().At(k)
+
+				groupedAnything, groupedAttrMap, nonGroupedAttrMap := gap.splitAttrMap(span.Attributes())
+				if groupedAnything {
+					mNumGroupedSpans.M(1)
+					overwriteAttributes(nonGroupedAttrMap, span.Attributes())
+				} else {
+					mNumNonGroupedSpans.M(1)
+				}
+
+				entry := extractedResourceSpans.attributeEntry(groupedAttrMap, rs.Resource())
+				entry.instrumentationLibrarySpans(ils.InstrumentationLibrary()).Spans().Append(span)
+			}
+		}
+
+		for _, ers := range extractedResourceSpans.entries {
+			ers.resourceSpans.CopyTo(rs)
+		}
+		mDistSpanGroups.M(int64(len(extractedResourceSpans.entries)))
+	}
 
 	return td, nil
 }
 
 func (gap *groupbyattrsprocessor) ProcessLogs(_ context.Context, ld pdata.Logs) (pdata.Logs, error) {
-	// TODO
+	rl := ld.ResourceLogs()
+
+	for i := 0; i < rl.Len(); i++ {
+		ls := rl.At(i)
+
+		extractedResourceLogs := newLogAttributeGroups()
+
+		ills := ls.InstrumentationLibraryLogs()
+		for j := 0; j < ills.Len(); j++ {
+			ill := ills.At(j)
+			for k := 0; k < ill.Logs().Len(); k++ {
+				log := ill.Logs().At(k)
+
+				groupedAnything, groupedAttrMap, nonGroupedAttrMap := gap.splitAttrMap(log.Attributes())
+				if groupedAnything {
+					mNumGroupedLogs.M(1)
+					overwriteAttributes(nonGroupedAttrMap, log.Attributes())
+				} else {
+					mNumNonGroupedLogs.M(1)
+				}
+
+				entry := extractedResourceLogs.attributeEntry(groupedAttrMap, ls.Resource())
+				entry.instrumentationLibraryLogs(ill.InstrumentationLibrary()).Logs().Append(log)
+			}
+		}
+
+		for _, erl := range extractedResourceLogs.entries {
+			erl.resourceLogs.CopyTo(ls)
+		}
+		mDistLogGroups.M(int64(len(extractedResourceLogs.entries)))
+	}
 
 	return ld, nil
+}
+
+func overwriteAttributes(selectedAttrs, targetAttrs pdata.AttributeMap) {
+	targetAttrs.InitEmptyWithCapacity(selectedAttrs.Len())
+	selectedAttrs.CopyTo(targetAttrs)
+}
+
+// splitAttrMap splits the AttributeMap by groupByKeys and returns three-tuple:
+//  - the first element indicates if anything was matched (true) or nothing (false)
+//  - the second element contains groupByKeys that did not match the keys
+//  - the third element contains groupByKeys that match given keys
+func (gap *groupbyattrsprocessor) splitAttrMap(attrMap pdata.AttributeMap) (bool, pdata.AttributeMap, pdata.AttributeMap) {
+	groupedAttrMap := pdata.NewAttributeMap()
+	nonGroupedAttrMap := pdata.NewAttributeMap()
+
+	groupedAnything := false
+
+	for _, attrKey := range gap.groupByKeys {
+		attrVal, found := attrMap.Get(attrKey)
+		if found {
+			groupedAttrMap.Insert(attrKey, attrVal)
+			groupedAnything = true
+		}
+	}
+
+	if !groupedAnything {
+		return groupedAnything, groupedAttrMap, attrMap
+	}
+
+	groupedAttrMap.Sort()
+
+	attrMap.ForEach(func(k string, v pdata.AttributeValue) {
+		_, selected := groupedAttrMap.Get(k)
+		if !selected {
+			nonGroupedAttrMap.Insert(k, v)
+		}
+	})
+
+	return groupedAnything, groupedAttrMap, nonGroupedAttrMap
 }

--- a/processor/groupbyattrsprocessor/processor.go
+++ b/processor/groupbyattrsprocessor/processor.go
@@ -43,7 +43,7 @@ func (gap *groupByAttrsProcessor) ProcessTraces(_ context.Context, td pdata.Trac
 				groupedAnything, groupedAttrMap := gap.splitAttrMap(span.Attributes())
 				if groupedAnything {
 					mNumGroupedSpans.M(1)
-					// Some attributes are going to be moved from log record to resource level,
+					// Some attributes are going to be moved from span to resource level,
 					// so we can delete those on the record level
 					deleteAttributes(groupedAttrMap, span.Attributes())
 				} else {

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -1,0 +1,186 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package groupbyattrsprocessor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+var (
+	attrMap = prepareAttributeMap()
+)
+
+func prepareAttributeMap() pdata.AttributeMap {
+	attributeValues := map[string]pdata.AttributeValue{
+		"xx": pdata.NewAttributeValueString("aa"),
+		"yy": pdata.NewAttributeValueInt(11),
+	}
+
+	am := pdata.NewAttributeMap()
+	am.InitFromMap(attributeValues)
+
+	am.Sort()
+	return am
+}
+
+func prepareResource(attrMap pdata.AttributeMap, selectedKeys []string) pdata.Resource {
+	res := pdata.NewResource()
+	for _, key := range selectedKeys {
+		val, found := attrMap.Get(key)
+		if found {
+			res.Attributes().Insert(key, val)
+		}
+	}
+	res.Attributes().Sort()
+	return res
+}
+
+func filterAttributeMap(attrMap pdata.AttributeMap, selectedKeys []string) pdata.AttributeMap {
+	filteredAttrMap := pdata.NewAttributeMap()
+	for _, key := range selectedKeys {
+		val, _ := attrMap.Get(key)
+		filteredAttrMap.Insert(key, val)
+	}
+	filteredAttrMap.Sort()
+	return filteredAttrMap
+}
+
+func TestAttributeGrouping(t *testing.T) {
+	tests := []struct {
+		name           string
+		groupByKeys    []string
+		nonGroupedKeys []string
+		count          int
+	}{
+		{
+			name:           "Two groupByKeys",
+			groupByKeys:    []string{"xx", "yy"},
+			nonGroupedKeys: []string{},
+			count:          4,
+		},
+		{
+			name:           "One attribute",
+			groupByKeys:    []string{"xx"},
+			nonGroupedKeys: []string{"yy"},
+			count:          4,
+		},
+		{
+			name:           "No groupByKeys",
+			groupByKeys:    []string{"zz"},
+			nonGroupedKeys: []string{"xx", "yy"},
+			count:          4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := someLogs(attrMap, tt.count)
+			spans := someSpans(attrMap, tt.count)
+
+			gap, err := createGroupByAttrsProcessor(logger, tt.groupByKeys)
+			require.NoError(t, err)
+
+			expectedResource := prepareResource(attrMap, tt.groupByKeys)
+			expectedAttributes := filterAttributeMap(attrMap, tt.nonGroupedKeys)
+
+			processedLogs, err := gap.ProcessLogs(context.Background(), logs)
+			assert.NoError(t, err)
+
+			processedSpans, err := gap.ProcessTraces(context.Background(), spans)
+			assert.NoError(t, err)
+
+			assert.Equal(t, 1, processedLogs.ResourceLogs().Len())
+			assert.Equal(t, 1, processedSpans.ResourceSpans().Len())
+
+			resources := []pdata.Resource{
+				processedLogs.ResourceLogs().At(0).Resource(),
+				processedSpans.ResourceSpans().At(0).Resource(),
+			}
+
+			for _, res := range resources {
+				res.Attributes().Sort()
+				assert.Equal(t, expectedResource, res)
+			}
+
+			ills := processedLogs.ResourceLogs().At(0).InstrumentationLibraryLogs()
+			ilss := processedSpans.ResourceSpans().At(0).InstrumentationLibrarySpans()
+
+			assert.Equal(t, 1, ills.Len())
+			assert.Equal(t, 1, ilss.Len())
+
+			ls := ills.At(0).Logs()
+			ss := ilss.At(0).Spans()
+			assert.Equal(t, tt.count, ls.Len())
+			assert.Equal(t, tt.count, ss.Len())
+
+			for i := 0; i < ls.Len(); i++ {
+				log := ls.At(i)
+				span := ss.At(i)
+
+				log.Attributes().Sort()
+				span.Attributes().Sort()
+
+				assert.Equal(t, expectedAttributes, log.Attributes())
+				assert.Equal(t, expectedAttributes, span.Attributes())
+			}
+		})
+	}
+}
+
+func someSpans(attrs pdata.AttributeMap, count int) pdata.Traces {
+	ils := pdata.NewInstrumentationLibrarySpans()
+
+	for i := 0; i < count; i++ {
+		span := pdata.NewSpan()
+		span.SetName(fmt.Sprint("foo-", i))
+		attrs.CopyTo(span.Attributes())
+
+		ils.Spans().Append(span)
+	}
+
+	rs := pdata.NewResourceSpans()
+	rs.InstrumentationLibrarySpans().Append(ils)
+
+	traces := pdata.NewTraces()
+	traces.ResourceSpans().Append(rs)
+
+	return traces
+}
+
+func someLogs(attrs pdata.AttributeMap, count int) pdata.Logs {
+	ill := pdata.NewInstrumentationLibraryLogs()
+
+	for i := 0; i < count; i++ {
+		log := pdata.NewLogRecord()
+		log.SetName(fmt.Sprint("foo-", i))
+		attrs.CopyTo(log.Attributes())
+
+		ill.Logs().Append(log)
+	}
+
+	rl := pdata.NewResourceLogs()
+	rl.InstrumentationLibraryLogs().Append(ill)
+
+	logs := pdata.NewLogs()
+	logs.ResourceLogs().Append(rl)
+
+	return logs
+}

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -55,6 +55,7 @@ func prepareResource(attrMap pdata.AttributeMap, selectedKeys []string) pdata.Re
 
 func filterAttributeMap(attrMap pdata.AttributeMap, selectedKeys []string) pdata.AttributeMap {
 	filteredAttrMap := pdata.NewAttributeMap()
+	filteredAttrMap.InitEmptyWithCapacity(10)
 	for _, key := range selectedKeys {
 		val, _ := attrMap.Get(key)
 		filteredAttrMap.Insert(key, val)
@@ -138,8 +139,8 @@ func TestAttributeGrouping(t *testing.T) {
 				log.Attributes().Sort()
 				span.Attributes().Sort()
 
-				assert.Equal(t, expectedAttributes, log.Attributes())
-				assert.Equal(t, expectedAttributes, span.Attributes())
+				assert.EqualValues(t, expectedAttributes, log.Attributes())
+				assert.EqualValues(t, expectedAttributes, span.Attributes())
 			}
 		})
 	}

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -142,7 +142,7 @@ func TestComplexAttributeGrouping(t *testing.T) {
 		outputTotalRecordsCount           int // Per each Instrumentation Library
 	}{
 		{
-			name:                             "With no unique Resource-level attributes",
+			name:                             "With not unique Resource-level attributes",
 			withResourceAttrIndex:            false,
 			inputResourceCount:               4,
 			inputInstrumentationLibraryCount: 4,
@@ -156,7 +156,7 @@ func TestComplexAttributeGrouping(t *testing.T) {
 			withResourceAttrIndex:            true,
 			inputResourceCount:               4,
 			inputInstrumentationLibraryCount: 4,
-			// Since each resource has unique attribute value, they cannot be joined together into one
+			// Since each resource has a unique attribute value, so they cannot be joined together into one
 			outputResourceCount:               4,
 			outputInstrumentationLibraryCount: 1,
 			outputTotalRecordsCount:           16,


### PR DESCRIPTION
**Description:**

Introduces  processor for grouping the trace or log records by specified key values, and then extracting the attributes from the record to resource level.

This initiative is broken down into 3 separate PRs:

1. [Config](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1744) (already merged)

👉  2. The processor logic (this PR)

3. Enabling the component

_Example: consider having such input:_

```
InstrumentationLibraryLogs #0
LogRecord #0
Timestamp: 1606158664897894000
Severity:
ShortName:
Body: STRING("foo")
Attributes:
     -> action: STRING(login)
     -> namespace_name: STRING(kube-apiserver-docker-desktop)
     -> pod_name: STRING(kube-system)
```

With following config:

```
groupbyattrs:
  group_by_keys:
    - pod_name
    - namespace_name
```

The output is going to be:

```
Resource labels:
     -> namespace_name: STRING(kube-apiserver-docker-desktop)
     -> pod_name: STRING(kube-system)
InstrumentationLibraryLogs #0
LogRecord #0
Timestamp: 1606158617133076000
Severity:
ShortName:
Body: STRING("foo")
Attributes:
     -> action: STRING(login)
```

Since this is a first iteration of the processor and it generally applies for logs workflow with Kubernetes tagging (the attributes need to move from the record to the resource level) - the processor is introduced into opentelemetry-collector-contrib rather than the core repo.

**Link to tracking Issue:** [#1884] open-telemetry/opentelemetry-collector#1884

**Testing:** Unit tests added, manual tests performed

**Documentation:** Processor README.md included