### PR TITLE
exporter/datadog: Translates otel exceptions to DataDog errors

### DIFF
--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -465,47 +465,19 @@ func getSpanErrorAndSetTags(s pdata.Span, tags map[string]string) int32 {
 	}
 
 	if isError == errorCode {
-		// Finds the last exception event in the span, and surfaces it to DataDog. DataDog spans only support a single
-		// exception per span, but otel supports many exceptions as "Events" on a given span. The last exception was
-		// chosen for now as most otel-instrumented libraries (http, pg, etc.) only capture a single exception (if any)
-		// per span. If multiple exceptions are logged, it's my assumption that the last exception is most likely the
-		// exception that escaped the scope of the span.
-		//
-		// TODO:
-		//  Seems that the spec has an attribute that hasn't made it to the collector yet -- "exception.escaped".
-		//  This seems optional (SHOULD vs. MUST be set), but it's likely that we want to bubble up the exception
-		//  that escaped the scope of the span ("exception.escaped" == true) instead of the last exception event
-		//  in the case that these events differ.
-		//
-		//  https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/exceptions.md#attributes
-		attribs := pdata.NewAttributeMap()
-		evts := s.Events()
-		for i := evts.Len() - 1; i >= 0; i-- {
-			evt := evts.At(i)
-			if evt.Name() == conventions.AttributeExceptionEventName {
-				attribs = evt.Attributes()
-				break
-			}
-		}
-
-		// Prefer translating from otel semantic conventions first -- then fallback to original behavior
-		if errType, ok := attribs.Get(conventions.AttributeExceptionType); ok {
-			tags[ext.ErrorType] = errType.StringVal()
-		} else {
+		extractErrorTagsFromEvents(s, tags)
+		// If we weren't able to pull an error type or message, go ahead and set
+		// these to the old defaults
+		if _, ok := tags[ext.ErrorType]; !ok {
 			tags[ext.ErrorType] = "ERR_CODE_" + strconv.FormatInt(int64(status.Code()), 10)
 		}
 
-		// try to add a message if possible
-		if errMsg, ok := attribs.Get(conventions.AttributeExceptionMessage); ok {
-			tags[ext.ErrorMsg] = errMsg.StringVal()
-		} else if status.Message() != "" {
-			tags[ext.ErrorMsg] = status.Message()
-		} else {
-			tags[ext.ErrorMsg] = "ERR_CODE_" + strconv.FormatInt(int64(status.Code()), 10)
-		}
-
-		if errStack, ok := attribs.Get(conventions.AttributeExceptionStacktrace); ok {
-			tags[ext.ErrorStack] = errStack.StringVal()
+		if _, ok := tags[ext.ErrorMsg]; !ok {
+			if status.Message() != "" {
+				tags[ext.ErrorMsg] = status.Message()
+			} else {
+				tags[ext.ErrorMsg] = "ERR_CODE_" + strconv.FormatInt(int64(status.Code()), 10)
+			}
 		}
 	}
 
@@ -524,4 +496,37 @@ func getSpanErrorAndSetTags(s pdata.Span, tags map[string]string) int32 {
 	}
 
 	return isError
+}
+
+// Finds the last exception event in the span, and surfaces it to DataDog. DataDog spans only support a single
+// exception per span, but otel supports many exceptions as "Events" on a given span. The last exception was
+// chosen for now as most otel-instrumented libraries (http, pg, etc.) only capture a single exception (if any)
+// per span. If multiple exceptions are logged, it's my assumption that the last exception is most likely the
+// exception that escaped the scope of the span.
+//
+// TODO:
+//  Seems that the spec has an attribute that hasn't made it to the collector yet -- "exception.escaped".
+//  This seems optional (SHOULD vs. MUST be set), but it's likely that we want to bubble up the exception
+//  that escaped the scope of the span ("exception.escaped" == true) instead of the last exception event
+//  in the case that these events differ.
+//
+//  https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/exceptions.md#attributes
+func extractErrorTagsFromEvents(s pdata.Span, tags map[string]string) {
+	evts := s.Events()
+	for i := evts.Len() - 1; i >= 0; i-- {
+		evt := evts.At(i)
+		if evt.Name() == conventions.AttributeExceptionEventName {
+			attribs := evt.Attributes()
+			if errType, ok := attribs.Get(conventions.AttributeExceptionType); ok {
+				tags[ext.ErrorType] = errType.StringVal()
+			}
+			if errMsg, ok := attribs.Get(conventions.AttributeExceptionMessage); ok {
+				tags[ext.ErrorMsg] = errMsg.StringVal()
+			}
+			if errStack, ok := attribs.Get(conventions.AttributeExceptionStacktrace); ok {
+				tags[ext.ErrorStack] = errStack.StringVal()
+			}
+			return
+		}
+	}
 }

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -473,9 +473,9 @@ func getSpanErrorAndSetTags(s pdata.Span, tags map[string]string) int32 {
 		//
 		// TODO:
 		//  Seems that the spec has an attribute that hasn't made it to the collector yet -- "exception.escaped".
-		//  This seems optional (SHOULD vs. MUST be set), but it's likely that we want to send the exception that
-		//  escaped the scope of the span instead of the last exception event, assuming that the span has an error
-		//  status and there is an exception event with "escaped.escaped" == true
+		//  This seems optional (SHOULD vs. MUST be set), but it's likely that we want to bubble up the exception
+		//  that escaped the scope of the span ("exception.escaped" == true) instead of the last exception event
+		//  in the case that these events differ.
 		//
 		//  https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/exceptions.md#attributes
 		attribs := pdata.NewAttributeMap()

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -284,45 +284,25 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 	assert.Contains(t, datadogPayload.Traces[0].Spans[0].Meta[tagContainersTags], "pod_name:example-pod-name")
 }
 
-func TestTracesTranslationErrorsFromEvents(t *testing.T) {
+// Ensures that if more than one error event occurs in a span, the last one is used for translation
+func TestTracesTranslationErrorsFromEventsUsesLast(t *testing.T) {
 	hostname := "testhostname"
 	calculator := newSublayerCalculator()
-	// translate mocks to datadog traces
-	cfg := config.Config{
-		TagsConfig: config.TagsConfig{
-			Version: "v1",
-		},
-	}
 
-	endTime := time.Now().Round(time.Second)
-	pdataEndTime := pdata.TimestampUnixNano(endTime.UnixNano())
-	startTime := endTime.Add(-90 * time.Second)
-	pdataStartTime := pdata.TimestampUnixNano(startTime.UnixNano())
+	// generate mock trace, span and parent span ids
+	mockTraceID := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
+	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
+	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
 
-	traces := pdata.NewTraces()
-	traces.ResourceSpans().Resize(1)
-	rs := traces.ResourceSpans().At(0)
-	resource := rs.Resource()
-	resource.Attributes().InitFromMap(map[string]pdata.AttributeValue{
-		"service.name": pdata.NewAttributeValueString("sure"),
-	})
-	rs.InstrumentationLibrarySpans().Resize(1)
-	ilss := rs.InstrumentationLibrarySpans().At(0)
-	instrumentationLibrary := ilss.InstrumentationLibrary()
-	instrumentationLibrary.SetName("flash")
-	instrumentationLibrary.SetVersion("v1")
-
-	ilss.Spans().Resize(1)
-	span := ilss.Spans().At(0)
-	span.Status().SetCode(pdata.StatusCodeError)
-
+	// create mock resource span data
+	// toggle on errors and custom service naming to test edge case code paths
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true)
+	span := rs.InstrumentationLibrarySpans().At(0).Spans().At(0)
 	events := span.Events()
 	events.Resize(4)
 
-	events.At(0).SetTimestamp(pdataStartTime)
 	events.At(0).SetName("start")
 
-	events.At(1).SetTimestamp(pdataEndTime)
 	events.At(1).SetName(conventions.AttributeExceptionEventName)
 	events.At(1).Attributes().InitFromMap(map[string]pdata.AttributeValue{
 		conventions.AttributeExceptionType:       pdata.NewAttributeValueString("SomeOtherErr"),
@@ -335,17 +315,23 @@ func TestTracesTranslationErrorsFromEvents(t *testing.T) {
 		conventions.AttributeExceptionStacktrace: pdata.NewAttributeValueString("HttpError at line 67\nthing at line 45"),
 		conventions.AttributeExceptionMessage:    pdata.NewAttributeValueString("HttpError error occurred"),
 	}
-	events.At(2).SetTimestamp(pdataEndTime)
 	events.At(2).SetName(conventions.AttributeExceptionEventName)
 	events.At(2).Attributes().InitFromMap(attribs)
 
-	events.At(3).SetTimestamp(pdataEndTime)
 	events.At(3).SetName("end")
 	events.At(3).Attributes().InitFromMap(map[string]pdata.AttributeValue{
 		"flag": pdata.NewAttributeValueBool(false),
 	})
 
+	// translate mocks to datadog traces
+	cfg := config.Config{
+		TagsConfig: config.TagsConfig{
+			Version: "v1",
+		},
+	}
+
 	datadogPayload := resourceSpansToDatadogSpans(rs, calculator, hostname, &cfg)
+
 	// Ensure the error type is copied over from the last error event logged
 	assert.Equal(t, attribs[conventions.AttributeExceptionType].StringVal(), datadogPayload.Traces[0].Spans[0].Meta[ext.ErrorType])
 
@@ -353,6 +339,80 @@ func TestTracesTranslationErrorsFromEvents(t *testing.T) {
 	assert.Equal(t, attribs[conventions.AttributeExceptionStacktrace].StringVal(), datadogPayload.Traces[0].Spans[0].Meta[ext.ErrorStack])
 
 	// Ensure the error message is copied over from the last error event logged
+	assert.Equal(t, attribs[conventions.AttributeExceptionMessage].StringVal(), datadogPayload.Traces[0].Spans[0].Meta[ext.ErrorMsg])
+}
+
+// Ensures that if the first or last event in the list is the error, that translation still behaves properly
+func TestTracesTranslationErrorsFromEventsBounds(t *testing.T) {
+	hostname := "testhostname"
+	calculator := newSublayerCalculator()
+
+	// generate mock trace, span and parent span ids
+	mockTraceID := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
+	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
+	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
+
+	// create mock resource span data
+	// toggle on errors and custom service naming to test edge case code paths
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true)
+	span := rs.InstrumentationLibrarySpans().At(0).Spans().At(0)
+	events := span.Events()
+	events.Resize(3)
+
+	// Start with the error as the first element in the list...
+	attribs := map[string]pdata.AttributeValue{
+		conventions.AttributeExceptionType:       pdata.NewAttributeValueString("HttpError"),
+		conventions.AttributeExceptionStacktrace: pdata.NewAttributeValueString("HttpError at line 67\nthing at line 45"),
+		conventions.AttributeExceptionMessage:    pdata.NewAttributeValueString("HttpError error occurred"),
+	}
+	events.At(0).SetName(conventions.AttributeExceptionEventName)
+	events.At(0).Attributes().InitFromMap(attribs)
+
+	events.At(1).SetName("start")
+
+	events.At(2).SetName("end")
+	events.At(2).Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"flag": pdata.NewAttributeValueBool(false),
+	})
+
+	// translate mocks to datadog traces
+	cfg := config.Config{
+		TagsConfig: config.TagsConfig{
+			Version: "v1",
+		},
+	}
+
+	datadogPayload := resourceSpansToDatadogSpans(rs, calculator, hostname, &cfg)
+
+	// Ensure the error type is copied over
+	assert.Equal(t, attribs[conventions.AttributeExceptionType].StringVal(), datadogPayload.Traces[0].Spans[0].Meta[ext.ErrorType])
+
+	// Ensure the stack trace is copied over
+	assert.Equal(t, attribs[conventions.AttributeExceptionStacktrace].StringVal(), datadogPayload.Traces[0].Spans[0].Meta[ext.ErrorStack])
+
+	// Ensure the error message is copied over
+	assert.Equal(t, attribs[conventions.AttributeExceptionMessage].StringVal(), datadogPayload.Traces[0].Spans[0].Meta[ext.ErrorMsg])
+
+	// Now with the error event at the end of the list...
+	events.At(0).SetName("start")
+	// Reset the attributes
+	events.At(0).Attributes().InitFromMap(map[string]pdata.AttributeValue{})
+
+	events.At(1).SetName("end")
+	events.At(1).Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"flag": pdata.NewAttributeValueBool(false),
+	})
+
+	events.At(2).SetName(conventions.AttributeExceptionEventName)
+	events.At(2).Attributes().InitFromMap(attribs)
+
+	// Ensure the error type is copied over
+	assert.Equal(t, attribs[conventions.AttributeExceptionType].StringVal(), datadogPayload.Traces[0].Spans[0].Meta[ext.ErrorType])
+
+	// Ensure the stack trace is copied over
+	assert.Equal(t, attribs[conventions.AttributeExceptionStacktrace].StringVal(), datadogPayload.Traces[0].Spans[0].Meta[ext.ErrorStack])
+
+	// Ensure the error message is copied over
 	assert.Equal(t, attribs[conventions.AttributeExceptionMessage].StringVal(), datadogPayload.Traces[0].Spans[0].Meta[ext.ErrorMsg])
 }
 


### PR DESCRIPTION
When an otel exception event is logged on a span, the datadog exporter will now translate the last exception event into an error on the datadog span.  If the semconv fields aren't added, or an exception event isn't logged, this code should fall back to the previous behavior.

It should also be noted that the golang library seems to deviate from the spec as detailed [here](https://github.com/open-telemetry/opentelemetry-go/issues/1491). But for libraries that conform to the spec, such as otel-JS, this should improve what the end user sees in DataDog.

**Description:** <Describe what has changed.>
The otel collector used to log all errors to datadog like so:

```javascript
error: { 
  message: "ERR_CODE_2"
}
```

When using the [`span.recordException`](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#record-exception) method, we should get much richer details about the error that occurred:

```javascript
error: { 
  message: "actual error message",
  stack: "something happened at line 67..."
  type: "HttpError"
}
```

**Testing:** 

Added a test to show that the semconv fields, when set on the last exception in a given span, will get translated to DataDog's `ext.Error*` fields. The existing tests should prove that the previous behavior still works in the absence of the exception event.

**Documentation:**

No public-facing changes, this should be a backwards-compatible upgrade.