### PR TITLE
[exporters/signalfx] add statusCode to logging field on dimension client

### DIFF
--- a/exporter/signalfxexporter/dimensions/dimclient.go
+++ b/exporter/signalfxexporter/dimensions/dimclient.go
@@ -243,6 +243,7 @@ func (dc *DimensionClient) handleDimensionUpdate(dimUpdate *DimensionUpdate) err
 					zap.Error(err),
 					zap.String("URL", req.URL.String()),
 					zap.String("dimensionUpdate", dimUpdate.String()),
+					zap.Int("statusCode", statusCode),
 				)
 
 				// Don't retry if it is a 4xx error (except 404) since these
@@ -258,6 +259,7 @@ func (dc *DimensionClient) handleDimensionUpdate(dimUpdate *DimensionUpdate) err
 				zap.Error(err),
 				zap.String("URL", req.URL.String()),
 				zap.String("dimensionUpdate", dimUpdate.String()),
+				zap.Int("statusCode", statusCode),
 			)
 			atomic.AddInt64(&dc.TotalRetriedUpdates, int64(1))
 			// The retry is meant to provide some measure of robustness against
@@ -270,6 +272,7 @@ func (dc *DimensionClient) handleDimensionUpdate(dimUpdate *DimensionUpdate) err
 					zap.Error(err),
 					zap.String("URL", req.URL.String()),
 					zap.String("dimensionUpdate", dimUpdate.String()),
+					zap.Int("statusCode", statusCode),
 				)
 			}
 		})))


### PR DESCRIPTION
Description: Adds status code to logging field in the dimension client.
It would be nice to see the status code of why we could not
update a dimension.