### PR TITLE
[exporter/datadog] Fix CI

### DIFF
--- a/exporter/datadogexporter/metadata/ec2/ec2_test.go
+++ b/exporter/datadogexporter/metadata/ec2/ec2_test.go
@@ -79,5 +79,5 @@ func TestHostInfoFromAttributes(t *testing.T) {
 
 	assert.Equal(t, hostInfo.InstanceID, testInstanceID)
 	assert.Equal(t, hostInfo.EC2Hostname, testIP)
-	assert.Equal(t, hostInfo.EC2Tags, []string{"tag1:val1", "tag2:val2"})
+	assert.ElementsMatch(t, hostInfo.EC2Tags, []string{"tag1:val1", "tag2:val2"})
 }


### PR DESCRIPTION
**Description:** 

My last PR, #2023, broke CI. This change fixes it: Go `map`s do not guarantee the order of keys.
