### PR TITLE
Removing james-bebbington as an approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs
 - [Anuraag Agrawal](https://github.com/anuraaga), AWS
 - [Daniel Jaglowski](https://github.com/djaglowski), observIQ
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
-- [James Bebbington](https://github.com/james-bebbington), Google
 - [Jay Camp](https://github.com/jrcamp), Splunk
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Red Hat
 - [Kevin Brockhoff](https://github.com/kbrockhoff), Daugherty Business Solutions


### PR DESCRIPTION
@james-bebbington is currently working on something else and cannot allocate time to the Collector. 
James, thanks for you work on the Collector, you are welcome back anytime in the future.
