### PR TITLE
[resourcedetectionprocessor] Add task revision to ECS resource detector

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -65,6 +65,7 @@ ec2:
     * aws.ecs.cluster.arn
     * aws.ecs.task.arn
     * aws.ecs.task.family
+    * aws.ecs.task.revision
     * aws.ecs.launchtype (V4 only)
     * aws.log.group.names (V4 only)
     * aws.log.group.arns (V4 only)

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs.go
@@ -69,6 +69,7 @@ func (d *Detector) Detect(context.Context) (pdata.Resource, error) {
 	attr.InsertString(conventions.AttributeCloudInfrastructureService, conventions.AttributeCloudProviderAWSECS)
 	attr.InsertString("aws.ecs.task.arn", tmdeResp.TaskARN)
 	attr.InsertString("aws.ecs.task.family", tmdeResp.Family)
+	attr.InsertString("aws.ecs.task.revision", tmdeResp.Revision)
 
 	region, account := parseRegionAndAccount(tmdeResp.TaskARN)
 	if account != "" {

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
@@ -154,6 +154,7 @@ func Test_ecsDetectV3(t *testing.T) {
 	attr.InsertString("aws.ecs.cluster.arn", "arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster")
 	attr.InsertString("aws.ecs.task.arn", "arn:aws:ecs:us-west-2:123456789123:task/123")
 	attr.InsertString("aws.ecs.task.family", "family")
+	attr.InsertString("aws.ecs.task.revision", "26")
 	attr.InsertString("cloud.region", "us-west-2")
 	attr.InsertString("cloud.zone", "us-west-2a")
 	attr.InsertString("cloud.account.id", "123456789123")

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
@@ -42,6 +42,7 @@ func (md *mockMetaDataProvider) fetchTaskMetaData(tmde string) (*TaskMetaData, e
 		TaskARN:          "arn:aws:ecs:us-west-2:123456789123:task/123",
 		Family:           "family",
 		AvailabilityZone: "us-west-2a",
+		Revision:         "26",
 		Containers:       cs,
 	}
 
@@ -118,6 +119,7 @@ func Test_ecsDetectV4(t *testing.T) {
 	attr.InsertString("aws.ecs.cluster.arn", "arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster")
 	attr.InsertString("aws.ecs.task.arn", "arn:aws:ecs:us-west-2:123456789123:task/123")
 	attr.InsertString("aws.ecs.task.family", "family")
+	attr.InsertString("aws.ecs.task.revision", "26")
 	attr.InsertString("cloud.region", "us-west-2")
 	attr.InsertString("cloud.zone", "us-west-2a")
 	attr.InsertString("cloud.account.id", "123456789123")

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/metadata_ecs.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/metadata_ecs.go
@@ -27,6 +27,7 @@ type TaskMetaData struct {
 	TaskARN          string
 	Family           string
 	AvailabilityZone string
+	Revision         string
 	Containers       []Container
 }
 

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/metadata_ecs_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/metadata_ecs_test.go
@@ -31,6 +31,7 @@ const (
 		"Family":"myFamily",
 		"LaunchType":"ec2",
 		"AvailabilityZone":"ap-southeast-1a",
+		"Revision":"26",
 		"Containers": []
 	}`
 
@@ -75,6 +76,7 @@ func Test_ecsMetadata_fetchTask(t *testing.T) {
 	assert.Equal(t, "myFamily", fetchResp.Family)
 	assert.Equal(t, "ec2", fetchResp.LaunchType)
 	assert.Equal(t, "ap-southeast-1a", fetchResp.AvailabilityZone)
+	assert.Equal(t, "26", fetchResp.Revision)
 	assert.Empty(t, fetchResp.Containers)
 }
 


### PR DESCRIPTION
**Description:** 

Add task `Revision` field, defined as

> The revision of the Amazon ECS task definition for the task.

It is available in both the [v3](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html) and [v4](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html) endpoints.

**Link to tracking Issue:** n/a

**Testing:** Updated unit tests.

**Documentation:** Added to README
