### PR TITLE
codecov: updated branch to 'main' from 'master'

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: yes
     # wait for unit and integration test builds.
     after_n_builds: 2
-  strict_yaml_branch: master  # only use the latest copy on master branch
+  strict_yaml_branch: main  # only use the latest copy on main branch
 
 coverage:
   precision: 2


### PR DESCRIPTION
**Description:**
Codecov is still pointing at the 'master' branch even after this project switched to 'main'. This PR updates this.

**Link to tracking Issue:**
N/A

**Testing:**
N/A

**Documentation:**
N/A

Signed-off-by: Granville Schmidt <1246157+gramidt@users.noreply.github.com>