### PR TITLE
exporter/awsprometheusremotewriteexporter: close HTTP body after RoundTrip

### DIFF
--- a/exporter/awsprometheusremotewriteexporter/auth.go
+++ b/exporter/awsprometheusremotewriteexporter/auth.go
@@ -47,6 +47,7 @@ func (si *signingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 
 	// Get the body
 	content, err := ioutil.ReadAll(reqBody)
+	reqBody.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ensures that after an HTTP request roundtrip, that signingRoundTripper closes
the HTTP body. The contract for net/http.RoundTripper requires that
after invoking RoundTrip, that the body must be closed by the caller.

Fixes #2953