### PR TITLE
uptraceexporter: implement span exporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,6 +39,7 @@ exporter/signalfxcorrelationexporter/      @open-telemetry/collector-contrib-app
 exporter/splunkhecexporter/                @open-telemetry/collector-contrib-approvers @atoulme
 exporter/stackdriverexporter/              @open-telemetry/collector-contrib-approvers @dashpole
 exporter/sumologicexporter/                @open-telemetry/collector-contrib-approvers @pmm-sumo @sumo-drosiek
+exporter/uptraceexporter/                  @open-telemetry/collector-contrib-approvers @vmihailenco
 
 extension/httpforwarder/                   @open-telemetry/collector-contrib-approvers @asuresh4
 extension/observer/                        @open-telemetry/collector-contrib-approvers @asuresh4 @jrcamp

--- a/exporter/uptraceexporter/config.go
+++ b/exporter/uptraceexporter/config.go
@@ -1,4 +1,4 @@
-// Copyright 2021 OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/uptraceexporter/config_test.go
+++ b/exporter/uptraceexporter/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/uptraceexporter/doc.go
+++ b/exporter/uptraceexporter/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2021 OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/uptraceexporter/exporter_test.go
+++ b/exporter/uptraceexporter/exporter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,11 +16,21 @@ package uptraceexporter
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/uptrace-go/spanexp"
+	"github.com/vmihailenco/msgpack/v5"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/otel/label"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/uptraceexporter/testdata"
 )
 
 func TestNewTraceExporterEmptyConfig(t *testing.T) {
@@ -54,4 +64,107 @@ func TestTraceExporterEmptyTraces(t *testing.T) {
 
 	err = exp.Shutdown(ctx)
 	require.NoError(t, err)
+}
+
+func TestTraceExporterGenTraces(t *testing.T) {
+	type In struct {
+		Spans []spanexp.Span `msgpack:"spans"`
+	}
+
+	var in In
+
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		require.Equal(t, "application/msgpack", req.Header.Get("Content-Type"))
+		require.Equal(t, "zstd", req.Header.Get("Content-Encoding"))
+
+		zr, err := zstd.NewReader(req.Body)
+		require.NoError(t, err)
+
+		dec := msgpack.NewDecoder(zr)
+		err = dec.Decode(&in)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusOK)
+	}
+
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	u, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.DSN = fmt.Sprintf("%s://key@%s/1", u.Scheme, u.Host)
+
+	exp, err := newTraceExporter(cfg, zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+
+	dropped, err := exp.pushTraceData(
+		ctx, testdata.GenerateTraceDataTwoSpansSameResource())
+	require.NoError(t, err)
+	require.Zero(t, dropped)
+
+	err = exp.Shutdown(ctx)
+	require.NoError(t, err)
+
+	var traceID [16]byte
+	traceID[0] = 0xff
+
+	require.Equal(t, In{
+		Spans: []spanexp.Span{
+			{
+				ID:        506097522914230528,
+				ParentID:  18446744073709551615,
+				TraceID:   traceID,
+				Name:      "operationA",
+				Kind:      "internal",
+				StartTime: 1581452772000000321,
+				EndTime:   1581452773000000789,
+
+				Resource: []label.KeyValue{
+					label.String("resource-attr", "resource-attr-val-1"),
+				},
+
+				StatusCode:    "error",
+				StatusMessage: "status-cancelled",
+
+				Events: []spanexp.Event{
+					{
+						Name: "event-with-attr",
+						Attrs: []label.KeyValue{
+							label.String("span-event-attr", "span-event-attr-val"),
+						},
+						Time: 1581452773000000123,
+					},
+					{
+						Name: "event",
+						Time: 1581452773000000123,
+					},
+				},
+			},
+			{
+				Name:      "operationB",
+				Kind:      "server",
+				StartTime: 1581452772000000321,
+				EndTime:   1581452773000000789,
+
+				Resource: []label.KeyValue{
+					label.String("resource-attr", "resource-attr-val-1"),
+				},
+
+				StatusCode:    "ok",
+				StatusMessage: "",
+
+				Links: []spanexp.Link{
+					{
+						Attrs: []label.KeyValue{
+							label.String("span-link-attr", "span-link-attr-val"),
+						},
+					},
+					{},
+				},
+			},
+		},
+	}, in)
 }

--- a/exporter/uptraceexporter/factory.go
+++ b/exporter/uptraceexporter/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2021 OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/uptraceexporter/factory_test.go
+++ b/exporter/uptraceexporter/factory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/exporter/uptraceexporter/go.mod
+++ b/exporter/uptraceexporter/go.mod
@@ -3,8 +3,11 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/uptrac
 go 1.14
 
 require (
+	github.com/klauspost/compress v1.11.7
 	github.com/stretchr/testify v1.7.0
 	github.com/uptrace/uptrace-go v0.8.3
+	github.com/vmihailenco/msgpack/v5 v5.2.0
 	go.opentelemetry.io/collector v0.21.1-0.20210225192722-e6319ac4c6fc
+	go.opentelemetry.io/otel v0.17.0
 	go.uber.org/zap v1.16.0
 )

--- a/exporter/uptraceexporter/testdata/testdata.go
+++ b/exporter/uptraceexporter/testdata/testdata.go
@@ -1,0 +1,139 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+var (
+	TestSpanStartTime      = time.Date(2020, 2, 11, 20, 26, 12, 321, time.UTC)
+	TestSpanStartTimestamp = pdata.Timestamp(TestSpanStartTime.UnixNano())
+
+	TestSpanEventTime      = time.Date(2020, 2, 11, 20, 26, 13, 123, time.UTC)
+	TestSpanEventTimestamp = pdata.Timestamp(TestSpanEventTime.UnixNano())
+
+	TestSpanEndTime      = time.Date(2020, 2, 11, 20, 26, 13, 789, time.UTC)
+	TestSpanEndTimestamp = pdata.Timestamp(TestSpanEndTime.UnixNano())
+)
+
+var (
+	resourceAttributes1 = map[string]pdata.AttributeValue{
+		"resource-attr": pdata.NewAttributeValueString("resource-attr-val-1"),
+	}
+	spanEventAttributes = map[string]pdata.AttributeValue{
+		"span-event-attr": pdata.NewAttributeValueString("span-event-attr-val"),
+	}
+	spanLinkAttributes = map[string]pdata.AttributeValue{
+		"span-link-attr": pdata.NewAttributeValueString("span-link-attr-val"),
+	}
+)
+
+func GenerateTraceDataTwoSpansSameResource() pdata.Traces {
+	td := GenerateTraceDataOneEmptyInstrumentationLibrary()
+	rs0ils0 := td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0)
+	rs0ils0.Spans().Resize(2)
+	fillSpanOne(rs0ils0.Spans().At(0))
+	fillSpanTwo(rs0ils0.Spans().At(1))
+	return td
+}
+
+func GenerateTraceDataOneEmptyInstrumentationLibrary() pdata.Traces {
+	td := GenerateTraceDataNoLibraries()
+	rs0 := td.ResourceSpans().At(0)
+	rs0.InstrumentationLibrarySpans().Resize(1)
+	return td
+}
+
+func GenerateTraceDataNoLibraries() pdata.Traces {
+	td := GenerateTraceDataOneEmptyResourceSpans()
+	rs0 := td.ResourceSpans().At(0)
+	initResource1(rs0.Resource())
+	return td
+}
+
+func GenerateTraceDataOneEmptyResourceSpans() pdata.Traces {
+	td := GenerateTraceDataEmpty()
+	td.ResourceSpans().Resize(1)
+	return td
+}
+
+func GenerateTraceDataEmpty() pdata.Traces {
+	td := pdata.NewTraces()
+	return td
+}
+
+func fillSpanOne(span pdata.Span) {
+	span.SetSpanID(pdata.NewSpanID([8]byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7}))
+	span.SetParentSpanID(pdata.NewSpanID([8]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}))
+	span.SetTraceID(genTraceID())
+	span.SetName("operationA")
+	span.SetStartTime(TestSpanStartTimestamp)
+	span.SetEndTime(TestSpanEndTimestamp)
+	span.SetDroppedAttributesCount(1)
+	evs := span.Events()
+	evs.Resize(2)
+	ev0 := evs.At(0)
+	ev0.SetTimestamp(TestSpanEventTimestamp)
+	ev0.SetName("event-with-attr")
+	initSpanEventAttributes(ev0.Attributes())
+	ev0.SetDroppedAttributesCount(2)
+	ev1 := evs.At(1)
+	ev1.SetTimestamp(TestSpanEventTimestamp)
+	ev1.SetName("event")
+	ev1.SetDroppedAttributesCount(2)
+	span.SetDroppedEventsCount(1)
+	status := span.Status()
+	status.SetCode(pdata.StatusCodeError)
+	status.SetMessage("status-cancelled")
+}
+
+func fillSpanTwo(span pdata.Span) {
+	span.SetName("operationB")
+	span.SetKind(pdata.SpanKindSERVER)
+	span.SetStartTime(TestSpanStartTimestamp)
+	span.SetEndTime(TestSpanEndTimestamp)
+	span.Links().Resize(2)
+	initSpanLinkAttributes(span.Links().At(0).Attributes())
+	span.Links().At(0).SetDroppedAttributesCount(4)
+	span.Links().At(1).SetDroppedAttributesCount(4)
+	span.SetDroppedLinksCount(3)
+	status := span.Status()
+	status.SetCode(pdata.StatusCodeOk)
+}
+
+func initResource1(r pdata.Resource) {
+	initResourceAttributes1(r.Attributes())
+}
+
+func initResourceAttributes1(dest pdata.AttributeMap) {
+	dest.InitFromMap(resourceAttributes1)
+}
+
+func initSpanEventAttributes(dest pdata.AttributeMap) {
+	dest.InitFromMap(spanEventAttributes)
+}
+
+func initSpanLinkAttributes(dest pdata.AttributeMap) {
+	dest.InitFromMap(spanLinkAttributes)
+}
+
+func genTraceID() pdata.TraceID {
+	var traceID [16]byte
+	traceID[0] = 0xff
+	return pdata.NewTraceID(traceID)
+}

--- a/exporter/uptraceexporter/translator.go
+++ b/exporter/uptraceexporter/translator.go
@@ -1,0 +1,231 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uptraceexporter
+
+import (
+	"encoding/binary"
+	"encoding/json"
+
+	"github.com/uptrace/uptrace-go/spanexp"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/otel/label"
+	"go.uber.org/zap"
+)
+
+func asUint64(b [8]byte) uint64 {
+	return binary.LittleEndian.Uint64(b[:])
+}
+
+func spanKind(kind pdata.SpanKind) string {
+	switch kind {
+	case pdata.SpanKindCLIENT:
+		return "client"
+	case pdata.SpanKindSERVER:
+		return "server"
+	case pdata.SpanKindPRODUCER:
+		return "producer"
+	case pdata.SpanKindCONSUMER:
+		return "consumer"
+	}
+	return "internal"
+}
+
+func statusCode(status pdata.StatusCode) string {
+	switch status {
+	case pdata.StatusCodeOk:
+		return "ok"
+	case pdata.StatusCodeError:
+		return "error"
+	}
+	return "unset"
+}
+
+func (e *traceExporter) keyValueSlice(attrs pdata.AttributeMap) spanexp.KeyValueSlice {
+	out := make(spanexp.KeyValueSlice, 0, attrs.Len())
+
+	attrs.ForEach(func(key string, value pdata.AttributeValue) {
+		switch value.Type() {
+		case pdata.AttributeValueSTRING:
+			out = append(out, label.String(key, value.StringVal()))
+		case pdata.AttributeValueBOOL:
+			out = append(out, label.Bool(key, value.BoolVal()))
+		case pdata.AttributeValueINT:
+			out = append(out, label.Int64(key, value.IntVal()))
+		case pdata.AttributeValueDOUBLE:
+			out = append(out, label.Float64(key, value.DoubleVal()))
+		case pdata.AttributeValueMAP:
+			if value, ok := mapLabelValue(value.MapVal()); ok {
+				out = append(out, label.KeyValue{
+					Key:   label.Key(key),
+					Value: value,
+				})
+			}
+		case pdata.AttributeValueARRAY:
+			if value, ok := arrayLabelValue(value.ArrayVal()); ok {
+				out = append(out, label.KeyValue{
+					Key:   label.Key(key),
+					Value: value,
+				})
+			}
+		case pdata.AttributeValueNULL:
+			// Ignore. Uptrace does not support nulls.
+		default:
+			e.logger.Warn("uptraceexporter: unsupported attribute value type",
+				zap.String("type", value.Type().String()))
+		}
+	})
+
+	return out
+}
+
+func (e *traceExporter) uptraceEvents(events pdata.SpanEventSlice) []spanexp.Event {
+	if events.Len() == 0 {
+		return nil
+	}
+
+	outEvents := make([]spanexp.Event, events.Len())
+	for i := 0; i < events.Len(); i++ {
+		event := events.At(i)
+
+		out := &outEvents[i]
+		out.Name = event.Name()
+		out.Attrs = e.keyValueSlice(event.Attributes())
+		out.Time = int64(event.Timestamp())
+	}
+	return outEvents
+}
+
+func (e *traceExporter) uptraceLinks(links pdata.SpanLinkSlice) []spanexp.Link {
+	if links.Len() == 0 {
+		return nil
+	}
+
+	outLinks := make([]spanexp.Link, links.Len())
+	for i := 0; i < links.Len(); i++ {
+		link := links.At(i)
+
+		out := &outLinks[i]
+		out.TraceID = link.TraceID().Bytes()
+		out.SpanID = asUint64(link.SpanID().Bytes())
+		out.Attrs = e.keyValueSlice(link.Attributes())
+	}
+	return outLinks
+}
+
+//------------------------------------------------------------------------------
+
+func mapLabelValue(m pdata.AttributeMap) (label.Value, bool) {
+	out := make(map[string]interface{}, m.Len())
+	m.ForEach(func(key string, val pdata.AttributeValue) {
+		out[key] = attrAsInterface(val)
+	})
+	return jsonLabelValue(out)
+}
+
+func arrayLabelValue(arr pdata.AnyValueArray) (label.Value, bool) {
+	if arr.Len() == 0 {
+		return label.Value{}, false
+	}
+
+	switch arrType := arr.At(0).Type(); arrType {
+	case pdata.AttributeValueSTRING:
+		out := make([]string, 0, arr.Len())
+		for i := 0; i < arr.Len(); i++ {
+			val := arr.At(i)
+			if val.Type() != arrType {
+				return label.Value{}, false
+			}
+			out = append(out, val.StringVal())
+		}
+		return label.ArrayValue(out), true
+
+	case pdata.AttributeValueBOOL:
+		out := make([]bool, 0, arr.Len())
+		for i := 0; i < arr.Len(); i++ {
+			val := arr.At(i)
+			if val.Type() != arrType {
+				return label.Value{}, false
+			}
+			out = append(out, val.BoolVal())
+		}
+		return label.ArrayValue(out), true
+
+	case pdata.AttributeValueINT:
+		out := make([]int64, 0, arr.Len())
+		for i := 0; i < arr.Len(); i++ {
+			val := arr.At(i)
+			if val.Type() != arrType {
+				return label.Value{}, false
+			}
+			out = append(out, val.IntVal())
+		}
+		return label.ArrayValue(out), true
+
+	case pdata.AttributeValueDOUBLE:
+		out := make([]float64, 0, arr.Len())
+		for i := 0; i < arr.Len(); i++ {
+			val := arr.At(i)
+			if val.Type() != arrType {
+				return label.Value{}, false
+			}
+			out = append(out, val.DoubleVal())
+		}
+		return label.ArrayValue(out), true
+
+	case pdata.AttributeValueNULL:
+		// Ignore. Uptrace does not support nulls.
+		return label.Value{}, false
+	}
+
+	out := make([]interface{}, arr.Len())
+	for i := 0; i < arr.Len(); i++ {
+		out[i] = attrAsInterface(arr.At(i))
+	}
+	return jsonLabelValue(out)
+}
+
+func jsonLabelValue(v interface{}) (label.Value, bool) {
+	if b, err := json.Marshal(v); err == nil {
+		return label.StringValue(string(b)), true
+	}
+	return label.Value{}, false
+}
+
+func attrAsInterface(val pdata.AttributeValue) interface{} {
+	switch val.Type() {
+	case pdata.AttributeValueSTRING:
+		return val.StringVal()
+	case pdata.AttributeValueINT:
+		return val.IntVal()
+	case pdata.AttributeValueDOUBLE:
+		return val.DoubleVal()
+	case pdata.AttributeValueBOOL:
+		return val.BoolVal()
+	case pdata.AttributeValueMAP:
+		out := map[string]interface{}{}
+		val.MapVal().ForEach(func(key string, val pdata.AttributeValue) {
+			out[key] = attrAsInterface(val)
+		})
+		return out
+	case pdata.AttributeValueARRAY:
+		arr := val.ArrayVal()
+		out := make([]interface{}, arr.Len())
+		for i := 0; i < arr.Len(); i++ {
+			out[i] = attrAsInterface(arr.At(i))
+		}
+		return out
+	}
+	return nil
+}

--- a/exporter/uptraceexporter/translator_test.go
+++ b/exporter/uptraceexporter/translator_test.go
@@ -1,0 +1,146 @@
+// Copyright OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uptraceexporter
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/otel/label"
+	"go.uber.org/zap"
+)
+
+func fillAttributeMap(m pdata.AttributeMap) {
+	m.InsertString("string", "bar")
+	m.InsertBool("bool", true)
+	m.InsertInt("int", 123)
+	m.InsertDouble("double", 0.123)
+	m.InsertNull("null")
+	m.Insert("map", pdata.NewAttributeValueMap())
+
+	arrVal := pdata.NewAttributeValueArray()
+	arr := arrVal.ArrayVal()
+	arr.Append(pdata.NewAttributeValueBool(true))
+	arr.Append(pdata.NewAttributeValueBool(false))
+	m.Insert("array", arrVal)
+}
+
+func TestMapLabelValue(t *testing.T) {
+	m := pdata.NewAttributeMap()
+	fillAttributeMap(m)
+
+	value, ok := mapLabelValue(m)
+	require.True(t, ok)
+	require.Equal(t, label.STRING, value.Type())
+	require.Equal(t, `{"array":[true,false],"bool":true,"double":0.123,"int":123,"map":{},"null":null,"string":"bar"}`, value.AsString())
+
+	e := &traceExporter{
+		logger: zap.NewNop(),
+	}
+	kvSlice := e.keyValueSlice(m)
+	require.Len(t, kvSlice, 6)
+}
+
+func TestInvalidMapLabelValue(t *testing.T) {
+	m := pdata.NewAttributeMap()
+	m.InsertDouble("double", math.NaN())
+
+	_, ok := mapLabelValue(m)
+	require.False(t, ok)
+}
+
+func TestEmptyArrayLabelValue(t *testing.T) {
+	_, ok := arrayLabelValue(pdata.NewAnyValueArray())
+	require.False(t, ok)
+}
+
+func TestArrayLabelValue(t *testing.T) {
+	arr := pdata.NewAnyValueArray()
+	arr.Append(pdata.NewAttributeValueNull())
+	_, ok := arrayLabelValue(arr)
+	require.False(t, ok)
+
+	mapVal := pdata.NewAttributeValueMap()
+	fillAttributeMap(mapVal.MapVal())
+
+	arr = pdata.NewAnyValueArray()
+	arr.Append(mapVal)
+	value, ok := arrayLabelValue(arr)
+	require.True(t, ok)
+	require.Equal(t, label.STRING, value.Type())
+
+	type Test struct {
+		val pdata.AttributeValue
+	}
+
+	tests := []Test{
+		{val: pdata.NewAttributeValueBool(true)},
+		{val: pdata.NewAttributeValueString("hello")},
+		{val: pdata.NewAttributeValueInt(123)},
+		{val: pdata.NewAttributeValueDouble(0.123)},
+	}
+	for _, test := range tests {
+		arr := pdata.NewAnyValueArray()
+		arr.Append(test.val)
+
+		value, ok := arrayLabelValue(arr)
+		require.True(t, ok)
+		require.Equal(t, label.ARRAY, value.Type())
+
+		arr.Append(pdata.NewAttributeValueNull())
+		_, ok = arrayLabelValue(arr)
+		require.False(t, ok)
+	}
+}
+
+func TestSpanKind(t *testing.T) {
+	type Test struct {
+		in  pdata.SpanKind
+		out string
+	}
+
+	tests := []Test{
+		{pdata.SpanKindCLIENT, "client"},
+		{pdata.SpanKindSERVER, "server"},
+		{pdata.SpanKindPRODUCER, "producer"},
+		{pdata.SpanKindCONSUMER, "consumer"},
+		{pdata.SpanKindINTERNAL, "internal"},
+	}
+
+	for _, test := range tests {
+		out := spanKind(test.in)
+		require.Equal(t, test.out, out)
+	}
+}
+
+func TestStatusCode(t *testing.T) {
+	type Test struct {
+		in  pdata.StatusCode
+		out string
+	}
+
+	tests := []Test{
+		{pdata.StatusCodeOk, "ok"},
+		{pdata.StatusCodeError, "error"},
+		{pdata.StatusCodeUnset, "unset"},
+	}
+
+	for _, test := range tests {
+		out := statusCode(test.in)
+		require.Equal(t, test.out, out)
+	}
+}


### PR DESCRIPTION
**Description:**
Allow exporting trace data to Uptrace.dev. This is the 2nd PR that adds spans exporter implementation. [First PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2022)

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2021

**Testing:**
Unit tests are included

**Documentation:**
The readme includes a short description and the configuration.