### PR TITLE
Add params to prometheus_simple

### DIFF
--- a/receiver/simpleprometheusreceiver/README.md
+++ b/receiver/simpleprometheusreceiver/README.md
@@ -19,6 +19,7 @@ The following settings are optional:
 - `collection_interval` (default = `10s`): The internal at which metrics should
 be emitted by this receiver.
 - `metrics_path` (default = `/metrics`): The path to the metrics endpoint.
+- `params` (default = `{}`): the parameters to pass to the metrics endpoint.
 - `use_service_account` (default = `false`): Whether or not to use the
 Kubernetes Pod service account for authentication.
 - `tls_enabled` (default = `false`): Whether or not to use TLS. Only if

--- a/receiver/simpleprometheusreceiver/README.md
+++ b/receiver/simpleprometheusreceiver/README.md
@@ -19,7 +19,7 @@ The following settings are optional:
 - `collection_interval` (default = `10s`): The internal at which metrics should
 be emitted by this receiver.
 - `metrics_path` (default = `/metrics`): The path to the metrics endpoint.
-- `params` (default = `{}`): the query parameters to pass to the metrics endpoint. If specified, params are appended to `metrics_path` to form the URL with which the target is scraped.
+- `params` (default = `{}`): The query parameters to pass to the metrics endpoint. If specified, params are appended to `metrics_path` to form the URL with which the target is scraped.
 - `use_service_account` (default = `false`): Whether or not to use the
 Kubernetes Pod service account for authentication.
 - `tls_enabled` (default = `false`): Whether or not to use TLS. Only if

--- a/receiver/simpleprometheusreceiver/README.md
+++ b/receiver/simpleprometheusreceiver/README.md
@@ -19,7 +19,7 @@ The following settings are optional:
 - `collection_interval` (default = `10s`): The internal at which metrics should
 be emitted by this receiver.
 - `metrics_path` (default = `/metrics`): The path to the metrics endpoint.
-- `params` (default = `{}`): the parameters to pass to the metrics endpoint.
+- `params` (default = `{}`): the query parameters to pass to the metrics endpoint. If specified, params are appended to `metrics_path` to form the URL with which the target is scraped.
 - `use_service_account` (default = `false`): Whether or not to use the
 Kubernetes Pod service account for authentication.
 - `tls_enabled` (default = `false`): Whether or not to use TLS. Only if

--- a/receiver/simpleprometheusreceiver/config.go
+++ b/receiver/simpleprometheusreceiver/config.go
@@ -15,6 +15,7 @@
 package simpleprometheusreceiver
 
 import (
+	"net/url"
 	"time"
 
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -30,6 +31,8 @@ type Config struct {
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
 	// MetricsPath the path to the metrics endpoint.
 	MetricsPath string `mapstructure:"metrics_path"`
+	// Params the parameters to the metrics endpoint.
+	Params url.Values `mapstructure:"params,omitempty"`
 	// Whether or not to use pod service account to authenticate.
 	UseServiceAccount bool `mapstructure:"use_service_account"`
 }

--- a/receiver/simpleprometheusreceiver/config_test.go
+++ b/receiver/simpleprometheusreceiver/config_test.go
@@ -68,7 +68,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 			CollectionInterval: 30 * time.Second,
 			MetricsPath:        "/v2/metrics",
-			Params:             url.Values{"columns": []string{"name", "messages"}},
+			Params:             url.Values{"columns": []string{"name", "messages"}, "key": []string{"foo", "bar"}},
 			UseServiceAccount:  true,
 		})
 

--- a/receiver/simpleprometheusreceiver/config_test.go
+++ b/receiver/simpleprometheusreceiver/config_test.go
@@ -15,6 +15,7 @@
 package simpleprometheusreceiver
 
 import (
+	"net/url"
 	"path"
 	"testing"
 	"time"
@@ -67,6 +68,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 			CollectionInterval: 30 * time.Second,
 			MetricsPath:        "/v2/metrics",
+			Params:             url.Values{"columns": []string{"name", "messages"}},
 			UseServiceAccount:  true,
 		})
 

--- a/receiver/simpleprometheusreceiver/receiver.go
+++ b/receiver/simpleprometheusreceiver/receiver.go
@@ -96,6 +96,7 @@ func getPrometheusConfig(cfg *Config) (*prometheusreceiver.Config, error) {
 		HonorTimestamps: true,
 		Scheme:          scheme,
 		MetricsPath:     cfg.MetricsPath,
+		Params:          cfg.Params,
 		ServiceDiscoveryConfigs: discovery.Configs{
 			&discovery.StaticConfig{
 				{

--- a/receiver/simpleprometheusreceiver/receiver_test.go
+++ b/receiver/simpleprometheusreceiver/receiver_test.go
@@ -16,6 +16,7 @@ package simpleprometheusreceiver
 
 import (
 	"context"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -90,6 +91,7 @@ func TestGetPrometheusConfig(t *testing.T) {
 				},
 				CollectionInterval: 10 * time.Second,
 				MetricsPath:        "/metric",
+				Params:             url.Values{"foo": []string{"bar", "foobar"}},
 			},
 			want: &prometheusreceiver.Config{
 				PrometheusConfig: &config.Config{
@@ -101,6 +103,7 @@ func TestGetPrometheusConfig(t *testing.T) {
 							HonorTimestamps: true,
 							Scheme:          "http",
 							MetricsPath:     "/metric",
+							Params:          url.Values{"foo": []string{"bar", "foobar"}},
 							ServiceDiscoveryConfigs: discovery.Configs{
 								&discovery.StaticConfig{
 									{

--- a/receiver/simpleprometheusreceiver/testdata/config.yaml
+++ b/receiver/simpleprometheusreceiver/testdata/config.yaml
@@ -6,6 +6,7 @@ receivers:
     metrics_path: /v2/metrics
     params:
       columns: "name,messages"
+      key: ["foo","bar"]
     use_service_account: true
     tls_enabled: true
     tls_config:

--- a/receiver/simpleprometheusreceiver/testdata/config.yaml
+++ b/receiver/simpleprometheusreceiver/testdata/config.yaml
@@ -4,6 +4,8 @@ receivers:
     endpoint: "localhost:1234"
     collection_interval: 30s
     metrics_path: /v2/metrics
+    params:
+      columns: "name,messages"
     use_service_account: true
     tls_enabled: true
     tls_config:


### PR DESCRIPTION
**Description:**
Add support for passing params to the prometheus scrape config.

**Testing:**
Unit tests.

**Documentation:** 
Added to README and testdata.