### PR TITLE
[awsemfexporter] Loosen assertion for floating point comparison.

### DIFF
--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -307,7 +307,7 @@ func TestIntDataPointSliceAt(t *testing.T) {
 			assert.Equal(t, 1, dps.Len())
 			dp := dps.At(0)
 			if strings.Contains(tc.testName, "2nd rate") {
-				assert.InDelta(t, expectedDP.Value.(float64), dp.Value.(float64), 0.01)
+				assert.InDelta(t, expectedDP.Value.(float64), dp.Value.(float64), 0.02)
 			} else {
 				assert.Equal(t, expectedDP, dp)
 			}


### PR DESCRIPTION
**Description:** Loosen comparison of floating point a bit since sometimes it's just off

**Link to tracking Issue:** Fixes #2792 

@mxiamxia Please check to see if this delta makes any sense - I noticed the flaky behavior is still quite close to 0.01, 0.0108, so it seems like it's probably OK at a glance.

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>