### PR TITLE
dotnet receiver: read initial responses from backend

### DIFF
--- a/receiver/dotnetdiagnosticsreceiver/dotnet/ipc_parser.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/ipc_parser.go
@@ -1,0 +1,93 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnet
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
+)
+
+type ipcMsg struct {
+	header    ipcHeader
+	sessionID int64
+}
+
+type ipcHeader struct {
+	magic      [14]byte
+	size       uint16
+	commandSet byte
+	responseID byte // aka CommandID
+	reserved   uint16
+}
+
+// Parses and validates an IPC message:
+// https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-protocol.md
+func parseIPC(r network.MultiReader) error {
+	ipc, err := doParseIPC(r)
+	if err != nil {
+		return err
+	}
+	return validateIPCHeader(ipc.header)
+}
+
+func doParseIPC(r network.MultiReader) (ipcMsg, error) {
+	ipc := ipcMsg{}
+	err := r.Read(&ipc.header.magic)
+	if err != nil {
+		return ipcMsg{}, err
+	}
+
+	err = r.Read(&ipc.header.size)
+	if err != nil {
+		return ipcMsg{}, err
+	}
+
+	err = r.Read(&ipc.header.commandSet)
+	if err != nil {
+		return ipcMsg{}, err
+	}
+
+	err = r.Read(&ipc.header.responseID)
+	if err != nil {
+		return ipcMsg{}, err
+	}
+
+	err = r.Read(&ipc.header.reserved)
+	if err != nil {
+		return ipcMsg{}, err
+	}
+
+	err = r.Read(&ipc.sessionID)
+	if err != nil {
+		return ipcMsg{}, err
+	}
+
+	return ipc, nil
+}
+
+const responseError = 0xFF
+
+func validateIPCHeader(hdr ipcHeader) error {
+	foundMagic := string(hdr.magic[:13])
+	if foundMagic != magic {
+		return fmt.Errorf("ipc header: expected magic %q got %q", magic, foundMagic)
+	}
+	if hdr.responseID == responseError {
+		return errors.New("ipc header: got error response")
+	}
+	return nil
+}

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/ipc_parser_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/ipc_parser_test.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnet
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
+)
+
+func TestIPCParser_NoErrors(t *testing.T) {
+	rw := &network.FakeRW{
+		ReadErrIdx: -1,
+		Responses: map[int][]byte{
+			0: []byte(magicTerminated),
+		},
+	}
+	r := network.NewMultiReader(rw)
+	err := parseIPC(r)
+	require.NoError(t, err)
+}
+
+func TestIPCParser_BadMagic(t *testing.T) {
+	rw := &network.FakeRW{
+		ReadErrIdx: -1,
+		Responses: map[int][]byte{
+			0: []byte("DOTNET_IPC_V2"),
+		},
+	}
+	err := parseIPC(network.NewMultiReader(rw))
+	require.EqualError(t, err, `ipc header: expected magic "DOTNET_IPC_V1" got "DOTNET_IPC_V2"`)
+}
+
+func TestIPCParser_BadResponseID(t *testing.T) {
+	rw := &network.FakeRW{
+		ReadErrIdx: -1,
+		Responses: map[int][]byte{
+			0: []byte(magic),
+			3: {responseError},
+		},
+	}
+	r := network.NewMultiReader(rw)
+	err := parseIPC(r)
+	assert.EqualError(t, err, "ipc header: got error response")
+}
+
+func TestIPCParser_ReadErrors(t *testing.T) {
+	for i := 0; i < 6; i++ {
+		testIPCError(t, i)
+	}
+}
+
+func testIPCError(t *testing.T, idx int) {
+	rw := &network.FakeRW{
+		ReadErrIdx: idx,
+	}
+	r := network.NewMultiReader(rw)
+	err := parseIPC(r)
+	require.EqualError(t, err, fmt.Sprintf("deliberate error on read %d", idx))
+}

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/nettrace_parser.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/nettrace_parser.go
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnet
+
+import (
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
+)
+
+const (
+	nettraceName          = "Nettrace"
+	nettraceSerialization = "!FastSerialization.1"
+)
+
+type nettrace struct {
+	name              string
+	serializationType string
+}
+
+// Parses and validates a nettrace message:
+// https://github.com/Microsoft/perfview/blob/main/src/TraceEvent/EventPipe/EventPipeFormat.md#first-bytes-nettrace-magic
+func parseNettrace(r network.MultiReader) error {
+	nt, err := doParseNettrace(r)
+	if err != nil {
+		return err
+	}
+	return validateNettrace(nt)
+}
+
+func doParseNettrace(r network.MultiReader) (h nettrace, err error) {
+	h.name, err = r.ReadASCII(len(nettraceName))
+	if err != nil {
+		return
+	}
+	var strlen int32
+	err = r.Read(&strlen)
+	if err != nil {
+		return
+	}
+	h.serializationType, err = r.ReadASCII(int(strlen))
+	return
+}
+
+func validateNettrace(h nettrace) error {
+	if h.name != nettraceName {
+		return fmt.Errorf(
+			"header name: expected %q got %q",
+			nettraceName,
+			h.name,
+		)
+	}
+	if h.serializationType != nettraceSerialization {
+		return fmt.Errorf(
+			"serialization type: expected %q got %q",
+			nettraceSerialization,
+			h.serializationType,
+		)
+	}
+	return nil
+}

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/nettrace_parser_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/nettrace_parser_test.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
+)
+
+func TestParseNettrace(t *testing.T) {
+	rw := &network.FakeRW{
+		ReadErrIdx: -1,
+		Responses: map[int][]byte{
+			0: []byte(nettraceName),
+			1: {byte(len(nettraceSerialization))},
+			2: []byte(nettraceSerialization),
+		},
+	}
+	r := network.NewMultiReader(rw)
+	err := parseNettrace(r)
+	require.NoError(t, err)
+}
+
+func TestParseNettrace_BadHeaderName(t *testing.T) {
+	rw := &network.FakeRW{
+		ReadErrIdx: -1,
+		Responses: map[int][]byte{
+			0: []byte("nettrace"),
+		},
+	}
+	r := network.NewMultiReader(rw)
+	err := parseNettrace(r)
+	require.EqualError(t, err, `header name: expected "Nettrace" got "nettrace"`)
+}
+
+func TestParseNettrace_BadSerializationName(t *testing.T) {
+	serType := "foo"
+	rw := &network.FakeRW{
+		ReadErrIdx: -1,
+		Responses: map[int][]byte{
+			0: []byte(nettraceName),
+			1: {byte(len(serType))},
+			2: []byte(serType),
+		},
+	}
+	r := network.NewMultiReader(rw)
+	err := parseNettrace(r)
+	require.EqualError(t, err, `serialization type: expected "!FastSerialization.1" got "foo"`)
+}
+
+func TestParseNettrace_ReadErr(t *testing.T) {
+	for i := 0; i < 3; i++ {
+		err := testParseNettraceReadErr(i)
+		require.Error(t, err)
+	}
+}
+
+func testParseNettraceReadErr(i int) error {
+	rw := &network.FakeRW{
+		ReadErrIdx: i,
+	}
+	r := network.NewMultiReader(rw)
+	return parseNettrace(r)
+}

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/parser.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/parser.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnet
+
+import (
+	"io"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
+)
+
+// Parser encapsulates all of the functionality to parse an IPC stream.
+type Parser struct {
+	r      network.MultiReader
+	logger *zap.Logger
+}
+
+// NewParser accepts an io.Reader and logger returns a Parser for processing an
+// IPC stream.
+func NewParser(rdr io.Reader, logger *zap.Logger) *Parser {
+	r := network.NewMultiReader(rdr)
+	return &Parser{r: r, logger: logger}
+}
+
+// ParseIPC parses the IPC response from the initial request to a dotnet process.
+func (p *Parser) ParseIPC() error {
+	return parseIPC(p.r)
+}
+
+// ParseNettrace parses the nettrace magic message.
+func (p *Parser) ParseNettrace() error {
+	return parseNettrace(p.r)
+}

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/parser_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/parser_test.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
+)
+
+func TestParser(t *testing.T) {
+	const fastSerialization = "!FastSerialization.1"
+	rw := &network.FakeRW{
+		WriteErrIdx: -1,
+		ReadErrIdx:  -1,
+		Responses: map[int][]byte{
+			0: []byte(magicTerminated),
+			6: []byte("Nettrace"),
+			7: {byte(len(fastSerialization))},
+			8: []byte(fastSerialization),
+		},
+	}
+	p := NewParser(rw, zap.NewNop())
+	err := p.ParseIPC()
+	require.NoError(t, err)
+	err = p.ParseNettrace()
+	require.NoError(t, err)
+}

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
@@ -76,12 +76,14 @@ type requestHeader struct {
 }
 
 const magic = "DOTNET_IPC_V1"
+const magicTerminated = magic + "\000"
+
 const requestHeaderSize = 20
 
 func (h requestHeader) serialize(payloadSize int) []byte {
 	buf := &bytes.Buffer{}
 	// no need to handle errors because Write always returns a nil error
-	_, _ = buf.Write([]byte(magic + "\000"))
+	_, _ = buf.Write([]byte(magicTerminated))
 	totSize := uint16(requestHeaderSize + payloadSize)
 	_ = binary.Write(buf, network.ByteOrder, totSize)
 	_, _ = buf.Write([]byte{h.commandSet, h.commandID, 0, 0})

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request_test.go
@@ -16,11 +16,12 @@ package dotnet
 
 import (
 	"bytes"
-	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
 )
 
 func TestProviderArgs(t *testing.T) {
@@ -75,25 +76,9 @@ func TestSessionCfg(t *testing.T) {
 }
 
 func TestRequestWriter_Send(t *testing.T) {
-	rw := &fakeRW{}
+	rw := &network.FakeRW{WriteErrIdx: -1}
 	w := NewRequestWriter(rw, 0, "")
 	err := w.SendRequest()
 	require.NoError(t, err)
-	require.Equal(t, 107, len(rw.writeBuf))
-}
-
-// fakeRW
-type fakeRW struct {
-	writeBuf []byte
-}
-
-var _ io.ReadWriter = (*fakeRW)(nil)
-
-func (rw *fakeRW) Write(p []byte) (n int, err error) {
-	rw.writeBuf = append(rw.writeBuf, p...)
-	return len(p), nil
-}
-
-func (rw *fakeRW) Read(p []byte) (n int, err error) {
-	return len(p), nil
+	require.Equal(t, 107, len(rw.Writes))
 }

--- a/receiver/dotnetdiagnosticsreceiver/network/fake_rw.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/fake_rw.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"fmt"
+	"io"
+)
+
+// FakeRW fakes an io.ReadWriter for testing.
+type FakeRW struct {
+	WriteErrIdx int
+	Writes      []byte
+	writeCount  int
+
+	ReadErrIdx int
+	Responses  map[int][]byte
+	readCount  int
+}
+
+var _ io.ReadWriter = (*FakeRW)(nil)
+
+func NewDefaultFakeRW(magic, nettrace, fastSerialization string) *FakeRW {
+	return &FakeRW{
+		WriteErrIdx: -1,
+		ReadErrIdx:  -1,
+		Responses: map[int][]byte{
+			0: []byte(magic),
+			6: []byte(nettrace),
+			7: {byte(len(fastSerialization))},
+			8: []byte(fastSerialization),
+		},
+	}
+}
+
+func (rw *FakeRW) Write(p []byte) (n int, err error) {
+	defer func() { rw.writeCount++ }()
+	if rw.writeCount == rw.WriteErrIdx {
+		return 0, fmt.Errorf("deliberate error on write %d", rw.writeCount)
+	}
+	rw.Writes = append(rw.Writes, p...)
+	return len(p), nil
+}
+
+func (rw *FakeRW) Read(p []byte) (n int, err error) {
+	defer func() { rw.readCount++ }()
+	if rw.readCount == rw.ReadErrIdx {
+		return 0, fmt.Errorf("deliberate error on read %d", rw.readCount)
+	}
+	resp, ok := rw.Responses[rw.readCount]
+	if ok {
+		copy(p, resp)
+	}
+	return len(p), nil
+}

--- a/receiver/dotnetdiagnosticsreceiver/network/fake_rw_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/fake_rw_test.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeRW_Write(t *testing.T) {
+	rw := &FakeRW{
+		WriteErrIdx: -1,
+	}
+	p := []byte{1, 2, 3, 4}
+	n, err := rw.Write(p)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, p, rw.Writes)
+}
+
+func TestFakeRW_WriteErr(t *testing.T) {
+	rw := &FakeRW{}
+	_, err := rw.Write(nil)
+	require.Error(t, err)
+}
+
+func TestFakeRW_Read(t *testing.T) {
+	resp := []byte{1, 2, 3, 4}
+	rw := &FakeRW{
+		ReadErrIdx: -1,
+		Responses: map[int][]byte{
+			0: resp,
+		},
+	}
+	p := make([]byte, 4)
+	n, err := rw.Read(p)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, resp, p)
+}
+
+func TestFakeRW_ReadErr(t *testing.T) {
+	rw := &FakeRW{}
+	p := make([]byte, 4)
+	_, err := rw.Read(p)
+	require.Error(t, err)
+}
+
+func TestNewDefaultFakeRW(t *testing.T) {
+	rw := NewDefaultFakeRW("magic", "nettrace", "fastserialization")
+	p := make([]byte, 5)
+	_, err := rw.Read(p)
+	require.NoError(t, err)
+	require.Equal(t, "magic", string(p))
+}

--- a/receiver/dotnetdiagnosticsreceiver/network/reader.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/reader.go
@@ -1,0 +1,247 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"unicode/utf16"
+)
+
+// MultiReader provides an abstraction to make reading from the diagnostics
+// stream easier for callers.
+type MultiReader interface {
+	Pos() int
+	Align() error
+	Seek(i int) error
+	ReadUTF16() (string, error)
+	ReadByte() (byte, error)
+	AssertNextByteEquals(byte) error
+	ReadCompressedUInt64() (uint64, error)
+	ReadCompressedInt64() (int64, error)
+	ReadCompressedUInt32() (uint32, error)
+	ReadCompressedInt32() (int32, error)
+	Read(interface{}) error
+	ReadASCII(int) (string, error)
+	Reset()
+}
+
+// mReader is an implementation of MultiReader. It wraps a PositionalReader,
+// which keeps track of the byte count.
+type mReader struct {
+	pr PositionalReader
+}
+
+func NewMultiReader(r io.Reader) MultiReader {
+	pr := NewPositionalReader(r)
+	return &mReader{pr: pr}
+}
+
+var _ MultiReader = (*mReader)(nil)
+
+// Align moves the current position forward for 4-byte alignment
+// https://github.com/Microsoft/perfview/blob/main/src/TraceEvent/EventPipe/EventPipeFormat.md
+func (r *mReader) Align() error {
+	mod := r.Pos() % 4
+	if mod > 0 {
+		err := r.Seek(4 - mod)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadUTF16 reads and returns a zero-terminated UTF16 string from the stream
+func (r *mReader) ReadUTF16() (s string, err error) {
+	var a []uint16
+	for {
+		var c uint16
+		err = r.Read(&c)
+		if err != nil {
+			return "", err
+		}
+		if c == 0 {
+			break
+		}
+		a = append(a, c)
+	}
+	return string(utf16.Decode(a)), nil
+}
+
+var singleByte = make([]byte, 1)
+
+// ReadByte reads and returns a single byte from the stream
+func (r *mReader) ReadByte() (byte, error) {
+	err := r.Read(singleByte)
+	if err != nil {
+		return 0, err
+	}
+	return singleByte[0], nil
+}
+
+// AssertNextByteEquals returns an error if the next byte doesn't equal the
+// passed in byte
+func (r *mReader) AssertNextByteEquals(b byte) error {
+	found, err := r.ReadByte()
+	if err != nil {
+		return err
+	}
+	if found != b {
+		return errors.New("next byte assertion failed")
+	}
+	return nil
+}
+
+// From https://github.com/Microsoft/perfview/blob/master/src/TraceEvent/EventPipe/EventPipeFormat.md
+// > Variable length encodings of int and long. This is a standard technique where
+// > the least significant 7 bits are encoded in a byte. If all remaining bits in the
+// > starting number are zero then the 8th bit is set to zero to mark the end of the
+// > encoding. Otherwise the 8th bit is set to 1 to indicate another byte is
+// > forthcoming containing the next 7 least significant bits. This pattern repeats
+// > until there are no more non-zero bits to encode, at most 5 bytes for a 32 bit
+// > int and 10 bytes for a 64 bit long.
+
+const shiftWidth = 7
+const valueMask = 0x7f
+const continueFlag = 0x80
+
+// ReadCompressedInt32 reads a compressed int32 from the stream
+func (r *mReader) ReadCompressedInt32() (int32, error) {
+	uInt32, err := r.ReadCompressedUInt32()
+	return int32(uInt32), err
+}
+
+// ReadCompressedUInt32 reads a compressed uint32 from the stream
+func (r *mReader) ReadCompressedUInt32() (out uint32, err error) {
+	const maxLen = 5
+	for i := 0; ; i++ {
+		if i > maxLen {
+			return 0, errors.New("CompressedInt32 is too long")
+		}
+		b, err := r.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		out |= uint32(b&valueMask) << (i * shiftWidth)
+		if (b & continueFlag) == 0 {
+			break
+		}
+	}
+	return out, nil
+}
+
+// ReadCompressedInt64 reads a compressed int64 from the stream
+func (r *mReader) ReadCompressedInt64() (int64, error) {
+	uInt64, err := r.ReadCompressedUInt64()
+	return int64(uInt64), err
+}
+
+// ReadCompressedUInt64 reads a compressed uint64 from the stream
+func (r *mReader) ReadCompressedUInt64() (out uint64, err error) {
+	const maxLen = 10
+	for i := 0; ; i++ {
+		if i > maxLen {
+			return 0, errors.New("CompressedInt64 is too long")
+		}
+		b, err := r.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		out |= uint64(b&valueMask) << (i * shiftWidth)
+		if (b & continueFlag) == 0 {
+			break
+		}
+	}
+	return out, nil
+}
+
+// Reset resets the underlying PositionalReader
+func (r *mReader) Reset() {
+	r.pr.Reset()
+}
+
+// Pos returns the position (byte offset) from the underlying PositionalReader
+func (r *mReader) Pos() int {
+	return r.pr.Position()
+}
+
+// Seek moves the current position forward by reading and throwing away the
+// specified number of bytes
+func (r *mReader) Seek(i int) error {
+	_, err := r.pr.Read(make([]byte, i))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Read reads bytes from the underlying stream into v
+func (r *mReader) Read(v interface{}) error {
+	return binary.Read(r.pr, ByteOrder, v)
+}
+
+// ReadASCII reads an ASCII string of the given length from the underlying stream
+func (r *mReader) ReadASCII(strlen int) (string, error) {
+	b := make([]byte, strlen)
+	_, err := r.pr.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// PositionalReader is an interface extracted from posReader so it can be
+// swapped for testing. It implements io.Reader, can return the number of bytes
+// read, and can reset the current position.
+type PositionalReader interface {
+	Read(p []byte) (n int, err error)
+	Position() int
+	Reset()
+}
+
+// posReader wraps an io.Reader, and keeps track of the number of bytes read.
+// Implements PositionalReader.
+type posReader struct {
+	r   io.Reader
+	pos int
+}
+
+// NewPositionalReader creates a PositionalReader, wrapping the passed-in
+// io.Reader, and keeping track of the number of bytes read.
+func NewPositionalReader(r io.Reader) PositionalReader {
+	return &posReader{r: r}
+}
+
+// Read implements io.Reader incrementing the current position by the number of
+// bytes read.
+func (r *posReader) Read(p []byte) (n int, err error) {
+	n, err = r.r.Read(p)
+	r.pos += n
+	return n, err
+}
+
+// Position returns the number of bytes read from the underlying io.Reader.
+func (r *posReader) Position() int {
+	return r.pos
+}
+
+// Reset resets the position to as close to zero as possible without altering
+// the current 4-byte alignment. This is to prevent integer overflow during
+// long-running usage.
+func (r *posReader) Reset() {
+	r.pos = r.pos % 4
+}

--- a/receiver/dotnetdiagnosticsreceiver/network/reader_test.go
+++ b/receiver/dotnetdiagnosticsreceiver/network/reader_test.go
@@ -1,0 +1,246 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+	"unicode/utf16"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMReader_Read(t *testing.T) {
+	fr := newFakeReader([]byte{42}, -1)
+	multi := NewMultiReader(fr)
+	var b byte
+	err := multi.Read(&b)
+	require.NoError(t, err)
+	assert.Equal(t, byte(42), b)
+}
+
+func TestMReader_Align(t *testing.T) {
+	fr := newFakeReader(make([]byte, 4), -1)
+	multi := NewMultiReader(fr)
+	var b byte
+	err := multi.Read(&b)
+	require.NoError(t, err)
+	assert.Equal(t, 1, multi.Pos())
+	err = multi.Align()
+	require.NoError(t, err)
+	assert.Equal(t, 4, multi.Pos())
+	// should do nothing, already aligned
+	err = multi.Align()
+	require.NoError(t, err)
+	assert.Equal(t, 4, multi.Pos())
+}
+
+func TestMReader_AlignErr(t *testing.T) {
+	fr := newFakeReader(make([]byte, 1), 1)
+	multi := NewMultiReader(fr)
+	_, _ = multi.ReadByte()
+	err := multi.Align()
+	require.Error(t, err)
+}
+
+func TestMReader_UTF16(t *testing.T) {
+	fr := newFakeReader(strToUTF16Bytes("hello\000"), -1)
+	multi := NewMultiReader(fr)
+	utfRead, err := multi.ReadUTF16()
+	require.NoError(t, err)
+	assert.Equal(t, "hello", utfRead)
+}
+
+func strToUTF16Bytes(msg string) []byte {
+	encoded := utf16.Encode([]rune(msg))
+	buf := &bytes.Buffer{}
+	for _, u := range encoded {
+		_ = binary.Write(buf, ByteOrder, u)
+	}
+	return buf.Bytes()
+}
+
+func TestMReader_UTF16Err(t *testing.T) {
+	fr := newFakeReader(nil, 0)
+	multi := NewMultiReader(fr)
+	_, err := multi.ReadUTF16()
+	require.Error(t, err)
+}
+
+func TestMReader_ReadByte(t *testing.T) {
+	fr := newFakeReader([]byte{111}, -1)
+	multi := NewMultiReader(fr)
+	b, err := multi.ReadByte()
+	require.NoError(t, err)
+	assert.Equal(t, byte(111), b)
+}
+
+func TestMReader_ReadByteErr(t *testing.T) {
+	fr := newFakeReader(nil, 0)
+	multi := NewMultiReader(fr)
+	_, err := multi.ReadByte()
+	require.Error(t, err)
+}
+
+func TestMReader_AssertNextByteEquals(t *testing.T) {
+	fr := newFakeReader([]byte{111}, -1)
+	multi := NewMultiReader(fr)
+	err := multi.AssertNextByteEquals(111)
+	require.NoError(t, err)
+}
+
+func TestMReader_AssertNextByteEquals_ReadErr(t *testing.T) {
+	fr := newFakeReader(nil, 0)
+	multi := NewMultiReader(fr)
+	err := multi.AssertNextByteEquals(111)
+	require.Error(t, err)
+}
+
+func TestMReader_AssertNextByteEquals_MismatchErr(t *testing.T) {
+	fr := newFakeReader([]byte{111}, -1)
+	multi := NewMultiReader(fr)
+	err := multi.AssertNextByteEquals(222)
+	require.Error(t, err, "next byte assertion failed")
+}
+
+func TestMReader_CompressedInt32_Simple(t *testing.T) {
+	fr := newFakeReader([]byte{42 | 0x80}, -1)
+	multi := NewMultiReader(fr)
+	i, err := multi.ReadCompressedInt32()
+	require.NoError(t, err)
+	require.Equal(t, int32(42), i)
+}
+
+func TestMReader_CompressedInt32_MultiByte(t *testing.T) {
+	fr := newFakeReader([]byte{1 | 0x80, 1}, -1)
+	multi := NewMultiReader(fr)
+	i, err := multi.ReadCompressedInt32()
+	require.NoError(t, err)
+	require.Equal(t, int32(0x81), i)
+}
+
+func TestMReader_CompressedInt32_LengthErr(t *testing.T) {
+	fr := newFakeReader([]byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80}, -1)
+	multi := NewMultiReader(fr)
+	_, err := multi.ReadCompressedInt32()
+	require.Error(t, err, "CompressedInt32 is too long")
+}
+
+func TestMReader_CompressedInt32_ReadErr(t *testing.T) {
+	fr := newFakeReader(nil, 0)
+	multi := NewMultiReader(fr)
+	_, err := multi.ReadCompressedInt32()
+	require.Error(t, err)
+}
+
+func TestMReader_CompressedInt64_Simple(t *testing.T) {
+	fr := newFakeReader([]byte{42 | 0x80}, -1)
+	multi := NewMultiReader(fr)
+	i, err := multi.ReadCompressedInt64()
+	require.NoError(t, err)
+	require.Equal(t, int64(42), i)
+}
+
+func TestMReader_CompressedInt64_MultiByte(t *testing.T) {
+	fr := newFakeReader([]byte{1 | 0x80, 1}, -1)
+	multi := NewMultiReader(fr)
+	i, err := multi.ReadCompressedInt64()
+	require.NoError(t, err)
+	require.Equal(t, int64(0x81), i)
+}
+
+func TestMReader_CompressedInt64_LengthErr(t *testing.T) {
+	p := make([]byte, 11)
+	for i := range p {
+		p[i] = 0x80
+	}
+	fr := newFakeReader(p, -1)
+	multi := NewMultiReader(fr)
+	_, err := multi.ReadCompressedInt64()
+	require.Error(t, err, "CompressedInt64 is too long")
+}
+
+func TestMReader_CompressedInt64_ReadErr(t *testing.T) {
+	fr := newFakeReader(nil, 0)
+	multi := NewMultiReader(fr)
+	_, err := multi.ReadCompressedInt64()
+	require.Error(t, err)
+}
+
+func TestMReader_SeekReset(t *testing.T) {
+	fr := newFakeReader(make([]byte, 6), -1)
+	multi := NewMultiReader(fr)
+	_, err := multi.ReadByte()
+	require.NoError(t, err)
+	multi.Reset()
+	assert.Equal(t, 1, multi.Pos())
+	err = multi.Seek(4)
+	require.NoError(t, err)
+	assert.Equal(t, 5, multi.Pos())
+	multi.Reset()
+	assert.Equal(t, 1, multi.Pos())
+}
+
+func TestMReader_Seek_ReadErr(t *testing.T) {
+	fr := newFakeReader(nil, 0)
+	multi := NewMultiReader(fr)
+	err := multi.Seek(1)
+	require.Error(t, err)
+}
+
+func TestMReader_ReadASCII(t *testing.T) {
+	fr := newFakeReader([]byte("hello"), -1)
+	multi := NewMultiReader(fr)
+	msg, err := multi.ReadASCII(5)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", msg)
+}
+
+func TestMReader_ReadASCIIErr(t *testing.T) {
+	fr := newFakeReader([]byte("hello"), 0)
+	multi := NewMultiReader(fr)
+	_, err := multi.ReadASCII(5)
+	require.Error(t, err)
+}
+
+// fakeReader
+type fakeReader struct {
+	source     []byte
+	pos        int
+	readCount  int
+	failOnRead int
+}
+
+func newFakeReader(source []byte, failOnRead int) *fakeReader {
+	return &fakeReader{
+		source:     source,
+		failOnRead: failOnRead,
+	}
+}
+
+func (r *fakeReader) Read(p []byte) (n int, err error) {
+	defer func() {
+		r.readCount++
+	}()
+	if r.readCount == r.failOnRead {
+		return 0, errors.New("")
+	}
+	copy(p, r.source[r.pos:])
+	r.pos += len(p)
+	return len(p), nil
+}

--- a/receiver/dotnetdiagnosticsreceiver/receiver.go
+++ b/receiver/dotnetdiagnosticsreceiver/receiver.go
@@ -66,6 +66,18 @@ func (r *receiver) Start(ctx context.Context, host component.Host) error {
 		return err
 	}
 
+	p := dotnet.NewParser(conn, r.logger)
+
+	err = p.ParseIPC()
+	if err != nil {
+		return err
+	}
+
+	err = p.ParseNettrace()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/receiver/dotnetdiagnosticsreceiver/receiver.go
+++ b/receiver/dotnetdiagnosticsreceiver/receiver.go
@@ -15,6 +15,7 @@
 package dotnetdiagnosticsreceiver
 
 import (
+	"bytes"
 	"context"
 	"io"
 

--- a/receiver/dotnetdiagnosticsreceiver/receiver.go
+++ b/receiver/dotnetdiagnosticsreceiver/receiver.go
@@ -15,7 +15,6 @@
 package dotnetdiagnosticsreceiver
 
 import (
-	"bytes"
 	"context"
 	"io"
 


### PR DESCRIPTION
This is the third PR in a series for the dotnet core diagnostics receiver.

This PR reads the initial responses made by the dotnet process after the initial request for metrics.

For the full implementation please see #2200