### PR TITLE
Update honeycomb exporter README with note for supporting OTLP

### DIFF
--- a/exporter/honeycombexporter/README.md
+++ b/exporter/honeycombexporter/README.md
@@ -1,6 +1,8 @@
 # Honeycomb Exporter
 
-This exporter supports sending trace data to [Honeycomb](https://www.honeycomb.io). 
+**NOTE:** Did you know that Honeycomb now supports OTLP ingest directly? This means you can use an [OTLP](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter) exporter and no longer need this exporter to send data to Honeycomb.
+
+This exporter supports sending trace data to [Honeycomb](https://www.honeycomb.io).
 
 The following configuration options are supported:
 

--- a/exporter/honeycombexporter/README.md
+++ b/exporter/honeycombexporter/README.md
@@ -1,6 +1,6 @@
 # Honeycomb Exporter
 
-**NOTE:** Did you know that Honeycomb now supports OTLP ingest directly? This means you can use an [OTLP](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter) exporter and no longer need this exporter to send data to Honeycomb.
+**NOTE:** Honeycomb now supports OTLP ingest directly. This means you can use an [OTLP](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter) exporter and no longer need this exporter to send data to Honeycomb.
 
 This exporter supports sending trace data to [Honeycomb](https://www.honeycomb.io).
 


### PR DESCRIPTION
**Description:**

Updates Honeycomb exporter README to indicate that the Honeycomb ingest API now supports OTLP format natively and can be used in place of the Honeycomb exporter.