### PR TITLE
Add Retry and Queue settings to honeycomb exporter

### DIFF
--- a/exporter/honeycombexporter/README.md
+++ b/exporter/honeycombexporter/README.md
@@ -12,6 +12,16 @@ The following configuration options are supported:
 * `sample_rate` (Optional): Constant sample rate. Can be used to send 1 / x events to Honeycomb. Defaults to 1 (always sample).
 * `sample_rate_attribute` (Optional): The name of an attribute that contains the sample_rate for each span. If the attribute is on the span, it takes precedence over the static sample_rate configuration
 * `debug` (Optional): Set this to true to get debug logs from the honeycomb SDK. Defaults to false.
+* `retry_on_failure` (Optional):
+  - `enabled` (default = true)
+  - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`
+  - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
+  - `max_elapsed_time` (default = 120s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`
+* `sending_queue` (Optional):
+  - `enabled` (default = true)
+  - `num_consumers` (default = 10): Number of consumers that dequeue batches; ignored if `enabled` is `false`
+  - `queue_size` (default = 5000): Maximum number of batches kept in memory before data; ignored if `enabled` is `false`;
+
 Example:
 
 ```yaml
@@ -23,4 +33,13 @@ exporters:
     sample_rate: 25
     sample_rate_attribute: "hny.sample_rate"
     debug: true
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5
+      max_interval: 30
+      max_elapsed_time: 120
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      queue_size: 10000
 ```

--- a/exporter/honeycombexporter/config.go
+++ b/exporter/honeycombexporter/config.go
@@ -14,7 +14,10 @@
 
 package honeycombexporter
 
-import "go.opentelemetry.io/collector/config"
+import (
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
 
 type Config struct {
 	*config.ExporterSettings `mapstructure:"-"`
@@ -31,4 +34,8 @@ type Config struct {
 	SampleRateAttribute string `mapstructure:"sample_rate_attribute"`
 	// Debug enables more verbose logging from the Honeycomb SDK. It defaults to false.
 	Debug bool `mapstructure:"debug"`
+	// RetrySettings helps configure retry on traces which failed to send
+	exporterhelper.RetrySettings `mapstructure:"retry_on_failure"`
+	// QueueSettings enable queued processing
+	exporterhelper.QueueSettings `mapstructure:"sending_queue"`
 }

--- a/exporter/honeycombexporter/config_test.go
+++ b/exporter/honeycombexporter/config_test.go
@@ -17,12 +17,14 @@ package honeycombexporter
 import (
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -49,6 +51,17 @@ func TestLoadConfig(t *testing.T) {
 		APIKey:           "test-apikey",
 		Dataset:          "test-dataset",
 		APIURL:           "https://api.testhost.io",
+		RetrySettings: exporterhelper.RetrySettings{
+			Enabled:         true,
+			InitialInterval: 10 * time.Second,
+			MaxInterval:     60 * time.Second,
+			MaxElapsedTime:  120 * time.Second,
+		},
+		QueueSettings: exporterhelper.QueueSettings{
+			Enabled:      true,
+			NumConsumers: 1,
+			QueueSize:    1,
+		},
 	})
 
 	r2 := cfg.Exporters["honeycomb/sample_rate"].(*Config)
@@ -57,5 +70,16 @@ func TestLoadConfig(t *testing.T) {
 		APIURL:              "https://api.honeycomb.io",
 		SampleRate:          5,
 		SampleRateAttribute: "custom.sample_rate",
+		RetrySettings: exporterhelper.RetrySettings{
+			Enabled:         true,
+			InitialInterval: 10 * time.Second,
+			MaxInterval:     60 * time.Second,
+			MaxElapsedTime:  120 * time.Second,
+		},
+		QueueSettings: exporterhelper.QueueSettings{
+			Enabled:      true,
+			NumConsumers: 1,
+			QueueSize:    1,
+		},
 	})
 }

--- a/exporter/honeycombexporter/factory.go
+++ b/exporter/honeycombexporter/factory.go
@@ -43,6 +43,8 @@ func createDefaultConfig() config.Exporter {
 		APIURL:              "https://api.honeycomb.io",
 		SampleRateAttribute: "",
 		Debug:               false,
+		RetrySettings:       exporterhelper.DefaultRetrySettings(),
+		QueueSettings:       exporterhelper.DefaultQueueSettings(),
 	}
 }
 
@@ -61,5 +63,7 @@ func createTraceExporter(
 		cfg,
 		params.Logger,
 		exporter.pushTraceData,
-		exporterhelper.WithShutdown(exporter.Shutdown))
+		exporterhelper.WithShutdown(exporter.Shutdown),
+		exporterhelper.WithRetry(eCfg.RetrySettings),
+		exporterhelper.WithQueue(eCfg.QueueSettings))
 }

--- a/exporter/honeycombexporter/testdata/config.yaml
+++ b/exporter/honeycombexporter/testdata/config.yaml
@@ -10,9 +10,27 @@ exporters:
     api_key: "test-apikey"
     dataset: "test-dataset"
     api_url: "https://api.testhost.io"
+    sending_queue:
+      enabled: true
+      num_consumers: 1
+      queue_size: 1
+    retry_on_failure:
+      enabled: true
+      initial_interval: 10s
+      max_interval: 60s
+      max_elapsed_time: 120s
   honeycomb/sample_rate:
     sample_rate: 5 # deprecated but left to ensure existing configs do not break
     sample_rate_attribute: "custom.sample_rate"
+    sending_queue:
+      enabled: true
+      num_consumers: 1
+      queue_size: 1
+    retry_on_failure:
+      enabled: true
+      initial_interval: 10s
+      max_interval: 60s
+      max_elapsed_time: 120s
 
 service:
   pipelines:


### PR DESCRIPTION
**Description:** 
Adding RetrySettings and QueueSettings to Honeycomb Exporter
Adding these settings offered by the exporterhelper will allow users of the Honeycomb exporter to retain queued retry behavior

**Testing:** 
RetrySettings and QueueSettings have been tested in exporterhelper, tests inside honeycomb exporter were changed to expect RetrySettings and QueueSettings

**Documentation:**
Added documentation on the new settings which can be configured on the exporter with descriptions on the defaults as well as their purpose