### PR TITLE
Send metrics to Dynatrace in chunks of 1000

### DIFF
--- a/exporter/dynatraceexporter/metrics_exporter.go
+++ b/exporter/dynatraceexporter/metrics_exporter.go
@@ -136,7 +136,7 @@ var lastLog int64 = 0
 // An error indicates all lines were dropped regardless of the returned number.
 func (e *exporter) send(ctx context.Context, lines []string) (int, error) {
 	if now := time.Now().Unix(); len(lines) > maxChunkSize && now-lastLog > 60 {
-		e.logger.Sugar().Warnf("Batch too large. Sending in chunks of %[1]s metrics. If any chunk fails, previous chunks in the batch could be retried by the batch processor. Please set send_batch_max_size to %[1]s or less. Suppressing this log for 60 seconds.", maxChunkSize)
+		e.logger.Warn(fmt.Sprintf("Batch too large. Sending in chunks of %[1]d metrics. If any chunk fails, previous chunks in the batch could be retried by the batch processor. Please set send_batch_max_size to %[1]d or less. Suppressing this log for 60 seconds.", maxChunkSize))
 		lastLog = time.Now().Unix()
 	}
 

--- a/exporter/dynatraceexporter/metrics_exporter_test.go
+++ b/exporter/dynatraceexporter/metrics_exporter_test.go
@@ -17,6 +17,7 @@ package dynatraceexporter
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -281,7 +282,7 @@ func Test_exporter_send_BadRequest(t *testing.T) {
 		},
 		client: ts.Client(),
 	}
-	invalid, err := e.send(context.Background(), []string{})
+	invalid, err := e.send(context.Background(), []string{""})
 	if invalid != 10 {
 		t.Errorf("Expected 10 lines to be reported invalid")
 		return
@@ -310,7 +311,7 @@ func Test_exporter_send_Unauthorized(t *testing.T) {
 		},
 		client: ts.Client(),
 	}
-	_, err := e.send(context.Background(), []string{})
+	_, err := e.send(context.Background(), []string{""})
 	if !consumererror.IsPermanent(err) {
 		t.Errorf("Expected error to be permanent %v", err)
 		return
@@ -335,7 +336,7 @@ func Test_exporter_send_TooLarge(t *testing.T) {
 		},
 		client: ts.Client(),
 	}
-	_, err := e.send(context.Background(), []string{})
+	_, err := e.send(context.Background(), []string{""})
 	if !consumererror.IsPermanent(err) {
 		t.Errorf("Expected error to be permanent %v", err)
 		return
@@ -363,13 +364,53 @@ func Test_exporter_send_NotFound(t *testing.T) {
 		},
 		client: ts.Client(),
 	}
-	_, err := e.send(context.Background(), []string{})
+	_, err := e.send(context.Background(), []string{""})
 	if !consumererror.IsPermanent(err) {
 		t.Errorf("Expected error to be permanent %v", err)
 		return
 	}
 	if !e.isDisabled {
 		t.Error("Expected exporter to be disabled")
+		return
+	}
+}
+
+func Test_exporter_send_chunking(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		body, _ := json.Marshal(metricsResponse{
+			Ok:      0,
+			Invalid: 10,
+		})
+		w.Write(body)
+	}))
+	defer ts.Close()
+
+	e := &exporter{
+		logger: zap.NewNop(),
+		cfg: &config.Config{
+			HTTPClientSettings: confighttp.HTTPClientSettings{Endpoint: ts.URL},
+		},
+		client: ts.Client(),
+	}
+
+	batch := make([]string, 1001)
+
+	for i := 0; i < 1001; i++ {
+		batch[i] = fmt.Sprintf("%d", i)
+	}
+
+	invalid, err := e.send(context.Background(), []string{""})
+	if invalid != 10 {
+		t.Errorf("Expected 10 lines to be reported invalid")
+		return
+	}
+	if consumererror.IsPermanent(err) {
+		t.Errorf("Expected error to not be permanent %v", err)
+		return
+	}
+	if e.isDisabled {
+		t.Error("Expected exporter to not be disabled")
 		return
 	}
 }


### PR DESCRIPTION
The Dynatrace metrics API cannot accept more than 1000 metrics in a single request. Attempt to send in chunks of 1000, warning the user not more than once per 60 seconds.