### PR TITLE
[processors/resourcedetection]: fix resource attribute env var

### DIFF
--- a/exporter/datadogexporter/example/example_k8s_manifest.yaml
+++ b/exporter/datadogexporter/example/example_k8s_manifest.yaml
@@ -122,7 +122,7 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
             # This is picked up by the resource detector
-          - name: OTEL_RESOURCE
+          - name: OTEL_RESOURCE_ATTRIBUTES
             value: "k8s.pod.ip=$(POD_IP)"
         volumeMounts:
         - name: otel-agent-config-vol

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -8,7 +8,7 @@ override the resource value in telemetry data with this information.
 
 Currently supported detectors include:
 
-* Environment Variable: Reads resource information from the `OTEL_RESOURCE` environment
+* Environment Variable: Reads resource information from the `OTEL_RESOURCE_ATTRIBUTES` environment
 variable. This is expected to be in the format `<key1>=<value1>,<key2>=<value2>,...`, the
 details of which are currently pending confirmation in the OpenTelemetry specification.
 

--- a/processor/resourcedetectionprocessor/internal/env/env.go
+++ b/processor/resourcedetectionprocessor/internal/env/env.go
@@ -35,7 +35,13 @@ import (
 const TypeStr = "env"
 
 // Environment variable used by "env" to decode a resource.
-const envVar = "OTEL_RESOURCE"
+const envVar = "OTEL_RESOURCE_ATTRIBUTES"
+
+// Deprecated environment variable used by "env" to decode a resource.
+// Specification states to use OTEL_RESOURCE_ATTRIBUTES however to avoid
+// breaking existing usage, maintain support for OTEL_RESOURCE
+// https://github.com/open-telemetry/opentelemetry-specification/blob/1afab39e5658f807315abf2f3256809293bfd421/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable
+const deprecatedEnvVar = "OTEL_RESOURCE"
 
 var _ internal.Detector = (*Detector)(nil)
 
@@ -50,7 +56,10 @@ func (d *Detector) Detect(context.Context) (pdata.Resource, error) {
 
 	labels := strings.TrimSpace(os.Getenv(envVar))
 	if labels == "" {
-		return res, nil
+		labels = strings.TrimSpace(os.Getenv(deprecatedEnvVar))
+		if labels == "" {
+			return res, nil
+		}
 	}
 
 	err := initializeAttributeMap(res.Attributes(), labels)

--- a/processor/resourcedetectionprocessor/internal/env/env_test.go
+++ b/processor/resourcedetectionprocessor/internal/env/env_test.go
@@ -52,6 +52,16 @@ func TestDetectFalse(t *testing.T) {
 	assert.True(t, internal.IsEmptyResource(res))
 }
 
+func TestDetectDeprecatedEnv(t *testing.T) {
+	os.Setenv(envVar, "")
+	os.Setenv(deprecatedEnvVar, "key=value")
+
+	detector := &Detector{}
+	res, err := detector.Detect(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, internal.NewResource(map[string]interface{}{"key": "value"}), res)
+}
+
 func TestDetectError(t *testing.T) {
 	os.Setenv(envVar, "key=value,key")
 


### PR DESCRIPTION


**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fixes  resource attribute env var docs and usage to [match specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable) but maintains backward compatibility because breaking things for no reason is a bad user experience.

**Link to tracking Issue:** <Issue number if applicable> No issue, discussed in slack ™️ (a salesforce company) with @jrcamp 

**Testing:** <Describe what testing was performed and which tests were added.> Added unit test to ensure fallback env var is supported.

**Documentation:** <Describe the documentation added.> Updated docs as well as other contrib docs (from datadogexporter, who i am employee of so i am fine with these changes).