### PR TITLE
[exporter/signalfx] add nonalphanumeric_dimension_chars config option

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -74,6 +74,10 @@ The following configuration options can also be configured:
   processor is enabled in the pipeline with one of the cloud provider detectors
   or environment variable detector setting a unique value to `host.name` attribute
   within your k8s cluster. And keep `override=true` in resourcedetection config.
+- `nonalphanumeric_dimension_chars`: (default = `"_-"`) A string of characters 
+that are allowed to be used as a dimension key in addition to alphanumeric 
+characters. Each nonalphanumeric dimension key character that isn't in this string 
+will be replaced with a `_`.
 
 In addition, this exporter offers queued retry which is enabled by default.
 Information about queued retry configuration parameters can be found

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -98,6 +98,10 @@ type Config struct {
 
 	// Correlation configuration for syncing traces service and environment to metrics.
 	Correlation *correlation.Config `mapstructure:"correlation"`
+
+	// NonAlphanumericDimensionChars is a list of allowable characters, in addition to alphanumeric ones,
+	// to be used in a dimension key.
+	NonAlphanumericDimensionChars string `mapstructure:"nonalphanumeric_dimension_chars"`
 }
 
 func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -160,6 +160,7 @@ func TestLoadConfig(t *testing.T) {
 				"host.name": "host",
 			},
 		},
+		NonAlphanumericDimensionChars: "_-",
 	}
 	assert.Equal(t, &expectedCfg, e1)
 

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -90,7 +90,7 @@ func newSignalFxExporter(
 
 	headers := buildHeaders(config)
 
-	converter, err := translation.NewMetricsConverter(logger, options.metricTranslator, config.ExcludeMetrics, config.IncludeMetrics)
+	converter, err := translation.NewMetricsConverter(logger, options.metricTranslator, config.ExcludeMetrics, config.IncludeMetrics, config.NonAlphanumericDimensionChars)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric converter: %v", err)
 	}

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -194,7 +194,7 @@ func TestConsumeMetrics(t *testing.T) {
 			serverURL, err := url.Parse(server.URL)
 			assert.NoError(t, err)
 
-			c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil)
+			c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil, "")
 			require.NoError(t, err)
 			require.NotNil(t, c)
 			dpClient := &sfxDPClient{
@@ -974,7 +974,7 @@ func BenchmarkExporterConsumeData(b *testing.B) {
 	serverURL, err := url.Parse(server.URL)
 	assert.NoError(b, err)
 
-	c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil)
+	c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil, "")
 	require.NoError(b, err)
 	require.NotNil(b, c)
 	dpClient := &sfxDPClient{

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -66,8 +66,9 @@ func createDefaultConfig() configmodels.Exporter {
 		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
 			AccessTokenPassthrough: true,
 		},
-		DeltaTranslationTTL: 3600,
-		Correlation:         correlation.DefaultConfig(),
+		DeltaTranslationTTL:           3600,
+		Correlation:                   correlation.DefaultConfig(),
+		NonAlphanumericDimensionChars: "_-",
 	}
 }
 

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -193,7 +193,7 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.NoError(t, err)
 	data := testMetricsData()
 
-	c, err := translation.NewMetricsConverter(zap.NewNop(), tr, nil, nil)
+	c, err := translation.NewMetricsConverter(zap.NewNop(), tr, nil, nil, "")
 	require.NoError(t, err)
 	translated := c.MetricDataToSignalFxV2(data)
 	require.NotNil(t, translated)
@@ -829,7 +829,7 @@ func TestDefaultExcludes_translated(t *testing.T) {
 	cfg := f.CreateDefaultConfig().(*Config)
 	setDefaultExcludes(cfg)
 
-	converter, err := translation.NewMetricsConverter(zap.NewNop(), testGetTranslator(t), cfg.ExcludeMetrics, cfg.IncludeMetrics)
+	converter, err := translation.NewMetricsConverter(zap.NewNop(), testGetTranslator(t), cfg.ExcludeMetrics, cfg.IncludeMetrics, "")
 	require.NoError(t, err)
 
 	var metrics []map[string]string
@@ -847,7 +847,7 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	cfg := f.CreateDefaultConfig().(*Config)
 	setDefaultExcludes(cfg)
 
-	converter, err := translation.NewMetricsConverter(zap.NewNop(), nil, cfg.ExcludeMetrics, cfg.IncludeMetrics)
+	converter, err := translation.NewMetricsConverter(zap.NewNop(), nil, cfg.ExcludeMetrics, cfg.IncludeMetrics, "")
 	require.NoError(t, err)
 
 	var metrics []map[string]string

--- a/exporter/signalfxexporter/translation/converter_test.go
+++ b/exporter/signalfxexporter/translation/converter_test.go
@@ -640,7 +640,7 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewMetricsConverter(logger, nil, tt.excludeMetrics, tt.includeMetrics)
+			c, err := NewMetricsConverter(logger, nil, tt.excludeMetrics, tt.includeMetrics, "")
 			require.NoError(t, err)
 			gotSfxDataPoints := c.MetricDataToSignalFxV2(tt.metricsDataFn())
 			// Sort SFx dimensions since they are built from maps and the order
@@ -689,9 +689,52 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 			},
 		},
 	}
-	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil)
+	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil, "")
 	require.NoError(t, err)
 	assert.EqualValues(t, expected, c.MetricDataToSignalFxV2(wrapMetric(md)))
+}
+
+func TestDimensionKeyCharsWithPeriod(t *testing.T) {
+	translator, err := NewMetricTranslator([]Rule{
+		{
+			Action: ActionRenameDimensionKeys,
+			Mapping: map[string]string{
+				"old.dim.with.periods": "new.dim.with.periods",
+			},
+		},
+	}, 1)
+	require.NoError(t, err)
+
+	md := pdata.NewMetric()
+	md.SetDataType(pdata.MetricDataTypeIntGauge)
+	md.IntGauge().DataPoints().Resize(1)
+	md.SetName("metric1")
+	dp := md.IntGauge().DataPoints().At(0)
+	dp.SetValue(123)
+	dp.LabelsMap().InitFromMap(map[string]string{
+		"old.dim.with.periods": "val1",
+	})
+
+	gaugeType := sfxpb.MetricType_GAUGE
+	expected := []*sfxpb.DataPoint{
+		{
+			Metric: "metric1",
+			Value: sfxpb.Datum{
+				IntValue: generateIntPtr(123),
+			},
+			MetricType: &gaugeType,
+			Dimensions: []*sfxpb.Dimension{
+				{
+					Key:   "new.dim.with.periods",
+					Value: "val1",
+				},
+			},
+		},
+	}
+	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil, "_-.")
+	require.NoError(t, err)
+	assert.EqualValues(t, expected, c.MetricDataToSignalFxV2(wrapMetric(md)))
+
 }
 
 func sortDimensions(points []*sfxpb.DataPoint) {
@@ -858,7 +901,7 @@ func TestNewMetricsConverter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewMetricsConverter(zap.NewNop(), nil, tt.excludes, nil)
+			got, err := NewMetricsConverter(zap.NewNop(), nil, tt.excludes, nil, "")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewMetricsConverter() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -2586,7 +2586,7 @@ func testConverter(t *testing.T, mapping map[string]string) *MetricsConverter {
 	tr, err := NewMetricTranslator(rules, 1)
 	require.NoError(t, err)
 
-	c, err := NewMetricsConverter(zap.NewNop(), tr, nil, nil)
+	c, err := NewMetricsConverter(zap.NewNop(), tr, nil, nil, "")
 	require.NoError(t, err)
 	return c
 }


### PR DESCRIPTION
**Description:** Adds a new config option to the SignalFx exporter `nonalphanumeric_dimension_chars`. This is a configurable string to allow non-alphanumeric characters on SignalFx dimensions. The driving force for this was to add support for having periods `.` in dimensions, but we need to keep backwards compatibility for current users. With a config option, we will be able to set this config option to "-_." for our deployments going forward, and current users will default to the current behavior.

**Testing:** Added a test to allow periods in dimensions.

**Documentation:** Added config option to readme and inline code.