### PR TITLE
[exporter/datadogexporter] Add Kubernetes conventions for hostnames

### DIFF
--- a/exporter/datadogexporter/metadata/host.go
+++ b/exporter/datadogexporter/metadata/host.go
@@ -83,13 +83,12 @@ func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
 		return customHostname.StringVal(), true
 	}
 
-	// Kubernetes: node-cluster if cluster is available, else node
+	// Kubernetes: node-cluster if cluster name is available, else node
 	if k8sNodeName, ok := attrs.Get(AttributeK8sNodeName); ok {
 		if k8sClusterName, ok := attrs.Get(conventions.AttributeK8sCluster); ok {
 			return k8sNodeName.StringVal() + "-" + k8sClusterName.StringVal(), true
-		} else {
-			return k8sNodeName.StringVal(), true
 		}
+		return k8sNodeName.StringVal(), true
 	}
 
 	// container id (e.g. from Docker)

--- a/exporter/datadogexporter/metadata/host.go
+++ b/exporter/datadogexporter/metadata/host.go
@@ -26,6 +26,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/utils/cache"
 )
 
+const (
+	AttributeDatadogHostname = "datadog.host.name"
+	AttributeK8sNodeName     = "k8s.node.name"
+)
+
 // GetHost gets the hostname according to configuration.
 // It checks in the following order
 // 1. Cache
@@ -65,12 +70,29 @@ func GetHost(logger *zap.Logger, cfg *config.Config) *string {
 
 // HostnameFromAttributes tries to get a valid hostname from attributes by checking, in order:
 //
-//   1. the container ID,
-//   2. the cloud provider host ID and
-//   3. the host.name attribute.
+//   1. a custom Datadog hostname provided by the "datadog.host.name" attribute
+//   2. the Kubernetes node name (and cluster name if available),
+//   3. the container ID,
+//   4. the cloud provider host ID and
+//   5. the host.name attribute.
 //
 //  It returns a boolean value indicated if any name was found
 func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
+	// Custom hostname: useful for overriding in k8s/cloud envs
+	if customHostname, ok := attrs.Get(AttributeDatadogHostname); ok {
+		return customHostname.StringVal(), true
+	}
+
+	// Kubernetes: node-cluster if cluster is available, else node
+	if k8sNodeName, ok := attrs.Get(AttributeK8sNodeName); ok {
+		if k8sClusterName, ok := attrs.Get(conventions.AttributeK8sCluster); ok {
+			return k8sNodeName.StringVal() + "-" + k8sClusterName.StringVal(), true
+		} else {
+			return k8sNodeName.StringVal(), true
+		}
+	}
+
+	// container id (e.g. from Docker)
 	if containerID, ok := attrs.Get(conventions.AttributeContainerID); ok {
 		return containerID.StringVal(), true
 	}
@@ -81,10 +103,12 @@ func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
 		return ec2.HostnameFromAttributes(attrs)
 	}
 
+	// host id from cloud provider
 	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
 		return hostID.StringVal(), true
 	}
 
+	// hostname from cloud provider or OS
 	if hostName, ok := attrs.Get(conventions.AttributeHostName); ok {
 		return hostName.StringVal(), true
 	}


### PR DESCRIPTION
**Description:** 

- If we get a payload with Kubernetes information, try to set the hostname similarly to what we do in the Datadog Agent (see e.g. [here](https://github.com/DataDog/datadog-agent/blob/757eb5e14cb0a42cbded964563184247386af114/pkg/util/hostname/apiserver/hostname.go#L23-L29))
- Add a custom hostname convention (Datadog specific)

**Link to tracking Issue:** n/a, related to issue reported internally

**Testing:** Added unit tests. Testing in progress (keeping as draft)
