### PR TITLE
[AzureMonitorExporter] Favor RPC over HTTP spans

### DIFF
--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -594,14 +594,14 @@ func mapIncomingSpanToType(attributeMap pdata.AttributeMap) spanType {
 		return unknownSpanType
 	}
 
-	// HTTP
-	if _, exists := attributeMap.Get(conventions.AttributeHTTPMethod); exists {
-		return httpSpanType
-	}
-
 	// RPC
 	if _, exists := attributeMap.Get(conventions.AttributeRPCSystem); exists {
 		return rpcSpanType
+	}
+
+	// HTTP
+	if _, exists := attributeMap.Get(conventions.AttributeHTTPMethod); exists {
+		return httpSpanType
 	}
 
 	// Database


### PR DESCRIPTION
**Description:** 
Some instrumentation libraries are sending an RPC server span with both RPC and HTTP semantic attributes present (dotnet). In these cases, we should favor the RPC attributes when figuring the  Span type.

**Testing:**
E2E testing performed.