### PR TITLE
f5cloudexporter: fixed module path and go version

### DIFF
--- a/exporter/f5cloudexporter/go.mod
+++ b/exporter/f5cloudexporter/go.mod
@@ -1,6 +1,6 @@
-module github.com/gramidt/opentelemetry-collector-contrib/exporter/f5cloudexporter
+module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/f5cloudexporter
 
-go 1.15
+go 1.14
 
 require (
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
Signed-off-by: Granville Schmidt <g.schmidt@f5.com>

**Description:**
The F5 Cloud module path within the `exporter/f5cloudexporter/go.mod` was committed with the incorrect module path and go 1.15 causing issues when being added to external collector builds. I shouldn't have missed this when I originally pushed the exporter.

**Link to tracking Issue:**
N/A

**Testing:**
N/A

**Documentation:** 
N/A