### PR TITLE
[receivercreator, observers]: Cleanup endpoints code

### DIFF
--- a/extension/observer/endpoints_test.go
+++ b/extension/observer/endpoints_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-func TestEndpointToEnv(t *testing.T) {
+func TestEndpointEnv(t *testing.T) {
 	tests := []struct {
 		name     string
 		endpoint Endpoint
@@ -31,7 +31,7 @@ func TestEndpointToEnv(t *testing.T) {
 			endpoint: Endpoint{
 				ID:     EndpointID("pod_id"),
 				Target: "192.68.73.2",
-				Details: Pod{
+				Details: &Pod{
 					Name: "pod_name",
 					Labels: map[string]string{
 						"label_key": "label_val",
@@ -42,9 +42,10 @@ func TestEndpointToEnv(t *testing.T) {
 				},
 			},
 			want: EndpointEnv{
-				"type": map[string]interface{}{
-					"port": false,
-					"pod":  true,
+				"type": map[EndpointType]bool{
+					PodType:      true,
+					HostPortType: false,
+					PortType:     false,
 				},
 				"endpoint": "192.68.73.2",
 				"name":     "pod_name",
@@ -62,7 +63,7 @@ func TestEndpointToEnv(t *testing.T) {
 			endpoint: Endpoint{
 				ID:     EndpointID("port_id"),
 				Target: "192.68.73.2",
-				Details: Port{
+				Details: &Port{
 					Name: "port_name",
 					Pod: Pod{
 						Name: "pod_name",
@@ -78,9 +79,10 @@ func TestEndpointToEnv(t *testing.T) {
 				},
 			},
 			want: EndpointEnv{
-				"type": map[string]interface{}{
-					"port": true,
-					"pod":  false,
+				"type": map[EndpointType]bool{
+					PodType:      false,
+					HostPortType: false,
+					PortType:     true,
 				},
 				"endpoint": "192.68.73.2",
 				"name":     "port_name",
@@ -103,7 +105,7 @@ func TestEndpointToEnv(t *testing.T) {
 			endpoint: Endpoint{
 				ID:     EndpointID("port_id"),
 				Target: "127.0.0.1",
-				Details: HostPort{
+				Details: &HostPort{
 					Name:      "process_name",
 					Command:   "./cmd --config config.yaml",
 					Port:      2379,
@@ -112,9 +114,10 @@ func TestEndpointToEnv(t *testing.T) {
 				},
 			},
 			want: EndpointEnv{
-				"type": map[string]interface{}{
-					"port": true,
-					"pod":  false,
+				"type": map[EndpointType]bool{
+					HostPortType: true,
+					PodType:      false,
+					PortType:     false,
 				},
 				"endpoint":  "127.0.0.1",
 				"name":      "process_name",
@@ -125,20 +128,10 @@ func TestEndpointToEnv(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{
-			name: "Unsupported endpoint",
-			endpoint: Endpoint{
-				ID:      EndpointID("port_id"),
-				Target:  "127.0.0.1:2379",
-				Details: map[string]interface{}{},
-			},
-			want:    nil,
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := EndpointToEnv(tt.endpoint)
+			got, err := tt.endpoint.Env()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("EndpointToEnv() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/extension/observer/endpoints_test.go
+++ b/extension/observer/endpoints_test.go
@@ -42,10 +42,10 @@ func TestEndpointEnv(t *testing.T) {
 				},
 			},
 			want: EndpointEnv{
-				"type": map[EndpointType]bool{
-					PodType:      true,
-					HostPortType: false,
-					PortType:     false,
+				"type": map[string]bool{
+					"pod":      true,
+					"hostport": false,
+					"port":     false,
 				},
 				"endpoint": "192.68.73.2",
 				"name":     "pod_name",
@@ -79,10 +79,10 @@ func TestEndpointEnv(t *testing.T) {
 				},
 			},
 			want: EndpointEnv{
-				"type": map[EndpointType]bool{
-					PodType:      false,
-					HostPortType: false,
-					PortType:     true,
+				"type": map[string]bool{
+					"pod":      false,
+					"hostport": false,
+					"port":     true,
 				},
 				"endpoint": "192.68.73.2",
 				"name":     "port_name",
@@ -114,10 +114,10 @@ func TestEndpointEnv(t *testing.T) {
 				},
 			},
 			want: EndpointEnv{
-				"type": map[EndpointType]bool{
-					HostPortType: true,
-					PodType:      false,
-					PortType:     false,
+				"type": map[string]bool{
+					"hostport": true,
+					"pod":      false,
+					"port":     false,
 				},
 				"endpoint":  "127.0.0.1",
 				"name":      "process_name",
@@ -133,11 +133,11 @@ func TestEndpointEnv(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.endpoint.Env()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("EndpointToEnv() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Env() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("EndpointToEnv() got = %v, want %v", got, tt.want)
+				t.Errorf("Env() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/extension/observer/hostobserver/extension.go
+++ b/extension/observer/hostobserver/extension.go
@@ -124,7 +124,7 @@ func (e endpointsLister) collectEndpoints(conns []net.ConnectionStat) []observer
 			endpoints = append(endpoints, observer.Endpoint{
 				ID:     id,
 				Target: cd.target,
-				Details: observer.HostPort{
+				Details: &observer.HostPort{
 					Port:      cd.port,
 					Transport: cd.transport,
 					// TODO: Move this field to observer.Endpoint and
@@ -166,7 +166,7 @@ func (e endpointsLister) collectEndpoints(conns []net.ConnectionStat) []observer
 			e := observer.Endpoint{
 				ID:     id,
 				Target: cd.target,
-				Details: observer.HostPort{
+				Details: &observer.HostPort{
 					Name:      pd.name,
 					Command:   pd.args,
 					Port:      cd.port,

--- a/extension/observer/hostobserver/extension_test.go
+++ b/extension/observer/hostobserver/extension_test.go
@@ -117,7 +117,7 @@ func TestHostObserver(t *testing.T) {
 				require.NotEmpty(t, actualEndpoint, "expected endpoint ID not found. ID: %v", expectedID)
 				assert.Equal(t, expectedID, actualEndpoint.ID, "unexpected endpoint ID found")
 
-				details, ok := actualEndpoint.Details.(observer.HostPort)
+				details, ok := actualEndpoint.Details.(*observer.HostPort)
 				assert.True(t, ok, "failed to get Endpoint.Details")
 				assert.Equal(t, filepath.Base(exe), details.Name)
 				assert.Equal(t, tt.protocol, details.Transport)
@@ -463,7 +463,7 @@ func TestCollectEndpoints(t *testing.T) {
 				{
 					ID:     observer.EndpointID("()123.345.567.789-80-TCP"),
 					Target: "123.345.567.789:80",
-					Details: observer.HostPort{
+					Details: &observer.HostPort{
 						Name:      "",
 						Port:      80,
 						Transport: observer.ProtocolTCP,

--- a/extension/observer/k8sobserver/extension_test.go
+++ b/extension/observer/k8sobserver/extension_test.go
@@ -57,7 +57,7 @@ func TestExtensionObserve(t *testing.T) {
 	assert.Equal(t, observer.Endpoint{
 		ID:     "k8s_observer/pod1-UID",
 		Target: "1.2.3.4",
-		Details: observer.Pod{
+		Details: &observer.Pod{
 			Name: "pod1",
 			Labels: map[string]string{
 				"env": "prod",
@@ -74,7 +74,7 @@ func TestExtensionObserve(t *testing.T) {
 	assert.Equal(t, observer.Endpoint{
 		ID:     "k8s_observer/pod1-UID",
 		Target: "1.2.3.4",
-		Details: observer.Pod{
+		Details: &observer.Pod{
 			Name: "pod1",
 			Labels: map[string]string{
 				"env":         "prod",

--- a/extension/observer/k8sobserver/handler.go
+++ b/extension/observer/k8sobserver/handler.go
@@ -57,7 +57,7 @@ func (h *handler) convertPodToEndpoints(pod *v1.Pod) []observer.Endpoint {
 	endpoints := []observer.Endpoint{{
 		ID:      podID,
 		Target:  podIP,
-		Details: podDetails,
+		Details: &podDetails,
 	}}
 
 	// Map of running containers by name.
@@ -84,7 +84,7 @@ func (h *handler) convertPodToEndpoints(pod *v1.Pod) []observer.Endpoint {
 			endpoints = append(endpoints, observer.Endpoint{
 				ID:     endpointID,
 				Target: fmt.Sprintf("%s:%d", podIP, port.ContainerPort),
-				Details: observer.Port{
+				Details: &observer.Port{
 					Pod:       podDetails,
 					Name:      port.Name,
 					Port:      uint16(port.ContainerPort),

--- a/extension/observer/k8sobserver/handler_test.go
+++ b/extension/observer/k8sobserver/handler_test.go
@@ -33,14 +33,14 @@ func TestEndpointsAdded(t *testing.T) {
 		{
 			ID:     "test-1/pod-2-UID",
 			Target: "1.2.3.4",
-			Details: observer.Pod{
+			Details: &observer.Pod{
 				Name:   "pod-2",
 				Labels: map[string]string{"env": "prod"},
 			},
 		}, {
 			ID:     "test-1/pod-2-UID/https(443)",
 			Target: "1.2.3.4:443",
-			Details: observer.Port{
+			Details: &observer.Port{
 				Name: "https",
 				Pod: observer.Pod{
 					Name:   "pod-2",
@@ -65,14 +65,14 @@ func TestEndpointsRemoved(t *testing.T) {
 		{
 			ID:     "test-1/pod-2-UID",
 			Target: "1.2.3.4",
-			Details: observer.Pod{
+			Details: &observer.Pod{
 				Name:   "pod-2",
 				Labels: map[string]string{"env": "prod"},
 			},
 		}, {
 			ID:     "test-1/pod-2-UID/https(443)",
 			Target: "1.2.3.4:443",
-			Details: observer.Port{
+			Details: &observer.Port{
 				Name: "https",
 				Pod: observer.Pod{
 					Name:   "pod-2",
@@ -120,13 +120,13 @@ func TestEndpointsChanged(t *testing.T) {
 		{
 			ID:     "test-1/pod-2-UID",
 			Target: "1.2.3.4",
-			Details: observer.Pod{
+			Details: &observer.Pod{
 				Name:   "pod-2",
 				Labels: map[string]string{"env": "prod", "updated-label": "true"}}},
 		{
 			ID:     "test-1/pod-2-UID/https(443)",
 			Target: "1.2.3.4:443",
-			Details: observer.Port{
+			Details: &observer.Port{
 				Name: "https", Pod: observer.Pod{
 					Name:   "pod-2",
 					Labels: map[string]string{"env": "prod", "updated-label": "true"}},

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/aliyun/aliyun-log-go-sdk v0.1.17 h1:jqEC4x1d7ZZaDwN1muKJJx5965AtriXDcKkuVBhOfYo=
+github.com/aliyun/aliyun-log-go-sdk v0.1.17/go.mod h1:arjbKu+pwifPdi8tMJSJtFszZlxs+6F34VPv+ecf3zA=
 github.com/aliyun/aliyun-log-go-sdk v0.1.18 h1:qOb5mjek+rQnWfz9WUyKRsT+WRZkpu+d2P+6qa3d5dU=
 github.com/aliyun/aliyun-log-go-sdk v0.1.18/go.mod h1:arjbKu+pwifPdi8tMJSJtFszZlxs+6F34VPv+ecf3zA=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
@@ -187,6 +189,9 @@ github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.35.5/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
+github.com/aws/aws-sdk-go v1.36.19/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.36.20 h1:IQr81xegCd40Xq21ZjFToKw9llaCzO1LRE75CgnvJ1Q=
+github.com/aws/aws-sdk-go v1.36.20/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.36.24 h1:uVuio0zA5ideP3DGZDpIoExQJd0WcoNUVlNZaKwBnf8=
 github.com/aws/aws-sdk-go v1.36.24/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
@@ -826,6 +831,8 @@ github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.10.10/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.4 h1:kz40R/YWls3iqT9zX9AHN3WoVsrAWVyui5sxuLqiXqU=
+github.com/klauspost/compress v1.11.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.6 h1:EgWPCW6O3n1D5n99Zq3xXBt9uCwRGvpwGOusOLNBRSQ=
 github.com/klauspost/compress v1.11.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
@@ -976,6 +983,8 @@ github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYhe
 github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc h1:49ewVBwLcy+eYqI4R0ICilCI4dPjddpFXWv3liXzUxM=
 github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc/go.mod h1:WXIHwGy+c7/IK2PiJ4oxuTHkpnkSut7TNFpKnI5llPU=
 github.com/observiq/stanza v0.13.9 h1:qfVbQAapgKkZqB5uV5Z6BSFrdYJYTft8LYS/AAqjxpU=
+github.com/observiq/stanza v0.13.8 h1:1pxlnUY58pEBaP1/3vW/uPuqa6wihRVOPAqAlrD6Ga0=
+github.com/observiq/stanza v0.13.8/go.mod h1:LJfJG+RiDGdUOyukMbdUJR0OVU+5Bnbwh7GP4QTZyMI=
 github.com/observiq/stanza v0.13.9/go.mod h1:LJfJG+RiDGdUOyukMbdUJR0OVU+5Bnbwh7GP4QTZyMI=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -33,7 +33,7 @@ This is configuration that will be used when creating the receiver at
 runtime.
 
 This option can use static and dynamic configuration values. Static values
-are normal YAML values. However the value can also be dynamically constructed
+are normal YAML values. However, the value can also be dynamically constructed
 from the discovered endpoint object. Dynamic values are surrounded by
 backticks (\`). If a literal backtick is needed use \\` to escape it. Dynamic
 values can be used with static values in which case they are concatenated.
@@ -82,6 +82,17 @@ targeting it will have different variables available.
 | pod.labels      | map of labels of the owning pod      |
 | pod.annotations | map of annotations of the owning pod |
 | protocol        | `TCP` or `UDP`                       |
+
+### Host Port
+
+| Variable  | Description                                      |
+|-----------|--------------------------------------------------|
+| type.host | `true`                                           |
+| name      | Name of the process                              |
+| command   | Command line with the used to invoke the process |
+| is_ipv6   | true if endpoint is IPv6, otherwise false        |
+| port      | Port number                                      |
+| transport | The transport protocol ("TCP" or "UDP")          |
 
 ## Example
 

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -58,7 +58,7 @@ config:
 
 ## Rule Expressions
 
-Each rule must start with `type.(pod|port) &&` such that the rule matches
+Each rule must start with `type.(pod|port|hostport) &&` such that the rule matches
 only one endpoint type. Depending on the type of endpoint the rule is
 targeting it will have different variables available.
 
@@ -85,14 +85,14 @@ targeting it will have different variables available.
 
 ### Host Port
 
-| Variable  | Description                                      |
-|-----------|--------------------------------------------------|
-| type.host | `true`                                           |
-| name      | Name of the process                              |
-| command   | Command line with the used to invoke the process |
-| is_ipv6   | true if endpoint is IPv6, otherwise false        |
-| port      | Port number                                      |
-| transport | The transport protocol ("TCP" or "UDP")          |
+| Variable       | Description                                      |
+|----------------|--------------------------------------------------|
+| type.hostport  | `true`                                           |
+| name           | Name of the process                              |
+| command        | Command line with the used to invoke the process |
+| is_ipv6        | true if endpoint is IPv6, otherwise false        |
+| port           | Port number                                      |
+| transport      | The transport protocol ("TCP" or "UDP")          |
 
 ## Example
 

--- a/receiver/receivercreator/config.go
+++ b/receiver/receivercreator/config.go
@@ -15,10 +15,6 @@
 package receivercreator
 
 import (
-	"reflect"
-
-	"github.com/spf13/cast"
-	"github.com/spf13/viper"
 	otelconfig "go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configmodels"
 )
@@ -79,20 +75,4 @@ type Config struct {
 	receiverTemplates             map[string]receiverTemplate
 	// WatchObservers are the extensions to listen to endpoints from.
 	WatchObservers []configmodels.Type `mapstructure:"watch_observers"`
-}
-
-// Copied from the Viper but changed to use the same delimiter.
-// See https://github.com/spf13/viper/issues/871
-func viperSub(v *viper.Viper, key string) *viper.Viper {
-	subv := otelconfig.NewViper()
-	data := v.Get(key)
-	if data == nil {
-		return subv
-	}
-
-	if reflect.TypeOf(data).Kind() == reflect.Map {
-		subv.MergeConfigMap(cast.ToStringMap(data))
-		return subv
-	}
-	return subv
 }

--- a/receiver/receivercreator/fixtures_test.go
+++ b/receiver/receivercreator/fixtures_test.go
@@ -32,13 +32,13 @@ var pod = observer.Pod{
 var podEndpoint = observer.Endpoint{
 	ID:      "pod-1",
 	Target:  "localhost",
-	Details: pod,
+	Details: &pod,
 }
 
 var portEndpoint = observer.Endpoint{
 	ID:     "port-1",
 	Target: "localhost:1234",
-	Details: observer.Port{
+	Details: &observer.Port{
 		Name:      "http",
 		Pod:       pod,
 		Port:      1234,
@@ -49,5 +49,5 @@ var portEndpoint = observer.Endpoint{
 var unsupportedEndpoint = observer.Endpoint{
 	ID:      "endpoint-1",
 	Target:  "localhost:1234",
-	Details: map[string]interface{}{},
+	Details: nil,
 }

--- a/receiver/receivercreator/go.mod
+++ b/receiver/receivercreator/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/antonmedv/expr v1.8.9
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.0.0-00010101000000-000000000000
-	github.com/spf13/cast v1.3.1
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.1
 	go.opentelemetry.io/collector v0.18.0

--- a/receiver/receivercreator/observerhandler.go
+++ b/receiver/receivercreator/observerhandler.go
@@ -66,7 +66,7 @@ func (obs *observerHandler) OnAdd(added []observer.Endpoint) {
 	defer obs.Unlock()
 
 	for _, e := range added {
-		env, err := observer.EndpointToEnv(e)
+		env, err := e.Env()
 		if err != nil {
 			obs.logger.Error("unable to convert endpoint to environment map", zap.String("endpoint", string(e.ID)), zap.Error(err))
 			continue

--- a/receiver/receivercreator/rules_test.go
+++ b/receiver/receivercreator/rules_test.go
@@ -54,7 +54,7 @@ func Test_ruleEval(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, got)
 
-			env, err := observer.EndpointToEnv(tt.args.endpoint)
+			env, err := tt.args.endpoint.Env()
 			require.NoError(t, err)
 
 			match, err := got.eval(env)


### PR DESCRIPTION
This is a more limited change from #1898 that just cleans up the endpoint code
but doesn't change how endpoint types are selected.

**Testing:**
Tested end to end with helm chart.

**Documentation:**
Updated receiver_creator docs to document hostport.