### PR TITLE
[StatsD receiver] Change OpenCensus type to OpenTelemetry type for statsD receiver

### DIFF
--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -19,7 +19,7 @@ The Following settings are optional:
 
 - `aggregation_interval: 70s`(default value is 60s): The aggregation time that the receiver aggregates the metrics (similar to the flush interval in StatsD server)
 
-- `enable_metric_type: true`(default value is false): Enbale the statsd receiver to be able to emit the mertic type(gauge, counter, timer(in the future), histogram(in the future)) as a lable.
+- `enable_metric_type: true`(default value is false): Enable the statsd receiver to be able to emit the metric type(gauge, counter, timer(in the future), histogram(in the future)) as a label.
 
 Example:
 

--- a/receiver/statsdreceiver/protocol/metric_translator.go
+++ b/receiver/statsdreceiver/protocol/metric_translator.go
@@ -1,0 +1,67 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func buildCounterMetric(parsedMetric statsDMetric, timeNow time.Time) pdata.InstrumentationLibraryMetrics {
+	dp := pdata.NewIntDataPoint()
+	dp.SetValue(parsedMetric.intvalue)
+	dp.SetTimestamp(pdata.TimestampFromTime(timeNow))
+	for i, key := range parsedMetric.labelKeys {
+		dp.LabelsMap().Insert(key, parsedMetric.labelValues[i])
+	}
+
+	nm := pdata.NewMetric()
+	nm.SetName(parsedMetric.description.name)
+	if parsedMetric.unit != "" {
+		nm.SetUnit(parsedMetric.unit)
+	}
+	nm.SetDataType(pdata.MetricDataTypeIntSum)
+	nm.IntSum().DataPoints().Append(dp)
+	nm.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
+	nm.IntSum().SetIsMonotonic(true)
+
+	ilm := pdata.NewInstrumentationLibraryMetrics()
+	ilm.Metrics().Append(nm)
+
+	return ilm
+}
+
+func buildGaugeMetric(parsedMetric statsDMetric, timeNow time.Time) pdata.InstrumentationLibraryMetrics {
+	dp := pdata.NewDoubleDataPoint()
+	dp.SetValue(parsedMetric.floatvalue)
+	dp.SetTimestamp(pdata.TimestampFromTime(timeNow))
+	for i, key := range parsedMetric.labelKeys {
+		dp.LabelsMap().Insert(key, parsedMetric.labelValues[i])
+	}
+
+	nm := pdata.NewMetric()
+	nm.SetName(parsedMetric.description.name)
+	if parsedMetric.unit != "" {
+		nm.SetUnit(parsedMetric.unit)
+	}
+	nm.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	nm.DoubleGauge().DataPoints().Append(dp)
+
+	ilm := pdata.NewInstrumentationLibraryMetrics()
+	ilm.Metrics().Append(nm)
+
+	return ilm
+}

--- a/receiver/statsdreceiver/protocol/metric_translator_test.go
+++ b/receiver/statsdreceiver/protocol/metric_translator_test.go
@@ -1,0 +1,76 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestBuildCounterMetric(t *testing.T) {
+	timeNow := time.Now()
+	metricDescription := statsDMetricdescription{
+		name: "testCounter",
+	}
+	parsedMetric := statsDMetric{
+		description: metricDescription,
+		intvalue:    32,
+		unit:        "meter",
+		labelKeys:   []string{"mykey"},
+		labelValues: []string{"myvalue"},
+	}
+	metric := buildCounterMetric(parsedMetric, timeNow)
+	expectedMetric := pdata.NewInstrumentationLibraryMetrics()
+	expectedMetric.Metrics().Resize(1)
+	expectedMetric.Metrics().At(0).SetName("testCounter")
+	expectedMetric.Metrics().At(0).SetUnit("meter")
+	expectedMetric.Metrics().At(0).SetDataType(pdata.MetricDataTypeIntSum)
+	expectedMetric.Metrics().At(0).IntSum().SetAggregationTemporality(pdata.AggregationTemporalityDelta)
+	expectedMetric.Metrics().At(0).IntSum().SetIsMonotonic(true)
+	expectedMetric.Metrics().At(0).IntSum().DataPoints().Resize(1)
+	expectedMetric.Metrics().At(0).IntSum().DataPoints().At(0).SetValue(32)
+	expectedMetric.Metrics().At(0).IntSum().DataPoints().At(0).SetTimestamp(pdata.TimestampFromTime(timeNow))
+	expectedMetric.Metrics().At(0).IntSum().DataPoints().At(0).LabelsMap().Insert("mykey", "myvalue")
+	assert.Equal(t, metric, expectedMetric)
+}
+
+func TestBuildGaugeMetric(t *testing.T) {
+	timeNow := time.Now()
+	metricDescription := statsDMetricdescription{
+		name: "testGauge",
+	}
+	parsedMetric := statsDMetric{
+		description: metricDescription,
+		floatvalue:  32.3,
+		unit:        "meter",
+		labelKeys:   []string{"mykey", "mykey2"},
+		labelValues: []string{"myvalue", "myvalue2"},
+	}
+	metric := buildGaugeMetric(parsedMetric, timeNow)
+	expectedMetric := pdata.NewInstrumentationLibraryMetrics()
+	expectedMetric.Metrics().Resize(1)
+	expectedMetric.Metrics().At(0).SetName("testGauge")
+	expectedMetric.Metrics().At(0).SetUnit("meter")
+	expectedMetric.Metrics().At(0).SetDataType(pdata.MetricDataTypeDoubleGauge)
+	expectedMetric.Metrics().At(0).DoubleGauge().DataPoints().Resize(1)
+	expectedMetric.Metrics().At(0).DoubleGauge().DataPoints().At(0).SetValue(32.3)
+	expectedMetric.Metrics().At(0).DoubleGauge().DataPoints().At(0).SetTimestamp(pdata.TimestampFromTime(timeNow))
+	expectedMetric.Metrics().At(0).DoubleGauge().DataPoints().At(0).LabelsMap().Insert("mykey", "myvalue")
+	expectedMetric.Metrics().At(0).DoubleGauge().DataPoints().At(0).LabelsMap().Insert("mykey2", "myvalue2")
+	assert.Equal(t, metric, expectedMetric)
+}

--- a/receiver/statsdreceiver/protocol/parser.go
+++ b/receiver/statsdreceiver/protocol/parser.go
@@ -15,12 +15,12 @@
 package protocol
 
 import (
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
 // Parser is something that can map input StatsD strings to OTLP Metric representations.
 type Parser interface {
 	Initialize(enableMetricType bool) error
-	GetMetrics() []*metricspb.Metric
+	GetMetrics() pdata.Metrics
 	Aggregate(line string) error
 }

--- a/receiver/statsdreceiver/receiver_test.go
+++ b/receiver/statsdreceiver/receiver_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenterror"
@@ -31,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/testutil"
 	"go.opentelemetry.io/collector/translator/internaldata"
 	"go.uber.org/zap"
@@ -87,7 +87,7 @@ func TestStatsdReceiver_Flush(t *testing.T) {
 	rcv, err := New(zap.NewNop(), *cfg, nextConsumer)
 	assert.NoError(t, err)
 	r := rcv.(*statsdReceiver)
-	var metrics = []*metricspb.Metric{}
+	var metrics = pdata.NewMetrics()
 	assert.Nil(t, r.Flush(ctx, metrics, nextConsumer))
 	r.Start(ctx, componenttest.NewNopHost())
 	r.Shutdown(ctx)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
1. Change StatsD receiver to use OpenTelemetry type instead of OpenCensus type.
1. Revise some typos in readme

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2732

**Testing:** revised unit tests
