### PR TITLE
exporter/signalfx: Update exclude_metrics option

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -44,7 +44,10 @@ The following configuration options can also be configured:
 - `exclude_metrics`: List of metric filters that will determine metrics to be
   excluded from sending to Signalfx backend. If `translation_rules` options
   are enabled, the exclusion will be applied on translated metrics.
-  See [here](./testdata/config.yaml) for examples.
+  See [here](./testdata/config.yaml) for examples. Apart from the values explicitly
+  provided via this option, by default, [these](./translation/default_metrics.go) are
+  also appended to this list. Setting this option to `[]` will override all the default
+  excludes.
 - `include_metrics`: List of filters to override exclusion of any metrics.
   This option can be used to included metrics that are otherwise dropped by
   default. See [here](./translation/default_metrics.go) for a list of metrics

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -187,9 +187,7 @@ func setDefaultExcludes(cfg *Config) error {
 	if err != nil {
 		return err
 	}
-	if cfg.ExcludeMetrics == nil {
-		cfg.ExcludeMetrics = defaultExcludeMetrics
-	} else {
+	if cfg.ExcludeMetrics == nil || len(cfg.ExcludeMetrics) > 0 {
 		cfg.ExcludeMetrics = append(cfg.ExcludeMetrics, defaultExcludeMetrics...)
 	}
 	return nil

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -331,6 +331,26 @@ func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
 	assert.Equal(t, 11, len(config.ExcludeMetrics))
 }
 
+func TestCreateMetricsExporterWithEmptyExcludeMetrics(t *testing.T) {
+	config := &Config{
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: configmodels.Type(typeStr),
+			NameVal: typeStr,
+		},
+		AccessToken:    "testToken",
+		Realm:          "us1",
+		ExcludeMetrics: []dpfilters.MetricFilter{},
+	}
+
+	te, err := createMetricsExporter(context.Background(), component.ExporterCreateParams{Logger: zap.NewNop()}, config)
+	require.NoError(t, err)
+	require.NotNil(t, te)
+
+	// Validate that default excludes are overridden when exclude metrics
+	// is explicitly set to an empty slice.
+	assert.Equal(t, 0, len(config.ExcludeMetrics))
+}
+
 func testMetricsData() pdata.ResourceMetrics {
 	md := internaldata.MetricsData{
 		Metrics: []*metricspb.Metric{


### PR DESCRIPTION
**Description:** Update the behavior of `exclude_metrics` option. The PR updates the behavior so that the default exclude rules can be overridden by setting `exclude_metrics` to `[]`. Currently, the exporter appends a list of default exclude rules. This update will mean that the exporter only appends default rules for if `exclude_metrics` is not specified or is a non-empty slice.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Added tests.

**Documentation:** Updated README