### PR TITLE
exporter/signalfx: Use updated network metric name

### DIFF
--- a/exporter/signalfxexporter/translation/default_metrics.go
+++ b/exporter/signalfxexporter/translation/default_metrics.go
@@ -101,6 +101,6 @@ exclude_metrics:
 # Network-IO metrics.
 - metric_names:
   - system.network.packets
-  - system.network.dropped_packets
+  - system.network.dropped
   - system.network.tcp_connections
 `


### PR DESCRIPTION
**Description:** Update usages of `system.network.dropped_packets` to `system.network.dropped` as a result of https://github.com/open-telemetry/opentelemetry-collector/pull/2311.

The occurrence in `translation/constants.go` is being removed here #2161 