### PR TITLE
signalfxexporter: add virtual memory metrics to defaults/constants

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -185,7 +185,7 @@ func TestFactory_CreateMetricsExporterFails(t *testing.T) {
 	}
 }
 
-func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
+func TestCreateMetricsExporterWithDefaultTranslationRules(t *testing.T) {
 	config := &Config{
 		ExporterSettings: configmodels.ExporterSettings{
 			TypeVal: configmodels.Type(typeStr),
@@ -202,7 +202,7 @@ func TestCreateMetricsExporterWithDefaultTranslaitonRules(t *testing.T) {
 
 	// Validate that default translation rules are loaded
 	// Expected values has to be updated once default config changed
-	assert.Equal(t, 60, len(config.TranslationRules))
+	assert.Equal(t, 64, len(config.TranslationRules))
 	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
 	assert.Equal(t, 33, len(config.TranslationRules[0].Mapping))
 }
@@ -326,7 +326,7 @@ func TestCreateMetricsExporterWithDefaultExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 8, len(config.ExcludeMetrics))
+	assert.Equal(t, 10, len(config.ExcludeMetrics))
 }
 
 func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
@@ -349,7 +349,7 @@ func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 9, len(config.ExcludeMetrics))
+	assert.Equal(t, 11, len(config.ExcludeMetrics))
 }
 
 func testMetricsData() pdata.ResourceMetrics {

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -602,6 +602,35 @@ translation_rules:
     memory.utilization: 100
     cpu.utilization: 100
 
+# Virtual memory metrics
+- action: split_metric
+  metric_name: system.paging.operations
+  dimension_key: direction
+  mapping:
+    page_in: system.paging.operations.page_in
+    page_out: system.paging.operations.page_out
+
+- action: split_metric
+  metric_name: system.paging.operations.page_in
+  dimension_key: type
+  mapping:
+    major: vmpage_io.swap.in
+    minor: vmpage_io.memory.in
+
+- action: split_metric
+  metric_name: system.paging.operations.page_out
+  dimension_key: type
+  mapping:
+    major: vmpage_io.swap.out
+    minor: vmpage_io.memory.out
+
+- action: split_metric
+  metric_name: system.paging.faults
+  dimension_key: type
+  mapping:
+    major: vmpage_faults.majflt
+    minor: vmpage_faults.minflt
+
 # remove redundant metrics
 - action: drop_metrics
   metric_names:
@@ -612,5 +641,7 @@ translation_rules:
     system.cpu.usage: true
     system.cpu.total: true
     system.cpu.delta: true
+    system.paging.operations.page_in: true
+    system.paging.operations.page_out: true
 `
 )

--- a/exporter/signalfxexporter/translation/default_metrics.go
+++ b/exporter/signalfxexporter/translation/default_metrics.go
@@ -73,6 +73,12 @@ exclude_metrics:
   - if_packets.rx
   - if_packets.tx
 
+  # Virtual memory metrics
+  - vmpage_io.memory.in
+  - vmpage_io.memory.out
+  - vmpage_faults.majflt
+  - vmpage_faults.minflt
+
   # k8s metrics
   # Derived from https://docs.signalfx.com/en/latest/integrations/agent/monitors/kubernetes-cluster.html.
   - kubernetes.cronjob.active
@@ -133,6 +139,14 @@ exclude_metrics:
   - system.network.packets
   - system.network.dropped
   - system.network.tcp_connections
+
+# Virtual memory metrics.
+- metric_names:
+  - system.paging.faults
+  - system.paging.usage
+- metric_name: system.paging.operations
+  dimensions:
+    type: [minor]
 
 # k8s metrics.
 - metric_names:


### PR DESCRIPTION
**Description:** Adding translation rules for generating the signalfx-agent `vmpage_io.swap.[in/out]` metrics, as well as excluding non-default virtual memory metrics, for parity with the Smart Agent.