### PR TITLE
Add VMScaleSetName field to Azure resource detection processor

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -89,6 +89,7 @@ ec2:
     * host.id (virtual machine ID)
     * host.name
     * azure.vm.size (virtual machine size)
+    * azure.vm.scaleset.name (name of the scale set if any)
     * azure.resourcegroup.name (resource group name)
 
 ## Configuration

--- a/processor/resourcedetectionprocessor/internal/azure/azure.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azure.go
@@ -59,6 +59,7 @@ func (d *Detector) Detect(ctx context.Context) (pdata.Resource, error) {
 	attrs.InsertString(conventions.AttributeHostID, compute.VMID)
 	attrs.InsertString(conventions.AttributeCloudAccount, compute.SubscriptionID)
 	attrs.InsertString("azure.vm.size", compute.VMSize)
+	attrs.InsertString("azure.vm.scaleset.name", compute.VMScaleSetName)
 	attrs.InsertString("azure.resourcegroup.name", compute.ResourceGroupName)
 
 	return res, nil

--- a/processor/resourcedetectionprocessor/internal/azure/azure_test.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azure_test.go
@@ -53,6 +53,7 @@ func TestDetectAzureAvailable(t *testing.T) {
 		VMSize:            "vmSize",
 		SubscriptionID:    "subscriptionID",
 		ResourceGroupName: "resourceGroup",
+		VMScaleSetName:    "myScaleset",
 	}, nil)
 
 	detector := &Detector{provider: mp}
@@ -70,6 +71,7 @@ func TestDetectAzureAvailable(t *testing.T) {
 		conventions.AttributeCloudAccount:               "subscriptionID",
 		"azure.vm.size":                                 "vmSize",
 		"azure.resourcegroup.name":                      "resourceGroup",
+		"azure.vm.scaleset.name":                        "myScaleset",
 	})
 	expected.Attributes().Sort()
 

--- a/processor/resourcedetectionprocessor/internal/azure/metadata.go
+++ b/processor/resourcedetectionprocessor/internal/azure/metadata.go
@@ -56,6 +56,7 @@ type computeMetadata struct {
 	VMSize            string `json:"vmSize"`
 	SubscriptionID    string `json:"subscriptionID"`
 	ResourceGroupName string `json:"resourceGroupName"`
+	VMScaleSetName    string `json:"vmScaleSetName"`
 }
 
 // queryEndpointWithContext queries a given endpoint and parses the output to the Azure IMDS format


### PR DESCRIPTION
The Splunk/SFx exporter needs a `VMScaleSetName` to generate the `azure_resource_id`.

Tested on Azure as a standalone VM and in a Scale Set.

README updated.