### PR TITLE
exporter/signalfx: Add k8s metrics to default excludes

### DIFF
--- a/exporter/signalfxexporter/testdata/json/non_default_metrics.json
+++ b/exporter/signalfxexporter/testdata/json/non_default_metrics.json
@@ -1,0 +1,188 @@
+[
+  {
+    "cpu.interrupt": null
+  },
+  {
+    "cpu.nice": null
+  },
+  {
+    "cpu.softirq": null
+  },
+  {
+    "cpu.steal": null
+  },
+  {
+    "cpu.system": null
+  },
+  {
+    "cpu.user": null
+  },
+  {
+    "cpu.utilization_per_core": null
+  },
+  {
+    "cpu.wait": null
+  },
+  {
+    "memory.available": null
+  },
+  {
+    "df_complex.reserved": null
+  },
+  {
+    "df_inodes.free": null
+  },
+  {
+    "df_inodes.used": null
+  },
+  {
+    "percent_inodes.free": null
+  },
+  {
+    "percent_inodes.used": null
+  },
+  {
+    "percent_bytes.free": null
+  },
+  {
+    "percent_bytes.free": null
+  },
+  {
+    "percent_bytes.free": null
+  },
+  {
+    "disk_merged.read": null
+  },
+  {
+    "disk_merged.write": null
+  },
+  {
+    "disk_octets.read": null
+  },
+  {
+    "disk_octets.write": null
+  },
+  {
+    "disk_ops.pending": null
+  },
+  {
+    "disk_time.read": null
+  },
+  {
+    "disk_time.write": null
+  },
+  {
+    "disk_octets.avg_read": null
+  },
+  {
+    "disk_octets.avg_write": null
+  },
+  {
+    "disk_time.avg_read": null
+  },
+  {
+    "disk_time.avg_write": null
+  },
+  {
+    "if_dropped.rx": null
+  },
+  {
+    "if_dropped.tx": null
+  },
+  {
+    "if_packets.rx": null
+  },
+  {
+    "if_packets.tx": null
+  },
+  {
+    "kubernetes.cronjob.active": null
+  },
+  {
+    "kubernetes.daemon_set.updated": null
+  },
+  {
+    "kubernetes.deployment.updated": null
+  },
+  {
+    "kubernetes.job.active": null
+  },
+  {
+    "kubernetes.job.completions": null
+  },
+  {
+    "kubernetes.job.failed": null
+  },
+  {
+    "kubernetes.job.parallelism": null
+  },
+  {
+    "kubernetes.job.succeeded": null
+  },
+  {
+    "kubernetes.stateful_set.current": null
+  },
+  {
+    "kubernetes.stateful_set.desired": null
+  },
+  {
+    "kubernetes.stateful_set.ready": null
+  },
+  {
+    "kubernetes.stateful_set.updated": null
+  },
+  {
+    "kubernetes.container_cpu_request": null
+  },
+  {
+    "kubernetes.container_ephemeral_storage_limit": null
+  },
+  {
+    "kubernetes.container_ephemeral_storage_request": null
+  },
+  {
+    "kubernetes.container_memory_request": null
+  },
+  {
+    "k8s.node.condition_memory_pressure": null
+  },
+  {
+    "k8s.node.condition_network_unavailable": null
+  },
+  {
+    "k8s.node.condition_out_of_disk": null
+  },
+  {
+    "k8s.node.condition_p_i_d_pressure": null
+  },
+  {
+    "container_memory_available_bytes": null
+  },
+  {
+    "container_memory_major_page_faults": null
+  },
+  {
+    "container_memory_page_faults": null
+  },
+  {
+    "container_memory_rss_bytes": null
+  },
+  {
+    "container_memory_working_set_bytes": null
+  },
+  {
+    "pod_ephemeral_storage_used_bytes": null
+  },
+  {
+    "pod_ephemeral_storage_capacity_bytes": null
+  },
+  {
+    "kubernetes.volume_inodes": null
+  },
+  {
+    "kubernetes.volume_inodes_free": null
+  },
+  {
+    "kubernetes.volume_inodes_used": null
+  }
+]

--- a/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
+++ b/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
@@ -1,0 +1,227 @@
+[
+  {
+    "system.cpu.time": null,
+    "state": "interrupt"
+  },
+  {
+    "system.cpu.time": null,
+    "state": "nice"
+  },
+  {
+    "system.cpu.time": null,
+    "state": "softirq"
+  },
+  {
+    "system.cpu.time": null,
+    "state": "steal"
+  },
+  {
+    "system.cpu.time": null,
+    "state": "system"
+  },
+  {
+    "system.cpu.time": null,
+    "state": "user"
+  },
+  {
+    "system.cpu.time": null,
+    "state": "wait"
+  },
+  {
+    "system.memory.usage": null,
+    "state": "inactive"
+  },
+  {
+    "system.filesystem.usage": null,
+    "state": "reserved"
+  },
+  {
+    "system.filesystem.inodes.usage": null
+  },
+  {
+    "system.disk.merged": null
+  },
+  {
+    "system.disk.io": null
+  },
+  {
+    "system.disk.time": null
+  },
+  {
+    "system.disk.pending_operations": null
+  },
+  {
+    "system.network.packets": null
+  },
+  {
+    "system.network.dropped": null
+  },
+  {
+    "system.network.tcp_connections": null
+  },
+  {
+    "k8s.cronjob.active_jobs": null
+  },
+  {
+    "k8s.job.active_pods": null
+  },
+  {
+    "k8s.job.desired_successful_pods": null
+  },
+  {
+    "k8s.job.failed_pods": null
+  },
+  {
+    "k8s.job.max_parallel_pods": null
+  },
+  {
+    "k8s.job.successful_pods": null
+  },
+  {
+    "k8s.statefulset.desired_pods": null
+  },
+  {
+    "k8s.statefulset.current_pods": null
+  },
+  {
+    "k8s.statefulset.ready_pods": null
+  },
+  {
+    "k8s.statefulset.updated_pods": null
+  },
+  {
+    "k8s.hpa.max_replicas": null
+  },
+  {
+    "k8s.hpa.min_replicas": null
+  },
+  {
+    "k8s.hpa.current_replicas": null
+  },
+  {
+    "k8s.hpa.desired_replicas": null
+  },
+  {
+    "k8s.container.cpu_request": null
+  },
+  {
+    "k8s.container.ephemeral-storage_limit": null
+  },
+  {
+    "k8s.container.ephemeral-storage_request": null
+  },
+  {
+    "k8s.container.memory_request": null
+  },
+  {
+    "k8s.node.condition_memory_pressure": null
+  },
+  {
+    "k8s.node.condition_network_unavailable": null
+  },
+  {
+    "k8s.node.condition_out_of_disk": null
+  },
+  {
+    "k8s.node.condition_p_i_d_pressure": null
+  },
+  {
+    "container.memory.available": null
+  },
+  {
+    "container.memory.major_page_faults": null
+  },
+  {
+    "container.memory.page_faults": null
+  },
+  {
+    "container.memory.rss": null
+  },
+  {
+    "container.memory.usage": null
+  },
+  {
+    "container.memory.working_set": null
+  },
+  {
+    "k8s.pod.memory.available": null
+  },
+  {
+    "k8s.pod.memory.major_page_faults": null
+  },
+  {
+    "k8s.pod.memory.page_faults": null
+  },
+  {
+    "k8s.pod.memory.rss": null
+  },
+  {
+    "k8s.pod.memory.usage": null
+  },
+  {
+    "k8s.pod.memory.working_set": null
+  },
+  {
+    "k8s.node.memory.available": null
+  },
+  {
+    "k8s.node.memory.major_page_faults": null
+  },
+  {
+    "k8s.node.memory.page_faults": null
+  },
+  {
+    "k8s.node.memory.rss": null
+  },
+  {
+    "k8s.node.memory.usage": null
+  },
+  {
+    "k8s.node.memory.working_set": null
+  },
+  {
+    "k8s.pod.filesystem.available": null
+  },
+  {
+    "k8s.pod.filesystem.capacity": null
+  },
+  {
+    "k8s.pod.filesystem.usage": null
+  },
+  {
+    "k8s.node.filesystem.available": null
+  },
+  {
+    "k8s.node.filesystem.capacity": null
+  },
+  {
+    "k8s.node.filesystem.usage": null
+  },
+  {
+    "k8s.pod.cpu.time": null
+  },
+  {
+    "k8s.node.cpu.time": null
+  },
+  {
+    "k8s.pod.cpu.utilization": null
+  },
+  {
+    "k8s.node.cpu.utilization": null
+  },
+  {
+    "k8s.node.network.io": null
+  },
+  {
+    "k8s.node.network.errors": null
+  },
+  {
+    "k8s.volume.inodes": null
+  },
+  {
+    "k8s.volume.inodes.free": null
+  },
+  {
+    "k8s.volume.inodes.used": null
+  }
+]

--- a/exporter/signalfxexporter/translation/default_metrics.go
+++ b/exporter/signalfxexporter/translation/default_metrics.go
@@ -131,4 +131,25 @@ exclude_metrics:
   # matches any node condition but k8s.node.condition_ready
   - /^k8s\.node\.condition_.+$/
   - '!k8s.node.condition_ready'
+
+  # kubelet metrics
+  # matches (container|k8s.node|k8s.pod).memory...
+  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.available$/
+  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.major_page_faults$/
+  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.page_faults$/
+  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.rss$/
+  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.usage$/
+  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.working_set$/
+  # matches (k8s.node|k8s.pod).filesystem...
+  - /^k8s\.(?i:(node)|(pod))\.filesystem\.available$/
+  - /^k8s\.(?i:(node)|(pod))\.filesystem\.capacity$/
+  - /^k8s\.(?i:(node)|(pod))\.filesystem\.usage$/
+  # matches (k8s.node|k8s.pod).cpu.time
+  - /^k8s\.(?i:(node)|(pod))\.cpu\.time$/
+  # matches (container|k8s.node|k8s.pod).cpu.utilization
+  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.cpu\.utilization$/
+  # matches k8s.node.network.io and k8s.node.network.errors
+  - /^k8s\.node\.network\.(?:(io)|(errors))$/
+  # matches k8s.volume.inodes, k8s.volume.inodes and k8s.volume.inodes.used
+  - /^k8s\.volume\.(?:(inodes)|(inodes\.free)|(inodes\.used))$/
 `

--- a/exporter/signalfxexporter/translation/default_metrics.go
+++ b/exporter/signalfxexporter/translation/default_metrics.go
@@ -73,6 +73,36 @@ exclude_metrics:
   - if_packets.rx
   - if_packets.tx
 
+  # k8s metrics
+  # Derived from https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html.
+  - kubernetes.cronjob.active
+  - kubernetes.daemon_set.updated
+  - kubernetes.deployment.updated
+
+  # matches kubernetes.job.(active|completions|failed|parallelism|succeeded)
+  - /^kubernetes\.job\.(?:active|completions|failed|parallelism|succeeded)$/
+
+  # matches kubernetes.stateful_set.(current|desired|ready|updated)
+  - /^kubernetes\.stateful_set\.(?:current|desired|ready|updated)$/
+
+  # matches all container limit metrics but kubernetes.container_cpu_limit and kubernetes.container_memory_limit
+  - /^kubernetes\.container_.+_limit$/
+  - '!kubernetes.container_memory_limit'
+  - '!kubernetes.container_cpu_limit'
+
+  - /^kubernetes\.container_.+_request$/
+
+  # matches all metrics that starts with kubernetes.node_ but kubernetes.node_ready
+  - /^kubernetes\.node_.+$/
+  - '!kubernetes.node_ready'
+
+  # kubelet metrics
+  # Derived from https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubelet-metrics.html
+  - /^container_memory_(?:available_bytes|major_page_faults|page_faults|rss_bytes|working_set_bytes)$/
+  - /^pod_ephemeral_storage_(?:used_bytes|capacity_bytes)$/
+  - /^kubernetes\.volume_inodes(_free|_used)*$/
+
+
 # Metrics in OpenTelemetry Convention.
 
 # CPU Metrics.
@@ -140,16 +170,21 @@ exclude_metrics:
   - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.rss$/
   - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.usage$/
   - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.memory\.working_set$/
+
   # matches (k8s.node|k8s.pod).filesystem...
   - /^k8s\.(?i:(node)|(pod))\.filesystem\.available$/
   - /^k8s\.(?i:(node)|(pod))\.filesystem\.capacity$/
   - /^k8s\.(?i:(node)|(pod))\.filesystem\.usage$/
+
   # matches (k8s.node|k8s.pod).cpu.time
   - /^k8s\.(?i:(node)|(pod))\.cpu\.time$/
+
   # matches (container|k8s.node|k8s.pod).cpu.utilization
   - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.cpu\.utilization$/
+
   # matches k8s.node.network.io and k8s.node.network.errors
   - /^k8s\.node\.network\.(?:(io)|(errors))$/
+
   # matches k8s.volume.inodes, k8s.volume.inodes and k8s.volume.inodes.used
-  - /^k8s\.volume\.(?:(inodes)|(inodes\.free)|(inodes\.used))$/
+  - /^k8s\.volume\.inodes(\.free|\.used)*$/
 `


### PR DESCRIPTION
- Add non-default kubelet metrics to default excludes list
- Add SignalFx Agent style equivalents for other kubernetes metrics