### PR TITLE
exporter/signalfx: Updates to metadata handling

### DIFF
--- a/exporter/signalfxexporter/dimensions/metadata.go
+++ b/exporter/signalfxexporter/dimensions/metadata.go
@@ -30,10 +30,6 @@ type MetadataUpdateClient interface {
 	PushMetadata([]*metadata.MetadataUpdate) error
 }
 
-var k8sLabelNameSanitizer = strings.NewReplacer(
-	".", "_",
-	"/", "_")
-
 func getDimensionUpdateFromMetadata(
 	metadata metadata.MetadataUpdate,
 	metricTranslator *translation.MetricTranslator,
@@ -56,18 +52,12 @@ func translateDimension(metricTranslator *translation.MetricTranslator, dim stri
 }
 
 const (
-	oTelK8sLabelPrefix   = "k8s.label."
 	oTelK8sServicePrefix = "k8s.service."
 	sfxK8sServicePrefix  = "kubernetes_service_"
 )
 
-// sanitizeProperty processes any property key or tag to ensure conformity with SFx values.
-// Currently this method only replaces "." and "/" in kubernetes labels with "_". This is done to
-// ensure compatibility with properties sent by kubernetes-cluster monitor in the SignalFx Agent.
 func sanitizeProperty(property string) string {
-	if strings.HasPrefix(property, oTelK8sLabelPrefix) {
-		return k8sLabelNameSanitizer.Replace(strings.TrimPrefix(property, oTelK8sLabelPrefix))
-	} else if strings.HasPrefix(property, oTelK8sServicePrefix) {
+	if strings.HasPrefix(property, oTelK8sServicePrefix) {
 		return strings.Replace(property, oTelK8sServicePrefix, sfxK8sServicePrefix, 1)
 	}
 	return property

--- a/exporter/signalfxexporter/dimensions/metadata_test.go
+++ b/exporter/signalfxexporter/dimensions/metadata_test.go
@@ -176,42 +176,27 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 			},
 		},
 		{
-			"Test with special characters in k8s labels",
+			"Test with k8s service properties",
 			args{
 				metadata: metadata.MetadataUpdate{
 					ResourceIDKey: "name",
 					ResourceID:    "val",
 					MetadataDelta: metadata.MetadataDelta{
 						MetadataToAdd: map[string]string{
-							"k8s.label.prope/rty1": "value1",
-							"k8s.label.ta.g1":      "",
-							"k8s.service.ta.g5":    "",
+							"k8s.service.ta.g5": "",
 						},
 						MetadataToRemove: map[string]string{
-							"k8s.label.prope.rty2": "value2",
-							"k8s.label.ta/g2":      "",
-							"k8s.service.ta.g6":    "",
-						},
-						MetadataToUpdate: map[string]string{
-							"k8s.label.prope_rty3": "value33",
-							"k8s.label.prope.rty4": "",
+							"k8s.service.ta.g6": "",
 						},
 					},
 				},
 				metricTranslator: nil,
 			},
 			&DimensionUpdate{
-				Name:  "name",
-				Value: "val",
-				Properties: getMapToPointers(map[string]string{
-					"prope_rty1": "value1",
-					"prope_rty2": "",
-					"prope_rty3": "value33",
-					"prope_rty4": "",
-				}),
+				Name:       "name",
+				Value:      "val",
+				Properties: map[string]*string{},
 				Tags: map[string]bool{
-					"ta_g1":                    true,
-					"ta_g2":                    false,
 					"kubernetes_service_ta.g5": true,
 					"kubernetes_service_ta.g6": false,
 				},

--- a/exporter/signalfxexporter/dimensions/metadata_test.go
+++ b/exporter/signalfxexporter/dimensions/metadata_test.go
@@ -25,11 +25,8 @@ import (
 func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 	translator, _ := translation.NewMetricTranslator([]translation.Rule{
 		{
-			Action: translation.ActionRenameDimensionKeys,
-			Mapping: map[string]string{
-				"prope/rty1": "rty1",
-				"prope_rty2": "rty2",
-				"prope.rty3": "rty3"},
+			Action:  translation.ActionRenameDimensionKeys,
+			Mapping: map[string]string{"name": "translated_name"},
 		},
 	}, 1)
 	type args struct {
@@ -103,7 +100,7 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 			},
 		},
 		{
-			"Test with unsupported characters",
+			"Test with special characters",
 			args{
 				metadata: metadata.MetadataUpdate{
 					ResourceIDKey: "name",
@@ -129,14 +126,14 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 				Name:  "name",
 				Value: "val",
 				Properties: getMapToPointers(map[string]string{
-					"prope_rty1": "value1",
-					"prope_rty2": "",
+					"prope/rty1": "value1",
+					"prope.rty2": "",
 					"prope_rty3": "value33",
-					"prope_rty4": "",
+					"prope.rty4": "",
 				}),
 				Tags: map[string]bool{
-					"ta_g1": true,
-					"ta_g2": false,
+					"ta.g1": true,
+					"ta/g2": false,
 				},
 			},
 		},
@@ -164,17 +161,59 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 				metricTranslator: translator,
 			},
 			&DimensionUpdate{
+				Name:  "translated_name",
+				Value: "val",
+				Properties: getMapToPointers(map[string]string{
+					"prope/rty1": "value1",
+					"prope_rty2": "",
+					"prope.rty3": "value33",
+					"prope.rty4": "",
+				}),
+				Tags: map[string]bool{
+					"ta.g1": true,
+					"ta/g2": false,
+				},
+			},
+		},
+		{
+			"Test with special characters in k8s labels",
+			args{
+				metadata: metadata.MetadataUpdate{
+					ResourceIDKey: "name",
+					ResourceID:    "val",
+					MetadataDelta: metadata.MetadataDelta{
+						MetadataToAdd: map[string]string{
+							"k8s.label.prope/rty1": "value1",
+							"k8s.label.ta.g1":      "",
+							"k8s.service.ta.g5":    "",
+						},
+						MetadataToRemove: map[string]string{
+							"k8s.label.prope.rty2": "value2",
+							"k8s.label.ta/g2":      "",
+							"k8s.service.ta.g6":    "",
+						},
+						MetadataToUpdate: map[string]string{
+							"k8s.label.prope_rty3": "value33",
+							"k8s.label.prope.rty4": "",
+						},
+					},
+				},
+				metricTranslator: nil,
+			},
+			&DimensionUpdate{
 				Name:  "name",
 				Value: "val",
 				Properties: getMapToPointers(map[string]string{
-					"rty1":       "value1",
-					"rty2":       "",
-					"rty3":       "value33",
+					"prope_rty1": "value1",
+					"prope_rty2": "",
+					"prope_rty3": "value33",
 					"prope_rty4": "",
 				}),
 				Tags: map[string]bool{
-					"ta_g1": true,
-					"ta_g2": false,
+					"ta_g1":                    true,
+					"ta_g2":                    false,
+					"kubernetes_service_ta.g5": true,
+					"kubernetes_service_ta.g6": false,
 				},
 			},
 		},

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -771,9 +771,9 @@ func TestConsumeMetadata(t *testing.T) {
 			fields{
 				map[string]interface{}{
 					"customProperties": map[string]interface{}{
-						"prop_erty1": "val1",
+						"prop.erty1": "val1",
 						"property2":  nil,
-						"prop_erty3": "val33",
+						"prop.erty3": "val33",
 						"property4":  nil,
 					},
 					"tags":         nil,
@@ -807,10 +807,10 @@ func TestConsumeMetadata(t *testing.T) {
 				map[string]interface{}{
 					"customProperties": map[string]interface{}{},
 					"tags": []interface{}{
-						"tag_1",
+						"tag.1",
 					},
 					"tagsToRemove": []interface{}{
-						"tag_2",
+						"tag/2",
 					},
 				},
 			},
@@ -842,10 +842,10 @@ func TestConsumeMetadata(t *testing.T) {
 						"property3": nil,
 					},
 					"tags": []interface{}{
-						"tag_2",
+						"tag/2",
 					},
 					"tagsToRemove": []interface{}{
-						"tag_1",
+						"tag.1",
 					},
 				},
 			},
@@ -909,7 +909,7 @@ func TestConsumeMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				b, err := ioutil.ReadAll(r.Body)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				p := map[string]interface{}{
 					"customProperties": map[string]*string{},
@@ -918,9 +918,9 @@ func TestConsumeMetadata(t *testing.T) {
 				}
 
 				err = json.Unmarshal(b, &p)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
-				require.Equal(t, tt.fields.payLoad, p)
+				assert.Equal(t, tt.fields.payLoad, p)
 				wg.Done()
 			}))
 			defer server.Close()

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -49,18 +49,6 @@ translation_rules:
     k8s.statefulset.uid: kubernetes_uid
     host.name: host
 
-    # properties
-    cronjob_uid: cronJob_uid
-    cronjob: cronJob
-    daemonset_uid: daemonSet_uid
-    daemonset: daemonSet
-    k8s.workload.kind: kubernetes_workload
-    k8s.workload.name: kubernetes_workload_name
-    replicaset_uid: replicaSet_uid
-    replicaset: replicaSet
-    statefulset_uid: statefulSet_uid
-    statefulset: statefulSet
-
 - action: rename_metrics
   mapping:
     # kubeletstats receiver metrics

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -25,6 +25,8 @@ translation_rules:
   mapping:
 
     # dimensions
+    k8s.cronjob.name: kubernetes_name
+    k8s.cronjob.uid: kubernetes_uid
     container.image.name: container_image
     k8s.container.name: container_spec_name
     k8s.cluster.name: kubernetes_cluster
@@ -34,6 +36,8 @@ translation_rules:
     k8s.deployment.uid: kubernetes_uid
     k8s.hpa.name: kubernetes_name
     k8s.hpa.uid: kubernetes_uid
+    k8s.job.name: kubernetes_name
+    k8s.job.uid: kubernetes_uid
     k8s.namespace.name: kubernetes_namespace
     k8s.node.name: kubernetes_node
     k8s.node.uid: kubernetes_node_uid


### PR DESCRIPTION
**Description:** Updates to metadata handling.

- Incorporate changes from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2530 to ensure compatibility with `kubernetes-cluster` monitor
  - Replace `k8s.service.` prefix with `kubernetes_service_`
- Do not replace `.` and `/` with `_` for properties/tags.
- `rename_dimension_keys` translation rules can no longer be used to rename properties
- Remove translations for properties from constants.go

**Testing:** Updated/added tests.