### PR TITLE
[AzureMonitorExporter ] Prioritize RPC over HTTP spans

### DIFF
--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -78,6 +78,14 @@ func spanToEnvelope(
 	envelope.Tags[contracts.OperationId] = span.TraceID().HexString()
 	envelope.Tags[contracts.OperationParentId] = span.ParentSpanID().HexString()
 
+	// If a specific ai.operation.parentid is specified as an attribute, use that instead of the parent span id.
+	// This is a by convention method to enable proper linking of legacy AppInsights hierarchical requests to OpenTelemetry instrumented requests.
+	// Services are responsible for parsing an inbound hierarchical request and adding this special tag.
+	if alternateParentIDAttributeValue, success := attributeMap.Get(contracts.OperationParentId); success {
+		envelope.Tags[contracts.OperationParentId] = alternateParentIDAttributeValue.StringVal()
+		attributeMap.Delete(contracts.OperationParentId)
+	}
+
 	data := contracts.NewData()
 	var dataSanitizeFunc func() []string
 	var dataProperties map[string]string

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -602,14 +602,14 @@ func mapIncomingSpanToType(attributeMap pdata.AttributeMap) spanType {
 		return unknownSpanType
 	}
 
-	// HTTP
-	if _, exists := attributeMap.Get(conventions.AttributeHTTPMethod); exists {
-		return httpSpanType
-	}
-
 	// RPC
 	if _, exists := attributeMap.Get(conventions.AttributeRPCSystem); exists {
 		return rpcSpanType
+	}
+
+	// HTTP
+	if _, exists := attributeMap.Get(conventions.AttributeHTTPMethod); exists {
+		return httpSpanType
 	}
 
 	// Database

--- a/exporter/loadbalancingexporter/exporter.go
+++ b/exporter/loadbalancingexporter/exporter.go
@@ -113,10 +113,7 @@ func newExporter(params component.ExporterCreateParams, cfg configmodels.Exporte
 func (e *exporterImp) Start(ctx context.Context, host component.Host) error {
 	e.res.onChange(e.onBackendChanges)
 	e.host = host
-	if err := e.res.start(ctx); err != nil {
-		return err
-	}
-
+	e.res.start(ctx)
 	return nil
 }
 
@@ -205,6 +202,11 @@ func (e *exporterImp) ConsumeTraces(ctx context.Context, td pdata.Traces) error 
 }
 
 func (e *exporterImp) consumeTrace(ctx context.Context, td pdata.Traces) error {
+	if e.ring == nil {
+		// something is really wrong... how come we couldn't find the exporter??
+		return fmt.Errorf("couldn't find the exporter for the given host")
+	}
+
 	traceID := traceIDFromTraces(td)
 	if traceID == pdata.InvalidTraceID() {
 		return errNoTracesInBatch

--- a/exporter/loadbalancingexporter/resolver_dns.go
+++ b/exporter/loadbalancingexporter/resolver_dns.go
@@ -76,10 +76,7 @@ func newDNSResolver(logger *zap.Logger, hostname string, port string) (*dnsResol
 }
 
 func (r *dnsResolver) start(ctx context.Context) error {
-	if _, err := r.resolve(ctx); err != nil {
-		return err
-	}
-
+	r.resolve(ctx)
 	go r.periodicallyResolve()
 
 	return nil

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -1,0 +1,74 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/sampling"
+)
+
+func getNewCompositePolicy(logger *zap.Logger, config CompositeCfg) (sampling.PolicyEvaluator, error) {
+	var subPolicyEvalParams []sampling.SubPolicyEvalParams
+	rateAllocationsMap := getRateAllocationMap(config)
+	for i := range config.SubPolicyCfg {
+		policyCfg := &config.SubPolicyCfg[i]
+		policy, _ := getSubPolicyEvaluator(logger, policyCfg)
+
+		evalParams := sampling.SubPolicyEvalParams{
+			Evaluator:         policy,
+			MaxSpansPerSecond: int64(rateAllocationsMap[policyCfg.Name]),
+		}
+		subPolicyEvalParams = append(subPolicyEvalParams, evalParams)
+	}
+	return sampling.NewComposite(logger, config.MaxTotalSpansPerSecond, subPolicyEvalParams, sampling.MonotonicClock{}), nil
+}
+
+// Apply rate allocations to the sub-policies
+func getRateAllocationMap(config CompositeCfg) map[string]float64 {
+	rateAllocationsMap := make(map[string]float64)
+	maxTotalSPS := float64(config.MaxTotalSpansPerSecond)
+	// Default SPS determined by equally diving number of sub policies
+	defaultSPS := maxTotalSPS / float64(len(config.SubPolicyCfg))
+	for i := 0; i < len(config.RateAllocation); i++ {
+		rAlloc := &config.RateAllocation[i]
+		rateAllocationsMap[rAlloc.Policy] = defaultSPS
+		if rAlloc.Percent > 0 {
+			rateAllocationsMap[rAlloc.Policy] = (float64(rAlloc.Percent) / 100) * maxTotalSPS
+		}
+	}
+	return rateAllocationsMap
+}
+
+// Return instance of composite sub-policy
+func getSubPolicyEvaluator(logger *zap.Logger, cfg *SubPolicyCfg) (sampling.PolicyEvaluator, error) {
+	switch cfg.Type {
+	case AlwaysSample:
+		return sampling.NewAlwaysSample(logger), nil
+	case NumericAttribute:
+		nafCfg := cfg.NumericAttributeCfg
+		return sampling.NewNumericAttributeFilter(logger, nafCfg.Key, nafCfg.MinValue, nafCfg.MaxValue), nil
+	case StringAttribute:
+		safCfg := cfg.StringAttributeCfg
+		return sampling.NewStringAttributeFilter(logger, safCfg.Key, safCfg.Values), nil
+	case RateLimiting:
+		rlfCfg := cfg.RateLimitingCfg
+		return sampling.NewRateLimiting(logger, rlfCfg.SpansPerSecond), nil
+	default:
+		return nil, fmt.Errorf("unknown sampling policy type %s", cfg.Type)
+	}
+}

--- a/processor/tailsamplingprocessor/composite_helper_test.go
+++ b/processor/tailsamplingprocessor/composite_helper_test.go
@@ -1,0 +1,85 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/config/configmodels"
+)
+
+func TestCompositeHelper(t *testing.T) {
+	cfg := &Config{
+		ProcessorSettings: configmodels.ProcessorSettings{
+			TypeVal: "tail_sampling",
+			NameVal: "tail_sampling",
+		},
+		DecisionWait:            10 * time.Second,
+		NumTraces:               100,
+		ExpectedNewTracesPerSec: 10,
+		PolicyCfgs: []PolicyCfg{
+			{
+				Name: "composite-policy-1",
+				Type: Composite,
+				CompositeCfg: CompositeCfg{
+					MaxTotalSpansPerSecond: 1000,
+					PolicyOrder:            []string{"test-composite-policy-1", "test-composite-policy-2", "test-composite-policy-3", "test-composite-policy-4", "test-composite-policy-5"},
+					SubPolicyCfg: []SubPolicyCfg{
+						{
+							Name:                "test-composite-policy-1",
+							Type:                NumericAttribute,
+							NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+						},
+						{
+							Name:               "test-composite-policy-2",
+							Type:               StringAttribute,
+							StringAttributeCfg: StringAttributeCfg{Key: "key2", Values: []string{"value1", "value2"}},
+						},
+						{
+							Name:            "test-composite-policy-3",
+							Type:            RateLimiting,
+							RateLimitingCfg: RateLimitingCfg{SpansPerSecond: 10},
+						},
+						{
+							Name: "test-composite-policy-4",
+							Type: AlwaysSample,
+						},
+						{
+							Name: "test-composite-policy-5",
+						},
+					},
+					RateAllocation: []RateAllocationCfg{
+						{
+							Policy:  "test-composite-policy-1",
+							Percent: 50,
+						},
+						{
+							Policy:  "test-composite-policy-2",
+							Percent: 25,
+						},
+					},
+				},
+			},
+		},
+	}
+	rlfCfg := cfg.PolicyCfgs[0].CompositeCfg
+	composite, e := getNewCompositePolicy(zap.NewNop(), rlfCfg)
+	require.NotNil(t, composite)
+	require.Nil(t, e)
+}

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -34,6 +34,8 @@ const (
 	StringAttribute PolicyType = "string_attribute"
 	// RateLimiting allows all traces until the specified limits are satisfied.
 	RateLimiting PolicyType = "rate_limiting"
+	// Composite allows a combination of above policies with rate limiting.
+	Composite PolicyType = "composite"
 )
 
 // PolicyCfg holds the common configuration to all policies.
@@ -48,6 +50,8 @@ type PolicyCfg struct {
 	StringAttributeCfg StringAttributeCfg `mapstructure:"string_attribute"`
 	// Configs for rate limiting filter sampling policy evaluator.
 	RateLimitingCfg RateLimitingCfg `mapstructure:"rate_limiting"`
+	// CompositeCfg for defining composite policy
+	CompositeCfg CompositeCfg `mapstructure:"composite"`
 }
 
 // NumericAttributeCfg holds the configurable settings to create a numeric attribute filter
@@ -75,6 +79,35 @@ type StringAttributeCfg struct {
 type RateLimitingCfg struct {
 	// SpansPerSecond sets the limit on the maximum nuber of spans that can be processed each second.
 	SpansPerSecond int64 `mapstructure:"spans_per_second"`
+}
+
+// RateAllocationCfg used within composite policy
+type RateAllocationCfg struct {
+	Policy  string `mapstructure:"policy"`
+	Percent int64  `mapstructure:"percent"`
+}
+
+// SubPolicyCfg holds the common configuration to all policies under composite policy.
+type SubPolicyCfg struct {
+	// Name given to the instance of the policy to make easy to identify it in metrics and logs.
+	Name string `mapstructure:"name"`
+	// Type of the policy this will be used to match the proper configuration of the policy.
+	Type PolicyType `mapstructure:"type"`
+	// Configs for numeric attribute filter sampling policy evaluator.
+	NumericAttributeCfg NumericAttributeCfg `mapstructure:"numeric_attribute"`
+	// Configs for string attribute filter sampling policy evaluator.
+	StringAttributeCfg StringAttributeCfg `mapstructure:"string_attribute"`
+	// Configs for rate limiting filter sampling policy evaluator.
+	RateLimitingCfg RateLimitingCfg `mapstructure:"rate_limiting"`
+}
+
+// CompositeCfg holds the configurable settings to create a composite
+// sampling policy evaluator.
+type CompositeCfg struct {
+	MaxTotalSpansPerSecond int64               `mapstructure:"max_total_spans_per_second"`
+	PolicyOrder            []string            `mapstructure:"policy_order"`
+	SubPolicyCfg           []SubPolicyCfg      `mapstructure:"composite_sub_policy"`
+	RateAllocation         []RateAllocationCfg `mapstructure:"rate_allocation"`
 }
 
 // Config holds the configuration for tail-based sampling.

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -126,6 +126,9 @@ func getPolicyEvaluator(logger *zap.Logger, cfg *PolicyCfg) (sampling.PolicyEval
 	case RateLimiting:
 		rlfCfg := cfg.RateLimitingCfg
 		return sampling.NewRateLimiting(logger, rlfCfg.SpansPerSecond), nil
+	case Composite:
+		rlfCfg := cfg.CompositeCfg
+		return getNewCompositePolicy(logger, rlfCfg)
 	default:
 		return nil, fmt.Errorf("unknown sampling policy type %s", cfg.Type)
 	}

--- a/processor/tailsamplingprocessor/sampling/composite.go
+++ b/processor/tailsamplingprocessor/sampling/composite.go
@@ -1,0 +1,162 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sampling
+
+import (
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+type subpolicy struct {
+	// the subpolicy evaluator
+	evaluator PolicyEvaluator
+
+	// spans per second allocated to each subpolicy
+	allocatedSPS int64
+
+	// spans per second that each subpolicy sampled in this period
+	sampledSPS int64
+}
+
+// Composite evaluator and its internal data
+type Composite struct {
+	// the subpolicy evaluators
+	subpolicies []*subpolicy
+
+	// maximum total spans per second that must be sampled
+	maxTotalSPS int64
+
+	// current unix timestamp second
+	currentSecond int64
+
+	// The time provider (can be different from clock for testing purposes)
+	timeProvider TimeProvider
+
+	logger *zap.Logger
+}
+
+var _ PolicyEvaluator = (*Composite)(nil)
+
+// SubPolicyEvalParams defines the evaluator and max rate for a sub-policy
+type SubPolicyEvalParams struct {
+	Evaluator         PolicyEvaluator
+	MaxSpansPerSecond int64
+}
+
+// NewComposite creates a policy evaluator that samples all subpolicies.
+func NewComposite(
+	logger *zap.Logger,
+	maxTotalSpansPerSecond int64,
+	subPolicyParams []SubPolicyEvalParams,
+	timeProvider TimeProvider,
+) PolicyEvaluator {
+
+	subpolicies := []*subpolicy{}
+
+	for i := 0; i < len(subPolicyParams); i++ {
+		sub := &subpolicy{}
+		sub.evaluator = subPolicyParams[i].Evaluator
+		sub.allocatedSPS = subPolicyParams[i].MaxSpansPerSecond
+
+		// We are just starting, so there is no previous input, set it to 0
+		sub.sampledSPS = 0
+
+		subpolicies = append(subpolicies, sub)
+	}
+
+	return &Composite{
+		maxTotalSPS:  maxTotalSpansPerSecond,
+		subpolicies:  subpolicies,
+		timeProvider: timeProvider,
+		logger:       logger,
+	}
+}
+
+// OnLateArrivingSpans notifies the evaluator that the given list of spans arrived
+// after the sampling decision was already taken for the trace.
+// This gives the evaluator a chance to log any message/metrics and/or update any
+// related internal state.
+func (c *Composite) OnLateArrivingSpans(Decision, []*pdata.Span) error {
+	return nil
+}
+
+// Evaluate looks at the trace data and returns a corresponding SamplingDecision.
+func (c *Composite) Evaluate(traceID pdata.TraceID, trace *TraceData) (Decision, error) {
+	// func (c *Composite) Evaluate(traceID []byte, trace *TraceData) (Decision, error) {
+	// Rate limiting works by counting spans that are sampled during each 1 second
+	// time period. Until the total number of spans during a particular second
+	// exceeds the allocated number of spans-per-second the traces are sampled,
+	// once the limit is exceeded the traces are no longer sampled. The counter
+	// restarts at the beginning of each second.
+	// Current counters and rate limits are kept separately for each subpolicy.
+
+	currSecond := c.timeProvider.getCurSecond()
+	if c.currentSecond != currSecond {
+		// This is a new second
+		c.currentSecond = currSecond
+		// Reset counters
+		for i := range c.subpolicies {
+			c.subpolicies[i].sampledSPS = 0
+		}
+	}
+
+	for _, sub := range c.subpolicies {
+		decision, err := sub.evaluator.Evaluate(traceID, trace)
+		if err != nil {
+			return Unspecified, err
+		}
+
+		if decision == Sampled {
+			// The subpolicy made a decision to Sample. Now we need to make our decision.
+
+			// Calculate resulting SPS counter if we decide to sample this trace
+			spansInSecondIfSampled := sub.sampledSPS + trace.SpanCount
+
+			// Check if the rate will be within the allocated bandwidth.
+			if spansInSecondIfSampled <= sub.allocatedSPS && spansInSecondIfSampled <= c.maxTotalSPS {
+				sub.sampledSPS = spansInSecondIfSampled
+
+				// Let the sampling happen
+				return Sampled, nil
+			}
+
+			// We exceeded the rate limit. Don't sample this trace.
+			// Note that we will continue evaluating new incoming traces against
+			// allocated SPS, we do not update sub.sampledSPS here in order to give
+			// chance to another smaller trace to be accepted later.
+			return NotSampled, nil
+		}
+	}
+
+	return NotSampled, nil
+}
+
+// OnDroppedSpans is called when the trace needs to be dropped, due to memory
+// pressure, before the decision_wait time has been reached.
+func (c *Composite) OnDroppedSpans(pdata.TraceID, *TraceData) (Decision, error) {
+	// Here we have a number of possible solutions:
+	// 1. Random sample traces based on maxTotalSPS.
+	// 2. Perform full composite sampling logic by calling Composite.Evaluate(), essentially
+	//    using partial trace data for sampling.
+	// 3. Sample everything.
+	//
+	// It seems that #2 may be the best choice from end user perspective, but
+	// it is not certain and it is also additional performance penalty when we are
+	// already under a memory (and possibly CPU) pressure situation.
+	//
+	// For now we are playing safe and go with #3. Investigating alternate options
+	// should be a future task.
+	return Sampled, nil
+}

--- a/processor/tailsamplingprocessor/sampling/composite_test.go
+++ b/processor/tailsamplingprocessor/sampling/composite_test.go
@@ -1,0 +1,263 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+type FakeTimeProvider struct {
+	second int64
+}
+
+func (f FakeTimeProvider) getCurSecond() int64 {
+	return f.second
+}
+
+var traceID = pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+func createTrace() *TraceData {
+	trace := &TraceData{SpanCount: 1}
+	return trace
+}
+
+func TestCompositeEvaluatorNotSampled(t *testing.T) {
+
+	// Create 2 policies which do not match any trace
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewNumericAttributeFilter(zap.NewNop(), "tag", 200, 300)
+	c := NewComposite(zap.NewNop(), 1000, []SubPolicyEvalParams{{n1, 100}, {n2, 100}}, FakeTimeProvider{})
+
+	trace := createTrace()
+
+	decision, err := c.Evaluate(traceID, trace)
+	if err != nil {
+		t.Fatalf("Failed to evaluate composite policy: %v", err)
+	}
+
+	// None of the numeric filters should match since input trace data does not contain
+	// the "tag", so the decision should be NotSampled.
+	expected := NotSampled
+	if decision != expected {
+		t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+	}
+}
+
+func TestCompositeEvaluatorSampled(t *testing.T) {
+
+	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewAlwaysSample(zap.NewNop())
+	c := NewComposite(zap.NewNop(), 1000, []SubPolicyEvalParams{{n1, 100}, {n2, 100}}, FakeTimeProvider{})
+
+	trace := createTrace()
+
+	decision, err := c.Evaluate(traceID, trace)
+	if err != nil {
+		t.Fatalf("Failed to evaluate composite policy: %v", err)
+	}
+
+	// The second policy is AlwaysSample, so the decision should be Sampled.
+	expected := Sampled
+	if decision != expected {
+		t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+	}
+}
+
+func TestCompositeEvaluatorSampled_AlwaysSampled(t *testing.T) {
+
+	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewAlwaysSample(zap.NewNop())
+	c := NewComposite(zap.NewNop(), 10, []SubPolicyEvalParams{{n1, 20}, {n2, 20}}, FakeTimeProvider{})
+
+	for i := 1; i <= 3; i++ {
+		trace := createTrace()
+
+		decision, err := c.Evaluate(traceID, trace)
+		if err != nil {
+			t.Fatalf("Failed to evaluate composite policy: %v", err)
+		}
+
+		// The second policy is AlwaysSample, so the decision should be Sampled.
+		expected := Sampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+}
+
+func TestCompositeEvaluatorThrottling(t *testing.T) {
+
+	// Create only one subpolicy, with 100% Sampled policy.
+	n1 := NewAlwaysSample(zap.NewNop())
+	timeProvider := &FakeTimeProvider{second: 0}
+	const totalSPS = 100
+	c := NewComposite(zap.NewNop(), totalSPS, []SubPolicyEvalParams{{n1, totalSPS}}, timeProvider)
+
+	trace := createTrace()
+
+	// First totalSPS traces should be 100% Sampled
+	for i := 0; i < totalSPS; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		if err != nil {
+			t.Fatalf("Failed to evaluate composite policy: %v", err)
+		}
+
+		expected := Sampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+
+	// Now we hit the rate limit, so subsequent evaluations should result in 100% NotSampled
+	for i := 0; i < totalSPS; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		if err != nil {
+			t.Fatalf("Failed to evaluate composite policy: %v", err)
+		}
+
+		expected := NotSampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+
+	// Let the time advance by one second.
+	timeProvider.second++
+
+	// Subsequent sampling should be Sampled again because it is a new second.
+	for i := 0; i < totalSPS; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		if err != nil {
+			t.Fatalf("Failed to evaluate composite policy: %v", err)
+		}
+
+		expected := Sampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+}
+
+func TestOnDroppedSpans_Composite(t *testing.T) {
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewAlwaysSample(zap.NewNop())
+	timeProvider := &FakeTimeProvider{second: 0}
+	const totalSPS = 100
+	trace := createTrace()
+	c := NewComposite(zap.NewNop(), totalSPS, []SubPolicyEvalParams{{n1, totalSPS / 2}, {n2, totalSPS / 2}}, timeProvider)
+	decision, e := c.OnDroppedSpans(traceID, trace)
+	assert.Nil(t, e)
+	assert.Equal(t, decision, Sampled)
+}
+
+func TestOnLateArrivingSpans_Composite(t *testing.T) {
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewAlwaysSample(zap.NewNop())
+	timeProvider := &FakeTimeProvider{second: 0}
+	const totalSPS = 100
+	c := NewComposite(zap.NewNop(), totalSPS, []SubPolicyEvalParams{{n1, totalSPS / 2}, {n2, totalSPS / 2}}, timeProvider)
+	e := c.OnLateArrivingSpans(Sampled, nil)
+	assert.Nil(t, e)
+}
+
+func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
+
+	n1 := NewNumericAttributeFilter(zap.NewNop(), "tag", 0, 100)
+	n2 := NewAlwaysSample(zap.NewNop())
+	timeProvider := &FakeTimeProvider{second: 0}
+	const totalSPS = 100
+	c := NewComposite(zap.NewNop(), totalSPS, []SubPolicyEvalParams{{n1, totalSPS / 2}, {n2, totalSPS / 2}}, timeProvider)
+
+	trace := createTrace()
+
+	// We have 2 subpolicies, so each should initially get half the bandwidth
+
+	// First totalSPS/2 should be Sampled until we hit the rate limit
+	for i := 0; i < totalSPS/2; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		if err != nil {
+			t.Fatalf("Failed to evaluate composite policy: %v", err)
+		}
+
+		expected := Sampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+
+	// Now we hit the rate limit for second subpolicy, so subsequent evaluations should result in NotSampled
+	for i := 0; i < totalSPS/2; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		if err != nil {
+			t.Fatalf("Failed to evaluate composite policy: %v", err)
+		}
+
+		expected := NotSampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+
+	// Let the time advance by one second.
+	timeProvider.second++
+
+	// It is a new second, so we should start sampling again.
+	for i := 0; i < totalSPS/2; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		if err != nil {
+			t.Fatalf("Failed to evaluate composite policy: %v", err)
+		}
+
+		expected := Sampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+
+	// Now let's hit the hard limit and exceed the total by a factor of 2
+	for i := 0; i < 2*totalSPS; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		if err != nil {
+			t.Fatalf("Failed to evaluate composite policy: %v", err)
+		}
+
+		expected := NotSampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+
+	// Let the time advance by one second.
+	timeProvider.second++
+
+	// It is a new second, so we should start sampling again.
+	for i := 0; i < totalSPS/2; i++ {
+		decision, err := c.Evaluate(traceID, trace)
+		if err != nil {
+			t.Fatalf("Failed to evaluate composite policy: %v", err)
+		}
+
+		expected := Sampled
+		if decision != expected {
+			t.Fatalf("Incorrect decision by composite policy evaluator: expected %v, actual %v", expected, decision)
+		}
+	}
+}

--- a/processor/tailsamplingprocessor/sampling/time_provider.go
+++ b/processor/tailsamplingprocessor/sampling/time_provider.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sampling
+
+import (
+	"time"
+)
+
+// TimeProvider allows to get current Unix second
+type TimeProvider interface {
+	getCurSecond() int64
+}
+
+// MonotonicClock provides monotonic real clock-based current Unix second.
+// Use it when creating a NewComposite which should measure sample rates
+// against a realtime clock (this is almost always what you want to do,
+// the exception is usually only automated testing where you may want
+// to have fake clocks).
+type MonotonicClock struct{}
+
+func (c MonotonicClock) getCurSecond() int64 {
+	return time.Now().Unix()
+}

--- a/processor/tailsamplingprocessor/sampling/time_provider_test.go
+++ b/processor/tailsamplingprocessor/sampling/time_provider_test.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sampling
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeProvider(t *testing.T) {
+	clock := MonotonicClock{}
+	assert.Greater(t, clock.getCurSecond(), int64(0))
+}

--- a/processor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
+++ b/processor/tailsamplingprocessor/testdata/tail_sampling_config.yaml
@@ -30,6 +30,36 @@ processors:
             type: rate_limiting,
             rate_limiting: {spans_per_second: 35}
          },
+         {
+					Name: "composite-policy-1",
+					Type: Composite,
+					CompositeCfg: CompositeCfg{
+						MaxTotalSpansPerSecond: 1000,
+						PolicyOrder:            []string{"test-composite-policy-1", "test-composite-policy-2"},
+						SubPolicyCfg: []SubPolicyCfg{
+							{
+								Name:                "test-composite-policy-1",
+								Type:                NumericAttribute,
+								NumericAttributeCfg: NumericAttributeCfg{Key: "key1", MinValue: 50, MaxValue: 100},
+							},
+							{
+								Name:               "test-composite-policy-2",
+								Type:               StringAttribute,
+								StringAttributeCfg: StringAttributeCfg{Key: "key2", Values: []string{"value1", "value2"}},
+							},
+						},
+						RateAllocation: []RateAllocationCfg{
+							{
+								Policy:  "test-composite-policy-1",
+								Percent: 50,
+							},
+							{
+								Policy:  "test-composite-policy-2",
+								Percent: 25,
+							},
+						},
+					},
+				},
       ]
 
 service:


### PR DESCRIPTION
Description:
Some instrumentation libraries are sending an RPC server span with both RPC and HTTP semantic attributes present (dotnet). In these cases, we should favor the RPC attributes when figuring the Span type.

Testing:
E2E tests performed.