### PR TITLE
exporter/signalfx: Remove redundant network and filesystem translations

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -202,7 +202,7 @@ func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
 
 	// Validate that default translation rules are loaded
 	// Expected values has to be updated once default config changed
-	assert.Equal(t, 59, len(config.TranslationRules))
+	assert.Equal(t, 55, len(config.TranslationRules))
 	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
 	assert.Equal(t, 33, len(config.TranslationRules[0].Mapping))
 }

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -403,7 +403,19 @@ translation_rules:
     slab_unreclaimable: memory.slab_unrecl
     used: memory.used
 
-# calculate disk.total
+
+# Translations to derive disk.utilization.
+- action: copy_metrics
+  mapping:
+    system.filesystem.usage: df_complex.used
+  dimension_key: state
+  dimension_values:
+    used: true
+- action: split_metric
+  metric_name: df_complex.used
+  dimension_key: state
+  mapping:
+    used: df_complex.used
 - action: copy_metrics
   mapping:
     system.filesystem.usage: disk.total
@@ -413,7 +425,33 @@ translation_rules:
   without_dimensions:
     - state
 
-# calculate disk.summary_total
+## disk.utilization
+- action: calculate_new_metric
+  metric_name: disk.utilization
+  operand1_metric: df_complex.used
+  operand2_metric: disk.total
+  operator: /
+- action: multiply_float
+  scale_factors_float:
+    disk.utilization: 100
+
+
+# Translations to derive disk.summary_utilization.
+- action: copy_metrics
+  mapping:
+    df_complex.used: df_complex.used_total
+- action: aggregate_metric
+  metric_name: df_complex.used_total
+  aggregation_method: avg
+  without_dimensions:
+    - mode
+    - mountpoint
+- action: aggregate_metric
+  metric_name: df_complex.used_total
+  aggregation_method: sum
+  without_dimensions:
+  - device
+  - type
 - action: copy_metrics
   mapping:
     system.filesystem.usage: disk.summary_total
@@ -431,48 +469,7 @@ translation_rules:
     - device
     - type
 
-# convert filesystem metrics
-- action: split_metric
-  metric_name: system.filesystem.usage
-  dimension_key: state
-  mapping:
-    free: df_complex.free
-    reserved: df_complex.reserved
-    used: df_complex.used
-- action: split_metric
-  metric_name: system.filesystem.inodes.usage
-  dimension_key: state
-  mapping:
-    free: df_inodes.free
-    used: df_inodes.used
-
-# df_complex.used_total
-- action: copy_metrics
-  mapping:
-    df_complex.used: df_complex.used_total
-- action: aggregate_metric
-  metric_name: df_complex.used_total
-  aggregation_method: avg
-  without_dimensions:
-    - mode
-    - mountpoint
-- action: aggregate_metric
-  metric_name: df_complex.used_total
-  aggregation_method: sum
-  without_dimensions:
-  - device
-  - type
-
-# disk utilization
-- action: calculate_new_metric
-  metric_name: disk.utilization
-  operand1_metric: df_complex.used
-  operand2_metric: disk.total
-  operator: /
-- action: multiply_float
-  scale_factors_float:
-    disk.utilization: 100
-
+## disk.summary_utilization
 - action: calculate_new_metric
   metric_name: disk.summary_utilization
   operand1_metric: df_complex.used_total
@@ -561,6 +558,7 @@ translation_rules:
 # remove redundant metrics
 - action: drop_metrics
   metric_names:
+    df_complex.used: true
     df_complex.used_total: true
     disk.ops: true
     disk.summary_total: true

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -545,30 +545,6 @@ translation_rules:
   without_dimensions:
   - direction
   - interface
-- action: split_metric
-  metric_name: system.network.dropped_packets
-  dimension_key: direction
-  mapping:
-    receive: if_dropped.rx
-    transmit: if_dropped.tx
-- action: split_metric
-  metric_name: system.network.errors
-  dimension_key: direction
-  mapping:
-    receive: if_errors.rx
-    transmit: if_errors.tx
-- action: split_metric
-  metric_name: system.network.io
-  dimension_key: direction
-  mapping:
-    receive: if_octets.rx
-    transmit: if_octets.tx
-- action: split_metric
-  metric_name: system.network.packets
-  dimension_key: direction
-  mapping:
-    receive: if_packets.rx
-    transmit: if_packets.tx
 
 # memory utilization
 - action: calculate_new_metric


### PR DESCRIPTION
**Description:** Remove network and filesystem metric translations that are redundant (can be handled post ingestion).