### PR TITLE
Elasticsearch exporter: event publishing

### DIFF
--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -81,9 +81,9 @@ func TestLoadConfig(t *testing.T) {
 	})
 }
 
-func withDefaultConfig(fn func(*Config)) *Config {
+func withDefaultConfig(fns ...func(*Config)) *Config {
 	cfg := createDefaultConfig().(*Config)
-	if fn != nil {
+	for _, fn := range fns {
 		fn(cfg)
 	}
 	return cfg

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -17,8 +17,11 @@
 package elasticsearchexporter
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -32,15 +35,22 @@ import (
 type esClientCurrent = elasticsearch7.Client
 type esConfigCurrent = elasticsearch7.Config
 type esBulkIndexerCurrent = esutil7.BulkIndexer
+type esBulkIndexerItem = esutil7.BulkIndexerItem
+type esBulkIndexerResponseItem = esutil7.BulkIndexerResponseItem
 
 type elasticsearchExporter struct {
 	logger *zap.Logger
+
+	index      string
+	maxRetries int
 
 	client      *esClientCurrent
 	bulkIndexer esBulkIndexerCurrent
 }
 
-var retryOnStatus = []int{502, 503, 504, 429}
+var retryOnStatus = []int{500, 502, 503, 504, 429}
+
+const createAction = "create"
 
 func newExporter(logger *zap.Logger, cfg *Config) (*elasticsearchExporter, error) {
 	if err := cfg.Validate(); err != nil {
@@ -52,15 +62,23 @@ func newExporter(logger *zap.Logger, cfg *Config) (*elasticsearchExporter, error
 		return nil, err
 	}
 
-	bulkIndexer, err := newBulkIndexer(client, cfg)
+	bulkIndexer, err := newBulkIndexer(logger, client, cfg)
 	if err != nil {
 		return nil, err
+	}
+
+	eventRetries := 0
+	if cfg.Retry.Enabled {
+		eventRetries = cfg.Retry.MaxRequests
 	}
 
 	return &elasticsearchExporter{
 		logger:      logger,
 		client:      client,
 		bulkIndexer: bulkIndexer,
+
+		index:      cfg.Index,
+		maxRetries: eventRetries,
 	}, nil
 }
 
@@ -72,17 +90,62 @@ func (e *elasticsearchExporter) pushLogsData(ctx context.Context, ld pdata.Logs)
 	panic("TODO")
 }
 
+func (e *elasticsearchExporter) pushEvent(ctx context.Context, document []byte) error {
+	attempts := 1
+	body := bytes.NewReader(document)
+	item := esBulkIndexerItem{Action: createAction, Index: e.index, Body: body}
+
+	// Setup error handler. The handler handles the per item response status based on the
+	// selective ACKing in the bulk response.
+	item.OnFailure = func(ctx context.Context, item esBulkIndexerItem, resp esBulkIndexerResponseItem, err error) {
+		switch {
+		case e.maxRetries < 0 || attempts < e.maxRetries && shouldRetryEvent(resp.Status):
+			e.logger.Debug("Retrying to index event",
+				zap.Int("attempt", attempts),
+				zap.Int("status", resp.Status),
+				zap.NamedError("reason", err))
+
+			attempts++
+			body.Seek(0, io.SeekStart)
+			e.bulkIndexer.Add(ctx, item)
+
+		case resp.Status == 0 && err != nil:
+			// Encoding error. We didn't even attempt to send the event
+			e.logger.Error("Drop event: failed to add event to the bulk request buffer.",
+				zap.NamedError("reason", err))
+
+		case err != nil:
+			e.logger.Error("Drop event: failed to index event",
+				zap.Int("attempt", attempts),
+				zap.Int("status", resp.Status),
+				zap.NamedError("reason", err))
+
+		default:
+			e.logger.Error(fmt.Sprintf("Drop event: failed to index event: %#v", resp.Error),
+				zap.Int("attempt", attempts),
+				zap.Int("status", resp.Status))
+		}
+	}
+
+	return e.bulkIndexer.Add(ctx, item)
+}
+
 // clientLogger implements the estransport.Logger interface
 // that is required by the Elasticsearch client for logging.
 type clientLogger zap.Logger
 
 // LogRoundTrip should not modify the request or response, except for consuming and closing the body.
 // Implementations have to check for nil values in request and response.
-func (cl *clientLogger) LogRoundTrip(_ *http.Request, resp *http.Response, err error, _ time.Time, dur time.Duration) error {
+func (cl *clientLogger) LogRoundTrip(requ *http.Request, resp *http.Response, err error, _ time.Time, dur time.Duration) error {
 	zl := (*zap.Logger)(cl)
 	switch {
 	case err == nil && resp != nil:
-		zl.Debug("Request roundtrip completed.", zap.Duration("duration", dur), zap.String("status", resp.Status))
+		zl.Debug("Request roundtrip completed.",
+			zap.String("path", requ.URL.Path),
+			zap.String("method", requ.Method),
+			zap.Duration("duration", dur),
+			zap.String("status", resp.Status))
+
 	case err != nil:
 		zl.Error("Request failed.", zap.NamedError("reason", err))
 	}
@@ -119,6 +182,11 @@ func newElasticsearchClient(logger *zap.Logger, config *Config) (*esClientCurren
 	//  - try to parse address and validate scheme (address must be a valid URL)
 	//  - check if cloud ID is valid
 
+	maxAttempts := config.Retry.MaxRequests
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
 	return elasticsearch7.NewClient(esConfigCurrent{
 		Transport: transport,
 
@@ -132,9 +200,9 @@ func newElasticsearchClient(logger *zap.Logger, config *Config) (*esClientCurren
 
 		// configure retry behavior
 		RetryOnStatus:        retryOnStatus,
-		DisableRetry:         false,
-		EnableRetryOnTimeout: true,
-		MaxRetries:           config.Retry.MaxRequests,
+		DisableRetry:         !config.Retry.Enabled,
+		EnableRetryOnTimeout: !config.Retry.Enabled,
+		MaxRetries:           maxAttempts,
 		RetryBackoff:         createElasticsearchBackoffFunc(&config.Retry),
 
 		// configure sniffing
@@ -163,16 +231,19 @@ func newTransport(config *Config, tlsCfg *tls.Config) *http.Transport {
 	return transport
 }
 
-func newBulkIndexer(client *elasticsearch7.Client, config *Config) (esBulkIndexerCurrent, error) {
+func newBulkIndexer(logger *zap.Logger, client *elasticsearch7.Client, config *Config) (esBulkIndexerCurrent, error) {
 	// TODO: add debug logger
 	return esutil7.NewBulkIndexer(esutil7.BulkIndexerConfig{
 		NumWorkers:    config.NumWorkers,
 		FlushBytes:    config.Flush.Bytes,
 		FlushInterval: config.Flush.Interval,
 		Client:        client,
-		Index:         config.Index,
 		Pipeline:      config.Pipeline,
 		Timeout:       config.Timeout,
+
+		OnError: func(_ context.Context, err error) {
+			logger.Error(fmt.Sprintf("Bulk indexer error: %v", err))
+		},
 	})
 }
 
@@ -197,4 +268,13 @@ func createElasticsearchBackoffFunc(config *RetrySettings) func(int) time.Durati
 
 		return expBackoff.NextBackOff()
 	}
+}
+
+func shouldRetryEvent(status int) bool {
+	for _, retryable := range retryOnStatus {
+		if status == retryable {
+			return true
+		}
+	}
+	return false
 }

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -134,7 +134,7 @@ func TestExporter_New(t *testing.T) {
 func TestExporter_PushEvent(t *testing.T) {
 	t.Run("publish with success", func(t *testing.T) {
 		rec := newBulkRecorder()
-		server := newESTestServer(t, func(docs []documentAction) ([]itemResponse, error) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
 			rec.Record(docs)
 			return itemsAllOK(docs)
 		})
@@ -149,7 +149,7 @@ func TestExporter_PushEvent(t *testing.T) {
 	t.Run("retry http request", func(t *testing.T) {
 		failures := 0
 		rec := newBulkRecorder()
-		server := newESTestServer(t, func(docs []documentAction) ([]itemResponse, error) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
 			if failures == 0 {
 				failures++
 				return nil, &httpTestError{message: "oops"}
@@ -167,7 +167,7 @@ func TestExporter_PushEvent(t *testing.T) {
 
 	t.Run("no http request retry", func(t *testing.T) {
 		var attempts int64
-		server := newESTestServer(t, func(docs []documentAction) ([]itemResponse, error) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
 			atomic.AddInt64(&attempts, 1)
 			return nil, &httpTestError{message: "oops"}
 		})
@@ -186,7 +186,7 @@ func TestExporter_PushEvent(t *testing.T) {
 
 	t.Run("do not retry invalid reuqest", func(t *testing.T) {
 		var attempts int64
-		server := newESTestServer(t, func(docs []documentAction) ([]itemResponse, error) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
 			atomic.AddInt64(&attempts, 1)
 			return nil, &httpTestError{message: "oops", status: http.StatusBadRequest}
 		})
@@ -201,7 +201,7 @@ func TestExporter_PushEvent(t *testing.T) {
 	t.Run("retry single item", func(t *testing.T) {
 		var attempts int
 		rec := newBulkRecorder()
-		server := newESTestServer(t, func(docs []documentAction) ([]itemResponse, error) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
 			attempts++
 
 			if attempts == 1 {
@@ -220,7 +220,7 @@ func TestExporter_PushEvent(t *testing.T) {
 
 	t.Run("disable retry single item", func(t *testing.T) {
 		var attempts int64
-		server := newESTestServer(t, func(docs []documentAction) ([]itemResponse, error) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
 			atomic.AddInt64(&attempts, 1)
 			return itemsReportStatus(docs, http.StatusTooManyRequests)
 		})
@@ -238,7 +238,7 @@ func TestExporter_PushEvent(t *testing.T) {
 
 	t.Run("do not retry bad item", func(t *testing.T) {
 		var attempts int64
-		server := newESTestServer(t, func(docs []documentAction) ([]itemResponse, error) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
 			atomic.AddInt64(&attempts, 1)
 			return itemsReportStatus(docs, http.StatusBadRequest)
 		})
@@ -257,7 +257,7 @@ func TestExporter_PushEvent(t *testing.T) {
 
 		const retryIdx = 1
 
-		server := newESTestServer(t, func(docs []documentAction) ([]itemResponse, error) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
 			resp := make([]itemResponse, len(docs))
 			for i, doc := range docs {
 				resp[i].Status = http.StatusOK

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -184,7 +184,7 @@ func TestExporter_PushEvent(t *testing.T) {
 		assert.Equal(t, int64(1), atomic.LoadInt64(&attempts))
 	})
 
-	t.Run("do not retry invalid reuqest", func(t *testing.T) {
+	t.Run("do not retry invalid request", func(t *testing.T) {
 		var attempts int64
 		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
 			atomic.AddInt64(&attempts, 1)

--- a/exporter/elasticsearchexporter/utils_test.go
+++ b/exporter/elasticsearchexporter/utils_test.go
@@ -1,0 +1,194 @@
+package elasticsearchexporter
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type documentAction struct {
+	Action   json.RawMessage
+	Document json.RawMessage
+}
+
+type itemResponse struct {
+	Status int `json:"status"`
+}
+
+type bulkResult struct {
+	Took      int            `json:"took"`
+	HasErrors bool           `json:"errors"`
+	Items     []itemResponse `json:"items"`
+}
+
+type bulkHandler func([]documentAction) ([]itemResponse, error)
+
+type httpTestError struct {
+	status  int
+	message string
+	cause   error
+}
+
+func (e *httpTestError) Error() string {
+	return fmt.Sprintf("http request failed (status=%v): %v", e.Status(), e.Message())
+}
+
+func (e *httpTestError) Status() int {
+	if e.status == 0 {
+		return http.StatusInternalServerError
+	}
+	return e.status
+}
+
+func (e *httpTestError) Message() string {
+	var buf strings.Builder
+	if e.message != "" {
+		buf.WriteString(e.message)
+	}
+	if e.cause != nil {
+		if buf.Len() > 0 {
+			buf.WriteString(": ")
+		}
+		buf.WriteString(e.cause.Error())
+	}
+	return buf.String()
+}
+
+type bulkRecorder struct {
+	mu         sync.Mutex
+	cond       *sync.Cond
+	recordings [][]documentAction
+}
+
+func newBulkRecorder() *bulkRecorder {
+	r := &bulkRecorder{}
+	r.cond = sync.NewCond(&r.mu)
+	return r
+}
+
+func (r *bulkRecorder) Record(bulk []documentAction) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.recordings = append(r.recordings, bulk)
+	r.cond.Broadcast()
+}
+
+func (r *bulkRecorder) WaitItems(n int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for n > r.countItems() {
+		r.cond.Wait()
+	}
+}
+
+func (r *bulkRecorder) Requests() [][]documentAction {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.recordings
+}
+
+func (r *bulkRecorder) Items() (docs []documentAction) {
+	for _, rec := range r.Requests() {
+		docs = append(docs, rec...)
+	}
+	return docs
+}
+
+func (r *bulkRecorder) NumItems() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.countItems()
+}
+
+func (r *bulkRecorder) countItems() (count int) {
+	for _, docs := range r.recordings {
+		count += len(docs)
+	}
+	return count
+}
+
+func newESTestServer(t *testing.T, bulkHandler bulkHandler) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_bulk", handleErr(func(w http.ResponseWriter, req *http.Request) error {
+		tsStart := time.Now()
+		var items []documentAction
+
+		dec := json.NewDecoder(req.Body)
+		for dec.More() {
+			var action, doc json.RawMessage
+			if err := dec.Decode(&action); err != nil {
+				return &httpTestError{status: http.StatusBadRequest, cause: err}
+			}
+			if !dec.More() {
+				return &httpTestError{status: http.StatusBadRequest, message: "action without document"}
+			}
+			if err := dec.Decode(&doc); err != nil {
+				return &httpTestError{status: http.StatusBadRequest, cause: err}
+			}
+
+			items = append(items, documentAction{Action: action, Document: doc})
+		}
+
+		resp, err := bulkHandler(items)
+		if err != nil {
+			return err
+		}
+		took := int(time.Since(tsStart) / time.Microsecond)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		enc := json.NewEncoder(w)
+		enc.Encode(bulkResult{Took: took, Items: resp, HasErrors: itemsHasError(resp)})
+		return nil
+	}))
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func handleErr(fn func(http.ResponseWriter, *http.Request) error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := fn(w, r)
+		if err != nil {
+			if httpError, ok := err.(*httpTestError); ok {
+				http.Error(w, httpError.Message(), httpError.Status())
+			} else {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		}
+	}
+}
+
+func (item *itemResponse) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, `{"create": {"status": %v}}`, item.Status)
+	return buf.Bytes(), nil
+}
+
+func itemsAllOK(docs []documentAction) ([]itemResponse, error) {
+	return itemsReportStatus(docs, http.StatusOK)
+}
+
+func itemsReportStatus(docs []documentAction, status int) ([]itemResponse, error) {
+	responses := make([]itemResponse, len(docs))
+	for i := range docs {
+		responses[i].Status = status
+	}
+	return responses, nil
+}
+
+func itemsHasError(resp []itemResponse) bool {
+	for _, r := range resp {
+		if r.Status != http.StatusOK {
+			return true
+		}
+	}
+	return false
+}

--- a/exporter/elasticsearchexporter/utils_test.go
+++ b/exporter/elasticsearchexporter/utils_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package elasticsearchexporter
 
 import (


### PR DESCRIPTION
**Description:** Implement per document retry behavior and a set of tests verifying that the retry behavior is correctly configured and executed in conjunction with the BulkIndexer.

The change introduces helpers for creating a fake Elasticsearch endpoint that accepts bulk requests. This allows us to test the retry behavior for different failure scenarios.

**Link to tracking Issue:** #1800 

**Testing:** `TestExporter_PushEvent` tests the retry behavior for multiple error scenarios like http requests failing, or single documents being rejected due to overload.

**Documentation:** None. No user visible changes