### PR TITLE
Direct EMF output to stdout to support AWS Lambda

### DIFF
--- a/exporter/awsemfexporter/README.md
+++ b/exporter/awsemfexporter/README.md
@@ -25,6 +25,7 @@ The following exporter configuration parameters are supported.
 | `max_retries`     | Maximum number of retries before abandoning an attempt to post data.   |    1    |
 | `dimension_rollup_option`| DimensionRollupOption is the option for metrics dimension rollup. Three options are available. |"ZeroAndSingleDimensionRollup" (Enable both zero dimension rollup and single dimension rollup)| 
 | `resource_to_telemetry_conversion` | "resource_to_telemetry_conversion" is the option for converting resource attributes to telemetry attributes. It has only one config onption- `enabled`. For metrics, if `enabled=true`, all the resource attributes will be converted to metric labels by default. See `Resource Attributes to Metric Labels` section below for examples. | `enabled=false` | 
+| `run_in_lambda` | "run_in_lambda" is the option to support AWS Lambda by directing EMF exporter output to stdout, which will then be sent to CWLogs by Lambda. | `false` | 
 | [`metric_declarations`](#metric_declaration) | List of rules for filtering exported metrics and their dimensions. |    [ ]   |
 | [`metric_descriptors`](#metric_descriptor) | List of rules for inserting or updating metric descriptors.| [ ]|
 

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -67,6 +67,9 @@ type Config struct {
 	// MetricDescriptors is the list of override metric descriptors that are sent to the CloudWatch
 	MetricDescriptors []MetricDescriptor `mapstructure:"metric_descriptors"`
 
+	// RunInLambda is an option to support AWS Lambda. (In Lambda, the EMF output will be directed to stdout)
+	RunInLambda bool `mapstructure:"run_in_lambda"`
+
 	// ResourceToTelemetrySettings is the option for converting resource attrihutes to telemetry attributes.
 	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.
 	// If enabled, all the resource attributes will be converted to metric labels by default.

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -123,6 +123,66 @@ func TestConsumeMetrics(t *testing.T) {
 	require.NoError(t, exp.Shutdown(ctx))
 }
 
+func TestConsumeMetricsWithRunInLambda(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	factory := NewFactory()
+	expCfg := factory.CreateDefaultConfig().(*Config)
+	expCfg.Region = "us-west-2"
+	expCfg.MaxRetries = 0
+	expCfg.RunInLambda = true
+	exp, err := New(expCfg, component.ExporterCreateParams{Logger: zap.NewNop()})
+	assert.Nil(t, err)
+	assert.NotNil(t, exp)
+
+	mdata := consumerdata.MetricsData{
+		Node: &commonpb.Node{
+			ServiceInfo: &commonpb.ServiceInfo{Name: "test-emf"},
+			LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "SomeVersion"},
+		},
+		Resource: &resourcepb.Resource{
+			Labels: map[string]string{
+				"resource": "R1",
+			},
+		},
+		Metrics: []*metricspb.Metric{
+			{
+				MetricDescriptor: &metricspb.MetricDescriptor{
+					Name:        "spanCounter",
+					Description: "Counting all the spans",
+					Unit:        "Count",
+					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+					LabelKeys: []*metricspb.LabelKey{
+						{Key: "spanName"},
+						{Key: "isItAnError"},
+					},
+				},
+				Timeseries: []*metricspb.TimeSeries{
+					{
+						LabelValues: []*metricspb.LabelValue{
+							{Value: "testSpan", HasValue: true},
+							{Value: "false", HasValue: true},
+						},
+						Points: []*metricspb.Point{
+							{
+								Timestamp: &timestamp.Timestamp{
+									Seconds: 1234567890123,
+								},
+								Value: &metricspb.Point_Int64Value{
+									Int64Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	md := internaldata.OCToMetrics(mdata)
+	require.NoError(t, exp.ConsumeMetrics(ctx, md))
+	require.NoError(t, exp.Shutdown(ctx))
+}
+
 func TestConsumeMetricsWithLogGroupStreamConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/exporter/awsemfexporter/factory.go
+++ b/exporter/awsemfexporter/factory.go
@@ -54,6 +54,7 @@ func createDefaultConfig() configmodels.Exporter {
 		RoleARN:               "",
 		DimensionRollupOption: "ZeroAndSingleDimensionRollup",
 		MetricDeclarations:    make([]*MetricDeclaration, 0),
+		RunInLambda:           false,
 		logger:                nil,
 	}
 }


### PR DESCRIPTION
**Description:** 
Direct EMF output to stdout to support AWS Lambda
Add an option in config to allow customer enable Lambda support.


**Testing:** 
Unit tests

**Documentation:** 
Add a description in README.
>"run_in_lambda" is the option to support AWS Lambda by directing EMF exporter output to stdout, which will then be sent to CWLogs by Lambda.