### PR TITLE
f5cloudexporter: Implemented User-Agent header with version

### DIFF
--- a/exporter/f5cloudexporter/config_test.go
+++ b/exporter/f5cloudexporter/config_test.go
@@ -66,7 +66,9 @@ func TestLoadConfig(t *testing.T) {
 				ReadBufferSize:  123,
 				WriteBufferSize: 345,
 				Timeout:         time.Second * 10,
-				Headers:         map[string]string{},
+				Headers: map[string]string{
+					"User-Agent": "opentelemetry-collector-contrib {{version}}",
+				},
 			},
 		},
 		Source: "dev",

--- a/exporter/f5cloudexporter/factory.go
+++ b/exporter/f5cloudexporter/factory.go
@@ -59,7 +59,7 @@ func (f *f5cloudFactory) CreateMetricsExporter(
 		return nil, err
 	}
 
-	setVersionInUserAgent(cfg, params.ApplicationStartInfo.Version)
+	fillUserAgent(cfg, params.ApplicationStartInfo.Version)
 
 	return f.ExporterFactory.CreateMetricsExporter(ctx, params, &cfg.Config)
 }
@@ -75,7 +75,7 @@ func (f *f5cloudFactory) CreateTracesExporter(
 		return nil, err
 	}
 
-	setVersionInUserAgent(cfg, params.ApplicationStartInfo.Version)
+	fillUserAgent(cfg, params.ApplicationStartInfo.Version)
 
 	return f.ExporterFactory.CreateTracesExporter(ctx, params, &cfg.Config)
 }
@@ -91,7 +91,7 @@ func (f *f5cloudFactory) CreateLogsExporter(
 		return nil, err
 	}
 
-	setVersionInUserAgent(cfg, params.ApplicationStartInfo.Version)
+	fillUserAgent(cfg, params.ApplicationStartInfo.Version)
 
 	return f.ExporterFactory.CreateLogsExporter(ctx, params, &cfg.Config)
 }
@@ -132,6 +132,6 @@ func getTokenSourceFromConfig(config *Config) (oauth2.TokenSource, error) {
 	return ts, nil
 }
 
-func setVersionInUserAgent(cfg *Config, version string) {
+func fillUserAgent(cfg *Config, version string) {
 	cfg.Headers["User-Agent"] = strings.ReplaceAll(cfg.Headers["User-Agent"], "{{version}}", version)
 }

--- a/exporter/f5cloudexporter/factory.go
+++ b/exporter/f5cloudexporter/factory.go
@@ -17,6 +17,7 @@ package f5cloudexporter
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -58,6 +59,8 @@ func (f *f5cloudFactory) CreateMetricsExporter(
 		return nil, err
 	}
 
+	setVersionInUserAgent(cfg, params.ApplicationStartInfo.Version)
+
 	return f.ExporterFactory.CreateMetricsExporter(ctx, params, &cfg.Config)
 }
 
@@ -71,6 +74,8 @@ func (f *f5cloudFactory) CreateTracesExporter(
 	if err := cfg.sanitize(); err != nil {
 		return nil, err
 	}
+
+	setVersionInUserAgent(cfg, params.ApplicationStartInfo.Version)
 
 	return f.ExporterFactory.CreateTracesExporter(ctx, params, &cfg.Config)
 }
@@ -86,6 +91,8 @@ func (f *f5cloudFactory) CreateLogsExporter(
 		return nil, err
 	}
 
+	setVersionInUserAgent(cfg, params.ApplicationStartInfo.Version)
+
 	return f.ExporterFactory.CreateLogsExporter(ctx, params, &cfg.Config)
 }
 
@@ -100,6 +107,8 @@ func (f *f5cloudFactory) CreateDefaultConfig() configmodels.Exporter {
 
 	cfg.TypeVal = typeStr
 	cfg.NameVal = typeStr
+
+	cfg.Headers["User-Agent"] = "opentelemetry-collector-contrib {{version}}"
 
 	cfg.HTTPClientSettings.CustomRoundTripper = func(next http.RoundTripper) (http.RoundTripper, error) {
 		ts, err := f.getTokenSource(cfg)
@@ -121,4 +130,8 @@ func getTokenSourceFromConfig(config *Config) (oauth2.TokenSource, error) {
 	}
 
 	return ts, nil
+}
+
+func setVersionInUserAgent(cfg *Config, version string) {
+	cfg.Headers["User-Agent"] = strings.ReplaceAll(cfg.Headers["User-Agent"], "{{version}}", version)
 }

--- a/exporter/f5cloudexporter/factory_test.go
+++ b/exporter/f5cloudexporter/factory_test.go
@@ -60,10 +60,17 @@ func TestFactory_CreateMetricsExporter(t *testing.T) {
 		Audience:       "tests",
 	}
 
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
+	creationParams := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+		ApplicationStartInfo: component.ApplicationStartInfo{
+			Version: "0.0.0",
+		},
+	}
 	oexp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
+
+	require.Equal(t, "opentelemetry-collector-contrib 0.0.0", cfg.Headers["User-Agent"])
 }
 
 func TestFactory_CreateMetricsExporterInvalidConfig(t *testing.T) {
@@ -86,10 +93,17 @@ func TestFactory_CreateTraceExporter(t *testing.T) {
 		Audience:       "tests",
 	}
 
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
+	creationParams := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+		ApplicationStartInfo: component.ApplicationStartInfo{
+			Version: "0.0.0",
+		},
+	}
 	oexp, err := factory.CreateTracesExporter(context.Background(), creationParams, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
+
+	require.Equal(t, "opentelemetry-collector-contrib 0.0.0", cfg.Headers["User-Agent"])
 }
 
 func Test_Factory_CreateTraceExporterInvalidConfig(t *testing.T) {
@@ -112,10 +126,17 @@ func TestFactory_CreateLogsExporter(t *testing.T) {
 		Audience:       "tests",
 	}
 
-	creationParams := component.ExporterCreateParams{Logger: zap.NewNop()}
+	creationParams := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+		ApplicationStartInfo: component.ApplicationStartInfo{
+			Version: "0.0.0",
+		},
+	}
 	oexp, err := factory.CreateLogsExporter(context.Background(), creationParams, cfg)
 	require.Nil(t, err)
 	require.NotNil(t, oexp)
+
+	require.Equal(t, "opentelemetry-collector-contrib 0.0.0", cfg.Headers["User-Agent"])
 }
 
 func TestFactory_CreateLogsExporterInvalidConfig(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Granville Schmidt <1246157+gramidt@users.noreply.github.com>

**Description:** 
Adds 'User-Agent' header with version to requests

**Link to tracking Issue:**
#2291 

**Testing:**
Unit tests

**Documentation:**
N/A