### PR TITLE
[processors/resourcedetection] Add missing entries for `cloud.infrastructure_service`

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -58,10 +58,10 @@ ec2:
 * Amazon ECS: Queries the [Task Metadata Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) (TMDE) to record information about the current ECS Task. Only TMDE V4 and V3 are supported.
 
     * cloud.provider ("aws")
+    * cloud.infrastructure_service ("aws_ecs")
     * cloud.account.id
     * cloud.region
     * cloud.zone
-    * cloud.infrastructure_service ("aws_ecs")
     * aws.ecs.cluster.arn
     * aws.ecs.task.arn
     * aws.ecs.task.family

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -20,7 +20,8 @@ details of which are currently pending confirmation in the OpenTelemetry specifi
 * GCE Metadata: Uses the [Google Cloud Client Libraries for Go](https://github.com/googleapis/google-cloud-go)
 to read resource information from the [GCE metadata server](https://cloud.google.com/compute/docs/storing-retrieving-metadata) to retrieve the following resource attributes:
 
-    * cloud.provider (gcp)
+    * cloud.provider ("gcp")
+    * cloud.infrastructure_service ("gcp_compute_engine")
     * cloud.account.id
     * cloud.region
     * cloud.zone
@@ -30,8 +31,8 @@ to read resource information from the [GCE metadata server](https://cloud.google
 
 * AWS EC2: Uses [AWS SDK for Go](https://docs.aws.amazon.com/sdk-for-go/api/aws/ec2metadata/) to read resource information from the [EC2 instance metadata API](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) to retrieve the following resource attributes:
 
-    * cloud.provider (aws)
-    * cloud.infrastructure_service (EC2)
+    * cloud.provider ("aws")
+    * cloud.infrastructure_service ("aws_ec2")
     * cloud.account.id
     * cloud.region
     * cloud.zone
@@ -56,11 +57,11 @@ ec2:
 
 * Amazon ECS: Queries the [Task Metadata Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) (TMDE) to record information about the current ECS Task. Only TMDE V4 and V3 are supported.
 
-    * cloud.provider (aws)
+    * cloud.provider ("aws")
     * cloud.account.id
     * cloud.region
     * cloud.zone
-    * cloud.infrastructure_service (ECS)
+    * cloud.infrastructure_service ("aws_ecs")
     * aws.ecs.cluster.arn
     * aws.ecs.task.arn
     * aws.ecs.task.family
@@ -72,15 +73,16 @@ ec2:
     
 * Amazon Elastic Beanstalk: Reads the AWS X-Ray configuration file available on all Beanstalk instances with [X-Ray Enabled](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-configuration-debugging.html).
 
-    * cloud.provider (aws)
-    * cloud.infrastructure_service (ElasticBeanstalk)
+    * cloud.provider ("aws")
+    * cloud.infrastructure_service ("aws_elastic_beanstalk")
     * deployment.environment
     * service.instance.id
     * service.version
     
 * Azure: Queries the [Azure Instance Metadata Service](https://aka.ms/azureimds) to retrieve the following resource attributes:
 
-    * cloud.provider (azure)
+    * cloud.provider ("azure")
+    * cloud.infrastructure_service ("azure_vm")
     * cloud.region
     * cloud.account.id (subscription ID)
     * host.id (virtual machine ID)
@@ -91,7 +93,7 @@ ec2:
 ## Configuration
 
 ```yaml
-# a list of resource detectors to run, valid options are: "env", "system",  "gce", "ec2", "ecs", "elastic_beanstalk", "azure"
+# a list of resource detectors to run, valid options are: "env", "system", "gce", "ec2", "ecs", "elastic_beanstalk", "azure"
 detectors: [ <string> ]
 # determines if existing resource attributes should be overridden or preserved, defaults to true
 override: <bool>

--- a/processor/resourcedetectionprocessor/internal/azure/azure.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azure.go
@@ -53,6 +53,7 @@ func (d *Detector) Detect(ctx context.Context) (pdata.Resource, error) {
 	}
 
 	attrs.InsertString(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAzure)
+	attrs.InsertString(conventions.AttributeCloudInfrastructureService, conventions.AttributeCloudProviderAzureVM)
 	attrs.InsertString(conventions.AttributeHostName, compute.Name)
 	attrs.InsertString(conventions.AttributeCloudRegion, compute.Location)
 	attrs.InsertString(conventions.AttributeHostID, compute.VMID)

--- a/processor/resourcedetectionprocessor/internal/azure/azure_test.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azure_test.go
@@ -62,13 +62,14 @@ func TestDetectAzureAvailable(t *testing.T) {
 	res.Attributes().Sort()
 
 	expected := internal.NewResource(map[string]interface{}{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
-		conventions.AttributeHostName:      "name",
-		conventions.AttributeCloudRegion:   "location",
-		conventions.AttributeHostID:        "vmID",
-		conventions.AttributeCloudAccount:  "subscriptionID",
-		"azure.vm.size":                    "vmSize",
-		"azure.resourcegroup.name":         "resourceGroup",
+		conventions.AttributeCloudProvider:              conventions.AttributeCloudProviderAzure,
+		conventions.AttributeCloudInfrastructureService: conventions.AttributeCloudProviderAzureVM,
+		conventions.AttributeHostName:                   "name",
+		conventions.AttributeCloudRegion:                "location",
+		conventions.AttributeHostID:                     "vmID",
+		conventions.AttributeCloudAccount:               "subscriptionID",
+		"azure.vm.size":                                 "vmSize",
+		"azure.resourcegroup.name":                      "resourceGroup",
 	})
 	expected.Attributes().Sort()
 

--- a/processor/resourcedetectionprocessor/internal/gcp/gce/gce.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gce/gce.go
@@ -58,6 +58,7 @@ func (d *Detector) Detect(context.Context) (pdata.Resource, error) {
 
 func (d *Detector) initializeCloudAttributes(attr pdata.AttributeMap) []error {
 	attr.InsertString(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderGCP)
+	attr.InsertString(conventions.AttributeCloudInfrastructureService, conventions.AttributeCloudProviderGCPComputeEngine)
 
 	var errors []error
 

--- a/processor/resourcedetectionprocessor/internal/gcp/gce/gce_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gce/gce_test.go
@@ -89,9 +89,10 @@ func TestDetectTrue(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := internal.NewResource(map[string]interface{}{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
-		conventions.AttributeCloudAccount:  "1",
-		conventions.AttributeCloudZone:     "zone",
+		conventions.AttributeCloudProvider:              conventions.AttributeCloudProviderGCP,
+		conventions.AttributeCloudInfrastructureService: conventions.AttributeCloudProviderGCPComputeEngine,
+		conventions.AttributeCloudAccount:               "1",
+		conventions.AttributeCloudZone:                  "zone",
 
 		conventions.AttributeHostID:   "2",
 		conventions.AttributeHostName: "hostname",
@@ -129,7 +130,10 @@ func TestDetectError(t *testing.T) {
 
 	assert.EqualError(t, err, "[err1; err2; err3; err4; err6]")
 
-	expected := internal.NewResource(map[string]interface{}{conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP})
+	expected := internal.NewResource(map[string]interface{}{
+		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
+		conventions.AttributeCloudInfrastructureService: conventions.AttributeCloudProviderGCPComputeEngine,
+	})
 
 	res.Attributes().Sort()
 	expected.Attributes().Sort()

--- a/processor/resourcedetectionprocessor/internal/gcp/gce/gce_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gce/gce_test.go
@@ -131,7 +131,7 @@ func TestDetectError(t *testing.T) {
 	assert.EqualError(t, err, "[err1; err2; err3; err4; err6]")
 
 	expected := internal.NewResource(map[string]interface{}{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
+		conventions.AttributeCloudProvider:              conventions.AttributeCloudProviderGCP,
 		conventions.AttributeCloudInfrastructureService: conventions.AttributeCloudProviderGCPComputeEngine,
 	})
 


### PR DESCRIPTION
This adds missing `cloud.infrastructure_service` for ec2, gcp, and azure. The
docs were corrected for AWS services to reflect what the code was already
doing.

Detectors for gke and eks will be added in a following PR. Those detectors will
add their own service-specific `cloud.infrastructure_service`.