### PR TITLE
Implement Span status code specification changes - gRPC

### DIFF
--- a/exporter/azuremonitorexporter/conventions.go
+++ b/exporter/azuremonitorexporter/conventions.go
@@ -27,16 +27,7 @@ import (
 
 const (
 	// TODO replace with convention.* values once available
-	attributeDBSystem              string = "db.system"
-	attributeDBConnectionString    string = "db.connection_string"
-	attributeDBMSSQLInstanceName   string = "db.mssql.instance_name"
-	attributeDBJDBCDriverClassName string = "db.jdbc.driver_classname"
-	attributeDBName                string = "db.name"
-	attributeDBOperation           string = "db.operation"
-	attributeDBCassandraKeyspace   string = "db.cassandra.keyspace"
-	attributeDBHBaseNamespace      string = "db.hbase.namespace"
-	attributeDBRedisDatabaseIndex  string = "db.redis.database_index"
-	attributeDBMongoDBCollection   string = "db.mongodb.collection"
+	attributeRPCGRPCStatusCode string = "rpc.grpc.status_code"
 )
 
 // NetworkAttributes is the set of known network attributes
@@ -160,6 +151,7 @@ type RPCAttributes struct {
 	RPCSystem         string
 	RPCService        string
 	RPCMethod         string
+	RPCGRPCStatusCode int64
 	NetworkAttributes NetworkAttributes
 }
 
@@ -172,6 +164,8 @@ func (attrs *RPCAttributes) MapAttribute(k string, v pdata.AttributeValue) {
 		attrs.RPCService = v.StringVal()
 	case conventions.AttributeRPCMethod:
 		attrs.RPCMethod = v.StringVal()
+	case attributeRPCGRPCStatusCode:
+		attrs.RPCGRPCStatusCode = v.IntVal()
 
 	default:
 		attrs.NetworkAttributes.MapAttribute(k, v)
@@ -198,27 +192,27 @@ type DatabaseAttributes struct {
 // MapAttribute attempts to map a Span attribute to one of the known types
 func (attrs *DatabaseAttributes) MapAttribute(k string, v pdata.AttributeValue) {
 	switch k {
-	case attributeDBSystem:
+	case conventions.AttributeDBSystem:
 		attrs.DBSystem = v.StringVal()
-	case attributeDBConnectionString:
+	case conventions.AttributeDBConnectionString:
 		attrs.DBConnectionString = v.StringVal()
 	case conventions.AttributeDBUser:
 		attrs.DBUser = v.StringVal()
 	case conventions.AttributeDBStatement:
 		attrs.DBStatement = v.StringVal()
-	case attributeDBOperation:
+	case conventions.AttributeDBOperation:
 		attrs.DBOperation = v.StringVal()
-	case attributeDBMSSQLInstanceName:
+	case conventions.AttributeDBMsSQLInstanceName:
 		attrs.DBMSSQLInstanceName = v.StringVal()
-	case attributeDBJDBCDriverClassName:
+	case conventions.AttributeDBJDBCDriverClassname:
 		attrs.DBJDBCDriverClassName = v.StringVal()
-	case attributeDBCassandraKeyspace:
+	case conventions.AttributeDBCassandraKeyspace:
 		attrs.DBCassandraKeyspace = v.StringVal()
-	case attributeDBHBaseNamespace:
+	case conventions.AttributeDBHBaseNamespace:
 		attrs.DBHBaseNamespace = v.StringVal()
-	case attributeDBRedisDatabaseIndex:
+	case conventions.AttributeDBRedisDatabaseIndex:
 		attrs.DBRedisDatabaseIndex = v.StringVal()
-	case attributeDBMongoDBCollection:
+	case conventions.AttributeDBMongoDBCollection:
 		attrs.DBMongoDBCollection = v.StringVal()
 
 	default:

--- a/exporter/azuremonitorexporter/conventions.go
+++ b/exporter/azuremonitorexporter/conventions.go
@@ -26,8 +26,11 @@ import (
 */
 
 const (
-	// TODO replace with convention.* values once available
-	attributeRPCGRPCStatusCode string = "rpc.grpc.status_code"
+	// TODO replace with convention.* values once/if available
+	attributeRPCGRPCStatusCode        string = "rpc.grpc.status_code"
+	attributeOtelStatusCode           string = "otel.status_code"
+	attributeOtelStatusDeprecatedCode string = "otel.status_deprecatedcode"
+	attributeOtelStatusDescription    string = "otel.status_description"
 )
 
 // NetworkAttributes is the set of known network attributes

--- a/exporter/azuremonitorexporter/conventions_test.go
+++ b/exporter/azuremonitorexporter/conventions_test.go
@@ -99,17 +99,17 @@ func TestRPCPAttributeMapping(t *testing.T) {
 
 func TestDatabaseAttributeMapping(t *testing.T) {
 	databaseAttributeValues := map[string]pdata.AttributeValue{
-		attributeDBSystem:                pdata.NewAttributeValueString(attributeDBSystem),
-		attributeDBConnectionString:      pdata.NewAttributeValueString(attributeDBConnectionString),
-		conventions.AttributeDBUser:      pdata.NewAttributeValueString(conventions.AttributeDBUser),
-		conventions.AttributeDBStatement: pdata.NewAttributeValueString(conventions.AttributeDBStatement),
-		attributeDBOperation:             pdata.NewAttributeValueString(attributeDBOperation),
-		attributeDBMSSQLInstanceName:     pdata.NewAttributeValueString(attributeDBMSSQLInstanceName),
-		attributeDBJDBCDriverClassName:   pdata.NewAttributeValueString(attributeDBJDBCDriverClassName),
-		attributeDBCassandraKeyspace:     pdata.NewAttributeValueString(attributeDBCassandraKeyspace),
-		attributeDBHBaseNamespace:        pdata.NewAttributeValueString(attributeDBHBaseNamespace),
-		attributeDBRedisDatabaseIndex:    pdata.NewAttributeValueString(attributeDBRedisDatabaseIndex),
-		attributeDBMongoDBCollection:     pdata.NewAttributeValueString(attributeDBMongoDBCollection),
+		conventions.AttributeDBSystem:              pdata.NewAttributeValueString(conventions.AttributeDBSystem),
+		conventions.AttributeDBConnectionString:    pdata.NewAttributeValueString(conventions.AttributeDBConnectionString),
+		conventions.AttributeDBUser:                pdata.NewAttributeValueString(conventions.AttributeDBUser),
+		conventions.AttributeDBStatement:           pdata.NewAttributeValueString(conventions.AttributeDBStatement),
+		conventions.AttributeDBOperation:           pdata.NewAttributeValueString(conventions.AttributeDBOperation),
+		conventions.AttributeDBMsSQLInstanceName:   pdata.NewAttributeValueString(conventions.AttributeDBMsSQLInstanceName),
+		conventions.AttributeDBJDBCDriverClassname: pdata.NewAttributeValueString(conventions.AttributeDBJDBCDriverClassname),
+		conventions.AttributeDBCassandraKeyspace:   pdata.NewAttributeValueString(conventions.AttributeDBCassandraKeyspace),
+		conventions.AttributeDBHBaseNamespace:      pdata.NewAttributeValueString(conventions.AttributeDBHBaseNamespace),
+		conventions.AttributeDBRedisDatabaseIndex:  pdata.NewAttributeValueString(conventions.AttributeDBRedisDatabaseIndex),
+		conventions.AttributeDBMongoDBCollection:   pdata.NewAttributeValueString(conventions.AttributeDBMongoDBCollection),
 	}
 
 	attributeMap := pdata.NewAttributeMap()
@@ -121,16 +121,16 @@ func TestDatabaseAttributeMapping(t *testing.T) {
 	databaseAttributes := &DatabaseAttributes{}
 	attributeMap.ForEach(databaseAttributes.MapAttribute)
 
-	assert.Equal(t, attributeDBSystem, databaseAttributes.DBSystem)
-	assert.Equal(t, attributeDBConnectionString, databaseAttributes.DBConnectionString)
+	assert.Equal(t, conventions.AttributeDBSystem, databaseAttributes.DBSystem)
+	assert.Equal(t, conventions.AttributeDBConnectionString, databaseAttributes.DBConnectionString)
 	assert.Equal(t, conventions.AttributeDBUser, databaseAttributes.DBUser)
 	assert.Equal(t, conventions.AttributeDBStatement, databaseAttributes.DBStatement)
-	assert.Equal(t, attributeDBOperation, databaseAttributes.DBOperation)
-	assert.Equal(t, attributeDBMSSQLInstanceName, databaseAttributes.DBMSSQLInstanceName)
-	assert.Equal(t, attributeDBJDBCDriverClassName, databaseAttributes.DBJDBCDriverClassName)
-	assert.Equal(t, attributeDBCassandraKeyspace, databaseAttributes.DBCassandraKeyspace)
-	assert.Equal(t, attributeDBHBaseNamespace, databaseAttributes.DBHBaseNamespace)
-	assert.Equal(t, attributeDBMongoDBCollection, databaseAttributes.DBMongoDBCollection)
+	assert.Equal(t, conventions.AttributeDBOperation, databaseAttributes.DBOperation)
+	assert.Equal(t, conventions.AttributeDBMsSQLInstanceName, databaseAttributes.DBMSSQLInstanceName)
+	assert.Equal(t, conventions.AttributeDBJDBCDriverClassname, databaseAttributes.DBJDBCDriverClassName)
+	assert.Equal(t, conventions.AttributeDBCassandraKeyspace, databaseAttributes.DBCassandraKeyspace)
+	assert.Equal(t, conventions.AttributeDBHBaseNamespace, databaseAttributes.DBHBaseNamespace)
+	assert.Equal(t, conventions.AttributeDBMongoDBCollection, databaseAttributes.DBMongoDBCollection)
 	networkAttributesValidations(t, databaseAttributes.NetworkAttributes)
 }
 

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -105,10 +105,12 @@ func spanToEnvelope(
 		data.BaseType = remoteDependencyData.BaseType()
 	}
 
-	// Record the Span status message as a property if there
+	// Record the raw Span status values as properties
+	dataProperties[attributeOtelStatusCode] = span.Status().Code().String()
+	dataProperties[attributeOtelStatusDeprecatedCode] = span.Status().DeprecatedCode().String()
 	statusMessage := span.Status().Message()
 	if len(statusMessage) > 0 {
-		dataProperties["Status.message"] = statusMessage
+		dataProperties[attributeOtelStatusDescription] = statusMessage
 	}
 
 	envelope.Data = data

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -26,7 +26,6 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
 )
 
 const (
@@ -104,6 +103,12 @@ func spanToEnvelope(
 		envelope.Name = remoteDependencyData.EnvelopeName("")
 		data.BaseData = remoteDependencyData
 		data.BaseType = remoteDependencyData.BaseType()
+	}
+
+	// Record the Span status message as a property if there
+	statusMessage := span.Status().Message()
+	if len(statusMessage) > 0 {
+		dataProperties["Status.message"] = statusMessage
 	}
 
 	envelope.Data = data
@@ -382,6 +387,8 @@ func fillRemoteDependencyDataHTTP(span pdata.Span, data *contracts.RemoteDepende
 func fillRequestDataRPC(span pdata.Span, data *contracts.RequestData) {
 	attrs := copyAndExtractRPCAttributes(span.Attributes(), data.Properties, data.Measurements)
 
+	data.ResponseCode = getRPCStatusCodeAsString(span, attrs)
+
 	var sb strings.Builder
 
 	sb.WriteString(attrs.RPCSystem)
@@ -406,6 +413,8 @@ func fillRequestDataRPC(span pdata.Span, data *contracts.RequestData) {
 func fillRemoteDependencyDataRPC(span pdata.Span, data *contracts.RemoteDependencyData) {
 	attrs := copyAndExtractRPCAttributes(span.Attributes(), data.Properties, data.Measurements)
 
+	data.ResultCode = getRPCStatusCodeAsString(span, attrs)
+
 	// Set the .Data property to .Name which contain the full RPC method
 	data.Data = data.Name
 
@@ -414,6 +423,19 @@ func fillRemoteDependencyDataRPC(span pdata.Span, data *contracts.RemoteDependen
 	var sb strings.Builder
 	writeFormattedPeerAddressFromNetworkAttributes(&attrs.NetworkAttributes, &sb)
 	data.Target = sb.String()
+}
+
+// Returns the RPC status code as a string
+func getRPCStatusCodeAsString(span pdata.Span, rpcAttributes *RPCAttributes) (statusCodeAsString string) {
+	// Honor the attribute rpc.grpc.status_code if there
+	if rpcAttributes.RPCGRPCStatusCode != 0 {
+		return strconv.FormatInt(rpcAttributes.RPCGRPCStatusCode, 10)
+	}
+
+	// Backwards compatibility with old senders.
+	// We lose the gRPC status code otherwise
+	deprecatedCode := span.Status().DeprecatedCode()
+	return strconv.FormatInt(int64(deprecatedCode), 10)
 }
 
 // Maps Database Client Span to AppInsights RemoteDependencyData
@@ -581,7 +603,7 @@ func mapIncomingSpanToType(attributeMap pdata.AttributeMap) spanType {
 	}
 
 	// Database
-	if _, exists := attributeMap.Get(attributeDBSystem); exists {
+	if _, exists := attributeMap.Get(conventions.AttributeDBSystem); exists {
 		return databaseSpanType
 	}
 
@@ -597,11 +619,35 @@ func mapIncomingSpanToType(attributeMap pdata.AttributeMap) spanType {
 	return unknownSpanType
 }
 
-// map to the standard gRPC status codes if specified, otherwise default to 0 - OK
-// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#status
+// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status
 func getDefaultFormattedSpanStatus(spanStatus pdata.SpanStatus) (statusCodeAsString string, success bool) {
-	statusCode := int32(spanStatus.Code())
-	return strconv.FormatInt(int64(statusCode), 10), statusCode == int32(codes.OK)
+	// For a description of backwards compatibility requirements for Status see
+	// https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/trace/v1/trace.proto
+	//
+	// Specifically:
+	// 3. New receivers MUST look at both the `code` and `deprecated_code` fields in order
+	// to interpret the overall status:
+	//
+	//   If code==STATUS_CODE_UNSET then the value of `deprecated_code` is the
+	//   carrier of the overall status according to these rules:
+	//
+	//     if deprecated_code==DEPRECATED_STATUS_CODE_OK then the receiver MUST interpret
+	//     the overall status to be STATUS_CODE_UNSET.
+	//
+	//     if deprecated_code!=DEPRECATED_STATUS_CODE_OK then the receiver MUST interpret
+	//     the overall status to be STATUS_CODE_ERROR.
+	//
+	//   If code!=STATUS_CODE_UNSET then the value of `deprecated_code` MUST be
+	//   ignored, the `code` field is the sole carrier of the status.
+	code := spanStatus.Code()
+
+	if code == pdata.StatusCodeUnset {
+		if spanStatus.DeprecatedCode() != pdata.DeprecatedStatusCodeOk {
+			code = pdata.StatusCodeError
+		}
+	}
+
+	return strconv.FormatInt(int64(code), 10), code != pdata.StatusCodeError
 }
 
 func writeFormattedPeerAddressFromNetworkAttributes(networkAttributes *NetworkAttributes, sb *strings.Builder) {

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -82,8 +82,8 @@ var (
 	}
 
 	requiredDatabaseAttributes = map[string]pdata.AttributeValue{
-		attributeDBSystem: pdata.NewAttributeValueString(defaultDBSystem),
-		attributeDBName:   pdata.NewAttributeValueString(defaultDBName),
+		conventions.AttributeDBSystem: pdata.NewAttributeValueString(defaultDBSystem),
+		conventions.AttributeDBName:   pdata.NewAttributeValueString(defaultDBName),
 	}
 
 	requiredMessagingAttributes = map[string]pdata.AttributeValue{
@@ -108,13 +108,14 @@ var (
 // http.scheme, http.host, http.target => data.Url
 // Also sets a few other things to increase code coverage:
 // - a specific SpanStatus as opposed to none
-// - an error  http.status_code
+// - an error http.status_code
 // - http.route is specified which should replace Span name as part of the RequestData name
 // - no  http.client_ip or net.peer.ip specified which causes data.Source to be empty
 // - adds a few different types of attributes
 func TestHTTPServerSpanToRequestDataAttributeSet1(t *testing.T) {
 	span := getDefaultHTTPServerSpan()
-	span.Status().SetCode(0)
+	span.Status().SetCode(pdata.StatusCodeError)
+	span.Status().SetMessage("Fubar")
 	spanAttributes := span.Attributes()
 
 	set := map[string]pdata.AttributeValue{
@@ -148,6 +149,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet1(t *testing.T) {
 	assert.Equal(t, "", data.Source)
 	assert.Equal(t, "GET /bizzle", data.Name)
 	assert.Equal(t, "https://foo/bar?biz=baz", data.Url)
+	assert.Equal(t, span.Status().Message(), data.Properties["Status.message"])
 }
 
 // Tests proper assignment for a HTTP server span
@@ -404,6 +406,30 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 	defaultRPCRemoteDependencyDataValidations(t, span, data, "127.0.0.1:81")
+
+	// test RPC error using the new rpc.grpc.status_code attribute
+	span.Status().SetCode(pdata.StatusCodeError)
+	span.Status().SetMessage("Resource exhausted")
+	spanAttributes.InsertInt(attributeRPCGRPCStatusCode, 8)
+
+	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+
+	assert.Equal(t, "8", data.ResultCode)
+	assert.Equal(t, span.Status().Message(), data.Properties["Status.message"])
+
+	// test RPC error using the legacy Deprecated status code
+	span.Status().SetCode(pdata.StatusCodeUnset)
+	spanAttributes.Delete(attributeRPCGRPCStatusCode)
+
+	span.Status().SetDeprecatedCode(8)
+	span.Status().SetMessage("Resource exhausted")
+
+	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())
+	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
+
+	assert.Equal(t, "8", data.ResultCode)
+	assert.Equal(t, span.Status().Message(), data.Properties["Status.message"])
 }
 
 // Tests proper assignment for a Database client span
@@ -432,7 +458,7 @@ func TestDatabaseClientSpanToRemoteDependencyData(t *testing.T) {
 		spanAttributes,
 		map[string]pdata.AttributeValue{
 			conventions.AttributeDBStatement: pdata.NewAttributeValueString(""),
-			attributeDBOperation:             pdata.NewAttributeValueString(defaultDBOperation),
+			conventions.AttributeDBOperation: pdata.NewAttributeValueString(defaultDBOperation),
 		})
 
 	envelope, _ = spanToEnvelope(defaultResource, defaultInstrumentationLibrary, span, zap.NewNop())

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -149,7 +149,7 @@ func TestHTTPServerSpanToRequestDataAttributeSet1(t *testing.T) {
 	assert.Equal(t, "", data.Source)
 	assert.Equal(t, "GET /bizzle", data.Name)
 	assert.Equal(t, "https://foo/bar?biz=baz", data.Url)
-	assert.Equal(t, span.Status().Message(), data.Properties["Status.message"])
+	assert.Equal(t, span.Status().Message(), data.Properties[attributeOtelStatusDescription])
 }
 
 // Tests proper assignment for a HTTP server span

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -416,7 +416,9 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
 	assert.Equal(t, "8", data.ResultCode)
-	assert.Equal(t, span.Status().Message(), data.Properties["Status.message"])
+	assert.Equal(t, span.Status().Code().String(), data.Properties[attributeOtelStatusCode])
+	assert.Equal(t, pdata.DeprecatedStatusCodeUnknownError.String(), data.Properties[attributeOtelStatusDeprecatedCode])
+	assert.Equal(t, span.Status().Message(), data.Properties[attributeOtelStatusDescription])
 
 	// test RPC error using the legacy Deprecated status code
 	span.Status().SetCode(pdata.StatusCodeUnset)
@@ -429,7 +431,9 @@ func TestRPCClientSpanToRemoteDependencyData(t *testing.T) {
 	data = envelope.Data.(*contracts.Data).BaseData.(*contracts.RemoteDependencyData)
 
 	assert.Equal(t, "8", data.ResultCode)
-	assert.Equal(t, span.Status().Message(), data.Properties["Status.message"])
+	assert.Equal(t, pdata.StatusCodeUnset.String(), data.Properties[attributeOtelStatusCode])
+	assert.Equal(t, pdata.DeprecatedStatusCodeResourceExhausted.String(), data.Properties[attributeOtelStatusDeprecatedCode])
+	assert.Equal(t, span.Status().Message(), data.Properties[attributeOtelStatusDescription])
 }
 
 // Tests proper assignment for a Database client span


### PR DESCRIPTION
**Description:** 
This change implements the status code specification changes according to:

https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-status

In a nutshell, Span status codes used to map directly to gRPC status codes and gRPC Spans used this feature to report status. The latest specification collapses the Span status code to UNSET (0), OK (1), ERROR(2), and gRPC Span status comes from the rpc.grpc.status_code required attribute.  For SDKs that have adopted this latest specification the result codes that we send to Azure monitor do not correspond to the actual gRPC error codes. Errors were always reported as 2 (Span status == error).

This change follows the backward compatibility guidelines outlined here:

https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/trace/v1/trace.proto

So the logic for setting the result code is:
- Record as the Span status code (0, 1, 2)
- For HTTP, overwrite with the value from the http.status_code attribute, if any
- For gRPC, overwrite with the value from the rpc.grpc.status_code attribute, if any, otherwise use the value from the DeprecatedStatusCode

Additionally, I am recording the Span Status.message as a custom property for both Request and Dependency envelopes. This information was not captured before.

**Testing:**
Added unit tests to test this logic
Performed E2E tests locally