### PR TITLE
signalfx exporter: add translation rules for cpu.utilization_per_core

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -843,7 +843,12 @@ func TestDefaultExcludes_translated(t *testing.T) {
 	rms := getResourceMetrics(metrics)
 	require.Equal(t, 62, rms.InstrumentationLibraryMetrics().At(0).Metrics().Len())
 	dps := converter.MetricDataToSignalFxV2(rms)
-	require.Equal(t, 0, len(dps))
+
+	// the default cpu.utilization metric is added after applying the default translations
+	// (because cpu.utilization_per_core is supplied) and should not be excluded
+	require.Equal(t, 1, len(dps))
+	require.Equal(t, "cpu.utilization", dps[0].Metric)
+
 }
 
 func TestDefaultExcludes_not_translated(t *testing.T) {

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -250,7 +250,7 @@ translation_rules:
     receive: pod_network_receive_errors_total
     transmit: pod_network_transmit_errors_total
 
-# compute cpu utilization
+# compute cpu utilization metrics: cpu.utilization_per_core (excluded by default) and cpu.utilization
 - action: delta_metric
   mapping:
     system.cpu.time: system.cpu.delta
@@ -271,7 +271,6 @@ translation_rules:
   aggregation_method: sum
   without_dimensions:
   - state
-  - cpu
 - action: copy_metrics
   mapping:
     system.cpu.delta: system.cpu.total
@@ -280,12 +279,19 @@ translation_rules:
   aggregation_method: sum
   without_dimensions:
   - state
-  - cpu
 - action: calculate_new_metric
-  metric_name: cpu.utilization
+  metric_name: cpu.utilization_per_core
   operand1_metric: system.cpu.usage
   operand2_metric: system.cpu.total
   operator: /
+- action: copy_metrics
+  mapping:
+    cpu.utilization_per_core: cpu.utilization
+- action: aggregate_metric
+  metric_name: cpu.utilization
+  aggregation_method: avg
+  without_dimensions:
+  - cpu
 
 # convert cpu metrics
 - action: split_metric


### PR DESCRIPTION
Calculate `cpu.utilization_per_core` metric additionally to `cpu.utilization`. The metric is disabled by default.