### PR TITLE
[F5cloudexporter] Add dependabot entry and code owner (2/3)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@ exporter/carbonexporter/                   @open-telemetry/collector-contrib-app
 exporter/datadogexporter/                  @open-telemetry/collector-contrib-approvers @KSerrania @ericmustin @mx-psi
 exporter/dynatraceexporter/                @open-telemetry/collector-contrib-approvers @dyladan
 exporter/elasticexporter/                  @open-telemetry/collector-contrib-approvers @axw @simitt @jalvz
+exporter/f5cloudexporter/                  @open-telemetry/collector-contrib-approvers @gramidt
 exporter/honeycombexporter/                @open-telemetry/collector-contrib-approvers @paulosman @lizthegrey @MikeGoldsmith
 exporter/jaegerthrifthttpexporter/         @open-telemetry/collector-contrib-approvers @jpkrohling @pavolloffay
 exporter/kinesisexporter/                  @open-telemetry/collector-contrib-approvers @owais

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -102,6 +102,10 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
+    directory: "/exporter/f5cloudexporter"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
     directory: "/exporter/honeycombexporter"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Description:
Adding F5 Cloud exporter dependabot entry and code owner ( #1965  )

Link to tracking Issue:
#1964

Testing:
N/A

Documentation:
N/A