### PR TITLE
loadbalancingexporter: narrow down critical area of ConsumeTraces

### DIFF
--- a/exporter/loadbalancingexporter/exporter.go
+++ b/exporter/loadbalancingexporter/exporter.go
@@ -190,9 +190,6 @@ func (e *exporterImp) Shutdown(context.Context) error {
 }
 
 func (e *exporterImp) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
-	e.updateLock.RLock()
-	defer e.updateLock.RUnlock()
-
 	var errors []error
 	batches := batchpertrace.Split(td)
 	for _, batch := range batches {
@@ -210,8 +207,13 @@ func (e *exporterImp) consumeTrace(ctx context.Context, td pdata.Traces) error {
 		return errNoTracesInBatch
 	}
 
+	// NOTE: make rolling updates of next tier of collectors work. currently this may cause
+	// data loss because the latest batches sent to outdated backend will never find their way out.
+	// for details: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1690
+	e.updateLock.RLock()
 	endpoint := e.ring.endpointFor(traceID)
 	exp, found := e.exporters[endpoint]
+	e.updateLock.RUnlock()
 	if !found {
 		// something is really wrong... how come we couldn't find the exporter??
 		return fmt.Errorf("couldn't find the exporter for the endpoint %q", endpoint)

--- a/exporter/loadbalancingexporter/exporter_test.go
+++ b/exporter/loadbalancingexporter/exporter_test.go
@@ -531,7 +531,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	// prepare
 
 	// simulate rolling updates, the dns resolver should resolve in the following order
-	// ["127.0.0.1"] -> ["127.0.0.1", "127.0.0.2"] -> ["127.0.0.1"]
+	// ["127.0.0.1"] -> ["127.0.0.1", "127.0.0.2"] -> ["127.0.0.2"]
 	res, err := newDNSResolver(zap.NewNop(), "service-1", "")
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Description:**

quick fix on the problem that rolling updates of next tier collectors will stop dns resolver from periodical checking.

**Link to tracking Issue:** 

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1690

**Testing:**

Add a test simulate rolling updates.

**Documentation:**

None