### PR TITLE
[spanmetricsprocessor] Validate duplicate dimensions at start

### DIFF
--- a/processor/spanmetricsprocessor/factory.go
+++ b/processor/spanmetricsprocessor/factory.go
@@ -47,5 +47,5 @@ func createDefaultConfig() configmodels.Processor {
 }
 
 func createTraceProcessor(_ context.Context, params component.ProcessorCreateParams, cfg configmodels.Processor, nextConsumer consumer.Traces) (component.TracesProcessor, error) {
-	return newProcessor(params.Logger, cfg, nextConsumer), nil
+	return newProcessor(params.Logger, cfg, nextConsumer)
 }

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configmodels"
@@ -38,6 +39,9 @@ const (
 	spanKindKey        = tracetranslator.TagSpanKind
 	statusCodeKey      = tracetranslator.TagStatusCode
 	metricKeySeparator = string(byte(0))
+
+	delimiter = "_"
+	keyStr    = "key"
 )
 
 var (
@@ -82,7 +86,7 @@ type processorImp struct {
 	metricKeyToDimensions map[metricKey]dimKV
 }
 
-func newProcessor(logger *zap.Logger, config configmodels.Exporter, nextConsumer consumer.Traces) *processorImp {
+func newProcessor(logger *zap.Logger, config configmodels.Exporter, nextConsumer consumer.Traces) (*processorImp, error) {
 	logger.Info("Building spanmetricsprocessor")
 	pConfig := config.(*Config)
 
@@ -98,6 +102,10 @@ func newProcessor(logger *zap.Logger, config configmodels.Exporter, nextConsumer
 		}
 	}
 
+	if err := validateDimensions(pConfig.Dimensions); err != nil {
+		return nil, err
+	}
+
 	return &processorImp{
 		logger:                logger,
 		config:                *pConfig,
@@ -110,7 +118,7 @@ func newProcessor(logger *zap.Logger, config configmodels.Exporter, nextConsumer
 		nextConsumer:          nextConsumer,
 		dimensions:            pConfig.Dimensions,
 		metricKeyToDimensions: make(map[metricKey]dimKV),
-	}
+	}, nil
 }
 
 func mapDurationsToMillis(vs []time.Duration, f func(duration time.Duration) float64) []float64 {
@@ -119,6 +127,35 @@ func mapDurationsToMillis(vs []time.Duration, f func(duration time.Duration) flo
 		vsm[i] = f(v)
 	}
 	return vsm
+}
+
+// validateDimensions checks duplicates for reserved dimensions and additional dimensions. Considering
+// the usage of Prometheus related exporters, we also validate the dimensions after sanitization.
+func validateDimensions(dimensions []Dimension) error {
+	labelNames := make(map[string]struct{})
+	for _, key := range []string{serviceNameKey, spanKindKey, statusCodeKey} {
+		labelNames[key] = struct{}{}
+		labelNames[sanitize(key)] = struct{}{}
+	}
+	labelNames[operationKey] = struct{}{}
+
+	for _, key := range dimensions {
+		if _, ok := labelNames[key.Name]; ok {
+			return fmt.Errorf("duplicate dimension name %s", key.Name)
+		}
+		labelNames[key.Name] = struct{}{}
+
+		sanitizedName := sanitize(key.Name)
+		if sanitizedName == key.Name {
+			continue
+		}
+		if _, ok := labelNames[sanitizedName]; ok {
+			return fmt.Errorf("duplicate dimension name %s after sanitization", sanitizedName)
+		}
+		labelNames[sanitizedName] = struct{}{}
+	}
+
+	return nil
 }
 
 // Start implements the component.Component interface.
@@ -378,4 +415,34 @@ func (p *processorImp) cache(serviceName string, span pdata.Span, k metricKey) {
 	if _, ok := p.metricKeyToDimensions[k]; !ok {
 		p.metricKeyToDimensions[k] = buildDimensionKVs(serviceName, span, p.dimensions)
 	}
+}
+
+// copied from prometheus-go-metric-exporter
+// sanitize replaces non-alphanumeric characters with underscores in s.
+func sanitize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+
+	// Note: No length limit for label keys because Prometheus doesn't
+	// define a length limit, thus we should NOT be truncating label keys.
+	// See https://github.com/orijtech/prometheus-go-metrics-exporter/issues/4.
+	s = strings.Map(sanitizeRune, s)
+	if unicode.IsDigit(rune(s[0])) {
+		s = keyStr + delimiter + s
+	}
+	if s[0] == '_' {
+		s = keyStr + s
+	}
+	return s
+}
+
+// copied from prometheus-go-metric-exporter
+// sanitizeRune converts anything that is not a letter or digit to an underscore
+func sanitizeRune(r rune) rune {
+	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		return r
+	}
+	// Everything else turns into an underscore
+	return '_'
 }

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -39,9 +39,6 @@ const (
 	spanKindKey        = tracetranslator.TagSpanKind
 	statusCodeKey      = tracetranslator.TagStatusCode
 	metricKeySeparator = string(byte(0))
-
-	delimiter = "_"
-	keyStr    = "key"
 )
 
 var (
@@ -429,10 +426,10 @@ func sanitize(s string) string {
 	// See https://github.com/orijtech/prometheus-go-metrics-exporter/issues/4.
 	s = strings.Map(sanitizeRune, s)
 	if unicode.IsDigit(rune(s[0])) {
-		s = keyStr + delimiter + s
+		s = "key_" + s
 	}
 	if s[0] == '_' {
-		s = keyStr + s
+		s = "key" + s
 	}
 	return s
 }

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -16,6 +16,7 @@ package spanmetricsprocessor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -125,8 +126,9 @@ func TestProcessorShutdown(t *testing.T) {
 
 	// Test
 	next := new(consumertest.TracesSink)
-	p := newProcessor(zap.NewNop(), cfg, next)
-	err := p.Shutdown(context.Background())
+	p, err := newProcessor(zap.NewNop(), cfg, next)
+	assert.NoError(t, err)
+	err = p.Shutdown(context.Background())
 
 	// Verify
 	assert.NoError(t, err)
@@ -139,7 +141,8 @@ func TestProcessorCapabilities(t *testing.T) {
 
 	// Test
 	next := new(consumertest.TracesSink)
-	p := newProcessor(zap.NewNop(), cfg, next)
+	p, err := newProcessor(zap.NewNop(), cfg, next)
+	assert.NoError(t, err)
 	caps := p.GetCapabilities()
 
 	// Verify
@@ -492,4 +495,77 @@ func TestBuildKey(t *testing.T) {
 	k1 := buildKey("a", span1, nil)
 
 	assert.NotEqual(t, k0, k1)
+}
+
+func TestValidateDimensions(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		dimensions  []Dimension
+		hasError bool
+		expectedErr error
+	}{
+		{
+			name: "no additional dimensions",
+			dimensions: []Dimension{},
+			hasError: false,
+		},
+		{
+			name: "no duplicate dimensions",
+			dimensions: []Dimension{
+				{Name: "http.service_name"},
+				{Name: "http.status_code"},
+			},
+			hasError: false,
+		},
+		{
+			name: "duplicate dimension with reserved labels",
+			dimensions: []Dimension{
+				{Name: "service.name"},
+			},
+			hasError: true,
+			expectedErr: errors.New("duplicate dimension name service.name"),
+		},
+		{
+			name: "duplicate dimension with reserved labels after sanitization",
+			dimensions: []Dimension{
+				{Name: "service_name"},
+			},
+			hasError: true,
+			expectedErr: errors.New("duplicate dimension name service_name after sanitization"),
+		},
+		{
+			name: "duplicate additional dimensions",
+			dimensions: []Dimension{
+				{Name: "service_name"},
+				{Name: "service_name"},
+			},
+			hasError: true,
+			expectedErr: errors.New("duplicate dimension name service_name sanitization"),
+		},
+		{
+			name: "duplicate additional dimensions after sanitization",
+			dimensions: []Dimension{
+				{Name: "http.status_code"},
+				{Name: "http_status_code"},
+			},
+			hasError: true,
+			expectedErr: errors.New("duplicate dimension name http_status_code sanitization"),
+		},
+		{
+			name: "we skip the case if the dimension name is the same after sanitization",
+			dimensions: []Dimension{
+				{Name: "http_status_code"},
+			},
+			hasError: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDimensions(tc.dimensions)
+			if tc.hasError {
+				assert.Error(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -555,9 +555,9 @@ func TestValidateDimensions(t *testing.T) {
 			name: "duplicate additional dimensions after sanitization",
 			dimensions: []Dimension{
 				{Name: "http.status_code"},
-				{Name: "http_status_code"},
+				{Name: "http!status_code"},
 			},
-			expectedErr: "duplicate dimension name http_status_code",
+			expectedErr: "duplicate dimension name http_status_code after sanitization",
 		},
 		{
 			name: "we skip the case if the dimension name is the same after sanitization",


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This pr adds a check at the start of span metrics processor for possible label duplication of the reserved dimensions and user-configured dimensions.

**Link to tracking Issue:** This fixes the problem mentioned in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2772#issuecomment-805347326

**Testing:** Added a unit test for the new `validateDimensions` method.

**Documentation:** <Describe the documentation added.>