### PR TITLE
dotnet receiver: send initial request to backend

### DIFF
--- a/receiver/dotnetdiagnosticsreceiver/README.md
+++ b/receiver/dotnetdiagnosticsreceiver/README.md
@@ -103,3 +103,9 @@ macOS. Windows is not yet supported.
 #### Current Status
 
 This receiver is _beta_. It has been tested on macOS and Linux with .NET v3.1.
+
+#### External Resources
+
+https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+
+https://github.com/Microsoft/perfview/blob/main/src/TraceEvent/EventPipe/EventPipeFormat.md

--- a/receiver/dotnetdiagnosticsreceiver/README.md
+++ b/receiver/dotnetdiagnosticsreceiver/README.md
@@ -1,0 +1,105 @@
+## Dotnet Diagnostics Receiver
+
+This receiver provides a capability similar to the
+[dotnet-counters](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-counters)
+tool, which takes a .NET process ID and reads metrics from that process,
+providing them to the CLI. Similarly, this receiver reads metrics from a given
+.NET process, translating them and providing them to the Collector.
+
+#### .NET Counters Overview
+
+The .NET runtime makes available metrics to interested clients over an IPC
+connection, listening for requests and responding with metrics sent at a
+specified interval. All .NET processes newer than 3.0 make available both
+default metrics (grouped under the name `System.Runtime`) and any custom metrics
+generated via the EventCounter
+[API](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventcounter?view=net-5.0)
+.
+
+Once a .NET process is running, a client (such as this receiver) may connect to
+it over IPC, which is either a _Unix domain socket_ on Linux/macOS, or a _named
+pipe_ on Windows. After connecting, the client sends the process a request,
+using a custom binary encoding, indicating both the counters it's interested in
+and the collection interval, then waits for data. If the request is successful,
+the .NET process sends metrics, also using a custom binary encoding, over the
+IPC connection, at the specified interval.
+
+#### Operation
+
+At startup, this recevier looks for a file in `TMPDIR` (or `/tmp` if not set)
+corresponding to the given PID and a naming convention. If found, a Unix domain
+socket connection is opened, using the file as the endpoint, and a request is
+made to the dotnet process for metrics, with the given (in the config)
+collection interval and counters.
+
+After that, it listens for metrics arriving from the connection, and sends them
+to the next consumer as soon as they arrive. If the connection fails, or an
+unexpected value is read, the receiver shuts down.
+
+#### Configuration
+
+This receiver accepts three configuration fields: `collection_interval`,
+`pid`, and `counters`.
+
+| Field Name | Description | Example | Default |
+| ---------- | ----------- | ------- | ------- |
+| `collection_interval` | The interval between metric collection (converted to seconds) | `1m` | `1s`
+| `pid` | The process ID of the .NET process from which to collect metrics | `1001` | |
+| `counters` | A list of counter groups (sometimes referred to as _providers_ or _event sources_) to request from the .NET process | `["MyCounters"]` | `["System.Runtime", "Microsoft.AspNetCore.Hosting"]` |
+
+Example yaml config:
+
+```yaml
+receivers:
+  dotnet_diagnostics:
+    collection_interval: 10s
+    pid: 23860
+    counters: [ "MyCounters", "System.Runtime" ]
+exporters:
+  logging:
+    loglevel: info
+service:
+  pipelines:
+    metrics:
+      receivers: [ dotnet_diagnostics ]
+      exporters: [ logging ]
+```
+
+#### Usage With Receiver Creator
+
+It is possible to create a config file for this receiver with a hard-coded
+process id, but it is expected that this receiver will often be used with a
+receiver creator, and a host observer, to discover .NET processes at runtime.
+
+Example receiver creator config:
+
+```yaml
+extensions:
+  host_observer:
+receivers:
+  receiver_creator:
+    watch_observers: [ host_observer ]
+    receivers:
+      dotnet_diagnostics:
+        rule: type.hostport && process_name == 'dotnet'
+        config:
+          pid: "`process_id`"
+exporters:
+  logging:
+    loglevel: info
+service:
+  extensions: [ host_observer ]
+  pipelines:
+    metrics:
+      receivers: [ receiver_creator ]
+      exporters: [ logging ]
+```
+
+#### Supported Versions
+
+This receiver is compatible with .NET Core 3.0 and later versions, running on Linux or
+macOS. Windows is not yet supported.
+
+#### Current Status
+
+This receiver is _beta_. It has been tested on macOS and Linux with .NET v3.1.

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
@@ -31,7 +31,7 @@ import (
 // after which it starts sending us metrics at the specified interval.
 // ByteBuffer is swappable for testing.
 // For docs on the protocol, see
-// https://github.com/Microsoft/perfview/blob/main/src/TraceEvent/EventPipe/EventPipeFormat.md
+// https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
 type RequestWriter struct {
 	w           io.Writer
 	intervalSec int

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
@@ -1,0 +1,235 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnet
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
+)
+
+// RequestWriter submits the initial request to the dotnet diagnostics backend,
+// after which it starts sending us metrics at the specified interval.
+// ByteBuffer is swappable for testing.
+type RequestWriter struct {
+	buf         network.ByteBuffer
+	w           io.Writer
+	intervalSec int
+	names       []string
+}
+
+func NewRequestWriter(buf network.ByteBuffer, w io.Writer, intervalSec int, names ...string) *RequestWriter {
+	return &RequestWriter{buf: buf, w: w, intervalSec: intervalSec, names: names}
+}
+
+func (w *RequestWriter) SendRequest() error {
+	req, err := w.createRequest()
+	if err != nil {
+		return err
+	}
+	_, err = w.w.Write(req)
+	return err
+}
+
+const eventPipeCommand = 2
+const collectTracing2CommandID = 3
+
+func (w *RequestWriter) createRequest() ([]byte, error) {
+	cfgReq := newConfigRequest(w.intervalSec, w.names...)
+	payload, payloadSize, err := cfgReq.serialize(w.buf)
+	if err != nil {
+		return nil, err
+	}
+
+	hdr := &requestHeader{
+		commandSet: eventPipeCommand,
+		commandID:  collectTracing2CommandID,
+	}
+	hdrBytes, err := hdr.serialize(w.buf, payloadSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(hdrBytes, payload...), nil
+}
+
+// requestHeader
+type requestHeader struct {
+	commandSet byte
+	commandID  byte
+}
+
+const magic = "DOTNET_IPC_V1"
+const requestHeaderSize = 20
+
+func (h requestHeader) serialize(buf network.ByteBuffer, payloadSize int) ([]byte, error) {
+	buf.Reset()
+
+	_, err := buf.Write([]byte(magic + "\000"))
+	if err != nil {
+		return nil, err
+	}
+
+	totSize := uint16(requestHeaderSize + payloadSize)
+	err = binary.Write(buf, network.ByteOrder, totSize)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = buf.Write([]byte{h.commandSet, h.commandID, 0, 0})
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// configRequest
+type configRequest struct {
+	circularBufferSizeInMB int32
+	format                 serializationFormat
+	requestRundown         bool
+	providers              []provider
+}
+
+type serializationFormat uint32
+
+const netTrace = 1
+
+func newConfigRequest(intervalSec int, names ...string) configRequest {
+	return configRequest{
+		circularBufferSizeInMB: 10,
+		format:                 netTrace,
+		requestRundown:         false,
+		providers:              createProviders(intervalSec, names...),
+	}
+}
+
+func (c configRequest) serialize(buf network.ByteBuffer) ([]byte, int, error) {
+	buf.Reset()
+	err := binary.Write(buf, network.ByteOrder, c.circularBufferSizeInMB)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	err = binary.Write(buf, network.ByteOrder, c.format)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	err = binary.Write(buf, network.ByteOrder, c.requestRundown)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	size := int32(len(c.providers))
+	err = binary.Write(buf, network.ByteOrder, size)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for _, p := range c.providers {
+		err = p.serialize(buf)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	return buf.Bytes(), buf.Len(), nil
+}
+
+// provider
+type provider struct {
+	name       string
+	eventLevel uint32
+	keywords   int64
+	args       providerArgs
+}
+
+func createProviders(intervalSec int, names ...string) (ps []provider) {
+	for _, name := range names {
+		ps = append(ps, createProvider(name, intervalSec))
+	}
+	return
+}
+
+const verboseEventLevel = 5
+
+func createProvider(name string, intervalSec int) provider {
+	s := strconv.Itoa(intervalSec)
+	return provider{
+		name:       name,
+		eventLevel: verboseEventLevel,
+		keywords:   math.MaxInt64,
+		args:       providerArgs{"EventCounterIntervalSec": s},
+	}
+}
+
+func (p provider) serialize(buf network.ByteBuffer) error {
+	err := binary.Write(buf, network.ByteOrder, p.keywords)
+	if err != nil {
+		return err
+	}
+
+	err = binary.Write(buf, network.ByteOrder, p.eventLevel)
+	if err != nil {
+		return err
+	}
+
+	err = network.WriteUTF16String(buf, p.name)
+	if err != nil {
+		return err
+	}
+
+	err = network.WriteUTF16String(buf, p.args.String())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// providerArgs
+type providerArgs map[string]string
+
+func (a providerArgs) String() string {
+	keys := make([]string, 0, len(a))
+	for k := range a {
+		keys = append(keys, k)
+	}
+	// sorted for testing
+	sort.Strings(keys)
+	s := ""
+	for _, k := range keys {
+		if len(s) > 0 {
+			s += ";"
+		}
+		v := a[k]
+		s += fmt.Sprintf("%s=%s", escapeArg(k), escapeArg(v))
+	}
+	return s
+}
+
+func escapeArg(s string) string {
+	if strings.ContainsAny(s, ";=") {
+		return fmt.Sprintf("%q", s)
+	}
+	return s
+}

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
@@ -80,6 +80,7 @@ const requestHeaderSize = 20
 
 func (h requestHeader) serialize(payloadSize int) []byte {
 	buf := &bytes.Buffer{}
+	// no need to handle errors because Write always returns a nil error
 	_, _ = buf.Write([]byte(magic + "\000"))
 	totSize := uint16(requestHeaderSize + payloadSize)
 	_ = binary.Write(buf, network.ByteOrder, totSize)

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request_test.go
@@ -57,10 +57,10 @@ func TestConfig(t *testing.T) {
 		requestRundown:         false,
 		providers:              []provider{p},
 	}
-	payload, l, err := config.serialize(&bytes.Buffer{})
+	payload, err := config.serialize(&bytes.Buffer{})
 	require.NoError(t, err)
 	assert.NotNil(t, payload)
-	assert.Equal(t, 115, l)
+	assert.Equal(t, 115, len(payload))
 }
 
 func TestRequestHeader_Serialize(t *testing.T) {
@@ -77,9 +77,9 @@ func TestRequestHeader_Serialize(t *testing.T) {
 func TestSessionCfg(t *testing.T) {
 	req := newConfigRequest(42, "foo")
 	buf := &bytes.Buffer{}
-	_, n, err := req.serialize(buf)
+	payload, err := req.serialize(buf)
 	require.NoError(t, err)
-	require.Equal(t, 95, n)
+	require.Equal(t, 95, len(payload))
 }
 
 func TestRequestWriter_Send(t *testing.T) {

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request_test.go
@@ -16,14 +16,11 @@ package dotnet
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
 )
 
 func TestProviderArgs(t *testing.T) {
@@ -39,8 +36,7 @@ func TestProviderArgs_Escaped(t *testing.T) {
 func TestProvider_Serialize(t *testing.T) {
 	p := createProvider("xx", 42)
 	buf := &bytes.Buffer{}
-	err := p.serialize(buf)
-	require.NoError(t, err)
+	p.serialize(buf)
 	require.Equal(t, 80, len(buf.Bytes()))
 }
 
@@ -57,8 +53,7 @@ func TestConfig(t *testing.T) {
 		requestRundown:         false,
 		providers:              []provider{p},
 	}
-	payload, err := config.serialize(&bytes.Buffer{})
-	require.NoError(t, err)
+	payload := config.serialize()
 	assert.NotNil(t, payload)
 	assert.Equal(t, 115, len(payload))
 }
@@ -68,71 +63,23 @@ func TestRequestHeader_Serialize(t *testing.T) {
 		commandSet: eventPipeCommand,
 		commandID:  collectTracing2CommandID,
 	}
-	p, err := h.serialize(&bytes.Buffer{}, 42)
-	require.NoError(t, err)
+	p := h.serialize(42)
 	assert.Equal(t, []byte(magic), p[:len(magic)])
 	assert.Equal(t, requestHeaderSize, len(p))
 }
 
 func TestSessionCfg(t *testing.T) {
 	req := newConfigRequest(42, "foo")
-	buf := &bytes.Buffer{}
-	payload, err := req.serialize(buf)
-	require.NoError(t, err)
+	payload := req.serialize()
 	require.Equal(t, 95, len(payload))
 }
 
 func TestRequestWriter_Send(t *testing.T) {
 	rw := &fakeRW{}
-	w := NewRequestWriter(&bytes.Buffer{}, rw, 0, "")
+	w := NewRequestWriter(rw, 0, "")
 	err := w.SendRequest()
 	require.NoError(t, err)
 	require.Equal(t, 107, len(rw.writeBuf))
-}
-
-func TestWriteRequest_Errors(t *testing.T) {
-	for i := 0; i < 15; i++ {
-		w := NewRequestWriter(&fakeByteBuf{errOn: i}, nil, 0, "")
-		err := w.SendRequest()
-		require.Error(t, err)
-	}
-}
-
-// fakeByteBuf
-type fakeByteBuf struct {
-	errOn int
-	i     int
-}
-
-var _ network.ByteBuffer = (*fakeByteBuf)(nil)
-
-func (b *fakeByteBuf) Write([]byte) (n int, err error) {
-	return 0, b.err()
-}
-
-func (b *fakeByteBuf) WriteByte(byte) error {
-	return b.err()
-}
-
-func (b *fakeByteBuf) err() error {
-	defer func() {
-		b.i++
-	}()
-	if b.i == b.errOn {
-		return errors.New("")
-	}
-	return nil
-}
-
-func (b *fakeByteBuf) Bytes() []byte {
-	return nil
-}
-
-func (b *fakeByteBuf) Len() int {
-	return 0
-}
-
-func (b *fakeByteBuf) Reset() {
 }
 
 // fakeRW

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request_test.go
@@ -1,0 +1,152 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnet
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
+)
+
+func TestProviderArgs(t *testing.T) {
+	a := providerArgs{"foo": "bar", "baz": "glarch"}
+	assert.Equal(t, "baz=glarch;foo=bar", a.String())
+}
+
+func TestProviderArgs_Escaped(t *testing.T) {
+	a := providerArgs{"f;o": "bar", "baz": "gl=rch"}
+	assert.Equal(t, `baz="gl=rch";"f;o"=bar`, a.String())
+}
+
+func TestProvider_Serialize(t *testing.T) {
+	p := createProvider("xx", 42)
+	buf := &bytes.Buffer{}
+	err := p.serialize(buf)
+	require.NoError(t, err)
+	require.Equal(t, 80, len(buf.Bytes()))
+}
+
+func TestConfig(t *testing.T) {
+	p := provider{
+		name:       "System.Runtime",
+		eventLevel: verboseEventLevel,
+		keywords:   0xffffffff,
+		args:       providerArgs{"EventCounterIntervalSec": "1"},
+	}
+	config := configRequest{
+		circularBufferSizeInMB: 10,
+		format:                 netTrace,
+		requestRundown:         false,
+		providers:              []provider{p},
+	}
+	payload, l, err := config.serialize(&bytes.Buffer{})
+	require.NoError(t, err)
+	assert.NotNil(t, payload)
+	assert.Equal(t, 115, l)
+}
+
+func TestRequestHeader_Serialize(t *testing.T) {
+	h := requestHeader{
+		commandSet: eventPipeCommand,
+		commandID:  collectTracing2CommandID,
+	}
+	p, err := h.serialize(&bytes.Buffer{}, 42)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(magic), p[:len(magic)])
+	assert.Equal(t, requestHeaderSize, len(p))
+}
+
+func TestSessionCfg(t *testing.T) {
+	req := newConfigRequest(42, "foo")
+	buf := &bytes.Buffer{}
+	_, n, err := req.serialize(buf)
+	require.NoError(t, err)
+	require.Equal(t, 95, n)
+}
+
+func TestRequestWriter_Send(t *testing.T) {
+	rw := &fakeRW{}
+	w := NewRequestWriter(&bytes.Buffer{}, rw, 0, "")
+	err := w.SendRequest()
+	require.NoError(t, err)
+	require.Equal(t, 107, len(rw.writeBuf))
+}
+
+func TestWriteRequest_Errors(t *testing.T) {
+	for i := 0; i < 15; i++ {
+		w := NewRequestWriter(&fakeByteBuf{errOn: i}, nil, 0, "")
+		err := w.SendRequest()
+		require.Error(t, err)
+	}
+}
+
+// fakeByteBuf
+type fakeByteBuf struct {
+	errOn int
+	i     int
+}
+
+var _ network.ByteBuffer = (*fakeByteBuf)(nil)
+
+func (b *fakeByteBuf) Write([]byte) (n int, err error) {
+	return 0, b.err()
+}
+
+func (b *fakeByteBuf) WriteByte(byte) error {
+	return b.err()
+}
+
+func (b *fakeByteBuf) err() error {
+	defer func() {
+		b.i++
+	}()
+	if b.i == b.errOn {
+		return errors.New("")
+	}
+	return nil
+}
+
+func (b *fakeByteBuf) Bytes() []byte {
+	return nil
+}
+
+func (b *fakeByteBuf) Len() int {
+	return 0
+}
+
+func (b *fakeByteBuf) Reset() {
+}
+
+// fakeRW
+type fakeRW struct {
+	writeBuf []byte
+}
+
+var _ io.ReadWriter = (*fakeRW)(nil)
+
+func (rw *fakeRW) Write(p []byte) (n int, err error) {
+	rw.writeBuf = append(rw.writeBuf, p...)
+	return len(p), nil
+}
+
+func (rw *fakeRW) Read(p []byte) (n int, err error) {
+	return len(p), nil
+}

--- a/receiver/dotnetdiagnosticsreceiver/factory_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/factory_test.go
@@ -16,9 +16,11 @@ package dotnetdiagnosticsreceiver
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -38,11 +40,22 @@ func TestCreateDefaultConfig(t *testing.T) {
 	)
 }
 
-func TestCreateReceiver(t *testing.T) {
+func TestNewFactory(t *testing.T) {
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig()
 	params := component.ReceiverCreateParams{Logger: zap.NewNop()}
 	r, err := f.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewMetricsNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
+}
+
+func TestMkConnectionSupplier(t *testing.T) {
+	connect := mkConnectionSupplier(0, func(network, address string) (net.Conn, error) {
+		return nil, nil
+	}, func(pattern string) (matches []string, err error) {
+		return []string{""}, nil
+	})
+	readWriter, err := connect()
+	require.NoError(t, err)
+	require.Nil(t, readWriter)
 }

--- a/receiver/dotnetdiagnosticsreceiver/network/net.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/net.go
@@ -29,10 +29,7 @@ type GlobFunc func(pattern string) (matches []string, err error)
 // Mac/Linux, this is a Unix domain socket. Windows (TBD) will use a named pipe.
 // DialFunc and GlobFunc are swappable for testing.
 func Connect(pid int, dial DialFunc, glob GlobFunc) (net.Conn, error) {
-	tmpdir := os.Getenv("TMPDIR")
-	if tmpdir == "" {
-		tmpdir = "/tmp"
-	}
+	tmpdir := os.TempDir()
 	sf, err := socketFile(pid, tmpdir, glob)
 	if err != nil {
 		return nil, err

--- a/receiver/dotnetdiagnosticsreceiver/network/net.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/net.go
@@ -40,6 +40,11 @@ func Connect(pid int, dial DialFunc, glob GlobFunc) (net.Conn, error) {
 	return dial("unix", sf)
 }
 
+// socketFile returns the path to a file on a Linux or macOS host that conforms
+// to the naming convention for a Unix domain socket file given a process ID.
+// This file is used as a Unix domain socket endpoint to communicate with the
+// dotnet process. For more information, please see the README for this
+// receiver.
 func socketFile(pid int, tempdir string, glob GlobFunc) (string, error) {
 	f := fullGlob(pid, tempdir)
 	matches, err := glob(f)
@@ -60,6 +65,9 @@ func fullGlob(pid int, tempdir string) string {
 	return path.Join(tempdir, globPattern(pid))
 }
 
+// globPattern generates a glob pattern that conforms to the .NET diagnostics
+// naming convention for a Unix domain socket file for a given process ID. For
+// more information, please see the README for this receiver.
 func globPattern(pid int) string {
 	return fmt.Sprintf("dotnet-diagnostic-%d-*-socket", pid)
 }

--- a/receiver/dotnetdiagnosticsreceiver/network/net.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/net.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path"
+)
+
+type DialFunc func(network, address string) (net.Conn, error)
+
+type GlobFunc func(pattern string) (matches []string, err error)
+
+// Connect opens an IPC connection to a local dotnet process, given a PID. On
+// Mac/Linux, this is a Unix domain socket. Windows (TBD) will use a named pipe.
+// DialFunc and GlobFunc are swappable for testing.
+func Connect(pid int, dial DialFunc, glob GlobFunc) (net.Conn, error) {
+	tmpdir := os.Getenv("TMPDIR")
+	if tmpdir == "" {
+		tmpdir = "/tmp"
+	}
+	sf, err := socketFile(pid, tmpdir, glob)
+	if err != nil {
+		return nil, err
+	}
+	return dial("unix", sf)
+}
+
+func socketFile(pid int, tempdir string, glob GlobFunc) (string, error) {
+	f := fullGlob(pid, tempdir)
+	matches, err := glob(f)
+	if err != nil {
+		return "", err
+	}
+	l := len(matches)
+	switch {
+	case l == 0:
+		return "", fmt.Errorf("found no matches for pid %d", pid)
+	case l > 1:
+		return "", fmt.Errorf("found multiple matches for pid %d", pid)
+	}
+	return matches[0], nil
+}
+
+func fullGlob(pid int, tempdir string) string {
+	return path.Join(tempdir, globPattern(pid))
+}
+
+func globPattern(pid int) string {
+	return fmt.Sprintf("dotnet-diagnostic-%d-*-socket", pid)
+}

--- a/receiver/dotnetdiagnosticsreceiver/network/net_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/net_test.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"errors"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnect(t *testing.T) {
+	conn, err := Connect(1234, func(network, address string) (net.Conn, error) {
+		return nil, nil
+	}, testMatcher)
+	assert.NoError(t, err)
+	assert.Nil(t, conn)
+}
+
+func TestConnect_UnsetTMPDIR(t *testing.T) {
+	err := os.Setenv("TMPDIR", "")
+	require.NoError(t, err)
+	_, err = Connect(0, func(network, address string) (net.Conn, error) {
+		assert.True(t, strings.HasPrefix(address, "/tmp/"))
+		return nil, nil
+	}, testMatcher)
+	require.NoError(t, err)
+}
+
+func TestConnect_SocketFileErr(t *testing.T) {
+	_, err := Connect(0, nil, func(pattern string) (matches []string, err error) {
+		return nil, errors.New("foo")
+	})
+	require.EqualError(t, err, "foo")
+}
+
+func TestGlob(t *testing.T) {
+	glob := globPattern(1234)
+	assert.Equal(t, "dotnet-diagnostic-1234-*-socket", glob)
+}
+
+func TestSocketFile(t *testing.T) {
+	socketFile, err := socketFile(1234, "/tmp", testMatcher)
+	assert.NoError(t, err)
+	assert.Equal(t, "/tmp/dotnet-diagnostic-1234-*-socket", socketFile)
+}
+
+func TestSocketFile_Error(t *testing.T) {
+	_, err := socketFile(1234, "/tmp", testErrorMatcher)
+	assert.Error(t, err)
+}
+
+func TestSocketFile_NoMatches(t *testing.T) {
+	_, err := socketFile(1234, "/tmp", testNoResultsMatcher)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no matches")
+}
+
+func TestSocketFile_MultiMatches(t *testing.T) {
+	_, err := socketFile(1234, "/tmp", testMultiResultsMatcher)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple matches")
+}
+
+func testMatcher(pattern string) (matches []string, err error) {
+	return []string{pattern}, nil
+}
+
+func testErrorMatcher(pattern string) (matches []string, err error) {
+	return nil, errors.New("")
+}
+
+func testNoResultsMatcher(pattern string) (matches []string, err error) {
+	return nil, nil
+}
+
+func testMultiResultsMatcher(pattern string) (matches []string, err error) {
+	return []string{pattern, "foo"}, nil
+}

--- a/receiver/dotnetdiagnosticsreceiver/network/net_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/net_test.go
@@ -17,8 +17,6 @@ package network
 import (
 	"errors"
 	"net"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,16 +29,6 @@ func TestConnect(t *testing.T) {
 	}, testMatcher)
 	assert.NoError(t, err)
 	assert.Nil(t, conn)
-}
-
-func TestConnect_UnsetTMPDIR(t *testing.T) {
-	err := os.Setenv("TMPDIR", "")
-	require.NoError(t, err)
-	_, err = Connect(0, func(network, address string) (net.Conn, error) {
-		assert.True(t, strings.HasPrefix(address, "/tmp/"))
-		return nil, nil
-	}, testMatcher)
-	require.NoError(t, err)
 }
 
 func TestConnect_SocketFileErr(t *testing.T) {

--- a/receiver/dotnetdiagnosticsreceiver/network/writer.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/writer.go
@@ -22,6 +22,8 @@ import (
 
 var ByteOrder = binary.LittleEndian
 
+// Writes a length-prefixed, zero-terminated utf16 string to the passed-in
+// buffer
 func WriteUTF16String(buf *bytes.Buffer, s string) {
 	encoded := utf16.Encode([]rune(s))
 	_ = binary.Write(buf, ByteOrder, int32(len(encoded)+1))

--- a/receiver/dotnetdiagnosticsreceiver/network/writer.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/writer.go
@@ -15,35 +15,16 @@
 package network
 
 import (
+	"bytes"
 	"encoding/binary"
-	"io"
 	"unicode/utf16"
 )
 
 var ByteOrder = binary.LittleEndian
 
-// ByteBuffer is an interface extracted from bytes.Buffer so that it can be
-// swapped for testing.
-type ByteBuffer interface {
-	io.Writer
-	io.ByteWriter
-	Bytes() []byte
-	Len() int
-	Reset()
-}
-
-func WriteUTF16String(buf ByteBuffer, s string) error {
+func WriteUTF16String(buf *bytes.Buffer, s string) {
 	encoded := utf16.Encode([]rune(s))
-	err := binary.Write(buf, ByteOrder, int32(len(encoded)+1))
-	if err != nil {
-		return err
-	}
-
-	err = binary.Write(buf, ByteOrder, encoded)
-	if err != nil {
-		return err
-	}
-
-	_, err = buf.Write([]byte{0, 0})
-	return err
+	_ = binary.Write(buf, ByteOrder, int32(len(encoded)+1))
+	_ = binary.Write(buf, ByteOrder, encoded)
+	_, _ = buf.Write([]byte{0, 0})
 }

--- a/receiver/dotnetdiagnosticsreceiver/network/writer.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/writer.go
@@ -1,0 +1,49 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"encoding/binary"
+	"io"
+	"unicode/utf16"
+)
+
+var ByteOrder = binary.LittleEndian
+
+// ByteBuffer is an interface extracted from bytes.Buffer so that it can be
+// swapped for testing.
+type ByteBuffer interface {
+	io.Writer
+	io.ByteWriter
+	Bytes() []byte
+	Len() int
+	Reset()
+}
+
+func WriteUTF16String(buf ByteBuffer, s string) error {
+	encoded := utf16.Encode([]rune(s))
+	err := binary.Write(buf, ByteOrder, int32(len(encoded)+1))
+	if err != nil {
+		return err
+	}
+
+	err = binary.Write(buf, ByteOrder, encoded)
+	if err != nil {
+		return err
+	}
+
+	_, err = buf.Write([]byte{0, 0})
+	return err
+}

--- a/receiver/dotnetdiagnosticsreceiver/network/writer_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/writer_test.go
@@ -17,7 +17,6 @@ package network
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,57 +26,12 @@ import (
 func TestWriteUTF16String(t *testing.T) {
 	buf := &bytes.Buffer{}
 	const msg = "hello"
-	err := WriteUTF16String(buf, msg)
-	require.NoError(t, err)
+	WriteUTF16String(buf, msg)
 	p := buf.Bytes()
 	buf.Reset()
 	var size int32
-	err = binary.Read(bytes.NewBuffer(p[:4]), ByteOrder, &size)
+	err := binary.Read(bytes.NewBuffer(p[:4]), ByteOrder, &size)
 	require.NoError(t, err)
 	assert.Equal(t, len(msg)+1, int(size))
 	assert.Equal(t, 4+2*(len(msg)+1), len(p))
-}
-
-func TestWriteUTF16String_Errors(t *testing.T) {
-	for i := 0; i < 3; i++ {
-		err := WriteUTF16String(&fakeByteBuf{errOn: i}, "hello")
-		require.Error(t, err)
-	}
-}
-
-// fakeByteBuf
-type fakeByteBuf struct {
-	errOn int
-	i     int
-}
-
-var _ ByteBuffer = (*fakeByteBuf)(nil)
-
-func (b *fakeByteBuf) Write([]byte) (n int, err error) {
-	return 0, b.err()
-}
-
-func (b *fakeByteBuf) WriteByte(byte) error {
-	return b.err()
-}
-
-func (b *fakeByteBuf) err() error {
-	defer func() {
-		b.i++
-	}()
-	if b.i == b.errOn {
-		return errors.New("")
-	}
-	return nil
-}
-
-func (b *fakeByteBuf) Bytes() []byte {
-	return nil
-}
-
-func (b *fakeByteBuf) Len() int {
-	return 0
-}
-
-func (b *fakeByteBuf) Reset() {
 }

--- a/receiver/dotnetdiagnosticsreceiver/network/writer_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/writer_test.go
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteUTF16String(t *testing.T) {
+	buf := &bytes.Buffer{}
+	const msg = "hello"
+	err := WriteUTF16String(buf, msg)
+	require.NoError(t, err)
+	p := buf.Bytes()
+	buf.Reset()
+	var size int32
+	err = binary.Read(bytes.NewBuffer(p[:4]), ByteOrder, &size)
+	require.NoError(t, err)
+	assert.Equal(t, len(msg)+1, int(size))
+	assert.Equal(t, 4+2*(len(msg)+1), len(p))
+}
+
+func TestWriteUTF16String_Errors(t *testing.T) {
+	for i := 0; i < 3; i++ {
+		err := WriteUTF16String(&fakeByteBuf{errOn: i}, "hello")
+		require.Error(t, err)
+	}
+}
+
+// fakeByteBuf
+type fakeByteBuf struct {
+	errOn int
+	i     int
+}
+
+var _ ByteBuffer = (*fakeByteBuf)(nil)
+
+func (b *fakeByteBuf) Write([]byte) (n int, err error) {
+	return 0, b.err()
+}
+
+func (b *fakeByteBuf) WriteByte(byte) error {
+	return b.err()
+}
+
+func (b *fakeByteBuf) err() error {
+	defer func() {
+		b.i++
+	}()
+	if b.i == b.errOn {
+		return errors.New("")
+	}
+	return nil
+}
+
+func (b *fakeByteBuf) Bytes() []byte {
+	return nil
+}
+
+func (b *fakeByteBuf) Len() int {
+	return 0
+}
+
+func (b *fakeByteBuf) Reset() {
+}

--- a/receiver/dotnetdiagnosticsreceiver/receiver.go
+++ b/receiver/dotnetdiagnosticsreceiver/receiver.go
@@ -15,7 +15,6 @@
 package dotnetdiagnosticsreceiver
 
 import (
-	"bytes"
 	"context"
 	"io"
 
@@ -61,7 +60,7 @@ func (r *receiver) Start(ctx context.Context, host component.Host) error {
 		return err
 	}
 
-	w := dotnet.NewRequestWriter(&bytes.Buffer{}, conn, r.intervalSec, r.counters...)
+	w := dotnet.NewRequestWriter(conn, r.intervalSec, r.counters...)
 	err = w.SendRequest()
 	if err != nil {
 		return err

--- a/receiver/dotnetdiagnosticsreceiver/receiver.go
+++ b/receiver/dotnetdiagnosticsreceiver/receiver.go
@@ -15,44 +15,58 @@
 package dotnetdiagnosticsreceiver
 
 import (
+	"bytes"
 	"context"
-	"net"
-	"time"
+	"io"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/dotnet"
 )
 
 type receiver struct {
-	logger             *zap.Logger
-	nextConsumer       consumer.MetricsConsumer
-	counters           []string
-	collectionInterval time.Duration
-	connect            connectionSupplier
+	nextConsumer consumer.MetricsConsumer
+	connect      connectionSupplier
+	counters     []string
+	intervalSec  int
+	logger       *zap.Logger
 }
 
-var _ = (component.MetricsReceiver)(nil)
+type connectionSupplier func() (io.ReadWriter, error)
 
+// NewReceiver creates a new receiver. connectionSupplier is swappable for
+// testing.
 func NewReceiver(
 	_ context.Context,
-	logger *zap.Logger,
-	cfg *Config,
 	mc consumer.MetricsConsumer,
 	connect connectionSupplier,
+	counters []string,
+	intervalSec int,
+	logger *zap.Logger,
 ) (component.MetricsReceiver, error) {
 	return &receiver{
-		logger:             logger,
-		nextConsumer:       mc,
-		counters:           cfg.Counters,
-		collectionInterval: cfg.CollectionInterval,
-		connect:            connect,
+		nextConsumer: mc,
+		connect:      connect,
+		counters:     counters,
+		intervalSec:  intervalSec,
+		logger:       logger,
 	}, nil
 }
 
-type connectionSupplier func() (net.Conn, error)
-
 func (r *receiver) Start(ctx context.Context, host component.Host) error {
+	conn, err := r.connect()
+	if err != nil {
+		return err
+	}
+
+	w := dotnet.NewRequestWriter(&bytes.Buffer{}, conn, r.intervalSec, r.counters...)
+	err = w.SendRequest()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/receiver/dotnetdiagnosticsreceiver/receiver_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/receiver_test.go
@@ -16,7 +16,8 @@ package dotnetdiagnosticsreceiver
 
 import (
 	"context"
-	"net"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,20 +28,81 @@ import (
 
 func TestReceiver(t *testing.T) {
 	ctx := context.Background()
+	rw := &fakeRW{writeErrOn: -1}
 	r, err := NewReceiver(
 		ctx,
-		zap.NewNop(),
-		createDefaultConfig().(*Config),
 		consumertest.NewMetricsNop(),
-		fakeConnect,
+		func() (io.ReadWriter, error) {
+			return rw, nil
+		},
+		nil,
+		1,
+		zap.NewNop(),
 	)
 	require.NoError(t, err)
 	err = r.Start(ctx, componenttest.NewNopHost())
 	require.NoError(t, err)
 	err = r.Shutdown(ctx)
 	require.NoError(t, err)
+	const magic = "DOTNET_IPC_V1"
+	magicBytes := rw.writeBuf[:len(magic)]
+	require.Equal(t, magic, string(magicBytes))
 }
 
-func fakeConnect() (net.Conn, error) {
-	return nil, nil
+func TestReceiver_ConnectError(t *testing.T) {
+	ctx := context.Background()
+	r, err := NewReceiver(
+		ctx,
+		consumertest.NewMetricsNop(),
+		func() (io.ReadWriter, error) {
+			return nil, errors.New("")
+		},
+		nil,
+		1,
+		zap.NewNop(),
+	)
+	require.NoError(t, err)
+	err = r.Start(ctx, componenttest.NewNopHost())
+	require.Error(t, err)
+}
+
+func TestReceiver_WriteRequestError(t *testing.T) {
+	ctx := context.Background()
+	rw := &fakeRW{}
+	r, err := NewReceiver(
+		ctx,
+		consumertest.NewMetricsNop(),
+		func() (io.ReadWriter, error) {
+			return rw, nil
+		},
+		nil,
+		1,
+		zap.NewNop(),
+	)
+	require.NoError(t, err)
+	err = r.Start(ctx, componenttest.NewNopHost())
+	require.Error(t, err)
+}
+
+type fakeRW struct {
+	writeErrOn int
+	writeBuf   []byte
+	writeCount int
+}
+
+var _ io.ReadWriter = (*fakeRW)(nil)
+
+func (rw *fakeRW) Write(p []byte) (n int, err error) {
+	defer func() {
+		rw.writeCount++
+	}()
+	if rw.writeCount == rw.writeErrOn {
+		return 0, errors.New("")
+	}
+	rw.writeBuf = append(rw.writeBuf, p...)
+	return len(p), nil
+}
+
+func (rw *fakeRW) Read(p []byte) (n int, err error) {
+	return len(p), nil
 }


### PR DESCRIPTION
This is the second PR in a series for the dotnet core diagnostics receiver.

This PR does the initial request made by the receiver to the dotnet process to start it sending metrics over IPC.

For the full implementation please see #2200