### PR TITLE
exporter/signalfx: Trim disk and network translation rules

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -212,26 +212,30 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.Equal(t, 1, len(dps))
 	require.Equal(t, 40.0, *dps[0].Value.DoubleValue)
 
-	// system.disk.operations metric split and dimension rename
-	dps, ok = metrics["disk_ops.read"]
-	require.True(t, ok, "disk_ops.read metrics not found")
-	require.Equal(t, 4, len(dps))
+	// system.disk.operations dimension rename
+	dps, ok = metrics["system.disk.operations"]
+	require.True(t, ok, "system.disk.operations metrics not found")
+	require.Equal(t, 8, len(dps))
 	require.Equal(t, int64(4e3), *dps[0].Value.IntValue)
-	require.Equal(t, "disk", dps[0].Dimensions[1].Key)
-	require.Equal(t, "sda1", dps[0].Dimensions[1].Value)
+	require.Equal(t, "direction", dps[0].Dimensions[1].Key)
+	require.Equal(t, "read", dps[0].Dimensions[1].Value)
+	require.Equal(t, "disk", dps[0].Dimensions[2].Key)
+	require.Equal(t, "sda1", dps[0].Dimensions[2].Value)
 	require.Equal(t, int64(6e3), *dps[1].Value.IntValue)
-	require.Equal(t, "disk", dps[1].Dimensions[1].Key)
-	require.Equal(t, "sda2", dps[1].Dimensions[1].Value)
-
-	dps, ok = metrics["disk_ops.write"]
-	require.True(t, ok, "disk_ops.write metrics not found")
-	require.Equal(t, 4, len(dps))
-	require.Equal(t, int64(1e3), *dps[0].Value.IntValue)
-	require.Equal(t, "disk", dps[0].Dimensions[1].Key)
-	require.Equal(t, "sda1", dps[0].Dimensions[1].Value)
-	require.Equal(t, int64(5e3), *dps[1].Value.IntValue)
-	require.Equal(t, "disk", dps[1].Dimensions[1].Key)
-	require.Equal(t, "sda2", dps[1].Dimensions[1].Value)
+	require.Equal(t, "direction", dps[1].Dimensions[1].Key)
+	require.Equal(t, "read", dps[1].Dimensions[1].Value)
+	require.Equal(t, "disk", dps[1].Dimensions[2].Key)
+	require.Equal(t, "sda2", dps[1].Dimensions[2].Value)
+	require.Equal(t, int64(1e3), *dps[2].Value.IntValue)
+	require.Equal(t, "direction", dps[2].Dimensions[1].Key)
+	require.Equal(t, "write", dps[2].Dimensions[1].Value)
+	require.Equal(t, "disk", dps[2].Dimensions[2].Key)
+	require.Equal(t, "sda1", dps[2].Dimensions[2].Value)
+	require.Equal(t, int64(5e3), *dps[3].Value.IntValue)
+	require.Equal(t, "direction", dps[3].Dimensions[1].Key)
+	require.Equal(t, "write", dps[3].Dimensions[1].Value)
+	require.Equal(t, "disk", dps[3].Dimensions[2].Key)
+	require.Equal(t, "sda2", dps[3].Dimensions[2].Value)
 
 	// disk_ops.total gauge from system.disk.operations cumulative, where is disk_ops.total
 	// is the cumulative across devices and directions.

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -511,30 +511,6 @@ translation_rules:
     system.disk.time: true
   mapping:
     device: disk
-- action: split_metric
-  metric_name: system.disk.merged
-  dimension_key: direction
-  mapping:
-    read: disk_merged.read
-    write: disk_merged.write
-- action: split_metric
-  metric_name: system.disk.io
-  dimension_key: direction
-  mapping:
-    read: disk_octets.read
-    write: disk_octets.write
-- action: split_metric
-  metric_name: system.disk.operations
-  dimension_key: direction
-  mapping:
-    read: disk_ops.read
-    write: disk_ops.write
-- action: split_metric
-  metric_name: system.disk.time
-  dimension_key: direction
-  mapping:
-    read: disk_time.read
-    write: disk_time.write
 - action: delta_metric
   mapping:
     system.disk.pending_operations: disk_ops.pending
@@ -566,30 +542,6 @@ translation_rules:
     system.network.packets: true
   mapping:
     device: interface
-- action: split_metric
-  metric_name: system.network.dropped
-  dimension_key: direction
-  mapping:
-    receive: if_dropped.rx
-    transmit: if_dropped.tx
-- action: split_metric
-  metric_name: system.network.errors
-  dimension_key: direction
-  mapping:
-    receive: if_errors.rx
-    transmit: if_errors.tx
-- action: split_metric
-  metric_name: system.network.io
-  dimension_key: direction
-  mapping:
-    receive: if_octets.rx
-    transmit: if_octets.tx
-- action: split_metric
-  metric_name: system.network.packets
-  dimension_key: direction
-  mapping:
-    receive: if_packets.rx
-    transmit: if_packets.tx
 
 
 # memory utilization


### PR DESCRIPTION
**Description:** Remove certain disk/network translations.

**Testing:** Updated tests.