### PR TITLE
[groupbyattrsprocessor] Fix go.mod to match package name

### DIFF
--- a/processor/groupbyattrsprocessor/go.mod
+++ b/processor/groupbyattrsprocessor/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrs
+module github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
 
 go 1.14
 


### PR DESCRIPTION
**Description:**  Fix go.mod for groupbyattrsprocessor

go.mod file had this:
```
module github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrs
```
but the package name is 'groupbyattrsprocessor'

This mis-match resulted in errors like:
```
$ go get github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
go get: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor@none updating to
	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor@v0.22.0: parsing go.mod:
	module declares its path as: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrs
	        but was required as: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
```

preventing the module being used on opentelemetry-collector-builder.

Naming the module 'groupbyattrsprocessor' in go.mod fixes this error.