### PR TITLE
awsprometheusremotewrite: Add support for given IAM roles

### DIFF
--- a/exporter/awsprometheusremotewriteexporter/README.md
+++ b/exporter/awsprometheusremotewriteexporter/README.md
@@ -8,7 +8,7 @@ of the AWS SDK for Go.
 Note: this exporter imports and uses the [Prometheus remote write exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/prometheusremotewriteexporter)
 from upstream, and simply wraps it in Sigv4 authentication logic
 
-Same as the Prometheus remote write exporter, this exporter checks the temporality and the type of each incoming metric 
+Same as the Prometheus remote write exporter, this exporter checks the temporality and the type of each incoming metric
 and only exports the following combination:
 
 - Int64 or Double type with any temporality
@@ -16,7 +16,7 @@ and only exports the following combination:
 
 ## Configuration
 The following settings are required:
-- `endpoint`: protocol:host:port to which the exporter is going to send traces or metrics, using the HTTP/HTTPS protocol. 
+- `endpoint`: protocol:host:port to which the exporter is going to send traces or metrics, using the HTTP/HTTPS protocol.
 
 The following settings can be optionally configured:
 - `namespace`: prefix attached to each exported metric name.
@@ -31,8 +31,9 @@ The following settings can be optionally configured:
 - `aws_auth`: specify if each request should be signed with AWS Sig v4. The following settings must be configured:
     - `region`: region of the AWS service being exported to.
     - `service`: AWS service being exported to.
-    
-    
+    - `role_arn`: Amazon Resource Name of the role to assume.
+
+
 #### Examples:
 
 Simplest configuration:

--- a/exporter/awsprometheusremotewriteexporter/README.md
+++ b/exporter/awsprometheusremotewriteexporter/README.md
@@ -33,7 +33,6 @@ The following settings can be optionally configured:
     - `service`: AWS service being exported to.
     - `role_arn`: Amazon Resource Name of the role to assume.
 
-
 #### Examples:
 
 Simplest configuration:

--- a/exporter/awsprometheusremotewriteexporter/auth.go
+++ b/exporter/awsprometheusremotewriteexporter/auth.go
@@ -83,12 +83,12 @@ func newSigningRoundTripper(auth AuthConfig, next http.RoundTripper) (http.Round
 	}
 
 	var creds *credentials.Credentials
-	if auth.RoleArn  != "" {
+	if auth.RoleArn != "" {
 		// Get credentials from an assumeRole API call
 		creds = stscreds.NewCredentials(sess, auth.RoleArn, func(p *stscreds.AssumeRoleProvider) {
-		    p.RoleSessionName = getRoleSessionName()
-	    })
-	}else{
+			p.RoleSessionName = getRoleSessionName()
+		})
+	} else {
 		if _, err = sess.Config.Credentials.Get(); err != nil {
 			return nil, err
 		}

--- a/exporter/awsprometheusremotewriteexporter/auth.go
+++ b/exporter/awsprometheusremotewriteexporter/auth.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -89,7 +88,7 @@ func getCredsFromConfig(auth AuthConfig) *credentials.Credentials {
 	if auth.RoleArn != "" {
 		// Get credentials from an assumeRole API call
 		creds = stscreds.NewCredentials(sess, auth.RoleArn, func(p *stscreds.AssumeRoleProvider) {
-			p.RoleSessionName = getRoleSessionName()
+			p.RoleSessionName = "aws-otel-collector-" + strconv.FormatInt(time.Now().Unix(), 10)
 		})
 	} else {
 		// Get Credentials, either from ./aws or from environmental variables
@@ -134,13 +133,4 @@ func cloneRequest(r *http.Request) *http.Request {
 		r2.Header[k] = append([]string(nil), s...)
 	}
 	return r2
-}
-
-func getRoleSessionName() string {
-
-	if suffix, err := os.Hostname(); err == nil {
-		return "aws-otel-collector-" + suffix
-	}
-
-	return "aws-otel-collector-" + strconv.FormatInt(time.Now().Unix(), 10)
 }

--- a/exporter/awsprometheusremotewriteexporter/auth_test.go
+++ b/exporter/awsprometheusremotewriteexporter/auth_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 
@@ -239,16 +238,6 @@ func TestCloneRequest(t *testing.T) {
 			assert.EqualValues(t, tt.request.Header, r2.Header)
 		})
 	}
-}
-
-func TestGetRoleSessionName(t *testing.T) {
-
-	sessionName := getRoleSessionName()
-	require.NotNil(t, sessionName)
-
-	osHostname, err := os.Hostname()
-	require.NoError(t, err)
-	assert.Contains(t, sessionName, osHostname)
 }
 
 func fetchMockCredentials() *credentials.Credentials {

--- a/exporter/awsprometheusremotewriteexporter/auth_test.go
+++ b/exporter/awsprometheusremotewriteexporter/auth_test.go
@@ -67,33 +67,26 @@ func TestRequestSignature(t *testing.T) {
 func TestGetCredsFromConfig(t *testing.T) {
 
 	tests := []struct {
-		name        string
-		authConfig  AuthConfig
-		returnError bool
+		name       string
+		authConfig AuthConfig
 	}{
 		{
 			"success_case_without_role",
 			AuthConfig{Region: "region", Service: "service"},
-			false,
 		},
 		{
-			"success_case_without_role",
+			"success_case_with_role",
 			AuthConfig{Region: "region", Service: "service", RoleArn: "arn:aws:iam::123456789012:role/IAMRole"},
-			false,
 		},
 	}
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			creds, err := getCredsFromConfig(tt.authConfig)
+			creds := getCredsFromConfig(tt.authConfig)
 			require.NotNil(t, creds)
-			if tt.returnError {
-				assert.Error(t, err)
-				return
-			}
+
 		})
 	}
-
 }
 
 type ErrorRoundTripper struct{}

--- a/exporter/awsprometheusremotewriteexporter/auth_test.go
+++ b/exporter/awsprometheusremotewriteexporter/auth_test.go
@@ -33,47 +33,67 @@ import (
 )
 
 func TestRequestSignature(t *testing.T) {
+	// Some form of AWS credentials must be set up for tests to succeed
+	awsCreds := fetchMockCredentials()
+	authConfig := AuthConfig{Region: "region", Service: "service"}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := v4.GetSignedRequestSignature(r)
+		assert.NoError(t, err)
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	setting := confighttp.HTTPClientSettings{
+		Endpoint:        serverURL.String(),
+		TLSSetting:      configtls.TLSClientSetting{},
+		ReadBufferSize:  0,
+		WriteBufferSize: 0,
+		Timeout:         0,
+		CustomRoundTripper: func(next http.RoundTripper) (http.RoundTripper, error) {
+			return createSigningRoundTripperWithCredentials(authConfig, awsCreds, next)
+		},
+	}
+	client, _ := setting.ToClient()
+	req, err := http.NewRequest("POST", setting.Endpoint, strings.NewReader("a=1&b=2"))
+	assert.NoError(t, err)
+	_, err = client.Do(req)
+	assert.NoError(t, err)
+}
+
+func TestGetCredsFromConfig(t *testing.T) {
 
 	tests := []struct {
-		authConfig AuthConfig
+		name        string
+		authConfig  AuthConfig
+		returnError bool
 	}{
 		{
+			"success_case_without_role",
 			AuthConfig{Region: "region", Service: "service"},
+			false,
 		},
 		{
+			"success_case_without_role",
 			AuthConfig{Region: "region", Service: "service", RoleArn: "arn:aws:iam::123456789012:role/IAMRole"},
+			false,
 		},
 	}
-
+	// run tests
 	for _, tt := range tests {
-		// Some form of AWS credentials must be set up for tests to succeed
-		awsCreds := fetchMockCredentials()
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, err := v4.GetSignedRequestSignature(r)
-			assert.NoError(t, err)
-			w.WriteHeader(200)
-		}))
-		defer server.Close()
-
-		serverURL, err := url.Parse(server.URL)
-		assert.NoError(t, err)
-
-		setting := confighttp.HTTPClientSettings{
-			Endpoint:        serverURL.String(),
-			TLSSetting:      configtls.TLSClientSetting{},
-			ReadBufferSize:  0,
-			WriteBufferSize: 0,
-			Timeout:         0,
-			CustomRoundTripper: func(next http.RoundTripper) (http.RoundTripper, error) {
-				return createSigningRoundTripperWithCredentials(tt.authConfig, awsCreds, next)
-			},
-		}
-		client, _ := setting.ToClient()
-		req, err := http.NewRequest("POST", setting.Endpoint, strings.NewReader("a=1&b=2"))
-		assert.NoError(t, err)
-		_, err = client.Do(req)
-		assert.NoError(t, err)
+		t.Run(tt.name, func(t *testing.T) {
+			creds, err := getCredsFromConfig(tt.authConfig)
+			require.NotNil(t, creds)
+			if tt.returnError {
+				assert.Error(t, err)
+				return
+			}
+		})
 	}
+
 }
 
 type ErrorRoundTripper struct{}
@@ -93,16 +113,19 @@ func TestRoundTrip(t *testing.T) {
 		name        string
 		rt          http.RoundTripper
 		shouldError bool
+		authConfig  AuthConfig
 	}{
 		{
 			"valid_round_tripper",
 			defaultRoundTripper,
 			false,
+			AuthConfig{Region: "region", Service: "service"},
 		},
 		{
 			"round_tripper_error",
 			errorRoundTripper,
 			true,
+			AuthConfig{Region: "region", Service: "service", RoleArn: "arn:aws:iam::123456789012:role/IAMRole"},
 		},
 	}
 

--- a/exporter/awsprometheusremotewriteexporter/config.go
+++ b/exporter/awsprometheusremotewriteexporter/config.go
@@ -34,4 +34,6 @@ type AuthConfig struct {
 	Region string `mapstructure:"region"`
 	// Service is the service name for AWS Sig v4
 	Service string `mapstructure:"service"`
+	// Amazon Resource Name (ARN) of a role to assume
+	RoleArn string `mapstructure:"role_arn"`
 }

--- a/exporter/awsprometheusremotewriteexporter/config_test.go
+++ b/exporter/awsprometheusremotewriteexporter/config_test.go
@@ -95,6 +95,7 @@ func TestLoadConfig(t *testing.T) {
 		AuthConfig: AuthConfig{
 			Region:  "us-west-2",
 			Service: "service-name",
+			RoleArn: "arn:aws:iam::123456789012:role/IAMRole",
 		},
 	}
 	// testing function equality is not supported in Go hence these will be ignored for this test

--- a/exporter/awsprometheusremotewriteexporter/factory.go
+++ b/exporter/awsprometheusremotewriteexporter/factory.go
@@ -51,6 +51,7 @@ func (af *awsFactory) CreateDefaultConfig() configmodels.Exporter {
 		AuthConfig: AuthConfig{
 			Region:  "",
 			Service: "",
+			RoleArn: "",
 		},
 	}
 

--- a/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
@@ -36,5 +36,3 @@ service:
             receivers: [nop]
             processors: [nop]
             exporters: [awsprometheusremotewrite]
-
-

--- a/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
@@ -1,9 +1,9 @@
 receivers:
     nop:
-  
+
 processors:
     nop:
- 
+
 exporters:
     awsprometheusremotewrite:
     awsprometheusremotewrite/2:
@@ -26,6 +26,7 @@ exporters:
         aws_auth:
             region: "us-west-2"
             service: "service-name"
+            role_arn: "arn:aws:iam::123456789012:role/IAMRole"
         external_labels:
             key1: value1
             key2: value2
@@ -35,5 +36,5 @@ service:
             receivers: [nop]
             processors: [nop]
             exporters: [awsprometheusremotewrite]
-    
-    
+
+


### PR DESCRIPTION
**Description:** 
Adding to the aws prometheus exporter the possibility to assume a role to unlock cross account scenarios

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2654

**Testing:** 
Added some unit tests to cover the new parameter by running `make`
Ran the collector using `make run` with a config to test the changes

Config
```
receivers:
  prometheus:
    config:
      global:
        scrape_interval: 15s
        scrape_timeout: 10s
      scrape_configs:
      - job_name: "prometheus-demo-app"
        static_configs:
        - targets: [ 0.0.0.0:8888 ]

exporters:
  awsprometheusremotewrite:
    endpoint: https://aps-workspaces.eu-west-1.amazonaws.com/workspaces/<ws_id>/api/v1/remote_write
    aws_auth:
      region: eu-west-1
      service: "aps"
      role_arn: "arn:aws:iam::account:role/role_name"
  logging:
    loglevel: debug
extensions:
  health_check:
  pprof:
    endpoint: :1888
  zpages:
    endpoint: :55679

service:
  extensions: [pprof, zpages, health_check]
  pipelines:
    metrics:
      receivers: [prometheus]
      exporters: [logging, awsprometheusremotewrite]
```

With metrics successfully being sent to the destination


**Documentation:** 
Configuration option