### PR TITLE
[sumologicexporter] Add prometheus formatter for metrics

### DIFF
--- a/exporter/sumologicexporter/prometheus_formatter.go
+++ b/exporter/sumologicexporter/prometheus_formatter.go
@@ -1,0 +1,448 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicexporter
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
+)
+
+type dataPoint interface {
+	Timestamp() pdata.TimestampUnixNano
+	LabelsMap() pdata.StringMap
+}
+
+type prometheusFormatter struct {
+	sanitNameRegex *regexp.Regexp
+	replacer       *strings.Replacer
+}
+
+type prometheusTags string
+
+const (
+	prometheusLeTag       string = "le"
+	prometheusQuantileTag string = "quantile"
+	prometheusInfValue    string = "+Inf"
+)
+
+func newPrometheusFormatter() (prometheusFormatter, error) {
+	sanitNameRegex, err := regexp.Compile(`[^0-9a-zA-Z]`)
+	if err != nil {
+		return prometheusFormatter{}, nil
+	}
+
+	return prometheusFormatter{
+		sanitNameRegex: sanitNameRegex,
+		replacer:       strings.NewReplacer(`\`, `\\`, `"`, `\"`),
+	}, nil
+}
+
+// PrometheusLabels returns all attributes as sanitized prometheus labels string
+func (f *prometheusFormatter) tags2String(attr pdata.AttributeMap, labels pdata.StringMap) prometheusTags {
+	mergedAttributes := pdata.NewAttributeMap()
+	attr.CopyTo(mergedAttributes)
+	labels.ForEach(func(k string, v string) {
+		mergedAttributes.UpsertString(k, v)
+	})
+	length := mergedAttributes.Len()
+
+	if length == 0 {
+		return ""
+	}
+
+	returnValue := make([]string, 0, length)
+	mergedAttributes.ForEach(func(k string, v pdata.AttributeValue) {
+		returnValue = append(
+			returnValue,
+			fmt.Sprintf(
+				`%s="%s"`,
+				f.sanitizeKey(k),
+				f.sanitizeValue(tracetranslator.AttributeValueToString(v, false)),
+			),
+		)
+	})
+
+	return prometheusTags(fmt.Sprintf("{%s}", strings.Join(returnValue, ",")))
+}
+
+// sanitizeKey returns sanitized key string by replacing
+// all non-alphanumeric chars with `_`
+func (f *prometheusFormatter) sanitizeKey(s string) string {
+	return f.sanitNameRegex.ReplaceAllString(s, "_")
+}
+
+// sanitizeKey returns sanitized value string performing the following substitutions:
+// `/` -> `//`
+// `"` -> `\"`
+// `\n` -> `\n`
+func (f *prometheusFormatter) sanitizeValue(s string) string {
+	return strings.ReplaceAll(f.replacer.Replace(s), `\\n`, `\n`)
+}
+
+// doubleLine builds metric based on the given arguments where value is float64
+func (f *prometheusFormatter) doubleLine(name string, attributes prometheusTags, value float64, timestamp pdata.TimestampUnixNano) string {
+	return fmt.Sprintf(
+		"%s%s %g %d",
+		f.sanitizeKey(name),
+		attributes,
+		value,
+		timestamp/pdata.TimestampUnixNano(time.Millisecond),
+	)
+}
+
+// intLine builds metric based on the given arguments where value is int64
+func (f *prometheusFormatter) intLine(name string, attributes prometheusTags, value int64, timestamp pdata.TimestampUnixNano) string {
+	return fmt.Sprintf(
+		"%s%s %d %d",
+		f.sanitizeKey(name),
+		attributes,
+		value,
+		timestamp/pdata.TimestampUnixNano(time.Millisecond),
+	)
+}
+
+// uintLine builds metric based on the given arguments where value is uint64
+func (f *prometheusFormatter) uintLine(name string, attributes prometheusTags, value uint64, timestamp pdata.TimestampUnixNano) string {
+	return fmt.Sprintf(
+		"%s%s %d %d",
+		f.sanitizeKey(name),
+		attributes,
+		value,
+		timestamp/pdata.TimestampUnixNano(time.Millisecond),
+	)
+}
+
+// doubleValueLine returns prometheus line with given value
+func (f *prometheusFormatter) doubleValueLine(name string, value float64, dp dataPoint, attributes pdata.AttributeMap) string {
+	return f.doubleLine(
+		name,
+		f.tags2String(attributes, dp.LabelsMap()),
+		value,
+		dp.Timestamp(),
+	)
+}
+
+// intValueLine returns prometheus line with given value
+func (f *prometheusFormatter) intValueLine(name string, value int64, dp dataPoint, attributes pdata.AttributeMap) string {
+	return f.intLine(
+		name,
+		f.tags2String(attributes, dp.LabelsMap()),
+		value,
+		dp.Timestamp(),
+	)
+}
+
+// uintValueLine returns prometheus line with given value
+func (f *prometheusFormatter) uintValueLine(name string, value uint64, dp dataPoint, attributes pdata.AttributeMap) string {
+	return f.uintLine(
+		name,
+		f.tags2String(attributes, dp.LabelsMap()),
+		value,
+		dp.Timestamp(),
+	)
+}
+
+// doubleDataPointValueLine returns prometheus line with value from pdata.DoubleDataPoint
+func (f *prometheusFormatter) doubleDataPointValueLine(name string, dp pdata.DoubleDataPoint, attributes pdata.AttributeMap) string {
+	return f.doubleValueLine(
+		name,
+		dp.Value(),
+		dp,
+		attributes,
+	)
+}
+
+// intDataPointValueLine returns prometheus line with value from pdata.IntDataPoint
+func (f *prometheusFormatter) intDataPointValueLine(name string, dp pdata.IntDataPoint, attributes pdata.AttributeMap) string {
+	return f.intLine(
+		name,
+		f.tags2String(attributes, dp.LabelsMap()),
+		dp.Value(),
+		dp.Timestamp(),
+	)
+}
+
+// sumMetric returns _sum suffixed metric name
+func (f *prometheusFormatter) sumMetric(name string) string {
+	return fmt.Sprintf("%s_sum", name)
+}
+
+// countMetric returns _count suffixed metric name
+func (f *prometheusFormatter) countMetric(name string) string {
+	return fmt.Sprintf("%s_count", name)
+}
+
+// intGauge2Strings converts IntGauge record to list of strings (one per dataPoint)
+func (f *prometheusFormatter) intGauge2Strings(record metricPair) []string {
+	dps := record.metric.IntGauge().DataPoints()
+	lines := make([]string, 0, dps.Len())
+
+	for i := 0; i < dps.Len(); i++ {
+		dp := record.metric.IntGauge().DataPoints().At(i)
+		line := f.intDataPointValueLine(
+			record.metric.Name(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// mergeAttributes gets two pdata.AttributeMaps and returns new which contains values from both of them
+func (f *prometheusFormatter) mergeAttributes(attributes pdata.AttributeMap, additionalAttributes pdata.AttributeMap) pdata.AttributeMap {
+	mergedAttributes := pdata.NewAttributeMap()
+	attributes.CopyTo(mergedAttributes)
+	additionalAttributes.ForEach(func(k string, v pdata.AttributeValue) {
+		mergedAttributes.Upsert(k, v)
+	})
+	return mergedAttributes
+}
+
+// doubleGauge2Strings converts DoubleGauge record to a list of strings (one per dataPoint)
+func (f *prometheusFormatter) doubleGauge2Strings(record metricPair) []string {
+	dps := record.metric.DoubleGauge().DataPoints()
+	lines := make([]string, 0, dps.Len())
+
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		line := f.doubleDataPointValueLine(
+			record.metric.Name(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+	}
+
+	return lines
+}
+
+// intSum2Strings converts IntSum record to a list of strings (one per dataPoint)
+func (f *prometheusFormatter) intSum2Strings(record metricPair) []string {
+	dps := record.metric.IntSum().DataPoints()
+	lines := make([]string, 0, dps.Len())
+
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		line := f.intDataPointValueLine(
+			record.metric.Name(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+	}
+
+	return lines
+}
+
+// doubleSum2Strings converts DoubleSum record to a list of strings (one per dataPoint)
+func (f *prometheusFormatter) doubleSum2Strings(record metricPair) []string {
+	dps := record.metric.DoubleSum().DataPoints()
+	lines := make([]string, 0, dps.Len())
+
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		line := f.doubleDataPointValueLine(
+			record.metric.Name(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+	}
+
+	return lines
+}
+
+// doubleSummary2Strings converts DoubleSummary record to a list of strings
+// n+2 where n is number of quantiles and 2 stands for sum and count metrics per each data point
+func (f *prometheusFormatter) doubleSummary2Strings(record metricPair) []string {
+	dps := record.metric.DoubleSummary().DataPoints()
+	var lines []string
+
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		qs := dp.QuantileValues()
+		additionalAttributes := pdata.NewAttributeMap()
+		for i := 0; i < qs.Len(); i++ {
+			q := qs.At(i)
+			additionalAttributes.UpsertDouble(prometheusQuantileTag, q.Quantile())
+
+			line := f.doubleValueLine(
+				record.metric.Name(),
+				q.Value(),
+				dp,
+				f.mergeAttributes(record.attributes, additionalAttributes),
+			)
+			lines = append(lines, line)
+		}
+
+		line := f.doubleValueLine(
+			f.sumMetric(record.metric.Name()),
+			dp.Sum(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+
+		line = f.uintValueLine(
+			f.countMetric(record.metric.Name()),
+			dp.Count(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// intHistogram2Strings converts IntHistogram record to a list of strings,
+// (n+1) where n is number of bounds plus two for sum and count per each data point
+func (f *prometheusFormatter) intHistogram2Strings(record metricPair) []string {
+	dps := record.metric.IntHistogram().DataPoints()
+	var lines []string
+
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+
+		explicitBounds := dp.ExplicitBounds()
+		var cumulative uint64
+		additionalAttributes := pdata.NewAttributeMap()
+
+		for i, bound := range explicitBounds {
+			cumulative += dp.BucketCounts()[i]
+			additionalAttributes.UpsertDouble(prometheusLeTag, bound)
+
+			line := f.uintValueLine(
+				record.metric.Name(),
+				cumulative,
+				dp,
+				f.mergeAttributes(record.attributes, additionalAttributes),
+			)
+			lines = append(lines, line)
+		}
+
+		cumulative += dp.BucketCounts()[len(explicitBounds)]
+		additionalAttributes.UpsertString(prometheusLeTag, prometheusInfValue)
+		line := f.uintValueLine(
+			record.metric.Name(),
+			cumulative,
+			dp,
+			f.mergeAttributes(record.attributes, additionalAttributes),
+		)
+		lines = append(lines, line)
+
+		line = f.intValueLine(
+			f.sumMetric(record.metric.Name()),
+			dp.Sum(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+
+		line = f.uintValueLine(
+			f.countMetric(record.metric.Name()),
+			dp.Count(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+	}
+
+	return lines
+}
+
+// doubleHistogram2Strings converts DoubleHistogram record to a list of strings,
+// (n+1) where n is number of bounds plus two for sum and count per each data point
+func (f *prometheusFormatter) doubleHistogram2Strings(record metricPair) []string {
+	dps := record.metric.DoubleHistogram().DataPoints()
+	var lines []string
+
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+
+		explicitBounds := dp.ExplicitBounds()
+		var cumulative uint64
+		additionalAttributes := pdata.NewAttributeMap()
+
+		for i, bound := range explicitBounds {
+			cumulative += dp.BucketCounts()[i]
+			additionalAttributes.UpsertDouble(prometheusLeTag, bound)
+
+			line := f.uintValueLine(
+				record.metric.Name(),
+				cumulative,
+				dp,
+				f.mergeAttributes(record.attributes, additionalAttributes),
+			)
+			lines = append(lines, line)
+		}
+
+		cumulative += dp.BucketCounts()[len(explicitBounds)]
+		additionalAttributes.UpsertString(prometheusLeTag, prometheusInfValue)
+		line := f.uintValueLine(
+			record.metric.Name(),
+			cumulative,
+			dp,
+			f.mergeAttributes(record.attributes, additionalAttributes),
+		)
+		lines = append(lines, line)
+
+		line = f.doubleValueLine(
+			f.sumMetric(record.metric.Name()),
+			dp.Sum(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+
+		line = f.uintValueLine(
+			f.countMetric(record.metric.Name()),
+			dp.Count(),
+			dp,
+			record.attributes,
+		)
+		lines = append(lines, line)
+	}
+
+	return lines
+}
+
+// metric2String returns stringified metricPair
+func (f *prometheusFormatter) metric2String(record metricPair) (string, error) {
+	var lines []string
+
+	switch record.metric.DataType() {
+	case pdata.MetricDataTypeIntGauge:
+		lines = f.intGauge2Strings(record)
+	case pdata.MetricDataTypeDoubleGauge:
+		lines = f.doubleGauge2Strings(record)
+	case pdata.MetricDataTypeIntSum:
+		lines = f.intSum2Strings(record)
+	case pdata.MetricDataTypeDoubleSum:
+		lines = f.doubleSum2Strings(record)
+	case pdata.MetricDataTypeDoubleSummary:
+		lines = f.doubleSummary2Strings(record)
+	case pdata.MetricDataTypeIntHistogram:
+		lines = f.intHistogram2Strings(record)
+	case pdata.MetricDataTypeDoubleHistogram:
+		lines = f.doubleHistogram2Strings(record)
+	}
+	return strings.Join(lines, "\n"), nil
+}

--- a/exporter/sumologicexporter/prometheus_formatter_test.go
+++ b/exporter/sumologicexporter/prometheus_formatter_test.go
@@ -1,0 +1,189 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func newTestPrometheusFormatter(t *testing.T) prometheusFormatter {
+	pf, err := newPrometheusFormatter()
+	require.NoError(t, err)
+
+	return pf
+}
+
+func TestSanitizeKey(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+
+	key := "&^*123-abc-ABC!?"
+	expected := "___123_abc_ABC__"
+	assert.Equal(t, expected, f.sanitizeKey(key))
+}
+
+func TestSanitizeValue(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+
+	value := `&^*123-abc-ABC!?"\\n`
+	expected := `&^*123-abc-ABC!?\"\\\n`
+	assert.Equal(t, expected, f.sanitizeValue(value))
+}
+
+func TestTags2StringNoLabels(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+
+	mp := exampleIntMetric()
+	mp.attributes.InitEmptyWithCapacity(0)
+	assert.Equal(t, prometheusTags(""), f.tags2String(mp.attributes, pdata.NewStringMap()))
+}
+
+func TestTags2String(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+
+	mp := exampleIntMetric()
+	assert.Equal(
+		t,
+		prometheusTags(`{test="test_value",test2="second_value"}`),
+		f.tags2String(mp.attributes, pdata.NewStringMap()),
+	)
+}
+
+func TestTags2StringNoAttributes(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+
+	mp := exampleIntMetric()
+	mp.attributes.InitEmptyWithCapacity(0)
+	assert.Equal(t, prometheusTags(""), f.tags2String(pdata.NewAttributeMap(), pdata.NewStringMap()))
+}
+
+func TestPrometheusMetricDataTypeIntGauge(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+	metric := exampleIntGaugeMetric()
+
+	result, err := f.metric2String(metric)
+	expected := `gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
+gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1608124662166`
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestPrometheusMetricDataTypeDoubleGauge(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+	metric := exampleDoubleGaugeMetric()
+
+	result, err := f.metric2String(metric)
+	expected := `gauge_metric_name_double_test{foo="bar",local_name="156720",endpoint="http://example_url"} 33.4 1608124661169
+gauge_metric_name_double_test{foo="bar",local_name="156155",endpoint="http://another_url"} 56.8 1608124662186`
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestPrometheusMetricDataTypeIntSum(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+	metric := exampleIntSumMetric()
+
+	result, err := f.metric2String(metric)
+	expected := `sum_metric_int_test{foo="bar",name="156720",address="http://example_url"} 45 1608124444169
+sum_metric_int_test{foo="bar",name="156155",address="http://another_url"} 1238 1608124699186`
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestPrometheusMetricDataTypeDoubleSum(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+	metric := exampleDoubleSumMetric()
+
+	result, err := f.metric2String(metric)
+	expected := `sum_metric_double_test{foo="bar",pod_name="lorem",namespace="default"} 45.6 1618124444169
+sum_metric_double_test{foo="bar",pod_name="opsum",namespace="kube-config"} 1238.1 1608424699186`
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestPrometheusMetricDataTypeDoubleSummary(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+	metric := exampleDoubleSummaryMetric()
+
+	result, err := f.metric2String(metric)
+	expected := `summary_metric_double_test{foo="bar",quantile="0.6",pod_name="dolor",namespace="sumologic"} 0.7 1618124444169
+summary_metric_double_test{foo="bar",quantile="2.6",pod_name="dolor",namespace="sumologic"} 4 1618124444169
+summary_metric_double_test_sum{foo="bar",pod_name="dolor",namespace="sumologic"} 45.6 1618124444169
+summary_metric_double_test_count{foo="bar",pod_name="dolor",namespace="sumologic"} 3 1618124444169
+summary_metric_double_test_sum{foo="bar",pod_name="sit",namespace="main"} 1238.1 1608424699186
+summary_metric_double_test_count{foo="bar",pod_name="sit",namespace="main"} 7 1608424699186`
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestPrometheusMetricDataTypeIntHistogram(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+	metric := exampleIntHistogramMetric()
+
+	result, err := f.metric2String(metric)
+	expected := `histogram_metric_int_test{foo="bar",le="0.1",pod_name="dolor",namespace="sumologic"} 0 1618124444169
+histogram_metric_int_test{foo="bar",le="0.2",pod_name="dolor",namespace="sumologic"} 12 1618124444169
+histogram_metric_int_test{foo="bar",le="0.5",pod_name="dolor",namespace="sumologic"} 19 1618124444169
+histogram_metric_int_test{foo="bar",le="0.8",pod_name="dolor",namespace="sumologic"} 24 1618124444169
+histogram_metric_int_test{foo="bar",le="1",pod_name="dolor",namespace="sumologic"} 32 1618124444169
+histogram_metric_int_test{foo="bar",le="+Inf",pod_name="dolor",namespace="sumologic"} 45 1618124444169
+histogram_metric_int_test_sum{foo="bar",pod_name="dolor",namespace="sumologic"} 45 1618124444169
+histogram_metric_int_test_count{foo="bar",pod_name="dolor",namespace="sumologic"} 3 1618124444169
+histogram_metric_int_test{foo="bar",le="0.1",pod_name="sit",namespace="main"} 0 1608424699186
+histogram_metric_int_test{foo="bar",le="0.2",pod_name="sit",namespace="main"} 10 1608424699186
+histogram_metric_int_test{foo="bar",le="0.5",pod_name="sit",namespace="main"} 11 1608424699186
+histogram_metric_int_test{foo="bar",le="0.8",pod_name="sit",namespace="main"} 12 1608424699186
+histogram_metric_int_test{foo="bar",le="1",pod_name="sit",namespace="main"} 16 1608424699186
+histogram_metric_int_test{foo="bar",le="+Inf",pod_name="sit",namespace="main"} 22 1608424699186
+histogram_metric_int_test_sum{foo="bar",pod_name="sit",namespace="main"} 54 1608424699186
+histogram_metric_int_test_count{foo="bar",pod_name="sit",namespace="main"} 5 1608424699186`
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestPrometheusMetricDataTypeDoubleHistogram(t *testing.T) {
+	f := newTestPrometheusFormatter(t)
+	metric := exampleDoubleHistogramMetric()
+
+	result, err := f.metric2String(metric)
+	expected := `histogram_metric_double_test{bar="foo",le="0.1",container="dolor",branch="sumologic"} 0 1618124444169
+histogram_metric_double_test{bar="foo",le="0.2",container="dolor",branch="sumologic"} 12 1618124444169
+histogram_metric_double_test{bar="foo",le="0.5",container="dolor",branch="sumologic"} 19 1618124444169
+histogram_metric_double_test{bar="foo",le="0.8",container="dolor",branch="sumologic"} 24 1618124444169
+histogram_metric_double_test{bar="foo",le="1",container="dolor",branch="sumologic"} 32 1618124444169
+histogram_metric_double_test{bar="foo",le="+Inf",container="dolor",branch="sumologic"} 45 1618124444169
+histogram_metric_double_test_sum{bar="foo",container="dolor",branch="sumologic"} 45.6 1618124444169
+histogram_metric_double_test_count{bar="foo",container="dolor",branch="sumologic"} 7 1618124444169
+histogram_metric_double_test{bar="foo",le="0.1",container="sit",branch="main"} 0 1608424699186
+histogram_metric_double_test{bar="foo",le="0.2",container="sit",branch="main"} 10 1608424699186
+histogram_metric_double_test{bar="foo",le="0.5",container="sit",branch="main"} 11 1608424699186
+histogram_metric_double_test{bar="foo",le="0.8",container="sit",branch="main"} 12 1608424699186
+histogram_metric_double_test{bar="foo",le="1",container="sit",branch="main"} 16 1608424699186
+histogram_metric_double_test{bar="foo",le="+Inf",container="sit",branch="main"} 22 1608424699186
+histogram_metric_double_test_sum{bar="foo",container="sit",branch="main"} 54.1 1608424699186
+histogram_metric_double_test_count{bar="foo",container="sit",branch="main"} 98 1608424699186`
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}

--- a/exporter/sumologicexporter/sender.go
+++ b/exporter/sumologicexporter/sender.go
@@ -35,14 +35,21 @@ type appendResponse struct {
 	appended bool
 }
 
+// metricPair represents information required to send one metric to the Sumo Logic
+type metricPair struct {
+	attributes pdata.AttributeMap
+	metric     pdata.Metric
+}
+
 type sender struct {
-	buffer     []pdata.LogRecord
-	config     *Config
-	client     *http.Client
-	filter     filter
-	ctx        context.Context
-	sources    sourceFormats
-	compressor compressor
+	buffer       []pdata.LogRecord
+	metricBuffer []metricPair
+	config       *Config
+	client       *http.Client
+	filter       filter
+	ctx          context.Context
+	sources      sourceFormats
+	compressor   compressor
 }
 
 const (

--- a/exporter/sumologicexporter/sender.go
+++ b/exporter/sumologicexporter/sender.go
@@ -42,14 +42,13 @@ type metricPair struct {
 }
 
 type sender struct {
-	buffer       []pdata.LogRecord
-	metricBuffer []metricPair
-	config       *Config
-	client       *http.Client
-	filter       filter
-	ctx          context.Context
-	sources      sourceFormats
-	compressor   compressor
+	buffer     []pdata.LogRecord
+	config     *Config
+	client     *http.Client
+	filter     filter
+	ctx        context.Context
+	sources    sourceFormats
+	compressor compressor
 }
 
 const (

--- a/exporter/sumologicexporter/test_data.go
+++ b/exporter/sumologicexporter/test_data.go
@@ -1,0 +1,261 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicexporter
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func exampleIntMetric() metricPair {
+	dp := pdata.NewIntDataPoint()
+	dp.SetTimestamp(1605534165 * 1e9)
+	dp.SetValue(14500)
+
+	metric := pdata.NewMetric()
+	metric.SetName("test.metric.data")
+	metric.SetUnit("bytes")
+	metric.SetDataType(pdata.MetricDataTypeIntSum)
+	metric.IntSum().DataPoints().Append(dp)
+
+	attributes := pdata.NewAttributeMap()
+	attributes.InsertString("test", "test_value")
+	attributes.InsertString("test2", "second_value")
+
+	return metricPair{
+		metric:     metric,
+		attributes: attributes,
+	}
+}
+
+func exampleIntGaugeMetric() metricPair {
+	metric := metricPair{
+		attributes: pdata.NewAttributeMap(),
+		metric:     pdata.NewMetric(),
+	}
+
+	metric.metric.SetDataType(pdata.MetricDataTypeIntGauge)
+	metric.metric.SetName("gauge_metric_name")
+
+	metric.attributes.InsertString("foo", "bar")
+
+	dp := pdata.NewIntDataPoint()
+	dp.LabelsMap().Insert("remote_name", "156920")
+	dp.LabelsMap().Insert("url", "http://example_url")
+	dp.SetValue(124)
+	dp.SetTimestamp(1608124661.166 * 1e9)
+	metric.metric.IntGauge().DataPoints().Append(dp)
+
+	dp = pdata.NewIntDataPoint()
+	dp.LabelsMap().Insert("remote_name", "156955")
+	dp.LabelsMap().Insert("url", "http://another_url")
+	dp.SetValue(245)
+	dp.SetTimestamp(1608124662.166 * 1e9)
+	metric.metric.IntGauge().DataPoints().Append(dp)
+
+	return metric
+}
+
+func exampleDoubleGaugeMetric() metricPair {
+	metric := metricPair{
+		attributes: pdata.NewAttributeMap(),
+		metric:     pdata.NewMetric(),
+	}
+
+	metric.metric.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	metric.metric.SetName("gauge_metric_name_double_test")
+
+	metric.attributes.InsertString("foo", "bar")
+
+	dp := pdata.NewDoubleDataPoint()
+	dp.LabelsMap().Insert("local_name", "156720")
+	dp.LabelsMap().Insert("endpoint", "http://example_url")
+	dp.SetValue(33.4)
+	dp.SetTimestamp(1608124661.169 * 1e9)
+	metric.metric.DoubleGauge().DataPoints().Append(dp)
+
+	dp = pdata.NewDoubleDataPoint()
+	dp.LabelsMap().Insert("local_name", "156155")
+	dp.LabelsMap().Insert("endpoint", "http://another_url")
+	dp.SetValue(56.8)
+	dp.SetTimestamp(1608124662.186 * 1e9)
+	metric.metric.DoubleGauge().DataPoints().Append(dp)
+
+	return metric
+}
+
+func exampleIntSumMetric() metricPair {
+	metric := metricPair{
+		attributes: pdata.NewAttributeMap(),
+		metric:     pdata.NewMetric(),
+	}
+
+	metric.metric.SetDataType(pdata.MetricDataTypeIntSum)
+	metric.metric.SetName("sum_metric_int_test")
+
+	metric.attributes.InsertString("foo", "bar")
+
+	dp := pdata.NewIntDataPoint()
+	dp.LabelsMap().Insert("name", "156720")
+	dp.LabelsMap().Insert("address", "http://example_url")
+	dp.SetValue(45)
+	dp.SetTimestamp(1608124444.169 * 1e9)
+	metric.metric.IntSum().DataPoints().Append(dp)
+
+	dp = pdata.NewIntDataPoint()
+	dp.LabelsMap().Insert("name", "156155")
+	dp.LabelsMap().Insert("address", "http://another_url")
+	dp.SetValue(1238)
+	dp.SetTimestamp(1608124699.186 * 1e9)
+	metric.metric.IntSum().DataPoints().Append(dp)
+
+	return metric
+}
+
+func exampleDoubleSumMetric() metricPair {
+	metric := metricPair{
+		attributes: pdata.NewAttributeMap(),
+		metric:     pdata.NewMetric(),
+	}
+
+	metric.metric.SetDataType(pdata.MetricDataTypeDoubleSum)
+	metric.metric.SetName("sum_metric_double_test")
+
+	metric.attributes.InsertString("foo", "bar")
+
+	dp := pdata.NewDoubleDataPoint()
+	dp.LabelsMap().Insert("pod_name", "lorem")
+	dp.LabelsMap().Insert("namespace", "default")
+	dp.SetValue(45.6)
+	dp.SetTimestamp(1618124444.169 * 1e9)
+	metric.metric.DoubleSum().DataPoints().Append(dp)
+
+	dp = pdata.NewDoubleDataPoint()
+	dp.LabelsMap().Insert("pod_name", "opsum")
+	dp.LabelsMap().Insert("namespace", "kube-config")
+	dp.SetValue(1238.1)
+	dp.SetTimestamp(1608424699.186 * 1e9)
+	metric.metric.DoubleSum().DataPoints().Append(dp)
+
+	return metric
+}
+
+func exampleDoubleSummaryMetric() metricPair {
+	metric := metricPair{
+		attributes: pdata.NewAttributeMap(),
+		metric:     pdata.NewMetric(),
+	}
+
+	metric.metric.SetDataType(pdata.MetricDataTypeDoubleSummary)
+	metric.metric.SetName("summary_metric_double_test")
+
+	metric.attributes.InsertString("foo", "bar")
+
+	dp := pdata.NewDoubleSummaryDataPoint()
+	dp.LabelsMap().Insert("pod_name", "dolor")
+	dp.LabelsMap().Insert("namespace", "sumologic")
+	dp.SetSum(45.6)
+	dp.SetCount(3)
+	dp.SetTimestamp(1618124444.169 * 1e9)
+
+	quantile := pdata.NewValueAtQuantile()
+	quantile.SetQuantile(0.6)
+	quantile.SetValue(0.7)
+	dp.QuantileValues().Append(quantile)
+
+	quantile = pdata.NewValueAtQuantile()
+	quantile.SetQuantile(2.6)
+	quantile.SetValue(4)
+	dp.QuantileValues().Append(quantile)
+
+	metric.metric.DoubleSummary().DataPoints().Append(dp)
+
+	dp = pdata.NewDoubleSummaryDataPoint()
+	dp.LabelsMap().Insert("pod_name", "sit")
+	dp.LabelsMap().Insert("namespace", "main")
+	dp.SetSum(1238.1)
+	dp.SetCount(7)
+	dp.SetTimestamp(1608424699.186 * 1e9)
+	metric.metric.DoubleSummary().DataPoints().Append(dp)
+
+	return metric
+}
+
+func exampleIntHistogramMetric() metricPair {
+	metric := metricPair{
+		attributes: pdata.NewAttributeMap(),
+		metric:     pdata.NewMetric(),
+	}
+
+	metric.metric.SetDataType(pdata.MetricDataTypeIntHistogram)
+	metric.metric.SetName("histogram_metric_int_test")
+
+	metric.attributes.InsertString("foo", "bar")
+
+	dp := pdata.NewIntHistogramDataPoint()
+	dp.LabelsMap().Insert("pod_name", "dolor")
+	dp.LabelsMap().Insert("namespace", "sumologic")
+	dp.SetBucketCounts([]uint64{0, 12, 7, 5, 8, 13})
+	dp.SetExplicitBounds([]float64{0.1, 0.2, 0.5, 0.8, 1})
+	dp.SetTimestamp(1618124444.169 * 1e9)
+	dp.SetSum(45)
+	dp.SetCount(3)
+	metric.metric.IntHistogram().DataPoints().Append(dp)
+
+	dp = pdata.NewIntHistogramDataPoint()
+	dp.LabelsMap().Insert("pod_name", "sit")
+	dp.LabelsMap().Insert("namespace", "main")
+	dp.SetBucketCounts([]uint64{0, 10, 1, 1, 4, 6})
+	dp.SetExplicitBounds([]float64{0.1, 0.2, 0.5, 0.8, 1})
+	dp.SetTimestamp(1608424699.186 * 1e9)
+	dp.SetSum(54)
+	dp.SetCount(5)
+	metric.metric.IntHistogram().DataPoints().Append(dp)
+
+	return metric
+}
+
+func exampleDoubleHistogramMetric() metricPair {
+	metric := metricPair{
+		attributes: pdata.NewAttributeMap(),
+		metric:     pdata.NewMetric(),
+	}
+
+	metric.metric.SetDataType(pdata.MetricDataTypeDoubleHistogram)
+	metric.metric.SetName("histogram_metric_double_test")
+
+	metric.attributes.InsertString("bar", "foo")
+
+	dp := pdata.NewDoubleHistogramDataPoint()
+	dp.LabelsMap().Insert("container", "dolor")
+	dp.LabelsMap().Insert("branch", "sumologic")
+	dp.SetBucketCounts([]uint64{0, 12, 7, 5, 8, 13})
+	dp.SetExplicitBounds([]float64{0.1, 0.2, 0.5, 0.8, 1})
+	dp.SetTimestamp(1618124444.169 * 1e9)
+	dp.SetSum(45.6)
+	dp.SetCount(7)
+	metric.metric.DoubleHistogram().DataPoints().Append(dp)
+
+	dp = pdata.NewDoubleHistogramDataPoint()
+	dp.LabelsMap().Insert("container", "sit")
+	dp.LabelsMap().Insert("branch", "main")
+	dp.SetBucketCounts([]uint64{0, 10, 1, 1, 4, 6})
+	dp.SetExplicitBounds([]float64{0.1, 0.2, 0.5, 0.8, 1})
+	dp.SetTimestamp(1608424699.186 * 1e9)
+	dp.SetSum(54.1)
+	dp.SetCount(98)
+	metric.metric.DoubleHistogram().DataPoints().Append(dp)
+
+	return metric
+}


### PR DESCRIPTION
**Description:**
Add prometheus formatter for metrics.

_NOTE: metricPair is a structure which will hold information about metrics attributes and metrics itself.
This structure is required to handle all information we want to export to sumologic_

**Link to tracking Issue:** #1498 

**Testing:**
- Unit tests
- Visual comparison tests with prometheus exporter

**Documentation:**
In-code comments