### PR TITLE
Refine load test limits

### DIFF
--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -39,8 +39,8 @@ func TestLog10kDPS(t *testing.T) {
 			sender:   testbed.NewOTLPLogsDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
-				ExpectedMaxCPU: 40,
-				ExpectedMaxRAM: 80,
+				ExpectedMaxCPU: 26,
+				ExpectedMaxRAM: 82,
 			},
 		},
 		{
@@ -48,8 +48,8 @@ func TestLog10kDPS(t *testing.T) {
 			sender:   datasenders.NewFileLogWriter(),
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
-				ExpectedMaxCPU: 50,
-				ExpectedMaxRAM: 150,
+				ExpectedMaxCPU: 30,
+				ExpectedMaxRAM: 85,
 			},
 		},
 	}

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -36,8 +36,8 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOTLPMetricDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 50,
-				ExpectedMaxRAM: 80,
+				ExpectedMaxCPU: 37,
+				ExpectedMaxRAM: 83,
 			},
 		},
 		{

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -47,8 +47,8 @@ func TestTrace10kSPS(t *testing.T) {
 			testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 20,
-				ExpectedMaxRAM: 70,
+				ExpectedMaxCPU: 16,
+				ExpectedMaxRAM: 80,
 			},
 		},
 		{
@@ -56,8 +56,8 @@ func TestTrace10kSPS(t *testing.T) {
 			datasenders.NewSapmDataSender(testbed.GetAvailablePort(t)),
 			datareceivers.NewSapmDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
-				ExpectedMaxCPU: 40,
-				ExpectedMaxRAM: 85,
+				ExpectedMaxCPU: 32,
+				ExpectedMaxRAM: 98,
 			},
 		},
 	}


### PR DESCRIPTION
Increased some which were on the fence and were occasionally failing
when CircleCI was slow. Decreased some which were too generous to help
catch performance regressions.

Using as a rule of thumb:
- Set limit at 1.5x of observed for CPU
- Set limit at 1.15 of observed for RAM

These proved to be reasonable both to help catch regressions but also
to give some room for CircleCI instability.
