### PR TITLE
Set unprivileged user to container image

### DIFF
--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -2,8 +2,12 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY otelcontribcol /
-EXPOSE 55680 55679
+EXPOSE 4317 55680 55679
 ENTRYPOINT ["/otelcontribcol"]
 CMD ["--config", "/etc/otel/config.yaml"]

--- a/examples/tracing/Dockerfile
+++ b/examples/tracing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS build
+FROM golang:1.16 AS build
 
 WORKDIR /src
 ADD . /src
@@ -9,7 +9,11 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /src/bin/otelcontribcol_linux_amd64 /otelcontribcol
 ENTRYPOINT ["/otelcontribcol"]
-EXPOSE 55680 55679
+EXPOSE 4317 55680 55679

--- a/exporter/loadbalancingexporter/example/Dockerfile
+++ b/exporter/loadbalancingexporter/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS build
+FROM golang:1.16 AS build
 
 WORKDIR /src
 ADD . /src
@@ -9,7 +9,11 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /src/bin/otelcontribcol_linux_amd64 /otelcontribcol
 ENTRYPOINT ["/otelcontribcol"]
-EXPOSE 55680 55679
+EXPOSE 4317 55680 55679

--- a/exporter/lokiexporter/example/Dockerfile
+++ b/exporter/lokiexporter/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS build
+FROM golang:1.16 AS build
 
 WORKDIR /src
 ADD . /src
@@ -9,7 +9,11 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /src/bin/otelcontribcol_linux_amd64 /otelcontribcol
 ENTRYPOINT ["/otelcontribcol"]
-EXPOSE 55680 55679
+EXPOSE 4317 55680 55679

--- a/exporter/splunkhecexporter/example/Dockerfile
+++ b/exporter/splunkhecexporter/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS build
+FROM golang:1.16 AS build
 
 WORKDIR /src
 ADD . /src
@@ -9,7 +9,11 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 FROM scratch
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /src/bin/otelcontribcol_linux_amd64 /otelcontribcol
 ENTRYPOINT ["/otelcontribcol"]
-EXPOSE 55680 55679
+EXPOSE 4317 55680 55679

--- a/receiver/simpleprometheusreceiver/examples/federation/prom-counter/Dockerfile
+++ b/receiver/simpleprometheusreceiver/examples/federation/prom-counter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-stretch
+FROM golang:1.16-stretch
 
 WORKDIR /go/src/app
 


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

**Description:** This change sets a custom user to the container image, under an ID that yields an unprivileged user.

Related PR: https://github.com/open-telemetry/opentelemetry-collector/pull/2838
