### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <strong>
     <a href="https://opentelemetry.io/docs/collector/getting-started/">Getting Started<a/>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
-    <a href="https://github.com/open-telemetry/community#agentcollector">Getting Involved<a/>
+    <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md">Getting Involved<a/>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://gitter.im/open-telemetry/opentelemetry-service">Getting In Touch<a/>
   </strong>
@@ -28,8 +28,6 @@
 
 <p align="center">
   <strong>
-    <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md">Contributing<a/>
-    &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/vision.md">Vision<a/>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/design.md">Design<a/>
@@ -37,6 +35,8 @@
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/monitoring.md">Monitoring<a/>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/performance.md">Performance<a/>
+    &nbsp;&nbsp;&bull;&nbsp;&nbsp;
+    <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security.md">Security<a/>
     &nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/roadmap.md">Roadmap<a/>
   </strong>
@@ -46,22 +46,14 @@
 
 # OpenTelemetry Collector Contrib
 
-This is a repository for OpenTelemetry Collector contributions that are not part of the
-[core repository](https://github.com/open-telemetry/opentelemetry-collector) and
-core distribution of the Collector. Typically, these contributions are vendor
-specific receivers/exporters and/or components that are only
-useful to a relatively small number of users.
+This is a repository for OpenTelemetry Collector contributions that are not
+part of the [core
+distribution](https://github.com/open-telemetry/opentelemetry-collector) of the
+Collector. Typically, these contributions are vendor specific
+receivers/exporters and/or components that are only useful to a relatively
+small number of users.
 
-Please note that this repository and its releases are a superset of the core repository.
-
-## Creating your own OpenTelemetry Collector distribution
-
-A guide on how to create your own distribution is available in this blog post:
-["Building your own OpenTelemetry Collector distribution"](https://medium.com/p/42337e994b63)
-
-If you are building your own distribution, the [OpenTelemetry Collector
-Builder](https://github.com/open-telemetry/opentelemetry-collector-builder)
-might be a good starting point.
+> Please note that this repository and its releases are a superset of the core repository.
 
 ## Contributing
 
@@ -97,14 +89,14 @@ here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRI
 News PRs will be automatically associated with the reviewers based on
 [CODEOWNERS](.github/CODEOWNERS). PRs will be also automatically assigned to one of the
 maintainers or approvers for facilitation.
- 
+
 The facilitator is responsible for helping the PR author and reviewers to make progress
 or if progress cannot be made for closing the PR.
- 
+
 If the reviewers do not have approval rights the facilitator is also responsible
 for the official approval that is required for the PR to be merged and if the facilitator
 is a maintainer they are responsible for merging the PR as well.
- 
+
 The facilitator is not required to perform a thorough review, but they are encouraged to
 enforce Collector best practices and consistency across the codebase and component
 behavior. The facilitators will typically rely on codeowner's detailed review of the code


### PR DESCRIPTION
- Ensure consistent with core README
- Remove distributions information as moved to website docs (see https://github.com/open-telemetry/opentelemetry.io/pull/391)