### PR TITLE
sfxexporter: Add include metrics option

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -51,7 +51,7 @@ The following configuration options can also be configured:
   that are dropped by default. For example, the following configuration can be
   used to send through some of that are dropped by default.
   ```yaml
-  include_metrics
+  include_metrics:
     # When sending in translated metrics.
     - metric_names: [cpu.interrupt, cpu.user, cpu.system]
     # When sending in metrics in OTel convention.

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -45,6 +45,20 @@ The following configuration options can also be configured:
   excluded from sending to Signalfx backend. If `send_compatible_metrics`
   or `translation_rules` options are enabled, the exclusion will be applied
   on translated metrics. See [here](./testdata/config.yaml) for examples.
+- `include_metrics`: List of filters to override exclusion of any metrics.
+  This option can be used to included metrics that are otherwise dropped by
+  default. See [here](./translation/default_metrics.go) for a list of metrics
+  that are dropped by default. For example, the following configuration can be
+  used to send through some of that are dropped by default.
+  ```yaml
+  include_metrics
+    # When sending in translated metrics.
+    - metric_names: [cpu.interrupt, cpu.user, cpu.system]
+    # When sending in metrics in OTel convention.
+    - metric_name: system.cpu.time
+      dimensions:
+        state: [interrupt, user, system]
+  ```
 - `headers` (no default): Headers to pass in the payload.
 - `log_dimension_updates` (default = `false`): Whether or not to log dimension
   updates.

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -92,6 +92,11 @@ type Config struct {
 	// on translated metrics.
 	ExcludeMetrics []dpfilters.MetricFilter `mapstructure:"exclude_metrics"`
 
+	// IncludeMetrics defines dpfilter.MetricFilters to override exclusion any of metric.
+	// This option can be used to included metrics that are otherwise dropped by default.
+	// See ./translation/default_metrics.go for a list of metrics that are dropped by default.
+	IncludeMetrics []dpfilters.MetricFilter `mapstructure:"include_metrics"`
+
 	// Correlation configuration for syncing traces service and environment to metrics.
 	Correlation *correlation.Config `mapstructure:"correlation"`
 }

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -127,6 +127,14 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
+		IncludeMetrics: []dpfilters.MetricFilter{
+			{
+				MetricName: "metric1",
+			},
+			{
+				MetricNames: []string{"metric2", "metric3"},
+			},
+		},
 		DeltaTranslationTTL: 3600,
 		Correlation: &correlation.Config{
 			HTTPClientSettings: confighttp.HTTPClientSettings{

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -90,7 +90,7 @@ func newSignalFxExporter(
 
 	headers := buildHeaders(config)
 
-	converter, err := translation.NewMetricsConverter(logger, options.metricTranslator, config.ExcludeMetrics)
+	converter, err := translation.NewMetricsConverter(logger, options.metricTranslator, config.ExcludeMetrics, config.IncludeMetrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric converter: %v", err)
 	}

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -194,7 +194,7 @@ func TestConsumeMetrics(t *testing.T) {
 			serverURL, err := url.Parse(server.URL)
 			assert.NoError(t, err)
 
-			c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil)
+			c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil)
 			require.NoError(t, err)
 			require.NotNil(t, c)
 			dpClient := &sfxDPClient{
@@ -974,7 +974,7 @@ func BenchmarkExporterConsumeData(b *testing.B) {
 	serverURL, err := url.Parse(server.URL)
 	assert.NoError(b, err)
 
-	c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil)
+	c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil)
 	require.NoError(b, err)
 	require.NotNil(b, c)
 	dpClient := &sfxDPClient{

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -245,7 +245,7 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.NoError(t, err)
 	data := testMetricsData()
 
-	c, err := translation.NewMetricsConverter(zap.NewNop(), tr, nil)
+	c, err := translation.NewMetricsConverter(zap.NewNop(), tr, nil, nil)
 	require.NoError(t, err)
 	translated := c.MetricDataToSignalFxV2(data)
 	require.NotNil(t, translated)

--- a/exporter/signalfxexporter/testdata/config.yaml
+++ b/exporter/signalfxexporter/testdata/config.yaml
@@ -44,6 +44,10 @@ exporters:
       - metric_name: cpu.utilization
         dimensions:
           container_name: /^[A-Z][A-Z]$/
+    include_metrics:
+      - metric_name: metric1
+      - metric_names: [metric2, metric3]
+
 
 
 

--- a/exporter/signalfxexporter/translation/converter.go
+++ b/exporter/signalfxexporter/translation/converter.go
@@ -58,8 +58,12 @@ type MetricsConverter struct {
 // NewMetricsConverter creates a MetricsConverter from the passed in logger and
 // MetricTranslator. Pass in a nil MetricTranslator to not use translation
 // rules.
-func NewMetricsConverter(logger *zap.Logger, t *MetricTranslator, excludes []dpfilters.MetricFilter) (*MetricsConverter, error) {
-	fs, err := dpfilters.NewFilterSet(excludes)
+func NewMetricsConverter(
+	logger *zap.Logger,
+	t *MetricTranslator,
+	excludes []dpfilters.MetricFilter,
+	includes []dpfilters.MetricFilter) (*MetricsConverter, error) {
+	fs, err := dpfilters.NewFilterSet(excludes, includes)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/signalfxexporter/translation/dpfilters/filterset.go
+++ b/exporter/signalfxexporter/translation/dpfilters/filterset.go
@@ -19,23 +19,48 @@ import sfxpb "github.com/signalfx/com_signalfx_metrics_protobuf/model"
 // FilterSet is a collection of datapont filters, any one of which must match
 // for a datapoint to be matched.
 type FilterSet struct {
-	ExcludeFilters []*dataPointFilter
+	excludeFilters []*dataPointFilter
+	includeFilters []*dataPointFilter
 }
 
 // Matches sends a datapoint through each of the filters in the set and returns
 // true if at least one of them matches the datapoint.
 func (fs *FilterSet) Matches(dp *sfxpb.DataPoint) bool {
-	for _, ex := range fs.ExcludeFilters {
+	for _, ex := range fs.excludeFilters {
 		if ex.Matches(dp) {
+			// If we match an exclusionary filter, run through each inclusion
+			// filter and see if anything includes the metrics.
+			for _, in := range fs.includeFilters {
+				if in.Matches(dp) {
+					return false
+				}
+			}
 			return true
 		}
 	}
 	return false
 }
 
-func NewFilterSet(excludes []MetricFilter) (*FilterSet, error) {
-	var excludeSet []*dataPointFilter
-	for _, f := range excludes {
+func NewFilterSet(excludes []MetricFilter, includes []MetricFilter) (*FilterSet, error) {
+	excludeSet, err := getDataPointFilters(excludes)
+	if err != nil {
+		return nil, err
+	}
+
+	includeSet, err := getDataPointFilters(includes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FilterSet{
+		excludeFilters: excludeSet,
+		includeFilters: includeSet,
+	}, nil
+}
+
+func getDataPointFilters(metricFilters []MetricFilter) ([]*dataPointFilter, error) {
+	var out []*dataPointFilter
+	for _, f := range metricFilters {
 		dimSet, err := f.normalize()
 		if err != nil {
 			return nil, err
@@ -46,9 +71,7 @@ func NewFilterSet(excludes []MetricFilter) (*FilterSet, error) {
 			return nil, err
 		}
 
-		excludeSet = append(excludeSet, dpf)
+		out = append(out, dpf)
 	}
-	return &FilterSet{
-		ExcludeFilters: excludeSet,
-	}, nil
+	return out, nil
 }

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -2586,7 +2586,7 @@ func testConverter(t *testing.T, mapping map[string]string) *MetricsConverter {
 	tr, err := NewMetricTranslator(rules, 1)
 	require.NoError(t, err)
 
-	c, err := NewMetricsConverter(zap.NewNop(), tr, nil)
+	c, err := NewMetricsConverter(zap.NewNop(), tr, nil, nil)
 	require.NoError(t, err)
 	return c
 }


### PR DESCRIPTION
Depends on #2145 

**Description:** Add `include_metrics` option. This option can be used to override the exclusion of metrics. This option can be used to included metrics that are otherwise dropped by default. For example, the following configuration can be used to send through some of that are dropped by default.

  ```yaml
  include_metrics
    # When sending in translated metrics.
    - metric_names: [cpu.interrupt, cpu.user, cpu.system]
    # When sending in metrics in OTel convention.
    - metric_name: system.cpu.time
      dimensions:
        state: [interrupt, user, system]
  ```

**Testing:** Updated/added tests.

**Documentation:** Updated README.