### PR TITLE
Enable filelog receiver

### DIFF
--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -57,6 +57,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver"
@@ -101,6 +102,7 @@ func components() (component.Factories, error) {
 		carbonreceiver.NewFactory(),
 		collectdreceiver.NewFactory(),
 		dockerstatsreceiver.NewFactory(),
+		filelogreceiver.NewFactory(),
 		jmxreceiver.NewFactory(),
 		k8sclusterreceiver.NewFactory(),
 		kubeletstatsreceiver.NewFactory(),

--- a/cmd/otelcontribcol/unstable_components_enabled.go
+++ b/cmd/otelcontribcol/unstable_components_enabled.go
@@ -18,12 +18,8 @@ package main
 
 import (
 	"go.opentelemetry.io/collector/component"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
 )
 
 func extraReceivers() []component.ReceiverFactory {
-	return []component.ReceiverFactory{
-		filelogreceiver.NewFactory(),
-	}
+	return []component.ReceiverFactory{}
 }

--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -26,15 +26,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
 )
 
-var contribPerfResultsSummary testbed.TestResultsSummary = &testbed.PerformanceResults{}
-
-// TestMain is used to initiate setup, execution and tear down of testbed.
-func TestMain(m *testing.M) {
-	// These tests are using the unstable executable.
-	testbed.GlobalConfig.DefaultAgentExeRelativeFile = "../../bin/otelcontribcol_unstable_{{.GOOS}}_{{.GOARCH}}"
-	testbed.DoTestMain(m, contribPerfResultsSummary)
-}
-
 func TestLog10kDPS(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/testbed/tests_unstable_exe/log_test.go
+++ b/testbed/tests_unstable_exe/log_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tests contains test cases. To run the tests go to tests directory and run:
+// RUN_TESTBED=1 go test -v
+
+package tests
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/testbed/testbed"
+)
+
+var contribPerfResultsSummary testbed.TestResultsSummary = &testbed.PerformanceResults{}
+
+// TestMain is used to initiate setup, execution and tear down of testbed.
+func TestMain(m *testing.M) {
+	testbed.GlobalConfig.DefaultAgentExeRelativeFile = "../../bin/otelcontribcol_{{.GOOS}}_{{.GOARCH}}"
+	testbed.DoTestMain(m, contribPerfResultsSummary)
+}
+
+// This file is left with no tests as a placeholder for future unstable exe tests


### PR DESCRIPTION
**Description:** 

Enables `filelogreceiver` by default

**Link to tracking Issue:** One of the prerequisites for #2536

**Testing:** on top of existing unit tests, manually tested file logging in several scenarios (local file logging, K8s DaemonSet file logging)

**Documentation:** Existing documentation describes the usage already