### PR TITLE
[datadogexporter] Switch from using rates to counts

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -74,5 +74,5 @@ There are a number of optional settings for configuring how to send your metrics
 
 | Option name | Description | Default |
 |-|-|-|
-| `send_monotonic_counters` | Cumulative monotonic metrics are sent as time-normalized deltas between successive measurements. Disable this flag to send get the raw, monotonically increasing value. | `true` |
+| `send_monotonic_counters` | Cumulative monotonic metrics are sent as deltas between successive measurements. Disable this flag to send get the raw, monotonically increasing value. | `true` |
 | `delta_ttl` | Maximum number of seconds values from cumulative monotonic metrics are kept in memory. | 3600 |

--- a/exporter/datadogexporter/metrics/utils.go
+++ b/exporter/datadogexporter/metrics/utils.go
@@ -27,7 +27,7 @@ import (
 const (
 	// Gauge is the Datadog Gauge metric type
 	Gauge               string = "gauge"
-	Rate                string = "rate"
+	Count               string = "count"
 	otelNamespacePrefix string = "otel"
 )
 
@@ -54,11 +54,11 @@ func NewGauge(name string, ts uint64, value float64, tags []string) datadog.Metr
 	return gauge
 }
 
-// NewRate creates a new Datadog rate metric given a name, a Unix nanoseconds timestamp
+// NewCount creates a new Datadog count metric given a name, a Unix nanoseconds timestamp
 // a value and a slice of tags
-func NewRate(name string, ts uint64, value float64, tags []string) datadog.Metric {
+func NewCount(name string, ts uint64, value float64, tags []string) datadog.Metric {
 	count := newMetric(name, ts, value, tags)
-	count.SetType(Rate)
+	count.SetType(Count)
 	return count
 }
 

--- a/exporter/datadogexporter/metrics/utils_test.go
+++ b/exporter/datadogexporter/metrics/utils_test.go
@@ -51,8 +51,8 @@ func TestNewType(t *testing.T) {
 	gauge := NewGauge(name, ts, value, tags)
 	assert.Equal(t, gauge.GetType(), Gauge)
 
-	count := NewRate(name, ts, value, tags)
-	assert.Equal(t, count.GetType(), Rate)
+	count := NewCount(name, ts, value, tags)
+	assert.Equal(t, count.GetType(), Count)
 
 }
 

--- a/exporter/datadogexporter/metrics_translator.go
+++ b/exporter/datadogexporter/metrics_translator.go
@@ -118,12 +118,11 @@ func mapIntMonotonicMetrics(name string, prevPts *ttlmap.TTLMap, slice pdata.Int
 
 			// We calculate the time-normalized delta
 			dx := float64(p.Value() - cnt.value)
-			dt := float64(ts-cnt.ts) / 1e9
 
 			// if dx < 0, we assume there was a reset, thus we save the point
 			// but don't export it (it's the first one so we can't do a delta)
 			if dx >= 0 {
-				ms = append(ms, metrics.NewRate(name, ts, dx/dt, tags))
+				ms = append(ms, metrics.NewCount(name, ts, dx, tags))
 			}
 
 		}
@@ -160,12 +159,11 @@ func mapDoubleMonotonicMetrics(name string, prevPts *ttlmap.TTLMap, slice pdata.
 
 			// We calculate the time-normalized delta
 			dx := p.Value() - cnt.value
-			dt := float64(ts-cnt.ts) / 1e9
 
 			// if dx < 0, we assume there was a reset, thus we save the point
 			// but don't export it (it's the first one so we can't do a delta)
 			if dx >= 0 {
-				ms = append(ms, metrics.NewRate(name, ts, dx/dt, tags))
+				ms = append(ms, metrics.NewCount(name, ts, dx, tags))
 			}
 
 		}

--- a/exporter/datadogexporter/metrics_translator_test.go
+++ b/exporter/datadogexporter/metrics_translator_test.go
@@ -192,7 +192,7 @@ func TestMapIntMonotonicMetrics(t *testing.T) {
 	metricName := "metric.example"
 	expected := make([]datadog.Metric, len(deltas))
 	for i, val := range deltas {
-		expected[i] = metrics.NewRate(metricName, uint64(seconds(i+1)), float64(val), []string{})
+		expected[i] = metrics.NewCount(metricName, uint64(seconds(i+1)), float64(val), []string{})
 	}
 
 	prevPts := newTTLMap()
@@ -239,9 +239,9 @@ func TestMapIntMonotonicDifferentDimensions(t *testing.T) {
 	assert.ElementsMatch(t,
 		mapIntMonotonicMetrics(metricName, prevPts, slice, []string{}),
 		[]datadog.Metric{
-			metrics.NewRate(metricName, uint64(seconds(1)), 20, []string{}),
-			metrics.NewRate(metricName, uint64(seconds(1)), 30, []string{"key1:valA"}),
-			metrics.NewRate(metricName, uint64(seconds(1)), 40, []string{"key1:valB"}),
+			metrics.NewCount(metricName, uint64(seconds(1)), 20, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(1)), 30, []string{"key1:valA"}),
+			metrics.NewCount(metricName, uint64(seconds(1)), 40, []string{"key1:valB"}),
 		},
 	)
 }
@@ -262,8 +262,8 @@ func TestMapIntMonotonicWithReboot(t *testing.T) {
 	assert.ElementsMatch(t,
 		mapIntMonotonicMetrics(metricName, prevPts, slice, []string{}),
 		[]datadog.Metric{
-			metrics.NewRate(metricName, uint64(seconds(1)), 30, []string{}),
-			metrics.NewRate(metricName, uint64(seconds(3)), 20, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(1)), 30, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(3)), 20, []string{}),
 		},
 	)
 }
@@ -286,8 +286,8 @@ func TestMapIntMonotonicOutOfOrder(t *testing.T) {
 	assert.ElementsMatch(t,
 		mapIntMonotonicMetrics(metricName, prevPts, slice, []string{}),
 		[]datadog.Metric{
-			metrics.NewRate(metricName, uint64(seconds(2)), 2, []string{}),
-			metrics.NewRate(metricName, uint64(seconds(3)), 1, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(2)), 2, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(3)), 1, []string{}),
 		},
 	)
 }
@@ -313,7 +313,7 @@ func TestMapDoubleMonotonicMetrics(t *testing.T) {
 	metricName := "metric.example"
 	expected := make([]datadog.Metric, len(deltas))
 	for i, val := range deltas {
-		expected[i] = metrics.NewRate(metricName, uint64(seconds(i+1)), val, []string{})
+		expected[i] = metrics.NewCount(metricName, uint64(seconds(i+1)), val, []string{})
 	}
 
 	prevPts := newTTLMap()
@@ -360,9 +360,9 @@ func TestMapDoubleMonotonicDifferentDimensions(t *testing.T) {
 	assert.ElementsMatch(t,
 		mapDoubleMonotonicMetrics(metricName, prevPts, slice, []string{}),
 		[]datadog.Metric{
-			metrics.NewRate(metricName, uint64(seconds(1)), 20, []string{}),
-			metrics.NewRate(metricName, uint64(seconds(1)), 30, []string{"key1:valA"}),
-			metrics.NewRate(metricName, uint64(seconds(1)), 40, []string{"key1:valB"}),
+			metrics.NewCount(metricName, uint64(seconds(1)), 20, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(1)), 30, []string{"key1:valA"}),
+			metrics.NewCount(metricName, uint64(seconds(1)), 40, []string{"key1:valB"}),
 		},
 	)
 }
@@ -383,8 +383,8 @@ func TestMapDoubleMonotonicWithReboot(t *testing.T) {
 	assert.ElementsMatch(t,
 		mapDoubleMonotonicMetrics(metricName, prevPts, slice, []string{}),
 		[]datadog.Metric{
-			metrics.NewRate(metricName, uint64(seconds(1)), 30, []string{}),
-			metrics.NewRate(metricName, uint64(seconds(3)), 20, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(1)), 30, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(3)), 20, []string{}),
 		},
 	)
 }
@@ -407,8 +407,8 @@ func TestMapDoubleMonotonicOutOfOrder(t *testing.T) {
 	assert.ElementsMatch(t,
 		mapDoubleMonotonicMetrics(metricName, prevPts, slice, []string{}),
 		[]datadog.Metric{
-			metrics.NewRate(metricName, uint64(seconds(2)), 2, []string{}),
-			metrics.NewRate(metricName, uint64(seconds(3)), 1, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(2)), 2, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(3)), 1, []string{}),
 		},
 	)
 }

--- a/exporter/datadogexporter/metrics_translator_test.go
+++ b/exporter/datadogexporter/metrics_translator_test.go
@@ -375,7 +375,7 @@ func TestMapDoubleMonotonicWithReboot(t *testing.T) {
 
 	for i, val := range values {
 		point := slice.At(i)
-		point.SetTimestamp(seconds(i))
+		point.SetTimestamp(seconds(2 * i))
 		point.SetValue(val)
 	}
 
@@ -383,8 +383,8 @@ func TestMapDoubleMonotonicWithReboot(t *testing.T) {
 	assert.ElementsMatch(t,
 		mapDoubleMonotonicMetrics(metricName, prevPts, slice, []string{}),
 		[]datadog.Metric{
-			metrics.NewCount(metricName, uint64(seconds(1)), 30, []string{}),
-			metrics.NewCount(metricName, uint64(seconds(3)), 20, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(2)), 30, []string{}),
+			metrics.NewCount(metricName, uint64(seconds(6)), 20, []string{}),
 		},
 	)
 }


### PR DESCRIPTION
**Description:** 

- Switch from using rates to represent monotonic cumulative counters to using counts. This is more in line with what the Datadog Agent does.

**Link to tracking Issue:** relates to #1688

**Testing:** Amended unit tests

**Documentation:** Updated docs to reflect new behavior