### PR TITLE
Add ResourceAttributes to Splunk Event

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -185,6 +185,7 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld pdata.Logs, send f
 
 	var rls = ld.ResourceLogs()
 	for i := 0; i < rls.Len(); i++ {
+		res := rls.At(i).Resource()
 		ills := rls.At(i).InstrumentationLibraryLogs()
 		for j := 0; j < ills.Len(); j++ {
 			logs := ills.At(j).Logs()
@@ -194,7 +195,7 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld pdata.Logs, send f
 				}
 
 				// Parsing log record to Splunk event.
-				event := mapLogRecordToSplunkEvent(logs.At(k), c.config, c.logger)
+				event := mapLogRecordToSplunkEvent(res, logs.At(k), c.config, c.logger)
 				// JSON encoding event and writing to buffer.
 				if err = encoder.Encode(event); err != nil {
 					permanentErrors = append(permanentErrors, consumererror.Permanent(fmt.Errorf("dropped log event: %v, error: %v", event, err)))

--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -32,6 +32,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 	tests := []struct {
 		name             string
 		logRecordFn      func() pdata.LogRecord
+		logResourceFn    func() pdata.Resource
 		configDataFn     func() *Config
 		wantSplunkEvents []*splunk.Event
 	}{
@@ -47,6 +48,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -70,6 +72,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -89,6 +92,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -105,6 +109,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord := pdata.NewLogRecord()
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -127,6 +132,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -149,6 +155,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -171,6 +178,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -197,6 +205,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -220,6 +229,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -246,6 +256,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
+			logResourceFn: pdata.NewResource,
 			configDataFn: func() *Config {
 				return &Config{
 					Source:     "source",
@@ -257,11 +268,45 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 					"myhost", "myapp", "myapp-type"),
 			},
 		},
+		{
+			name: "log resource attribute",
+			logRecordFn: func() pdata.LogRecord {
+				logRecord := pdata.NewLogRecord()
+				logRecord.Body().SetStringVal("mylog")
+				logRecord.Attributes().InsertString(conventions.AttributeServiceName, "myapp")
+				logRecord.Attributes().InsertString(conventions.AttributeHostName, "myhost")
+				logRecord.Attributes().InsertString("custom", "custom")
+				logRecord.SetTimestamp(ts)
+				return logRecord
+			},
+			logResourceFn: func() pdata.Resource {
+				attr := map[string]pdata.AttributeValue{
+					"resourceAttr1":        pdata.NewAttributeValueString("some_string"),
+					splunk.SourcetypeLabel: pdata.NewAttributeValueString("myapp-type-from-resource-attr"),
+				}
+				resource := pdata.NewResource()
+
+				for key, value := range attr {
+					resource.Attributes().Insert(key, value)
+				}
+				return resource
+			},
+			configDataFn: func() *Config {
+				return &Config{
+					Source:     "source",
+					SourceType: "sourcetype",
+				}
+			},
+			wantSplunkEvents: []*splunk.Event{
+				commonLogSplunkEvent("mylog", ts, map[string]interface{}{"custom": "custom", "service.name": "myapp", "host.name": "myhost", "resourceAttr1": "some_string"},
+					"myhost", "myapp", "myapp-type-from-resource-attr"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, want := range tt.wantSplunkEvents {
-				got := mapLogRecordToSplunkEvent(tt.logRecordFn(), tt.configDataFn(), logger)
+				got := mapLogRecordToSplunkEvent(tt.logResourceFn(), tt.logRecordFn(), tt.configDataFn(), logger)
 				assert.EqualValues(t, want, got)
 			}
 		})
@@ -297,7 +342,7 @@ func commonLogSplunkEvent(
 }
 
 func Test_emptyLogRecord(t *testing.T) {
-	event := mapLogRecordToSplunkEvent(pdata.NewLogRecord(), &Config{}, zap.NewNop())
+	event := mapLogRecordToSplunkEvent(pdata.NewResource(), pdata.NewLogRecord(), &Config{}, zap.NewNop())
 	assert.Nil(t, event.Time)
 	assert.Equal(t, event.Host, "unknown")
 	assert.Zero(t, event.Source)


### PR DESCRIPTION
**Description:** 
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2799

**Testing:** 
```
ResourceLog #6
Resource labels:
     -> k8s.container.name: STRING(loggen)
     -> k8s.pod.uid: STRING(f7880852-38f9-4158-b37a-41b3436a3b95)
     -> k8s.namespace.name: STRING(default)
     -> k8s.pod.startTime: STRING(2021-03-24 23:18:27 +0000 UTC)
     -> k8s.node.name: STRING(ip-192-168-68-130.us-west-1.compute.internal)
     -> k8s.pod.labels.hello: STRING(world)
     -> k8s.pod.labels.app: STRING(appName)
     -> k8s.pod.annotations.splunk.com/index: STRING(main)
     -> host.name: STRING(ip-192-168-68-130.us-west-1.compute.internal)
     -> com.splunk.sourcetype: STRING(loggen)
     -> com.splunk.index: STRING(main)
InstrumentationLibraryLogs #0
InstrumentationLibrary
LogRecord #0
Timestamp: 1616627909498109658
Severity: Undefined
ShortName:
Body: {
     -> log: STRING(EPS: 99
)
}
Attributes:
     -> k8s.namespace.name: STRING(default)
     -> k8s.pod.name: STRING(loggen-65dvk)
     -> run_id: STRING(0)
     -> k8s.container.name: STRING(loggen)
```

![image](https://user-images.githubusercontent.com/12387289/112396117-d7f79780-8cbc-11eb-879f-07bb1eb4413a.png)

**Documentation:**
I fixed documentation for k8sprocessor as well.