### PR TITLE
sapm/signalfxexporter: Add note about access token

### DIFF
--- a/exporter/sapmexporter/README.md
+++ b/exporter/sapmexporter/README.md
@@ -11,7 +11,8 @@ Supported pipeline types: traces
 The following configuration options are required:
 
 - `access_token` (no default): AccessToken is the authentication token provided by SignalFx or
-another backend that supports the SAPM proto.
+another backend that supports the SAPM proto. The SignalFx access token can be obtained from the
+web app. For details on how to do so please refer the documentation [here](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#access-tokens).
 - `endpoint` (no default): This is the destination to where traces will be sent to in SAPM
 format. It must be a full URL and include the scheme, port and path e.g,
 https://ingest.us0.signalfx.com/v2/trace. This can be pointed to the SignalFx backend or to

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -14,7 +14,8 @@ Supported pipeline types: logs (events), metrics, traces (trace to metric correl
 The following configuration options are required:
 
 - `access_token` (no default): The access token is the authentication token
-  provided by SignalFx.
+  provided by SignalFx. The SignalFx access token can be obtained from the
+  web app. For details on how to do so please refer the documentation [here](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#access-tokens).
 - Either `realm` or both `api_url` and `ingest_url`. Both `api_url` and
   `ingest_url` take precedence over `realm`.
   - `realm` (no default): SignalFx realm where the data will be received.


### PR DESCRIPTION
**Description:** Add note about obtaining access tokens in README.