### PR TITLE
[Statsd receiver]Add metric type as a label 

### DIFF
--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -19,7 +19,7 @@ The Following settings are optional:
 
 - `aggregation_interval: 70s`(default value is 60s): The aggregation time that the receiver aggregates the metrics (similar to the flush interval in StatsD server)
 
-- `enable_metric_type: true`(default value is false): Enbale the statsd receiver to be able to emit the mertic type(guage, counter, timer(in the future), histogram(in the future)) as a lable.
+- `enable_metric_type: true`(default value is false): Enbale the statsd receiver to be able to emit the mertic type(gauge, counter, timer(in the future), histogram(in the future)) as a lable.
 
 Example:
 

--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -19,6 +19,8 @@ The Following settings are optional:
 
 - `aggregation_interval: 70s`(default value is 60s): The aggregation time that the receiver aggregates the metrics (similar to the flush interval in StatsD server)
 
+- `enable_metric_type: true`(default value is false): Enbale the statsd receiver to be able to emit the mertic type(guage, counter, timer(in the future), histogram(in the future)) as a lable.
+
 Example:
 
 ```yaml
@@ -27,6 +29,7 @@ receivers:
   statsd/2:
     endpoint: "localhost:8127"
     aggregation_interval: 70s
+    enable_metric_type: true
 ```
 
 The full list of settings exposed for this receiver are documented [here](./config.go)
@@ -95,6 +98,7 @@ receivers:
   statsd:
     endpoint: "localhost:8125" # default
     aggregation_interval: 60s  # default
+    enable_metric_type: false   # default
 
 exporters:
   file:

--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -26,4 +26,5 @@ type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 	NetAddr                       confignet.NetAddr `mapstructure:",squash"`
 	AggregationInterval           time.Duration     `mapstructure:"aggregation_interval"`
+	EnableMetricType              bool              `mapstructure:"enable_metric_type"`
 }

--- a/receiver/statsdreceiver/factory.go
+++ b/receiver/statsdreceiver/factory.go
@@ -31,6 +31,7 @@ const (
 	defaultBindEndpoint        = "localhost:8125"
 	defaultTransport           = "udp"
 	defaultAggregationInterval = 60 * time.Second
+	defaultEnableMetricType    = false
 )
 
 // NewFactory creates a factory for the StatsD receiver.
@@ -53,6 +54,7 @@ func createDefaultConfig() configmodels.Receiver {
 			Transport: defaultTransport,
 		},
 		AggregationInterval: defaultAggregationInterval,
+		EnableMetricType:    defaultEnableMetricType,
 	}
 }
 

--- a/receiver/statsdreceiver/protocol/parser.go
+++ b/receiver/statsdreceiver/protocol/parser.go
@@ -20,7 +20,7 @@ import (
 
 // Parser is something that can map input StatsD strings to OTLP Metric representations.
 type Parser interface {
-	Initialize() error
+	Initialize(enableMetricType bool) error
 	GetMetrics() []*metricspb.Metric
 	Aggregate(line string) error
 }

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -35,10 +35,13 @@ func getSupportedTypes() []string {
 	return []string{"c", "g"}
 }
 
+const TagMetricType = "metric_type"
+
 // StatsDParser supports the Parse method for parsing StatsD messages with Tags.
 type StatsDParser struct {
-	gauges   map[statsDMetricdescription]*metricspb.Metric
-	counters map[statsDMetricdescription]*metricspb.Metric
+	gauges           map[statsDMetricdescription]*metricspb.Metric
+	counters         map[statsDMetricdescription]*metricspb.Metric
+	enableMetricType bool
 }
 
 type statsDMetric struct {
@@ -60,9 +63,10 @@ type statsDMetricdescription struct {
 	labels           label.Distinct
 }
 
-func (p *StatsDParser) Initialize() error {
+func (p *StatsDParser) Initialize(enableMetricType bool) error {
 	p.gauges = make(map[statsDMetricdescription]*metricspb.Metric)
 	p.counters = make(map[statsDMetricdescription]*metricspb.Metric)
+	p.enableMetricType = enableMetricType
 	return nil
 }
 
@@ -90,7 +94,7 @@ var timeNowFunc = func() int64 {
 
 //aggregate for each metric line
 func (p *StatsDParser) Aggregate(line string) error {
-	parsedMetric, err := parseMessageToMetric(line)
+	parsedMetric, err := parseMessageToMetric(line, p.enableMetricType)
 	if err != nil {
 		return err
 	}
@@ -128,7 +132,7 @@ func (p *StatsDParser) Aggregate(line string) error {
 	return nil
 }
 
-func parseMessageToMetric(line string) (statsDMetric, error) {
+func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, error) {
 	result := statsDMetric{}
 
 	parts := strings.Split(line, "|")
@@ -159,6 +163,10 @@ func parseMessageToMetric(line string) (statsDMetric, error) {
 	}
 
 	additionalParts := parts[2:]
+
+	var kvs []label.KeyValue
+	var sortable label.Sortable
+
 	for _, part := range additionalParts {
 		// TODO: Sample rate doesn't currently have a place to go in the protocol
 		if strings.HasPrefix(part, "@") {
@@ -175,11 +183,6 @@ func parseMessageToMetric(line string) (statsDMetric, error) {
 
 			tagSets := strings.Split(tagsStr, ",")
 
-			result.labelKeys = make([]*metricspb.LabelKey, 0, len(tagSets))
-			result.labelValues = make([]*metricspb.LabelValue, 0, len(tagSets))
-
-			var kvs []label.KeyValue
-			var sortable label.Sortable
 			for _, tagSet := range tagSets {
 				tagParts := strings.Split(tagSet, ":")
 				if len(tagParts) != 2 {
@@ -192,13 +195,11 @@ func parseMessageToMetric(line string) (statsDMetric, error) {
 				})
 				kvs = append(kvs, label.String(tagParts[0], tagParts[1]))
 			}
-			set := label.NewSetWithSortable(kvs, &sortable)
-			result.description.labels = set.Equivalent()
+
 		} else {
 			return result, fmt.Errorf("unrecognized message part: %s", part)
 		}
 	}
-
 	switch result.description.statsdMetricType {
 	case "g":
 		f, err := strconv.ParseFloat(result.value, 64)
@@ -218,6 +219,29 @@ func parseMessageToMetric(line string) (statsDMetric, error) {
 		}
 		result.intvalue = i
 		result.metricType = metricspb.MetricDescriptor_GAUGE_INT64
+	}
+
+	// add metric_type dimension for all metrics
+
+	if enableMetricType {
+		var metricType = ""
+		switch result.description.statsdMetricType {
+		case "g":
+			metricType = "gauge"
+		case "c":
+			metricType = "counter"
+		}
+		result.labelKeys = append(result.labelKeys, &metricspb.LabelKey{Key: TagMetricType})
+		result.labelValues = append(result.labelValues, &metricspb.LabelValue{
+			Value:    metricType,
+			HasValue: true,
+		})
+		kvs = append(kvs, label.String(TagMetricType, metricType))
+	}
+
+	if len(kvs) != 0 {
+		set := label.NewSetWithSortable(kvs, &sortable)
+		result.description.labels = set.Equivalent()
 	}
 
 	return result, nil

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -158,7 +158,6 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 	}
 
 	result.description.statsdMetricType = parts[1]
-	
 	if !contains(getSupportedTypes(), result.description.statsdMetricType) {
 		return result, fmt.Errorf("unsupported metric type: %s", result.description.statsdMetricType)
 	}

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -158,6 +158,7 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 	}
 
 	result.description.statsdMetricType = parts[1]
+	
 	if !contains(getSupportedTypes(), result.description.statsdMetricType) {
 		return result, fmt.Errorf("unsupported metric type: %s", result.description.statsdMetricType)
 	}

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -222,6 +222,7 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 	}
 
 	// add metric_type dimension for all metrics
+
 	if enableMetricType {
 		var metricType = ""
 		switch result.description.statsdMetricType {

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -222,7 +222,6 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 	}
 
 	// add metric_type dimension for all metrics
-
 	if enableMetricType {
 		var metricType = ""
 		switch result.description.statsdMetricType {

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -101,7 +101,7 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 		var transferChan = make(chan string, 10)
 		ticker := time.NewTicker(r.config.AggregationInterval)
 		err = nil
-		r.parser.Initialize()
+		r.parser.Initialize(r.config.EnableMetricType)
 		go func() {
 			err = r.server.ListenAndServe(r.parser, r.nextConsumer, r.reporter, transferChan)
 			if err != nil {

--- a/receiver/statsdreceiver/testdata/config.yaml
+++ b/receiver/statsdreceiver/testdata/config.yaml
@@ -4,6 +4,7 @@ receivers:
     endpoint: "localhost:12345"
     transport: "custom_transport"
     aggregation_interval: 70s
+    enable_metric_type: false
 
 processors:
   exampleprocessor:


### PR DESCRIPTION
**Backgrounds:** 

One of our customer has a requirement to get a metric_type label. This label is same with the statsd data type.
Because this dimension is only required by one of our customer, we decide to add flag to enable this label in the config file.

**Description:** 

1, Add a new label called metric_type for statsd receiver.

2, Add a new flag label for the config file of the statsd.  `enable_metric_type`

3, Add unit tests for the config when `enable_metric_type = true`

**Testing:** 
Unit test and local test.