### PR TITLE
[metricstransform] Add resource attribute copy to metric label

### DIFF
--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -15,12 +15,13 @@ not suitable for aggregating metrics from multiple sources (e.g. multiple nodes
 or clients).
 
 | Operation                     | Example (based on metric `system.cpu.usage`)                                                    |
-|-------------------------------|-------------------------------------------------------------------------------------------------|
+| ----------------------------- | ----------------------------------------------------------------------------------------------- |
 | Rename metrics                | Rename to `system.cpu.usage_time`                                                               |
 | Add labels                    | Add new label `identifier` with value `1` to all points                                         |
 | Rename label keys             | Rename label `state` to `cpu_state`                                                             |
 | Rename label values           | For label `state`, rename value `idle` to `-`                                                   |
 | Delete data points            | Delete all points where label `state` has value `idle`                                          |
+| Copy labels from resources    | Copy resource attributes to metric labels                                                       |
 | Toggle data type              | Change from `int` data points to `double` data points                                           |
 | Aggregate across label sets   | Retain only the label `state`, average all points with the same value for this label            |
 | Aggregate across label values | For label `state`, sum points where the value is `user` or `system` into `used = user + system` |
@@ -83,6 +84,8 @@ transforms:
         aggregated_values: [values...]
         # new_value specifies the updated name of the label value; if action is add_label or aggregate_label_values, new_value is required
         new_value: <new_value>
+        # attribute_name specifies the resource attribute name used as a source if op is `copy_resource_attribute`
+        attribute_name: <resource_attribute>
         # label_value specifies the label value for which points should be deleted; if action is delete_label_value, label_value is required
         label_value: <label_value>
         # label_set contains a list of labels that will remain after aggregation; if action is aggregate_labels, label_set is required
@@ -195,6 +198,16 @@ operation:
   - action: delete_label_value
     label: state
     label_value: idle
+```
+
+### Copy a resource attribute
+```yaml
+# Apply resource attribute 'host.name' as a metric label
+include: host.name
+action: update
+operation:
+  - action: copy_resource_attribute
+    attribute_name: host.name
 ```
 
 ### Toggle datatype

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -34,6 +34,9 @@ const (
 	// NewNameFieldName is the mapstructure field name for NewName field
 	NewNameFieldName = "new_name"
 
+	// AttributeNameFieldName is the mapstructure field name for AttributeName
+	AttributeNameFieldName = "attribute_name"
+
 	// GroupResouceLabelsFieldName is the mapstructure field name for GroupResouceLabels field
 	GroupResouceLabelsFieldName = "group_resource_labels"
 
@@ -136,6 +139,9 @@ type Operation struct {
 	// NewValue is used to set a new label value either when the operation is `AggregatedValues` or `AddLabel`.
 	NewValue string `mapstructure:"new_value"`
 
+	// AttributeName is used as the source resource attribute when the operation is `CopyResourceAttribute`.
+	AttributeName string `mapstructure:"attribute_name"`
+
 	// ValueActions is a list of renaming actions for label values.
 	ValueActions []ValueAction `mapstructure:"value_actions"`
 
@@ -191,6 +197,9 @@ const (
 	// UpdateLabel applies name changes to label and/or label values.
 	UpdateLabel OperationAction = "update_label"
 
+	// CopyResourceAttribute takes the value of a resource attribute and adds it as a label
+	CopyResourceAttribute OperationAction = "copy_resource_attribute"
+
 	// DeleteLabelValue deletes a label value by also removing all the points associated with this label value
 	DeleteLabelValue OperationAction = "delete_label_value"
 
@@ -206,7 +215,7 @@ const (
 	AggregateLabelValues OperationAction = "aggregate_label_values"
 )
 
-var OperationActions = []OperationAction{AddLabel, UpdateLabel, DeleteLabelValue, ToggleScalarDataType, AggregateLabels, AggregateLabelValues}
+var OperationActions = []OperationAction{AddLabel, UpdateLabel, CopyResourceAttribute, DeleteLabelValue, ToggleScalarDataType, AggregateLabels, AggregateLabelValues}
 
 func (oa OperationAction) isValid() bool {
 	for _, operationAction := range OperationActions {

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -127,6 +127,9 @@ func validateConfiguration(config *Config) error {
 			if op.Action == AddLabel && op.NewValue == "" {
 				return fmt.Errorf("operation %v: missing required field %q while %q is %v", i+1, NewValueFieldName, ActionFieldName, AddLabel)
 			}
+			if op.Action == CopyResourceAttribute && op.AttributeName == "" {
+				return fmt.Errorf("operation %v: missing required field %q while %q is %v", i+1, AttributeNameFieldName, ActionFieldName, CopyResourceAttribute)
+			}
 
 			if op.AggregationType != "" && !op.AggregationType.isValid() {
 				return fmt.Errorf("operation %v: %q must be in %q", i+1, AggregationTypeFieldName, AggregationTypes)

--- a/processor/metricstransformprocessor/factory_test.go
+++ b/processor/metricstransformprocessor/factory_test.go
@@ -119,6 +119,11 @@ func TestCreateProcessors(t *testing.T) {
 			succeed:      false,
 			errorMessage: fmt.Sprintf("%q must be in %q", SubmatchCaseFieldName, SubmatchCases),
 		},
+		{
+			configName:   "config_invalid_attribute_name.yaml",
+			succeed:      false,
+			errorMessage: fmt.Sprintf("operation %v: missing required field %q while %q is %v", 1, AttributeNameFieldName, ActionFieldName, CopyResourceAttribute),
+		},
 	}
 
 	for _, test := range tests {

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -180,7 +180,7 @@ func (mtp *metricsTransformProcessor) ProcessMetrics(_ context.Context, md pdata
 					data.Metrics = append(data.Metrics, match.metric)
 				}
 
-				mtp.update(match, transform)
+				mtp.update(match, transform, data.Resource)
 
 				if transform.NewName != "" {
 					if transform.Action == Update {
@@ -340,7 +340,7 @@ func (mtp *metricsTransformProcessor) removeMatchedMetricsAndAppendCombined(metr
 }
 
 // update updates the metric content based on operations indicated in transform.
-func (mtp *metricsTransformProcessor) update(match *match, transform internalTransform) {
+func (mtp *metricsTransformProcessor) update(match *match, transform internalTransform, resource *resourcepb.Resource) {
 	if transform.NewName != "" {
 		if match.pattern == nil {
 			match.metric.MetricDescriptor.Name = transform.NewName
@@ -361,6 +361,8 @@ func (mtp *metricsTransformProcessor) update(match *match, transform internalTra
 			mtp.ToggleScalarDataType(match.metric)
 		case AddLabel:
 			mtp.addLabelOp(match.metric, op)
+		case CopyResourceAttribute:
+			mtp.copyResourceAttributeOp(match.metric, op, resource)
 		case DeleteLabelValue:
 			mtp.deleteLabelValueOp(match.metric, op)
 		}

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -55,7 +55,7 @@ func TestMetricsTransformProcessor(t *testing.T) {
 			ctx := context.Background()
 
 			// construct metrics data to feed into the processor
-			md := internaldata.MetricsData{Metrics: test.in}
+			md := internaldata.MetricsData{Metrics: test.in, Resource: test.resource}
 
 			// process
 			cErr := mtp.ConsumeMetrics(context.Background(), internaldata.OCToMetrics(md))

--- a/processor/metricstransformprocessor/operation_copy_resource_attribute.go
+++ b/processor/metricstransformprocessor/operation_copy_resource_attribute.go
@@ -1,0 +1,42 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricstransformprocessor
+
+import (
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
+)
+
+func (mtp *metricsTransformProcessor) copyResourceAttributeOp(metric *metricspb.Metric, op internalOperation, resource *resourcepb.Resource) {
+	var attrVal metricspb.LabelValue
+
+	if !attrVal.HasValue && resource != nil {
+		if val, ok := resource.Labels[op.configOperation.AttributeName]; ok {
+			attrVal.Value = val
+			attrVal.HasValue = true
+		}
+	}
+
+	if !attrVal.HasValue {
+		return
+	}
+
+	metric.MetricDescriptor.LabelKeys = append(metric.MetricDescriptor.LabelKeys, &metricspb.LabelKey{
+		Key: op.configOperation.AttributeName,
+	})
+	for _, ts := range metric.Timeseries {
+		ts.LabelValues = append(ts.LabelValues, &attrVal)
+	}
+}

--- a/processor/metricstransformprocessor/testdata/config_invalid_attribute_name.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_attribute_name.yaml
@@ -1,0 +1,24 @@
+receivers:
+    nop:
+
+processors:
+    metricstransform:
+        transforms:
+            - include: old_name
+              action: update
+              operations:
+                  - action: copy_resource_attribute
+
+exporters:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [metricstransform]
+            exporters: [nop]
+        metrics:
+            receivers: [nop]
+            processors: [metricstransform]
+            exporters: [nop]


### PR DESCRIPTION
**Description:** 

Add the ability to copy resource attributes into metric labels. This allows users to use resource attributes like "hostname" or "pod name" as labels in metrics without having to re-instrument the application.

This is a WIP as I can't get the tests to pass yet and I would like some feedback before spending any more time on it.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2568

**Testing:**

I added a test case for the new operation

**Documentation:**