### PR TITLE
Add FluentForward to SplunkHEC e2e test

### DIFF
--- a/testbed/datareceivers/splunk.go
+++ b/testbed/datareceivers/splunk.go
@@ -1,0 +1,79 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datareceivers
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/testbed/testbed"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver"
+)
+
+// SplunkHECDataReceiver implements Splunk HEC format receiver.
+type SplunkHECDataReceiver struct {
+	testbed.DataReceiverBase
+	receiver component.LogsReceiver
+}
+
+// Ensure SplunkHECDataReceiver implements LogDataSender.
+var _ testbed.DataReceiver = (*SplunkHECDataReceiver)(nil)
+
+// NewSplunkHECDataReceiver creates a new SplunkHECDataReceiver that will listen on the
+// specified port after Start is called.
+func NewSplunkHECDataReceiver(port int) *SplunkHECDataReceiver {
+	return &SplunkHECDataReceiver{DataReceiverBase: testbed.DataReceiverBase{Port: port}}
+}
+
+// Start the receiver.
+func (sr *SplunkHECDataReceiver) Start(_ consumer.Traces, _ consumer.Metrics, lc consumer.Logs) error {
+	config := splunkhecreceiver.Config{
+		HTTPServerSettings: confighttp.HTTPServerSettings{
+			Endpoint: fmt.Sprintf("localhost:%d", sr.Port),
+		},
+	}
+	var err error
+	f := splunkhecreceiver.NewFactory()
+	sr.receiver, err = f.CreateLogsReceiver(context.Background(), component.ReceiverCreateParams{Logger: zap.L()}, &config, lc)
+	if err != nil {
+		return err
+	}
+
+	return sr.receiver.Start(context.Background(), sr)
+}
+
+// Stop the receiver.
+func (sr *SplunkHECDataReceiver) Stop() error {
+	return sr.receiver.Shutdown(context.Background())
+}
+
+// GenConfigYAMLStr returns exporter config for the agent.
+func (sr *SplunkHECDataReceiver) GenConfigYAMLStr() string {
+	// Note that this generates an exporter config for agent.
+	return fmt.Sprintf(`
+    splunk_hec:
+      endpoint: "http://localhost:%d"
+      token: "token"`, sr.Port)
+}
+
+// ProtocolName returns protocol name as it is specified in Collector config.
+func (sr *SplunkHECDataReceiver) ProtocolName() string {
+	return "splunk_hec"
+}

--- a/testbed/datasenders/fluent.go
+++ b/testbed/datasenders/fluent.go
@@ -1,0 +1,167 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasenders
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/fluent/fluent-logger-golang/fluent"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/testbed/testbed"
+)
+
+const (
+	fluentDatafileVar = "FLUENT_DATA_SENDER_DATA_FILE"
+	fluentPortVar     = "FLUENT_DATA_SENDER_RECEIVER_PORT"
+)
+
+// FluentLogsForwarder forwards logs to fluent forwader
+type FluentLogsForwarder struct {
+	testbed.DataSenderBase
+	fluentLogger *fluent.Fluent
+	dataFile     *os.File
+}
+
+// Ensure FluentLogsForwarder implements LogDataSender.
+var _ testbed.LogDataSender = (*FluentLogsForwarder)(nil)
+
+func NewFluentLogsForwarder(t *testing.T, port int) *FluentLogsForwarder {
+	var err error
+	portOverride := os.Getenv(fluentPortVar)
+	if portOverride != "" {
+		port, err = strconv.Atoi(portOverride)
+		require.NoError(t, err)
+	}
+
+	f := &FluentLogsForwarder{DataSenderBase: testbed.DataSenderBase{Port: port}}
+
+	// When FLUENT_DATA_SENDER_DATA_FILE is set, the data sender, writes to a
+	// file. This enables users to optionally run the e2e test against a real
+	// fluentd/fluentbit agent rather than using the fluent writer the data sender
+	// uses by default. In case, one is looking to point a real fluentd/fluentbit agent
+	// to the e2e test, they can do so by configuring the fluent agent to read from the
+	// file FLUENT_DATA_SENDER_DATA_FILE and forward data to FLUENT_DATA_SENDER_RECEIVER_PORT
+	// on 127.0.0.1.
+	if dataFileName := os.Getenv(fluentDatafileVar); dataFileName != "" {
+		f.dataFile, err = os.OpenFile(dataFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		require.NoError(t, err)
+	} else {
+		logger, err := fluent.New(fluent.Config{FluentPort: port, Async: true})
+		require.NoError(t, err)
+		f.fluentLogger = logger
+	}
+	return f
+}
+
+func (f *FluentLogsForwarder) Start() error {
+	return nil
+}
+
+func (f *FluentLogsForwarder) Stop() error {
+	return f.fluentLogger.Close()
+}
+
+func (f *FluentLogsForwarder) ConsumeLogs(_ context.Context, logs pdata.Logs) error {
+	for i := 0; i < logs.ResourceLogs().Len(); i++ {
+		for j := 0; j < logs.ResourceLogs().At(i).InstrumentationLibraryLogs().Len(); j++ {
+			ills := logs.ResourceLogs().At(i).InstrumentationLibraryLogs().At(j)
+			for k := 0; k < ills.Logs().Len(); k++ {
+				if f.dataFile == nil {
+					if err := f.fluentLogger.Post("", f.convertLogToMap(ills.Logs().At(k))); err != nil {
+						return err
+					}
+				} else {
+					if _, err := f.dataFile.Write(append(f.convertLogToJSON(ills.Logs().At(k)), '\n')); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (f *FluentLogsForwarder) convertLogToMap(lr pdata.LogRecord) map[string]string {
+	out := map[string]string{}
+
+	if lr.Body().Type() == pdata.AttributeValueSTRING {
+		out["log"] = lr.Body().StringVal()
+	}
+
+	lr.Attributes().ForEach(func(k string, v pdata.AttributeValue) {
+		switch v.Type() {
+		case pdata.AttributeValueSTRING:
+			out[k] = v.StringVal()
+		case pdata.AttributeValueINT:
+			out[k] = strconv.FormatInt(v.IntVal(), 10)
+		case pdata.AttributeValueDOUBLE:
+			out[k] = strconv.FormatFloat(v.DoubleVal(), 'f', -1, 64)
+		case pdata.AttributeValueBOOL:
+			out[k] = strconv.FormatBool(v.BoolVal())
+		default:
+			panic("missing case")
+		}
+	})
+
+	return out
+}
+
+func (f *FluentLogsForwarder) convertLogToJSON(lr pdata.LogRecord) []byte {
+	rec := map[string]string{
+		"time": time.Unix(0, int64(lr.Timestamp())).Format("02/01/2006:15:04:05Z"),
+	}
+	rec["log"] = lr.Body().StringVal()
+
+	lr.Attributes().ForEach(func(k string, v pdata.AttributeValue) {
+		switch v.Type() {
+		case pdata.AttributeValueSTRING:
+			rec[k] = v.StringVal()
+		case pdata.AttributeValueINT:
+			rec[k] = strconv.FormatInt(v.IntVal(), 10)
+		case pdata.AttributeValueDOUBLE:
+			rec[k] = strconv.FormatFloat(v.DoubleVal(), 'f', -1, 64)
+		case pdata.AttributeValueBOOL:
+			rec[k] = strconv.FormatBool(v.BoolVal())
+		default:
+			panic("missing case")
+		}
+	})
+	b, err := json.Marshal(rec)
+	if err != nil {
+		panic("failed to write log: " + err.Error())
+	}
+	return b
+}
+
+func (f *FluentLogsForwarder) Flush() {
+	_ = f.dataFile.Sync()
+}
+
+func (f *FluentLogsForwarder) GenConfigYAMLStr() string {
+	return fmt.Sprintf(`
+  fluentforward:
+    endpoint: localhost:%d`, f.Port)
+}
+
+func (f *FluentLogsForwarder) ProtocolName() string {
+	return "fluentforward"
+}

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/testbed
 go 1.14
 
 require (
+	github.com/fluent/fluent-logger-golang v1.5.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter v0.0.0-00010101000000-000000000000
@@ -10,7 +11,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatareceivers/mockawsxrayreceiver v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.7.0
+	github.com/tinylib/msgp v1.1.5 // indirect
 	go.opentelemetry.io/collector v0.23.1-0.20210331155714-fe86ab5cba6d
 	go.uber.org/zap v1.16.0
 )
@@ -20,6 +24,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbo
 replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter => ../exporter/sapmexporter
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter => ../exporter/signalfxexporter
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter => ../exporter/splunkhecexporter
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../internal/common
 
@@ -34,5 +40,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbo
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver => ../receiver/sapmreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver => ../receiver/signalfxreceiver
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver => ../receiver/splunkhecreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatareceivers/mockawsxrayreceiver => ../testbed/mockdatareceivers/mockawsxrayreceiver

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -153,6 +153,7 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
@@ -274,6 +275,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fluent/fluent-logger-golang v1.5.0 h1:wBpSzYjRlzgwwAOw/3ig3Jaxrb5xTJlvBu7TRcgJeCg=
+github.com/fluent/fluent-logger-golang v1.5.0/go.mod h1:2/HCT/jTy78yGyeNGQLGQsjF3zzzAuy6Xlk6FCMV5eU=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -938,7 +941,10 @@ github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
+github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
+github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
+github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v0.0.0-20190327172049-315a67e90e41/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -1148,7 +1154,10 @@ github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0
 github.com/tetafro/godot v1.4.4/go.mod h1:FVDd4JuKliW3UgjswZfJfHq4vAx0bD/Jd5brJjGeaz4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
+github.com/tinylib/msgp v1.0.2 h1:DfdQrzQa7Yh2es9SuLkixqxuXS2SxsdYn0KbdrOGWD8=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
+github.com/tinylib/msgp v1.1.5 h1:2gXmtWueD2HefZHQe1QOy9HVzmFrLOVvsXwXBQ0ayy0=
+github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/tklauser/go-sysconf v0.3.4 h1:HT8SVixZd3IzLdfs/xlpq0jeSfTX57g1v6wB1EuzV7M=
 github.com/tklauser/go-sysconf v0.3.4/go.mod h1:Cl2c8ZRWfHD5IrfHo9VN+FX9kCFjIOyVklgXycLB6ek=
 github.com/tklauser/numcpus v0.2.1 h1:ct88eFm+Q7m2ZfXJdan1xYoXKlmwsfP+k88q05KvlZc=
@@ -1157,6 +1166,7 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomarrell/wrapcheck v0.0.0-20201130113247-1683564d9756/go.mod h1:yiFB6fFoV7saXirUGfuK+cPtUh4NX/Hf5y2WC2lehu0=
 github.com/tommy-muehle/go-mnd/v2 v2.3.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
+github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber/jaeger-client-go v2.25.0+incompatible h1:IxcNZ7WRY1Y3G4poYlx24szfsn/3LvK9QHCq9oQw8+U=
 github.com/uber/jaeger-client-go v2.25.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
@@ -1563,6 +1573,7 @@ golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82u
 golang.org/x/tools v0.0.0-20201001104356-43ebab892c4c/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201002184944-ecd9fd270d5d/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201011145850-ed2f50202694/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201028025901-8cd080b735b3/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/testbed/testbed"
 	scenarios "go.opentelemetry.io/collector/testbed/tests"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders"
 )
 
@@ -125,6 +126,15 @@ func TestLog10kDPS(t *testing.T) {
 				ExpectedMaxRAM: 155,
 			},
 			extensions: flw.Extensions(),
+		},
+		{
+			name:     "FluentForward-SplunkHEC",
+			sender:   datasenders.NewFluentLogsForwarder(t, testbed.GetAvailablePort(t)),
+			receiver: datareceivers.NewSplunkHECDataReceiver(testbed.GetAvailablePort(t)),
+			resourceSpec: testbed.ResourceSpec{
+				ExpectedMaxCPU: 60,
+				ExpectedMaxRAM: 150,
+			},
 		},
 	}
 


### PR DESCRIPTION
**Description:** Add e2e test in testbed for sending data from `fluentforward` receiver to `splunk_hec` exporter. By default the fluent data sender directly sends log records to the `fluentforward` receiver. Optionally, it is also possible to write the data generated to a file. This can be used when one wants to run the e2e test with a real fluentd/fluentbit agent pointed to the receiver.