### PR TITLE
Add parsing of JavaScript stack traces to AWS X-Ray Exporter

### DIFF
--- a/exporter/awsxrayexporter/translator/cause.go
+++ b/exporter/awsxrayexporter/translator/cause.go
@@ -17,7 +17,6 @@ package translator
 import (
 	"bufio"
 	"net/textproto"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -26,10 +25,6 @@ import (
 	semconventions "go.opentelemetry.io/collector/translator/conventions"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray"
-)
-
-var (
-	javascriptStackTracePrefixRegex = regexp.MustCompile(`\ *at (.*?)`)
 )
 
 func makeCause(span pdata.Span, attributes map[string]string, resource pdata.Resource) (isError, isFault bool,
@@ -368,7 +363,7 @@ func fillJavaScriptStacktrace(stacktrace string, exceptions []awsxray.Exception)
 
 	exception.Stack = make([]awsxray.StackFrame, 0)
 	for {
-		if javascriptStackTracePrefixRegex.MatchString(line) {
+		if strings.HasPrefix(line, "    at ") {
 			parenIdx := strings.IndexByte(line, '(')
 			atIdx := strings.Index(line, "at ")
 			label := ""

--- a/exporter/awsxrayexporter/translator/cause.go
+++ b/exporter/awsxrayexporter/translator/cause.go
@@ -17,6 +17,7 @@ package translator
 import (
 	"bufio"
 	"net/textproto"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -25,6 +26,10 @@ import (
 	semconventions "go.opentelemetry.io/collector/translator/conventions"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray"
+)
+
+var (
+	javascriptStackTracePrefixRegex = regexp.MustCompile(`\ *at (.*?)`)
 )
 
 func makeCause(span pdata.Span, attributes map[string]string, resource pdata.Resource) (isError, isFault bool,
@@ -151,6 +156,8 @@ func parseException(exceptionType string, message string, stacktrace string, lan
 		exceptions = fillJavaStacktrace(stacktrace, exceptions)
 	case "python":
 		exceptions = fillPythonStacktrace(stacktrace, exceptions)
+	case "javascript":
+		exceptions = fillJavaScriptStacktrace(stacktrace, exceptions)
 	}
 
 	return exceptions
@@ -345,4 +352,73 @@ func fillPythonStacktrace(stacktrace string, exceptions []awsxray.Exception) []a
 	}
 
 	return exceptions
+}
+
+func fillJavaScriptStacktrace(stacktrace string, exceptions []awsxray.Exception) []awsxray.Exception {
+	r := textproto.NewReader(bufio.NewReader(strings.NewReader(stacktrace)))
+
+	// Skip first line containing top level exception / message
+	r.ReadLine()
+	exception := &exceptions[0]
+	var line string
+	line, err := r.ReadLine()
+	if err != nil {
+		return exceptions
+	}
+
+	exception.Stack = make([]awsxray.StackFrame, 0)
+	for {
+		if javascriptStackTracePrefixRegex.MatchString(line) {
+			parenIdx := strings.IndexByte(line, '(')
+			atIdx := strings.Index(line, "at ")
+			label := ""
+			path := ""
+			lineIdx := 0
+			if parenIdx >= 0 && line[len(line)-1] == ')' {
+				label = line[atIdx+3 : parenIdx]
+				path = line[parenIdx+1 : len(line)-1]
+			} else if parenIdx < 0 {
+				label = ""
+				path = line[atIdx+3:]
+			}
+
+			colonFirstIdx := strings.IndexByte(path, ':')
+			colonSecondIdx := indexOf(path, ':', colonFirstIdx)
+
+			if colonFirstIdx >= 0 && colonSecondIdx >= 0 && colonFirstIdx != colonSecondIdx {
+				lineStr := path[colonFirstIdx+1 : colonSecondIdx]
+				path = path[0:colonFirstIdx]
+				lineIdx, _ = strconv.Atoi(lineStr)
+			} else if colonFirstIdx < 0 && strings.Contains(path, "native") {
+				path = "native"
+			}
+
+			// only append the exception if all the values of the exception are not default
+			if path != "" || label != "" || lineIdx != 0 {
+				stack := awsxray.StackFrame{
+					Path:  aws.String(path),
+					Label: aws.String(label),
+					Line:  aws.Int(lineIdx),
+				}
+				exception.Stack = append(exception.Stack, stack)
+			}
+		}
+		line, err = r.ReadLine()
+		if err != nil {
+			break
+		}
+	}
+	return exceptions
+}
+
+// indexOf returns position of the first occurrence of a Byte in str starting at pos index.
+func indexOf(str string, c byte, pos int) int {
+	if pos < 0 {
+		return -1
+	}
+	index := strings.IndexByte(str[pos+1:], c)
+	if index > -1 {
+		return index + pos + 1
+	}
+	return -1
 }

--- a/exporter/awsxrayexporter/translator/cause.go
+++ b/exporter/awsxrayexporter/translator/cause.go
@@ -365,16 +365,15 @@ func fillJavaScriptStacktrace(stacktrace string, exceptions []awsxray.Exception)
 	for {
 		if strings.HasPrefix(line, "    at ") {
 			parenIdx := strings.IndexByte(line, '(')
-			atIdx := strings.Index(line, "at ")
 			label := ""
 			path := ""
 			lineIdx := 0
 			if parenIdx >= 0 && line[len(line)-1] == ')' {
-				label = line[atIdx+3 : parenIdx]
+				label = line[7:parenIdx]
 				path = line[parenIdx+1 : len(line)-1]
 			} else if parenIdx < 0 {
 				label = ""
-				path = line[atIdx+3:]
+				path = line[7:]
 			}
 
 			colonFirstIdx := strings.IndexByte(path, ':')

--- a/exporter/awsxrayexporter/translator/cause_test.go
+++ b/exporter/awsxrayexporter/translator/cause_test.go
@@ -629,3 +629,78 @@ TypeError: must be str, not int`
 	assert.Equal(t, "main.py", *exceptions[0].Stack[1].Path)
 	assert.Equal(t, 14, *exceptions[0].Stack[1].Line)
 }
+
+func TestParseExceptionWithJavaScriptStacktrace(t *testing.T) {
+	exceptionType := "TypeError"
+	message := "Cannot read property 'value' of null"
+	// We ignore the exception type / message from the stacktrace
+	stacktrace := `TypeError: Cannot read property 'value' of null
+    at speedy (/home/gbusey/file.js:6:11)
+    at makeFaster (/home/gbusey/file.js:5:3)
+    at Object.<anonymous> (/home/gbusey/file.js:10:1)
+    at node.js:906:3
+    at Array.forEach (native)
+    at native`
+
+	exceptions := parseException(exceptionType, message, stacktrace, "javascript")
+	assert.Len(t, exceptions, 1)
+	assert.NotEmpty(t, exceptions[0].ID)
+	assert.Equal(t, "TypeError", *exceptions[0].Type)
+	assert.Equal(t, "Cannot read property 'value' of null", *exceptions[0].Message)
+	assert.Len(t, exceptions[0].Stack, 6)
+	assert.Equal(t, "speedy ", *exceptions[0].Stack[0].Label)
+	assert.Equal(t, "/home/gbusey/file.js", *exceptions[0].Stack[0].Path)
+	assert.Equal(t, 6, *exceptions[0].Stack[0].Line)
+	assert.Equal(t, "makeFaster ", *exceptions[0].Stack[1].Label)
+	assert.Equal(t, "/home/gbusey/file.js", *exceptions[0].Stack[1].Path)
+	assert.Equal(t, 5, *exceptions[0].Stack[1].Line)
+	assert.Equal(t, "Object.<anonymous> ", *exceptions[0].Stack[2].Label)
+	assert.Equal(t, "/home/gbusey/file.js", *exceptions[0].Stack[2].Path)
+	assert.Equal(t, 10, *exceptions[0].Stack[2].Line)
+	assert.Equal(t, "", *exceptions[0].Stack[3].Label)
+	assert.Equal(t, "node.js", *exceptions[0].Stack[3].Path)
+	assert.Equal(t, 906, *exceptions[0].Stack[3].Line)
+	assert.Equal(t, "Array.forEach ", *exceptions[0].Stack[4].Label)
+	assert.Equal(t, "native", *exceptions[0].Stack[4].Path)
+	assert.Equal(t, 0, *exceptions[0].Stack[4].Line)
+	assert.Equal(t, "", *exceptions[0].Stack[5].Label)
+	assert.Equal(t, "native", *exceptions[0].Stack[5].Path)
+	assert.Equal(t, 0, *exceptions[0].Stack[5].Line)
+}
+
+func TestParseExceptionWithStacktraceNotJavaScript(t *testing.T) {
+	exceptionType := "TypeError"
+	message := "Cannot read property 'value' of null"
+	// We ignore the exception type / message from the stacktrace
+	stacktrace := `TypeError: Cannot read property 'value' of null
+    at speedy (/home/gbusey/file.js:6:11)
+    at makeFaster (/home/gbusey/file.js:5:3)
+    at Object.<anonymous> (/home/gbusey/file.js:10:1)`
+
+	exceptions := parseException(exceptionType, message, stacktrace, "")
+	assert.Len(t, exceptions, 1)
+	assert.NotEmpty(t, exceptions[0].ID)
+	assert.Equal(t, "TypeError", *exceptions[0].Type)
+	assert.Equal(t, "Cannot read property 'value' of null", *exceptions[0].Message)
+	assert.Empty(t, exceptions[0].Stack)
+}
+
+func TestParseExceptionWithJavaScriptStactracekMalformedLines(t *testing.T) {
+	exceptionType := "TypeError"
+	message := "Cannot read property 'value' of null"
+	// We ignore the exception type / message from the stacktrace
+	stacktrace := `TypeError: Cannot read property 'value' of null
+    at speedy (/home/gbusey/file.js)
+    at makeFaster (/home/gbusey/file.js:5:3)malformed123
+    at Object.<anonymous> (/home/gbusey/file.js:10`
+
+	exceptions := parseException(exceptionType, message, stacktrace, "javascript")
+	assert.Len(t, exceptions, 1)
+	assert.NotEmpty(t, exceptions[0].ID)
+	assert.Equal(t, "TypeError", *exceptions[0].Type)
+	assert.Equal(t, "Cannot read property 'value' of null", *exceptions[0].Message)
+	assert.Len(t, exceptions[0].Stack, 1)
+	assert.Equal(t, "speedy ", *exceptions[0].Stack[0].Label)
+	assert.Equal(t, "/home/gbusey/file.js", *exceptions[0].Stack[0].Path)
+	assert.Equal(t, 0, *exceptions[0].Stack[0].Line)
+}


### PR DESCRIPTION
**Description:**
This pull request adds parsing of JavaScript stack traces in x-ray exporter, similar to the current Java and Python parsing with respect to JavaScript stack trace format.

**Testing:**
Added corresponding unit tests:
- Correctly parse JS stack trace
- Parse with language not JavaScript
- Parse malformed JS stack trace