### PR TITLE
Enable groupbyatttrs processor

### DIFF
--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -44,6 +44,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
@@ -158,6 +159,7 @@ func components() (component.Factories, error) {
 	}
 
 	processors := []component.ProcessorFactory{
+		groupbyattrsprocessor.NewFactory(),
 		groupbytraceprocessor.NewFactory(),
 		k8sprocessor.NewFactory(),
 		metricstransformprocessor.NewFactory(),

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.0.0-00010101000000-000000000000
@@ -169,6 +170,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zooke
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/stanzareceiver => ./receiver/stanzareceiver/
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver => ./receiver/memcachedreceiver
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor => ./processor/groupbyattrsprocessor
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor => ./processor/groupbytraceprocessor
 

--- a/processor/groupbyattrsprocessor/README.md
+++ b/processor/groupbyattrsprocessor/README.md
@@ -1,7 +1,6 @@
 # Group by Attributes processor
 
 Supported pipeline types: traces, logs
-Status: in development
 
 This processor groups the records by provided attributes, extracting them from the 
 record to resource level. When the grouped attribute key already exists at the resource-level,
@@ -11,7 +10,7 @@ under matching InstrumentationLibrary.
 Typical use-cases:
 
 * extracting resources from "flat" data formats, such as Fluentbit logs
-* optimizing data by extracting common attributes
+* optimizing data packaging by extracting common attributes
 
 Please refer to [config.go](./config.go) for the config spec.
 
@@ -35,8 +34,8 @@ the grouping occurs.
 ## Metrics
 
 The following metrics are recorded by this processor:
-* `num_grouped_traces` represents the number of spans that had attributes grouped
-* `num_non_grouped_traces` represents the number of spans that did not have attributes grouped
+* `num_grouped_spans` represents the number of spans that had attributes grouped
+* `num_non_grouped_spans` represents the number of spans that did not have attributes grouped
 * `span_groups` represents the distributon of groups extracted for spans
 * `num_grouped_logs` represents the number of logs that had attributes grouped
 * `num_non_grouped_logs` represents the number of logs that did not have attributes grouped

--- a/processor/groupbyattrsprocessor/factory.go
+++ b/processor/groupbyattrsprocessor/factory.go
@@ -17,6 +17,7 @@ package groupbyattrsprocessor
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
@@ -36,10 +37,14 @@ var (
 	processorCapabilities        = component.ProcessorCapabilities{MutatesConsumedData: true}
 )
 
+var once sync.Once
+
 // NewFactory returns a new factory for the Filter processor.
 func NewFactory() component.ProcessorFactory {
-	// TODO: as with other -contrib factories registering metrics, this is causing the error being ignored
-	_ = view.Register(MetricViews()...)
+	once.Do(func() {
+		// TODO: as with other -contrib factories registering metrics, this is causing the error being ignored
+		_ = view.Register(MetricViews()...)
+	})
 
 	return processorhelper.NewFactory(
 		typeStr,

--- a/processor/groupbyattrsprocessor/metrics.go
+++ b/processor/groupbyattrsprocessor/metrics.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	mNumGroupedSpans    = stats.Int64("num_grouped_traces", "Number of spans that had attributes grouped", stats.UnitDimensionless)
-	mNumNonGroupedSpans = stats.Int64("num_non_grouped_traces", "Number of spans that did not have attributes grouped", stats.UnitDimensionless)
+	mNumGroupedSpans    = stats.Int64("num_grouped_spans", "Number of spans that had attributes grouped", stats.UnitDimensionless)
+	mNumNonGroupedSpans = stats.Int64("num_non_grouped_spans", "Number of spans that did not have attributes grouped", stats.UnitDimensionless)
 	mDistSpanGroups     = stats.Int64("span_groups", "Distributon of groups extracted for spans", stats.UnitDimensionless)
 	mNumGroupedLogs     = stats.Int64("num_grouped_logs", "Number of logs that had attributes grouped", stats.UnitDimensionless)
 	mNumNonGroupedLogs  = stats.Int64("num_non_grouped_logs", "Number of logs that did not have attributes grouped", stats.UnitDimensionless)

--- a/processor/groupbyattrsprocessor/metrics_test.go
+++ b/processor/groupbyattrsprocessor/metrics_test.go
@@ -22,8 +22,8 @@ import (
 
 func TestProcessorMetrics(t *testing.T) {
 	expectedViewNames := []string{
-		"processor/groupbyattrs/num_grouped_traces",
-		"processor/groupbyattrs/num_non_grouped_traces",
+		"processor/groupbyattrs/num_grouped_spans",
+		"processor/groupbyattrs/num_non_grouped_spans",
 		"processor/groupbyattrs/span_groups",
 		"processor/groupbyattrs/num_grouped_logs",
 		"processor/groupbyattrs/num_non_grouped_logs",


### PR DESCRIPTION
**Description:**

Introduces  processor for grouping the trace or log records by specified key values, and then extracting the attributes from the record to resource level.

This initiative is broken down into 3 separate PRs:

1. [Config](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1744) (already merged)

2. [The processor logic](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1792) (already merged)

👉  3. Enabling the component (this PR)

_Example: consider having such input:_

```
InstrumentationLibraryLogs #0
LogRecord #0
Timestamp: 1606158664897894000
Severity:
ShortName:
Body: STRING("foo")
Attributes:
     -> action: STRING(login)
     -> namespace_name: STRING(kube-apiserver-docker-desktop)
     -> pod_name: STRING(kube-system)
```

With following config:

```
groupbyattrs:
  group_by_keys:
    - pod_name
    - namespace_name
```

The output is going to be:

```
Resource labels:
     -> namespace_name: STRING(kube-apiserver-docker-desktop)
     -> pod_name: STRING(kube-system)
InstrumentationLibraryLogs #0
LogRecord #0
Timestamp: 1606158617133076000
Severity:
ShortName:
Body: STRING("foo")
Attributes:
     -> action: STRING(login)
```

**Link to tracking Issue:** [#1884](https://github.com/open-telemetry/opentelemetry-collector/issues/1884)

**Testing:** Unit tests added, manual tests performed on logs and traces

**Documentation:** Processor README.md included
