### PR TITLE
Dynatrace exporter allows underscores anywhere

### DIFF
--- a/exporter/dynatraceexporter/metrics_exporter_test.go
+++ b/exporter/dynatraceexporter/metrics_exporter_test.go
@@ -497,7 +497,7 @@ func Test_normalizeMetricName(t *testing.T) {
 				name:   "^*&(metric_name^&*(_",
 				prefix: "prefix",
 			},
-			want:    "prefix.metric_name",
+			want:    "prefix._metric_name",
 			wantErr: false,
 		},
 	}

--- a/exporter/dynatraceexporter/serialization/serialization.go
+++ b/exporter/dynatraceexporter/serialization/serialization.go
@@ -153,7 +153,7 @@ func escapeDimension(dim string) string {
 func NormalizeString(str string, max int) (normalizedString string, err error) {
 	normalizedString = reNameDisallowedCharList.ReplaceAllString(str, "_")
 
-	// Strip Digits and underscores if they are at the beginning of the string
+	// Strip Digits if they are at the beginning of the string
 	normalizedString = strings.TrimLeft(normalizedString, ".0123456789")
 
 	if len(normalizedString) > max {

--- a/exporter/dynatraceexporter/serialization/serialization.go
+++ b/exporter/dynatraceexporter/serialization/serialization.go
@@ -154,7 +154,7 @@ func NormalizeString(str string, max int) (normalizedString string, err error) {
 	normalizedString = reNameDisallowedCharList.ReplaceAllString(str, "_")
 
 	// Strip Digits and underscores if they are at the beginning of the string
-	normalizedString = strings.TrimLeft(normalizedString, "._0123456789")
+	normalizedString = strings.TrimLeft(normalizedString, ".0123456789")
 
 	if len(normalizedString) > max {
 		normalizedString = normalizedString[:max]

--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -421,7 +421,7 @@ func TestNormalizeString(t *testing.T) {
 		},
 		{
 			name:    "Strings trimmed to nothing cause an error",
-			args:    args{str: "_0.231", max: 5},
+			args:    args{str: "0.231", max: 5},
 			want:    "",
 			wantErr: true,
 		},

--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -433,7 +433,7 @@ func TestNormalizeString(t *testing.T) {
 		},
 		{
 			name:    "Leading _ are not stripped",
-			args:    args{str: "_strip", max: 5},
+			args:    args{str: "_strip", max: 6},
 			want:    "_strip",
 			wantErr: false,
 		},

--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -431,6 +431,12 @@ func TestNormalizeString(t *testing.T) {
 			want:    "strip",
 			wantErr: false,
 		},
+		{
+			name:    "Leading _ are not stripped",
+			args:    args{str: "_strip", max: 5},
+			want:    "_strip",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
A server-side change to the protocol now allows underscores anywhere in metric or dimension names.