### PR TITLE
[exporter/datadog]: add env normalization to trace payloads

### DIFF
--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -117,7 +117,7 @@ func aggregateTracePayloadsByEnv(tracePayloads []*pb.TracePayload) []*pb.TracePa
 // converts a Trace's resource spans into a trace payload
 func resourceSpansToDatadogSpans(rs pdata.ResourceSpans, calculator *sublayerCalculator, hostname string, cfg *config.Config) pb.TracePayload {
 	// get env tag
-	env := cfg.Env
+	env := utils.NormalizeTag(cfg.Env)
 
 	resource := rs.Resource()
 	ilss := rs.InstrumentationLibrarySpans()
@@ -138,7 +138,7 @@ func resourceSpansToDatadogSpans(rs pdata.ResourceSpans, calculator *sublayerCal
 	// specification states that the resource level deployment.environment should be used for passing env, so defer to that
 	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/deployment_environment.md#deployment
 	if resourceEnv, ok := datadogTags[conventions.AttributeDeploymentEnvironment]; ok {
-		payload.Env = resourceEnv
+		payload.Env = utils.NormalizeTag(resourceEnv)
 	}
 
 	apiTraces := map[uint64]*pb.APITrace{}

--- a/exporter/datadogexporter/utils/trace_helpers.go
+++ b/exporter/datadogexporter/utils/trace_helpers.go
@@ -136,6 +136,7 @@ func NormalizeServiceName(service string) string {
 
 // NormalizeTag applies some normalization to ensure the tags match the backend requirements.
 // Specifically used for env tag currently
+// port from: https://github.com/DataDog/datadog-agent/blob/c87e93a75b1fc97f0691faf78ae8eb2c280d6f55/pkg/trace/traceutil/normalize.go#L89
 func NormalizeTag(v string) string {
 	// the algorithm works by creating a set of cuts marking start and end offsets in v
 	// that have to be replaced with underscore (_)

--- a/exporter/datadogexporter/utils/trace_helpers.go
+++ b/exporter/datadogexporter/utils/trace_helpers.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
@@ -131,4 +132,118 @@ func NormalizeServiceName(service string) string {
 	}
 
 	return s
+}
+
+// NormalizeTag applies some normalization to ensure the tags match the backend requirements.
+// Specifically used for env tag currently
+func NormalizeTag(v string) string {
+	// the algorithm works by creating a set of cuts marking start and end offsets in v
+	// that have to be replaced with underscore (_)
+	if len(v) == 0 {
+		return ""
+	}
+	var (
+		trim  int      // start character (if trimming)
+		cuts  [][2]int // sections to discard: (start, end) pairs
+		chars int      // number of characters processed
+	)
+	var (
+		i    int  // current byte
+		r    rune // current rune
+		jump int  // tracks how many bytes the for range advances on its next iteration
+	)
+	tag := []byte(v)
+	for i, r = range v {
+		jump = utf8.RuneLen(r) // next i will be i+jump
+		if r == utf8.RuneError {
+			// On invalid UTF-8, the for range advances only 1 byte (see: https://golang.org/ref/spec#For_range (point 2)).
+			// However, utf8.RuneError is equivalent to unicode.ReplacementChar so we should rely on utf8.DecodeRune to tell
+			// us whether this is an actual error or just a unicode.ReplacementChar that was present in the string.
+			_, width := utf8.DecodeRune(tag[i:])
+			jump = width
+		}
+		// fast path; all letters (and colons) are ok
+		switch {
+		case r >= 'a' && r <= 'z' || r == ':':
+			chars++
+			goto end
+		case r >= 'A' && r <= 'Z':
+			// lower-case
+			tag[i] += 'a' - 'A'
+			chars++
+			goto end
+		}
+		if unicode.IsUpper(r) {
+			// lowercase this character
+			if low := unicode.ToLower(r); utf8.RuneLen(r) == utf8.RuneLen(low) {
+				// but only if the width of the lowercased character is the same;
+				// there are some rare edge-cases where this is not the case, such
+				// as \u017F (ſ)
+				utf8.EncodeRune(tag[i:], low)
+				r = low
+			}
+		}
+		switch {
+		case unicode.IsLetter(r):
+			chars++
+		case chars == 0:
+			// this character can not start the string, trim
+			trim = i + jump
+			goto end
+		case unicode.IsDigit(r) || r == '.' || r == '/' || r == '-':
+			chars++
+		default:
+			// illegal character
+			if n := len(cuts); n > 0 && cuts[n-1][1] >= i {
+				// merge intersecting cuts
+				cuts[n-1][1] += jump
+			} else {
+				// start a new cut
+				cuts = append(cuts, [2]int{i, i + jump})
+			}
+		}
+	end:
+		if i+jump >= 2*MaxTagLength {
+			// bail early if the tag contains a lot of non-letter/digit characters.
+			// If a tag is test🍣🍣[...]🍣, then it's unlikely to be a properly formatted tag
+			break
+		}
+		if chars >= MaxTagLength {
+			// we've reached the maximum
+			break
+		}
+	}
+
+	tag = tag[trim : i+jump] // trim start and end
+	if len(cuts) == 0 {
+		// tag was ok, return it as it is
+		return string(tag)
+	}
+	delta := trim // cut offsets delta
+	for _, cut := range cuts {
+		// start and end of cut, including delta from previous cuts:
+		start, end := cut[0]-delta, cut[1]-delta
+
+		if end >= len(tag) {
+			// this cut includes the end of the string; discard it
+			// completely and finish the loop.
+			tag = tag[:start]
+			break
+		}
+		// replace the beginning of the cut with '_'
+		tag[start] = '_'
+		if end-start == 1 {
+			// nothing to discard
+			continue
+		}
+		// discard remaining characters in the cut
+		copy(tag[start+1:], tag[end:])
+
+		// shorten the slice
+		tag = tag[:len(tag)-(end-start)+1]
+
+		// count the new delta for future cuts
+		delta += cut[1] - cut[0] - 1
+	}
+	return string(tag)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This PR adds additional normalization to the datadogexporter for ensuring that the `env` output matches what the [`datadogagent` output would be](https://github.com/DataDog/datadog-agent/blob/c87e93a75b1fc97f0691faf78ae8eb2c280d6f55/pkg/trace/traceutil/normalize.go#L89). Specifically, we want to ensure that envs are lowercased

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Added unit tests

**Documentation:** <Describe the documentation added.>

