### PR TITLE
sumologicexporter: add support for all types of log body

### DIFF
--- a/exporter/sumologicexporter/exporter.go
+++ b/exporter/sumologicexporter/exporter.go
@@ -141,8 +141,8 @@ func newMetricsExporter(
 // so they can be handled by OTC retry mechanism
 func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) (int, error) {
 	var (
-		currentMetadata  fields
-		previousMetadata fields
+		currentMetadata  fields = newFields()
+		previousMetadata fields = newFields()
 		errs             []error
 		droppedRecords   []pdata.LogRecord
 		err              error
@@ -236,8 +236,8 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) (i
 // so they can be handle by the OTC retry mechanism
 func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metrics) (int, error) {
 	var (
-		currentMetadata  fields
-		previousMetadata fields
+		currentMetadata  fields = newFields()
+		previousMetadata fields = newFields()
 		errs             []error
 		droppedRecords   []metricPair
 		attributes       pdata.AttributeMap

--- a/exporter/sumologicexporter/exporter.go
+++ b/exporter/sumologicexporter/exporter.go
@@ -141,8 +141,8 @@ func newMetricsExporter(
 // so they can be handled by OTC retry mechanism
 func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) (int, error) {
 	var (
-		currentMetadata  fields = newFields()
-		previousMetadata fields = newFields()
+		currentMetadata  fields = newFields(pdata.NewAttributeMap())
+		previousMetadata fields = newFields(pdata.NewAttributeMap())
 		errs             []error
 		droppedRecords   []pdata.LogRecord
 		err              error
@@ -236,8 +236,8 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld pdata.Logs) (i
 // so they can be handle by the OTC retry mechanism
 func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pdata.Metrics) (int, error) {
 	var (
-		currentMetadata  fields = newFields()
-		previousMetadata fields = newFields()
+		currentMetadata  fields = newFields(pdata.NewAttributeMap())
+		previousMetadata fields = newFields(pdata.NewAttributeMap())
 		errs             []error
 		droppedRecords   []metricPair
 		attributes       pdata.AttributeMap

--- a/exporter/sumologicexporter/fields.go
+++ b/exporter/sumologicexporter/fields.go
@@ -18,27 +18,27 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
 // fields represents metadata
-type fields map[string]string
+type fields struct {
+	orig pdata.AttributeMap
+}
+
+func newFields() fields {
+	return fields{orig: pdata.NewAttributeMap()}
+}
 
 // string returns fields as ordered key=value string with `, ` as separator
 func (f fields) string() string {
-	rv := make([]string, 0, len(f))
-	for k, v := range f {
-		rv = append(rv, fmt.Sprintf("%s=%s", k, v))
-	}
-	sort.Strings(rv)
+	returnValue := make([]string, 0, f.orig.Len())
+	f.orig.ForEach(func(k string, v pdata.AttributeValue) {
+		returnValue = append(returnValue, fmt.Sprintf("%s=%s", k, tracetranslator.AttributeValueToString(v, false)))
+	})
+	sort.Strings(returnValue)
 
-	return strings.Join(rv, ", ")
-}
-
-func (f fields) asInterfaceMap() map[string]interface{} {
-	rv := make(map[string]interface{}, len(f))
-
-	for k, v := range f {
-		rv[k] = v
-	}
-	return rv
+	return strings.Join(returnValue, ", ")
 }

--- a/exporter/sumologicexporter/fields.go
+++ b/exporter/sumologicexporter/fields.go
@@ -33,3 +33,12 @@ func (f fields) string() string {
 
 	return strings.Join(rv, ", ")
 }
+
+func (f fields) asInterfaceMap() map[string]interface{} {
+	rv := make(map[string]interface{}, len(f))
+
+	for k, v := range f {
+		rv[k] = v
+	}
+	return rv
+}

--- a/exporter/sumologicexporter/fields_test.go
+++ b/exporter/sumologicexporter/fields_test.go
@@ -22,11 +22,11 @@ import (
 
 func TestFieldsAsString(t *testing.T) {
 	expected := "key1=value1, key2=value2, key3=value3"
-	flds := fields{
+	flds := fieldsFromMap(map[string]string{
 		"key1": "value1",
 		"key3": "value3",
 		"key2": "value2",
-	}
+	})
 
 	assert.Equal(t, expected, flds.string())
 }

--- a/exporter/sumologicexporter/fields_test.go
+++ b/exporter/sumologicexporter/fields_test.go
@@ -30,3 +30,14 @@ func TestFieldsAsString(t *testing.T) {
 
 	assert.Equal(t, expected, flds.string())
 }
+
+func TestFieldsSanitization(t *testing.T) {
+	expected := "key1=value_1, key3=value_3, key__2=valu_e_2"
+	flds := fieldsFromMap(map[string]string{
+		"key1":   "value,1",
+		"key3":   "value\n3",
+		"key=,2": "valu,e=2",
+	})
+
+	assert.Equal(t, expected, flds.string())
+}

--- a/exporter/sumologicexporter/filter.go
+++ b/exporter/sumologicexporter/filter.go
@@ -18,7 +18,6 @@ import (
 	"regexp"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
 type filter struct {
@@ -44,22 +43,23 @@ func newFilter(flds []string) (filter, error) {
 
 // filterIn returns fields which match at least one of the filter regexes
 func (f *filter) filterIn(attributes pdata.AttributeMap) fields {
-	returnValue := make(fields)
+	returnValue := pdata.NewAttributeMap()
 
 	attributes.ForEach(func(k string, v pdata.AttributeValue) {
 		for _, regex := range f.regexes {
 			if regex.MatchString(k) {
-				returnValue[k] = tracetranslator.AttributeValueToString(v, false)
+				returnValue.Insert(k, v)
 				return
 			}
 		}
 	})
-	return returnValue
+	returnValue.Sort()
+	return fields{orig: returnValue}
 }
 
 // filterOut returns fields which don't match any of the filter regexes
 func (f *filter) filterOut(attributes pdata.AttributeMap) fields {
-	returnValue := make(fields)
+	returnValue := pdata.NewAttributeMap()
 
 	attributes.ForEach(func(k string, v pdata.AttributeValue) {
 		for _, regex := range f.regexes {
@@ -67,7 +67,8 @@ func (f *filter) filterOut(attributes pdata.AttributeMap) fields {
 				return
 			}
 		}
-		returnValue[k] = tracetranslator.AttributeValueToString(v, false)
+		returnValue.Insert(k, v)
 	})
-	return returnValue
+	returnValue.Sort()
+	return fields{orig: returnValue}
 }

--- a/exporter/sumologicexporter/filter.go
+++ b/exporter/sumologicexporter/filter.go
@@ -54,7 +54,7 @@ func (f *filter) filterIn(attributes pdata.AttributeMap) fields {
 		}
 	})
 	returnValue.Sort()
-	return fields{orig: returnValue}
+	return newFields(returnValue)
 }
 
 // filterOut returns fields which don't match any of the filter regexes
@@ -70,5 +70,5 @@ func (f *filter) filterOut(attributes pdata.AttributeMap) fields {
 		returnValue.Insert(k, v)
 	})
 	returnValue.Sort()
-	return fields{orig: returnValue}
+	return newFields(returnValue)
 }

--- a/exporter/sumologicexporter/filter_test.go
+++ b/exporter/sumologicexporter/filter_test.go
@@ -35,7 +35,11 @@ func TestGetMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	metadata := f.filterIn(attributes)
-	expected := fields{"key1": "value1", "key2": "value2", "key3": "value3"}
+	expected := fieldsFromMap(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	})
 	assert.Equal(t, expected, metadata)
 }
 
@@ -52,9 +56,9 @@ func TestFilterOutMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	data := f.filterOut(attributes)
-	expected := fields{
+	expected := fieldsFromMap(map[string]string{
 		"additional_key2": "value2",
 		"additional_key3": "value3",
-	}
+	})
 	assert.Equal(t, expected, data)
 }

--- a/exporter/sumologicexporter/filter_test.go
+++ b/exporter/sumologicexporter/filter_test.go
@@ -40,7 +40,8 @@ func TestGetMetadata(t *testing.T) {
 		"key2": "value2",
 		"key3": "value3",
 	})
-	assert.Equal(t, expected, metadata)
+	// Use string() because object comparison has not been reliable
+	assert.Equal(t, expected.string(), metadata.string())
 }
 
 func TestFilterOutMetadata(t *testing.T) {
@@ -60,5 +61,6 @@ func TestFilterOutMetadata(t *testing.T) {
 		"additional_key2": "value2",
 		"additional_key3": "value3",
 	})
-	assert.Equal(t, expected, data)
+	// Use string() because object comparison has not been reliable
+	assert.Equal(t, expected.string(), data.string())
 }

--- a/exporter/sumologicexporter/sender.go
+++ b/exporter/sumologicexporter/sender.go
@@ -165,18 +165,10 @@ func (s *sender) logToText(record pdata.LogRecord) string {
 
 // logToJSON converts LogRecord to a json line, returns it and error eventually
 func (s *sender) logToJSON(record pdata.LogRecord) (string, error) {
-	data := s.filter.filterOut(record.Attributes()).asInterfaceMap()
-	body := record.Body()
-	switch body.Type() {
-	case pdata.AttributeValueMAP:
-		data[logKey] = tracetranslator.AttributeMapToMap(body.MapVal())
-	case pdata.AttributeValueARRAY:
-		data[logKey] = tracetranslator.AttributeArrayToSlice(body.ArrayVal())
-	default:
-		data[logKey] = tracetranslator.AttributeValueToString(body, false)
-	}
+	data := s.filter.filterOut(record.Attributes())
+	data.orig.Upsert(logKey, record.Body())
 
-	nextLine, err := json.Marshal(data)
+	nextLine, err := json.Marshal(tracetranslator.AttributeMapToMap(data.orig))
 	if err != nil {
 		return "", err
 	}

--- a/exporter/sumologicexporter/sender_test.go
+++ b/exporter/sumologicexporter/sender_test.go
@@ -178,7 +178,7 @@ func TestSendLogs(t *testing.T) {
 
 	test.s.logBuffer = exampleTwoLogs()
 
-	_, err := test.s.sendLogs(context.Background(), fields{"key1": "value", "key2": "value2"})
+	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
 	assert.NoError(t, err)
 }
 
@@ -198,7 +198,7 @@ func TestSendLogsMultitype(t *testing.T) {
 
 	test.s.logBuffer = exampleMultitypeLogs()
 
-	_, err := test.s.sendLogs(context.Background(), fields{"key1": "value", "key2": "value2"})
+	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "value", "key2": "value2"}))
 	assert.NoError(t, err)
 }
 
@@ -217,7 +217,7 @@ func TestSendLogsSplit(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = exampleTwoLogs()
 
-	_, err := test.s.sendLogs(context.Background(), fields{})
+	_, err := test.s.sendLogs(context.Background(), newFields())
 	assert.NoError(t, err)
 }
 func TestSendLogsSplitFailedOne(t *testing.T) {
@@ -238,7 +238,7 @@ func TestSendLogsSplitFailedOne(t *testing.T) {
 	test.s.config.LogFormat = TextFormat
 	test.s.logBuffer = exampleTwoLogs()
 
-	dropped, err := test.s.sendLogs(context.Background(), fields{})
+	dropped, err := test.s.sendLogs(context.Background(), newFields())
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 	assert.Equal(t, test.s.logBuffer[0:1], dropped)
 }
@@ -263,7 +263,7 @@ func TestSendLogsSplitFailedAll(t *testing.T) {
 	test.s.config.LogFormat = TextFormat
 	test.s.logBuffer = exampleTwoLogs()
 
-	dropped, err := test.s.sendLogs(context.Background(), fields{})
+	dropped, err := test.s.sendLogs(context.Background(), newFields())
 	assert.EqualError(
 		t,
 		err,
@@ -288,7 +288,7 @@ func TestSendLogsJson(t *testing.T) {
 	test.s.config.LogFormat = JSONFormat
 	test.s.logBuffer = exampleTwoLogs()
 
-	_, err := test.s.sendLogs(context.Background(), fields{"key": "value"})
+	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
 	assert.NoError(t, err)
 }
 
@@ -308,7 +308,7 @@ func TestSendLogsJsonMultitype(t *testing.T) {
 	test.s.config.LogFormat = JSONFormat
 	test.s.logBuffer = exampleMultitypeLogs()
 
-	_, err := test.s.sendLogs(context.Background(), fields{"key": "value"})
+	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key": "value"}))
 	assert.NoError(t, err)
 }
 
@@ -328,7 +328,7 @@ func TestSendLogsJsonSplit(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = exampleTwoLogs()
 
-	_, err := test.s.sendLogs(context.Background(), fields{})
+	_, err := test.s.sendLogs(context.Background(), newFields())
 	assert.NoError(t, err)
 }
 
@@ -350,7 +350,7 @@ func TestSendLogsJsonSplitFailedOne(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = exampleTwoLogs()
 
-	dropped, err := test.s.sendLogs(context.Background(), fields{})
+	dropped, err := test.s.sendLogs(context.Background(), newFields())
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 	assert.Equal(t, test.s.logBuffer[0:1], dropped)
 }
@@ -375,7 +375,7 @@ func TestSendLogsJsonSplitFailedAll(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = exampleTwoLogs()
 
-	dropped, err := test.s.sendLogs(context.Background(), fields{})
+	dropped, err := test.s.sendLogs(context.Background(), newFields())
 	assert.EqualError(
 		t,
 		err,
@@ -394,7 +394,7 @@ func TestSendLogsUnexpectedFormat(t *testing.T) {
 	logs := exampleTwoLogs()
 	test.s.logBuffer = logs
 
-	dropped, err := test.s.sendLogs(context.Background(), fields{})
+	dropped, err := test.s.sendLogs(context.Background(), newFields())
 	assert.Error(t, err)
 	assert.Equal(t, logs, dropped)
 }
@@ -410,7 +410,7 @@ func TestOverrideSourceName(t *testing.T) {
 	test.s.sources.name = getTestSourceFormat(t, "Test source name/%{key1}")
 	test.s.logBuffer = exampleLog()
 
-	_, err := test.s.sendLogs(context.Background(), fields{"key1": "test_name"})
+	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 	assert.NoError(t, err)
 }
 
@@ -425,7 +425,7 @@ func TestOverrideSourceCategory(t *testing.T) {
 	test.s.sources.category = getTestSourceFormat(t, "Test source category/%{key1}")
 	test.s.logBuffer = exampleLog()
 
-	_, err := test.s.sendLogs(context.Background(), fields{"key1": "test_name"})
+	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 	assert.NoError(t, err)
 }
 
@@ -440,7 +440,7 @@ func TestOverrideSourceHost(t *testing.T) {
 	test.s.sources.host = getTestSourceFormat(t, "Test source host/%{key1}")
 	test.s.logBuffer = exampleLog()
 
-	_, err := test.s.sendLogs(context.Background(), fields{"key1": "test_name"})
+	_, err := test.s.sendLogs(context.Background(), fieldsFromMap(map[string]string{"key1": "test_name"}))
 	assert.NoError(t, err)
 }
 
@@ -451,13 +451,13 @@ func TestLogsBuffer(t *testing.T) {
 	assert.Equal(t, test.s.countLogs(), 0)
 	logs := exampleTwoLogs()
 
-	droppedLogs, err := test.s.batchLog(context.Background(), logs[0], fields{})
+	droppedLogs, err := test.s.batchLog(context.Background(), logs[0], newFields())
 	require.NoError(t, err)
 	assert.Nil(t, droppedLogs)
 	assert.Equal(t, 1, test.s.countLogs())
 	assert.Equal(t, []pdata.LogRecord{logs[0]}, test.s.logBuffer)
 
-	droppedLogs, err = test.s.batchLog(context.Background(), logs[1], fields{})
+	droppedLogs, err = test.s.batchLog(context.Background(), logs[1], newFields())
 	require.NoError(t, err)
 	assert.Nil(t, droppedLogs)
 	assert.Equal(t, 2, test.s.countLogs())
@@ -475,7 +475,7 @@ func TestInvalidEndpoint(t *testing.T) {
 	test.s.config.HTTPClientSettings.Endpoint = ":"
 	test.s.logBuffer = exampleLog()
 
-	_, err := test.s.sendLogs(context.Background(), fields{})
+	_, err := test.s.sendLogs(context.Background(), newFields())
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
 }
 
@@ -486,7 +486,7 @@ func TestInvalidPostRequest(t *testing.T) {
 	test.s.config.HTTPClientSettings.Endpoint = ""
 	test.s.logBuffer = exampleLog()
 
-	_, err := test.s.sendLogs(context.Background(), fields{})
+	_, err := test.s.sendLogs(context.Background(), newFields())
 	assert.EqualError(t, err, `Post "": unsupported protocol scheme ""`)
 }
 
@@ -498,11 +498,11 @@ func TestLogsBufferOverflow(t *testing.T) {
 	log := exampleLog()
 
 	for test.s.countLogs() < maxBufferSize-1 {
-		_, err := test.s.batchLog(context.Background(), log[0], fields{})
+		_, err := test.s.batchLog(context.Background(), log[0], newFields())
 		require.NoError(t, err)
 	}
 
-	_, err := test.s.batchLog(context.Background(), log[0], fields{})
+	_, err := test.s.batchLog(context.Background(), log[0], newFields())
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
 	assert.Equal(t, 0, test.s.countLogs())
 }
@@ -513,7 +513,7 @@ func TestInvalidMetricFormat(t *testing.T) {
 
 	test.s.config.MetricFormat = "invalid"
 
-	err := test.s.send(context.Background(), MetricsPipeline, strings.NewReader(""), fields{})
+	err := test.s.send(context.Background(), MetricsPipeline, strings.NewReader(""), newFields())
 	assert.EqualError(t, err, `unsupported metrics format: invalid`)
 }
 
@@ -521,7 +521,7 @@ func TestInvalidPipeline(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 	defer func() { test.srv.Close() }()
 
-	err := test.s.send(context.Background(), "invalidPipeline", strings.NewReader(""), fields{})
+	err := test.s.send(context.Background(), "invalidPipeline", strings.NewReader(""), newFields())
 	assert.EqualError(t, err, `unexpected pipeline`)
 }
 
@@ -545,7 +545,7 @@ func TestSendCompressGzip(t *testing.T) {
 	test.s.compressor = c
 	reader := strings.NewReader("Some example log")
 
-	err = test.s.send(context.Background(), LogsPipeline, reader, fields{})
+	err = test.s.send(context.Background(), LogsPipeline, reader, newFields())
 	require.NoError(t, err)
 }
 
@@ -569,7 +569,7 @@ func TestSendCompressDeflate(t *testing.T) {
 	test.s.compressor = c
 	reader := strings.NewReader("Some example log")
 
-	err = test.s.send(context.Background(), LogsPipeline, reader, fields{})
+	err = test.s.send(context.Background(), LogsPipeline, reader, newFields())
 	require.NoError(t, err)
 }
 
@@ -580,7 +580,7 @@ func TestCompressionError(t *testing.T) {
 	test.s.compressor = getTestCompressor(errors.New("read error"), nil)
 	reader := strings.NewReader("Some example log")
 
-	err := test.s.send(context.Background(), LogsPipeline, reader, fields{})
+	err := test.s.send(context.Background(), LogsPipeline, reader, newFields())
 	assert.EqualError(t, err, "read error")
 }
 
@@ -591,7 +591,7 @@ func TestInvalidContentEncoding(t *testing.T) {
 	test.s.config.CompressEncoding = "test"
 	reader := strings.NewReader("Some example log")
 
-	err := test.s.send(context.Background(), LogsPipeline, reader, fields{})
+	err := test.s.send(context.Background(), LogsPipeline, reader, newFields())
 	assert.EqualError(t, err, "invalid content encoding: test")
 }
 
@@ -608,13 +608,17 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		},
 	})
 	defer func() { test.srv.Close() }()
+	flds := fieldsFromMap(map[string]string{
+		"key1": "value",
+		"key2": "value2",
+	})
 
 	test.s.config.MetricFormat = PrometheusFormat
 	test.s.metricBuffer = []metricPair{
 		exampleIntMetric(),
 		exampleIntGaugeMetric(),
 	}
-	_, err := test.s.sendMetrics(context.Background(), fields{"key1": "value", "key2": "value2"})
+	_, err := test.s.sendMetrics(context.Background(), flds)
 	assert.NoError(t, err)
 }
 
@@ -640,7 +644,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntGaugeMetric(),
 	}
 
-	_, err := test.s.sendMetrics(context.Background(), fields{})
+	_, err := test.s.sendMetrics(context.Background(), newFields())
 	assert.NoError(t, err)
 }
 
@@ -668,7 +672,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntGaugeMetric(),
 	}
 
-	dropped, err := test.s.sendMetrics(context.Background(), fields{})
+	dropped, err := test.s.sendMetrics(context.Background(), newFields())
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 	assert.Equal(t, test.s.metricBuffer[0:1], dropped)
 }
@@ -699,7 +703,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntGaugeMetric(),
 	}
 
-	dropped, err := test.s.sendMetrics(context.Background(), fields{})
+	dropped, err := test.s.sendMetrics(context.Background(), newFields())
 	assert.EqualError(
 		t,
 		err,
@@ -720,7 +724,7 @@ func TestSendMetricsUnexpectedFormat(t *testing.T) {
 	}
 	test.s.metricBuffer = metrics
 
-	dropped, err := test.s.sendMetrics(context.Background(), fields{})
+	dropped, err := test.s.sendMetrics(context.Background(), newFields())
 	assert.EqualError(t, err, "unexpected metric format: invalid")
 	assert.Equal(t, dropped, metrics)
 }
@@ -735,13 +739,13 @@ func TestMetricsBuffer(t *testing.T) {
 		exampleIntGaugeMetric(),
 	}
 
-	droppedMetrics, err := test.s.batchMetric(context.Background(), metrics[0], fields{})
+	droppedMetrics, err := test.s.batchMetric(context.Background(), metrics[0], newFields())
 	require.NoError(t, err)
 	assert.Nil(t, droppedMetrics)
 	assert.Equal(t, 1, test.s.countMetrics())
 	assert.Equal(t, metrics[0:1], test.s.metricBuffer)
 
-	droppedMetrics, err = test.s.batchMetric(context.Background(), metrics[1], fields{})
+	droppedMetrics, err = test.s.batchMetric(context.Background(), metrics[1], newFields())
 	require.NoError(t, err)
 	assert.Nil(t, droppedMetrics)
 	assert.Equal(t, 2, test.s.countMetrics())
@@ -763,11 +767,11 @@ func TestMetricsBufferOverflow(t *testing.T) {
 	metric := exampleIntMetric()
 
 	for test.s.countMetrics() < maxBufferSize-1 {
-		_, err := test.s.batchMetric(context.Background(), metric, fields{})
+		_, err := test.s.batchMetric(context.Background(), metric, newFields())
 		require.NoError(t, err)
 	}
 
-	_, err := test.s.batchMetric(context.Background(), metric, fields{})
+	_, err := test.s.batchMetric(context.Background(), metric, newFields())
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
 	assert.Equal(t, 0, test.s.countMetrics())
 }

--- a/exporter/sumologicexporter/sender_test.go
+++ b/exporter/sumologicexporter/sender_test.go
@@ -217,7 +217,7 @@ func TestSendLogsSplit(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = exampleTwoLogs()
 
-	_, err := test.s.sendLogs(context.Background(), newFields())
+	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
 }
 func TestSendLogsSplitFailedOne(t *testing.T) {
@@ -238,7 +238,7 @@ func TestSendLogsSplitFailedOne(t *testing.T) {
 	test.s.config.LogFormat = TextFormat
 	test.s.logBuffer = exampleTwoLogs()
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields())
+	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 	assert.Equal(t, test.s.logBuffer[0:1], dropped)
 }
@@ -263,7 +263,7 @@ func TestSendLogsSplitFailedAll(t *testing.T) {
 	test.s.config.LogFormat = TextFormat
 	test.s.logBuffer = exampleTwoLogs()
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields())
+	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
 		t,
 		err,
@@ -328,7 +328,7 @@ func TestSendLogsJsonSplit(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = exampleTwoLogs()
 
-	_, err := test.s.sendLogs(context.Background(), newFields())
+	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
 }
 
@@ -350,7 +350,7 @@ func TestSendLogsJsonSplitFailedOne(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = exampleTwoLogs()
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields())
+	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 	assert.Equal(t, test.s.logBuffer[0:1], dropped)
 }
@@ -375,7 +375,7 @@ func TestSendLogsJsonSplitFailedAll(t *testing.T) {
 	test.s.config.MaxRequestBodySize = 10
 	test.s.logBuffer = exampleTwoLogs()
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields())
+	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
 		t,
 		err,
@@ -394,7 +394,7 @@ func TestSendLogsUnexpectedFormat(t *testing.T) {
 	logs := exampleTwoLogs()
 	test.s.logBuffer = logs
 
-	dropped, err := test.s.sendLogs(context.Background(), newFields())
+	dropped, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.Error(t, err)
 	assert.Equal(t, logs, dropped)
 }
@@ -451,13 +451,13 @@ func TestLogsBuffer(t *testing.T) {
 	assert.Equal(t, test.s.countLogs(), 0)
 	logs := exampleTwoLogs()
 
-	droppedLogs, err := test.s.batchLog(context.Background(), logs[0], newFields())
+	droppedLogs, err := test.s.batchLog(context.Background(), logs[0], newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
 	assert.Nil(t, droppedLogs)
 	assert.Equal(t, 1, test.s.countLogs())
 	assert.Equal(t, []pdata.LogRecord{logs[0]}, test.s.logBuffer)
 
-	droppedLogs, err = test.s.batchLog(context.Background(), logs[1], newFields())
+	droppedLogs, err = test.s.batchLog(context.Background(), logs[1], newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
 	assert.Nil(t, droppedLogs)
 	assert.Equal(t, 2, test.s.countLogs())
@@ -475,7 +475,7 @@ func TestInvalidEndpoint(t *testing.T) {
 	test.s.config.HTTPClientSettings.Endpoint = ":"
 	test.s.logBuffer = exampleLog()
 
-	_, err := test.s.sendLogs(context.Background(), newFields())
+	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
 }
 
@@ -486,7 +486,7 @@ func TestInvalidPostRequest(t *testing.T) {
 	test.s.config.HTTPClientSettings.Endpoint = ""
 	test.s.logBuffer = exampleLog()
 
-	_, err := test.s.sendLogs(context.Background(), newFields())
+	_, err := test.s.sendLogs(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `Post "": unsupported protocol scheme ""`)
 }
 
@@ -498,11 +498,11 @@ func TestLogsBufferOverflow(t *testing.T) {
 	log := exampleLog()
 
 	for test.s.countLogs() < maxBufferSize-1 {
-		_, err := test.s.batchLog(context.Background(), log[0], newFields())
+		_, err := test.s.batchLog(context.Background(), log[0], newFields(pdata.NewAttributeMap()))
 		require.NoError(t, err)
 	}
 
-	_, err := test.s.batchLog(context.Background(), log[0], newFields())
+	_, err := test.s.batchLog(context.Background(), log[0], newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
 	assert.Equal(t, 0, test.s.countLogs())
 }
@@ -513,7 +513,7 @@ func TestInvalidMetricFormat(t *testing.T) {
 
 	test.s.config.MetricFormat = "invalid"
 
-	err := test.s.send(context.Background(), MetricsPipeline, strings.NewReader(""), newFields())
+	err := test.s.send(context.Background(), MetricsPipeline, strings.NewReader(""), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `unsupported metrics format: invalid`)
 }
 
@@ -521,7 +521,7 @@ func TestInvalidPipeline(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){})
 	defer func() { test.srv.Close() }()
 
-	err := test.s.send(context.Background(), "invalidPipeline", strings.NewReader(""), newFields())
+	err := test.s.send(context.Background(), "invalidPipeline", strings.NewReader(""), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `unexpected pipeline`)
 }
 
@@ -545,7 +545,7 @@ func TestSendCompressGzip(t *testing.T) {
 	test.s.compressor = c
 	reader := strings.NewReader("Some example log")
 
-	err = test.s.send(context.Background(), LogsPipeline, reader, newFields())
+	err = test.s.send(context.Background(), LogsPipeline, reader, newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
 }
 
@@ -569,7 +569,7 @@ func TestSendCompressDeflate(t *testing.T) {
 	test.s.compressor = c
 	reader := strings.NewReader("Some example log")
 
-	err = test.s.send(context.Background(), LogsPipeline, reader, newFields())
+	err = test.s.send(context.Background(), LogsPipeline, reader, newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
 }
 
@@ -580,7 +580,7 @@ func TestCompressionError(t *testing.T) {
 	test.s.compressor = getTestCompressor(errors.New("read error"), nil)
 	reader := strings.NewReader("Some example log")
 
-	err := test.s.send(context.Background(), LogsPipeline, reader, newFields())
+	err := test.s.send(context.Background(), LogsPipeline, reader, newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "read error")
 }
 
@@ -591,7 +591,7 @@ func TestInvalidContentEncoding(t *testing.T) {
 	test.s.config.CompressEncoding = "test"
 	reader := strings.NewReader("Some example log")
 
-	err := test.s.send(context.Background(), LogsPipeline, reader, newFields())
+	err := test.s.send(context.Background(), LogsPipeline, reader, newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "invalid content encoding: test")
 }
 
@@ -644,7 +644,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntGaugeMetric(),
 	}
 
-	_, err := test.s.sendMetrics(context.Background(), newFields())
+	_, err := test.s.sendMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.NoError(t, err)
 }
 
@@ -672,7 +672,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntGaugeMetric(),
 	}
 
-	dropped, err := test.s.sendMetrics(context.Background(), newFields())
+	dropped, err := test.s.sendMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 	assert.Equal(t, test.s.metricBuffer[0:1], dropped)
 }
@@ -703,7 +703,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 		exampleIntGaugeMetric(),
 	}
 
-	dropped, err := test.s.sendMetrics(context.Background(), newFields())
+	dropped, err := test.s.sendMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(
 		t,
 		err,
@@ -724,7 +724,7 @@ func TestSendMetricsUnexpectedFormat(t *testing.T) {
 	}
 	test.s.metricBuffer = metrics
 
-	dropped, err := test.s.sendMetrics(context.Background(), newFields())
+	dropped, err := test.s.sendMetrics(context.Background(), newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, "unexpected metric format: invalid")
 	assert.Equal(t, dropped, metrics)
 }
@@ -739,13 +739,13 @@ func TestMetricsBuffer(t *testing.T) {
 		exampleIntGaugeMetric(),
 	}
 
-	droppedMetrics, err := test.s.batchMetric(context.Background(), metrics[0], newFields())
+	droppedMetrics, err := test.s.batchMetric(context.Background(), metrics[0], newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
 	assert.Nil(t, droppedMetrics)
 	assert.Equal(t, 1, test.s.countMetrics())
 	assert.Equal(t, metrics[0:1], test.s.metricBuffer)
 
-	droppedMetrics, err = test.s.batchMetric(context.Background(), metrics[1], newFields())
+	droppedMetrics, err = test.s.batchMetric(context.Background(), metrics[1], newFields(pdata.NewAttributeMap()))
 	require.NoError(t, err)
 	assert.Nil(t, droppedMetrics)
 	assert.Equal(t, 2, test.s.countMetrics())
@@ -767,11 +767,11 @@ func TestMetricsBufferOverflow(t *testing.T) {
 	metric := exampleIntMetric()
 
 	for test.s.countMetrics() < maxBufferSize-1 {
-		_, err := test.s.batchMetric(context.Background(), metric, newFields())
+		_, err := test.s.batchMetric(context.Background(), metric, newFields(pdata.NewAttributeMap()))
 		require.NoError(t, err)
 	}
 
-	_, err := test.s.batchMetric(context.Background(), metric, newFields())
+	_, err := test.s.batchMetric(context.Background(), metric, newFields(pdata.NewAttributeMap()))
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
 	assert.Equal(t, 0, test.s.countMetrics())
 }

--- a/exporter/sumologicexporter/sender_test.go
+++ b/exporter/sumologicexporter/sender_test.go
@@ -496,13 +496,14 @@ func TestLogsBufferOverflow(t *testing.T) {
 
 	test.s.config.HTTPClientSettings.Endpoint = ":"
 	log := exampleLog()
+	flds := newFields(pdata.NewAttributeMap())
 
 	for test.s.countLogs() < maxBufferSize-1 {
-		_, err := test.s.batchLog(context.Background(), log[0], newFields(pdata.NewAttributeMap()))
+		_, err := test.s.batchLog(context.Background(), log[0], flds)
 		require.NoError(t, err)
 	}
 
-	_, err := test.s.batchLog(context.Background(), log[0], newFields(pdata.NewAttributeMap()))
+	_, err := test.s.batchLog(context.Background(), log[0], flds)
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
 	assert.Equal(t, 0, test.s.countLogs())
 }
@@ -765,13 +766,14 @@ func TestMetricsBufferOverflow(t *testing.T) {
 	test.s.config.MetricFormat = PrometheusFormat
 	test.s.config.MaxRequestBodySize = 1024 * 1024 * 1024 * 1024
 	metric := exampleIntMetric()
+	flds := newFields(pdata.NewAttributeMap())
 
 	for test.s.countMetrics() < maxBufferSize-1 {
-		_, err := test.s.batchMetric(context.Background(), metric, newFields(pdata.NewAttributeMap()))
+		_, err := test.s.batchMetric(context.Background(), metric, flds)
 		require.NoError(t, err)
 	}
 
-	_, err := test.s.batchMetric(context.Background(), metric, newFields(pdata.NewAttributeMap()))
+	_, err := test.s.batchMetric(context.Background(), metric, flds)
 	assert.EqualError(t, err, `parse ":": missing protocol scheme`)
 	assert.Equal(t, 0, test.s.countMetrics())
 }

--- a/exporter/sumologicexporter/source_format.go
+++ b/exporter/sumologicexporter/source_format.go
@@ -17,6 +17,8 @@ package sumologicexporter
 import (
 	"fmt"
 	"regexp"
+
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 )
 
 type sourceFormats struct {
@@ -74,7 +76,12 @@ func (s *sourceFormat) format(f fields) string {
 	labels := make([]interface{}, 0, len(s.matches))
 
 	for _, matchset := range s.matches {
-		labels = append(labels, f[matchset])
+		v, ok := f.orig.Get(matchset)
+		if ok {
+			labels = append(labels, tracetranslator.AttributeValueToString(v, false))
+		} else {
+			labels = append(labels, "")
+		}
 	}
 
 	return fmt.Sprintf(s.template, labels...)

--- a/exporter/sumologicexporter/source_format_test.go
+++ b/exporter/sumologicexporter/source_format_test.go
@@ -80,7 +80,10 @@ func TestNewSourceFormats(t *testing.T) {
 }
 
 func TestFormat(t *testing.T) {
-	f := fields{"key_1": "value_1", "key_2.subkey": "value_2"}
+	f := fieldsFromMap(map[string]string{
+		"key_1":        "value_1",
+		"key_2.subkey": "value_2",
+	})
 	s := getTestSourceFormat(t, "%{key_1}/%{key_2.subkey}")
 	expected := "value_1/value_2"
 
@@ -89,8 +92,9 @@ func TestFormat(t *testing.T) {
 }
 
 func TestFormatNonExistingKey(t *testing.T) {
-	f := fields{"key_2": "value_2"}
+	f := fieldsFromMap(map[string]string{"key_2": "value_2"})
 	s := getTestSourceFormat(t, "%{key_1}/%{key_2}")
+
 	expected := "/value_2"
 
 	result := s.format(f)

--- a/exporter/sumologicexporter/test_data.go
+++ b/exporter/sumologicexporter/test_data.go
@@ -273,9 +273,9 @@ func metricPairToMetrics(mp []metricPair) pdata.Metrics {
 }
 
 func fieldsFromMap(s map[string]string) fields {
-	am := pdata.NewAttributeMap()
+	attrMap := pdata.NewAttributeMap()
 	for k, v := range s {
-		am.InsertString(k, v)
+		attrMap.InsertString(k, v)
 	}
-	return fields{orig: am}
+	return newFields(attrMap)
 }

--- a/exporter/sumologicexporter/test_data.go
+++ b/exporter/sumologicexporter/test_data.go
@@ -271,3 +271,11 @@ func metricPairToMetrics(mp []metricPair) pdata.Metrics {
 
 	return metrics
 }
+
+func fieldsFromMap(s map[string]string) fields {
+	am := pdata.NewAttributeMap()
+	for k, v := range s {
+		am.InsertString(k, v)
+	}
+	return fields{orig: am}
+}


### PR DESCRIPTION
**Description:**

- Add support for all types of log body (only string has been supported so far)
- Refactor fields (change type to AttributeMap) to simplify above change

**Link to tracking Issue:** N/A

**Testing:** Unit-tests, manual tests

**Documentation:** N/A