### PR TITLE
Adding grouping option to MetricsTransformProcessor

### DIFF
--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -232,3 +232,21 @@ submatch_case: lower
 operations:
   ...
 ```
+
+### Group Metrics 
+```yaml
+# Group metrics from one single ResourceMetrics and report them as multiple ResourceMetrics.
+# 
+# ex: Consider pod and container metrics collected from Kubernetes. Both the metrics are recorded under under one ResourceMetric
+# applying this transformation will result in two separate ResourceMetric packets with corresponding resource labels in the resource headers
+
+
+- include: ^k8s\.pod\.(.*)$
+  match_type: regexp
+  action: group
+  group_resource_labels: {"resouce.type": "k8s.pod", "source": "kubelet"}
+- include: ^container\.(.*)$
+  match_type: regexp
+  action: group
+  group_resource_labels: {"resouce.type": "container", "source": "kubelet"}
+```

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -79,7 +79,7 @@ type Transform struct {
 	// REQUIRED only if Action is INSERT.
 	NewName string `mapstructure:"new_name"`
 
-	GroupName string `mapstructure:"group_name"`
+	GroupResourceLabels map[string]string `mapstructure:"group_resource_labels"`
 
 	// AggregationType specifies how to aggregate.
 	// REQUIRED only if Action is COMBINE.

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -34,6 +34,9 @@ const (
 	// NewNameFieldName is the mapstructure field name for NewName field
 	NewNameFieldName = "new_name"
 
+	// GroupResouceLabelsFieldName is the mapstructure field name for GroupResouceLabels field
+	GroupResouceLabelsFieldName = "group_resource_labels"
+
 	// AggregationTypeFieldName is the mapstructure field name for AggregationType field
 	AggregationTypeFieldName = "aggregation_type"
 

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -34,6 +34,9 @@ const (
 	// NewNameFieldName is the mapstructure field name for NewName field
 	NewNameFieldName = "new_name"
 
+	//
+	GroupName = "group_name"
+
 	// AggregationTypeFieldName is the mapstructure field name for AggregationType field
 	AggregationTypeFieldName = "aggregation_type"
 
@@ -75,6 +78,8 @@ type Transform struct {
 	// NewName specifies the name of the new metric when inserting or updating.
 	// REQUIRED only if Action is INSERT.
 	NewName string `mapstructure:"new_name"`
+
+	GroupName string `mapstructure:"group_name"`
 
 	// AggregationType specifies how to aggregate.
 	// REQUIRED only if Action is COMBINE.
@@ -147,9 +152,12 @@ const (
 
 	// Combine combines multiple metrics into a single metric.
 	Combine ConfigAction = "combine"
+
+	//
+	Group ConfigAction = "group"
 )
 
-var Actions = []ConfigAction{Insert, Update, Combine}
+var Actions = []ConfigAction{Insert, Update, Combine, Group}
 
 func (ca ConfigAction) isValid() bool {
 	for _, configAction := range Actions {

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -152,7 +152,7 @@ const (
 	// Combine combines multiple metrics into a single metric.
 	Combine ConfigAction = "combine"
 
-	//
+	// Group groups mutiple metrics matching the predicate into multiple ResourceMetrics messages
 	Group ConfigAction = "group"
 )
 

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -34,9 +34,6 @@ const (
 	// NewNameFieldName is the mapstructure field name for NewName field
 	NewNameFieldName = "new_name"
 
-	//
-	GroupName = "group_name"
-
 	// AggregationTypeFieldName is the mapstructure field name for AggregationType field
 	AggregationTypeFieldName = "aggregation_type"
 
@@ -79,6 +76,8 @@ type Transform struct {
 	// REQUIRED only if Action is INSERT.
 	NewName string `mapstructure:"new_name"`
 
+	// GroupResourceLabels specifes resource labels that will be appended to this group's new ResourceMetrics message
+	// REQUIRED only if Action is GROUP
 	GroupResourceLabels map[string]string `mapstructure:"group_resource_labels"`
 
 	// AggregationType specifies how to aggregate.

--- a/processor/metricstransformprocessor/config_test.go
+++ b/processor/metricstransformprocessor/config_test.go
@@ -127,6 +127,16 @@ func TestLoadingFullConfig(t *testing.T) {
 						NewName:      "combined_metric_name",
 						SubmatchCase: "lower",
 					},
+					{
+						MetricIncludeFilter: FilterConfig{
+							Include:   "name2",
+							MatchType: "strict",
+						},
+						Action:       "group",
+						GroupResourceLabels: map[string]string{"metric_group": "2"},
+					},
+
+
 				},
 			},
 		},

--- a/processor/metricstransformprocessor/config_test.go
+++ b/processor/metricstransformprocessor/config_test.go
@@ -132,11 +132,9 @@ func TestLoadingFullConfig(t *testing.T) {
 							Include:   "name2",
 							MatchType: "strict",
 						},
-						Action:       "group",
+						Action:              "group",
 						GroupResourceLabels: map[string]string{"metric_group": "2"},
 					},
-
-
 				},
 			},
 		},

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -101,7 +101,7 @@ func validateConfiguration(config *Config) error {
 			return fmt.Errorf("missing required field %q while %q is %v", NewNameFieldName, ActionFieldName, Insert)
 		}
 
-		if transform.Action == Group && transform.GroupName == "" {
+		if transform.Action == Group && transform.GroupResourceLabels == nil {
 			return fmt.Errorf("missing required field %q while %q is %v", GroupName, ActionFieldName, Group)
 		}
 
@@ -154,7 +154,7 @@ func buildHelperConfig(config *Config, version string) []internalTransform {
 			MetricIncludeFilter: createFilter(t.MetricIncludeFilter),
 			Action:              t.Action,
 			NewName:             t.NewName,
-			GroupName: 			 t.GroupName,
+			GroupResourceLabels: t.GroupResourceLabels,
 			AggregationType:     t.AggregationType,
 			Operations:          make([]internalOperation, len(t.Operations)),
 		}

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -102,7 +102,7 @@ func validateConfiguration(config *Config) error {
 		}
 
 		if transform.Action == Group && transform.GroupResourceLabels == nil {
-			return fmt.Errorf("missing required field %q while %q is %v", GroupName, ActionFieldName, Group)
+			return fmt.Errorf("missing required field %q while %q is %v", GroupResouceLabelsFieldName, ActionFieldName, Group)
 		}
 
 		if transform.AggregationType != "" && !transform.AggregationType.isValid() {

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -101,6 +101,10 @@ func validateConfiguration(config *Config) error {
 			return fmt.Errorf("missing required field %q while %q is %v", NewNameFieldName, ActionFieldName, Insert)
 		}
 
+		if transform.Action == Group && transform.GroupName == "" {
+			return fmt.Errorf("missing required field %q while %q is %v", GroupName, ActionFieldName, Group)
+		}
+
 		if transform.AggregationType != "" && !transform.AggregationType.isValid() {
 			return fmt.Errorf("%q must be in %q", AggregationTypeFieldName, AggregationTypes)
 		}
@@ -150,6 +154,7 @@ func buildHelperConfig(config *Config, version string) []internalTransform {
 			MetricIncludeFilter: createFilter(t.MetricIncludeFilter),
 			Action:              t.Action,
 			NewName:             t.NewName,
+			GroupName: 			 t.GroupName,
 			AggregationType:     t.AggregationType,
 			Operations:          make([]internalOperation, len(t.Operations)),
 		}

--- a/processor/metricstransformprocessor/factory_test.go
+++ b/processor/metricstransformprocessor/factory_test.go
@@ -119,7 +119,6 @@ func TestCreateProcessors(t *testing.T) {
 			succeed:      false,
 			errorMessage: fmt.Sprintf("%q must be in %q", SubmatchCaseFieldName, SubmatchCases),
 		},
-
 	}
 
 	for _, test := range tests {

--- a/processor/metricstransformprocessor/factory_test.go
+++ b/processor/metricstransformprocessor/factory_test.go
@@ -65,6 +65,11 @@ func TestCreateProcessors(t *testing.T) {
 			errorMessage: fmt.Sprintf("missing required field %q while %q is %v", NewNameFieldName, ActionFieldName, Insert),
 		},
 		{
+			configName:   "config_invalid_group.yaml",
+			succeed:      false,
+			errorMessage: fmt.Sprintf("missing required field %q while %q is %v", GroupResouceLabelsFieldName, ActionFieldName, Group),
+		},
+		{
 			configName:   "config_invalid_action.yaml",
 			succeed:      false,
 			errorMessage: fmt.Sprintf("%q must be in %q", ActionFieldName, Actions),
@@ -114,6 +119,7 @@ func TestCreateProcessors(t *testing.T) {
 			succeed:      false,
 			errorMessage: fmt.Sprintf("%q must be in %q", SubmatchCaseFieldName, SubmatchCases),
 		},
+
 	}
 
 	for _, test := range tests {

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -153,7 +153,7 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 			matchedMetrics := transform.MetricIncludeFilter.getMatches(nameToMetricMapping)
 
 			if transform.Action == Group && len(matchedMetrics) > 0 {
-				nData := mtp.regroupMatchedMetrics(data, matchedMetrics, transform)
+				nData := mtp.groupMatchedMetrics(data, matchedMetrics, transform)
 				groupedMds = append(groupedMds, *nData)
 				data.Metrics = mtp.removeMatchedMetrics(data.Metrics, matchedMetrics)
 			}
@@ -198,7 +198,7 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 }
 
 // regroupMatchedMetrics groups matched metrics into a new MetricsData with a new Resource and returns it.
-func (mtp *metricsTransformProcessor) regroupMatchedMetrics(oData *consumerdata.MetricsData, matchedMetrics []*match,
+func (mtp *metricsTransformProcessor) groupMatchedMetrics(oData *consumerdata.MetricsData, matchedMetrics []*match,
 	transform internalTransform) (nData *consumerdata.MetricsData) {
 	// create new ResouceMetrics bucket
 	nData = &consumerdata.MetricsData{

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -310,6 +310,7 @@ func replaceCaseOfSubmatch(replacement SubmatchCase, submatch string) string {
 	return submatch
 }
 
+// removeMatchedMetrics removes the set of matched metrics from metrics
 func (mtp *metricsTransformProcessor) removeMatchedMetrics(metrics []*metricspb.Metric, matchedMetrics []*match) []*metricspb.Metric {
 	filteredMetrics := make([]*metricspb.Metric, 0, len(metrics)-len(matchedMetrics))
 	for _, metric := range metrics {

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -24,7 +24,6 @@ import (
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/processor/processorhelper"

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -160,10 +160,17 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 					Resource: proto.Clone(data.Resource).(*resourcepb.Resource),
 					Metrics:  make([]*metricspb.Metric, 0),
 				}
+
 				// update new resouce labels to the new ResouceMetrics bucket
-				nResource := nData.Resource.GetLabels()
+				if nData.Resource == nil || nData.Resource.GetLabels() == nil {
+					nData.Resource = &resourcepb.Resource{
+						Labels: make(map[string]string),
+					}
+				}
+
+				rlabels := nData.Resource.GetLabels()
 				for k, v := range transform.GroupResourceLabels {
-					nResource[k] = v
+					rlabels[k] = v
 				}
 
 				// reassign matched metrics to the new ResouceMetrics bucket

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -197,7 +197,7 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 	return internaldata.OCSliceToMetrics(resultmds), nil
 }
 
-// regroupMatchedMetrics groups matched metrics into a new MetricsData with a new Resource and returns it.
+// groupMatchedMetrics groups matched metrics into a new MetricsData with a new Resource and returns it.
 func (mtp *metricsTransformProcessor) groupMatchedMetrics(oData *consumerdata.MetricsData, matchedMetrics []*match,
 	transform internalTransform) (nData *consumerdata.MetricsData) {
 	// create new ResouceMetrics bucket

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -161,7 +161,7 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 					Metrics:  make([]*metricspb.Metric, 0),
 				}
 
-				// update new resouce labels to the new ResouceMetrics bucket
+				// update new resource labels to the new ResouceMetrics bucket
 				if nData.Resource == nil || nData.Resource.GetLabels() == nil {
 					nData.Resource = &resourcepb.Resource{
 						Labels: make(map[string]string),

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -1,4 +1,4 @@
-// Copyright -c Google LLC
+// Copyright 2020 OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -2,6 +2,10 @@ package metricstransformprocessor
 
 import (
 	"context"
+	"regexp"
+	"sort"
+	"strings"
+
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
 	"github.com/google/go-cmp/cmp"
@@ -13,12 +17,10 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/collector/translator/internaldata"
 	"google.golang.org/protobuf/testing/protocmp"
-	"regexp"
-	"sort"
-	"strings"
+
+	"testing"
 
 	"go.uber.org/zap"
-	"testing"
 )
 
 type metricsGroupingTest struct {

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"testing"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
@@ -16,11 +17,8 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/collector/translator/internaldata"
-	"google.golang.org/protobuf/testing/protocmp"
-
-	"testing"
-
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 type metricsGroupingTest struct {

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -13,6 +13,9 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/collector/translator/internaldata"
 	"google.golang.org/protobuf/testing/protocmp"
+	"regexp"
+	"sort"
+	"strings"
 
 	"go.uber.org/zap"
 	"testing"
@@ -28,23 +31,25 @@ type metricsGroupingTest struct {
 var (
 	groupingTests = []metricsGroupingTest{
 		{
-			name: "metric_group",
+			name: "metric_group_by_strict_name",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "foometric"},
+					MetricIncludeFilter: internalFilterStrict{include: "foo/metric"},
 					Action:              Group,
 					GroupResourceLabels: map[string]string{"resource.type": "foo"},
 				},
 			},
-			in:  consumerdata.MetricsData{
+			in: consumerdata.MetricsData{
 				Resource: &resourcepb.Resource{
 					Labels: map[string]string{
 						"original": "label",
 					},
 				},
-				Metrics:  []*metricspb.Metric{
-					metricBuilder().setName("foometric").setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-					metricBuilder().setName("barmetric").setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+				Metrics: []*metricspb.Metric{
+					metricBuilder().setName("foo/metric").
+						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					metricBuilder().setName("bar/metric").
+						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
 				},
 			},
 			out: []consumerdata.MetricsData{
@@ -54,25 +59,98 @@ var (
 							"original": "label",
 						},
 					},
-					Metrics:  []*metricspb.Metric{
-						metricBuilder().setName("barmetric").setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					Metrics: []*metricspb.Metric{
+						metricBuilder().setName("bar/metric").
+							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
 					},
 				},
 				{
 					Resource: &resourcepb.Resource{
 						Labels: map[string]string{
-							"original": "label",
+							"original":      "label",
 							"resource.type": "foo",
 						},
 					},
-					Metrics:  []*metricspb.Metric{
-						metricBuilder().setName("foometric").setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					Metrics: []*metricspb.Metric{
+						metricBuilder().setName("foo/metric").
+							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					},
+				},
+			},
+		},
+		{
+			name: "metric_group_regex_multiple_empty_resource",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^container.(.*)$")},
+					Action:              Group,
+					GroupResourceLabels: map[string]string{"resource.type": "container"},
+				},
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^k8s.pod.(.*)$")},
+					Action:              Group,
+					GroupResourceLabels: map[string]string{"resource.type": "k8s.pod"},
+				},
+			},
+			in: consumerdata.MetricsData{
+				Metrics: []*metricspb.Metric{
+					metricBuilder().setName("container.cpu.utilization").
+						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					metricBuilder().setName("container.memory.usage").
+						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					metricBuilder().setName("k8s.pod.cpu.utilization").
+						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					metricBuilder().setName("k8s.pod.memory.usage").
+						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+				},
+			},
+			out: []consumerdata.MetricsData{
+				{
+					Resource: &resourcepb.Resource{
+						Labels: map[string]string{
+							"resource.type": "container",
+						},
+					},
+					Metrics: []*metricspb.Metric{
+						metricBuilder().setName("container.cpu.utilization").
+							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+						metricBuilder().setName("container.memory.usage").
+							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					},
+				},
+				{
+					Resource: &resourcepb.Resource{
+						Labels: map[string]string{
+							"resource.type": "k8s.pod",
+						},
+					},
+					Metrics: []*metricspb.Metric{
+						metricBuilder().setName("k8s.pod.cpu.utilization").
+							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+						metricBuilder().setName("k8s.pod.memory.usage").
+							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
 					},
 				},
 			},
 		},
 	}
 )
+
+func sortResourceMetricsByResourceType(l []consumerdata.MetricsData) {
+	sort.Slice(l, func(i, j int) bool {
+		return strings.Compare(
+			l[i].Resource.GetLabels()["resource.type"],
+			l[j].Resource.GetLabels()["resource.type"]) < 0
+	})
+}
+
+func sortMetricsByMetricName(m []*metricspb.Metric) {
+	sort.Slice(m, func(i, j int) bool {
+		return strings.Compare(
+			m[i].MetricDescriptor.GetName(),
+			m[j].MetricDescriptor.GetName()) < 0
+	})
+}
 
 func TestMetricsGrouping(t *testing.T) {
 	for _, test := range groupingTests {
@@ -104,15 +182,22 @@ func TestMetricsGrouping(t *testing.T) {
 			gotMD := internaldata.MetricsToOC(got[0])
 			require.Equal(t, len(test.out), len(gotMD))
 
+			sortResourceMetricsByResourceType(gotMD)
+			sortResourceMetricsByResourceType(test.out)
+
 			for idx, out := range gotMD {
 				if diff := cmp.Diff(test.out[idx].Resource, out.Resource, protocmp.Transform()); diff != "" {
-					t.Errorf("Unexpected difference:\n%v", diff)
+					t.Errorf("Unexpected difference in resource labels:\n%v", diff)
 				}
 
+				sortMetricsByMetricName(out.Metrics)
+				sortMetricsByMetricName(test.out[idx].Metrics)
+
+				require.Equal(t, len(test.out[idx].Metrics), len(out.Metrics))
 				if diff := cmp.Diff(test.out[idx].Metrics, out.Metrics, protocmp.Transform()); diff != "" {
-					t.Errorf("Unexpected difference:\n%v", diff)
+					t.Errorf("Unexpected difference in Metrics:\n%v", diff)
 				}
- 			}
+			}
 
 			ctx := context.Background()
 			assert.NoError(t, mtp.Shutdown(ctx))

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -1,3 +1,17 @@
+// Copyright -c Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metricstransformprocessor
 
 import (

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -1,0 +1,122 @@
+package metricstransformprocessor
+
+import (
+	"context"
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/consumerdata"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.opentelemetry.io/collector/translator/internaldata"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"go.uber.org/zap"
+	"testing"
+)
+
+type metricsGroupingTest struct {
+	name       string // test name
+	transforms []internalTransform
+	in         consumerdata.MetricsData
+	out        []consumerdata.MetricsData
+}
+
+var (
+	groupingTests = []metricsGroupingTest{
+		{
+			name: "metric_group",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "foometric"},
+					Action:              Group,
+					GroupResourceLabels: map[string]string{"resource.type": "foo"},
+				},
+			},
+			in:  consumerdata.MetricsData{
+				Resource: &resourcepb.Resource{
+					Labels: map[string]string{
+						"original": "label",
+					},
+				},
+				Metrics:  []*metricspb.Metric{
+					metricBuilder().setName("foometric").setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					metricBuilder().setName("barmetric").setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+				},
+			},
+			out: []consumerdata.MetricsData{
+				{
+					Resource: &resourcepb.Resource{
+						Labels: map[string]string{
+							"original": "label",
+						},
+					},
+					Metrics:  []*metricspb.Metric{
+						metricBuilder().setName("barmetric").setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					},
+				},
+				{
+					Resource: &resourcepb.Resource{
+						Labels: map[string]string{
+							"original": "label",
+							"resource.type": "foo",
+						},
+					},
+					Metrics:  []*metricspb.Metric{
+						metricBuilder().setName("foometric").setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestMetricsGrouping(t *testing.T) {
+	for _, test := range groupingTests {
+		t.Run(test.name, func(t *testing.T) {
+			next := new(consumertest.MetricsSink)
+			p := newMetricsTransformProcessor(zap.NewExample(), test.transforms)
+
+			mtp, err := processorhelper.NewMetricsProcessor(&Config{
+				ProcessorSettings: configmodels.ProcessorSettings{
+					TypeVal: typeStr,
+					NameVal: typeStr,
+				},
+			}, next, p, processorhelper.WithCapabilities(processorCapabilities))
+
+			require.NoError(t, err)
+
+			caps := mtp.GetCapabilities()
+			assert.Equal(t, true, caps.MutatesConsumedData)
+
+			// process
+			cErr := mtp.ConsumeMetrics(context.Background(), internaldata.OCToMetrics(test.in))
+			assert.NoError(t, cErr)
+
+			// get and check results
+
+			got := next.AllMetrics()
+			require.Equal(t, 1, len(got))
+
+			gotMD := internaldata.MetricsToOC(got[0])
+			require.Equal(t, len(test.out), len(gotMD))
+
+			for idx, out := range gotMD {
+				if diff := cmp.Diff(test.out[idx].Resource, out.Resource, protocmp.Transform()); diff != "" {
+					t.Errorf("Unexpected difference:\n%v", diff)
+				}
+
+				if diff := cmp.Diff(test.out[idx].Metrics, out.Metrics, protocmp.Transform()); diff != "" {
+					t.Errorf("Unexpected difference:\n%v", diff)
+				}
+ 			}
+
+			ctx := context.Background()
+			assert.NoError(t, mtp.Shutdown(ctx))
+
+		})
+	}
+}

--- a/processor/metricstransformprocessor/testdata/config_full.yaml
+++ b/processor/metricstransformprocessor/testdata/config_full.yaml
@@ -51,6 +51,11 @@ processors:
         new_name: combined_metric_name
         submatch_case: lower
 
+      - include: name2
+        match_type: strict
+        action: group
+        group_resource_labels: {"metric_group": "2"}
+
 exporters:
   exampleexporter:
 

--- a/processor/metricstransformprocessor/testdata/config_invalid_group.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_group.yaml
@@ -1,0 +1,24 @@
+receivers:
+  examplereceiver:
+
+processors:
+  metricstransform:
+    transforms:
+      - include: some.metric.name
+        action: group
+        match_type: strict
+        # group_resource_labels: absent
+
+exporters:
+  exampleexporter:
+
+service:
+  pipelines:
+    traces:
+      receivers: [examplereceiver]
+      processors: [metricstransform]
+      exporters: [exampleexporter]
+    metrics:
+      receivers: [examplereceiver]
+      processors: [metricstransform]
+      exporters: [exampleexporter]


### PR DESCRIPTION
**Description:** 

Adding a feature - Added "group" option to metrics transform processor.  

Grouping option splits a ResourceMetric message into multiple ResourceMetric Messages based on grouping predicate (string/regexp match to the name). Each new Message Resource header is updated with what is specified in "group_resource_labels" along with resource labels present in original message

**Purpose**: 

- Often times we receive metrics from variety of resources (for example k8s.pod.* metrics and container.* metrics) in a single ResourceMetric. While this is very space/network efficient, backends who rely on "resource types" can take advantage of this Option. 
- In some cases where metrics are translated to OpenTelemetry format from other standard formats (ex: Prometheus) there is no resource header to begin with. This option will provide users to place such into dedicated buckets creating name spacing


**Testing:** Added unit tests/functional test cases. E2E testing using docker locally 

**Documentation:** Yes updated README.md of the processor