### PR TITLE
add proper sfx env variables to deployment

### DIFF
--- a/exporter/sapmexporter/examples/signalfx-k8s.yaml
+++ b/exporter/sapmexporter/examples/signalfx-k8s.yaml
@@ -148,6 +148,11 @@ spec:
           requests:
             cpu: 200m
             memory: 400Mi
+        env:
+        - name: SFX_REALM
+          value: # set your realm here
+        - name: SFX_TOKEN
+          value: # set your token here
         ports:
         - containerPort: 55679 # Default endpoint for ZPages.
         - containerPort: 55680 # Default endpoint for OpenTelemetry receiver.


### PR DESCRIPTION
the deployment spec of the service is missing the realm and token variables needed to work correctly...

I've added this as an example starting on 152:

        env:
        - name: SFX_REALM
          value: # set your realm here
        - name: SFX_TOKEN
          value: # set your token here

We'll need to change the referring docs as well indicating that these need to be set.
Taking from $() variables doesn't seem to want to work in this example.

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>