### PR TITLE
Added Loki exporter codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@ exporter/jaegerthrifthttpexporter/         @open-telemetry/collector-contrib-app
 exporter/kinesisexporter/                  @open-telemetry/collector-contrib-approvers @owais
 exporter/loadbalancingexporter/            @open-telemetry/collector-contrib-approvers @jpkrohling
 exporter/logzioexporter/                   @open-telemetry/collector-contrib-approvers @yyyogev
+exporter/lokiexporter/                     @open-telemetry/collector-contrib-approvers @gramidt
 exporter/newrelicexporter/                 @open-telemetry/collector-contrib-approvers @MrAlias
 exporter/sapmexporter/                     @open-telemetry/collector-contrib-approvers @owais @dmitryax
 exporter/sentryexporter/                   @open-telemetry/collector-contrib-approvers @AbhiPrasad


### PR DESCRIPTION
Signed-off-by: Granville Schmidt <1246157+gramidt@users.noreply.github.com>

**Description:** 
Adding myself as the code owner of the Loki exporter ( https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1900 )

**Link to tracking Issue:**
#1894 

**Testing:**
N/A

**Documentation:**
N/A