### PR TITLE
Add the ability to flush remaining telemetry before shutdown for azuremonitor exporter

### DIFF
--- a/exporter/azuremonitorexporter/README.md
+++ b/exporter/azuremonitorexporter/README.md
@@ -13,6 +13,7 @@ The following settings can be optionally configured:
 - `endpoint` (default = "https://dc.services.visualstudio.com/v2/track"): The endpoint URL where data will be submitted.
 - `maxbatchsize` (default = 1024): The maximum number of telemetry items that can be submitted in each request. If this many items are buffered, the buffer will be flushed before `maxbatchinterval` expires.
 - `maxbatchinterval` (default = 10s): The maximum time to wait before sending a batch of telemetry.
+- `shutdown_timeout` (default = 5s): The maximum time to wait to flush any remaining telemetry before giving up and shutting down.
 
 Example:
 

--- a/exporter/azuremonitorexporter/channels.go
+++ b/exporter/azuremonitorexporter/channels.go
@@ -14,8 +14,13 @@
 
 package azuremonitorexporter
 
-import "github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
+import (
+	"time"
+
+	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
+)
 
 type transportChannel interface {
 	Send(*contracts.Envelope)
+	Close(timeout ...time.Duration) <-chan struct{}
 }

--- a/exporter/azuremonitorexporter/config.go
+++ b/exporter/azuremonitorexporter/config.go
@@ -28,4 +28,5 @@ type Config struct {
 	InstrumentationKey            string        `mapstructure:"instrumentation_key"`
 	MaxBatchSize                  int           `mapstructure:"maxbatchsize"`
 	MaxBatchInterval              time.Duration `mapstructure:"maxbatchinterval"`
+	ShutdownTimeout               time.Duration `mapstructure:"shutdown_timeout"`
 }

--- a/exporter/azuremonitorexporter/config_test.go
+++ b/exporter/azuremonitorexporter/config_test.go
@@ -57,6 +57,7 @@ func TestLoadConfig(t *testing.T) {
 			InstrumentationKey: "abcdefg",
 			MaxBatchSize:       100,
 			MaxBatchInterval:   10 * time.Second,
+			ShutdownTimeout:    3 * time.Second,
 		},
 		exporter)
 }

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -59,6 +59,7 @@ func createDefaultConfig() configmodels.Exporter {
 		Endpoint:         defaultEndpoint,
 		MaxBatchSize:     1024,
 		MaxBatchInterval: 10 * time.Second,
+		ShutdownTimeout:  5 * time.Second,
 	}
 }
 

--- a/exporter/azuremonitorexporter/mock_transportChannel.go
+++ b/exporter/azuremonitorexporter/mock_transportChannel.go
@@ -17,6 +17,8 @@
 package azuremonitorexporter
 
 import (
+	"time"
+
 	contracts "github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -29,4 +31,10 @@ type mockTransportChannel struct {
 // Send provides a mock function with given fields: _a0
 func (_m *mockTransportChannel) Send(_a0 *contracts.Envelope) {
 	_m.Called(_a0)
+}
+
+func (_m *mockTransportChannel) Close(timeout ...time.Duration) <-chan struct{} {
+	end := make(chan struct{}, 1)
+	end <- struct{}{}
+	return end
 }

--- a/exporter/azuremonitorexporter/testdata/config.yaml
+++ b/exporter/azuremonitorexporter/testdata/config.yaml
@@ -15,6 +15,8 @@ exporters:
     maxbatchsize: 100
     # maxbatchinterval is the maximum time to wait before calling the configured endpoint.
     maxbatchinterval: 10s
+    # shutdown_timeout is the maximum time to wait to flush any remaining telemetry before giving up and shutting down
+    shutdown_timeout: 3s
 
 service:
   pipelines:

--- a/exporter/azuremonitorexporter/traceexporter_test.go
+++ b/exporter/azuremonitorexporter/traceexporter_test.go
@@ -16,6 +16,7 @@ package azuremonitorexporter
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
@@ -105,6 +106,12 @@ func TestExporterTraceDataCallbackSingleSpanNoEnvelope(t *testing.T) {
 	mockTransportChannel.AssertNumberOfCalls(t, "Send", 0)
 }
 
+func TestExporterShutdownCorrectly(t *testing.T) {
+	mockTransportChannel := getMockTransportChannel()
+	exporter := getExporter(defaultConfig, mockTransportChannel)
+	exporter.Shutdown(context.Background())
+}
+
 func getMockTransportChannel() *mockTransportChannel {
 	transportChannelMock := mockTransportChannel{}
 	transportChannelMock.On("Send", mock.Anything)
@@ -116,5 +123,6 @@ func getExporter(config *Config, transportChannel transportChannel) *traceExport
 		config,
 		transportChannel,
 		zap.NewNop(),
+		time.Second,
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add the ability to flush remaining telemetry before shutdown for azuremonitor exporter

**Link to tracking Issue:** <Issue number if applicable>
N/A

**Testing:** <Describe what testing was performed and which tests were added.>
Tested the new config and made sure the traceexporter called the transport channel correctly

**Documentation:** <Describe the documentation added.>
Added the new config to the documentation of azuremonitor exporter.