### PR TITLE
Simplify the awsprometheusremotewriteexporter Sigv4 handling and improve README

### DIFF
--- a/exporter/awsprometheusremotewriteexporter/README.md
+++ b/exporter/awsprometheusremotewriteexporter/README.md
@@ -16,7 +16,7 @@ and only exports the following combination:
 
 ## Configuration
 The following settings are required:
-- `endpoint`: protocol:host:port to which the exporter is going to send traces or metrics, using the HTTP/HTTPS protocol. 
+- `endpoint`: The Prometheus remote write endpoint in the format. For example, https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-xxx/api/v1/remote_write.
 
 The following settings can be optionally configured:
 - `namespace`: prefix attached to each exported metric name.
@@ -39,13 +39,20 @@ Simplest configuration:
 ```yaml
 exporters:
   awsprometheusremotewrite:
-    endpoint: "http://some.url:9411/api/prom/push"
+    endpoint: "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-xxx/api/v1/remote_write"
+    aws_auth: # required for the Amazon Managed Service for Prometheus.
+      region: "us-east-1"
+      service: "aps"
 ```
 
 All configurations:
 ```yaml
 exporters:
   awsprometheusremotewrite:
+    endpoint: "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-xxx/api/v1/remote_write"
+    aws_auth:
+      region: "us-east-1"
+      service: "aps"
     namespace: "test-space"
     sending_queue:
         enabled: true
@@ -56,15 +63,11 @@ exporters:
         initial_interval: 10s
         max_interval: 60s
         max_elapsed_time: 10m
-    endpoint: "http://localhost:9009"
     ca_file: "/var/lib/mycert.pem"
     write_buffer_size: 524288
     headers:
         Prometheus-Remote-Write-Version: "0.1.0"
         X-Scope-OrgID: 234
-    aws_auth:
-        region: "us-west-2"
-        service: "service-name"
     external_labels:
         key1: value1
         key2: value2

--- a/exporter/awsprometheusremotewriteexporter/factory.go
+++ b/exporter/awsprometheusremotewriteexporter/factory.go
@@ -17,7 +17,6 @@ package awsprometheusremotewriteexporter
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"go.opentelemetry.io/collector/component"
@@ -56,18 +55,8 @@ func (af *awsFactory) CreateDefaultConfig() configmodels.Exporter {
 
 	cfg.TypeVal = typeStr
 	cfg.NameVal = typeStr
-
 	cfg.HTTPClientSettings.CustomRoundTripper = func(next http.RoundTripper) (http.RoundTripper, error) {
-		if !isAuthConfigValid(cfg.AuthConfig) {
-			return nil, errors.New("invalid authentication configuration")
-		}
-
 		return newSigningRoundTripper(cfg.AuthConfig, next)
 	}
-
 	return cfg
-}
-
-func isAuthConfigValid(params AuthConfig) bool {
-	return !(params.Region != "" && params.Service == "" || params.Region == "" && params.Service != "")
 }


### PR DESCRIPTION
SigV4 signing will be mainly used for the Amazon Managed Service for Prometheus. Revise the basic configuration to capture the aws_auth configuration.

On the other hand, simplify the factory by delegating the auth configuration verification to the signingRoundTripper. This change doesn't remove functionality, it removes some dead code.

cc @amanbrar1999 @JasonXZLiu 