### PR TITLE
exporter/signalfx: Remove send_compatible_metrics option

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -42,9 +42,9 @@ The following configuration options can also be configured:
   receiver](../../receiver/signalfxreceiver/README.md) to preserve datapoint
   origin.
 - `exclude_metrics`: List of metric filters that will determine metrics to be
-  excluded from sending to Signalfx backend. If `send_compatible_metrics`
-  or `translation_rules` options are enabled, the exclusion will be applied
-  on translated metrics. See [here](./testdata/config.yaml) for examples.
+  excluded from sending to Signalfx backend. If `translation_rules` options
+  are enabled, the exclusion will be applied on translated metrics.
+  See [here](./testdata/config.yaml) for examples.
 - `include_metrics`: List of filters to override exclusion of any metrics.
   This option can be used to included metrics that are otherwise dropped by
   default. See [here](./translation/default_metrics.go) for a list of metrics
@@ -62,13 +62,11 @@ The following configuration options can also be configured:
 - `headers` (no default): Headers to pass in the payload.
 - `log_dimension_updates` (default = `false`): Whether or not to log dimension
   updates.
-- `send_compatible_metrics` (default = `false`): Whether metrics must be
-  translated to a format backward-compatible with SignalFx naming conventions.
 - `timeout` (default = 5s): Amount of time to wait for a send operation to
   complete.
 - `translation_rules`: Set of rules on how to translate metrics to a SignalFx
   compatible format. Rules defined in `translation/constants.go` are used by
-  default. Applicable only when `send_compatible_metrics` set to `true`.
+  default. Set this option to `[]` to override the default behavior.
 - `sync_host_metadata`: Defines whether the exporter should scrape host metadata
   and send it as property updates to SignalFx backend. Disabled by default.
   IMPORTANT: Host metadata synchronization relies on `resourcedetection`

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -29,6 +29,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
+const (
+	translationRulesConfigKey = "translation_rules"
+)
+
 // Config defines configuration for SignalFx exporter.
 type Config struct {
 	configmodels.ExporterSettings  `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
@@ -63,10 +67,6 @@ type Config struct {
 	LogDimensionUpdates bool `mapstructure:"log_dimension_updates"`
 
 	splunk.AccessTokenPassthroughConfig `mapstructure:",squash"`
-
-	// SendCompatibleMetrics specifies if metrics must be sent in a format backward-compatible with
-	// SignalFx naming conventions, "false" by default.
-	SendCompatibleMetrics bool `mapstructure:"send_compatible_metrics"`
 
 	// TranslationRules defines a set of rules how to translate metrics to a SignalFx compatible format
 	// Rules defined in translation/constants.go are used by default.
@@ -120,12 +120,9 @@ func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {
 		cfg.Timeout = 5 * time.Second
 	}
 
-	var metricTranslator *translation.MetricTranslator
-	if cfg.SendCompatibleMetrics {
-		metricTranslator, err = translation.NewMetricTranslator(cfg.TranslationRules, cfg.DeltaTranslationTTL)
-		if err != nil {
-			return nil, fmt.Errorf("invalid \"translation_rules\": %v", err)
-		}
+	metricTranslator, err := translation.NewMetricTranslator(cfg.TranslationRules, cfg.DeltaTranslationTTL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid \"%s\": %v", translationRulesConfigKey, err)
 	}
 
 	return &exporterOptions{

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -83,9 +83,7 @@ func customUnmarshaler(componentViperSection *viper.Viper, intoCfg interface{}) 
 
 	config := intoCfg.(*Config)
 
-	// custom unmarhalling is required to get []translation.Rule, the default
-	// unmarshaller only supports string slices. If translations_config is not
-	// set in the config, set it to the defaults and return.
+	// If translations_config is not set in the config, set it to the defaults and return.
 	if !componentViperSection.IsSet(translationRulesConfigKey) {
 		config.TranslationRules, err = loadDefaultTranslationRules()
 		return err

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -185,58 +185,6 @@ func TestFactory_CreateMetricsExporterFails(t *testing.T) {
 	}
 }
 
-func TestCreateMetricsExporterWithDefaultTranslationRules(t *testing.T) {
-	config := &Config{
-		ExporterSettings: configmodels.ExporterSettings{
-			TypeVal: configmodels.Type(typeStr),
-			NameVal: typeStr,
-		},
-		AccessToken:           "testToken",
-		Realm:                 "us1",
-		SendCompatibleMetrics: true,
-	}
-
-	te, err := createMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, config)
-	assert.NoError(t, err)
-	assert.NotNil(t, te)
-
-	// Validate that default translation rules are loaded
-	// Expected values has to be updated once default config changed
-	assert.Equal(t, 64, len(config.TranslationRules))
-	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
-	assert.Equal(t, 33, len(config.TranslationRules[0].Mapping))
-}
-
-func TestCreateMetricsExporterWithSpecifiedTranslaitonRules(t *testing.T) {
-	config := &Config{
-		ExporterSettings: configmodels.ExporterSettings{
-			TypeVal: configmodels.Type(typeStr),
-			NameVal: typeStr,
-		},
-		AccessToken:           "testToken",
-		Realm:                 "us1",
-		SendCompatibleMetrics: true,
-		TranslationRules: []translation.Rule{
-			{
-				Action: translation.ActionRenameDimensionKeys,
-				Mapping: map[string]string{
-					"old_dimension": "new_dimension",
-				},
-			},
-		},
-	}
-
-	te, err := createMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, config)
-	assert.NoError(t, err)
-	assert.NotNil(t, te)
-
-	// Validate that specified translation rules are loaded instead of default ones
-	assert.Equal(t, 1, len(config.TranslationRules))
-	assert.Equal(t, translation.ActionRenameDimensionKeys, config.TranslationRules[0].Action)
-	assert.Equal(t, 1, len(config.TranslationRules[0].Mapping))
-	assert.Equal(t, "new_dimension", config.TranslationRules[0].Mapping["old_dimension"])
-}
-
 func TestDefaultTranslationRules(t *testing.T) {
 	rules, err := loadDefaultTranslationRules()
 	require.NoError(t, err)

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -12,11 +12,13 @@ require (
 	github.com/shirou/gopsutil v3.21.1+incompatible
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.2
 	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201202163743-65b4fa925fc8
+	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.19.1-0.20210127225953-68c5961f7bc2
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
 	google.golang.org/protobuf v1.25.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/exporter/signalfxexporter/testdata/config.yaml
+++ b/exporter/signalfxexporter/testdata/config.yaml
@@ -24,7 +24,6 @@ exporters:
       added-entry: "added value"
       dot.test: test
     access_token_passthrough: false
-    send_compatible_metrics: true
     translation_rules:
     - action: rename_dimension_keys
       mapping:


### PR DESCRIPTION
**Description:** This is a **breaking change**. Remove `send_compatible_metrics` options. Instead
just use the `translation_rules` field to determine whether or not compatible
metrics are to be sent. If `translation_rules` is not specified, default rules
will be applied and compatible metrics will be sent. Compatible metrics can be
turned off by setting it to `[]`.

**Testing:** Updated tests.

**Documentation:** Updated documentation.