### PR TITLE
sumologicexporter: add graphite format

### DIFF
--- a/exporter/sumologicexporter/README.md
+++ b/exporter/sumologicexporter/README.md
@@ -10,11 +10,16 @@ Empty string means no compression
 - `max_request_body_size` (optional): Max HTTP request body size in bytes before compression (if applied). By default `1_048_576` (1MB) is used.
 - `metadata_attributes` (optional): List of regexes for attributes which should be send as metadata
 - `log_format` (optional) (logs only): Format to use when sending logs to Sumo. (default `json`) (possible values: `json`, `text`)
-- `metric_format` (optional) (metrics only): Format of the metrics to be sent (default is `prometheus`) (possible values: `carbon2`, `prometheus`)
-  `carbon2` and `graphite` are going to be supported soon.
+- `metric_format` (optional) (metrics only): Format of the metrics to be sent (default is `prometheus`) (possible values: `carbon2`, `graphite`, `prometheus`).
+- `graphite_template` (default=`%{_metric_}`) (optional) (metrics only): Template for Graphite format.
+Placeholders `%{attr_name}` will be replaced with attribute value for `attr_name`. `%{_metric_}` is going to be replaced with metric name.
+Applied only if `metric_format` is set to `graphite`.
 - `source_category` (optional): Desired source category. Useful if you want to override the source category configured for the source.
+Placeholders `%{attr_name}` will be replaced with attribute value for `attr_name`.
 - `source_name` (optional): Desired source name. Useful if you want to override the source name configured for the source.
+Placeholders `%{attr_name}` will be replaced with attribute value for `attr_name`.
 - `source_host` (optional): Desired host name. Useful if you want to override the source host configured for the source.
+Placeholders `%{attr_name}` will be replaced with attribute value for `attr_name`.
 - `timeout` (default = 5s): Is the timeout for every attempt to send data to the backend.
 Maximum connection timeout is 55s.
 - `retry_on_failure`

--- a/exporter/sumologicexporter/README.md
+++ b/exporter/sumologicexporter/README.md
@@ -12,14 +12,14 @@ Empty string means no compression
 - `log_format` (optional) (logs only): Format to use when sending logs to Sumo. (default `json`) (possible values: `json`, `text`)
 - `metric_format` (optional) (metrics only): Format of the metrics to be sent (default is `prometheus`) (possible values: `carbon2`, `graphite`, `prometheus`).
 - `graphite_template` (default=`%{_metric_}`) (optional) (metrics only): Template for Graphite format.
-Placeholders `%{attr_name}` will be replaced with attribute value for `attr_name`. `%{_metric_}` is going to be replaced with metric name.
+[Source templates](#source-templates) are going to be applied.
 Applied only if `metric_format` is set to `graphite`.
 - `source_category` (optional): Desired source category. Useful if you want to override the source category configured for the source.
-Placeholders `%{attr_name}` will be replaced with attribute value for `attr_name`.
+[Source templates](#source-templates) are going to be applied.
 - `source_name` (optional): Desired source name. Useful if you want to override the source name configured for the source.
-Placeholders `%{attr_name}` will be replaced with attribute value for `attr_name`.
+[Source templates](#source-templates) are going to be applied.
 - `source_host` (optional): Desired host name. Useful if you want to override the source host configured for the source.
-Placeholders `%{attr_name}` will be replaced with attribute value for `attr_name`.
+[Source templates](#source-templates) are going to be applied.
 - `timeout` (default = 5s): Is the timeout for every attempt to send data to the backend.
 Maximum connection timeout is 55s.
 - `retry_on_failure`
@@ -35,7 +35,15 @@ Maximum connection timeout is 55s.
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
 
-Example:
+## Source Templates
+
+You can specify a template with an attribute for `source_category`, `source_name`, `source_host` or `graphite_template` using `%{attr_name}`.
+
+For example, when there is an attribute `my_attr`: `my_value`, `metrics/%{my_attr}` would be expanded to `metrics/my_value`.
+
+For `graphite_template`, in addition to above, `%{_metric_}` is going to be replaced with metric name.
+
+## Example Configuration
 
 ```yaml
 exporters:

--- a/exporter/sumologicexporter/carbon_formatter.go
+++ b/exporter/sumologicexporter/carbon_formatter.go
@@ -42,16 +42,25 @@ func carbon2TagString(record metricPair) string {
 		if k == "name" || k == "unit" {
 			k = fmt.Sprintf("_%s", k)
 		}
-		returnValue = append(returnValue, fmt.Sprintf("%s=%s", k, tracetranslator.AttributeValueToString(v, false)))
+		returnValue = append(returnValue, fmt.Sprintf(
+			"%s=%s",
+			sanitizeCarbonString(k),
+			sanitizeCarbonString(tracetranslator.AttributeValueToString(v, false)),
+			))
 	})
 
-	returnValue = append(returnValue, fmt.Sprintf("metric=%s", record.metric.Name()))
+	returnValue = append(returnValue, fmt.Sprintf("metric=%s", sanitizeCarbonString(record.metric.Name())))
 
 	if len(record.metric.Unit()) > 0 {
-		returnValue = append(returnValue, fmt.Sprintf("unit=%s", record.metric.Unit()))
+		returnValue = append(returnValue, fmt.Sprintf("unit=%s", sanitizeCarbonString(record.metric.Unit())))
 	}
 
 	return strings.Join(returnValue, " ")
+}
+
+// sanitizeCarbonString replaces problematic characters with underscore
+func sanitizeCarbonString(text string) string {
+	return strings.NewReplacer(" ", "_", "=", "_", "\n", "_").Replace(text)
 }
 
 // carbon2IntRecord converts IntDataPoint to carbon2 metric string

--- a/exporter/sumologicexporter/carbon_formatter.go
+++ b/exporter/sumologicexporter/carbon_formatter.go
@@ -46,7 +46,7 @@ func carbon2TagString(record metricPair) string {
 			"%s=%s",
 			sanitizeCarbonString(k),
 			sanitizeCarbonString(tracetranslator.AttributeValueToString(v, false)),
-			))
+		))
 	})
 
 	returnValue = append(returnValue, fmt.Sprintf("metric=%s", sanitizeCarbonString(record.metric.Name())))
@@ -60,7 +60,7 @@ func carbon2TagString(record metricPair) string {
 
 // sanitizeCarbonString replaces problematic characters with underscore
 func sanitizeCarbonString(text string) string {
-	return strings.NewReplacer(" ", "_", "=", "_", "\n", "_").Replace(text)
+	return strings.NewReplacer(" ", "_", "=", ":", "\n", "_").Replace(text)
 }
 
 // carbon2IntRecord converts IntDataPoint to carbon2 metric string

--- a/exporter/sumologicexporter/config.go
+++ b/exporter/sumologicexporter/config.go
@@ -46,6 +46,9 @@ type Config struct {
 	// The format of metrics you will be sending, either graphite or carbon2 or prometheus (Default is prometheus)
 	// Possible values are `carbon2` and `prometheus`
 	MetricFormat MetricFormatType `mapstructure:"metric_format"`
+	// Graphite template.
+	// Placeholders `%{attr_name}` will be replaced with attribute value for attr_name.
+	GraphiteTemplate string `mapstructure:"graphite_template"`
 
 	// List of regexes for attributes which should be send as metadata
 	MetadataAttributes []string `mapstructure:"metadata_attributes"`
@@ -53,12 +56,15 @@ type Config struct {
 	// Sumo specific options
 	// Desired source category.
 	// Useful if you want to override the source category configured for the source.
+	// Placeholders `%{attr_name}` will be replaced with attribute value for attr_name.
 	SourceCategory string `mapstructure:"source_category"`
 	// Desired source name.
 	// Useful if you want to override the source name configured for the source.
+	// Placeholders `%{attr_name}` will be replaced with attribute value for attr_name.
 	SourceName string `mapstructure:"source_name"`
 	// Desired host name.
 	// Useful if you want to override the source host configured for the source.
+	// Placeholders `%{attr_name}` will be replaced with attribute value for attr_name.
 	SourceHost string `mapstructure:"source_host"`
 	// Name of the client
 	Client string `mapstructure:"client"`
@@ -124,4 +130,6 @@ const (
 	DefaultSourceHost string = ""
 	// DefaultClient defines default Client
 	DefaultClient string = "otelcol"
+	// DefaultGraphiteTemplate defines default template for Graphite
+	DefaultGraphiteTemplate string = "%{_metric_}"
 )

--- a/exporter/sumologicexporter/factory.go
+++ b/exporter/sumologicexporter/factory.go
@@ -56,6 +56,7 @@ func createDefaultConfig() configmodels.Exporter {
 		SourceName:         DefaultSourceName,
 		SourceHost:         DefaultSourceHost,
 		Client:             DefaultClient,
+		GraphiteTemplate:   DefaultGraphiteTemplate,
 
 		HTTPClientSettings: CreateDefaultHTTPClientSettings(),
 		RetrySettings:      exporterhelper.DefaultRetrySettings(),

--- a/exporter/sumologicexporter/factory_test.go
+++ b/exporter/sumologicexporter/factory_test.go
@@ -50,6 +50,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 		SourceName:         "",
 		SourceHost:         "",
 		Client:             "otelcol",
+		GraphiteTemplate:   "%{_metric_}",
 
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Timeout: 5 * time.Second,

--- a/exporter/sumologicexporter/fields.go
+++ b/exporter/sumologicexporter/fields.go
@@ -32,7 +32,7 @@ type fields struct {
 func newFields(attrMap pdata.AttributeMap) fields {
 	return fields{
 		orig:     attrMap,
-		replacer: strings.NewReplacer(",", "_", "=", "_", "\n", "_"),
+		replacer: strings.NewReplacer(",", "_", "=", ":", "\n", "_"),
 	}
 }
 

--- a/exporter/sumologicexporter/fields_test.go
+++ b/exporter/sumologicexporter/fields_test.go
@@ -32,7 +32,7 @@ func TestFieldsAsString(t *testing.T) {
 }
 
 func TestFieldsSanitization(t *testing.T) {
-	expected := "key1=value_1, key3=value_3, key__2=valu_e_2"
+	expected := "key1=value_1, key3=value_3, key:_2=valu_e:2"
 	flds := fieldsFromMap(map[string]string{
 		"key1":   "value,1",
 		"key3":   "value\n3",

--- a/exporter/sumologicexporter/graphite_formatter.go
+++ b/exporter/sumologicexporter/graphite_formatter.go
@@ -1,0 +1,138 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicexporter
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
+)
+
+type graphiteFormatter struct {
+	template sourceFormat
+	replacer *strings.Replacer
+}
+
+const (
+	graphiteMetricNamePlaceholder = "_metric_"
+)
+
+// newGraphiteFormatter creates new formatter for given SourceFormat template
+func newGraphiteFormatter(template string) (graphiteFormatter, error) {
+	r, err := regexp.Compile(sourceRegex)
+	if err != nil {
+		return graphiteFormatter{}, err
+	}
+
+	sf := newSourceFormat(r, template)
+
+	return graphiteFormatter{
+		template: sf,
+		replacer: strings.NewReplacer(`.`, `_`, ` `, `_`),
+	}, nil
+}
+
+// escapeGraphiteString replaces dot and space using replacer,
+// as dot is special character for graphite format
+func (gf *graphiteFormatter) escapeGraphiteString(value string) string {
+	return gf.replacer.Replace(value)
+}
+
+// format returns metric name basing on template for given fields nas metric name
+func (gf *graphiteFormatter) format(f fields, metricName string) string {
+	s := gf.template
+	labels := make([]interface{}, 0, len(s.matches))
+
+	for _, matchset := range s.matches {
+		if matchset == graphiteMetricNamePlaceholder {
+			labels = append(labels, gf.escapeGraphiteString(metricName))
+		} else {
+			attr, ok := f.orig.Get(matchset)
+			var value string
+			if ok {
+				value = tracetranslator.AttributeValueToString(attr, false)
+			} else {
+				value = ""
+			}
+			labels = append(labels, gf.escapeGraphiteString(value))
+		}
+	}
+
+	return fmt.Sprintf(s.template, labels...)
+}
+
+// intRecord converts IntDataPoint to graphite metric string
+// with additional information from fields
+func (gf *graphiteFormatter) intRecord(fs fields, name string, dataPoint pdata.IntDataPoint) string {
+	return fmt.Sprintf("%s %d %d",
+		gf.format(fs, name),
+		dataPoint.Value(),
+		dataPoint.Timestamp()/pdata.Timestamp(time.Second),
+	)
+}
+
+// doubleRecord converts DoubleDataPoint to graphite metric string
+// with additional information from fields
+func (gf *graphiteFormatter) doubleRecord(fs fields, name string, dataPoint pdata.DoubleDataPoint) string {
+	return fmt.Sprintf("%s %g %d",
+		gf.format(fs, name),
+		dataPoint.Value(),
+		dataPoint.Timestamp()/pdata.Timestamp(time.Second),
+	)
+}
+
+// metric2String returns stringified metricPair
+func (gf *graphiteFormatter) metric2String(record metricPair) string {
+	var nextLines []string
+	fs := newFields(record.attributes)
+	name := record.metric.Name()
+
+	switch record.metric.DataType() {
+	case pdata.MetricDataTypeIntGauge:
+		dps := record.metric.IntGauge().DataPoints()
+		nextLines = make([]string, 0, dps.Len())
+		for i := 0; i < dps.Len(); i++ {
+			nextLines = append(nextLines, gf.intRecord(fs, name, dps.At(i)))
+		}
+	case pdata.MetricDataTypeIntSum:
+		dps := record.metric.IntSum().DataPoints()
+		nextLines = make([]string, 0, dps.Len())
+		for i := 0; i < dps.Len(); i++ {
+			nextLines = append(nextLines, gf.intRecord(fs, name, dps.At(i)))
+		}
+	case pdata.MetricDataTypeDoubleGauge:
+		dps := record.metric.DoubleGauge().DataPoints()
+		nextLines = make([]string, 0, dps.Len())
+		for i := 0; i < dps.Len(); i++ {
+			nextLines = append(nextLines, gf.doubleRecord(fs, name, dps.At(i)))
+		}
+	case pdata.MetricDataTypeDoubleSum:
+		dps := record.metric.DoubleSum().DataPoints()
+		nextLines = make([]string, 0, dps.Len())
+		for i := 0; i < dps.Len(); i++ {
+			nextLines = append(nextLines, gf.doubleRecord(fs, name, dps.At(i)))
+		}
+	// Skip complex metrics
+	case pdata.MetricDataTypeDoubleHistogram:
+	case pdata.MetricDataTypeIntHistogram:
+	case pdata.MetricDataTypeDoubleSummary:
+	}
+
+	return strings.Join(nextLines, "\n")
+}

--- a/exporter/sumologicexporter/graphite_formatter_test.go
+++ b/exporter/sumologicexporter/graphite_formatter_test.go
@@ -1,0 +1,164 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sumologicexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscapeGraphiteString(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{k8s.cluster}.%{k8s.namespace}.%{k8s.pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	value := gf.escapeGraphiteString("this.is_example&metric.value")
+	expected := "this_is_example&metric_value"
+
+	assert.Equal(t, expected, value)
+}
+
+func TestGraphiteFormat(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{k8s.cluster}.%{k8s.namespace}.%{k8s.pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	fs := fieldsFromMap(map[string]string{
+		"k8s.cluster":   "test_cluster",
+		"k8s.namespace": "sumologic",
+		"k8s.pod":       "example_pod",
+	})
+
+	expected := "test_cluster.sumologic.example_pod.test_metric"
+	result := gf.format(fs, "test_metric")
+
+	assert.Equal(t, expected, result)
+}
+
+func TestGraphiteMetricDataTypeIntGauge(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{cluster}.%{namespace}.%{pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	metric := exampleIntGaugeMetric()
+	metric.attributes.InsertString("cluster", "my_cluster")
+	metric.attributes.InsertString("namespace", "default")
+	metric.attributes.InsertString("pod", "some pod")
+
+	result := gf.metric2String(metric)
+	expected := `my_cluster.default.some_pod.gauge_metric_name 124 1608124661
+my_cluster.default.some_pod.gauge_metric_name 245 1608124662`
+	assert.Equal(t, expected, result)
+}
+
+func TestGraphiteMetricDataTypeDoubleGauge(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{cluster}.%{namespace}.%{pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	metric := exampleDoubleGaugeMetric()
+	metric.attributes.InsertString("cluster", "my_cluster")
+	metric.attributes.InsertString("namespace", "default")
+	metric.attributes.InsertString("pod", "some pod")
+
+	result := gf.metric2String(metric)
+	expected := `my_cluster.default.some_pod.gauge_metric_name_double_test 33.4 1608124661
+my_cluster.default.some_pod.gauge_metric_name_double_test 56.8 1608124662`
+	assert.Equal(t, expected, result)
+}
+
+func TestGraphiteNoattribute(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{cluster}.%{namespace}.%{pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	metric := exampleDoubleGaugeMetric()
+	metric.attributes.InsertString("cluster", "my_cluster")
+	metric.attributes.InsertString("pod", "some pod")
+
+	result := gf.metric2String(metric)
+	expected := `my_cluster..some_pod.gauge_metric_name_double_test 33.4 1608124661
+my_cluster..some_pod.gauge_metric_name_double_test 56.8 1608124662`
+	assert.Equal(t, expected, result)
+}
+
+func TestGraphiteMetricDataTypeIntSum(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{cluster}.%{namespace}.%{pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	metric := exampleIntSumMetric()
+	metric.attributes.InsertString("cluster", "my_cluster")
+	metric.attributes.InsertString("namespace", "default")
+	metric.attributes.InsertString("pod", "some pod")
+
+	result := gf.metric2String(metric)
+	expected := `my_cluster.default.some_pod.sum_metric_int_test 45 1608124444
+my_cluster.default.some_pod.sum_metric_int_test 1238 1608124699`
+	assert.Equal(t, expected, result)
+}
+
+func TestGraphiteMetricDataTypeDoubleSum(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{cluster}.%{namespace}.%{pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	metric := exampleDoubleSumMetric()
+	metric.attributes.InsertString("cluster", "my_cluster")
+	metric.attributes.InsertString("namespace", "default")
+	metric.attributes.InsertString("pod", "some pod")
+
+	result := gf.metric2String(metric)
+	expected := `my_cluster.default.some_pod.sum_metric_double_test 45.6 1618124444
+my_cluster.default.some_pod.sum_metric_double_test 1238.1 1608424699`
+	assert.Equal(t, expected, result)
+}
+
+func TestGraphiteMetricDataTypeDoubleSummary(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{cluster}.%{namespace}.%{pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	metric := exampleDoubleSummaryMetric()
+	metric.attributes.InsertString("cluster", "my_cluster")
+	metric.attributes.InsertString("namespace", "default")
+	metric.attributes.InsertString("pod", "some pod")
+
+	result := gf.metric2String(metric)
+	expected := ``
+	assert.Equal(t, expected, result)
+}
+
+func TestGraphiteMetricDataTypeIntHistogram(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{cluster}.%{namespace}.%{pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	metric := exampleIntHistogramMetric()
+	metric.attributes.InsertString("cluster", "my_cluster")
+	metric.attributes.InsertString("namespace", "default")
+	metric.attributes.InsertString("pod", "some pod")
+
+	result := gf.metric2String(metric)
+	expected := ``
+	assert.Equal(t, expected, result)
+}
+
+func TestGraphiteMetricDataTypeDoubleHistogram(t *testing.T) {
+	gf, err := newGraphiteFormatter("%{cluster}.%{namespace}.%{pod}.%{_metric_}")
+	require.NoError(t, err)
+
+	metric := exampleDoubleHistogramMetric()
+	metric.attributes.InsertString("cluster", "my_cluster")
+	metric.attributes.InsertString("namespace", "default")
+	metric.attributes.InsertString("pod", "some pod")
+
+	result := gf.metric2String(metric)
+	expected := ``
+	assert.Equal(t, expected, result)
+}

--- a/exporter/sumologicexporter/sender_test.go
+++ b/exporter/sumologicexporter/sender_test.go
@@ -786,7 +786,7 @@ func TestSendCarbon2Metrics(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
-			expected := `test=test_value test2=second_value _unit=m/s metric=true metric=test.metric.data unit=bytes  14500 1605534165
+			expected := `test=test_value test2=second_value _unit=m/s escape_me=_invalid_ metric=true metric=test.metric.data unit=bytes  14500 1605534165
 foo=bar metric=gauge_metric_name  124 1608124661
 foo=bar metric=gauge_metric_name  245 1608124662`
 			assert.Equal(t, expected, body)
@@ -808,6 +808,7 @@ foo=bar metric=gauge_metric_name  245 1608124662`
 	})
 
 	test.s.metricBuffer[0].attributes.InsertString("unit", "m/s")
+	test.s.metricBuffer[0].attributes.InsertString("escape me", "=invalid\n")
 	test.s.metricBuffer[0].attributes.InsertBool("metric", true)
 
 	_, err := test.s.sendMetrics(context.Background(), flds)

--- a/exporter/sumologicexporter/sender_test.go
+++ b/exporter/sumologicexporter/sender_test.go
@@ -786,7 +786,7 @@ func TestSendCarbon2Metrics(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
 		func(w http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
-			expected := `test=test_value test2=second_value _unit=m/s escape_me=_invalid_ metric=true metric=test.metric.data unit=bytes  14500 1605534165
+			expected := `test=test_value test2=second_value _unit=m/s escape_me=:invalid_ metric=true metric=test.metric.data unit=bytes  14500 1605534165
 foo=bar metric=gauge_metric_name  124 1608124661
 foo=bar metric=gauge_metric_name  245 1608124662`
 			assert.Equal(t, expected, body)


### PR DESCRIPTION
**Description:**
 - Add support for graphite format to sumo logic exporter
 - Add sanitization for carbon2 format
 - Replace `=` with `:` for sanitization

**Link to tracking Issue:**
#1498 

**Testing:**
Unit tests, manual tests

**Documentation:**
Code comments