### PR TITLE
SFx Exporter: add resource attributes to events

### DIFF
--- a/exporter/signalfxexporter/eventclient.go
+++ b/exporter/signalfxexporter/eventclient.go
@@ -50,10 +50,11 @@ func (s *sfxEventClient) pushLogsData(ctx context.Context, ld pdata.Logs) (int, 
 	numDroppedLogRecords := 0
 
 	for i := 0; i < rls.Len(); i++ {
-		ills := rls.At(0).InstrumentationLibraryLogs()
+		rl := rls.At(i)
+		ills := rl.InstrumentationLibraryLogs()
 		for j := 0; j < ills.Len(); j++ {
 			ill := ills.At(j)
-			events, dropped := translation.LogSliceToSignalFxV2(s.logger, ill.Logs())
+			events, dropped := translation.LogSliceToSignalFxV2(s.logger, ill.Logs(), rl.Resource().Attributes())
 			sfxEvents = append(sfxEvents, events...)
 			numDroppedLogRecords += dropped
 		}


### PR DESCRIPTION
**Description:**
These changes add a minor feature and fix a bug in the logs -> events conversion for the SignalFx exporter.  They adopt resource attributes to use as SFx event dimensions and also ensure that all log records are getting serialized in the conversion iterator.  Before these changes resource attributes weren't included so no processor enhancements like resource detection were supported.  Also before these the same resource log's instrumentation library logs were converted multiple times instead of a complete iteration.

**Testing:**
Updated existing unit tests to exercise addition.

**Documentation:**
None required.