### PR TITLE
Remove the check of Content-Type for splunk HEC requests

### DIFF
--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -43,7 +43,6 @@ const (
 	responseOK                        = "OK"
 	responseNotFound                  = "Not found"
 	responseInvalidMethod             = `Only "POST" method is supported`
-	responseInvalidContentType        = `"Content-Type" must be "application/json"`
 	responseInvalidEncoding           = `"Content-Encoding" must be "gzip" or empty`
 	responseErrGzipReader             = "Error on gzip body"
 	responseErrUnmarshalBody          = "Failed to unmarshal message body"
@@ -52,9 +51,7 @@ const (
 	responseErrUnsupportedLogEvent    = "Unsupported log event"
 
 	// Centralizing some HTTP and related string constants.
-	jsonContentType           = "application/json"
 	gzipEncoding              = "gzip"
-	httpContentTypeHeader     = "Content-Type"
 	httpContentEncodingHeader = "Content-Encoding"
 )
 
@@ -66,7 +63,6 @@ var (
 	okRespBody                = initJSONResponse(responseOK)
 	notFoundRespBody          = initJSONResponse(responseNotFound)
 	invalidMethodRespBody     = initJSONResponse(responseInvalidMethod)
-	invalidContentRespBody    = initJSONResponse(responseInvalidContentType)
 	invalidEncodingRespBody   = initJSONResponse(responseInvalidEncoding)
 	errGzipReaderRespBody     = initJSONResponse(responseErrGzipReader)
 	errUnmarshalBodyRespBody  = initJSONResponse(responseErrUnmarshalBody)
@@ -210,11 +206,6 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 
 	if req.Method != http.MethodPost {
 		r.failRequest(ctx, resp, http.StatusBadRequest, invalidMethodRespBody, nil)
-		return
-	}
-
-	if req.Header.Get(httpContentTypeHeader) != jsonContentType {
-		r.failRequest(ctx, resp, http.StatusUnsupportedMediaType, invalidContentRespBody, nil)
 		return
 	}
 

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -197,6 +197,18 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			},
 		},
 		{
+			name: "incorrect_content_type",
+			req: func() *http.Request {
+				req := httptest.NewRequest("POST", "http://localhost/foo", nil)
+				req.Header.Set("Content-Type", "application/not-json")
+				return req
+			}(),
+			assertResponse: func(t *testing.T, status int, body string) {
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, responseOK, body)
+			},
+		},
+		{
 			name: "metric_unsupported",
 			req: func() *http.Request {
 				metricMsg := buildSplunkHecMsg(currentTime, 3)
@@ -499,8 +511,6 @@ func Test_splunkhecReceiver_AccessTokenPassthrough(t *testing.T) {
 			splunkhecMsg := buildSplunkHecMsg(currentTime, 3)
 			msgBytes, _ := json.Marshal(splunkhecMsg)
 			req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
-			// unchecked Content-Type:
-			req.Header.Set("Content-Type", "application/splunk")
 			if tt.token.Type() != pdata.AttributeValueNULL {
 				req.Header.Set("Splunk", tt.token.StringVal())
 			}


### PR DESCRIPTION
**Description:** 
Splunk HEC doesn't mandate a specific Content-Type header to be set. Some applications, such as Docker logging, do not use the header.

**Link to tracking Issue:**
#2025 

**Testing:**
Removed all checks, added a fantasist content type "application/splunk" to show no checks are made.
