### PR TITLE
[DRAFT] #2529 Fix empty log sended if no raw body

### DIFF
--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -195,7 +195,7 @@ func convertLogToLokiEntry(lr pdata.LogRecord) *logproto.Entry {
 	if lr.SeverityText() != "" {
 		mapObject["_otel_severity"] = lr.SeverityText()
 	}
-	if lr.SeverityText() != "" {
+	if lr.Body().StringVal() != "" {
 		mapObject["_otel_raw_log"] = lr.Body().StringVal()
 	}
 	jsonStruct, _ := json.Marshal(mapObject)

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -17,13 +17,13 @@ package lokiexporter
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"sync"
 	"time"
-	"encoding/json"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
@@ -31,8 +31,8 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.uber.org/zap"
 	translator "go.opentelemetry.io/collector/translator/trace"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/third_party/loki/logproto"
 )

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -198,8 +198,8 @@ func convertLogToLokiEntry(lr pdata.LogRecord) *logproto.Entry {
 	if lr.SeverityText() != "" {
 		mapObject["_otel_raw_log"] = lr.Body().StringVal()
 	}
-	json_struct, _ := json.Marshal(mapObject)
-	log := string(json_struct)
+	jsonStruct, _ := json.Marshal(mapObject)
+	log := string(jsonStruct)
 
 	return &logproto.Entry{
 		Timestamp: time.Unix(0, int64(lr.Timestamp())),

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -476,7 +476,7 @@ func TestExporter_convertLogToLokiEntry(t *testing.T) {
 
 	expEntry := &logproto.Entry{
 		Timestamp: time.Unix(0, int64(lr.Timestamp())),
-		Line:      "log message",
+		Line:      "{\"_otel_raw_log\":\"log message\"}",
 	}
 	require.NotNil(t, entry)
 	require.Equal(t, expEntry, entry)


### PR DESCRIPTION
**Description:** 
Final plan to discuss (still in WIP for this reason).
For now this PR is working as expected, all logs sended from OTEL collector to Loki will be encapsulated in a JSON containing all OTEL attributes at its root level.
If you have a OTEL log body it wil be appened to the entry `_otel_raw_log`, and same thing for OTEL Name and OTEL Severity (in `_otel_shortname` and `_otel_severity`).

JSON Format is ok ?
Idea to have all attributes as top level is ok ?

**Link to tracking Issue:** #2529 

**Testing:** Tested localy with a fluentbit windows exporter > OTEL fluentforward > OTEL Loki exporter > Loki

**Documentation:** Potential log format breaking change on Loki side, if you had previously raw unstructured logs exported they will be in a global structure in key `_otel_raw_log`. But all your OTEL attributes will be at the root level of this main JSON structure