### PR TITLE
Log metric lines rejected by Dynatrace

### DIFF
--- a/exporter/dynatraceexporter/metrics_exporter.go
+++ b/exporter/dynatraceexporter/metrics_exporter.go
@@ -172,7 +172,9 @@ func (e *exporter) send(ctx context.Context, lines []string) (int, error) {
 
 		for _, line := range responseBody.Error.InvalidLines {
 			// Enabled debug logging to see which lines were dropped
-			e.logger.Debug(fmt.Sprintf("line %3d %s %s", line.Line, line.Error, lines[line.Line]))
+			if line.Line >= 0 && line.Line < len(lines) {
+				e.logger.Debug(fmt.Sprintf("rejected line %3d: [%s] %s", line.Line, line.Error, lines[line.Line]))
+			}
 		}
 
 		return responseBody.Invalid, nil

--- a/exporter/dynatraceexporter/metrics_exporter.go
+++ b/exporter/dynatraceexporter/metrics_exporter.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -61,15 +62,15 @@ func (e *exporter) PushMetricsData(ctx context.Context, md pdata.Metrics) (int, 
 		return md.MetricCount(), nil
 	}
 
-	request, dropped := e.serializeMetrics(md)
+	lines, dropped := e.serializeMetrics(md)
 
 	// If request is empty string, there are no serializable metrics in the batch.
 	// This can happen if all metric names are invalid
-	if request == "" {
+	if len(lines) == 0 {
 		return md.MetricCount(), nil
 	}
 
-	droppedByCluster, err := e.send(ctx, request)
+	droppedByCluster, err := e.send(ctx, lines)
 
 	if err != nil {
 		return md.MetricCount(), err
@@ -78,8 +79,8 @@ func (e *exporter) PushMetricsData(ctx context.Context, md pdata.Metrics) (int, 
 	return dropped + droppedByCluster, nil
 }
 
-func (e *exporter) serializeMetrics(md pdata.Metrics) (string, int) {
-	output := ""
+func (e *exporter) serializeMetrics(md pdata.Metrics) ([]string, int) {
+	lines := make([]string, 0)
 	dropped := 0
 
 	resourceMetrics := md.ResourceMetrics()
@@ -105,29 +106,30 @@ func (e *exporter) serializeMetrics(md pdata.Metrics) (string, int) {
 				case pdata.MetricDataTypeNone:
 					continue
 				case pdata.MetricDataTypeIntGauge:
-					output += serialization.SerializeIntDataPoints(name, metric.IntGauge().DataPoints(), e.cfg.Tags)
+					lines = append(lines, serialization.SerializeIntDataPoints(name, metric.IntGauge().DataPoints(), e.cfg.Tags))
 				case pdata.MetricDataTypeDoubleGauge:
-					output += serialization.SerializeDoubleDataPoints(name, metric.DoubleGauge().DataPoints(), e.cfg.Tags)
+					lines = append(lines, serialization.SerializeDoubleDataPoints(name, metric.DoubleGauge().DataPoints(), e.cfg.Tags))
 				case pdata.MetricDataTypeIntSum:
-					output += serialization.SerializeIntDataPoints(name, metric.IntSum().DataPoints(), e.cfg.Tags)
+					lines = append(lines, serialization.SerializeIntDataPoints(name, metric.IntSum().DataPoints(), e.cfg.Tags))
 				case pdata.MetricDataTypeDoubleSum:
-					output += serialization.SerializeDoubleDataPoints(name, metric.DoubleSum().DataPoints(), e.cfg.Tags)
+					lines = append(lines, serialization.SerializeDoubleDataPoints(name, metric.DoubleSum().DataPoints(), e.cfg.Tags))
 				case pdata.MetricDataTypeIntHistogram:
-					output += serialization.SerializeIntHistogramMetrics(name, metric.IntHistogram().DataPoints(), e.cfg.Tags)
+					lines = append(lines, serialization.SerializeIntHistogramMetrics(name, metric.IntHistogram().DataPoints(), e.cfg.Tags))
 				case pdata.MetricDataTypeDoubleHistogram:
-					output += serialization.SerializeDoubleHistogramMetrics(name, metric.DoubleHistogram().DataPoints(), e.cfg.Tags)
+					lines = append(lines, serialization.SerializeDoubleHistogramMetrics(name, metric.DoubleHistogram().DataPoints(), e.cfg.Tags))
 				}
 			}
 		}
 	}
 
-	return output, dropped
+	return lines, dropped
 }
 
 // send sends a serialized metric batch to Dynatrace.
 // Returns the number of lines rejected by Dynatrace.
 // An error indicates all lines were dropped regardless of the returned number.
-func (e *exporter) send(ctx context.Context, message string) (int, error) {
+func (e *exporter) send(ctx context.Context, lines []string) (int, error) {
+	message := strings.Join(lines, "\n")
 	e.logger.Debug("Sending lines to Dynatrace\n" + message)
 	req, err := http.NewRequestWithContext(ctx, "POST", e.cfg.Endpoint, bytes.NewBufferString(message))
 	if err != nil {
@@ -164,12 +166,16 @@ func (e *exporter) send(ctx context.Context, message string) (int, error) {
 		e.logger.Debug(fmt.Sprintf("Accepted %d lines", responseBody.Ok))
 		e.logger.Error(fmt.Sprintf("Rejected %d lines", responseBody.Invalid))
 
-		if responseBody.Error != "" {
-			e.logger.Error(fmt.Sprintf("Error from Dynatrace: %s", responseBody.Error))
+		if responseBody.Error.Message != "" {
+			e.logger.Error(fmt.Sprintf("Error from Dynatrace: %s", responseBody.Error.Message))
+		}
+
+		for _, line := range responseBody.Error.InvalidLines {
+			// Enabled debug logging to see which lines were dropped
+			e.logger.Debug(fmt.Sprintf("line %3d %s %s", line.Line, line.Error, lines[line.Line]))
 		}
 
 		return responseBody.Invalid, nil
-
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
@@ -209,7 +215,18 @@ func normalizeMetricName(prefix, name string) (string, error) {
 
 // Response from Dynatrace is expected to be in JSON format
 type metricsResponse struct {
-	Ok      int    `json:"linesOk"`
-	Invalid int    `json:"linesInvalid"`
-	Error   string `json:"error"`
+	Ok      int                  `json:"linesOk"`
+	Invalid int                  `json:"linesInvalid"`
+	Error   metricsResponseError `json:"error"`
+}
+
+type metricsResponseError struct {
+	Code         string                            `json:"code"`
+	Message      string                            `json:"message"`
+	InvalidLines []metricsResponseErrorInvalidLine `json:"invalidLines"`
+}
+
+type metricsResponseErrorInvalidLine struct {
+	Line  int    `json:"line"`
+	Error string `json:"error"`
 }

--- a/exporter/dynatraceexporter/metrics_exporter_test.go
+++ b/exporter/dynatraceexporter/metrics_exporter_test.go
@@ -176,7 +176,7 @@ func Test_exporter_PushMetricsData(t *testing.T) {
 		}
 	})
 
-	if wantBody := "prefix.int_gauge 10 100\nprefix.int_sum 10 100\nprefix.double_histogram gauge,min=9.5,max=9.5,sum=19,count=2 100\nprefix.double_gauge 10.1 100\nprefix.double_sum 10.1 100\nprefix.double_histogram gauge,min=5.05,max=5.05,sum=10.1,count=2 100\n"; sent != wantBody {
+	if wantBody := "prefix.int_gauge 10 100\nprefix.int_sum 10 100\nprefix.double_histogram gauge,min=9.5,max=9.5,sum=19,count=2 100\nprefix.double_gauge 10.1 100\nprefix.double_sum 10.1 100\nprefix.double_histogram gauge,min=5.05,max=5.05,sum=10.1,count=2 100"; sent != wantBody {
 		t.Errorf("exporter.PushMetricsData():ResponseBody = %v, want %v", sent, wantBody)
 	}
 }
@@ -281,7 +281,7 @@ func Test_exporter_send_BadRequest(t *testing.T) {
 		},
 		client: ts.Client(),
 	}
-	invalid, err := e.send(context.Background(), "")
+	invalid, err := e.send(context.Background(), []string{})
 	if invalid != 10 {
 		t.Errorf("Expected 10 lines to be reported invalid")
 		return
@@ -310,7 +310,7 @@ func Test_exporter_send_Unauthorized(t *testing.T) {
 		},
 		client: ts.Client(),
 	}
-	_, err := e.send(context.Background(), "")
+	_, err := e.send(context.Background(), []string{})
 	if !consumererror.IsPermanent(err) {
 		t.Errorf("Expected error to be permanent %v", err)
 		return
@@ -335,7 +335,7 @@ func Test_exporter_send_TooLarge(t *testing.T) {
 		},
 		client: ts.Client(),
 	}
-	_, err := e.send(context.Background(), "")
+	_, err := e.send(context.Background(), []string{})
 	if !consumererror.IsPermanent(err) {
 		t.Errorf("Expected error to be permanent %v", err)
 		return
@@ -363,7 +363,7 @@ func Test_exporter_send_NotFound(t *testing.T) {
 		},
 		client: ts.Client(),
 	}
-	_, err := e.send(context.Background(), "")
+	_, err := e.send(context.Background(), []string{})
 	if !consumererror.IsPermanent(err) {
 		t.Errorf("Expected error to be permanent %v", err)
 		return

--- a/exporter/dynatraceexporter/serialization/serialization.go
+++ b/exporter/dynatraceexporter/serialization/serialization.go
@@ -115,7 +115,7 @@ func serializeLine(name, tagline, valueline string, timestamp pdata.TimestampUni
 
 	tsMilli := timestamp / 1_000_000
 
-	output += " " + valueline + " " + strconv.FormatUint(uint64(tsMilli), 10) + "\n"
+	output += " " + valueline + " " + strconv.FormatUint(uint64(tsMilli), 10)
 
 	return output
 }

--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -52,7 +52,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: intSlice,
 				tags: []string{},
 			},
-			want: "my_int_gauge 13 100\n",
+			want: "my_int_gauge 13 100",
 		},
 		{
 			name: "Serialize integer data points with tags",
@@ -61,7 +61,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: intSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: "my_int_gauge_with_tags,test_key=testval 13 100\n",
+			want: "my_int_gauge_with_tags,test_key=testval 13 100",
 		},
 		{
 			name: "Serialize integer data points with labels",
@@ -70,7 +70,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: labelIntSlice,
 				tags: []string{},
 			},
-			want: "my_int_gauge_with_labels,labelkey=\"labelValue\" 13 100\n",
+			want: "my_int_gauge_with_labels,labelkey=\"labelValue\" 13 100",
 		},
 	}
 	for _, tt := range tests {
@@ -113,7 +113,7 @@ func TestSerializeDoubleDataPoints(t *testing.T) {
 				data: doubleSlice,
 				tags: []string{},
 			},
-			want: "my_double_gauge 13.1 100\n",
+			want: "my_double_gauge 13.1 100",
 		},
 		{
 			name: "Serialize double data points with tags",
@@ -122,7 +122,7 @@ func TestSerializeDoubleDataPoints(t *testing.T) {
 				data: doubleSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: "my_double_gauge_with_tags,test_key=testval 13.1 100\n",
+			want: "my_double_gauge_with_tags,test_key=testval 13.1 100",
 		},
 		{
 			name: "Serialize double data points with labels",
@@ -131,7 +131,7 @@ func TestSerializeDoubleDataPoints(t *testing.T) {
 				data: labelDoubleSlice,
 				tags: []string{},
 			},
-			want: "my_double_gauge_with_labels,labelkey=\"labelValue\" 13.1 100\n",
+			want: "my_double_gauge_with_labels,labelkey=\"labelValue\" 13.1 100",
 		},
 	}
 	for _, tt := range tests {
@@ -183,7 +183,7 @@ func TestSerializeDoubleHistogramMetrics(t *testing.T) {
 				data: doubleHistSlice,
 				tags: []string{},
 			},
-			want: "my_double_hist gauge,min=10.1,max=10.1,sum=101,count=10 100\n",
+			want: "my_double_hist gauge,min=10.1,max=10.1,sum=101,count=10 100",
 		},
 		{
 			name: "Serialize double histogram data points with tags",
@@ -192,7 +192,7 @@ func TestSerializeDoubleHistogramMetrics(t *testing.T) {
 				data: doubleHistSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: "my_double_hist_with_tags,test_key=testval gauge,min=10.1,max=10.1,sum=101,count=10 100\n",
+			want: "my_double_hist_with_tags,test_key=testval gauge,min=10.1,max=10.1,sum=101,count=10 100",
 		},
 		{
 			name: "Serialize double histogram data points with labels",
@@ -201,7 +201,7 @@ func TestSerializeDoubleHistogramMetrics(t *testing.T) {
 				data: labelDoubleHistSlice,
 				tags: []string{},
 			},
-			want: "my_double_hist_with_labels,labelkey=\"labelValue\" gauge,min=10.1,max=10.1,sum=101,count=10 100\n",
+			want: "my_double_hist_with_labels,labelkey=\"labelValue\" gauge,min=10.1,max=10.1,sum=101,count=10 100",
 		},
 		{
 			name: "Serialize zero double histogram",
@@ -262,7 +262,7 @@ func TestSerializeIntHistogramMetrics(t *testing.T) {
 				data: intHistSlice,
 				tags: []string{},
 			},
-			want: "my_int_hist gauge,min=11,max=11,sum=110,count=10 100\n",
+			want: "my_int_hist gauge,min=11,max=11,sum=110,count=10 100",
 		},
 		{
 			name: "Serialize integer histogram data points with tags",
@@ -271,7 +271,7 @@ func TestSerializeIntHistogramMetrics(t *testing.T) {
 				data: intHistSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: "my_int_hist_with_tags,test_key=testval gauge,min=11,max=11,sum=110,count=10 100\n",
+			want: "my_int_hist_with_tags,test_key=testval gauge,min=11,max=11,sum=110,count=10 100",
 		},
 		{
 			name: "Serialize integer histogram data points with labels",
@@ -280,7 +280,7 @@ func TestSerializeIntHistogramMetrics(t *testing.T) {
 				data: labelIntHistSlice,
 				tags: []string{},
 			},
-			want: "my_int_hist_with_labels,labelkey=\"labelValue\" gauge,min=11,max=11,sum=110,count=10 100\n",
+			want: "my_int_hist_with_labels,labelkey=\"labelValue\" gauge,min=11,max=11,sum=110,count=10 100",
 		},
 		{
 			name: "Serialize zero integer histogram",
@@ -316,7 +316,7 @@ func Test_serializeLine(t *testing.T) {
 		{
 			name: "Constructs a Dynatrace metrics ingest string",
 			args: args{name: "metric_name", tagline: "tag=value", valueline: "gauge,60", timestamp: pdata.TimestampUnixNano(uint64(100_000_000))},
-			want: "metric_name,tag=value gauge,60 100\n",
+			want: "metric_name,tag=value gauge,60 100",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
During testing it was discovered that the Dynatrace metric exporter was logging errors incorrectly. This updates it to properly log the error message, and log lines which are rejected by the server at a debug level.