### PR TITLE
Log error when translating span.

### DIFF
--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -61,6 +61,7 @@ func newTraceExporter(
 						document, localErr := translator.MakeSegmentDocumentString(spans.At(k), resource,
 							config.(*Config).IndexedAttributes, config.(*Config).IndexAllAttributes)
 						if localErr != nil {
+							logger.Debug("Error translating span.", zap.Error(localErr))
 							totalDroppedSpans++
 							continue
 						}


### PR DESCRIPTION
**Description:** A translation error is usually a bug in instrumentation or configuration, not a transient error. We need a log message to find it.

**Link to tracking Issue:** #1646 

**Testing:** Unit tests