### PR TITLE
exporter/signalfx: Add non-default k8s metrics to default excludes

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -326,7 +326,7 @@ func TestCreateMetricsExporterWithDefaultExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 7, len(config.ExcludeMetrics))
+	assert.Equal(t, 8, len(config.ExcludeMetrics))
 }
 
 func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
@@ -349,7 +349,7 @@ func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 8, len(config.ExcludeMetrics))
+	assert.Equal(t, 9, len(config.ExcludeMetrics))
 }
 
 func testMetricsData() pdata.ResourceMetrics {

--- a/exporter/signalfxexporter/translation/default_metrics.go
+++ b/exporter/signalfxexporter/translation/default_metrics.go
@@ -103,4 +103,32 @@ exclude_metrics:
   - system.network.packets
   - system.network.dropped_packets
   - system.network.tcp_connections
+
+# k8s metrics.
+- metric_names:
+  - k8s.cronjob.active_jobs
+  - k8s.job.active_pods
+  - k8s.job.desired_successful_pods
+  - k8s.job.failed_pods
+  - k8s.job.max_parallel_pods
+  - k8s.job.successful_pods
+  - k8s.statefulset.desired_pods
+  - k8s.statefulset.current_pods
+  - k8s.statefulset.ready_pods
+  - k8s.statefulset.updated_pods
+  - k8s.hpa.max_replicas
+  - k8s.hpa.min_replicas
+  - k8s.hpa.current_replicas
+  - k8s.hpa.desired_replicas
+
+  # matches all container limit metrics but k8s.container.cpu_limit and k8s.container.memory_limit
+  - /^k8s\.container\..+_limit$/
+  - '!k8s.container.memory_limit'
+  - '!k8s.container.cpu_limit'
+
+  - /^k8s\.container\..+_request$/
+
+  # matches any node condition but k8s.node.condition_ready
+  - /^k8s\.node\.condition_.+$/
+  - '!k8s.node.condition_ready'
 `


### PR DESCRIPTION
Add non-default kubernetes metrics to default exclude list.