### PR TITLE
exporter/signalfx: Correctly convert dimensions on metadata updates

### DIFF
--- a/exporter/signalfxexporter/dimensions/dimclient.go
+++ b/exporter/signalfxexporter/dimensions/dimclient.go
@@ -72,7 +72,7 @@ type DimensionClient struct {
 	TotalSuccessfulUpdates       int64
 	logUpdates                   bool
 	logger                       *zap.Logger
-	metricTranslator             *translation.MetricTranslator
+	metricsConverter             translation.MetricsConverter
 }
 
 type queuedDimension struct {
@@ -87,12 +87,11 @@ type DimensionClientOptions struct {
 	Logger                *zap.Logger
 	SendDelay             int
 	PropertiesMaxBuffered int
-	MetricTranslator      *translation.MetricTranslator
+	MetricsConverter      translation.MetricsConverter
 }
 
 // NewDimensionClient returns a new client
 func NewDimensionClient(ctx context.Context, options DimensionClientOptions) *DimensionClient {
-
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
@@ -122,7 +121,7 @@ func NewDimensionClient(ctx context.Context, options DimensionClientOptions) *Di
 		now:              time.Now,
 		logger:           options.Logger,
 		logUpdates:       options.LogUpdates,
-		metricTranslator: options.MetricTranslator,
+		metricsConverter: options.MetricsConverter,
 	}
 }
 

--- a/exporter/signalfxexporter/dimensions/metadata.go
+++ b/exporter/signalfxexporter/dimensions/metadata.go
@@ -32,23 +32,15 @@ type MetadataUpdateClient interface {
 
 func getDimensionUpdateFromMetadata(
 	metadata metadata.MetadataUpdate,
-	metricTranslator *translation.MetricTranslator,
-) *DimensionUpdate {
+	metricsConverter translation.MetricsConverter) *DimensionUpdate {
 	properties, tags := getPropertiesAndTags(metadata)
 
 	return &DimensionUpdate{
-		Name:       translateDimension(metricTranslator, metadata.ResourceIDKey),
+		Name:       metricsConverter.ConvertDimension(metadata.ResourceIDKey),
 		Value:      string(metadata.ResourceID),
 		Properties: properties,
 		Tags:       tags,
 	}
-}
-
-func translateDimension(metricTranslator *translation.MetricTranslator, dim string) string {
-	if metricTranslator != nil {
-		return metricTranslator.TranslateDimension(dim)
-	}
-	return dim
 }
 
 const (
@@ -116,7 +108,7 @@ func getPropertiesAndTags(kmu metadata.MetadataUpdate) (map[string]*string, map[
 func (dc *DimensionClient) PushMetadata(metadata []*metadata.MetadataUpdate) error {
 	var errs []error
 	for _, m := range metadata {
-		dimensionUpdate := getDimensionUpdateFromMetadata(*m, dc.metricTranslator)
+		dimensionUpdate := getDimensionUpdateFromMetadata(*m, dc.metricsConverter)
 
 		if dimensionUpdate.Name == "" || dimensionUpdate.Value == "" {
 			atomic.AddInt64(&dc.TotalInvalidDimensions, int64(1))

--- a/exporter/signalfxexporter/dimensions/metadata_test.go
+++ b/exporter/signalfxexporter/dimensions/metadata_test.go
@@ -18,6 +18,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/translation"
 	metadata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata"
 )
@@ -205,7 +208,16 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getDimensionUpdateFromMetadata(tt.args.metadata, tt.args.metricTranslator)
+
+			converter, err := translation.NewMetricsConverter(
+				zap.NewNop(),
+				tt.args.metricTranslator,
+				nil,
+				nil,
+				"-_.",
+			)
+			require.NoError(t, err)
+			got := getDimensionUpdateFromMetadata(tt.args.metadata, *converter)
 			if !reflect.DeepEqual(*got, *tt.want) {
 				t.Errorf("getDimensionUpdateFromMetadata() = %v, want %v", *got, *tt.want)
 			}

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -125,7 +125,7 @@ func newSignalFxExporter(
 			// buffer a fixed number of updates. Might also be a good candidate
 			// to make configurable.
 			PropertiesMaxBuffered: 10000,
-			MetricTranslator:      options.metricTranslator,
+			MetricsConverter:      *converter,
 		})
 	dimClient.Start()
 

--- a/exporter/signalfxexporter/translation/converter.go
+++ b/exporter/signalfxexporter/translation/converter.go
@@ -411,3 +411,11 @@ func timestampToSignalFx(ts pdata.Timestamp) int64 {
 	// Convert nanosecs to millisecs.
 	return int64(ts) / 1e6
 }
+
+func (c *MetricsConverter) ConvertDimension(dim string) string {
+	res := dim
+	if c.metricTranslator != nil {
+		res = c.metricTranslator.translateDimension(dim)
+	}
+	return filterKeyChars(res, c.nonAlphanumericDimChars)
+}

--- a/exporter/signalfxexporter/translation/translator.go
+++ b/exporter/signalfxexporter/translation/translator.go
@@ -588,7 +588,7 @@ func ptToFloatVal(pt *sfxpb.DataPoint) *float64 {
 	return &f
 }
 
-func (mp *MetricTranslator) TranslateDimension(orig string) string {
+func (mp *MetricTranslator) translateDimension(orig string) string {
 	if translated, ok := mp.dimensionsMap[orig]; ok {
 		return translated
 	}

--- a/exporter/signalfxexporter/translation/translator_test.go
+++ b/exporter/signalfxexporter/translation/translator_test.go
@@ -1923,14 +1923,14 @@ func TestTestTranslateDimension(t *testing.T) {
 	}, 1)
 	require.NoError(t, err)
 
-	assert.Equal(t, "new_dimension", mt.TranslateDimension("old_dimension"))
-	assert.Equal(t, "new.dimension", mt.TranslateDimension("old.dimension"))
-	assert.Equal(t, "another_dimension", mt.TranslateDimension("another_dimension"))
+	assert.Equal(t, "new_dimension", mt.translateDimension("old_dimension"))
+	assert.Equal(t, "new.dimension", mt.translateDimension("old.dimension"))
+	assert.Equal(t, "another_dimension", mt.translateDimension("another_dimension"))
 
 	// Test no rename_dimension_keys translation rule
 	mt, err = NewMetricTranslator([]Rule{}, 1)
 	require.NoError(t, err)
-	assert.Equal(t, "old_dimension", mt.TranslateDimension("old_dimension"))
+	assert.Equal(t, "old_dimension", mt.translateDimension("old_dimension"))
 }
 
 func TestNewCalculateNewMetricErrors(t *testing.T) {


### PR DESCRIPTION
**Description:** Correctly convert dimension values while making metadata updates. Currently, the exporter invokes `sanitizeDataPointDimensions` on all translated datapoints which cleans up non-alphanumeric dimension keys. This is not being done for dimensions in metadata updates. This PR ensures that dimensions are correctly translated and sanitized even in metadata updates.

**Testing:** Added tests.

