### PR TITLE
Fixes the Loki example memory limiter processor configuration

### DIFF
--- a/exporter/lokiexporter/example/docker-compose.yml
+++ b/exporter/lokiexporter/example/docker-compose.yml
@@ -5,12 +5,16 @@ networks:
 
 services:
   otel-collector:
-#    build:
-#      context: ../../..
-#      dockerfile: exporter/lokiexporter/example/Dockerfile
-    image: otelcontribcol:latest
+    build:
+      context: ../../..
+      dockerfile: exporter/lokiexporter/example/Dockerfile
+    # Uncomment the next line to use a preexisting image
+    # image: otelcontribcol:latest
     container_name: otel
-    command: ["--config=/etc/otel-collector-config.yml"]
+    command:
+      - "--config=/etc/otel-collector-config.yml"
+      # Memory Ballast size should be max 1/3 to 1/2 of memory.
+      - "--mem-ballast-size-mib=683"
     volumes:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
     ports:

--- a/exporter/lokiexporter/example/otel-collector-config.yml
+++ b/exporter/lokiexporter/example/otel-collector-config.yml
@@ -6,11 +6,20 @@ processors:
   batch:
     send_batch_size: 50
     timeout: 5s
+  # Enabling the memory_limiter is strongly recommended for every pipeline.
+  # Configuration is based on the amount of memory allocated to the collector.
+  # The configuration below assumes 2GB of memory. In general, the ballast
+  # should be set to 1/3 of the collector's memory, the limit should be 90% of
+  # the collector's memory up to 2GB, and the spike should be 25% of the
+  # collector's memory up to 2GB. In addition, the "--mem-ballast-size-mib" CLI
+  # flag must be set to the same value as the "ballast_size_mib". For more
+  # information, see
+  # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiter/README.md
   memory_limiter:
-    ballast_size_mib: 2000
-    check_interval: 1s
-    limit_percentage: 50
-    spike_limit_percentage: 30
+    ballast_size_mib: 683
+    check_interval: 2s
+    limit_mib: 1800
+    spike_limit_mib: 500
 
 exporters:
   loki:


### PR DESCRIPTION
**Description:**
Fixes the Loki example memory limiter processor configuration. The previous one was invalid and caused the collector to fail upon startup, thus preventing the Docker fluentd driver from sending logs to it for the demo.

Fixes: #2463

**Link to tracking Issue:**
#2463 

**Testing:**

- Successfully spun up the Loki example demo in a clean Docker environment: `./exporter/lokiexporter/example/docker-compose up`

- Tested by user who submitted the issue.

**Documentation:**
N/A

Signed-off-by: Granville Schmidt <1246157+gramidt@users.noreply.github.com>