### PR TITLE
serialize each datapoint into separate line

### DIFF
--- a/exporter/dynatraceexporter/serialization/serialization.go
+++ b/exporter/dynatraceexporter/serialization/serialization.go
@@ -32,27 +32,28 @@ const (
 )
 
 // SerializeIntDataPoints serializes a slice of integer datapoints to a Dynatrace gauge.
-func SerializeIntDataPoints(name string, data pdata.IntDataPointSlice, tags []string) string {
+func SerializeIntDataPoints(name string, data pdata.IntDataPointSlice, tags []string) []string {
 	// {name} {value} {timestamp}
-	output := ""
+	output := []string{}
+
 	for i := 0; i < data.Len(); i++ {
 		p := data.At(i)
 		tagline := serializeTags(p.LabelsMap(), tags)
 		valueLine := strconv.FormatInt(p.Value(), 10)
 
-		output += serializeLine(name, tagline, valueLine, p.Timestamp())
+		output = append(output, serializeLine(name, tagline, valueLine, p.Timestamp()))
 	}
 
 	return output
 }
 
 // SerializeDoubleDataPoints serializes a slice of double datapoints to a Dynatrace gauge.
-func SerializeDoubleDataPoints(name string, data pdata.DoubleDataPointSlice, tags []string) string {
+func SerializeDoubleDataPoints(name string, data pdata.DoubleDataPointSlice, tags []string) []string {
 	// {name} {value} {timestamp}
-	output := ""
+	output := []string{}
 	for i := 0; i < data.Len(); i++ {
 		p := data.At(i)
-		output += serializeLine(name, serializeTags(p.LabelsMap(), tags), serializeFloat64(p.Value()), p.Timestamp())
+		output = append(output, serializeLine(name, serializeTags(p.LabelsMap(), tags), serializeFloat64(p.Value()), p.Timestamp()))
 	}
 
 	return output
@@ -61,20 +62,20 @@ func SerializeDoubleDataPoints(name string, data pdata.DoubleDataPointSlice, tag
 // SerializeDoubleHistogramMetrics serializes a slice of double histogram datapoints to a Dynatrace gauge.
 //
 // IMPORTANT: Min and max are required by Dynatrace but not provided by histogram so they are assumed to be the average.
-func SerializeDoubleHistogramMetrics(name string, data pdata.DoubleHistogramDataPointSlice, tags []string) string {
+func SerializeDoubleHistogramMetrics(name string, data pdata.DoubleHistogramDataPointSlice, tags []string) []string {
 	// {name} gauge,min=9.75,max=9.75,sum=19.5,count=2 {timestamp_unix_ms}
-	output := ""
+	output := []string{}
 	for i := 0; i < data.Len(); i++ {
 		p := data.At(i)
 		tagline := serializeTags(p.LabelsMap(), tags)
 		if p.Count() == 0 {
-			return ""
+			return []string{}
 		}
 		avg := p.Sum() / float64(p.Count())
 
 		valueLine := fmt.Sprintf("gauge,min=%[1]s,max=%[1]s,sum=%s,count=%d", serializeFloat64(avg), serializeFloat64(p.Sum()), p.Count())
 
-		output += serializeLine(name, tagline, valueLine, p.Timestamp())
+		output = append(output, serializeLine(name, tagline, valueLine, p.Timestamp()))
 	}
 
 	return output
@@ -83,23 +84,23 @@ func SerializeDoubleHistogramMetrics(name string, data pdata.DoubleHistogramData
 // SerializeIntHistogramMetrics serializes a slice of integer histogram datapoints to a Dynatrace gauge.
 //
 // IMPORTANT: Min and max are required by Dynatrace but not provided by histogram so they are assumed to be the average.
-func SerializeIntHistogramMetrics(name string, data pdata.IntHistogramDataPointSlice, tags []string) string {
+func SerializeIntHistogramMetrics(name string, data pdata.IntHistogramDataPointSlice, tags []string) []string {
 	// {name} gauge,min=9.5,max=9.5,sum=19,count=2 {timestamp_unix_ms}
-	output := ""
+	output := []string{}
 	for i := 0; i < data.Len(); i++ {
 		p := data.At(i)
 		tagline := serializeTags(p.LabelsMap(), tags)
 		count := p.Count()
 
 		if count == 0 {
-			return ""
+			return []string{}
 		}
 
 		avg := float64(p.Sum()) / float64(count)
 
 		valueLine := fmt.Sprintf("gauge,min=%[1]s,max=%[1]s,sum=%d,count=%d", serializeFloat64(avg), p.Sum(), count)
 
-		output += serializeLine(name, tagline, valueLine, p.Timestamp())
+		output = append(output, serializeLine(name, tagline, valueLine, p.Timestamp()))
 	}
 
 	return output

--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -28,10 +28,13 @@ func TestSerializeIntDataPoints(t *testing.T) {
 	}
 
 	intSlice := pdata.NewIntDataPointSlice()
-	intSlice.Resize(1)
+	intSlice.Resize(2)
 	intPoint := intSlice.At(0)
 	intPoint.SetValue(13)
 	intPoint.SetTimestamp(pdata.Timestamp(100_000_000))
+	intPoint1 := intSlice.At(1)
+	intPoint1.SetValue(13)
+	intPoint1.SetTimestamp(pdata.Timestamp(100_000_000))
 
 	labelIntSlice := pdata.NewIntDataPointSlice()
 	labelIntSlice.Resize(1)
@@ -59,7 +62,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: intSlice,
 				tags: []string{},
 			},
-			want: []string{"my_int_gauge 13 100"},
+			want: []string{"my_int_gauge 13 100", "my_int_gauge 13 100"},
 		},
 		{
 			name: "Serialize integer data points with tags",
@@ -68,7 +71,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: intSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: []string{"my_int_gauge_with_tags,test_key=testval 13 100"},
+			want: []string{"my_int_gauge_with_tags,test_key=testval 13 100", "my_int_gauge_with_tags,test_key=testval 13 100"},
 		},
 		{
 			name: "Serialize integer data points with labels",
@@ -226,7 +229,7 @@ func TestSerializeDoubleHistogramMetrics(t *testing.T) {
 				data: zeroDoubleHistogramSlice,
 				tags: []string{},
 			},
-			want: []string{""},
+			want: []string{},
 		},
 	}
 	for _, tt := range tests {
@@ -305,7 +308,7 @@ func TestSerializeIntHistogramMetrics(t *testing.T) {
 				data: zeroIntHistogramSlice,
 				tags: []string{},
 			},
-			want: []string{""},
+			want: []string{},
 		},
 	}
 	for _, tt := range tests {

--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -50,7 +50,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want string
+		want []string
 	}{
 		{
 			name: "Serialize integer data points",
@@ -59,7 +59,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: intSlice,
 				tags: []string{},
 			},
-			want: "my_int_gauge 13 100",
+			want: []string{"my_int_gauge 13 100"},
 		},
 		{
 			name: "Serialize integer data points with tags",
@@ -68,7 +68,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: intSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: "my_int_gauge_with_tags,test_key=testval 13 100",
+			want: []string{"my_int_gauge_with_tags,test_key=testval 13 100"},
 		},
 		{
 			name: "Serialize integer data points with labels",
@@ -77,7 +77,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: labelIntSlice,
 				tags: []string{},
 			},
-			want: "my_int_gauge_with_labels,labelkey=\"labelValue\" 13 100",
+			want: []string{"my_int_gauge_with_labels,labelkey=\"labelValue\" 13 100"},
 		},
 		{
 			name: "Serialize integer data points with empty label",
@@ -86,12 +86,12 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: emptyLabelIntSlice,
 				tags: []string{},
 			},
-			want: "my_int_gauge_with_empty_labels,emptylabelkey=\"\" 13 100",
+			want: []string{"my_int_gauge_with_empty_labels,emptylabelkey=\"\" 13 100"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SerializeIntDataPoints(tt.args.name, tt.args.data, tt.args.tags); got != tt.want {
+			if got := SerializeIntDataPoints(tt.args.name, tt.args.data, tt.args.tags); !equal(got, tt.want) {
 				t.Errorf("SerializeIntDataPoints() = %#v, want %#v", got, tt.want)
 			}
 		})
@@ -120,7 +120,7 @@ func TestSerializeDoubleDataPoints(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want string
+		want []string
 	}{
 		{
 			name: "Serialize double data points",
@@ -129,7 +129,7 @@ func TestSerializeDoubleDataPoints(t *testing.T) {
 				data: doubleSlice,
 				tags: []string{},
 			},
-			want: "my_double_gauge 13.1 100",
+			want: []string{"my_double_gauge 13.1 100"},
 		},
 		{
 			name: "Serialize double data points with tags",
@@ -138,7 +138,7 @@ func TestSerializeDoubleDataPoints(t *testing.T) {
 				data: doubleSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: "my_double_gauge_with_tags,test_key=testval 13.1 100",
+			want: []string{"my_double_gauge_with_tags,test_key=testval 13.1 100"},
 		},
 		{
 			name: "Serialize double data points with labels",
@@ -147,12 +147,12 @@ func TestSerializeDoubleDataPoints(t *testing.T) {
 				data: labelDoubleSlice,
 				tags: []string{},
 			},
-			want: "my_double_gauge_with_labels,labelkey=\"labelValue\" 13.1 100",
+			want: []string{"my_double_gauge_with_labels,labelkey=\"labelValue\" 13.1 100"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SerializeDoubleDataPoints(tt.args.name, tt.args.data, tt.args.tags); got != tt.want {
+			if got := SerializeDoubleDataPoints(tt.args.name, tt.args.data, tt.args.tags); !equal(got, tt.want) {
 				t.Errorf("SerializeDoubleDataPoints() = %v, want %v", got, tt.want)
 			}
 		})
@@ -190,7 +190,7 @@ func TestSerializeDoubleHistogramMetrics(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want string
+		want []string
 	}{
 		{
 			name: "Serialize double histogram data points",
@@ -199,7 +199,7 @@ func TestSerializeDoubleHistogramMetrics(t *testing.T) {
 				data: doubleHistSlice,
 				tags: []string{},
 			},
-			want: "my_double_hist gauge,min=10.1,max=10.1,sum=101,count=10 100",
+			want: []string{"my_double_hist gauge,min=10.1,max=10.1,sum=101,count=10 100"},
 		},
 		{
 			name: "Serialize double histogram data points with tags",
@@ -208,7 +208,7 @@ func TestSerializeDoubleHistogramMetrics(t *testing.T) {
 				data: doubleHistSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: "my_double_hist_with_tags,test_key=testval gauge,min=10.1,max=10.1,sum=101,count=10 100",
+			want: []string{"my_double_hist_with_tags,test_key=testval gauge,min=10.1,max=10.1,sum=101,count=10 100"},
 		},
 		{
 			name: "Serialize double histogram data points with labels",
@@ -217,7 +217,7 @@ func TestSerializeDoubleHistogramMetrics(t *testing.T) {
 				data: labelDoubleHistSlice,
 				tags: []string{},
 			},
-			want: "my_double_hist_with_labels,labelkey=\"labelValue\" gauge,min=10.1,max=10.1,sum=101,count=10 100",
+			want: []string{"my_double_hist_with_labels,labelkey=\"labelValue\" gauge,min=10.1,max=10.1,sum=101,count=10 100"},
 		},
 		{
 			name: "Serialize zero double histogram",
@@ -226,12 +226,12 @@ func TestSerializeDoubleHistogramMetrics(t *testing.T) {
 				data: zeroDoubleHistogramSlice,
 				tags: []string{},
 			},
-			want: "",
+			want: []string{""},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SerializeDoubleHistogramMetrics(tt.args.name, tt.args.data, tt.args.tags); got != tt.want {
+			if got := SerializeDoubleHistogramMetrics(tt.args.name, tt.args.data, tt.args.tags); !equal(got, tt.want) {
 				t.Errorf("SerializeDoubleHistogramMetrics() = %v, want %v", got, tt.want)
 			}
 		})
@@ -269,7 +269,7 @@ func TestSerializeIntHistogramMetrics(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want string
+		want []string
 	}{
 		{
 			name: "Serialize integer histogram data points",
@@ -278,7 +278,7 @@ func TestSerializeIntHistogramMetrics(t *testing.T) {
 				data: intHistSlice,
 				tags: []string{},
 			},
-			want: "my_int_hist gauge,min=11,max=11,sum=110,count=10 100",
+			want: []string{"my_int_hist gauge,min=11,max=11,sum=110,count=10 100"},
 		},
 		{
 			name: "Serialize integer histogram data points with tags",
@@ -287,7 +287,7 @@ func TestSerializeIntHistogramMetrics(t *testing.T) {
 				data: intHistSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: "my_int_hist_with_tags,test_key=testval gauge,min=11,max=11,sum=110,count=10 100",
+			want: []string{"my_int_hist_with_tags,test_key=testval gauge,min=11,max=11,sum=110,count=10 100"},
 		},
 		{
 			name: "Serialize integer histogram data points with labels",
@@ -296,7 +296,7 @@ func TestSerializeIntHistogramMetrics(t *testing.T) {
 				data: labelIntHistSlice,
 				tags: []string{},
 			},
-			want: "my_int_hist_with_labels,labelkey=\"labelValue\" gauge,min=11,max=11,sum=110,count=10 100",
+			want: []string{"my_int_hist_with_labels,labelkey=\"labelValue\" gauge,min=11,max=11,sum=110,count=10 100"},
 		},
 		{
 			name: "Serialize zero integer histogram",
@@ -305,12 +305,12 @@ func TestSerializeIntHistogramMetrics(t *testing.T) {
 				data: zeroIntHistogramSlice,
 				tags: []string{},
 			},
-			want: "",
+			want: []string{""},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SerializeIntHistogramMetrics(tt.args.name, tt.args.data, tt.args.tags); got != tt.want {
+			if got := SerializeIntHistogramMetrics(tt.args.name, tt.args.data, tt.args.tags); !equal(got, tt.want) {
 				t.Errorf("SerializeIntHistogramMetrics() = %v, want %v", got, tt.want)
 			}
 		})
@@ -505,4 +505,16 @@ func Test_serializeFloat64(t *testing.T) {
 			}
 		})
 	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) == len(b) {
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }

--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -33,8 +33,8 @@ func TestSerializeIntDataPoints(t *testing.T) {
 	intPoint.SetValue(13)
 	intPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 	intPoint1 := intSlice.At(1)
-	intPoint1.SetValue(13)
-	intPoint1.SetTimestamp(pdata.Timestamp(100_000_000))
+	intPoint1.SetValue(14)
+	intPoint1.SetTimestamp(pdata.Timestamp(101_000_000))
 
 	labelIntSlice := pdata.NewIntDataPointSlice()
 	labelIntSlice.Resize(1)
@@ -62,7 +62,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: intSlice,
 				tags: []string{},
 			},
-			want: []string{"my_int_gauge 13 100", "my_int_gauge 13 100"},
+			want: []string{"my_int_gauge 13 100", "my_int_gauge 14 101"},
 		},
 		{
 			name: "Serialize integer data points with tags",
@@ -71,7 +71,7 @@ func TestSerializeIntDataPoints(t *testing.T) {
 				data: intSlice,
 				tags: []string{"test_key=testval"},
 			},
-			want: []string{"my_int_gauge_with_tags,test_key=testval 13 100", "my_int_gauge_with_tags,test_key=testval 13 100"},
+			want: []string{"my_int_gauge_with_tags,test_key=testval 13 100", "my_int_gauge_with_tags,test_key=testval 14 101"},
 		},
 		{
 			name: "Serialize integer data points with labels",


### PR DESCRIPTION
**Description:** Dynatrace API api expects each metric and its value to be on a separate line.

I might be wrong here, but to me it looks like the Dynatrace exporter incorrectly concatenates multiple data points  for a single metric into one line. When this one line exceeds 2000 chars, the dynatrace server returns an error.

This change changes the way a DataPointSlice is serialized. 

Now each data data point is serialised into its own line. The chunking later on can easily break this into 1000 lines (as required by the api).

versions:
otel library (used by client app): v0.17.0
otel-collector: 0.21.0
dynatrace: 1.211.111.20210222-093946

**Link to tracking Issue:** none.

**Testing:** unit testing and also able to push the metrics to a live instance of dynatrace server.

**Documentation:** none.
