### PR TITLE
codecov: Added 'third_party' ignore to match Makefile ALL_SRC

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,3 +18,6 @@ coverage:
       default:
         enabled: yes
         target: 95%
+
+ignore:
+  - "*/**/third_party/**/*" # Ignore all 'third_party' directories and files within those directories recursively.


### PR DESCRIPTION
**Description:** 
Added 'third_party' ignore within codecov to match Makefile ALL_SRC. The 'third_party' directory pattern is used in the [windowsperfcounterreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/windowsperfcountersreceiver/internal/third_party/telegraf/win_perf_counters) and #2389. 

**Link to tracking Issue:**
#2390

**Testing:**
N/A

**Documentation:**
N/A

Signed-off-by: Granville Schmidt <1246157+gramidt@users.noreply.github.com>