### PR TITLE
[exporter/signalfx] Remove temporary host translation workaround

### DIFF
--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -156,9 +156,6 @@ func TestLoadConfig(t *testing.T) {
 				RetryDelay:      30 * time.Second,
 				CleanupInterval: 1 * time.Minute,
 			},
-			HostTranslations: map[string]string{
-				"host.name": "host",
-			},
 		},
 		NonAlphanumericDimensionChars: "_-.",
 	}

--- a/exporter/signalfxexporter/correlation/config.go
+++ b/exporter/signalfxexporter/correlation/config.go
@@ -29,9 +29,6 @@ func DefaultConfig() *Config {
 	return &Config{
 		HTTPClientSettings:  confighttp.HTTPClientSettings{Timeout: 5 * time.Second},
 		StaleServiceTimeout: 5 * time.Minute,
-		HostTranslations: map[string]string{
-			conventions.AttributeHostName: "host",
-		},
 		SyncAttributes: map[string]string{
 			conventions.AttributeK8sPodUID:   conventions.AttributeK8sPodUID,
 			conventions.AttributeContainerID: conventions.AttributeContainerID,
@@ -57,10 +54,6 @@ type Config struct {
 	StaleServiceTimeout time.Duration `mapstructure:"stale_service_timeout"`
 	// SyncAttributes is a key of the span attribute name to sync to the dimension as the value.
 	SyncAttributes map[string]string `mapstructure:"sync_attributes"`
-
-	// HostTranslations is a map where the key is the host attribute name to rename to the value.
-	// TODO: Remove once translations are removed from signalfx exporter.
-	HostTranslations map[string]string `mapstructure:"host_translations"`
 }
 
 func (c *Config) validate() error {

--- a/exporter/signalfxexporter/correlation/correlation.go
+++ b/exporter/signalfxexporter/correlation/correlation.go
@@ -114,11 +114,6 @@ func (cor *Tracker) AddSpans(ctx context.Context, traces pdata.Traces) (dropped 
 
 		hostDimension := string(hostID.Key)
 
-		// Translate host dimension (e.g. from host.name to host depending on configuration).
-		if newHostDimension, ok := cor.cfg.HostTranslations[string(hostID.Key)]; ok {
-			hostDimension = newHostDimension
-		}
-
 		cor.traceTracker = tracetracker.New(
 			newZapShim(cor.params.Logger),
 			cor.cfg.StaleServiceTimeout,


### PR DESCRIPTION
This isn't needed anymore now that we're sending in `host.name`.
