### PR TITLE
Make the path of the splunk HEC receiver configurable

### DIFF
--- a/receiver/splunkhecreceiver/README.md
+++ b/receiver/splunkhecreceiver/README.md
@@ -29,7 +29,7 @@ The following settings are optional:
       Note: Both `key_file` and `cert_file` are required for TLS connection.
     * `key_file`: Specifies the key file to use for TLS connection. Note: Both
       `key_file` and `cert_file` are required for TLS connection.
-
+* `path` (default = '/*): The path to listen on, as a glob expression.
 Example:
 
 ```yaml
@@ -40,6 +40,7 @@ receivers:
     tls:
       cert_file: /test.crt
       key_file: /test.key
+    path: "/myhecreceiver"
 ```
 
 The full list of settings exposed for this receiver are documented [here](./config.go)

--- a/receiver/splunkhecreceiver/config.go
+++ b/receiver/splunkhecreceiver/config.go
@@ -15,15 +15,15 @@
 package splunkhecreceiver
 
 import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/gobwas/glob"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configmodels"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
-)
-
-const (
-	// hecPath is the default HEC path on the Splunk instance.
-	hecPath = "/services/collector"
 )
 
 // Config defines configuration for the SignalFx receiver.
@@ -32,4 +32,39 @@ type Config struct {
 	confighttp.HTTPServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	splunk.AccessTokenPassthroughConfig `mapstructure:",squash"`
+	// Path we will listen on, defaults to `*` (anything matches)
+	Path     string `mapstructure:"path"`
+	pathGlob glob.Glob
+}
+
+// initialize and initialize the configuration
+func (c *Config) initialize() error {
+	path := c.Path
+	if path == "" {
+		path = "*"
+	}
+	glob, err := glob.Compile(path)
+	if err != nil {
+		return err
+	}
+	c.pathGlob = glob
+	_, err = extractPortFromEndpoint(c.Endpoint)
+	return err
+}
+
+// extract the port number from string in "address:port" format. If the
+// port number cannot be extracted returns an error.
+func extractPortFromEndpoint(endpoint string) (int, error) {
+	_, portStr, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return 0, fmt.Errorf("endpoint is not formatted correctly: %s", err.Error())
+	}
+	port, err := strconv.ParseInt(portStr, 10, 0)
+	if err != nil {
+		return 0, fmt.Errorf("endpoint port is not a number: %s", err.Error())
+	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("port number must be between 1 and 65535")
+	}
+	return int(port), nil
 }

--- a/receiver/splunkhecreceiver/config_test.go
+++ b/receiver/splunkhecreceiver/config_test.go
@@ -38,6 +38,13 @@ func TestDefaultPath(t *testing.T) {
 	assert.True(t, c.(*Config).pathGlob.Match("/bar"))
 }
 
+func TestBadGlob(t *testing.T) {
+	c := createDefaultConfig().(*Config)
+	c.Path = "["
+	err := c.initialize()
+	assert.Error(t, err)
+}
+
 func TestFixedPath(t *testing.T) {
 	c := createDefaultConfig()
 	c.(*Config).Path = "/foo"

--- a/receiver/splunkhecreceiver/config_test.go
+++ b/receiver/splunkhecreceiver/config_test.go
@@ -29,6 +29,71 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
+func TestDefaultPath(t *testing.T) {
+	c := createDefaultConfig()
+	err := c.(*Config).initialize()
+	assert.NoError(t, err)
+	assert.True(t, c.(*Config).pathGlob.Match("/foo"))
+	assert.True(t, c.(*Config).pathGlob.Match("/foo/bar"))
+	assert.True(t, c.(*Config).pathGlob.Match("/bar"))
+}
+
+func TestFixedPath(t *testing.T) {
+	c := createDefaultConfig()
+	c.(*Config).Path = "/foo"
+	err := c.(*Config).initialize()
+	assert.NoError(t, err)
+	assert.True(t, c.(*Config).pathGlob.Match("/foo"))
+	assert.False(t, c.(*Config).pathGlob.Match("/foo/bar"))
+	assert.False(t, c.(*Config).pathGlob.Match("/bar"))
+}
+
+func TestPathWithGlob(t *testing.T) {
+	c := createDefaultConfig()
+	c.(*Config).Path = "/foo/*"
+	err := c.(*Config).initialize()
+	assert.NoError(t, err)
+	assert.False(t, c.(*Config).pathGlob.Match("/foo"))
+	assert.True(t, c.(*Config).pathGlob.Match("/foo/bar"))
+	assert.False(t, c.(*Config).pathGlob.Match("/bar"))
+}
+
+func TestInvalidPathGlobPattern(t *testing.T) {
+	c := Config{Path: "**/ "}
+	err := c.initialize()
+	assert.Error(t, err)
+}
+
+func TestInvalidPathSpaces(t *testing.T) {
+	c := Config{Path: "  foo  "}
+	err := c.initialize()
+	assert.Error(t, err)
+}
+
+func TestCreateValidEndpoint(t *testing.T) {
+	endpoint, err := extractPortFromEndpoint("localhost:123")
+	assert.NoError(t, err)
+	assert.Equal(t, 123, endpoint)
+}
+
+func TestCreateInvalidEndpoint(t *testing.T) {
+	endpoint, err := extractPortFromEndpoint("")
+	assert.EqualError(t, err, "endpoint is not formatted correctly: missing port in address")
+	assert.Equal(t, 0, endpoint)
+}
+
+func TestCreateNoPort(t *testing.T) {
+	endpoint, err := extractPortFromEndpoint("localhost:")
+	assert.EqualError(t, err, "endpoint port is not a number: strconv.ParseInt: parsing \"\": invalid syntax")
+	assert.Equal(t, 0, endpoint)
+}
+
+func TestCreateLargePort(t *testing.T) {
+	endpoint, err := extractPortFromEndpoint("localhost:65536")
+	assert.EqualError(t, err, "port number must be between 1 and 65535")
+	assert.Equal(t, 0, endpoint)
+}
+
 func TestLoadConfig(t *testing.T) {
 	factories, err := componenttest.ExampleComponents()
 	assert.Nil(t, err)
@@ -60,6 +125,7 @@ func TestLoadConfig(t *testing.T) {
 			AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
 				AccessTokenPassthrough: true,
 			},
+			Path: "/foo",
 		})
 
 	r2 := cfg.Receivers["splunk_hec/tls"].(*Config)
@@ -81,5 +147,6 @@ func TestLoadConfig(t *testing.T) {
 			AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
 				AccessTokenPassthrough: false,
 			},
+			Path: "",
 		})
 }

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -16,9 +16,6 @@ package splunkhecreceiver
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"strconv"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configerror"
@@ -61,30 +58,8 @@ func createDefaultConfig() configmodels.Receiver {
 			Endpoint: defaultEndpoint,
 		},
 		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{},
+		Path:                         "",
 	}
-}
-
-// extract the port number from string in "address:port" format. If the
-// port number cannot be extracted returns an error.
-func extractPortFromEndpoint(endpoint string) (int, error) {
-	_, portStr, err := net.SplitHostPort(endpoint)
-	if err != nil {
-		return 0, fmt.Errorf("endpoint is not formatted correctly: %s", err.Error())
-	}
-	port, err := strconv.ParseInt(portStr, 10, 0)
-	if err != nil {
-		return 0, fmt.Errorf("endpoint port is not a number: %s", err.Error())
-	}
-	if port < 1 || port > 65535 {
-		return 0, fmt.Errorf("port number must be between 1 and 65535")
-	}
-	return int(port), nil
-}
-
-// verify that the configured port is not 0
-func (rCfg *Config) validate() error {
-	_, err := extractPortFromEndpoint(rCfg.Endpoint)
-	return err
 }
 
 // CreateTracesReceiver creates a trace receiver based on provided config.
@@ -108,7 +83,7 @@ func createMetricsReceiver(
 
 	rCfg := cfg.(*Config)
 
-	err := rCfg.validate()
+	err := rCfg.initialize()
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +101,7 @@ func createLogsReceiver(
 
 	rCfg := cfg.(*Config)
 
-	err := rCfg.validate()
+	err := rCfg.initialize()
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/splunkhecreceiver/factory_test.go
+++ b/receiver/splunkhecreceiver/factory_test.go
@@ -78,6 +78,26 @@ func TestCreateNilNextConsumerMetrics(t *testing.T) {
 	assert.Nil(t, mReceiver, "receiver creation failed")
 }
 
+func TestCreateMetricsReceiverWithBadConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Endpoint = "localhost:1"
+	cfg.Path = " *[* "
+
+	mReceiver, err := createMetricsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewMetricsNop())
+	assert.EqualError(t, err, "unexpected end of input")
+	assert.Nil(t, mReceiver, "receiver creation failed")
+}
+
+func TestCreateLogsReceiverWithBadConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Endpoint = "localhost:1"
+	cfg.Path = " *[* "
+
+	mReceiver, err := createLogsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.NewNop()}, cfg, consumertest.NewLogsNop())
+	assert.EqualError(t, err, "unexpected end of input")
+	assert.Nil(t, mReceiver, "receiver creation failed")
+}
+
 func TestCreateNilNextConsumerLogs(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Endpoint = "localhost:1"

--- a/receiver/splunkhecreceiver/factory_test.go
+++ b/receiver/splunkhecreceiver/factory_test.go
@@ -57,39 +57,15 @@ func TestFactoryType(t *testing.T) {
 	assert.Equal(t, configmodels.Type("splunk_hec"), NewFactory().Type())
 }
 
-func TestCreateValidEndpoint(t *testing.T) {
-	endpoint, err := extractPortFromEndpoint("localhost:123")
-	assert.NoError(t, err)
-	assert.Equal(t, 123, endpoint)
-}
-
-func TestCreateInvalidEndpoint(t *testing.T) {
-	endpoint, err := extractPortFromEndpoint("")
-	assert.EqualError(t, err, "endpoint is not formatted correctly: missing port in address")
-	assert.Equal(t, 0, endpoint)
-}
-
-func TestCreateNoPort(t *testing.T) {
-	endpoint, err := extractPortFromEndpoint("localhost:")
-	assert.EqualError(t, err, "endpoint port is not a number: strconv.ParseInt: parsing \"\": invalid syntax")
-	assert.Equal(t, 0, endpoint)
-}
-
-func TestCreateLargePort(t *testing.T) {
-	endpoint, err := extractPortFromEndpoint("localhost:65536")
-	assert.EqualError(t, err, "port number must be between 1 and 65535")
-	assert.Equal(t, 0, endpoint)
-}
-
 func TestValidate(t *testing.T) {
-	err := createDefaultConfig().(*Config).validate()
+	err := createDefaultConfig().(*Config).initialize()
 	assert.NoError(t, err)
 }
 
 func TestValidateBadEndpoint(t *testing.T) {
 	config := createDefaultConfig().(*Config)
 	config.Endpoint = "localhost:abr"
-	err := config.validate()
+	err := config.initialize()
 	assert.EqualError(t, err, "endpoint port is not a number: strconv.ParseInt: parsing \"abr\": invalid syntax")
 }
 

--- a/receiver/splunkhecreceiver/go.mod
+++ b/receiver/splunkhecreceiver/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunk
 go 1.14
 
 require (
+	github.com/gobwas/glob v0.2.3
 	github.com/gorilla/mux v1.8.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.0.0-00010101000000-000000000000

--- a/receiver/splunkhecreceiver/go.sum
+++ b/receiver/splunkhecreceiver/go.sum
@@ -366,6 +366,8 @@ github.com/gobuffalo/packd v0.1.0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWe
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gocql/gocql v0.0.0-20200228163523-cd4b606dd2fb/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=

--- a/receiver/splunkhecreceiver/testdata/config.yaml
+++ b/receiver/splunkhecreceiver/testdata/config.yaml
@@ -5,6 +5,7 @@ receivers:
     # Splunk metrics.
     endpoint: localhost:8088
     access_token_passthrough: true
+    path: "/foo"
   splunk_hec/tls:
     tls_settings:
       cert_file: /test.crt


### PR DESCRIPTION
**Description:** 
Make the HEC receiver path configurable, and use `/*` by default.

**Link to tracking Issue:**
#2025 

**Testing:**
Unit test coverage

**Documentation:**
Added to README.
