### PR TITLE
googlecloudexporter: handle cloud.availability_zone semconv

### DIFF
--- a/exporter/googlecloudexporter/resource_mapper.go
+++ b/exporter/googlecloudexporter/resource_mapper.go
@@ -45,6 +45,13 @@ func (mr *resourceMapper) mapResource(res *resource.Resource) *monitoredrespb.Mo
 		return result
 	}
 
+	// cloud.zone was renamed to cloud.availability_zone in the semantic conventions.
+	// Accept either, for backwards compatibility.
+	availabilityZone, ok := res.Labels["cloud.availability_zone"]
+	if ok {
+		res.Labels["cloud.zone"] = availabilityZone
+	}
+
 	// Keep original behavior by default
 	return stackdriver.DefaultMapResource(res)
 }

--- a/exporter/googlecloudexporter/resource_mapper_test.go
+++ b/exporter/googlecloudexporter/resource_mapper_test.go
@@ -132,16 +132,38 @@ func TestResourceMapper(t *testing.T) {
 				Type: "source.resource3",
 				Labels: map[string]string{
 					"source.label1": "value1", // unknown label is dropped
-					"contrib.opencensus.io/exporter/stackdriver/project_id": "123",
-					// TODO: Change this to use `cloud.availability_zone` as per semantic conventions.
-					//  Changes are required in dependency package.
-					"cloud.zone": "zone1",
+					"contrib.opencensus.io/exporter/stackdriver/project_id":             "123",
+					"cloud.availability_zone":                                           "zone1",
 					"contrib.opencensus.io/exporter/stackdriver/generic_task/namespace": "ns1",
 					"contrib.opencensus.io/exporter/stackdriver/generic_task/job":       "job1",
 					"contrib.opencensus.io/exporter/stackdriver/generic_task/task_id":   "task1",
 				},
 			},
 			// Resource without matching config should be converted via default implementation
+			wantResource: &monitoredres.MonitoredResource{
+				Type: "global",
+				// All labels are transformed by default function
+				Labels: map[string]string{
+					"project_id": "123",
+					"location":   "zone1",
+					"namespace":  "ns1",
+					"job":        "job1",
+					"task_id":    "task1",
+				},
+			},
+		},
+		{
+			name: "Handle cloud.zone for backcompat",
+			sourceResource: &resource.Resource{
+				Type: "source.resource3",
+				Labels: map[string]string{
+					"contrib.opencensus.io/exporter/stackdriver/project_id": "123",
+					"cloud.zone": "zone1",
+					"contrib.opencensus.io/exporter/stackdriver/generic_task/namespace": "ns1",
+					"contrib.opencensus.io/exporter/stackdriver/generic_task/job":       "job1",
+					"contrib.opencensus.io/exporter/stackdriver/generic_task/task_id":   "task1",
+				},
+			},
 			wantResource: &monitoredres.MonitoredResource{
 				Type: "global",
 				// All labels are transformed by default function


### PR DESCRIPTION
In GCP exporter, handle `cloud.availability_zone` (the current semconv) as well as `cloud.zone` (for backcompat).