### PR TITLE
Signalfx exporter: fix calculation of network.total metric

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -576,7 +576,7 @@ func testMetricsData() pdata.ResourceMetrics {
 					Type:        metricspb.MetricDescriptor_GAUGE_INT64,
 					LabelKeys: []*metricspb.LabelKey{
 						{Key: "direction"},
-						{Key: "interface"},
+						{Key: "device"},
 						{Key: "host"},
 						{Key: "kubernetes_node"},
 						{Key: "kubernetes_cluster"},

--- a/exporter/signalfxexporter/translation/constants.go
+++ b/exporter/signalfxexporter/translation/constants.go
@@ -515,7 +515,8 @@ translation_rules:
 
 
 # Translations to derive Network I/O metrics.
-## network.total.
+
+## Calculate network.total.
 - action: copy_metrics
   mapping:
     system.network.io: network.total
@@ -528,10 +529,9 @@ translation_rules:
   aggregation_method: sum
   without_dimensions:
   - direction
-  - interface
+  - device
 
-
-## other Network I/O metrics. Note that these translations depend on renaming dimension device to interface.
+## Rename dimension device to interface.
 - action: rename_dimension_keys
   metric_names:
     system.network.dropped: true


### PR DESCRIPTION
memory.total was calculated based on "interface" dimension which is not ready at that point and created from "device" in the next step. It causes several duplicates of memory.total not aggregated by device/interface.

This PR fixes the problem
