### PR TITLE
 Add consumer group metrics to kafkametricsreceiver

### DIFF
--- a/receiver/kafkametricsreceiver/broker_scraper.go
+++ b/receiver/kafkametricsreceiver/broker_scraper.go
@@ -61,7 +61,7 @@ func (s *brokerScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, err
 func createBrokerScraper(_ context.Context, config Config, saramaConfig *sarama.Config, logger *zap.Logger) (scraperhelper.ResourceMetricsScraper, error) {
 	client, err := newSaramaClient(config.Brokers, saramaConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create sarama client: %w ", err)
+		return nil, fmt.Errorf("failed to create sarama client: %w", err)
 	}
 	s := brokerScraper{
 		client: client,

--- a/receiver/kafkametricsreceiver/broker_scraper.go
+++ b/receiver/kafkametricsreceiver/broker_scraper.go
@@ -16,6 +16,7 @@ package kafkametricsreceiver
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -60,7 +61,7 @@ func (s *brokerScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, err
 func createBrokerScraper(_ context.Context, config Config, saramaConfig *sarama.Config, logger *zap.Logger) (scraperhelper.ResourceMetricsScraper, error) {
 	client, err := newSaramaClient(config.Brokers, saramaConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create sarama client: %w ", err)
 	}
 	s := brokerScraper{
 		client: client,

--- a/receiver/kafkametricsreceiver/broker_scraper.go
+++ b/receiver/kafkametricsreceiver/broker_scraper.go
@@ -34,7 +34,7 @@ type brokerScraper struct {
 }
 
 func (s *brokerScraper) Name() string {
-	return "brokers"
+	return brokersScraperName
 }
 
 func (s *brokerScraper) shutdown(context.Context) error {

--- a/receiver/kafkametricsreceiver/broker_scraper_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_test.go
@@ -56,7 +56,7 @@ func TestBrokerShutdown_closed(t *testing.T) {
 
 func TestBrokerScraper_Name(t *testing.T) {
 	s := brokerScraper{}
-	assert.Equal(t, s.Name(), "brokers")
+	assert.Equal(t, s.Name(), brokersScraperName)
 }
 
 func TestBrokerScraper_createBrokerScraper(t *testing.T) {

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -160,15 +160,15 @@ func createConsumerScraper(_ context.Context, config Config, saramaConfig *saram
 	}
 	topicFilter, err := regexp.Compile(config.TopicMatch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compile topic filter: %w ", err)
+		return nil, fmt.Errorf("failed to compile topic filter: %w", err)
 	}
 	client, err := newSaramaClient(config.Brokers, saramaConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create sarama client: %w ", err)
+		return nil, fmt.Errorf("failed to create sarama client: %w", err)
 	}
 	clusterAdmin, err := newClusterAdmin(config.Brokers, saramaConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create sarama cluster admin: %w ", err)
+		return nil, fmt.Errorf("failed to create sarama cluster admin: %w", err)
 	}
 	s := consumerScraper{
 		client:       client,

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -16,6 +16,7 @@ package kafkametricsreceiver
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -155,19 +156,19 @@ func (s *consumerScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, e
 func createConsumerScraper(_ context.Context, config Config, saramaConfig *sarama.Config, logger *zap.Logger) (scraperhelper.ResourceMetricsScraper, error) {
 	groupFilter, err := regexp.Compile(config.GroupMatch)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to compile group_match: %w", err)
 	}
 	topicFilter, err := regexp.Compile(config.TopicMatch)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to compile topic filter: %w ", err)
 	}
 	client, err := newSaramaClient(config.Brokers, saramaConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create sarama client: %w ", err)
 	}
 	clusterAdmin, err := newClusterAdmin(config.Brokers, saramaConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create sarama cluster admin: %w ", err)
 	}
 	s := consumerScraper{
 		client:       client,

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -153,8 +153,14 @@ func (s *consumerScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, e
 }
 
 func createConsumerScraper(_ context.Context, config Config, saramaConfig *sarama.Config, logger *zap.Logger) (scraperhelper.ResourceMetricsScraper, error) {
-	groupFilter := regexp.MustCompile(config.GroupMatch)
-	topicFilter := regexp.MustCompile(config.TopicMatch)
+	groupFilter, err := regexp.Compile(config.GroupMatch)
+	if err != nil {
+		return nil, err
+	}
+	topicFilter, err := regexp.Compile(config.TopicMatch)
+	if err != nil {
+		return nil, err
+	}
 	client, err := newSaramaClient(config.Brokers, saramaConfig)
 	if err != nil {
 		return nil, err

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -16,13 +16,13 @@ package kafkametricsreceiver
 
 import (
 	"context"
-	"github.com/Shopify/sarama"
-	"go.opentelemetry.io/collector/receiver/scrapererror"
 	"regexp"
 	"time"
 
+	"github.com/Shopify/sarama"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/consumer/simple"
+	"go.opentelemetry.io/collector/receiver/scrapererror"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/zap"
 

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -1,0 +1,179 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkametricsreceiver
+
+import (
+	"context"
+	"github.com/Shopify/sarama"
+	"go.opentelemetry.io/collector/receiver/scrapererror"
+	"regexp"
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/consumer/simple"
+	"go.opentelemetry.io/collector/receiver/scraperhelper"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver/internal/metadata"
+)
+
+type consumerScraper struct {
+	client       sarama.Client
+	logger       *zap.Logger
+	groupFilter  *regexp.Regexp
+	topicFilter  *regexp.Regexp
+	clusterAdmin sarama.ClusterAdmin
+}
+
+func (s *consumerScraper) Name() string {
+	return "consumers"
+}
+
+func (s *consumerScraper) shutdown(_ context.Context) error {
+	if !s.client.Closed() {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func (s *consumerScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, error) {
+	metrics := simple.Metrics{
+		Metrics:                    pdata.NewMetrics(),
+		Timestamp:                  time.Now(),
+		MetricFactoriesByName:      metadata.M.FactoriesByName(),
+		InstrumentationLibraryName: InstrumentationLibName,
+	}
+
+	cgs, listErr := s.clusterAdmin.ListConsumerGroups()
+	if listErr != nil {
+		return metrics.ResourceMetrics(), listErr
+	}
+
+	var matchedGrpIds []string
+	for grpID := range cgs {
+		if s.groupFilter.MatchString(grpID) {
+			matchedGrpIds = append(matchedGrpIds, grpID)
+		}
+	}
+
+	allTopics, listErr := s.clusterAdmin.ListTopics()
+	if listErr != nil {
+		return metrics.ResourceMetrics(), listErr
+	}
+
+	matchedTopics := make(map[string]sarama.TopicDetail)
+	for t, d := range allTopics {
+		if s.topicFilter.MatchString(t) {
+			matchedTopics[t] = d
+		}
+	}
+	var scrapeErrors = scrapererror.ScrapeErrors{}
+	// partitionIds in matchedTopics
+	topicPartitions := make(map[string][]int32)
+	// currentOffset for each partition in matchedTopics
+	topicPartitionOffset := make(map[string]map[int32]int64)
+	for topic := range matchedTopics {
+		topicPartitions[topic] = make([]int32, 0)
+		topicPartitionOffset[topic] = make(map[int32]int64)
+		partitions, err := s.client.Partitions(topic)
+		if err != nil {
+			scrapeErrors.Add(err)
+			continue
+		}
+		for _, p := range partitions {
+			o, err := s.client.GetOffset(topic, p, sarama.OffsetNewest)
+			if err != nil {
+				scrapeErrors.Add(err)
+				continue
+			}
+			topicPartitions[topic] = append(topicPartitions[topic], p)
+			topicPartitionOffset[topic][p] = o
+		}
+	}
+	consumerGroups, listErr := s.clusterAdmin.DescribeConsumerGroups(matchedGrpIds)
+	if listErr != nil {
+		return metrics.ResourceMetrics(), listErr
+	}
+	for _, group := range consumerGroups {
+		grpMetrics := metrics.WithLabels(map[string]string{metadata.L.Group: group.GroupId})
+		grpMetrics.AddGaugeDataPoint(metadata.M.KafkaConsumerGroupMembers.Name(), int64(len(group.Members)))
+		groupOffsetFetchResponse, err := s.clusterAdmin.ListConsumerGroupOffsets(group.GroupId, topicPartitions)
+		if err != nil {
+			scrapeErrors.Add(err)
+			continue
+		}
+		for topic, partitions := range groupOffsetFetchResponse.Blocks {
+			// tracking matchedTopics consumed by this group
+			// by checking if any of the blocks has an offset
+			isConsumed := false
+			for _, block := range partitions {
+				if block.Offset != -1 {
+					isConsumed = true
+					break
+				}
+			}
+			grpTopicMetrics := grpMetrics.WithLabels(map[string]string{metadata.L.Topic: topic})
+			if isConsumed {
+				var lagSum int64 = 0
+				var offsetSum int64 = 0
+				for partition, block := range partitions {
+					grpPartitionMetrics := grpTopicMetrics.WithLabels(map[string]string{metadata.L.Partition: string(partition)})
+					consumerOffset := block.Offset
+					offsetSum += consumerOffset
+					grpPartitionMetrics.AddGaugeDataPoint(metadata.M.KafkaConsumerGroupOffset.Name(), consumerOffset)
+					// default -1 to indicate no lag measured.
+					var consumerLag int64 = -1
+					if partitionOffset, ok := topicPartitionOffset[topic][partition]; ok {
+						// only consider partitions with an offset
+						if block.Offset != -1 {
+							consumerLag = partitionOffset - consumerOffset
+							lagSum += consumerLag
+						}
+					}
+					grpPartitionMetrics.AddGaugeDataPoint(metadata.M.KafkaConsumerGroupLag.Name(), consumerLag)
+				}
+				grpTopicMetrics.AddGaugeDataPoint(metadata.M.KafkaConsumerGroupOffsetSum.Name(), offsetSum)
+				grpTopicMetrics.AddGaugeDataPoint(metadata.M.KafkaConsumerGroupLagSum.Name(), lagSum)
+			}
+		}
+	}
+
+	return metrics.ResourceMetrics(), scrapeErrors.Combine()
+}
+
+func createConsumerScraper(_ context.Context, config Config, saramaConfig *sarama.Config, logger *zap.Logger) (scraperhelper.ResourceMetricsScraper, error) {
+	groupFilter := regexp.MustCompile(config.GroupMatch)
+	topicFilter := regexp.MustCompile(config.TopicMatch)
+	client, err := newSaramaClient(config.Brokers, saramaConfig)
+	if err != nil {
+		return nil, err
+	}
+	clusterAdmin, err := newClusterAdmin(config.Brokers, saramaConfig)
+	if err != nil {
+		return nil, err
+	}
+	s := consumerScraper{
+		client:       client,
+		logger:       logger,
+		groupFilter:  groupFilter,
+		topicFilter:  topicFilter,
+		clusterAdmin: clusterAdmin,
+	}
+	return scraperhelper.NewResourceMetricsScraper(
+		s.Name(),
+		s.scrape,
+		scraperhelper.WithShutdown(s.shutdown),
+	), nil
+}

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -38,7 +38,7 @@ type consumerScraper struct {
 }
 
 func (s *consumerScraper) Name() string {
-	return "consumers"
+	return consumersScraperName
 }
 
 func (s *consumerScraper) shutdown(_ context.Context) error {

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -73,20 +73,19 @@ func (s *consumerScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, e
 		return metrics.ResourceMetrics(), listErr
 	}
 
-	matchedTopics := make(map[string]sarama.TopicDetail)
+	matchedTopics := map[string]sarama.TopicDetail{}
 	for t, d := range allTopics {
 		if s.topicFilter.MatchString(t) {
 			matchedTopics[t] = d
 		}
 	}
-	var scrapeErrors = scrapererror.ScrapeErrors{}
+	scrapeErrors := scrapererror.ScrapeErrors{}
 	// partitionIds in matchedTopics
-	topicPartitions := make(map[string][]int32)
+	topicPartitions := map[string][]int32{}
 	// currentOffset for each partition in matchedTopics
-	topicPartitionOffset := make(map[string]map[int32]int64)
+	topicPartitionOffset := map[string]map[int32]int64{}
 	for topic := range matchedTopics {
-		topicPartitions[topic] = make([]int32, 0)
-		topicPartitionOffset[topic] = make(map[int32]int64)
+		topicPartitionOffset[topic] = map[int32]int64{}
 		partitions, err := s.client.Partitions(topic)
 		if err != nil {
 			scrapeErrors.Add(err)

--- a/receiver/kafkametricsreceiver/consumer_scraper_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_test.go
@@ -86,6 +86,28 @@ func TestConsumerScraper_createScraper_handles_clusterAdmin_error(t *testing.T) 
 	assert.Nil(t, ms)
 }
 
+func TestConsumerScraper_createScraper_handles_invalid_topic_match(t *testing.T) {
+	newSaramaClient = mockNewSaramaClient
+	newClusterAdmin = mockNewClusterAdmin
+	sc := sarama.NewConfig()
+	ms, err := createConsumerScraper(context.Background(), Config{
+		TopicMatch: "[",
+	}, sc, zap.NewNop())
+	assert.NotNil(t, err)
+	assert.Nil(t, ms)
+}
+
+func TestConsumerScraper_createScraper_handles_invalid_group_match(t *testing.T) {
+	newSaramaClient = mockNewSaramaClient
+	newClusterAdmin = mockNewClusterAdmin
+	sc := sarama.NewConfig()
+	ms, err := createConsumerScraper(context.Background(), Config{
+		GroupMatch: "[",
+	}, sc, zap.NewNop())
+	assert.NotNil(t, err)
+	assert.Nil(t, ms)
+}
+
 func TestConsumerScraper_scrape(t *testing.T) {
 	filter := regexp.MustCompile(defaultGroupMatch)
 	cs := consumerScraper{

--- a/receiver/kafkametricsreceiver/consumer_scraper_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_test.go
@@ -53,7 +53,7 @@ func TestConsumerShutdown_closed(t *testing.T) {
 
 func TestConsumerScraper_Name(t *testing.T) {
 	s := consumerScraper{}
-	assert.Equal(t, s.Name(), "consumers")
+	assert.Equal(t, s.Name(), consumersScraperName)
 }
 
 func TestConsumerScraper_createConsumerScraper(t *testing.T) {

--- a/receiver/kafkametricsreceiver/consumer_scraper_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_test.go
@@ -1,0 +1,183 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkametricsreceiver
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestConsumerShutdown(t *testing.T) {
+	client := newMockClient()
+	client.closed = false
+	client.close = nil
+	client.Mock.
+		On("Close").Return(nil).
+		On("Closed").Return(false)
+	scraper := consumerScraper{
+		client: client,
+	}
+	_ = scraper.shutdown(context.Background())
+	client.AssertExpectations(t)
+}
+
+func TestConsumerShutdown_closed(t *testing.T) {
+	client := newMockClient()
+	client.closed = true
+	client.Mock.
+		On("Closed").Return(true)
+	scraper := consumerScraper{
+		client: client,
+	}
+	_ = scraper.shutdown(context.Background())
+	client.AssertExpectations(t)
+}
+
+func TestConsumerScraper_Name(t *testing.T) {
+	s := consumerScraper{}
+	assert.Equal(t, s.Name(), "consumers")
+}
+
+func TestConsumerScraper_createConsumerScraper(t *testing.T) {
+	sc := sarama.NewConfig()
+	newSaramaClient = mockNewSaramaClient
+	newClusterAdmin = mockNewClusterAdmin
+	ms, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.Nil(t, err)
+	assert.NotNil(t, ms)
+}
+
+func TestConsumerScraper_createScraper_handles_client_error(t *testing.T) {
+	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
+		return nil, fmt.Errorf("new client failed")
+	}
+	sc := sarama.NewConfig()
+	ms, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NotNil(t, err)
+	assert.Nil(t, ms)
+}
+
+func TestConsumerScraper_createScraper_handles_clusterAdmin_error(t *testing.T) {
+	newSaramaClient = mockNewSaramaClient
+	newClusterAdmin = func(addrs []string, conf *sarama.Config) (sarama.ClusterAdmin, error) {
+		return nil, fmt.Errorf("new cluster admin failed")
+	}
+	sc := sarama.NewConfig()
+	ms, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NotNil(t, err)
+	assert.Nil(t, ms)
+}
+
+func TestConsumerScraper_scrape(t *testing.T) {
+	filter := regexp.MustCompile(defaultGroupMatch)
+	cs := consumerScraper{
+		client:       newMockClient(),
+		logger:       zap.NewNop(),
+		clusterAdmin: newMockClusterAdmin(),
+		topicFilter:  filter,
+		groupFilter:  filter,
+	}
+	ms, err := cs.scrape(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, ms)
+}
+
+func TestConsumerScraper_scrape_handlesListTopicError(t *testing.T) {
+	filter := regexp.MustCompile(defaultGroupMatch)
+	clusterAdmin := newMockClusterAdmin()
+	client := newMockClient()
+	clusterAdmin.topics = nil
+	cs := consumerScraper{
+		client:       client,
+		logger:       zap.NewNop(),
+		clusterAdmin: clusterAdmin,
+		topicFilter:  filter,
+		groupFilter:  filter,
+	}
+	_, err := cs.scrape(context.Background())
+	assert.NotNil(t, err)
+}
+
+func TestConsumerScraper_scrape_handlesListConsumerGroupError(t *testing.T) {
+	filter := regexp.MustCompile(defaultGroupMatch)
+	clusterAdmin := newMockClusterAdmin()
+	clusterAdmin.consumerGroups = nil
+	cs := consumerScraper{
+		client:       newMockClient(),
+		logger:       zap.NewNop(),
+		clusterAdmin: clusterAdmin,
+		topicFilter:  filter,
+		groupFilter:  filter,
+	}
+	_, err := cs.scrape(context.Background())
+	assert.NotNil(t, err)
+}
+
+func TestConsumerScraper_scrape_handlesDescribeConsumerError(t *testing.T) {
+	filter := regexp.MustCompile(defaultGroupMatch)
+	clusterAdmin := newMockClusterAdmin()
+	clusterAdmin.consumerGroupDescriptions = nil
+	cs := consumerScraper{
+		client:       newMockClient(),
+		logger:       zap.NewNop(),
+		clusterAdmin: clusterAdmin,
+		topicFilter:  filter,
+		groupFilter:  filter,
+	}
+	_, err := cs.scrape(context.Background())
+	assert.NotNil(t, err)
+}
+
+func TestConsumerScraper_scrape_handlesOffsetPartialError(t *testing.T) {
+	filter := regexp.MustCompile(defaultGroupMatch)
+	clusterAdmin := newMockClusterAdmin()
+	client := newMockClient()
+	client.offset = -1
+	clusterAdmin.consumerGroupOffsets = nil
+	cs := consumerScraper{
+		client:       client,
+		logger:       zap.NewNop(),
+		groupFilter:  filter,
+		topicFilter:  filter,
+		clusterAdmin: clusterAdmin,
+	}
+	s, err := cs.scrape(context.Background())
+	assert.NotNil(t, s)
+	assert.NotNil(t, err)
+}
+
+func TestConsumerScraper_scrape_handlesPartitionPartialError(t *testing.T) {
+	filter := regexp.MustCompile(defaultGroupMatch)
+	clusterAdmin := newMockClusterAdmin()
+	client := newMockClient()
+	client.partitions = nil
+	clusterAdmin.consumerGroupOffsets = nil
+	cs := consumerScraper{
+		client:       client,
+		logger:       zap.NewNop(),
+		groupFilter:  filter,
+		topicFilter:  filter,
+		clusterAdmin: clusterAdmin,
+	}
+	s, err := cs.scrape(context.Background())
+	assert.NotNil(t, s)
+	assert.NotNil(t, err)
+}

--- a/receiver/kafkametricsreceiver/receiver.go
+++ b/receiver/kafkametricsreceiver/receiver.go
@@ -28,8 +28,9 @@ import (
 
 var (
 	allScrapers = map[string]func(context.Context, Config, *sarama.Config, *zap.Logger) (scraperhelper.ResourceMetricsScraper, error){
-		"brokers": createBrokerScraper,
-		"topics":  createTopicsScraper,
+		"brokers":   createBrokerScraper,
+		"topics":    createTopicsScraper,
+		"consumers": createConsumerScraper,
 	}
 )
 

--- a/receiver/kafkametricsreceiver/receiver.go
+++ b/receiver/kafkametricsreceiver/receiver.go
@@ -26,15 +26,20 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	allScrapers = map[string]func(context.Context, Config, *sarama.Config, *zap.Logger) (scraperhelper.ResourceMetricsScraper, error){
-		"brokers":   createBrokerScraper,
-		"topics":    createTopicsScraper,
-		"consumers": createConsumerScraper,
-	}
+const (
+	InstrumentationLibName = "otelcol/kafkametrics"
+	brokersScraperName     = "brokers"
+	topicsScraperName      = "topics"
+	consumersScraperName   = "consumers"
 )
 
-const InstrumentationLibName = "otelcol/kafkametrics"
+var (
+	allScrapers = map[string]func(context.Context, Config, *sarama.Config, *zap.Logger) (scraperhelper.ResourceMetricsScraper, error){
+		brokersScraperName:   createBrokerScraper,
+		topicsScraperName:    createTopicsScraper,
+		consumersScraperName: createConsumerScraper,
+	}
+)
 
 var newMetricsReceiver = func(
 	ctx context.Context,

--- a/receiver/kafkametricsreceiver/scraper_test_helper.go
+++ b/receiver/kafkametricsreceiver/scraper_test_helper.go
@@ -26,6 +26,7 @@ const (
 )
 
 var newSaramaClient = sarama.NewClient
+var newClusterAdmin = sarama.NewClusterAdmin
 
 var testTopics = []string{"test_topic"}
 var testPartitions = []int32{1}

--- a/receiver/kafkametricsreceiver/scraper_test_helper.go
+++ b/receiver/kafkametricsreceiver/scraper_test_helper.go
@@ -22,19 +22,27 @@ import (
 )
 
 const (
-	testBroker = "test_broker"
+	testBroker         = "test_broker"
+	testGroup          = "test_group"
+	testTopic          = "test_topic"
+	testConsumerClient = "test_consumer_client"
+	testPartition      = 1
 )
 
 var newSaramaClient = sarama.NewClient
 var newClusterAdmin = sarama.NewClusterAdmin
 
-var testTopics = []string{"test_topic"}
+var testTopics = []string{testTopic}
 var testPartitions = []int32{1}
 var testReplicas = []int32{1}
 var testBrokers = make([]*sarama.Broker, 1)
 
 func mockNewSaramaClient([]string, *sarama.Config) (sarama.Client, error) {
 	return newMockClient(), nil
+}
+
+func mockNewClusterAdmin([]string, *sarama.Config) (sarama.ClusterAdmin, error) {
+	return newMockClusterAdmin(), nil
 }
 
 type mockSaramaClient struct {
@@ -108,7 +116,7 @@ func newMockClient() *mockSaramaClient {
 	testBrokers[0] = r
 
 	client.closed = false
-	client.offset = -1
+	client.offset = 1
 	client.brokers = testBrokers
 	client.partitions = testPartitions
 	client.topics = testTopics
@@ -116,4 +124,80 @@ func newMockClient() *mockSaramaClient {
 	client.replicas = testReplicas
 
 	return client
+}
+
+type mockClusterAdmin struct {
+	mock.Mock
+	sarama.ClusterAdmin
+
+	topics                    map[string]sarama.TopicDetail
+	consumerGroups            map[string]string
+	consumerGroupDescriptions []*sarama.GroupDescription
+	consumerGroupOffsets      *sarama.OffsetFetchResponse
+}
+
+func (s *mockClusterAdmin) ListTopics() (map[string]sarama.TopicDetail, error) {
+	if s.topics == nil {
+		return nil, fmt.Errorf("error getting topics")
+	}
+	return s.topics, nil
+}
+
+func (s *mockClusterAdmin) ListConsumerGroups() (map[string]string, error) {
+	if s.consumerGroups == nil {
+		return nil, fmt.Errorf("error getting consumer groups")
+	}
+	return s.consumerGroups, nil
+}
+
+func (s *mockClusterAdmin) DescribeConsumerGroups([]string) ([]*sarama.GroupDescription, error) {
+	if s.consumerGroupDescriptions == nil {
+		return nil, fmt.Errorf("error describing consumer groups")
+	}
+	return s.consumerGroupDescriptions, nil
+}
+
+func (s *mockClusterAdmin) ListConsumerGroupOffsets(string, map[string][]int32) (*sarama.OffsetFetchResponse, error) {
+	if s.consumerGroupOffsets == nil {
+		return nil, fmt.Errorf("mock consumer group offset error")
+	}
+	return s.consumerGroupOffsets, nil
+}
+
+func newMockClusterAdmin() *mockClusterAdmin {
+	clusterAdmin := new(mockClusterAdmin)
+	r := make(map[string]string)
+	r[testGroup] = testGroup
+	clusterAdmin.consumerGroups = r
+
+	td := make(map[string]sarama.TopicDetail)
+	td[testTopic] = sarama.TopicDetail{}
+	clusterAdmin.topics = td
+
+	desc := sarama.GroupMemberDescription{
+		ClientId: testConsumerClient,
+	}
+	gmd := make(map[string]*sarama.GroupMemberDescription)
+	gmd[testConsumerClient] = &desc
+	d := sarama.GroupDescription{
+		GroupId: testGroup,
+		Members: gmd,
+	}
+	gd := make([]*sarama.GroupDescription, 1)
+	gd[0] = &d
+	clusterAdmin.consumerGroupDescriptions = gd
+
+	blocks := make(map[string]map[int32]*sarama.OffsetFetchResponseBlock)
+	topicBlocks := make(map[int32]*sarama.OffsetFetchResponseBlock)
+	block := sarama.OffsetFetchResponseBlock{
+		Offset: 1,
+	}
+	topicBlocks[testPartition] = &block
+	blocks[testTopic] = topicBlocks
+	offsetRes := sarama.OffsetFetchResponse{
+		Blocks: blocks,
+	}
+	clusterAdmin.consumerGroupOffsets = &offsetRes
+
+	return clusterAdmin
 }

--- a/receiver/kafkametricsreceiver/topic_scraper.go
+++ b/receiver/kafkametricsreceiver/topic_scraper.go
@@ -38,7 +38,7 @@ type topicScraper struct {
 }
 
 func (s *topicScraper) Name() string {
-	return "topics"
+	return topicsScraperName
 }
 
 func (s *topicScraper) shutdown(context.Context) error {

--- a/receiver/kafkametricsreceiver/topic_scraper.go
+++ b/receiver/kafkametricsreceiver/topic_scraper.go
@@ -116,11 +116,11 @@ func (s *topicScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, erro
 func createTopicsScraper(_ context.Context, config Config, saramaConfig *sarama.Config, logger *zap.Logger) (scraperhelper.ResourceMetricsScraper, error) {
 	topicFilter, err := regexp.Compile(config.TopicMatch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to compile topic filter: %w ", err)
+		return nil, fmt.Errorf("failed to compile topic filter: %w", err)
 	}
 	client, err := newSaramaClient(config.Brokers, saramaConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create sarama client: %w ", err)
+		return nil, fmt.Errorf("failed to create sarama client: %w", err)
 	}
 	s := topicScraper{
 		client:       client,

--- a/receiver/kafkametricsreceiver/topic_scraper.go
+++ b/receiver/kafkametricsreceiver/topic_scraper.go
@@ -113,7 +113,10 @@ func (s *topicScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, erro
 }
 
 func createTopicsScraper(_ context.Context, config Config, saramaConfig *sarama.Config, logger *zap.Logger) (scraperhelper.ResourceMetricsScraper, error) {
-	topicFilter := regexp.MustCompile(config.TopicMatch)
+	topicFilter, err := regexp.Compile(config.TopicMatch)
+	if err != nil {
+		return nil, err
+	}
 	client, err := newSaramaClient(config.Brokers, saramaConfig)
 	if err != nil {
 		return nil, err

--- a/receiver/kafkametricsreceiver/topic_scraper.go
+++ b/receiver/kafkametricsreceiver/topic_scraper.go
@@ -16,6 +16,7 @@ package kafkametricsreceiver
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -115,11 +116,11 @@ func (s *topicScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, erro
 func createTopicsScraper(_ context.Context, config Config, saramaConfig *sarama.Config, logger *zap.Logger) (scraperhelper.ResourceMetricsScraper, error) {
 	topicFilter, err := regexp.Compile(config.TopicMatch)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to compile topic filter: %w ", err)
 	}
 	client, err := newSaramaClient(config.Brokers, saramaConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create sarama client: %w ", err)
 	}
 	s := topicScraper{
 		client:       client,

--- a/receiver/kafkametricsreceiver/topic_scraper_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_test.go
@@ -59,7 +59,7 @@ func TestTopicShutdown_closed(t *testing.T) {
 
 func TestTopicScraper_Name(t *testing.T) {
 	s := topicScraper{}
-	assert.Equal(t, s.Name(), "topics")
+	assert.Equal(t, s.Name(), topicsScraperName)
 }
 
 func TestTopicScraper_createsScraper(t *testing.T) {

--- a/receiver/kafkametricsreceiver/topic_scraper_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_test.go
@@ -80,6 +80,16 @@ func TestTopicScraper_createScraperHandlesError(t *testing.T) {
 	assert.Nil(t, ms)
 }
 
+func TestTopicScraper_createScraperHandles_invalid_topicMatch(t *testing.T) {
+	newSaramaClient = mockNewSaramaClient
+	sc := sarama.NewConfig()
+	ms, err := createTopicsScraper(context.Background(), Config{
+		TopicMatch: "[",
+	}, sc, zap.NewNop())
+	assert.NotNil(t, err)
+	assert.Nil(t, ms)
+}
+
 func TestTopicScraper_scrapes(t *testing.T) {
 	client := newMockClient()
 	var testOffset int64 = 5


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Adds implementation of the scrape functionality for the consumers scraper for the receiver.
Metrics for consumer group lag and lag sum are an approximate based on the offset information on the topic/partition and offset of the consumer group.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Unit Tests for added code

**Documentation:** <Describe the documentation added.>
No new documentation, all metrics collected are listed [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kafkametricsreceiver/metadata.yaml)