### PR TITLE
Fix New Relic default metric URL.

### DIFF
--- a/exporter/newrelicexporter/config.go
+++ b/exporter/newrelicexporter/config.go
@@ -63,10 +63,12 @@ func (c Config) HarvestOption(cfg *telemetry.Config) {
 	cfg.Product = product
 	cfg.ProductVersion = version
 	var prefix string
-	if c.metricsInsecure {
-		prefix = "http://"
-	} else {
-		prefix = "https://"
+	if c.MetricsHostOverride != "" {
+		if c.metricsInsecure {
+			prefix = "http://"
+		} else {
+			prefix = "https://"
+		}
+		cfg.MetricsURLOverride = prefix + c.MetricsHostOverride
 	}
-	cfg.MetricsURLOverride = prefix + c.MetricsHostOverride
 }

--- a/exporter/newrelicexporter/config_test.go
+++ b/exporter/newrelicexporter/config_test.go
@@ -43,7 +43,13 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, len(cfg.Exporters), 2)
 
 	r0 := cfg.Exporters["newrelic"]
-	assert.Equal(t, r0, factory.CreateDefaultConfig())
+	defaultConfig := factory.CreateDefaultConfig().(*Config)
+	assert.Equal(t, r0, defaultConfig)
+
+	defaultNrConfig := new(telemetry.Config)
+	defaultConfig.HarvestOption(defaultNrConfig)
+	assert.Empty(t, defaultNrConfig.MetricsURLOverride)
+	assert.Empty(t, defaultNrConfig.SpansURLOverride)
 
 	r1 := cfg.Exporters["newrelic/alt"].(*Config)
 	assert.Equal(t, r1, &Config{


### PR DESCRIPTION
**Description:** This fixes a bug in the New Relic exporter where the default metric URL was not set correctly inside of the metric harvester.

**Testing:** Added regression test.