### PR TITLE
Update codeowners for newrelicexporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,7 @@ exporter/awskinesisexporter/                  @open-telemetry/collector-contrib-
 exporter/loadbalancingexporter/            @open-telemetry/collector-contrib-approvers @jpkrohling
 exporter/logzioexporter/                   @open-telemetry/collector-contrib-approvers @yyyogev
 exporter/lokiexporter/                     @open-telemetry/collector-contrib-approvers @gramidt
-exporter/newrelicexporter/                 @open-telemetry/collector-contrib-approvers @MrAlias
+exporter/newrelicexporter/                 @open-telemetry/collector-contrib-approvers @alanwest @a-feld @jack-berg @nrcventura
 exporter/sapmexporter/                     @open-telemetry/collector-contrib-approvers @owais @dmitryax
 exporter/sentryexporter/                   @open-telemetry/collector-contrib-approvers @AbhiPrasad
 exporter/signalfxexporter/                 @open-telemetry/collector-contrib-approvers @pmcollins @asuresh4


### PR DESCRIPTION
@MrAlias is no longer at New Relic 😢. Updating codeowners for `newrelicexporter` with the individuals who will maintain it.