### PR TITLE
loadbalancingexporter: add support for logs - 2/5

### DIFF
--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -1,0 +1,193 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultPort = "55680"
+)
+
+var (
+	errNoResolver                = errors.New("no resolvers specified for the exporter")
+	errMultipleResolversProvided = errors.New("only one resolver should be specified")
+)
+
+var _ loadBalancer = (*loadBalancerImp)(nil)
+
+type componentFactory func(ctx context.Context, endpoint string) (component.Exporter, error)
+
+type loadBalancer interface {
+	component.Component
+	Exporter(traceID pdata.TraceID) (component.Exporter, string, error)
+}
+
+type loadBalancerImp struct {
+	logger *zap.Logger
+	host   component.Host
+
+	res  resolver
+	ring *hashRing
+
+	componentFactory componentFactory
+	exporters        map[string]component.Exporter
+
+	stopped    bool
+	updateLock sync.RWMutex
+}
+
+// Create new load balancer
+func newLoadBalancer(params component.ExporterCreateParams, cfg configmodels.Exporter, factory componentFactory) (*loadBalancerImp, error) {
+	oCfg := cfg.(*Config)
+
+	if oCfg.Resolver.DNS != nil && oCfg.Resolver.Static != nil {
+		return nil, errMultipleResolversProvided
+	}
+
+	var res resolver
+	if oCfg.Resolver.Static != nil {
+		var err error
+		res, err = newStaticResolver(oCfg.Resolver.Static.Hostnames)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if oCfg.Resolver.DNS != nil {
+		dnsLogger := params.Logger.With(zap.String("resolver", "dns"))
+
+		var err error
+		res, err = newDNSResolver(dnsLogger, oCfg.Resolver.DNS.Hostname, oCfg.Resolver.DNS.Port)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if res == nil {
+		return nil, errNoResolver
+	}
+
+	return &loadBalancerImp{
+		logger:           params.Logger,
+		res:              res,
+		componentFactory: factory,
+		exporters:        map[string]component.Exporter{},
+	}, nil
+}
+
+func (lb *loadBalancerImp) Start(ctx context.Context, host component.Host) error {
+	lb.res.onChange(lb.onBackendChanges)
+	lb.host = host
+	if err := lb.res.start(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (lb *loadBalancerImp) onBackendChanges(resolved []string) {
+	newRing := newHashRing(resolved)
+
+	if !newRing.equal(lb.ring) {
+		lb.updateLock.Lock()
+		defer lb.updateLock.Unlock()
+
+		lb.ring = newRing
+
+		// TODO: set a timeout?
+		ctx := context.Background()
+
+		// add the missing exporters first
+		lb.addMissingExporters(ctx, resolved)
+		lb.removeExtraExporters(ctx, resolved)
+	}
+}
+
+func (lb *loadBalancerImp) addMissingExporters(ctx context.Context, endpoints []string) {
+	for _, endpoint := range endpoints {
+		endpoint = endpointWithPort(endpoint)
+
+		if _, exists := lb.exporters[endpoint]; !exists {
+			exp, err := lb.componentFactory(ctx, endpoint)
+			if err != nil {
+				lb.logger.Error("failed to create new exporter for endpoint", zap.String("endpoint", endpoint), zap.Error(err))
+				continue
+			}
+
+			if err = exp.Start(ctx, lb.host); err != nil {
+				lb.logger.Error("failed to start new exporter for endpoint", zap.String("endpoint", endpoint), zap.Error(err))
+				continue
+			}
+			lb.exporters[endpoint] = exp
+		}
+	}
+}
+
+func endpointWithPort(endpoint string) string {
+	if !strings.Contains(endpoint, ":") {
+		endpoint = fmt.Sprintf("%s:%s", endpoint, defaultPort)
+	}
+	return endpoint
+}
+
+func (lb *loadBalancerImp) removeExtraExporters(ctx context.Context, endpoints []string) {
+	for existing := range lb.exporters {
+		if !endpointFound(existing, endpoints) {
+			lb.exporters[existing].Shutdown(ctx)
+			delete(lb.exporters, existing)
+		}
+	}
+}
+
+func endpointFound(endpoint string, endpoints []string) bool {
+	for _, candidate := range endpoints {
+		if candidate == endpoint {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (lb *loadBalancerImp) Shutdown(context.Context) error {
+	lb.stopped = true
+	return nil
+}
+
+func (lb *loadBalancerImp) Exporter(traceID pdata.TraceID) (component.Exporter, string, error) {
+	// NOTE: make rolling updates of next tier of collectors work. currently this may cause
+	// data loss because the latest batches sent to outdated backend will never find their way out.
+	// for details: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1690
+	lb.updateLock.RLock()
+	endpoint := lb.ring.endpointFor(traceID)
+	exp, found := lb.exporters[endpoint]
+	lb.updateLock.RUnlock()
+	if !found {
+		// something is really wrong... how come we couldn't find the exporter??
+		return nil, endpoint, fmt.Errorf("couldn't find the exporter for the endpoint %q", endpoint)
+	}
+
+	return exp, endpoint, nil
+}

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -267,7 +267,7 @@ func TestAddMissingExporters(t *testing.T) {
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
-	p.exporters["endpoint-1:55680"] = &componenttest.ExampleExporterConsumer{}
+	p.exporters["endpoint-1:4317"] = &componenttest.ExampleExporterConsumer{}
 	resolved := []string{"endpoint-1", "endpoint-2"}
 
 	// test
@@ -275,7 +275,7 @@ func TestAddMissingExporters(t *testing.T) {
 
 	// verify
 	assert.Len(t, p.exporters, 2)
-	assert.Contains(t, p.exporters, "endpoint-2:55680")
+	assert.Contains(t, p.exporters, "endpoint-2:4317")
 }
 
 func TestFailedToAddMissingExporters(t *testing.T) {
@@ -346,7 +346,7 @@ func TestEndpointWithPort(t *testing.T) {
 	}{
 		{
 			"endpoint-1",
-			"endpoint-1:55680",
+			"endpoint-1:4317",
 		},
 		{
 			"endpoint-1:55690",
@@ -390,7 +390,7 @@ func TestFailedExporterInRing(t *testing.T) {
 
 	// test
 	// this trace ID will reach the endpoint-2 -- see the consistent hashing tests for more info
-	_, _, err = p.Exporter(pdata.NewTraceID([16]byte{128, 128, 0, 0}))
+	_, err = p.Exporter(p.Endpoint(pdata.NewTraceID([16]byte{128, 128, 0, 0})))
 
 	// verify
 	assert.Error(t, err)

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -1,0 +1,409 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configmodels"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.uber.org/zap"
+)
+
+func TestNewLoadBalancerNoResolver(t *testing.T) {
+	// prepare
+	config := &Config{}
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+
+	// test
+	p, err := newLoadBalancer(params, config, nil)
+
+	// verify
+	require.Nil(t, p)
+	require.Equal(t, errNoResolver, err)
+}
+
+func TestNewLoadBalancerInvalidStaticResolver(t *testing.T) {
+	// prepare
+	config := &Config{
+		Resolver: ResolverSettings{
+			Static: &StaticResolver{Hostnames: []string{}},
+		},
+	}
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+
+	// test
+	p, err := newLoadBalancer(params, config, nil)
+
+	// verify
+	require.Nil(t, p)
+	require.Equal(t, errNoEndpoints, err)
+}
+
+func TestNewLoadBalancerInvalidDNSResolver(t *testing.T) {
+	// prepare
+	config := &Config{
+		Resolver: ResolverSettings{
+			DNS: &DNSResolver{
+				Hostname: "",
+			},
+		},
+	}
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+
+	// test
+	p, err := newLoadBalancer(params, config, nil)
+
+	// verify
+	require.Nil(t, p)
+	require.Equal(t, errNoHostname, err)
+}
+
+func TestLoadBalancerStart(t *testing.T) {
+	// prepare
+	config := simpleConfig()
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+	p, err := newLoadBalancer(params, config, nil)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+	p.res = &mockResolver{}
+
+	// test
+	res := p.Start(context.Background(), componenttest.NewNopHost())
+	defer p.Shutdown(context.Background())
+
+	// verify
+	assert.Nil(t, res)
+}
+
+func TestWithDNSResolver(t *testing.T) {
+	config := &Config{
+		Resolver: ResolverSettings{
+			DNS: &DNSResolver{
+				Hostname: "service-1",
+			},
+		},
+	}
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+	p, err := newLoadBalancer(params, config, nil)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	// test
+	res, ok := p.res.(*dnsResolver)
+
+	// verify
+	assert.NotNil(t, res)
+	assert.True(t, ok)
+}
+
+func TestMultipleResolvers(t *testing.T) {
+	config := &Config{
+		Resolver: ResolverSettings{
+			Static: &StaticResolver{
+				Hostnames: []string{"endpoint-1", "endpoint-2"},
+			},
+			DNS: &DNSResolver{
+				Hostname: "service-1",
+			},
+		},
+	}
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+
+	// test
+	p, err := newLoadBalancer(params, config, nil)
+
+	// verify
+	assert.Nil(t, p)
+	assert.Equal(t, errMultipleResolversProvided, err)
+}
+
+func TestStartFailureStaticResolver(t *testing.T) {
+	// prepare
+	config := simpleConfig()
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+	p, err := newLoadBalancer(params, config, nil)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	expectedErr := errors.New("some expected err")
+	p.res = &mockResolver{
+		onStart: func(context.Context) error {
+			return expectedErr
+		},
+	}
+
+	// test
+	res := p.Start(context.Background(), componenttest.NewNopHost())
+
+	// verify
+	assert.Equal(t, expectedErr, res)
+}
+
+func TestLoadBalancerShutdown(t *testing.T) {
+	// prepare
+	config := simpleConfig()
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+	p, err := newTracesExporter(params, config)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	// test
+	res := p.Shutdown(context.Background())
+
+	// verify
+	assert.Nil(t, res)
+}
+
+func TestOnBackendChanges(t *testing.T) {
+	// prepare
+	config := simpleConfig()
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		return mockComponent{}, nil
+	}
+	p, err := newLoadBalancer(params, config, componentFactory)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	// test
+	p.onBackendChanges([]string{"endpoint-1"})
+	require.Len(t, p.ring.items, defaultWeight)
+
+	// this should resolve to two endpoints
+	endpoints := []string{"endpoint-1", "endpoint-2"}
+	p.onBackendChanges(endpoints)
+
+	// verify
+	assert.Len(t, p.ring.items, 2*defaultWeight)
+}
+
+func TestRemoveExtraExporters(t *testing.T) {
+	// prepare
+	config := simpleConfig()
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+	p, err := newLoadBalancer(params, config, nil)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.exporters["endpoint-1"] = &componenttest.ExampleExporterConsumer{}
+	p.exporters["endpoint-2"] = &componenttest.ExampleExporterConsumer{}
+	resolved := []string{"endpoint-1"}
+
+	// test
+	p.removeExtraExporters(context.Background(), resolved)
+
+	// verify
+	assert.Len(t, p.exporters, 1)
+	assert.NotContains(t, p.exporters, "endpoint-2")
+}
+
+func TestAddMissingExporters(t *testing.T) {
+	// prepare
+	config := simpleConfig()
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+	exporterFactory := exporterhelper.NewFactory("otlp", func() configmodels.Exporter {
+		return &otlpexporter.Config{}
+	}, exporterhelper.WithTraces(func(
+		_ context.Context,
+		_ component.ExporterCreateParams,
+		_ configmodels.Exporter,
+	) (component.TracesExporter, error) {
+		return &componenttest.ExampleExporterConsumer{}, nil
+	}))
+	tmplParams := component.ExporterCreateParams{
+		Logger:               params.Logger,
+		ApplicationStartInfo: params.ApplicationStartInfo,
+	}
+	fn := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		oCfg := config.Protocol.OTLP
+		oCfg.Endpoint = endpoint
+		return exporterFactory.CreateTracesExporter(ctx, tmplParams, &oCfg)
+	}
+
+	p, err := newLoadBalancer(params, config, fn)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.exporters["endpoint-1:55680"] = &componenttest.ExampleExporterConsumer{}
+	resolved := []string{"endpoint-1", "endpoint-2"}
+
+	// test
+	p.addMissingExporters(context.Background(), resolved)
+
+	// verify
+	assert.Len(t, p.exporters, 2)
+	assert.Contains(t, p.exporters, "endpoint-2:55680")
+}
+
+func TestFailedToAddMissingExporters(t *testing.T) {
+	// prepare
+	config := simpleConfig()
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+	expectedErr := errors.New("some expected error")
+	exporterFactory := exporterhelper.NewFactory("otlp", func() configmodels.Exporter {
+		return &otlpexporter.Config{}
+	}, exporterhelper.WithTraces(func(
+		_ context.Context,
+		_ component.ExporterCreateParams,
+		_ configmodels.Exporter,
+	) (component.TracesExporter, error) {
+		return nil, expectedErr
+	}))
+	tmplParams := component.ExporterCreateParams{
+		Logger:               params.Logger,
+		ApplicationStartInfo: params.ApplicationStartInfo,
+	}
+	fn := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		oCfg := config.Protocol.OTLP
+		oCfg.Endpoint = endpoint
+		return exporterFactory.CreateTracesExporter(ctx, tmplParams, &oCfg)
+	}
+
+	p, err := newLoadBalancer(params, config, fn)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	p.exporters["endpoint-1"] = &componenttest.ExampleExporterConsumer{}
+	resolved := []string{"endpoint-1", "endpoint-2"}
+
+	// test
+	p.addMissingExporters(context.Background(), resolved)
+
+	// verify
+	assert.Len(t, p.exporters, 1)
+	assert.NotContains(t, p.exporters, "endpoint-2")
+}
+
+func TestEndpointFound(t *testing.T) {
+	for _, tt := range []struct {
+		endpoint  string
+		endpoints []string
+		expected  bool
+	}{
+		{
+			"endpoint-1",
+			[]string{"endpoint-1", "endpoint-2"},
+			true,
+		},
+		{
+			"endpoint-3",
+			[]string{"endpoint-1", "endpoint-2"},
+			false,
+		},
+	} {
+		assert.Equal(t, tt.expected, endpointFound(tt.endpoint, tt.endpoints))
+	}
+}
+
+func TestEndpointWithPort(t *testing.T) {
+	for _, tt := range []struct {
+		input, expected string
+	}{
+		{
+			"endpoint-1",
+			"endpoint-1:55680",
+		},
+		{
+			"endpoint-1:55690",
+			"endpoint-1:55690",
+		},
+	} {
+		assert.Equal(t, tt.expected, endpointWithPort(tt.input))
+	}
+}
+
+func TestFailedExporterInRing(t *testing.T) {
+	// this test is based on the discussion in the original PR for this exporter:
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1542#discussion_r521268180
+	// prepare
+	config := &Config{
+		Resolver: ResolverSettings{
+			Static: &StaticResolver{Hostnames: []string{"endpoint-1", "endpoint-2"}},
+		},
+	}
+	params := component.ExporterCreateParams{
+		Logger: zap.NewNop(),
+	}
+	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		return mockComponent{}, nil
+	}
+	p, err := newLoadBalancer(params, config, componentFactory)
+	require.NotNil(t, p)
+	require.NoError(t, err)
+
+	err = p.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	// simulate the case where one of the exporters failed to be created and do not exist in the internal map
+	// this is a case that we are not even sure that might happen, so, this test case is here to document
+	// this behavior. As the solution would require more locks/syncs/checks, we should probably wait to see
+	// if this is really a problem in the real world
+	delete(p.exporters, "endpoint-2")
+
+	// sanity check
+	require.Contains(t, p.res.(*staticResolver).endpoints, "endpoint-2")
+
+	// test
+	// this trace ID will reach the endpoint-2 -- see the consistent hashing tests for more info
+	_, _, err = p.Exporter(pdata.NewTraceID([16]byte{128, 128, 0, 0}))
+
+	// verify
+	assert.Error(t, err)
+}
+
+var _ component.Exporter = (*mockComponent)(nil)
+
+type mockComponent struct{}
+
+func (m mockComponent) Start(ctx context.Context, host component.Host) error {
+	return nil
+}
+
+func (m mockComponent) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -17,6 +17,7 @@ package loadbalancingexporter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -36,7 +37,6 @@ var _ component.TracesExporter = (*traceExporterImp)(nil)
 
 var (
 	errNoTracesInBatch        = errors.New("no traces were found in the batch")
-	errUnexpectedExporterType = errors.New("unexpected exporter type")
 )
 
 type traceExporterImp struct {
@@ -117,7 +117,8 @@ func (e *traceExporterImp) consumeTrace(ctx context.Context, td pdata.Traces) er
 
 	te, ok := exp.(component.TracesExporter)
 	if !ok {
-		return errUnexpectedExporterType
+		expectType := (*component.TracesExporter)(nil)
+		return fmt.Errorf("expected %T but got %T", expectType, exp)
 	}
 
 	start := time.Now()

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -36,7 +36,7 @@ import (
 var _ component.TracesExporter = (*traceExporterImp)(nil)
 
 var (
-	errNoTracesInBatch        = errors.New("no traces were found in the batch")
+	errNoTracesInBatch = errors.New("no traces were found in the batch")
 )
 
 type traceExporterImp struct {

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -17,8 +17,6 @@ package loadbalancingexporter
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -36,151 +34,54 @@ import (
 
 var _ component.TracesExporter = (*traceExporterImp)(nil)
 
-const (
-	defaultPort = "55680"
-)
-
 var (
-	errNoResolver                = errors.New("no resolvers specified for the exporter")
-	errMultipleResolversProvided = errors.New("only one resolver should be specified")
-	errNoTracesInBatch           = errors.New("no traces were found in the batch")
+	errNoTracesInBatch = errors.New("no traces were found in the batch")
 )
 
 type traceExporterImp struct {
 	logger *zap.Logger
-	config Config
-	host   component.Host
 
-	res  resolver
-	ring *hashRing
-
-	exporters            map[string]component.TracesExporter
-	exporterFactory      component.ExporterFactory
-	templateCreateParams component.ExporterCreateParams
+	loadBalancer loadBalancer
 
 	stopped    bool
 	shutdownWg sync.WaitGroup
-	updateLock sync.RWMutex
 }
 
-// Crete new exporter
+// Crete new traces exporter
 func newTracesExporter(params component.ExporterCreateParams, cfg configmodels.Exporter) (*traceExporterImp, error) {
-	oCfg := cfg.(*Config)
+	exporterFactory := otlpexporter.NewFactory()
 
 	tmplParams := component.ExporterCreateParams{
 		Logger:               params.Logger,
 		ApplicationStartInfo: params.ApplicationStartInfo,
 	}
 
-	if oCfg.Resolver.DNS != nil && oCfg.Resolver.Static != nil {
-		return nil, errMultipleResolversProvided
-	}
-
-	var res resolver
-	if oCfg.Resolver.Static != nil {
-		var err error
-		res, err = newStaticResolver(oCfg.Resolver.Static.Hostnames)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if oCfg.Resolver.DNS != nil {
-		dnsLogger := params.Logger.With(zap.String("resolver", "dns"))
-
-		var err error
-		res, err = newDNSResolver(dnsLogger, oCfg.Resolver.DNS.Hostname, oCfg.Resolver.DNS.Port)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if res == nil {
-		return nil, errNoResolver
+	loadBalancer, err := newLoadBalancer(params, cfg, func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		oCfg := buildExporterConfig(cfg.(*Config), endpoint)
+		return exporterFactory.CreateTracesExporter(ctx, tmplParams, &oCfg)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &traceExporterImp{
-		logger: params.Logger,
-		config: *oCfg,
-
-		res: res,
-
-		exporters:            map[string]component.TracesExporter{},
-		exporterFactory:      otlpexporter.NewFactory(),
-		templateCreateParams: tmplParams,
+		logger:       params.Logger,
+		loadBalancer: loadBalancer,
 	}, nil
 }
 
-func (e *traceExporterImp) Start(ctx context.Context, host component.Host) error {
-	e.res.onChange(e.onBackendChanges)
-	e.host = host
-	if err := e.res.start(ctx); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (e *traceExporterImp) onBackendChanges(resolved []string) {
-	newRing := newHashRing(resolved)
-
-	if !newRing.equal(e.ring) {
-		e.updateLock.Lock()
-		defer e.updateLock.Unlock()
-
-		e.ring = newRing
-
-		// TODO: set a timeout?
-		ctx := context.Background()
-
-		// add the missing exporters first
-		e.addMissingExporters(ctx, resolved)
-		e.removeExtraExporters(ctx, resolved)
-	}
-}
-
-func (e *traceExporterImp) addMissingExporters(ctx context.Context, endpoints []string) {
-	for _, endpoint := range endpoints {
-		endpoint = endpointWithPort(endpoint)
-
-		if _, exists := e.exporters[endpoint]; !exists {
-			cfg := e.buildExporterConfig(endpoint)
-			exp, err := e.exporterFactory.CreateTracesExporter(ctx, e.templateCreateParams, &cfg)
-			if err != nil {
-				e.logger.Error("failed to create new trace exporter for endpoint", zap.String("endpoint", endpoint), zap.Error(err))
-				continue
-			}
-			if err = exp.Start(ctx, e.host); err != nil {
-				e.logger.Error("failed to start new trace exporter for endpoint", zap.String("endpoint", endpoint), zap.Error(err))
-				continue
-			}
-			e.exporters[endpoint] = exp
-		}
-	}
-}
-
-func (e *traceExporterImp) buildExporterConfig(endpoint string) otlpexporter.Config {
-	oCfg := e.config.Protocol.OTLP
+func buildExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
+	oCfg := cfg.Protocol.OTLP
 	oCfg.Endpoint = endpoint
 	return oCfg
 }
 
-func (e *traceExporterImp) removeExtraExporters(ctx context.Context, endpoints []string) {
-	for existing := range e.exporters {
-		if !endpointFound(existing, endpoints) {
-			e.exporters[existing].Shutdown(ctx)
-			delete(e.exporters, existing)
-		}
-	}
-}
-
-func endpointFound(endpoint string, endpoints []string) bool {
-	for _, candidate := range endpoints {
-		if candidate == endpoint {
-			return true
-		}
+func (e *traceExporterImp) Start(ctx context.Context, host component.Host) error {
+	if err := e.loadBalancer.Start(ctx, host); err != nil {
+		return err
 	}
 
-	return false
+	return nil
 }
 
 func (e *traceExporterImp) Shutdown(context.Context) error {
@@ -207,20 +108,13 @@ func (e *traceExporterImp) consumeTrace(ctx context.Context, td pdata.Traces) er
 		return errNoTracesInBatch
 	}
 
-	// NOTE: make rolling updates of next tier of collectors work. currently this may cause
-	// data loss because the latest batches sent to outdated backend will never find their way out.
-	// for details: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1690
-	e.updateLock.RLock()
-	endpoint := e.ring.endpointFor(traceID)
-	exp, found := e.exporters[endpoint]
-	e.updateLock.RUnlock()
-	if !found {
-		// something is really wrong... how come we couldn't find the exporter??
-		return fmt.Errorf("couldn't find the exporter for the endpoint %q", endpoint)
+	exp, endpoint, err := e.loadBalancer.Exporter(traceID)
+	if err != nil {
+		return err
 	}
 
 	start := time.Now()
-	err := exp.ConsumeTraces(ctx, td)
+	err = exp.(component.TracesExporter).ConsumeTraces(ctx, td)
 	duration := time.Since(start)
 	ctx, _ = tag.New(ctx, tag.Upsert(tag.MustNewKey("endpoint"), endpoint))
 
@@ -233,10 +127,6 @@ func (e *traceExporterImp) consumeTrace(ctx context.Context, td pdata.Traces) er
 	}
 
 	return err
-}
-
-func (e *traceExporterImp) GetCapabilities() component.ProcessorCapabilities {
-	return component.ProcessorCapabilities{MutatesConsumedData: false}
 }
 
 func traceIDFromTraces(td pdata.Traces) pdata.TraceID {
@@ -256,11 +146,4 @@ func traceIDFromTraces(td pdata.Traces) pdata.TraceID {
 	}
 
 	return spans.At(0).TraceID()
-}
-
-func endpointWithPort(endpoint string) string {
-	if !strings.Contains(endpoint, ":") {
-		endpoint = fmt.Sprintf("%s:%s", endpoint, defaultPort)
-	}
-	return endpoint
 }

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -17,6 +17,7 @@ package loadbalancingexporter
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"net"
 	"path"
@@ -27,177 +28,104 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenthelper"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config/configmodels"
 	"go.opentelemetry.io/collector/config/configtest"
-	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.uber.org/zap"
 )
 
-func TestNewTracesExporterNoResolver(t *testing.T) {
-	// prepare
-	config := &Config{}
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-
-	// test
-	p, err := newTracesExporter(params, config)
-
-	// verify
-	require.Nil(t, p)
-	require.Equal(t, errNoResolver, err)
-}
-
-func TestNewTracesExporterInvalidStaticResolver(t *testing.T) {
-	// prepare
-	config := &Config{
-		Resolver: ResolverSettings{
-			Static: &StaticResolver{Hostnames: []string{}},
+func TestNewTracesExporter(t *testing.T) {
+	for _, tt := range []struct {
+		desc   string
+		config *Config
+		err    error
+	}{
+		{
+			"simple",
+			simpleConfig(),
+			nil,
 		},
-	}
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-
-	// test
-	p, err := newTracesExporter(params, config)
-
-	// verify
-	require.Nil(t, p)
-	require.Equal(t, errNoEndpoints, err)
-}
-
-func TestNewTracesExporterInvalidDNSResolver(t *testing.T) {
-	// prepare
-	config := &Config{
-		Resolver: ResolverSettings{
-			DNS: &DNSResolver{
-				Hostname: "",
-			},
+		{
+			"empty",
+			&Config{},
+			errNoResolver,
 		},
-	}
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			// prepare
+			config := tt.config
+			params := component.ExporterCreateParams{
+				Logger: zap.NewNop(),
+			}
 
-	// test
-	p, err := newTracesExporter(params, config)
+			// test
+			_, err := newTracesExporter(params, config)
 
-	// verify
-	require.Nil(t, p)
-	require.Equal(t, errNoHostname, err)
+			// verify
+			require.Equal(t, tt.err, err)
+		})
+	}
 }
 
-func TestExporterCapabilities(t *testing.T) {
-	// prepare
-	config := simpleConfig()
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-	p, err := newTracesExporter(params, config)
+func TestTraceExporterStart(t *testing.T) {
+	for _, tt := range []struct {
+		desc string
+		te   *traceExporterImp
+		err  error
+	}{
+		{
+			"ok",
+			func() *traceExporterImp {
+				// prepare
+				config := simpleConfig()
+				params := component.ExporterCreateParams{
+					Logger: zap.NewNop(),
+				}
 
-	// test
-	caps := p.GetCapabilities()
-
-	// verify
-	assert.NoError(t, err)
-	assert.NotNil(t, p)
-	assert.Equal(t, false, caps.MutatesConsumedData)
-}
-
-func TestStart(t *testing.T) {
-	// prepare
-	config := simpleConfig()
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-	p, err := newTracesExporter(params, config)
-	require.NotNil(t, p)
-	require.NoError(t, err)
-	p.res = &mockResolver{}
-
-	// test
-	res := p.Start(context.Background(), componenttest.NewNopHost())
-	defer p.Shutdown(context.Background())
-
-	// verify
-	assert.Nil(t, res)
-}
-
-func TestWithDNSResolver(t *testing.T) {
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-	p, err := newTracesExporter(params, &Config{
-		Resolver: ResolverSettings{
-			DNS: &DNSResolver{
-				Hostname: "service-1",
-			},
+				p, _ := newTracesExporter(params, config)
+				return p
+			}(),
+			nil,
 		},
-	})
-	require.NotNil(t, p)
-	require.NoError(t, err)
+		{
+			"error",
+			func() *traceExporterImp {
+				// prepare
+				config := simpleConfig()
+				params := component.ExporterCreateParams{
+					Logger: zap.NewNop(),
+				}
 
-	// test
-	res, ok := p.res.(*dnsResolver)
+				lb, _ := newLoadBalancer(params, config, nil)
+				p, _ := newTracesExporter(params, config)
 
-	// verify
-	assert.NotNil(t, res)
-	assert.True(t, ok)
-}
+				lb.res = &mockResolver{
+					onStart: func(context.Context) error {
+						return errors.New("some expected err")
+					},
+				}
+				p.loadBalancer = lb
 
-func TestMultipleResolvers(t *testing.T) {
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-
-	// test
-	p, err := newTracesExporter(params, &Config{
-		Resolver: ResolverSettings{
-			Static: &StaticResolver{
-				Hostnames: []string{"endpoint-1", "endpoint-2"},
-			},
-			DNS: &DNSResolver{
-				Hostname: "service-1",
-			},
+				return p
+			}(),
+			errors.New("some expected err"),
 		},
-	})
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			p := tt.te
 
-	// verify
-	assert.Nil(t, p)
-	assert.Equal(t, errMultipleResolversProvided, err)
+			// test
+			res := p.Start(context.Background(), componenttest.NewNopHost())
+			defer p.Shutdown(context.Background())
+
+			// verify
+			require.Equal(t, tt.err, res)
+		})
+	}
 }
 
-func TestStartFailureStaticResolver(t *testing.T) {
-	// prepare
-	config := simpleConfig()
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-	p, err := newTracesExporter(params, config)
-	require.NotNil(t, p)
-	require.NoError(t, err)
-
-	expectedErr := errors.New("some expected err")
-	p.res = &mockResolver{
-		onStart: func(context.Context) error {
-			return expectedErr
-		},
-	}
-
-	// test
-	res := p.Start(context.Background(), componenttest.NewNopHost())
-
-	// verify
-	assert.Equal(t, expectedErr, res)
-}
-
-func TestShutdown(t *testing.T) {
+func TestTraceExporterShutdown(t *testing.T) {
 	// prepare
 	config := simpleConfig()
 	params := component.ExporterCreateParams{
@@ -220,18 +148,26 @@ func TestConsumeTraces(t *testing.T) {
 	params := component.ExporterCreateParams{
 		Logger: zap.NewNop(),
 	}
+	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		return mockComponent{}, nil
+	}
+	lb, err := newLoadBalancer(params, config, componentFactory)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
 	p, err := newTracesExporter(params, config)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
 	// pre-load an exporter here, so that we don't use the actual OTLP exporter
-	p.exporters["endpoint-1"] = newNopMockTracesExporter()
-	p.res = &mockResolver{
+	lb.exporters["endpoint-1"] = &componenttest.ExampleExporterConsumer{}
+	lb.res = &mockResolver{
 		triggerCallbacks: true,
 		onResolve: func(ctx context.Context) ([]string, error) {
 			return []string{"endpoint-1"}, nil
 		},
 	}
+	p.loadBalancer = lb
 
 	err = p.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
@@ -244,154 +180,46 @@ func TestConsumeTraces(t *testing.T) {
 	assert.Nil(t, res)
 }
 
-func TestOnBackendChanges(t *testing.T) {
+func TestExporterNotFound(t *testing.T) {
 	// prepare
 	config := simpleConfig()
 	params := component.ExporterCreateParams{
 		Logger: zap.NewNop(),
 	}
+	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		return mockComponent{}, nil
+	}
+	lb, err := newLoadBalancer(params, config, componentFactory)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
 	p, err := newTracesExporter(params, config)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
-	// test
-	p.onBackendChanges([]string{"endpoint-1"})
-	require.Len(t, p.ring.items, defaultWeight)
-
-	// this should resolve to two endpoints
-	endpoints := []string{"endpoint-1", "endpoint-2"}
-	p.onBackendChanges(endpoints)
-
-	// verify
-	assert.Len(t, p.ring.items, 2*defaultWeight)
-}
-
-func TestRemoveExtraExporters(t *testing.T) {
-	// prepare
-	config := simpleConfig()
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
+	lb.res = &mockResolver{
+		triggerCallbacks: true,
+		onResolve: func(ctx context.Context) ([]string, error) {
+			return []string{"endpoint-1"}, nil
+		},
 	}
-	p, err := newTracesExporter(params, config)
-	require.NotNil(t, p)
+	p.loadBalancer = lb
+
+	err = p.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
-
-	p.exporters["endpoint-1"] = newNopMockTracesExporter()
-	p.exporters["endpoint-2"] = newNopMockTracesExporter()
-	resolved := []string{"endpoint-1"}
+	defer p.Shutdown(context.Background())
 
 	// test
-	p.removeExtraExporters(context.Background(), resolved)
+	res := p.ConsumeTraces(context.Background(), simpleTraces())
 
 	// verify
-	assert.Len(t, p.exporters, 1)
-	assert.NotContains(t, p.exporters, "endpoint-2")
-}
-
-func TestAddMissingExporters(t *testing.T) {
-	// prepare
-	config := simpleConfig()
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-	p, err := newTracesExporter(params, config)
-	require.NotNil(t, p)
-	require.NoError(t, err)
-
-	p.exporterFactory = exporterhelper.NewFactory("otlp", func() configmodels.Exporter {
-		return &otlpexporter.Config{}
-	}, exporterhelper.WithTraces(func(
-		_ context.Context,
-		_ component.ExporterCreateParams,
-		_ configmodels.Exporter,
-	) (component.TracesExporter, error) {
-		return newNopMockTracesExporter(), nil
-	}))
-
-	p.exporters["endpoint-1:55680"] = newNopMockTracesExporter()
-	resolved := []string{"endpoint-1", "endpoint-2"}
-
-	// test
-	p.addMissingExporters(context.Background(), resolved)
-
-	// verify
-	assert.Len(t, p.exporters, 2)
-	assert.Contains(t, p.exporters, "endpoint-2:55680")
-}
-
-func TestFailedToAddMissingExporters(t *testing.T) {
-	// prepare
-	config := simpleConfig()
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-	p, err := newTracesExporter(params, config)
-	require.NotNil(t, p)
-	require.NoError(t, err)
-
-	expectedErr := errors.New("some expected error")
-	p.exporterFactory = exporterhelper.NewFactory("otlp", func() configmodels.Exporter {
-		return &otlpexporter.Config{}
-	}, exporterhelper.WithTraces(func(
-		_ context.Context,
-		_ component.ExporterCreateParams,
-		_ configmodels.Exporter,
-	) (component.TracesExporter, error) {
-		return nil, expectedErr
-	}))
-
-	p.exporters["endpoint-1"] = newNopMockTracesExporter()
-	resolved := []string{"endpoint-1", "endpoint-2"}
-
-	// test
-	p.addMissingExporters(context.Background(), resolved)
-
-	// verify
-	assert.Len(t, p.exporters, 1)
-	assert.NotContains(t, p.exporters, "endpoint-2")
-}
-
-func TestEndpointFound(t *testing.T) {
-	for _, tt := range []struct {
-		endpoint  string
-		endpoints []string
-		expected  bool
-	}{
-		{
-			"endpoint-1",
-			[]string{"endpoint-1", "endpoint-2"},
-			true,
-		},
-		{
-			"endpoint-3",
-			[]string{"endpoint-1", "endpoint-2"},
-			false,
-		},
-	} {
-		assert.Equal(t, tt.expected, endpointFound(tt.endpoint, tt.endpoints))
-	}
-}
-
-func TestEndpointWithPort(t *testing.T) {
-	for _, tt := range []struct {
-		input, expected string
-	}{
-		{
-			"endpoint-1",
-			"endpoint-1:55680",
-		},
-		{
-			"endpoint-1:55690",
-			"endpoint-1:55690",
-		},
-	} {
-		assert.Equal(t, tt.expected, endpointWithPort(tt.input))
-	}
+	assert.Error(t, res)
+	assert.EqualError(t, res, fmt.Sprintf("couldn't find the exporter for the endpoint %q", "endpoint-1"))
 }
 
 func TestBuildExporterConfig(t *testing.T) {
 	// prepare
-	factories, err := componenttest.NopFactories()
+	factories, err := componenttest.ExampleComponents()
 	require.NoError(t, err)
 
 	factories.Exporters[typeStr] = NewFactory()
@@ -401,16 +229,11 @@ func TestBuildExporterConfig(t *testing.T) {
 	require.NotNil(t, cfg)
 	require.NotNil(t, cfg.Exporters["loadbalancing"])
 
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-	e, err := newTracesExporter(params, cfg.Exporters["loadbalancing"])
-	require.NotNil(t, e)
-	require.NoError(t, err)
+	c := cfg.Exporters["loadbalancing"]
 
 	// test
-	defaultCfg := e.exporterFactory.CreateDefaultConfig().(*otlpexporter.Config)
-	exporterCfg := e.buildExporterConfig("the-endpoint")
+	defaultCfg := otlpexporter.NewFactory().CreateDefaultConfig().(*otlpexporter.Config)
+	exporterCfg := buildExporterConfig(c.(*Config), "the-endpoint")
 
 	// verify
 	grpcSettings := defaultCfg.GRPCClientSettings
@@ -429,15 +252,23 @@ func TestBatchWithTwoTraces(t *testing.T) {
 	params := component.ExporterCreateParams{
 		Logger: zap.NewNop(),
 	}
+	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		return mockComponent{}, nil
+	}
+	lb, err := newLoadBalancer(params, config, componentFactory)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
 	p, err := newTracesExporter(params, config)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
+	p.loadBalancer = lb
 	err = p.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
-	sink := new(consumertest.TracesSink)
-	p.exporters["endpoint-1"] = newMockTracesExporter(sink.ConsumeTraces)
+	sink := &componenttest.ExampleExporterConsumer{}
+	lb.exporters["endpoint-1"] = sink
 
 	first := simpleTraces()
 	second := simpleTraceWithID(pdata.NewTraceID([16]byte{2, 3, 4, 5}))
@@ -450,44 +281,7 @@ func TestBatchWithTwoTraces(t *testing.T) {
 
 	// verify
 	assert.NoError(t, err)
-	assert.Len(t, sink.AllTraces(), 2)
-}
-
-func TestFailedExporterInRing(t *testing.T) {
-	// this test is based on the discussion in the original PR for this exporter:
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1542#discussion_r521268180
-	// prepare
-	config := &Config{
-		Resolver: ResolverSettings{
-			Static: &StaticResolver{Hostnames: []string{"endpoint-1", "endpoint-2"}},
-		},
-	}
-	params := component.ExporterCreateParams{
-		Logger: zap.NewNop(),
-	}
-	p, err := newTracesExporter(params, config)
-	require.NotNil(t, p)
-	require.NoError(t, err)
-
-	err = p.Start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
-
-	// simulate the case where one of the exporters failed to be created and do not exist in the internal map
-	// this is a case that we are not even sure that might happen, so, this test case is here to document
-	// this behavior. As the solution would require more locks/syncs/checks, we should probably wait to see
-	// if this is really a problem in the real world
-	delete(p.exporters, "endpoint-2")
-
-	// sanity check
-	require.Contains(t, p.res.(*staticResolver).endpoints, "endpoint-2")
-
-	// test
-	// this trace ID will reach the endpoint-2 -- see the consistent hashing tests for more info
-	traceForMissingEndpoint := simpleTraceWithID(pdata.NewTraceID([16]byte{128, 128, 0, 0}))
-	err = p.ConsumeTraces(context.Background(), traceForMissingEndpoint)
-
-	// verify
-	assert.Error(t, err)
+	assert.Len(t, sink.Traces, 2)
 }
 
 func TestNoTracesInBatch(t *testing.T) {
@@ -575,28 +369,36 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 		},
 	}
 	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		return mockComponent{}, nil
+	}
+	lb, err := newLoadBalancer(params, config, componentFactory)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
 	p, err := newTracesExporter(params, config)
 	require.NotNil(t, p)
 	require.NoError(t, err)
 
-	p.res = res
+	lb.res = res
+	p.loadBalancer = lb
 
 	var counter1, counter2 int64
-	defaultExporters := map[string]component.TracesExporter{
-		"127.0.0.1": newMockTracesExporter(
-			func(ctx context.Context, td pdata.Traces) error {
+	defaultExporters := map[string]component.Exporter{
+		"127.0.0.1": &mockTracesExporter{
+			ConsumeTracesFn: func(ctx context.Context, td pdata.Traces) error {
 				atomic.AddInt64(&counter1, 1)
 				// simulate an unreachable backend
 				time.Sleep(10 * time.Second)
 				return nil
 			},
-		),
-		"127.0.0.2": newMockTracesExporter(
-			func(ctx context.Context, td pdata.Traces) error {
+		},
+		"127.0.0.2": &mockTracesExporter{
+			ConsumeTracesFn: func(ctx context.Context, td pdata.Traces) error {
 				atomic.AddInt64(&counter2, 1)
 				return nil
 			},
-		),
+		},
 	}
 
 	// test
@@ -604,13 +406,13 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	require.NoError(t, err)
 	defer p.Shutdown(context.Background())
 	// ensure using default exporters
-	p.updateLock.Lock()
-	p.exporters = defaultExporters
-	p.updateLock.Unlock()
-	p.res.onChange(func(endpoints []string) {
-		p.updateLock.Lock()
-		p.exporters = defaultExporters
-		p.updateLock.Unlock()
+	lb.updateLock.Lock()
+	lb.exporters = defaultExporters
+	lb.updateLock.Unlock()
+	lb.res.onChange(func(endpoints []string) {
+		lb.updateLock.Lock()
+		lb.exporters = defaultExporters
+		lb.updateLock.Unlock()
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -680,24 +482,9 @@ func simpleConfig() *Config {
 }
 
 type mockTracesExporter struct {
-	component.Component
 	ConsumeTracesFn func(ctx context.Context, td pdata.Traces) error
-}
-
-func newMockTracesExporter(consumeTracesFn func(ctx context.Context, td pdata.Traces) error) component.TracesExporter {
-	return &mockTracesExporter{
-		Component:       componenthelper.NewComponent(componenthelper.DefaultComponentSettings()),
-		ConsumeTracesFn: consumeTracesFn,
-	}
-}
-
-func newNopMockTracesExporter() component.TracesExporter {
-	return &mockTracesExporter{
-		Component: componenthelper.NewComponent(componenthelper.DefaultComponentSettings()),
-		ConsumeTracesFn: func(ctx context.Context, td pdata.Traces) error {
-			return nil
-		},
-	}
+	StartFn         func(ctx context.Context, host component.Host) error
+	ShutdownFn      func(ctx context.Context) error
 }
 
 func (e *mockTracesExporter) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
@@ -705,4 +492,18 @@ func (e *mockTracesExporter) ConsumeTraces(ctx context.Context, td pdata.Traces)
 		return nil
 	}
 	return e.ConsumeTracesFn(ctx, td)
+}
+
+func (e *mockTracesExporter) Start(ctx context.Context, host component.Host) error {
+	if e.StartFn == nil {
+		return nil
+	}
+	return e.StartFn(ctx, host)
+}
+
+func (e *mockTracesExporter) Shutdown(ctx context.Context) error {
+	if e.ShutdownFn == nil {
+		return nil
+	}
+	return e.ShutdownFn(ctx)
 }

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -28,8 +28,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenthelper"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.uber.org/zap"
@@ -149,7 +151,7 @@ func TestConsumeTraces(t *testing.T) {
 		Logger: zap.NewNop(),
 	}
 	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
-		return mockComponent{}, nil
+		return newNopMockTracesExporter(), nil
 	}
 	lb, err := newLoadBalancer(params, config, componentFactory)
 	require.NotNil(t, lb)
@@ -160,7 +162,7 @@ func TestConsumeTraces(t *testing.T) {
 	require.NoError(t, err)
 
 	// pre-load an exporter here, so that we don't use the actual OTLP exporter
-	lb.exporters["endpoint-1"] = &componenttest.ExampleExporterConsumer{}
+	lb.exporters["endpoint-1"] = newNopMockTracesExporter()
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
 		onResolve: func(ctx context.Context) ([]string, error) {
@@ -187,7 +189,7 @@ func TestExporterNotFound(t *testing.T) {
 		Logger: zap.NewNop(),
 	}
 	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
-		return mockComponent{}, nil
+		return newNopMockTracesExporter(), nil
 	}
 	lb, err := newLoadBalancer(params, config, componentFactory)
 	require.NotNil(t, lb)
@@ -224,7 +226,7 @@ func TestUnexpectedExporterType(t *testing.T) {
 		Logger: zap.NewNop(),
 	}
 	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
-		return mockComponent{}, nil
+		return newNopMockExporter(), nil
 	}
 	lb, err := newLoadBalancer(params, config, componentFactory)
 	require.NotNil(t, lb)
@@ -235,7 +237,7 @@ func TestUnexpectedExporterType(t *testing.T) {
 	require.NoError(t, err)
 
 	// pre-load an exporter here, so that we don't use the actual OTLP exporter
-	lb.exporters["endpoint-1"] = &mockComponent{}
+	lb.exporters["endpoint-1"] = newNopMockExporter()
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
 		onResolve: func(ctx context.Context) ([]string, error) {
@@ -253,12 +255,12 @@ func TestUnexpectedExporterType(t *testing.T) {
 
 	// verify
 	assert.Error(t, res)
-	assert.EqualError(t, res, fmt.Sprintf("expected *component.TracesExporter but got %T", &mockComponent{}))
+	assert.EqualError(t, res, fmt.Sprintf("expected *component.TracesExporter but got %T", newNopMockExporter()))
 }
 
 func TestBuildExporterConfig(t *testing.T) {
 	// prepare
-	factories, err := componenttest.ExampleComponents()
+	factories, err := componenttest.NopFactories()
 	require.NoError(t, err)
 
 	factories.Exporters[typeStr] = NewFactory()
@@ -292,7 +294,7 @@ func TestBatchWithTwoTraces(t *testing.T) {
 		Logger: zap.NewNop(),
 	}
 	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
-		return mockComponent{}, nil
+		return newNopMockTracesExporter(), nil
 	}
 	lb, err := newLoadBalancer(params, config, componentFactory)
 	require.NotNil(t, lb)
@@ -306,8 +308,8 @@ func TestBatchWithTwoTraces(t *testing.T) {
 	err = p.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
-	sink := &componenttest.ExampleExporterConsumer{}
-	lb.exporters["endpoint-1"] = sink
+	sink := new(consumertest.TracesSink)
+	lb.exporters["endpoint-1"] = newMockTracesExporter(sink.ConsumeTraces)
 
 	first := simpleTraces()
 	second := simpleTraceWithID(pdata.NewTraceID([16]byte{2, 3, 4, 5}))
@@ -320,7 +322,7 @@ func TestBatchWithTwoTraces(t *testing.T) {
 
 	// verify
 	assert.NoError(t, err)
-	assert.Len(t, sink.Traces, 2)
+	assert.Len(t, sink.AllTraces(), 2)
 }
 
 func TestNoTracesInBatch(t *testing.T) {
@@ -409,7 +411,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	}
 	params := component.ExporterCreateParams{Logger: zap.NewNop()}
 	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
-		return mockComponent{}, nil
+		return newNopMockTracesExporter(), nil
 	}
 	lb, err := newLoadBalancer(params, config, componentFactory)
 	require.NotNil(t, lb)
@@ -424,20 +426,18 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 
 	var counter1, counter2 int64
 	defaultExporters := map[string]component.Exporter{
-		"127.0.0.1": &mockTracesExporter{
-			ConsumeTracesFn: func(ctx context.Context, td pdata.Traces) error {
-				atomic.AddInt64(&counter1, 1)
-				// simulate an unreachable backend
-				time.Sleep(10 * time.Second)
-				return nil
-			},
+		"127.0.0.1": newMockTracesExporter(func(ctx context.Context, td pdata.Traces) error {
+			atomic.AddInt64(&counter1, 1)
+			// simulate an unreachable backend
+			time.Sleep(10 * time.Second)
+			return nil
 		},
-		"127.0.0.2": &mockTracesExporter{
-			ConsumeTracesFn: func(ctx context.Context, td pdata.Traces) error {
-				atomic.AddInt64(&counter2, 1)
-				return nil
-			},
+		),
+		"127.0.0.2": newMockTracesExporter(func(ctx context.Context, td pdata.Traces) error {
+			atomic.AddInt64(&counter2, 1)
+			return nil
 		},
+		),
 	}
 
 	// test
@@ -521,9 +521,24 @@ func simpleConfig() *Config {
 }
 
 type mockTracesExporter struct {
+	component.Component
 	ConsumeTracesFn func(ctx context.Context, td pdata.Traces) error
-	StartFn         func(ctx context.Context, host component.Host) error
-	ShutdownFn      func(ctx context.Context) error
+}
+
+func newMockTracesExporter(consumeTracesFn func(ctx context.Context, td pdata.Traces) error) component.TracesExporter {
+	return &mockTracesExporter{
+		Component:       componenthelper.NewComponent(componenthelper.DefaultComponentSettings()),
+		ConsumeTracesFn: consumeTracesFn,
+	}
+}
+
+func newNopMockTracesExporter() component.TracesExporter {
+	return &mockTracesExporter{
+		Component: componenthelper.NewComponent(componenthelper.DefaultComponentSettings()),
+		ConsumeTracesFn: func(ctx context.Context, td pdata.Traces) error {
+			return nil
+		},
+	}
 }
 
 func (e *mockTracesExporter) ConsumeTraces(ctx context.Context, td pdata.Traces) error {
@@ -531,18 +546,4 @@ func (e *mockTracesExporter) ConsumeTraces(ctx context.Context, td pdata.Traces)
 		return nil
 	}
 	return e.ConsumeTracesFn(ctx, td)
-}
-
-func (e *mockTracesExporter) Start(ctx context.Context, host component.Host) error {
-	if e.StartFn == nil {
-		return nil
-	}
-	return e.StartFn(ctx, host)
-}
-
-func (e *mockTracesExporter) Shutdown(ctx context.Context) error {
-	if e.ShutdownFn == nil {
-		return nil
-	}
-	return e.ShutdownFn(ctx)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>

In preparation for introducing log exporter to the loadbalancingexporter.

- In `exporter/loadbalacingexporter`
  - Add `loadBalancer` interface.
  - Add `loadBalancerImp`.
  - Extract logic relating to loadbalancing from `traceExporterImp` to `loadBalancerImp`.
    - This refers to all the logic related to adding / removing exporters on DNS changes and maintaining the hashRing and resolver.

The main motivation for this change is to share the common logic between `traceExporterImp` and (upcoming) `logExporterImp` by abstracting away the logic related to maintaining the list of exporters and adding / removing exporter based on changes in the resolver.

**Link to tracking Issue:** 
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2470
- next step after https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2549

Testing: Unit tests

Documentation: none (as part of this PR)

Signed-off-by: Vijayender Joshi vijayeder.joshi@gmail.com