### PR TITLE
[WIP] Multi-architecture container images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,27 @@ commands:
         type: string
       tag:
         type: string
+    environment:
+      DOCKER_BUILDKIT: 1
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64
     steps:
+      - run:
+          name: Install Docker buildx
+          command: |
+            BUILDX_BINARY_URL="https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64"
+
+            curl --output docker-buildx \
+              --silent --show-error --location --fail --retry 3 \
+              "$BUILDX_BINARY_URL"
+
+            mkdir -p ~/.docker/cli-plugins
+
+            mv docker-buildx ~/.docker/cli-plugins/
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+
+            docker buildx install
+            # Run binfmt
+            docker run --rm --privileged tonistiigi/binfmt:latest --install "$BUILDX_PLATFORMS"
       - run:
           name: Build image
           command: |

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ docker-component: check-component
 	docker build -t $(COMPONENT) ./cmd/$(COMPONENT)/
 	rm ./cmd/$(COMPONENT)/$(COMPONENT)
 
+# Requires Docker buildx = v0.5.1 https://github.com/docker/buildx
 DOCKER_BUILDX_PLATFORMS := linux/amd64,linux/arm64
 .PHONY: docker-cross-build-component # Not intended to be used directly
 docker-cross-build-component: check-component

--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY otelcontribcol_${TARGETOS}_${TARGETARCH} /otelcontribcol
 EXPOSE 55680 55679

--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -2,8 +2,10 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY otelcontribcol /
+COPY otelcontribcol_${TARGETOS}_${TARGETARCH} /otelcontribcol
 EXPOSE 55680 55679
 ENTRYPOINT ["/otelcontribcol"]
 CMD ["--config", "/etc/otel/config.yaml"]


### PR DESCRIPTION
**Description:**
Update CI/CD to build multi-architecture container images. Currently multiple binaries are created for OS/architectures; however, only a single container image is created (linux/amd64). This PR will build and push both linux/amd64 and linux/arm64 container images and setup the foundation to make it trivial to build additional architecture images in the future.

**Link to tracking Issue:**
#2379 

**Testing:**
TODO

**Documentation:**
TODO