### PR TITLE
[exporters/signalfx] breaking change: do not convert periods to underscores in dimension keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- `signalfx` exporter: **breaking change** - Allow periods to be sent in dimension keys (#2456). Existing users who do not want to change this functionality can set `nonalphanumeric_dimension_chars` to `_-`
 
 ## v0.20.0
 

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -74,7 +74,7 @@ The following configuration options can also be configured:
   processor is enabled in the pipeline with one of the cloud provider detectors
   or environment variable detector setting a unique value to `host.name` attribute
   within your k8s cluster. And keep `override=true` in resourcedetection config.
-- `nonalphanumeric_dimension_chars`: (default = `"_-"`) A string of characters 
+- `nonalphanumeric_dimension_chars`: (default = `"_-."`) A string of characters 
 that are allowed to be used as a dimension key in addition to alphanumeric 
 characters. Each nonalphanumeric dimension key character that isn't in this string 
 will be replaced with a `_`.

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -160,7 +160,7 @@ func TestLoadConfig(t *testing.T) {
 				"host.name": "host",
 			},
 		},
-		NonAlphanumericDimensionChars: "_-",
+		NonAlphanumericDimensionChars: "_-.",
 	}
 	assert.Equal(t, &expectedCfg, e1)
 

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -68,7 +68,7 @@ func createDefaultConfig() configmodels.Exporter {
 		},
 		DeltaTranslationTTL:           3600,
 		Correlation:                   correlation.DefaultConfig(),
-		NonAlphanumericDimensionChars: "_-",
+		NonAlphanumericDimensionChars: "_-.",
 	}
 }
 


### PR DESCRIPTION
**Description:** **breaking change**: This PR introduces a
breaking change for current users upon upgrading, unless
explicitly setting the `nonalphanumeric_dimension_chars` config
option on the signalfx exporter.

This PR changes the config option `nonalphanumeric_dimension_chars`
default from `_-` to `_-.`.

The resulting behavior change is dimensions keys with periods in them
will no longer be converted to underscores. For example, if the
dimension `k8s.pod.uid` was currently sent, the exporter would
automatically convert this to `k8s_pod-uid`. This change will allow
`k8s.pod.uid` to be sent as is.

Why? The SignalFx backend now allows periods in dimension keys,
and much of our content will rely on this.
Existing users who do not wish to break MTSs and keep current
functionality can set `nonalphanumeric_dimension_chars` to `_-`.