### PR TITLE
Reduce QPS in Stackdriver exporter

### DIFF
--- a/exporter/stackdriverexporter/stackdriver_test.go
+++ b/exporter/stackdriverexporter/stackdriver_test.go
@@ -267,27 +267,71 @@ func TestStackdriverMetricExport(t *testing.T) {
 		},
 		Metrics: []*metricspb.Metric{
 			metricstestutil.Gauge(
-				"test_gauge",
+				"test_gauge1",
+				[]string{"k0"},
+				metricstestutil.Timeseries(
+					time.Now(),
+					[]string{"v0"},
+					metricstestutil.Double(time.Now(), 1))),
+			metricstestutil.Gauge(
+				"test_gauge2",
 				[]string{"k0", "k1"},
 				metricstestutil.Timeseries(
 					time.Now(),
 					[]string{"v0", "v1"},
+					metricstestutil.Double(time.Now(), 12))),
+			metricstestutil.Gauge(
+				"test_gauge3",
+				[]string{"k0", "k1", "k2"},
+				metricstestutil.Timeseries(
+					time.Now(),
+					[]string{"v0", "v1", "v2"},
 					metricstestutil.Double(time.Now(), 123))),
 		},
 	}
 
 	assert.NoError(t, sde.ConsumeMetrics(context.Background(), internaldata.OCToMetrics(md)), err)
 
-	drm := <-descriptorReqCh
-	assert.Regexp(t, "MyAgent v0\\.0\\.1", drm.metadata["user-agent"])
-	dr := drm.req.(*cloudmonitoringpb.CreateMetricDescriptorRequest)
-	assert.Equal(t, "projects/idk/metricDescriptors/custom.googleapis.com/opencensus/test_gauge", dr.MetricDescriptor.Name)
+	expectedNames := map[string]struct{}{
+		"projects/idk/metricDescriptors/custom.googleapis.com/opencensus/test_gauge1": {},
+		"projects/idk/metricDescriptors/custom.googleapis.com/opencensus/test_gauge2": {},
+		"projects/idk/metricDescriptors/custom.googleapis.com/opencensus/test_gauge3": {},
+	}
+	for i := 0; i < 3; i++ {
+		drm := <-descriptorReqCh
+		assert.Regexp(t, "MyAgent v0\\.0\\.1", drm.metadata["user-agent"])
+		dr := drm.req.(*cloudmonitoringpb.CreateMetricDescriptorRequest)
+		assert.Contains(t, expectedNames, dr.MetricDescriptor.Name)
+		delete(expectedNames, dr.MetricDescriptor.Name)
+	}
 
 	trm := <-timeSeriesReqCh
 	assert.Regexp(t, "MyAgent v0\\.0\\.1", trm.metadata["user-agent"])
 	tr := trm.req.(*cloudmonitoringpb.CreateTimeSeriesRequest)
-	require.Len(t, tr.TimeSeries, 1)
-	assert.Equal(t, map[string]string{"k0": "v0", "k1": "v1"}, tr.TimeSeries[0].Metric.Labels)
-	require.Len(t, tr.TimeSeries[0].Points, 1)
-	assert.Equal(t, float64(123), tr.TimeSeries[0].Points[0].Value.GetDoubleValue())
+	require.Len(t, tr.TimeSeries, 3)
+
+	expectedTimeSeries := map[string]struct {
+		value  float64
+		labels map[string]string
+	}{
+		"custom.googleapis.com/opencensus/test_gauge1": {
+			value:  float64(1),
+			labels: map[string]string{"k0": "v0"},
+		},
+		"custom.googleapis.com/opencensus/test_gauge2": {
+			value:  float64(12),
+			labels: map[string]string{"k0": "v0", "k1": "v1"},
+		},
+		"custom.googleapis.com/opencensus/test_gauge3": {
+			value:  float64(123),
+			labels: map[string]string{"k0": "v0", "k1": "v1", "k2": "v2"},
+		},
+	}
+	for i := 0; i < 3; i++ {
+		require.Contains(t, expectedTimeSeries, tr.TimeSeries[i].Metric.Type)
+		ts := expectedTimeSeries[tr.TimeSeries[i].Metric.Type]
+		assert.Equal(t, ts.labels, tr.TimeSeries[i].Metric.Labels)
+		require.Len(t, tr.TimeSeries[i].Points, 1)
+		assert.Equal(t, ts.value, tr.TimeSeries[i].Points[0].Value.GetDoubleValue())
+	}
 }


### PR DESCRIPTION
**Description:** Every call to underlying OpenCensus code results in gRPC call to
Monitoring API. In some edge cases, this causes the exporter to send
each metrics data point in an individual request.

This change bundles all the metrics data before forwarding it to
OpenCensus exporter code, which can reduce QPS to Monitoring API by up
to 200x.

**Link to tracking Issue:** n/a

**Testing:** extended unit tests, also tested my own build e2e.

**Documentation:** n/a

@nilebox @bogdandrutu @james-bebbington @dashpole