### PR TITLE
elasticexporter: translate exception span events

### DIFF
--- a/exporter/elasticexporter/exporter.go
+++ b/exporter/elasticexporter/exporter.go
@@ -144,7 +144,7 @@ func (e *elasticExporter) ExportResourceSpans(ctx context.Context, rs pdata.Reso
 			count++
 			span := spanSlice.At(i)
 			before := w.Size()
-			if err := elastic.EncodeSpan(span, instrumentationLibrary, &w); err != nil {
+			if err := elastic.EncodeSpan(span, instrumentationLibrary, rs.Resource(), &w); err != nil {
 				w.Rewind(before)
 				errs = append(errs, err)
 			}

--- a/exporter/elasticexporter/go.mod
+++ b/exporter/elasticexporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/elastic/go-sysinfo v1.4.0 // indirect
 	github.com/elastic/go-windows v1.0.1 // indirect
 	github.com/stretchr/testify v1.6.1
-	go.elastic.co/apm v1.9.0
+	go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6
 	go.elastic.co/fastjson v1.1.0
 	go.opentelemetry.io/collector v0.17.0
 	go.uber.org/zap v1.16.0

--- a/exporter/elasticexporter/go.sum
+++ b/exporter/elasticexporter/go.sum
@@ -976,8 +976,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.elastic.co/apm v1.9.0 h1:uLOZniTuJ2rU2fFGiNI0ZswzKr9fryHDkNMV8iVDDDI=
-go.elastic.co/apm v1.9.0/go.mod h1:qoOSi09pnzJDh5fKnfY7bPmQgl8yl2tULdOu03xhui0=
+go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6 h1:0f5DeTBm0f+uMovH0QvlVH1S3j4RrGV8Gk7RvYfYp0A=
+go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6/go.mod h1:qoOSi09pnzJDh5fKnfY7bPmQgl8yl2tULdOu03xhui0=
 go.elastic.co/fastjson v1.1.0 h1:3MrGBWWVIxe/xvsbpghtkFoPciPhOCmjsR/HfwEeQR4=
 go.elastic.co/fastjson v1.1.0/go.mod h1:boNGISWMjQsUPy/t6yqt2/1Wx4YNPSe+mZjlyw9vKKI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/exporter/elasticexporter/internal/translator/elastic/exceptions.go
+++ b/exporter/elasticexporter/internal/translator/elastic/exceptions.go
@@ -1,0 +1,204 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elastic
+
+import (
+	"bufio"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.elastic.co/apm/model"
+	"go.elastic.co/fastjson"
+)
+
+var (
+	javaStacktraceAtRegexp   = regexp.MustCompile(`at (.*)\(([^:]*)(?::([0-9]+))?\)`)
+	javaStacktraceMoreRegexp = regexp.MustCompile(`\.\.\. ([0-9]+) more`)
+)
+
+func encodeExceptionSpanEvent(
+	timestamp time.Time,
+	exceptionType, exceptionMessage, exceptionStacktrace string,
+	exceptionEscaped bool,
+	traceID model.TraceID, spanID model.SpanID,
+	language string,
+	w *fastjson.Writer,
+) error {
+	if exceptionMessage == "" {
+		exceptionMessage = "[EMPTY]"
+	}
+	exceptionError := model.Error{
+		Timestamp: model.Time(timestamp),
+		TraceID:   traceID,
+		ParentID:  spanID,
+		Exception: model.Exception{
+			Message: exceptionMessage,
+			Type:    exceptionType,
+			Handled: !exceptionEscaped,
+		},
+	}
+	if exceptionStacktrace != "" {
+		if err := setExceptionStacktrace(exceptionStacktrace, language, &exceptionError.Exception); err != nil {
+			// Couldn't parse stacktrace, just add it as an attribute to the
+			// exception so the user can still access it.
+			exceptionError.Exception.Stacktrace = nil
+			exceptionError.Exception.Cause = nil
+			exceptionError.Exception.Attributes = map[string]interface{}{
+				"stacktrace": exceptionStacktrace,
+			}
+		}
+	}
+	w.RawString(`{"error":`)
+	if err := exceptionError.MarshalFastJSON(w); err != nil {
+		return err
+	}
+	w.RawString("}\n")
+	return nil
+}
+
+func setExceptionStacktrace(s, language string, out *model.Exception) error {
+	switch language {
+	case "java":
+		return setJavaExceptionStacktrace(s, out)
+	}
+	return fmt.Errorf("parsing %q stacktraces not implemented", language)
+}
+
+func setJavaExceptionStacktrace(s string, out *model.Exception) error {
+	const (
+		causedByPrefix   = "Caused by: "
+		suppressedPrefix = "Suppressed: "
+	)
+
+	type Exception struct {
+		*model.Exception
+		enclosing *model.Exception
+		indent    int
+	}
+	first := true
+	current := Exception{out, nil, 0}
+	stack := []Exception{}
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		if first {
+			// Ignore the first line, we only care about the locations.
+			first = false
+			continue
+		}
+		var indent int
+		line := scanner.Text()
+		if i := strings.IndexFunc(line, isNotTab); i > 0 {
+			line = line[i:]
+			indent = i
+		}
+		for indent < current.indent {
+			n := len(stack)
+			current, stack = stack[n-1], stack[:n-1]
+		}
+		switch {
+		case strings.HasPrefix(line, "at "):
+			if err := parseJavaStacktraceFrame(line, current.Exception); err != nil {
+				return err
+			}
+		case strings.HasPrefix(line, "..."):
+			// "... N more" lines indicate that the last N frames from the enclosing
+			// exception's stacktrace are common to this exception.
+			if current.enclosing == nil {
+				return fmt.Errorf("no enclosing exception preceding line %q", line)
+			}
+			submatch := javaStacktraceMoreRegexp.FindStringSubmatch(line)
+			if submatch == nil {
+				return fmt.Errorf("failed to parse stacktrace line %q", line)
+			}
+			if n, err := strconv.Atoi(submatch[1]); err == nil {
+				enclosing := current.enclosing
+				if len(enclosing.Stacktrace) < n {
+					return fmt.Errorf(
+						"enclosing exception stacktrace has %d frames, cannot satisfy %q",
+						len(enclosing.Stacktrace), line,
+					)
+				}
+				m := len(enclosing.Stacktrace)
+				current.Stacktrace = append(current.Stacktrace, enclosing.Stacktrace[m-n:]...)
+			}
+		case strings.HasPrefix(line, causedByPrefix):
+			// "Caused by:" lines are at the same level of indentation
+			// as the enclosing exception.
+			current.Cause = make([]model.Exception, 1)
+			current.enclosing = current.Exception
+			current.Exception = &current.Cause[0]
+			current.Exception.Handled = current.enclosing.Handled
+			current.Message = line[len(causedByPrefix):]
+		case strings.HasPrefix(line, suppressedPrefix):
+			// Suppressed exceptions have no place in the Elastic APM
+			// model, so they are ignored.
+			//
+			// Unlike "Caused by:", "Suppressed:" lines are indented within their
+			// enclosing exception; we just account for the indentation here.
+			stack = append(stack, current)
+			current.enclosing = current.Exception
+			current.Exception = &model.Exception{}
+			current.indent = indent
+		default:
+			return fmt.Errorf("unexpected line %q", line)
+		}
+	}
+	return scanner.Err()
+}
+
+func parseJavaStacktraceFrame(s string, out *model.Exception) error {
+	submatch := javaStacktraceAtRegexp.FindStringSubmatch(s)
+	if submatch == nil {
+		return fmt.Errorf("failed to parse stacktrace line %q", s)
+	}
+	var module string
+	function := submatch[1]
+	if slash := strings.IndexRune(function, '/'); slash >= 0 {
+		// We could have either:
+		//  - "class_loader/module/class.method"
+		//  - "module/class.method"
+		module, function = function[:slash], function[slash+1:]
+		if slash := strings.IndexRune(function, '/'); slash >= 0 {
+			module, function = function[:slash], function[slash+1:]
+		}
+	}
+	var classname string
+	if dot := strings.LastIndexByte(function, '.'); dot > 0 {
+		// Split into classname and method.
+		classname, function = function[:dot], function[dot+1:]
+	}
+	file := submatch[2]
+	var line int
+	if submatch[3] != "" {
+		if n, err := strconv.Atoi(submatch[3]); err == nil {
+			line = n
+		}
+	}
+	out.Stacktrace = append(out.Stacktrace, model.StacktraceFrame{
+		Module:    module,
+		Classname: classname,
+		Function:  function,
+		File:      file,
+		Line:      line,
+	})
+	return nil
+}
+
+func isNotTab(r rune) bool {
+	return r != '\t'
+}

--- a/exporter/elasticexporter/internal/translator/elastic/exceptions_test.go
+++ b/exporter/elasticexporter/internal/translator/elastic/exceptions_test.go
@@ -1,0 +1,321 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elastic_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.elastic.co/apm/model"
+	"go.elastic.co/apm/transport/transporttest"
+	"go.elastic.co/fastjson"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticexporter/internal/translator/elastic"
+)
+
+func TestEncodeSpanEventsNonExceptions(t *testing.T) {
+	nonExceptionEvent := pdata.NewSpanEvent()
+	nonExceptionEvent.SetName("not_exception")
+
+	incompleteExceptionEvent := pdata.NewSpanEvent()
+	incompleteExceptionEvent.SetName("exception")
+	incompleteExceptionEvent.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		// At least one of exception.message and exception.type is required.
+		conventions.AttributeExceptionStacktrace: pdata.NewAttributeValueString("stacktrace"),
+	})
+
+	_, errors := encodeSpanEvents(t, "java", nonExceptionEvent, incompleteExceptionEvent)
+	require.Empty(t, errors)
+}
+
+func TestEncodeSpanEventsJavaExceptions(t *testing.T) {
+	timestamp := time.Unix(123, 0).UTC()
+
+	exceptionEvent1 := pdata.NewSpanEvent()
+	exceptionEvent1.SetTimestamp(pdata.TimestampUnixNano(timestamp.UnixNano()))
+	exceptionEvent1.SetName("exception")
+	exceptionEvent1.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"exception.type":    pdata.NewAttributeValueString("java.net.ConnectException.OSError"),
+		"exception.message": pdata.NewAttributeValueString("Division by zero"),
+		"exception.escaped": pdata.NewAttributeValueBool(true),
+		"exception.stacktrace": pdata.NewAttributeValueString(`
+Exception in thread "main" java.lang.RuntimeException: Test exception
+	at com.example.GenerateTrace.methodB(GenerateTrace.java:13)
+	at com.example.GenerateTrace.methodA(GenerateTrace.java:9)
+	at com.example.GenerateTrace.main(GenerateTrace.java:5)
+	at com.foo.loader/foo@9.0/com.foo.Main.run(Main.java)
+	at com.foo.loader//com.foo.bar.App.run(App.java:12)
+	at java.base/java.lang.Thread.run(Unknown Source)
+`[1:],
+		),
+	})
+	exceptionEvent2 := pdata.NewSpanEvent()
+	exceptionEvent2.SetTimestamp(pdata.TimestampUnixNano(timestamp.UnixNano()))
+	exceptionEvent2.SetName("exception")
+	exceptionEvent2.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"exception.type":    pdata.NewAttributeValueString("HighLevelException"),
+		"exception.message": pdata.NewAttributeValueString("MidLevelException: LowLevelException"),
+		"exception.stacktrace": pdata.NewAttributeValueString(`
+HighLevelException: MidLevelException: LowLevelException
+	at Junk.a(Junk.java:13)
+	at Junk.main(Junk.java:4)
+Caused by: MidLevelException: LowLevelException
+	at Junk.c(Junk.java:23)
+	at Junk.b(Junk.java:17)
+	at Junk.a(Junk.java:11)
+	... 1 more
+	Suppressed: java.lang.ArithmeticException: / by zero
+		at Junk.c(Junk.java:25)
+		... 3 more
+Caused by: LowLevelException
+	at Junk.e(Junk.java:37)
+	at Junk.d(Junk.java:34)
+	at Junk.c(Junk.java:21)
+	... 3 more`[1:],
+		),
+	})
+
+	transaction, errors := encodeSpanEvents(t, "java", exceptionEvent1, exceptionEvent2)
+	assert.Equal(t, []model.Error{{
+		TraceID:   transaction.TraceID,
+		ParentID:  transaction.ID,
+		Timestamp: model.Time(timestamp),
+		Exception: model.Exception{
+			Type:    "java.net.ConnectException.OSError",
+			Message: "Division by zero",
+			Handled: false,
+			Stacktrace: []model.StacktraceFrame{{
+				Classname: "com.example.GenerateTrace",
+				Function:  "methodB",
+				File:      "GenerateTrace.java",
+				Line:      13,
+			}, {
+				Classname: "com.example.GenerateTrace",
+				Function:  "methodA",
+				File:      "GenerateTrace.java",
+				Line:      9,
+			}, {
+				Classname: "com.example.GenerateTrace",
+				Function:  "main",
+				File:      "GenerateTrace.java",
+				Line:      5,
+			}, {
+				Module:    "foo@9.0",
+				Classname: "com.foo.Main",
+				Function:  "run",
+				File:      "Main.java",
+			}, {
+				Classname: "com.foo.bar.App",
+				Function:  "run",
+				File:      "App.java",
+				Line:      12,
+			}, {
+				Module:    "java.base",
+				Classname: "java.lang.Thread",
+				Function:  "run",
+				File:      "Unknown Source",
+			}},
+		},
+	}, {
+		TraceID:   transaction.TraceID,
+		ParentID:  transaction.ID,
+		Timestamp: model.Time(timestamp),
+		Exception: model.Exception{
+			Type:    "HighLevelException",
+			Message: "MidLevelException: LowLevelException",
+			Handled: true,
+			Stacktrace: []model.StacktraceFrame{{
+				Classname: "Junk",
+				Function:  "a",
+				File:      "Junk.java",
+				Line:      13,
+			}, {
+				Classname: "Junk",
+				Function:  "main",
+				File:      "Junk.java",
+				Line:      4,
+			}},
+			Cause: []model.Exception{{
+				Message: "MidLevelException: LowLevelException",
+				Handled: true,
+				Stacktrace: []model.StacktraceFrame{{
+					Classname: "Junk",
+					Function:  "c",
+					File:      "Junk.java",
+					Line:      23,
+				}, {
+					Classname: "Junk",
+					Function:  "b",
+					File:      "Junk.java",
+					Line:      17,
+				}, {
+					Classname: "Junk",
+					Function:  "a",
+					File:      "Junk.java",
+					Line:      11,
+				}, {
+					Classname: "Junk",
+					Function:  "main",
+					File:      "Junk.java",
+					Line:      4,
+				}},
+				Cause: []model.Exception{{
+					Message: "LowLevelException",
+					Handled: true,
+					Stacktrace: []model.StacktraceFrame{{
+						Classname: "Junk",
+						Function:  "e",
+						File:      "Junk.java",
+						Line:      37,
+					}, {
+						Classname: "Junk",
+						Function:  "d",
+						File:      "Junk.java",
+						Line:      34,
+					}, {
+						Classname: "Junk",
+						Function:  "c",
+						File:      "Junk.java",
+						Line:      21,
+					}, {
+						Classname: "Junk",
+						Function:  "b",
+						File:      "Junk.java",
+						Line:      17,
+					}, {
+						Classname: "Junk",
+						Function:  "a",
+						File:      "Junk.java",
+						Line:      11,
+					}, {
+						Classname: "Junk",
+						Function:  "main",
+						File:      "Junk.java",
+						Line:      4,
+					}},
+				}},
+			}},
+		},
+	}}, errors)
+}
+
+func TestEncodeSpanEventsJavaExceptionsUnparsedStacktrace(t *testing.T) {
+	stacktraces := []string{
+		// Unexpected prefix.
+		"abc\ndef",
+
+		// "... N more" with no preceding exception.
+		"abc\n... 1 more",
+
+		// "... N more" where N is greater than the number of stack
+		// frames in the enclosing exception.
+		`ignored message
+	at Class.method(Class.java:1)
+Caused by: something else
+	at Class.method(Class.java:2)
+	... 2 more`,
+
+		// "... N more" where N is not a sequence of digits.
+		`abc
+	at Class.method(Class.java:1)
+Caused by: whatever
+	at Class.method(Class.java:2)
+	... lots more`,
+
+		// "at <location>" where <location> is invalid.
+		`abc
+	at the movies`,
+	}
+
+	var events []pdata.SpanEvent
+	for _, stacktrace := range stacktraces {
+		event := pdata.NewSpanEvent()
+		event.SetName("exception")
+		event.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+			"exception.type":       pdata.NewAttributeValueString("ExceptionType"),
+			"exception.stacktrace": pdata.NewAttributeValueString(stacktrace),
+		})
+		events = append(events, event)
+	}
+
+	_, errors := encodeSpanEvents(t, "java", events...)
+	require.Len(t, errors, len(stacktraces))
+
+	for i, e := range errors {
+		assert.Empty(t, e.Exception.Stacktrace)
+		assert.Equal(t, map[string]interface{}{"stacktrace": stacktraces[i]}, e.Exception.Attributes)
+	}
+}
+
+func TestEncodeSpanEventsNonJavaExceptions(t *testing.T) {
+	timestamp := time.Unix(123, 0).UTC()
+
+	exceptionEvent := pdata.NewSpanEvent()
+	exceptionEvent.SetTimestamp(pdata.TimestampUnixNano(timestamp.UnixNano()))
+	exceptionEvent.SetName("exception")
+	exceptionEvent.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"exception.type":       pdata.NewAttributeValueString("the_type"),
+		"exception.message":    pdata.NewAttributeValueString("the_message"),
+		"exception.stacktrace": pdata.NewAttributeValueString("the_stacktrace"),
+	})
+
+	// For languages where we do not explicitly parse the stacktrace,
+	// the raw stacktrace is stored as an attribute on the exception.
+	transaction, errors := encodeSpanEvents(t, "COBOL", exceptionEvent)
+	require.Len(t, errors, 1)
+
+	assert.Equal(t, model.Error{
+		TraceID:   transaction.TraceID,
+		ParentID:  transaction.ID,
+		Timestamp: model.Time(timestamp),
+		Exception: model.Exception{
+			Type:    "the_type",
+			Message: "the_message",
+			Handled: true,
+			Attributes: map[string]interface{}{
+				"stacktrace": "the_stacktrace",
+			},
+		},
+	}, errors[0])
+}
+
+func encodeSpanEvents(t *testing.T, language string, events ...pdata.SpanEvent) (model.Transaction, []model.Error) {
+	traceID := model.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	transactionID := model.SpanID{1, 1, 1, 1, 1, 1, 1, 1}
+
+	span := pdata.NewSpan()
+	span.SetTraceID(pdata.NewTraceID(traceID))
+	span.SetSpanID(pdata.NewSpanID(transactionID))
+	for _, event := range events {
+		span.Events().Append(event)
+	}
+
+	var w fastjson.Writer
+	var recorder transporttest.RecorderTransport
+	resource := pdata.NewResource()
+	resource.Attributes().InsertString(conventions.AttributeTelemetrySDKLanguage, language)
+	elastic.EncodeResourceMetadata(resource, &w)
+	err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), resource, &w)
+	assert.NoError(t, err)
+	sendStream(t, &w, &recorder)
+
+	payloads := recorder.Payloads()
+	require.Len(t, payloads.Transactions, 1)
+	return payloads.Transactions[0], payloads.Errors
+}

--- a/exporter/elasticexporter/internal/translator/elastic/traces_test.go
+++ b/exporter/elasticexporter/internal/translator/elastic/traces_test.go
@@ -79,7 +79,7 @@ func TestEncodeSpan(t *testing.T) {
 	}
 
 	for _, span := range []pdata.Span{rootSpan, clientSpan, serverSpan} {
-		err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), &w)
+		err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), pdata.NewResource(), &w)
 		require.NoError(t, err)
 	}
 	sendStream(t, &w, &recorder)
@@ -165,7 +165,7 @@ func TestEncodeSpanStatus(t *testing.T) {
 			span.Status().SetCode(statusCode)
 		}
 
-		err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), &w)
+		err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), pdata.NewResource(), &w)
 		require.NoError(t, err)
 		sendStream(t, &w, &recorder)
 		payloads := recorder.Payloads()
@@ -187,7 +187,7 @@ func TestEncodeSpanTruncation(t *testing.T) {
 	var w fastjson.Writer
 	var recorder transporttest.RecorderTransport
 	elastic.EncodeResourceMetadata(pdata.NewResource(), &w)
-	err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), &w)
+	err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), pdata.NewResource(), &w)
 	require.NoError(t, err)
 	sendStream(t, &w, &recorder)
 
@@ -499,8 +499,9 @@ func TestInstrumentationLibrary(t *testing.T) {
 	library.SetName("library-name")
 	library.SetVersion("1.2.3")
 
-	elastic.EncodeResourceMetadata(pdata.NewResource(), &w)
-	err := elastic.EncodeSpan(span, library, &w)
+	resource := pdata.NewResource()
+	elastic.EncodeResourceMetadata(resource, &w)
+	err := elastic.EncodeSpan(span, library, resource, &w)
 	assert.NoError(t, err)
 	sendStream(t, &w, &recorder)
 
@@ -523,8 +524,9 @@ func transactionWithAttributes(t *testing.T, attrs map[string]pdata.AttributeVal
 	span := pdata.NewSpan()
 	span.Attributes().InitFromMap(attrs)
 
-	elastic.EncodeResourceMetadata(pdata.NewResource(), &w)
-	err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), &w)
+	resource := pdata.NewResource()
+	elastic.EncodeResourceMetadata(resource, &w)
+	err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), resource, &w)
 	assert.NoError(t, err)
 	sendStream(t, &w, &recorder)
 
@@ -541,8 +543,9 @@ func spanWithAttributes(t *testing.T, attrs map[string]pdata.AttributeValue) mod
 	span.SetParentSpanID(pdata.NewSpanID([8]byte{1}))
 	span.Attributes().InitFromMap(attrs)
 
-	elastic.EncodeResourceMetadata(pdata.NewResource(), &w)
-	err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), &w)
+	resource := pdata.NewResource()
+	elastic.EncodeResourceMetadata(resource, &w)
+	err := elastic.EncodeSpan(span, pdata.NewInstrumentationLibrary(), resource, &w)
 	assert.NoError(t, err)
 	sendStream(t, &w, &recorder)
 

--- a/go.sum
+++ b/go.sum
@@ -1452,8 +1452,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zorkian/go-datadog-api v2.29.0+incompatible h1:uZZg0POZ6tLmVFtjUSaTZYwR6Q6RrHx6f/blTEDn8dA=
 github.com/zorkian/go-datadog-api v2.29.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
-go.elastic.co/apm v1.9.0 h1:uLOZniTuJ2rU2fFGiNI0ZswzKr9fryHDkNMV8iVDDDI=
-go.elastic.co/apm v1.9.0/go.mod h1:qoOSi09pnzJDh5fKnfY7bPmQgl8yl2tULdOu03xhui0=
+go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6 h1:0f5DeTBm0f+uMovH0QvlVH1S3j4RrGV8Gk7RvYfYp0A=
+go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6/go.mod h1:qoOSi09pnzJDh5fKnfY7bPmQgl8yl2tULdOu03xhui0=
 go.elastic.co/fastjson v1.1.0 h1:3MrGBWWVIxe/xvsbpghtkFoPciPhOCmjsR/HfwEeQR4=
 go.elastic.co/fastjson v1.1.0/go.mod h1:boNGISWMjQsUPy/t6yqt2/1Wx4YNPSe+mZjlyw9vKKI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
**Description:**

Translate exception span events to Elastic APM's error model.

Arbitrary span events are not currently supported, so we only handle exceptions for now.
Support for parsing Java stacktraces has been added; this may be expanded to other languages later.

Once https://github.com/elastic/apm-agent-go/pull/862 lands I'll update this PR to split class.method.

**Link to tracking Issue:**

Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1803

**Testing:**

Unit tests added. Also tested with the span events provided in the linked issue.