### PR TITLE
[datadogexporter] Improve logging of hostname detection

### DIFF
--- a/exporter/datadogexporter/metadata/ec2/ec2.go
+++ b/exporter/datadogexporter/metadata/ec2/ec2.go
@@ -54,7 +54,7 @@ func GetHostInfo(logger *zap.Logger) (hostInfo *HostInfo) {
 	meta := ec2metadata.New(sess)
 
 	if !meta.Available() {
-		logger.Info("EC2 Metadata not available")
+		logger.Debug("EC2 Metadata not available")
 		return
 	}
 

--- a/exporter/datadogexporter/metadata/metadata.go
+++ b/exporter/datadogexporter/metadata/metadata.go
@@ -120,8 +120,7 @@ func pushMetadata(cfg *config.Config, startInfo component.ApplicationStartInfo, 
 
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf(
-			"'%d - %s' error when sending metadata payload to %s",
-			resp.StatusCode,
+			"'%s' error when sending metadata payload to %s",
 			resp.Status,
 			path,
 		)

--- a/exporter/datadogexporter/metadata/system/host.go
+++ b/exporter/datadogexporter/metadata/system/host.go
@@ -18,6 +18,8 @@ import (
 	"os"
 
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/metadata/valid"
 )
 
 type HostInfo struct {
@@ -42,4 +44,17 @@ func GetHostInfo(logger *zap.Logger) (hostInfo *HostInfo) {
 	}
 
 	return
+}
+
+// GetHostname gets the hostname provided by the system
+func (hi *HostInfo) GetHostname(logger *zap.Logger) string {
+	if hi.FQDN == "" {
+		// Don't report failure since FQDN was just not available
+		return hi.OS
+	} else if err := valid.Hostname(hi.FQDN); err != nil {
+		logger.Info("FQDN is not valid", zap.Error(err))
+		return hi.OS
+	}
+
+	return hi.FQDN
 }

--- a/exporter/datadogexporter/metadata/system/host_test.go
+++ b/exporter/datadogexporter/metadata/system/host_test.go
@@ -33,3 +33,25 @@ func TestGetHostInfo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, hostInfo.OS, osHostname)
 }
+
+func TestGetHostname(t *testing.T) {
+	logger := zap.NewNop()
+
+	hostInfoAll := &HostInfo{
+		FQDN: "fqdn",
+		OS:   "os",
+	}
+	assert.Equal(t, hostInfoAll.GetHostname(logger), "fqdn")
+
+	hostInfoInvalid := &HostInfo{
+		FQDN: "fqdn_invalid",
+		OS:   "os",
+	}
+	assert.Equal(t, hostInfoInvalid.GetHostname(logger), "os")
+
+	hostInfoMissingFQDN := &HostInfo{
+		OS: "os",
+	}
+	assert.Equal(t, hostInfoMissingFQDN.GetHostname(logger), "os")
+
+}

--- a/exporter/datadogexporter/metadata/system/host_unix.go
+++ b/exporter/datadogexporter/metadata/system/host_unix.go
@@ -17,6 +17,7 @@ package system
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -26,6 +27,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/metadata/valid"
 )
 
+const hostnamePath = "/bin/hostname"
+
 func getSystemFQDN() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
 	defer cancel()
@@ -33,14 +36,21 @@ func getSystemFQDN() (string, error) {
 	// Go does not provide a way to get the full hostname
 	// so we make a best-effort by running the hostname binary
 	// if available
-	cmd := exec.CommandContext(ctx, "/bin/hostname", "-f")
+	if _, err := os.Stat(hostnamePath); err == nil {
+		cmd := exec.CommandContext(ctx, hostnamePath, "-f")
+		out, err := cmd.Output()
+		return strings.TrimSpace(string(out)), err
+	}
 
-	out, err := cmd.Output()
-	return strings.TrimSpace(string(out)), err
+	// if stat failed for any reason, fail silently
+	return "", nil
 }
 
 func (hi *HostInfo) GetHostname(logger *zap.Logger) string {
-	if err := valid.Hostname(hi.FQDN); err != nil {
+	if hi.FQDN == "" {
+		// Don't report failure since FQDN was just not available
+		return hi.OS
+	} else if err := valid.Hostname(hi.FQDN); err != nil {
 		logger.Info("FQDN is not valid", zap.Error(err))
 		return hi.OS
 	}

--- a/exporter/datadogexporter/metadata/system/host_unix_test.go
+++ b/exporter/datadogexporter/metadata/system/host_unix_test.go
@@ -16,28 +16,15 @@
 package system
 
 import (
-	"context"
-	"os"
-	"os/exec"
-	"strings"
-	"time"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// keep as var for testing
-var hostnamePath string = "/bin/hostname"
+func TestGetSystemFQDN(t *testing.T) {
+	hostnamePath = "/nonexistent"
+	_, err := getSystemFQDN()
 
-func getSystemFQDN() (string, error) {
-	// Go does not provide a way to get the full hostname
-	// so we make a best-effort by running the hostname binary
-	// if available
-	if _, err := os.Stat(hostnamePath); err == nil {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*1)
-		defer cancel()
-		cmd := exec.CommandContext(ctx, hostnamePath, "-f")
-		out, err := cmd.Output()
-		return strings.TrimSpace(string(out)), err
-	}
-
-	// if stat failed for any reason, fail silently
-	return "", nil
+	// Fail silently when not available
+	require.NoError(t, err)
 }

--- a/exporter/datadogexporter/metadata/system/host_windows.go
+++ b/exporter/datadogexporter/metadata/system/host_windows.go
@@ -16,15 +16,9 @@
 
 package system
 
-import "go.uber.org/zap"
-
 func getSystemFQDN() (string, error) {
 	// The Datadog Agent uses CGo to get the FQDN of the host
 	// OpenTelemetry does not allow the use of CGo so this feature
 	// is disabled on Windows
 	return "", nil
-}
-
-func (hi *HostInfo) GetHostname(logger *zap.Logger) string {
-	return hi.OS
 }


### PR DESCRIPTION
**Description:** 

For compatibility reasons with the Datadog Agent the Datadog exporter fetches a series of hostnames from different sources and sends them as metadata. Some of the logging related to this was confusing to some users. This PR:

- removes warning about FQDN hostname on Docker (and other container-like platforms),
- lowers EC2 metadata availability to debug messages to avoid confusion and
- improves error message when sending metadata.

**Link to tracking Issue:** n/a, reported to Datadog

**Testing:** Added some new unit tests. Tested in e2e environment.
