### PR TITLE
Set spanmetricsprocessor call metric IsMonotonic to true

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -246,7 +246,7 @@ func (p *processorImp) collectCallMetrics(ilm *pdata.InstrumentationLibraryMetri
 
 		mCalls := pdata.NewMetric()
 		mCalls.SetDataType(pdata.MetricDataTypeIntSum)
-		mCalls.SetName("calls")
+		mCalls.SetName("calls_total")
 		mCalls.IntSum().SetIsMonotonic(true)
 		mCalls.IntSum().DataPoints().Append(dpCalls)
 		mCalls.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -247,6 +247,7 @@ func (p *processorImp) collectCallMetrics(ilm *pdata.InstrumentationLibraryMetri
 		mCalls := pdata.NewMetric()
 		mCalls.SetDataType(pdata.MetricDataTypeIntSum)
 		mCalls.SetName("calls")
+		mCalls.IntSum().SetIsMonotonic(true)
 		mCalls.IntSum().DataPoints().Append(dpCalls)
 		mCalls.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 		ilm.Metrics().Append(mCalls)

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -311,7 +311,7 @@ func verifyConsumeMetricsInput(input pdata.Metrics, t *testing.T) bool {
 
 		data := m.At(mi).IntSum()
 		assert.Equal(t, pdata.AggregationTemporalityCumulative, data.AggregationTemporality())
-		assert.Equal(t, true, data.IsMonotonic())
+		assert.True(t, data.IsMonotonic())
 
 		dps := data.DataPoints()
 		require.Equal(t, 1, dps.Len())

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -307,10 +307,11 @@ func verifyConsumeMetricsInput(input pdata.Metrics, t *testing.T) bool {
 	mi := 0
 	// The first 3 metrics are for call counts.
 	for ; mi < 3; mi++ {
-		assert.Equal(t, "calls", m.At(mi).Name())
+		assert.Equal(t, "calls_total", m.At(mi).Name())
 
 		data := m.At(mi).IntSum()
 		assert.Equal(t, pdata.AggregationTemporalityCumulative, data.AggregationTemporality())
+		assert.Equal(t, true, data.IsMonotonic())
 
 		dps := data.DataPoints()
 		require.Equal(t, 1, dps.Len())


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

As mentioned in the issue, set `IsMonotonic` to true.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2829

**Testing:** Tested manually with prometheusremotewrite exporter and it works well.
![Screenshot from 2021-03-23 20-34-10](https://user-images.githubusercontent.com/25150124/112236561-281c1e80-8c17-11eb-8b6c-52a1c0c4a4ab.png)


**Documentation:** <Describe the documentation added.>