### PR TITLE
signalfxexporter: Update CPU metric translations

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -180,7 +180,7 @@ func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
 
 	// Validate that default translation rules are loaded
 	// Expected values has to be updated once default config changed
-	assert.Equal(t, 51, len(config.TranslationRules))
+	assert.Equal(t, 59, len(config.TranslationRules))
 	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
 	assert.Equal(t, 33, len(config.TranslationRules[0].Mapping))
 }

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -331,7 +331,48 @@ translation_rules:
 - action: aggregate_metric
   metric_name: cpu.num_processors
   aggregation_method: count
-  without_dimensions: 
+  without_dimensions:
+  - cpu
+
+- action: aggregate_metric
+  metric_name: cpu.idle
+  aggregation_method: sum
+  without_dimensions:
+  - cpu
+- action: aggregate_metric
+  metric_name: cpu.interrupt
+  aggregation_method: sum
+  without_dimensions:
+  - cpu
+- action: aggregate_metric
+  metric_name: cpu.system
+  aggregation_method: sum
+  without_dimensions:
+  - cpu
+- action: aggregate_metric
+  metric_name: cpu.user
+  aggregation_method: sum
+  without_dimensions:
+  - cpu
+- action: aggregate_metric
+  metric_name: cpu.steal
+  aggregation_method: sum
+  without_dimensions:
+  - cpu
+- action: aggregate_metric
+  metric_name: cpu.wait
+  aggregation_method: sum
+  without_dimensions:
+  - cpu
+- action: aggregate_metric
+  metric_name: cpu.softirq
+  aggregation_method: sum
+  without_dimensions:
+  - cpu
+- action: aggregate_metric
+  metric_name: cpu.nice
+  aggregation_method: sum
+  without_dimensions:
   - cpu
 
 # compute memory.total
@@ -347,7 +388,7 @@ translation_rules:
 - action: aggregate_metric
   metric_name: memory.total
   aggregation_method: sum
-  without_dimensions: 
+  without_dimensions:
   - state
 
 # convert memory metrics
@@ -501,7 +542,7 @@ translation_rules:
 - action: aggregate_metric
   metric_name: network.total
   aggregation_method: sum
-  without_dimensions: 
+  without_dimensions:
   - direction
   - interface
 - action: split_metric


### PR DESCRIPTION
**Description:** Add translation rules to aggregate per core CPU metrics in default translations.

**Testing:** Update tests.