### PR TITLE
Fix concurrency in emf exporter

### DIFF
--- a/exporter/awsemfexporter/cwlog_client_test.go
+++ b/exporter/awsemfexporter/cwlog_client_test.go
@@ -32,14 +32,14 @@ import (
 	"go.uber.org/zap"
 )
 
-func NewAlwaysPassMockLogClient() LogClient {
+func NewAlwaysPassMockLogClient(putLogEventsFunc func(args mock.Arguments)) LogClient {
 	logger := zap.NewNop()
 	svc := new(mockCloudWatchLogsClient)
 
 	svc.On("PutLogEvents", mock.Anything).Return(
 		&cloudwatchlogs.PutLogEventsOutput{
 			NextSequenceToken: &expectedNextSequenceToken},
-		nil)
+		nil).Run(putLogEventsFunc)
 
 	svc.On("CreateLogGroup", mock.Anything).Return(new(cloudwatchlogs.CreateLogGroupOutput), nil)
 

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -315,7 +315,7 @@ func translateCWMetricToEMF(cWMetric *CWMetrics) *LogEvent {
 	}
 
 	metricCreationTime := cWMetric.TimestampMs
-	logEvent := NewLogEvent(
+	logEvent := newLogEvent(
 		metricCreationTime,
 		string(pleMsg),
 	)


### PR DESCRIPTION
**Why do we need it?**
This PR fixes the concurrency issue described in https://github.com/aws-observability/aws-otel-collector/issues/387, and does a code refactoring to `pusher`.

We add two locks, one for `logEventBatch` instance update and one for `streamToken` replacement to ensure they're both goroutine safe. It also fixes an issue of deciding where a new logEvent should go to when the current batch could not meet the requirement *before or after* the new entry appending. In today's implementation, it is added to the old batch, and this PR changes it to be added to a newly created batch.