### PR TITLE
[exporter/datadog] add basic span events support (updates #2337)

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -70,7 +70,7 @@ service:
 
 ### Span Events
 
-*Please Note:* Currently Span Events are extracted and added to Spans as Json on the Datadog Span Tag `events`.
+*Please Note:* Currently [Span Events](https://github.com/open-telemetry/opentelemetry-specification/blob/11cc73939a32e3a2e6f11bdeab843c61cf8594e9/specification/trace/api.md#add-events) are extracted and added to Spans as Json on the Datadog Span Tag `events`.
 
 ## Metric exporter
 

--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -1,24 +1,25 @@
 # Datadog Exporter
 
-This exporter sends metric and trace data to [Datadog](https://datadoghq.com).
+This exporter sends metric and trace data to [Datadog](https://datadoghq.com). For environment specific setup instructions visit the [Datadog Documentation](https://docs.datadoghq.com/tracing/setup_overview/open_standards/#opentelemetry-collector-datadog-exporter).
 
 ## Configuration
 
 The only required setting is a [Datadog API key](https://app.datadoghq.com/account/settings#api).
- ```yaml
+
+```yaml
 datadog:
   api:
     key: "<API key>"
- ```
+```
  
  To send data to the Datadog EU site, set the `api.site` parameter to `datadoghq.eu`:
 
- ```yaml
+```yaml
 datadog:
   api:
     key: "<API key>"
     site: datadoghq.eu
- ```
+```
 
 The hostname, environment, service and version can be set in the configuration for unified service tagging.
 The exporter will try to retrieve a hostname following the OpenTelemetry semantic conventions if there is one available.
@@ -37,7 +38,7 @@ A batch representing 10 seconds of traces is a constraint of Datadog's API Intak
 
 Example:
 
- ```
+```yaml
 receivers:
   examplereceiver:
 
@@ -65,7 +66,11 @@ service:
       receivers: [examplereceiver]
       processors: [batch]
       exporters: [datadog/api]
- ```
+```
+
+### Span Events
+
+*Please Note:* Currently Span Events are extracted and added to Spans as Json on the Datadog Span Tag `events`.
 
 ## Metric exporter
 

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -16,6 +16,7 @@ package datadogexporter
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -46,6 +47,10 @@ const (
 	webKind             string = "web"
 	customKind          string = "custom"
 	grpcPath            string = "grpc.path"
+	eventsTag           string = "events"
+	eventNameTag        string = "name"
+	eventAttrTag        string = "attribute"
+	eventTimeTag        string = "time"
 	// tagContainersTags specifies the name of the tag which holds key/value
 	// pairs representing information about the container (Docker, EC2, etc).
 	tagContainersTags = "_dd.tags.container"
@@ -215,6 +220,11 @@ func spanToDatadogSpan(s pdata.Span,
 	// get tracestate as just a general tag
 	if len(s.TraceState()) > 0 {
 		tags[tracetranslator.TagW3CTraceState] = string(s.TraceState())
+	}
+
+	// get tracestate as just a general tag
+	if s.Events().Len() > 0 {
+		tags[eventsTag] = eventsToString(s.Events())
 	}
 
 	// get start/end time to calc duration
@@ -538,4 +548,28 @@ func extractErrorTagsFromEvents(s pdata.Span, tags map[string]string) {
 			return
 		}
 	}
+}
+
+// Convert Span Events to a string so that they can be appended to the span as a tag.
+// Span events are probably better served as Structured Logs sent to the logs API
+// with the trace id and span id added for log/trace correlation. However this would
+// mean a separate API intake endpoint and also Logs and Traces may not be enabled for
+// a user, so for now just surfacing this information as a string is better than not
+// including it at all. The tradeoff is that this increases the size of the span and the
+// span may have a tag that exceeds max size allowed in backend/ui/etc.
+//
+// TODO: Expose configuration option for collecting Span Events as Logs within Datadog
+// and add forwarding to Logs API intake.
+func eventsToString(evts pdata.SpanEventSlice) string {
+	eventArray := make([]map[string]interface{}, 0, evts.Len())
+	for i := 0; i < evts.Len(); i++ {
+		spanEvent := evts.At(i)
+		event := map[string]interface{}{}
+		event[eventNameTag] = spanEvent.Name()
+		event[eventTimeTag] = spanEvent.Timestamp()
+		event[eventAttrTag] = tracetranslator.AttributeMapToMap(spanEvent.Attributes())
+		eventArray = append(eventArray, event)
+	}
+	eventArrayBytes, _ := json.Marshal(&eventArray)
+	return string(eventArrayBytes)
 }

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -222,7 +222,7 @@ func spanToDatadogSpan(s pdata.Span,
 		tags[tracetranslator.TagW3CTraceState] = string(s.TraceState())
 	}
 
-	// get tracestate as just a general tag
+	// get events as just a general tag
 	if s.Events().Len() > 0 {
 		tags[eventsTag] = eventsToString(s.Events())
 	}

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -49,7 +49,7 @@ const (
 	grpcPath            string = "grpc.path"
 	eventsTag           string = "events"
 	eventNameTag        string = "name"
-	eventAttrTag        string = "attribute"
+	eventAttrTag        string = "attributes"
 	eventTimeTag        string = "time"
 	// tagContainersTags specifies the name of the tag which holds key/value
 	// pairs representing information about the container (Docker, EC2, etc).

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -258,7 +258,7 @@ func TestBasicTracesTranslation(t *testing.T) {
 	assert.Equal(t, "web", datadogPayload.Traces[0].Spans[0].Type)
 
 	// ensure that span.meta and span.metrics pick up attibutes, instrumentation ibrary and resource attribs
-	assert.Equal(t, 9, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 10, len(datadogPayload.Traces[0].Spans[0].Meta))
 	assert.Equal(t, 1, len(datadogPayload.Traces[0].Spans[0].Metrics))
 
 	// ensure that span error is based on otlp span status
@@ -273,6 +273,13 @@ func TestBasicTracesTranslation(t *testing.T) {
 	// ensure a duration and start time are calculated
 	assert.NotNil(t, datadogPayload.Traces[0].Spans[0].Start)
 	assert.NotNil(t, datadogPayload.Traces[0].Spans[0].Duration)
+
+	// ensure that events tag is set if span events exist and contains structured json fields
+	assert.Contains(t, "start", datadogPayload.Traces[0].Spans[0].Meta["Events"])
+	assert.Contains(t, "end", datadogPayload.Traces[0].Spans[0].Meta["Events"])
+	assert.Contains(t, "attribute", datadogPayload.Traces[0].Spans[0].Meta["Events"])
+	assert.Contains(t, "name", datadogPayload.Traces[0].Spans[0].Meta["Events"])
+	assert.Contains(t, "timestamp", datadogPayload.Traces[0].Spans[0].Meta["Events"])
 }
 
 func TestTracesTranslationErrorsAndResource(t *testing.T) {
@@ -318,7 +325,7 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 	// ensure that version gives resource service.version priority
 	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
 
-	assert.Equal(t, 17, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 18, len(datadogPayload.Traces[0].Spans[0].Meta))
 
 	assert.Contains(t, datadogPayload.Traces[0].Spans[0].Meta[tagContainersTags], "container_id:3249847017410247")
 	assert.Contains(t, datadogPayload.Traces[0].Spans[0].Meta[tagContainersTags], "pod_name:example-pod-name")
@@ -499,7 +506,7 @@ func TestTracesTranslationOkStatus(t *testing.T) {
 	// ensure that version gives resource service.version priority
 	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
 
-	assert.Equal(t, 17, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 18, len(datadogPayload.Traces[0].Spans[0].Meta))
 }
 
 // ensure that the datadog span uses the configured unified service tags
@@ -544,7 +551,7 @@ func TestTracesTranslationConfig(t *testing.T) {
 	// ensure that version gives resource service.version priority
 	assert.Equal(t, "test-version", datadogPayload.Traces[0].Spans[0].Meta["version"])
 
-	assert.Equal(t, 14, len(datadogPayload.Traces[0].Spans[0].Meta))
+	assert.Equal(t, 15, len(datadogPayload.Traces[0].Spans[0].Meta))
 }
 
 // ensure that the translation returns early if no resource instrumentation library spans

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -36,11 +36,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/utils"
 )
 
-func NewResourceSpansData(mockTraceID [16]byte, mockSpanID [8]byte, mockParentSpanID [8]byte, statusCode pdata.StatusCode, resourceEnvAndService bool) pdata.ResourceSpans {
+func NewResourceSpansData(mockTraceID [16]byte, mockSpanID [8]byte, mockParentSpanID [8]byte, statusCode pdata.StatusCode, resourceEnvAndService bool, endTime time.Time) pdata.ResourceSpans {
 	// The goal of this test is to ensure that each span in
 	// pdata.ResourceSpans is transformed to its *trace.SpanData correctly!
 
-	endTime := time.Now().Round(time.Second)
 	pdataEndTime := pdata.TimestampUnixNano(endTime.UnixNano())
 	startTime := endTime.Add(-90 * time.Second)
 	pdataStartTime := pdata.TimestampUnixNano(startTime.UnixNano())
@@ -221,10 +220,11 @@ func TestBasicTracesTranslation(t *testing.T) {
 	mockTraceID := [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
 	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
 	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
+	mockEndTime := time.Now().Round(time.Second)
 
 	// create mock resource span data
 	// set shouldError and resourceServiceandEnv to false to test defaut behavior
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeUnset, false)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeUnset, false, mockEndTime)
 
 	// translate mocks to datadog traces
 	datadogPayload := resourceSpansToDatadogSpans(rs, calculator, hostname, &config.Config{})
@@ -274,12 +274,12 @@ func TestBasicTracesTranslation(t *testing.T) {
 	assert.NotNil(t, datadogPayload.Traces[0].Spans[0].Start)
 	assert.NotNil(t, datadogPayload.Traces[0].Spans[0].Duration)
 
+	pdataMockEndTime := pdata.TimestampUnixNano(mockEndTime.UnixNano())
+	pdataMockStartTime := pdata.TimestampUnixNano(mockEndTime.Add(-90 * time.Second).UnixNano())
+	mockEventsString := fmt.Sprintf("[{\"attributes\":{},\"name\":\"start\",\"time\":%d},{\"attributes\":{\"flag\":false},\"name\":\"end\",\"time\":%d}]", pdataMockStartTime, pdataMockEndTime)
+
 	// ensure that events tag is set if span events exist and contains structured json fields
-	assert.Contains(t, "start", datadogPayload.Traces[0].Spans[0].Meta["Events"])
-	assert.Contains(t, "end", datadogPayload.Traces[0].Spans[0].Meta["Events"])
-	assert.Contains(t, "attribute", datadogPayload.Traces[0].Spans[0].Meta["Events"])
-	assert.Contains(t, "name", datadogPayload.Traces[0].Spans[0].Meta["Events"])
-	assert.Contains(t, "timestamp", datadogPayload.Traces[0].Spans[0].Meta["Events"])
+	assert.Equal(t, mockEventsString, datadogPayload.Traces[0].Spans[0].Meta["events"])
 }
 
 func TestTracesTranslationErrorsAndResource(t *testing.T) {
@@ -291,9 +291,11 @@ func TestTracesTranslationErrorsAndResource(t *testing.T) {
 	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
 	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
 
+	mockEndTime := time.Now().Round(time.Second)
+
 	// create mock resource span data
 	// toggle on errors and custom service naming to test edge case code paths
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true, mockEndTime)
 
 	// translate mocks to datadog traces
 	cfg := config.Config{
@@ -341,9 +343,11 @@ func TestTracesTranslationErrorsFromEventsUsesLast(t *testing.T) {
 	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
 	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
 
+	mockEndTime := time.Now().Round(time.Second)
+
 	// create mock resource span data
 	// toggle on errors and custom service naming to test edge case code paths
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true, mockEndTime)
 	span := rs.InstrumentationLibrarySpans().At(0).Spans().At(0)
 	events := span.Events()
 	events.Resize(4)
@@ -399,9 +403,11 @@ func TestTracesTranslationErrorsFromEventsBounds(t *testing.T) {
 	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
 	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
 
+	mockEndTime := time.Now().Round(time.Second)
+
 	// create mock resource span data
 	// toggle on errors and custom service naming to test edge case code paths
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true, mockEndTime)
 	span := rs.InstrumentationLibrarySpans().At(0).Spans().At(0)
 	events := span.Events()
 	events.Resize(3)
@@ -472,9 +478,11 @@ func TestTracesTranslationOkStatus(t *testing.T) {
 	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
 	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
 
+	mockEndTime := time.Now().Round(time.Second)
+
 	// create mock resource span data
 	// toggle on errors and custom service naming to test edge case code paths
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true, mockEndTime)
 
 	// translate mocks to datadog traces
 	cfg := config.Config{
@@ -519,9 +527,11 @@ func TestTracesTranslationConfig(t *testing.T) {
 	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
 	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
 
+	mockEndTime := time.Now().Round(time.Second)
+
 	// create mock resource span data
 	// toggle on errors and custom service naming to test edge case code paths
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeUnset, true)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeUnset, true, mockEndTime)
 
 	cfg := config.Config{
 		TagsConfig: config.TagsConfig{
@@ -588,9 +598,11 @@ func TestTracesTranslationInvalidService(t *testing.T) {
 	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
 	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
 
+	mockEndTime := time.Now().Round(time.Second)
+
 	// create mock resource span data
 	// toggle on errors and custom service naming to test edge case code paths
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeUnset, false)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeUnset, false, mockEndTime)
 
 	// add a tab and an invalid character to see if it gets normalized
 	cfgInvalidService := config.Config{
@@ -947,9 +959,11 @@ func TestStatsAggregations(t *testing.T) {
 	mockSpanID := [8]byte{0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8}
 	mockParentSpanID := [8]byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8}
 
+	mockEndTime := time.Now().Round(time.Second)
+
 	// create mock resource span data
 	// toggle on errors and custom service naming to test edge case code paths
-	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true)
+	rs := NewResourceSpansData(mockTraceID, mockSpanID, mockParentSpanID, pdata.StatusCodeError, true, mockEndTime)
 
 	// translate mocks to datadog traces
 	cfg := config.Config{}


### PR DESCRIPTION
**Description:** <Describe what has changed.>

The PR adds support for appending OTLP Span Events and their Attributes to Datadog Spans. It adds a tag `events` to Datadog Spans that contains a stringified representation of all events on the span.

Long term, Span events are probably best treated as logs within the Datadog Platform, and we'd like to add a configuration option which allows users to toggle btwn sending span events as datadog span metadata, or as enriched logs. However this would entail adding support for sending logs to Datadog, which is not present in the datadogexporter at this time, and also datadog apm users may not be using the logging product, which could mean this data would be lost. So for now, while it does have tradeoffs, adding default behavior of attaching span event info as a tag on datadog spans is the simplest and least complicated way to surface this valuable information to users.

_(updates https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2337 which was using master not main)_

**Link to tracking Issue:** <Issue number if applicable> N/A but has been requested by users

**Testing:** <Describe what testing was performed and which tests were added.>

Added unit tests

**Documentation:** <Describe the documentation added.> n/a

cc @mx-psi @KSerrania for review from datadog