### PR TITLE
Add custom auth header/token functionality for splunkhecexporter.

### DIFF
--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -22,6 +22,8 @@ The following configuration options can also be configured:
 - `disable_compression` (default: false): Whether to disable gzip compression over HTTP.
 - `timeout` (default: 10s): HTTP timeout when sending data.
 - `insecure_skip_verify` (default: false): Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS.
+- `auth_header` (default: Authorization): Optional custom authentication header.
+- `auth_token` (default: Splunk \<hec_token\>) Optional custom authentication token. Replaces `token` value.
 
 In addition, this exporter offers queued retry which is enabled by default.
 Information about queued retry configuration parameters can be found
@@ -50,6 +52,10 @@ exporters:
     timeout: 10s
     # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
     insecure_skip_verify: false
+    # Optional custom authentication header.
+    auth_header: "X-Auth-Token"
+    # Optional custom authentication token. Replaces `token` value.
+    auth_token: "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
 ```
 
 The full list of settings exposed for this exporter are documented [here](config.go)

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -60,6 +60,12 @@ type Config struct {
 
 	// insecure_skip_verify skips checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
 	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify"`
+
+	// Optional custom authentication header. Defaults to Authorization.
+	AuthHeader string `mapstructure:"auth_header"`
+
+	// Optional custom authentication token. Defaults to "Splunk <hec_token>".
+	AuthToken string `mapstructure:"auth_token"`
 }
 
 func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -64,6 +64,7 @@ func TestLoadConfig(t *testing.T) {
 		SourceType:     "otel",
 		Index:          "metrics",
 		MaxConnections: 100,
+		AuthHeader:     "Authorization",
 		TimeoutSettings: exporterhelper.TimeoutSettings{
 			Timeout: 10 * time.Second,
 		},

--- a/exporter/splunkhecexporter/exporter.go
+++ b/exporter/splunkhecexporter/exporter.go
@@ -80,6 +80,10 @@ func createExporter(
 }
 
 func buildClient(options *exporterOptions, config *Config, logger *zap.Logger) *client {
+	if config.AuthToken == "" {
+		config.AuthToken = splunk.HECTokenHeader + " " + config.Token
+	}
+
 	return &client{
 		url: options.url,
 		client: &http.Client{
@@ -104,10 +108,10 @@ func buildClient(options *exporterOptions, config *Config, logger *zap.Logger) *
 			return gzip.NewWriter(nil)
 		}},
 		headers: map[string]string{
-			"Connection":    "keep-alive",
-			"Content-Type":  "application/json",
-			"User-Agent":    "OpenTelemetry-Collector Splunk Exporter/v0.0.1",
-			"Authorization": splunk.HECTokenHeader + " " + config.Token,
+			"Connection":      "keep-alive",
+			"Content-Type":    "application/json",
+			"User-Agent":      "OpenTelemetry-Collector Splunk Exporter/v0.0.1",
+			config.AuthHeader: config.AuthToken,
 		},
 		config: config,
 	}

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -29,6 +29,7 @@ const (
 	typeStr            = "splunk_hec"
 	defaultMaxIdleCons = 100
 	defaultHTTPTimeout = 10 * time.Second
+	defaultAuthHeader  = "Authorization"
 )
 
 // NewFactory creates a factory for Splunk HEC exporter.
@@ -54,6 +55,7 @@ func createDefaultConfig() configmodels.Exporter {
 		QueueSettings:      exporterhelper.DefaultQueueSettings(),
 		DisableCompression: false,
 		MaxConnections:     defaultMaxIdleCons,
+		AuthHeader:         defaultAuthHeader,
 	}
 }
 


### PR DESCRIPTION
**Description:** Adding a custom auth header and token options for `splunkhecexporter.`

**Link to tracking Issue:** n/a

**Testing:** Run docker demo from the example. 

**Documentation:** `splunkhecexporter` Readme updated.