### PR TITLE
Add documentation URL explaining how to obtain a HEC token

### DIFF
--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -10,7 +10,7 @@ Supported pipeline types: logs, metrics, traces
 
 The following configuration options are required:
 
-- `token` (no default): HEC requires a token to authenticate incoming traffic.
+- `token` (no default): HEC requires a token to authenticate incoming traffic. To procure a token, please refer to the [Splunk documentation](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector).
 - `endpoint` (no default): Splunk HEC URL.
 
 The following configuration options can also be configured:

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -36,7 +36,7 @@ type Config struct {
 	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
 
-	// HEC Token is the authentication token provided by Splunk.
+	// HEC Token is the authentication token provided by Splunk: https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector.
 	Token string `mapstructure:"token"`
 
 	// URL is the Splunk HEC endpoint where data is going to be sent to.


### PR DESCRIPTION
**Description:** 
Add more documentation to the hec token field of the configuration of the splunk HEC exporter.
