### PR TITLE
Fix the case to prevent CloudWatch Metrics Dimension is Nil

### DIFF
--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -417,7 +417,7 @@ func calculateRate(fields map[string]interface{}, val float64, timestamp int64) 
 // dimensionRollup creates rolled-up dimensions from the metric's label set.
 func dimensionRollup(dimensionRollupOption string, originalDimensionSlice []string, instrumentationLibName string) [][]string {
 	var rollupDimensionArray [][]string
-	var dimensionZero []string
+	dimensionZero := make([]string, 0)
 	if instrumentationLibName != noInstrumentationLibraryName {
 		dimensionZero = append(dimensionZero, OTellibDimensionKey)
 	}

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -516,6 +516,7 @@ func assertDimsEqual(t *testing.T, expected, actual [][]string) {
 		expectedStringified[i] = strings.Join(v, ",")
 	}
 	for i, v := range actual {
+		assert.NotNil(t, v)
 		sort.Strings(v)
 		actualStringified[i] = strings.Join(v, ",")
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
CloudWatch EMF Metrics doesn't support dimension key with `null`. If the metric doesn't have any dimension it should be given an empty array `[]` instead of `null` value under the `Dimensions` section below. 

Replace `null` value under `Dimensions` to an `[]` so CloudWatch backend can generate the expected metrics.
```
{
   "_aws":{
      "CloudWatchMetrics":[
         {
            "Namespace":"StatsD-receiver-test",
            "Dimensions":[
               null,
               [
                  "mykey"
               ]
            ],
            "Metrics":[
               {
                  "Name":“statsdTestMetric1234”,
                  "Unit":""
               }
            ]
         }
      ],
      "Timestamp":1611682101355
   },
   "mykey":"myvalue",
   "statsdTestMetric1234":2
}
```
===>
```
{
   "_aws":{
      "CloudWatchMetrics":[
         {
            "Namespace":"StatsD-receiver-test",
            "Dimensions":[
               [],
               [
                  "mykey"
               ]
            ],
            "Metrics":[
               {
                  "Name":“statsdTestMetric1234”,
                  "Unit":""
               }
            ]
         }
      ],
      "Timestamp":1611682101355
   },
   "mykey":"myvalue",
   "statsdTestMetric1234":2
}
```
**Link to tracking Issue:**
https://github.com/aws-observability/aws-otel-collector/issues/309

**Testing:** 
Update Unit Test to cover `nil` case

**Documentation:** 
N/A