### PR TITLE
make: Remove -y flag for addlicense

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -62,7 +62,7 @@ benchmark:
 
 .PHONY: addlicense
 addlicense:
-	@ADDLICENCESEOUT=`$(ADDLICENCESE) -c 'OpenTelemetry Authors' $(ALL_SRC) 2>&1`; \
+	@ADDLICENCESEOUT=`$(ADDLICENCESE) -y "" -c 'OpenTelemetry Authors' $(ALL_SRC) 2>&1`; \
 		if [ "$$ADDLICENCESEOUT" ]; then \
 			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
 			echo "$$ADDLICENCESEOUT\n"; \

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -62,7 +62,7 @@ benchmark:
 
 .PHONY: addlicense
 addlicense:
-	@ADDLICENCESEOUT=`$(ADDLICENCESE) -y -c 'OpenTelemetry Authors' $(ALL_SRC) 2>&1`; \
+	@ADDLICENCESEOUT=`$(ADDLICENCESE) -c 'OpenTelemetry Authors' $(ALL_SRC) 2>&1`; \
 		if [ "$$ADDLICENCESEOUT" ]; then \
 			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
 			echo "$$ADDLICENCESEOUT\n"; \


### PR DESCRIPTION
**Description:** <Describe what has changed.>

When using `-y` it is expecting next arg is year, so it was taking `-c` as year and `OpenTelemetry Authors' as input file and end up having error like the following:

```
make addlicense                                                                                                                                                                                          15:23:58
addlicense FAILED => add License errors:

2021/03/15 15:24:10 OpenTelemetry Authors error: lstat OpenTelemetry Authors: no such file or directory

make: *** [addlicense] Error 1
```

The `-y` flag is a string flag and default value is current year.

```go
	year      = flag.String("y", fmt.Sprint(time.Now().Year()), "copyright year(s)")
```


**Link to tracking Issue:** <Issue number if applicable>

N/A

**Testing:** <Describe what testing was performed and which tests were added.>

```
make addlicense                                                                                                                                                                       
Add License finished successfully
```

**Documentation:** <Describe the documentation added.>