### PR TITLE
Fixed typo in Makefile for target 'unit-tests-with-cover'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ e2e-test: otelcontribcol otelcontribcol-unstable
 	$(MAKE) -C testbed run-tests
 	$(MAKE) -C testbed run-tests TESTS_DIR=tests_unstable_exe
 
-.PHONY: test-with-cover
+.PHONY: unit-tests-with-cover
 unit-tests-with-cover:
 	@echo Verifying that all packages have test files to count in coverage
 	@internal/buildscripts/check-test-files.sh $(subst github.com/open-telemetry/opentelemetry-collector-contrib/,./,$(ALL_PKGS))


### PR DESCRIPTION
Signed-off-by: Granville Schmidt <1246157+gramidt@users.noreply.github.com>

**Description:**
The Makefile target 'unit-tests-with-cover' has a declaration to mark it phony, but it has the incorrect name of the target to do so.

**Link to tracking Issue:**
N/A

**Testing:**
Executed targets via Make and ensured it would always executed without being considered up-to-date.

**Documentation:**
N/A