### PR TITLE
Add more goroutines for Xray receiver to improve the performance

### DIFF
--- a/receiver/awsxrayreceiver/receiver.go
+++ b/receiver/awsxrayreceiver/receiver.go
@@ -133,11 +133,11 @@ func (x *xrayReceiver) start() {
 	incomingSegments := x.poller.SegmentsChan()
 	bufPool := x.poller.BufferPool()
 	for w := 1; w <= x.numOfWorkerToStart; w++ {
-		go x.worker(incomingSegments, bufPool)
+		go x.worker(incomingSegments, &bufPool)
 	}
 }
 
-func (x *xrayReceiver) worker(incomingSegments <-chan udppoller.RawSegment, bufferPool sync.Pool) {
+func (x *xrayReceiver) worker(incomingSegments <-chan udppoller.RawSegment, bufferPool *sync.Pool) {
 	for{
 		select {
 		case <-x.shutDown:

--- a/receiver/awsxrayreceiver/receiver.go
+++ b/receiver/awsxrayreceiver/receiver.go
@@ -125,6 +125,12 @@ func (x *xrayReceiver) Shutdown(_ context.Context) error {
 
 func (x *xrayReceiver) start() {
 	incomingSegments := x.poller.SegmentsChan()
+	for w := 1; w <= 4; w++ {
+		go x.woker(incomingSegments)
+	}
+}
+
+func (x *xrayReceiver) woker(incomingSegments <-chan udppoller.RawSegment) {
 	for seg := range incomingSegments {
 		traces, totalSpansCount, err := translator.ToTraces(seg.Payload)
 		if err != nil {


### PR DESCRIPTION
**Description:** 
The current code for xray receiver will lose data when it got more than 600 spans/second, because of the execution speed of translator and consumer. This pr will use 4 go routines to increase the execution speed to improve the performance. After the performance testing, it can handle 3000spans
Add more go routines for Xray receiver to improve the performance.
