### PR TITLE
Calculate delta instead of rate for cumulative metrics in EMF exporter

### DIFF
--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -18,25 +18,24 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws"
 )
 
-var rateMetricCalculator = newFloat64RateCalculator()
+var deltaMetricCalculator = aws.NewFloat64DeltaCalculator()
+var summaryMetricCalculator = aws.NewMetricCalculator(calculateSummaryDelta)
 
-func newFloat64RateCalculator() aws.MetricCalculator {
-	return aws.NewMetricCalculator(func(prev *aws.MetricValue, val interface{}, timestamp time.Time) (interface{}, bool) {
-		if prev != nil {
-			deltaTimestampMs := timestamp.Sub(prev.Timestamp).Milliseconds()
-			deltaValue := val.(float64) - prev.RawValue.(float64)
-			if deltaTimestampMs > 50*time.Millisecond.Milliseconds() && deltaValue >= 0 {
-				return deltaValue * 1e3 / float64(deltaTimestampMs), true
-			}
-		}
-		return float64(0), true
-	})
+func calculateSummaryDelta(prev *aws.MetricValue, val interface{}, timestampMs time.Time) (interface{}, bool) {
+	metricEntry := val.(summaryMetricEntry)
+	summaryDelta := metricEntry.sum
+	countDelta := metricEntry.count
+	if prev != nil {
+		prevSummaryEntry := prev.RawValue.(summaryMetricEntry)
+		summaryDelta = summaryDelta - prevSummaryEntry.sum
+		countDelta = countDelta - prevSummaryEntry.count
+	}
+	return summaryMetricEntry{summaryDelta, countDelta}, true
 }
 
 // DataPoint represents a processed metric data point
@@ -58,33 +57,39 @@ type DataPoints interface {
 	At(i int) DataPoint
 }
 
-// rateCalculationMetadata contains the metadata required to perform rate calculation
-type rateCalculationMetadata struct {
-	needsCalculateRate bool
-	rateKeyParams      rateKeyParams
-	timestampMs        int64
+// deltaMetricMetadata contains the metadata required to perform rate/delta calculation
+type deltaMetricMetadata struct {
+	adjustToDelta bool
+	metricName    string
+	timestampMs   int64
+	namespace     string
+	logGroup      string
+	logStream     string
 }
 
-type rateKeyParams struct {
-	namespaceKey  string
-	metricNameKey string
-	logGroupKey   string
-	logStreamKey  string
-	timestampKey  string
-	labels        attribute.Distinct
+func mergeLabels(m deltaMetricMetadata, labels map[string]string) map[string]string {
+	result := map[string]string{
+		"namespace": m.namespace,
+		"logGroup":  m.logGroup,
+		"logStream": m.logStream,
+	}
+	for k, v := range labels {
+		result[k] = v
+	}
+	return result
 }
 
 // IntDataPointSlice is a wrapper for pdata.IntDataPointSlice
 type IntDataPointSlice struct {
 	instrumentationLibraryName string
-	rateCalculationMetadata
+	deltaMetricMetadata
 	pdata.IntDataPointSlice
 }
 
 // DoubleDataPointSlice is a wrapper for pdata.DoubleDataPointSlice
 type DoubleDataPointSlice struct {
 	instrumentationLibraryName string
-	rateCalculationMetadata
+	deltaMetricMetadata
 	pdata.DoubleDataPointSlice
 }
 
@@ -97,26 +102,27 @@ type DoubleHistogramDataPointSlice struct {
 // SummaryDataPointSlice is a wrapper for pdata.SummaryDataPointSlice
 type SummaryDataPointSlice struct {
 	instrumentationLibraryName string
+	deltaMetricMetadata
 	pdata.SummaryDataPointSlice
 }
 
-// At retrieves the IntDataPoint at the given index and performs rate calculation if necessary.
+type summaryMetricEntry struct {
+	sum   float64
+	count uint64
+}
+
+// At retrieves the IntDataPoint at the given index and performs rate/delta calculation if necessary.
 func (dps IntDataPointSlice) At(i int) DataPoint {
 	metric := dps.IntDataPointSlice.At(i)
+	timestampMs := unixNanoToMilliseconds(metric.Timestamp())
 	labels := createLabels(metric.LabelsMap(), dps.instrumentationLibraryName)
 
-	timestampMs := unixNanoToMilliseconds(metric.Timestamp())
-	rateTimestamp := metric.Timestamp().AsTime()
-	if timestampMs == 0 {
-		rateTimestamp = time.Unix(0, dps.timestampMs*int64(time.Millisecond))
-	}
 	var metricVal float64
 	metricVal = float64(metric.Value())
-
-	if dps.needsCalculateRate {
-		rateVal, _ := rateMetricCalculator.Calculate(dps.rateKeyParams.metricNameKey, labels,
-			metricVal, rateTimestamp)
-		metricVal = rateVal.(float64)
+	if dps.adjustToDelta {
+		deltaVal, _ := deltaMetricCalculator.Calculate(dps.metricName, mergeLabels(dps.deltaMetricMetadata, labels),
+			metricVal, metric.Timestamp().AsTime())
+		metricVal = deltaVal.(float64)
 	}
 
 	return DataPoint{
@@ -126,22 +132,18 @@ func (dps IntDataPointSlice) At(i int) DataPoint {
 	}
 }
 
-// At retrieves the DoubleDataPoint at the given index and performs rate calculation if necessary.
+// At retrieves the DoubleDataPoint at the given index and performs rate/delta calculation if necessary.
 func (dps DoubleDataPointSlice) At(i int) DataPoint {
 	metric := dps.DoubleDataPointSlice.At(i)
 	labels := createLabels(metric.LabelsMap(), dps.instrumentationLibraryName)
-
 	timestampMs := unixNanoToMilliseconds(metric.Timestamp())
-	rateTimestamp := metric.Timestamp().AsTime()
-	if timestampMs == 0 {
-		rateTimestamp = time.Unix(0, dps.timestampMs*int64(time.Millisecond))
-	}
-	metricVal := metric.Value()
 
-	if dps.needsCalculateRate {
-		rateVal, _ := rateMetricCalculator.Calculate(dps.rateKeyParams.metricNameKey, labels,
-			metricVal, rateTimestamp)
-		metricVal = rateVal.(float64)
+	var metricVal float64
+	metricVal = metric.Value()
+	if dps.adjustToDelta {
+		deltaVal, _ := deltaMetricCalculator.Calculate(dps.metricName, mergeLabels(dps.deltaMetricMetadata, labels),
+			metricVal, metric.Timestamp().AsTime())
+		metricVal = deltaVal.(float64)
 	}
 
 	return DataPoint{
@@ -173,9 +175,19 @@ func (dps SummaryDataPointSlice) At(i int) DataPoint {
 	labels := createLabels(metric.LabelsMap(), dps.instrumentationLibraryName)
 	timestampMs := unixNanoToMilliseconds(metric.Timestamp())
 
+	sum := metric.Sum()
+	count := metric.Count()
+	if dps.adjustToDelta {
+		delta, _ := summaryMetricCalculator.Calculate(dps.metricName, mergeLabels(dps.deltaMetricMetadata, labels),
+			summaryMetricEntry{metric.Sum(), metric.Count()}, metric.Timestamp().AsTime())
+		summaryMetricDelta := delta.(summaryMetricEntry)
+		sum = summaryMetricDelta.sum
+		count = summaryMetricDelta.count
+	}
+
 	metricVal := &CWMetricStats{
-		Count: metric.Count(),
-		Sum:   metric.Sum(),
+		Count: count,
+		Sum:   sum,
 	}
 	if quantileValues := metric.QuantileValues(); quantileValues.Len() > 0 {
 		metricVal.Min = quantileValues.At(0).Value()
@@ -205,29 +217,19 @@ func createLabels(labelsMap pdata.StringMap, instrLibName string) map[string]str
 	return labels
 }
 
-// getSortedLabels converts OTel StringMap labels to sorted labels as attribute.Distinct
-func getSortedLabels(labels map[string]string) attribute.Distinct {
-	var kvs []attribute.KeyValue
-	var sortable attribute.Sortable
-	for k, v := range labels {
-		kvs = append(kvs, attribute.String(k, v))
-	}
-	set := attribute.NewSetWithSortable(kvs, &sortable)
-
-	return set.Equivalent()
-}
-
 // getDataPoints retrieves data points from OT Metric.
 func getDataPoints(pmd *pdata.Metric, metadata CWMetricMetadata, logger *zap.Logger) (dps DataPoints) {
 	if pmd == nil {
 		return
 	}
 
-	rateKeys := rateKeyParams{
-		namespaceKey:  metadata.Namespace,
-		metricNameKey: pmd.Name(),
-		logGroupKey:   metadata.LogGroup,
-		logStreamKey:  metadata.LogStream,
+	adjusterMetadata := deltaMetricMetadata{
+		false,
+		pmd.Name(),
+		metadata.TimestampMs,
+		metadata.Namespace,
+		metadata.LogGroup,
+		metadata.LogStream,
 	}
 
 	switch pmd.DataType() {
@@ -235,44 +237,30 @@ func getDataPoints(pmd *pdata.Metric, metadata CWMetricMetadata, logger *zap.Log
 		metric := pmd.IntGauge()
 		dps = IntDataPointSlice{
 			metadata.InstrumentationLibraryName,
-			rateCalculationMetadata{
-				false,
-				rateKeys,
-				metadata.TimestampMs,
-			},
+			adjusterMetadata,
 			metric.DataPoints(),
 		}
 	case pdata.MetricDataTypeDoubleGauge:
 		metric := pmd.DoubleGauge()
 		dps = DoubleDataPointSlice{
 			metadata.InstrumentationLibraryName,
-			rateCalculationMetadata{
-				false,
-				rateKeys,
-				metadata.TimestampMs,
-			},
+			adjusterMetadata,
 			metric.DataPoints(),
 		}
 	case pdata.MetricDataTypeIntSum:
 		metric := pmd.IntSum()
+		adjusterMetadata.adjustToDelta = metric.AggregationTemporality() == pdata.AggregationTemporalityCumulative
 		dps = IntDataPointSlice{
 			metadata.InstrumentationLibraryName,
-			rateCalculationMetadata{
-				metric.AggregationTemporality() == pdata.AggregationTemporalityCumulative,
-				rateKeys,
-				metadata.TimestampMs,
-			},
+			adjusterMetadata,
 			metric.DataPoints(),
 		}
 	case pdata.MetricDataTypeDoubleSum:
 		metric := pmd.DoubleSum()
+		adjusterMetadata.adjustToDelta = metric.AggregationTemporality() == pdata.AggregationTemporalityCumulative
 		dps = DoubleDataPointSlice{
 			metadata.InstrumentationLibraryName,
-			rateCalculationMetadata{
-				metric.AggregationTemporality() == pdata.AggregationTemporalityCumulative,
-				rateKeys,
-				metadata.TimestampMs,
-			},
+			adjusterMetadata,
 			metric.DataPoints(),
 		}
 	case pdata.MetricDataTypeDoubleHistogram:
@@ -283,8 +271,10 @@ func getDataPoints(pmd *pdata.Metric, metadata CWMetricMetadata, logger *zap.Log
 		}
 	case pdata.MetricDataTypeSummary:
 		metric := pmd.Summary()
+		adjusterMetadata.adjustToDelta = true
 		dps = SummaryDataPointSlice{
 			metadata.InstrumentationLibraryName,
+			adjusterMetadata,
 			metric.DataPoints(),
 		}
 	default:

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -28,6 +28,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws"
 )
 
 func generateTestIntGauge(name string) *metricspb.Metric {
@@ -241,45 +243,39 @@ func generateTestSummary(name string) *metricspb.Metric {
 	}
 }
 
-func TestIntDataPointSliceAt(t *testing.T) {
-	instrLibName := "cloudwatch-otel"
-	labels := map[string]string{"label1": "value1"}
-	rateKeys := rateKeyParams{
-		namespaceKey:  "namespace",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-	}
+func setupDataPointCache() {
+	deltaMetricCalculator = aws.NewFloat64DeltaCalculator()
+	summaryMetricCalculator = aws.NewMetricCalculator(calculateSummaryDelta)
+}
 
-	testCases := []struct {
-		testName           string
-		needsCalculateRate bool
-		value              interface{}
-		calculatedValue    interface{}
+func TestIntDataPointSliceAt(t *testing.T) {
+	setupDataPointCache()
+
+	instrLibName := "cloudwatch-otel"
+	labels := map[string]string{"label": "value"}
+
+	testDeltaCases := []struct {
+		testName        string
+		adjustToDelta   bool
+		value           interface{}
+		calculatedValue interface{}
 	}{
 		{
-			"no rate calculation",
-			false,
+			"w/ 1st delta calculation",
+			true,
 			int64(-17),
 			float64(-17),
 		},
 		{
-			"w/ 1st rate calculation",
+			"w/ 2st delta calculation",
 			true,
 			int64(1),
-			float64(0),
-		},
-		{
-			"w/ 2nd rate calculation",
-			true,
-			int64(2),
-			float64(1),
+			float64(18),
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range testDeltaCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 			testDPS := pdata.NewIntDataPointSlice()
 			testDPS.Resize(1)
 			testDP := testDPS.At(0)
@@ -288,10 +284,13 @@ func TestIntDataPointSliceAt(t *testing.T) {
 
 			dps := IntDataPointSlice{
 				instrLibName,
-				rateCalculationMetadata{
-					tc.needsCalculateRate,
-					rateKeys,
-					timestamp,
+				deltaMetricMetadata{
+					tc.adjustToDelta,
+					"foo",
+					0,
+					"namespace",
+					"log-group",
+					"log-stream",
 				},
 				testDPS,
 			}
@@ -300,7 +299,7 @@ func TestIntDataPointSliceAt(t *testing.T) {
 				Value: tc.calculatedValue,
 				Labels: map[string]string{
 					oTellibDimensionKey: instrLibName,
-					"label1":            "value1",
+					"label":             "value",
 				},
 			}
 
@@ -311,51 +310,38 @@ func TestIntDataPointSliceAt(t *testing.T) {
 			} else {
 				assert.Equal(t, expectedDP, dp)
 			}
-			// sleep 1s for verifying the cumulative metric delta rate
-			time.Sleep(1000 * time.Millisecond)
 		})
 	}
 }
 
 func TestDoubleDataPointSliceAt(t *testing.T) {
+	setupDataPointCache()
+
 	instrLibName := "cloudwatch-otel"
 	labels := map[string]string{"label1": "value1"}
-	rateKeys := rateKeyParams{
-		namespaceKey:  "namespace",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-	}
 
-	testCases := []struct {
-		testName           string
-		needsCalculateRate bool
-		value              interface{}
-		calculatedValue    interface{}
+	testDeltaCases := []struct {
+		testName        string
+		adjustToDelta   bool
+		value           interface{}
+		calculatedValue interface{}
 	}{
 		{
-			"no rate calculation",
-			false,
-			float64(0.3),
-			float64(0.3),
-		},
-		{
-			"w/ 1st rate calculation",
+			"w/ 1st delta calculation",
 			true,
 			float64(0.4),
-			float64(0.0),
+			float64(0.4),
 		},
 		{
-			"w/ 2nd rate calculation",
-			true,
+			"w/ 2nd delta calculation",
+			false,
 			float64(0.5),
 			float64(0.1),
 		},
 	}
 
-	for _, tc := range testCases {
+	for _, tc := range testDeltaCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 			testDPS := pdata.NewDoubleDataPointSlice()
 			testDPS.Resize(1)
 			testDP := testDPS.At(0)
@@ -364,10 +350,13 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 
 			dps := DoubleDataPointSlice{
 				instrLibName,
-				rateCalculationMetadata{
-					tc.needsCalculateRate,
-					rateKeys,
-					timestamp,
+				deltaMetricMetadata{
+					tc.adjustToDelta,
+					"foo",
+					0,
+					"namespace",
+					"log-group",
+					"log-stream",
 				},
 				testDPS,
 			}
@@ -382,13 +371,7 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 
 			assert.Equal(t, 1, dps.Len())
 			dp := dps.At(0)
-			if strings.Contains(tc.testName, "2nd rate") {
-				assert.InDelta(t, expectedDP.Value.(float64), dp.Value.(float64), 0.002)
-			} else {
-				assert.Equal(t, expectedDP, dp)
-			}
-			// sleep 10ms for verifying the cumulative metric delta rate
-			time.Sleep(1000 * time.Millisecond)
+			assert.True(t, (expectedDP.Value.(float64)-dp.Value.(float64)) < 0.002)
 		})
 	}
 }
@@ -428,44 +411,88 @@ func TestDoubleHistogramDataPointSliceAt(t *testing.T) {
 }
 
 func TestSummaryDataPointSliceAt(t *testing.T) {
+	setupDataPointCache()
+
 	instrLibName := "cloudwatch-otel"
 	labels := map[string]string{"label1": "value1"}
+	metadataTimeStamp := time.Now().UnixNano() / int64(time.Millisecond)
 
-	testDPS := pdata.NewSummaryDataPointSlice()
-	testDPS.Resize(1)
-	testDP := testDPS.At(0)
-	testDP.SetCount(uint64(17))
-	testDP.SetSum(float64(17.13))
-	testDP.QuantileValues().Resize(2)
-	testQuantileValue := testDP.QuantileValues().At(0)
-	testQuantileValue.SetQuantile(0)
-	testQuantileValue.SetValue(float64(1))
-	testQuantileValue = testDP.QuantileValues().At(1)
-	testQuantileValue.SetQuantile(100)
-	testQuantileValue.SetValue(float64(5))
-	testDP.LabelsMap().InitFromMap(labels)
-
-	dps := SummaryDataPointSlice{
-		instrLibName,
-		testDPS,
-	}
-
-	expectedDP := DataPoint{
-		Value: &CWMetricStats{
-			Max:   5,
-			Min:   1,
-			Count: 17,
-			Sum:   17.13,
+	testCases := []struct {
+		testName           string
+		inputSumCount      []interface{}
+		calculatedSumCount []interface{}
+	}{
+		{
+			"1st summary count calculation",
+			[]interface{}{float64(17.3), uint64(17)},
+			[]interface{}{float64(17.3), uint64(17)},
 		},
-		Labels: map[string]string{
-			oTellibDimensionKey: instrLibName,
-			"label1":            "value1",
+		{
+			"2nd summary count calculation",
+			[]interface{}{float64(100), uint64(25)},
+			[]interface{}{float64(82.7), uint64(8)},
+		},
+		{
+			"3rd summary count calculation",
+			[]interface{}{float64(120), uint64(26)},
+			[]interface{}{float64(20), uint64(1)},
 		},
 	}
 
-	assert.Equal(t, 1, dps.Len())
-	dp := dps.At(0)
-	assert.Equal(t, expectedDP, dp)
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			testDPS := pdata.NewSummaryDataPointSlice()
+			testDPS.Resize(1)
+			testDP := testDPS.At(0)
+			testDP.SetSum(tt.inputSumCount[0].(float64))
+			testDP.SetCount(tt.inputSumCount[1].(uint64))
+
+			testDP.QuantileValues().Resize(2)
+			testQuantileValue := testDP.QuantileValues().At(0)
+			testQuantileValue.SetQuantile(0)
+			testQuantileValue.SetValue(float64(1))
+			testQuantileValue = testDP.QuantileValues().At(1)
+			testQuantileValue.SetQuantile(100)
+			testQuantileValue.SetValue(float64(5))
+			testDP.LabelsMap().InitFromMap(labels)
+
+			dps := SummaryDataPointSlice{
+				instrLibName,
+				deltaMetricMetadata{
+					true,
+					"foo",
+					metadataTimeStamp,
+					"namespace",
+					"log-group",
+					"log-stream",
+				},
+				testDPS,
+			}
+
+			expectedDP := DataPoint{
+				Value: &CWMetricStats{
+					Max:   5,
+					Min:   1,
+					Sum:   tt.calculatedSumCount[0].(float64),
+					Count: tt.calculatedSumCount[1].(uint64),
+				},
+				Labels: map[string]string{
+					oTellibDimensionKey: instrLibName,
+					"label1":            "value1",
+				},
+			}
+
+			assert.Equal(t, 1, dps.Len())
+			dp := dps.At(0)
+			expectedMetricStats := expectedDP.Value.(*CWMetricStats)
+			actualMetricsStats := dp.Value.(*CWMetricStats)
+			assert.Equal(t, expectedDP.Labels, dp.Labels)
+			assert.Equal(t, expectedMetricStats.Max, actualMetricsStats.Max)
+			assert.Equal(t, expectedMetricStats.Min, actualMetricsStats.Min)
+			assert.InDelta(t, expectedMetricStats.Count, actualMetricsStats.Count, 0.1)
+			assert.True(t, expectedMetricStats.Sum-actualMetricsStats.Sum < float64(0.02))
+		})
+	}
 }
 
 func TestCreateLabels(t *testing.T) {
@@ -485,52 +512,33 @@ func TestCreateLabels(t *testing.T) {
 	assert.Equal(t, expectedLabels, labels)
 }
 
-func TestCalculateRate(t *testing.T) {
-	intRateKey := "foo"
-	doubleRateKey := "bar"
-	time1 := time.Now().UnixNano() / int64(time.Millisecond)
-	time2 := time.Unix(0, time1*int64(time.Millisecond)).Add(time.Second*10).UnixNano() / int64(time.Millisecond)
-	time3 := time.Unix(0, time2*int64(time.Millisecond)).Add(time.Second*10).UnixNano() / int64(time.Millisecond)
-
-	intVal1 := float64(0)
-	intVal2 := float64(10)
-	intVal3 := float64(200)
-	doubleVal1 := 0.0
-	doubleVal2 := 5.0
-	doubleVal3 := 15.1
-
-	rate := calculateRate(intRateKey, intVal1, time1)
-	assert.Equal(t, float64(0), rate)
-	rate = calculateRate(doubleRateKey, doubleVal1, time1)
-	assert.Equal(t, float64(0), rate)
-
-	rate = calculateRate(intRateKey, intVal2, time2)
-	assert.InDelta(t, float64(1), rate, 0.1)
-	rate = calculateRate(doubleRateKey, doubleVal2, time2)
-	assert.InDelta(t, 0.5, rate, 0.1)
-
-	// Test change of data type
-	rate = calculateRate(intRateKey, doubleVal3, time3)
-	assert.InDelta(t, float64(0.51), rate, 0.1)
-	rate = calculateRate(doubleRateKey, intVal3, time3)
-	assert.InDelta(t, float64(19.5), rate, 0.1)
-}
-
-func calculateRate(metricName string, value float64, timestampMs int64) interface{} {
-	time := time.Unix(0, timestampMs*int64(time.Millisecond))
-	val, _ := rateMetricCalculator.Calculate(metricName, nil, value, time)
-	return val
-}
-
 func TestGetDataPoints(t *testing.T) {
 	metadata := CWMetricMetadata{
-		Namespace:                  "Namespace",
-		TimestampMs:                time.Now().UnixNano() / int64(time.Millisecond),
-		LogGroup:                   "log-group",
-		LogStream:                  "log-stream",
+		GroupedMetricMetadata: GroupedMetricMetadata{
+			Namespace:   "namespace",
+			TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
+			LogGroup:    "log-group",
+			LogStream:   "log-stream",
+		},
 		InstrumentationLibraryName: "cloudwatch-otel",
 	}
 
+	dmm := deltaMetricMetadata{
+		false,
+		"foo",
+		metadata.TimestampMs,
+		"namespace",
+		"log-group",
+		"log-stream",
+	}
+	cumulativeDmm := deltaMetricMetadata{
+		true,
+		"foo",
+		metadata.TimestampMs,
+		"namespace",
+		"log-group",
+		"log-stream",
+	}
 	testCases := []struct {
 		testName           string
 		metric             *metricspb.Metric
@@ -541,16 +549,7 @@ func TestGetDataPoints(t *testing.T) {
 			generateTestIntGauge("foo"),
 			IntDataPointSlice{
 				metadata.InstrumentationLibraryName,
-				rateCalculationMetadata{
-					false,
-					rateKeyParams{
-						namespaceKey:  metadata.Namespace,
-						metricNameKey: "foo",
-						logGroupKey:   metadata.LogGroup,
-						logStreamKey:  metadata.LogStream,
-					},
-					metadata.TimestampMs,
-				},
+				dmm,
 				pdata.IntDataPointSlice{},
 			},
 		},
@@ -559,16 +558,7 @@ func TestGetDataPoints(t *testing.T) {
 			generateTestDoubleGauge("foo"),
 			DoubleDataPointSlice{
 				metadata.InstrumentationLibraryName,
-				rateCalculationMetadata{
-					false,
-					rateKeyParams{
-						namespaceKey:  metadata.Namespace,
-						metricNameKey: "foo",
-						logGroupKey:   metadata.LogGroup,
-						logStreamKey:  metadata.LogStream,
-					},
-					metadata.TimestampMs,
-				},
+				dmm,
 				pdata.DoubleDataPointSlice{},
 			},
 		},
@@ -577,16 +567,7 @@ func TestGetDataPoints(t *testing.T) {
 			generateTestIntSum("foo"),
 			IntDataPointSlice{
 				metadata.InstrumentationLibraryName,
-				rateCalculationMetadata{
-					true,
-					rateKeyParams{
-						namespaceKey:  metadata.Namespace,
-						metricNameKey: "foo",
-						logGroupKey:   metadata.LogGroup,
-						logStreamKey:  metadata.LogStream,
-					},
-					metadata.TimestampMs,
-				},
+				cumulativeDmm,
 				pdata.IntDataPointSlice{},
 			},
 		},
@@ -595,16 +576,7 @@ func TestGetDataPoints(t *testing.T) {
 			generateTestDoubleSum("foo"),
 			DoubleDataPointSlice{
 				metadata.InstrumentationLibraryName,
-				rateCalculationMetadata{
-					true,
-					rateKeyParams{
-						namespaceKey:  metadata.Namespace,
-						metricNameKey: "foo",
-						logGroupKey:   metadata.LogGroup,
-						logStreamKey:  metadata.LogStream,
-					},
-					metadata.TimestampMs,
-				},
+				cumulativeDmm,
 				pdata.DoubleDataPointSlice{},
 			},
 		},
@@ -621,6 +593,7 @@ func TestGetDataPoints(t *testing.T) {
 			generateTestSummary("foo"),
 			SummaryDataPointSlice{
 				metadata.InstrumentationLibraryName,
+				cumulativeDmm,
 				pdata.SummaryDataPointSlice{},
 			},
 		},
@@ -647,7 +620,7 @@ func TestGetDataPoints(t *testing.T) {
 			case IntDataPointSlice:
 				expectedDPS := tc.expectedDataPoints.(IntDataPointSlice)
 				assert.Equal(t, metadata.InstrumentationLibraryName, convertedDPS.instrumentationLibraryName)
-				assert.Equal(t, expectedDPS.rateCalculationMetadata, convertedDPS.rateCalculationMetadata)
+				assert.Equal(t, expectedDPS.deltaMetricMetadata, convertedDPS.deltaMetricMetadata)
 				assert.Equal(t, 1, convertedDPS.Len())
 				dp := convertedDPS.IntDataPointSlice.At(0)
 				assert.Equal(t, int64(1), dp.Value())
@@ -655,7 +628,7 @@ func TestGetDataPoints(t *testing.T) {
 			case DoubleDataPointSlice:
 				expectedDPS := tc.expectedDataPoints.(DoubleDataPointSlice)
 				assert.Equal(t, metadata.InstrumentationLibraryName, convertedDPS.instrumentationLibraryName)
-				assert.Equal(t, expectedDPS.rateCalculationMetadata, convertedDPS.rateCalculationMetadata)
+				assert.Equal(t, expectedDPS.deltaMetricMetadata, convertedDPS.deltaMetricMetadata)
 				assert.Equal(t, 1, convertedDPS.Len())
 				dp := convertedDPS.DoubleDataPointSlice.At(0)
 				assert.Equal(t, 0.1, dp.Value())
@@ -730,10 +703,12 @@ func BenchmarkGetDataPoints(b *testing.B) {
 	numMetrics := metrics.Len()
 
 	metadata := CWMetricMetadata{
-		Namespace:                  "Namespace",
-		TimestampMs:                int64(1596151098037),
-		LogGroup:                   "log-group",
-		LogStream:                  "log-stream",
+		GroupedMetricMetadata: GroupedMetricMetadata{
+			Namespace:   "Namespace",
+			TimestampMs: int64(1596151098037),
+			LogGroup:    "log-group",
+			LogStream:   "log-stream",
+		},
 		InstrumentationLibraryName: "cloudwatch-otel",
 	}
 
@@ -748,105 +723,33 @@ func BenchmarkGetDataPoints(b *testing.B) {
 	}
 }
 
-func TestGetSortedLabelsEquals(t *testing.T) {
-	labelMap1 := make(map[string]string)
-	labelMap1["k1"] = "v1"
-	labelMap1["k2"] = "v2"
-
-	labelMap2 := make(map[string]string)
-	labelMap2["k2"] = "v2"
-	labelMap2["k1"] = "v1"
-
-	sortedLabels1 := getSortedLabels(labelMap1)
-	sortedLabels2 := getSortedLabels(labelMap2)
-
-	rateKeyParams1 := rateKeyParams{
-		namespaceKey:  "namespace",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-		labels:        sortedLabels1,
+func TestIntDataPointSlice_At(t *testing.T) {
+	type fields struct {
+		instrumentationLibraryName string
+		deltaMetricMetadata        deltaMetricMetadata
+		IntDataPointSlice          pdata.IntDataPointSlice
 	}
-	rateKeyParams2 := rateKeyParams{
-		namespaceKey:  "namespace",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-		labels:        sortedLabels2,
+	type args struct {
+		i int
 	}
-	assert.Equal(t, rateKeyParams1, rateKeyParams2)
-}
-
-func TestGetSortedLabelsNotEqual(t *testing.T) {
-	labelMap1 := make(map[string]string)
-	labelMap1["k1"] = "v1"
-	labelMap1["k2"] = "v2"
-
-	labelMap2 := make(map[string]string)
-	labelMap2["k2"] = "v2"
-	labelMap2["k1"] = "v3"
-
-	sortedLabels1 := getSortedLabels(labelMap1)
-	sortedLabels2 := getSortedLabels(labelMap2)
-
-	rateKeyParams1 := rateKeyParams{
-		namespaceKey:  "namespace",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-		labels:        sortedLabels1,
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   DataPoint
+	}{
+		// TODO: Add test cases.
 	}
-	rateKeyParams2 := rateKeyParams{
-		namespaceKey:  "namespace",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-		labels:        sortedLabels2,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dps := IntDataPointSlice{
+				instrumentationLibraryName: tt.fields.instrumentationLibraryName,
+				deltaMetricMetadata:        tt.fields.deltaMetricMetadata,
+				IntDataPointSlice:          tt.fields.IntDataPointSlice,
+			}
+			if got := dps.At(tt.args.i); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("At() = %v, want %v", got, tt.want)
+			}
+		})
 	}
-	assert.NotEqual(t, rateKeyParams1, rateKeyParams2)
-}
-
-func TestGetSortedLabelsNotEqualOnPram(t *testing.T) {
-	labelMap1 := make(map[string]string)
-	labelMap1["k1"] = "v1"
-	labelMap1["k2"] = "v2"
-
-	labelMap2 := make(map[string]string)
-	labelMap2["k2"] = "v2"
-	labelMap2["k1"] = "v1"
-
-	sortedLabels1 := getSortedLabels(labelMap1)
-	sortedLabels2 := getSortedLabels(labelMap2)
-
-	rateKeyParams1 := rateKeyParams{
-		namespaceKey:  "namespaceA",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-		labels:        sortedLabels1,
-	}
-	rateKeyParams2 := rateKeyParams{
-		namespaceKey:  "namespaceB",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-		labels:        sortedLabels2,
-	}
-	assert.NotEqual(t, rateKeyParams1, rateKeyParams2)
-}
-
-func TestGetSortedLabelsNotEqualOnEmptyLabel(t *testing.T) {
-	rateKeyParams1 := rateKeyParams{
-		namespaceKey:  "namespaceA",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-	}
-	rateKeyParams2 := rateKeyParams{
-		namespaceKey:  "namespaceA",
-		metricNameKey: "foo",
-		logGroupKey:   "log-group",
-		logStreamKey:  "log-stream",
-	}
-	assert.Equal(t, rateKeyParams1, rateKeyParams2)
 }

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -15,10 +15,10 @@
 package awsemfexporter
 
 import (
-	"strconv"
-
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws"
 )
 
 // GroupedMetric defines set of metrics with same namespace, timestamp and labels
@@ -59,15 +59,7 @@ func addToGroupedMetric(pmd *pdata.Metric, groupedMetrics map[interface{}]*Group
 		}
 
 		// Extra params to use when grouping metrics
-		groupKey := rateKeyParams{
-			namespaceKey: metadata.Namespace,
-			timestampKey: strconv.FormatInt(metadata.TimestampMs, 10),
-			logGroupKey:  metadata.LogGroup,
-			logStreamKey: metadata.LogStream,
-		}
-
-		sortedLabels := getSortedLabels(labels)
-		groupKey.labels = sortedLabels
+		groupKey := groupedMetricKey(metadata.GroupedMetricMetadata, labels)
 		if _, ok := groupedMetrics[groupKey]; ok {
 			// if metricName already exists in metrics map, print warning log
 			if _, ok := groupedMetrics[groupKey].Metrics[metricName]; ok {
@@ -87,6 +79,10 @@ func addToGroupedMetric(pmd *pdata.Metric, groupedMetrics map[interface{}]*Group
 			}
 		}
 	}
+}
+
+func groupedMetricKey(metadata GroupedMetricMetadata, labels map[string]string) aws.Key {
+	return aws.NewKey(metadata, labels)
 }
 
 func translateUnit(metric *pdata.Metric, descriptor map[string]MetricDescriptor) string {

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -32,18 +32,18 @@ import (
 )
 
 func TestAddToGroupedMetric(t *testing.T) {
-	rateMetricCalculator = newFloat64RateCalculator()
-
 	namespace := "namespace"
 	instrumentationLibName := "cloudwatch-otel"
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 	logger := zap.NewNop()
 
 	metadata := CWMetricMetadata{
-		Namespace:                  namespace,
-		TimestampMs:                timestamp,
-		LogGroup:                   logGroup,
-		LogStream:                  logStreamName,
+		GroupedMetricMetadata: GroupedMetricMetadata{
+			Namespace:   namespace,
+			TimestampMs: timestamp,
+			LogGroup:    logGroup,
+			LogStream:   logStreamName,
+		},
 		InstrumentationLibraryName: instrumentationLibName,
 	}
 
@@ -77,7 +77,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			generateTestIntSum("foo"),
 			map[string]*MetricInfo{
 				"foo": {
-					Value: float64(0),
+					Value: float64(1),
 					Unit:  "Count",
 				},
 			},
@@ -87,7 +87,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			generateTestDoubleSum("foo"),
 			map[string]*MetricInfo{
 				"foo": {
-					Value: float64(0),
+					Value: float64(0.1),
 					Unit:  "Count",
 				},
 			},
@@ -124,6 +124,8 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
+			setupDataPointCache()
+
 			groupedMetrics := make(map[interface{}]*GroupedMetric)
 			oc := internaldata.MetricsData{
 				Node: &commonpb.Node{},
@@ -291,19 +293,23 @@ func TestAddToGroupedMetric(t *testing.T) {
 		metric := ilms.At(0).Metrics().At(0)
 
 		metricMetadata1 := CWMetricMetadata{
-			Namespace:                  namespace,
-			TimestampMs:                timestamp,
-			LogGroup:                   "log-group-1",
-			LogStream:                  logStreamName,
+			GroupedMetricMetadata: GroupedMetricMetadata{
+				Namespace:   namespace,
+				TimestampMs: timestamp,
+				LogGroup:    "log-group-1",
+				LogStream:   logStreamName,
+			},
 			InstrumentationLibraryName: instrumentationLibName,
 		}
 		addToGroupedMetric(&metric, groupedMetrics, metricMetadata1, logger, nil)
 
 		metricMetadata2 := CWMetricMetadata{
-			Namespace:                  namespace,
-			TimestampMs:                timestamp,
-			LogGroup:                   "log-group-2",
-			LogStream:                  logStreamName,
+			GroupedMetricMetadata: GroupedMetricMetadata{
+				Namespace:   namespace,
+				TimestampMs: timestamp,
+				LogGroup:    "log-group-2",
+				LogStream:   logStreamName,
+			},
 			InstrumentationLibraryName: instrumentationLibName,
 		}
 		addToGroupedMetric(&metric, groupedMetrics, metricMetadata2, logger, nil)
@@ -438,10 +444,12 @@ func BenchmarkAddToGroupedMetric(b *testing.B) {
 	numMetrics := metrics.Len()
 
 	metadata := CWMetricMetadata{
-		Namespace:                  "Namespace",
-		TimestampMs:                int64(1596151098037),
-		LogGroup:                   "log-group",
-		LogStream:                  "log-stream",
+		GroupedMetricMetadata: GroupedMetricMetadata{
+			Namespace:   "Namespace",
+			TimestampMs: int64(1596151098037),
+			LogGroup:    "log-group",
+			LogStream:   "log-stream",
+		},
 		InstrumentationLibraryName: "cloudwatch-otel",
 	}
 

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -71,12 +71,16 @@ type CWMetricStats struct {
 	Sum   float64
 }
 
+type GroupedMetricMetadata struct {
+	Namespace   string
+	TimestampMs int64
+	LogGroup    string
+	LogStream   string
+}
+
 // CWMetricMetadata represents the metadata associated with a given CloudWatch metric
 type CWMetricMetadata struct {
-	Namespace                  string
-	TimestampMs                int64
-	LogGroup                   string
-	LogStream                  string
+	GroupedMetricMetadata
 	InstrumentationLibraryName string
 
 	receiver       string
@@ -121,10 +125,12 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetric
 		for k := 0; k < metrics.Len(); k++ {
 			metric := metrics.At(k)
 			metadata := CWMetricMetadata{
-				Namespace:                  cWNamespace,
-				TimestampMs:                timestamp,
-				LogGroup:                   logGroup,
-				LogStream:                  logStream,
+				GroupedMetricMetadata: GroupedMetricMetadata{
+					Namespace:   cWNamespace,
+					TimestampMs: timestamp,
+					LogGroup:    logGroup,
+					LogStream:   logStream,
+				},
 				InstrumentationLibraryName: instrumentationLibName,
 				receiver:                   metricReceiver,
 				metricDataType:             metric.DataType(),

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -408,11 +408,11 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 
 	counterMetrics := map[string]*MetricInfo{
 		"spanCounter": {
-			Value: float64(0),
+			Value: float64(1),
 			Unit:  "Count",
 		},
 		"spanDoubleCounter": {
-			Value: float64(0),
+			Value: float64(0.1),
 			Unit:  "Count",
 		},
 		"spanGaugeCounter": {
@@ -568,8 +568,10 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			nil,
@@ -606,8 +608,10 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			[]*MetricDeclaration{
@@ -658,8 +662,10 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			nil,
@@ -716,8 +722,10 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			[]*MetricDeclaration{
@@ -777,8 +785,10 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 				},
 				Metrics: nil,
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			nil,
@@ -809,8 +819,10 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:      namespace,
-					TimestampMs:    timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 					receiver:       prometheusReceiver,
 					metricDataType: pdata.MetricDataTypeDoubleGauge,
 				},
@@ -881,8 +893,10 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			CWMeasurement{
@@ -919,8 +933,10 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			CWMeasurement{
@@ -956,8 +972,10 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			CWMeasurement{
@@ -994,8 +1012,10 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			CWMeasurement{
@@ -1031,8 +1051,10 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 				},
 				Metrics: nil,
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			},
 			CWMeasurement{
@@ -1192,8 +1214,10 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			}
 			config := &Config{
@@ -1444,8 +1468,10 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				Labels:  labels,
 				Metrics: metrics,
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			}
 			config := &Config{
@@ -1470,8 +1496,10 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 			Labels:  labels,
 			Metrics: metrics,
 			Metadata: CWMetricMetadata{
-				Namespace:   namespace,
-				TimestampMs: timestamp,
+				GroupedMetricMetadata: GroupedMetricMetadata{
+					Namespace:   namespace,
+					TimestampMs: timestamp,
+				},
 			},
 		}
 		metricDeclarations := []*MetricDeclaration{
@@ -1549,8 +1577,10 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 			Labels:  labels,
 			Metrics: metrics,
 			Metadata: CWMetricMetadata{
-				Namespace:   namespace,
-				TimestampMs: timestamp,
+				GroupedMetricMetadata: GroupedMetricMetadata{
+					Namespace:   namespace,
+					TimestampMs: timestamp,
+				},
 			},
 		}
 		metricDeclarations := []*MetricDeclaration{
@@ -1956,8 +1986,10 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 					},
 				},
 				Metadata: CWMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+					GroupedMetricMetadata: GroupedMetricMetadata{
+						Namespace:   namespace,
+						TimestampMs: timestamp,
+					},
 				},
 			}
 			for _, decl := range tc.metricDeclarations {
@@ -2055,8 +2087,10 @@ func BenchmarkTranslateGroupedMetricToCWMetric(b *testing.B) {
 			},
 		},
 		Metadata: CWMetricMetadata{
-			Namespace:   "Namespace",
-			TimestampMs: int64(1596151098037),
+			GroupedMetricMetadata: GroupedMetricMetadata{
+				Namespace:   "Namespace",
+				TimestampMs: int64(1596151098037),
+			},
 		},
 	}
 	config := &Config{
@@ -2088,8 +2122,10 @@ func BenchmarkTranslateGroupedMetricToCWMetricWithFiltering(b *testing.B) {
 			},
 		},
 		Metadata: CWMetricMetadata{
-			Namespace:   "Namespace",
-			TimestampMs: int64(1596151098037),
+			GroupedMetricMetadata: GroupedMetricMetadata{
+				Namespace:   "Namespace",
+				TimestampMs: int64(1596151098037),
+			},
 		},
 	}
 	m := &MetricDeclaration{

--- a/internal/aws/metric_calculator.go
+++ b/internal/aws/metric_calculator.go
@@ -87,11 +87,11 @@ func (rm *MetricCalculator) Calculate(metricName string, labels map[string]strin
 }
 
 type Key struct {
-	MetricName   string
-	MetricLabels attribute.Distinct
+	MetricMetadata interface{}
+	MetricLabels   attribute.Distinct
 }
 
-func NewKey(metricName string, labels map[string]string) Key {
+func NewKey(metricMetadata interface{}, labels map[string]string) Key {
 	var kvs []attribute.KeyValue
 	var sortable attribute.Sortable
 	for k, v := range labels {
@@ -101,8 +101,8 @@ func NewKey(metricName string, labels map[string]string) Key {
 
 	dedupSortedLabels := set.Equivalent()
 	return Key{
-		MetricName:   metricName,
-		MetricLabels: dedupSortedLabels,
+		MetricMetadata: metricMetadata,
+		MetricLabels:   dedupSortedLabels,
 	}
 }
 


### PR DESCRIPTION
**Why do we need it?**
This is a follow-up PR of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2627.

Currently,  when cumulative metrics, e.g. counter/summary, come into EMF exporter, the value will be adjusted to rate (in seconds). However, this is not the correct behavior, as what we observed from CloudWatch dashboard, the backend expects delta calculation result.

In this PR, we change the rate calculation to delta regarding cumulative metrics.