### PR TITLE
K8s processor metrics refactor:

### DIFF
--- a/processor/k8sprocessor/doc.go
+++ b/processor/k8sprocessor/doc.go
@@ -132,4 +132,14 @@
 // as a sidecar. While this can be done, we think it is simpler to just use the kubernetes
 // downward API to inject environment variables into the pods and directly use their values
 // as tags.
+//
+// Metrics
+//
+// The following metrics are recorded by this processor
+//
+//    otelcol_k8s_pod_updated - Number of pod update events received.
+//    otelcol_k8s_pod_added - Number of pod add events received.
+//    otelcol_k8s_pod_deleted - Number of pod delete events received.
+//    otelcol_k8s_pod_table_size - Size of table containing pod info.
+//    otelcol_k8s_ip_lookup_miss - Number of times pod by identifier (IP, UID) lookup failed.
 package k8sprocessor

--- a/processor/k8sprocessor/kube/client.go
+++ b/processor/k8sprocessor/kube/client.go
@@ -197,7 +197,7 @@ func (c *WatchClient) GetPod(identifier PodIdentifier) (*Pod, bool) {
 		}
 		return pod, ok
 	}
-	observability.RecordIPLookupMiss()
+	observability.RecordIDLookupMiss()
 	return nil, false
 }
 

--- a/processor/k8sprocessor/observability/observability.go
+++ b/processor/k8sprocessor/observability/observability.go
@@ -39,7 +39,6 @@ var (
 	mPodsAdded    = stats.Int64("otelcol_k8s_pod_added", "Number of pod add events received", "1")
 	mPodsDeleted  = stats.Int64("otelcol_k8s_pod_deleted", "Number of pod delete events received", "1")
 	mPodTableSize = stats.Int64("otelcol_k8s_pod_table_size", "Size of table containing pod info", "1")
-
 	mIDLookupMiss = stats.Int64("otelcol_k8s_ip_lookup_miss", "Number of times pod by identifier (IP, UID) lookup failed.", "1")
 )
 

--- a/processor/k8sprocessor/observability/observability.go
+++ b/processor/k8sprocessor/observability/observability.go
@@ -35,12 +35,12 @@ func init() {
 }
 
 var (
-	mPodsUpdated  = stats.Int64("otelsvc/k8s/pod_updated", "Number of pod update events received", "1")
-	mPodsAdded    = stats.Int64("otelsvc/k8s/pod_added", "Number of pod add events received", "1")
-	mPodsDeleted  = stats.Int64("otelsvc/k8s/pod_deleted", "Number of pod delete events received", "1")
-	mPodTableSize = stats.Int64("otelsvc/k8s/pod_table_size", "Size of table containing pod info", "1")
+	mPodsUpdated  = stats.Int64("otelcol_k8s_pod_updated", "Number of pod update events received", "1")
+	mPodsAdded    = stats.Int64("otelcol_k8s_pod_added", "Number of pod add events received", "1")
+	mPodsDeleted  = stats.Int64("otelcol_k8s_pod_deleted", "Number of pod delete events received", "1")
+	mPodTableSize = stats.Int64("otelcol_k8s_pod_table_size", "Size of table containing pod info", "1")
 
-	mIPLookupMiss = stats.Int64("otelsvc/k8s/ip_lookup_miss", "Number of times pod by IP lookup failed.", "1")
+	mIDLookupMiss = stats.Int64("otelcol_k8s_ip_lookup_miss", "Number of times pod by identifier (IP, UID) lookup failed.", "1")
 )
 
 var viewPodsUpdated = &view.View{
@@ -65,9 +65,9 @@ var viewPodsDeleted = &view.View{
 }
 
 var viewIPLookupMiss = &view.View{
-	Name:        mIPLookupMiss.Name(),
-	Description: mIPLookupMiss.Description(),
-	Measure:     mIPLookupMiss,
+	Name:        mIDLookupMiss.Name(),
+	Description: mIDLookupMiss.Description(),
+	Measure:     mIDLookupMiss,
 	Aggregation: view.Sum(),
 }
 var viewPodTableSize = &view.View{
@@ -92,9 +92,9 @@ func RecordPodDeleted() {
 	stats.Record(context.Background(), mPodsDeleted.M(int64(1)))
 }
 
-// RecordIPLookupMiss increments the metric that records Pod lookup by IP misses.
-func RecordIPLookupMiss() {
-	stats.Record(context.Background(), mIPLookupMiss.M(int64(1)))
+// RecordIDLookupMiss increments the metric that records Pod lookup by ID (IP, UID) misses.
+func RecordIDLookupMiss() {
+	stats.Record(context.Background(), mIDLookupMiss.M(int64(1)))
 }
 
 // RecordPodTableSize store size of pod table field in WatchClient

--- a/processor/k8sprocessor/observability/observability_test.go
+++ b/processor/k8sprocessor/observability/observability_test.go
@@ -63,20 +63,20 @@ func TestMetrics(t *testing.T) {
 	}
 	tests := []testCase{
 		{
-			"otelsvc/k8s/pod_added",
+			"otelcol_k8s_pod_added",
 			RecordPodAdded,
 		},
 		{
-			"otelsvc/k8s/pod_deleted",
+			"otelcol_k8s_pod_deleted",
 			RecordPodDeleted,
 		},
 		{
-			"otelsvc/k8s/pod_updated",
+			"otelcol_k8s_pod_updated",
 			RecordPodUpdated,
 		},
 		{
-			"otelsvc/k8s/ip_lookup_miss",
-			RecordIPLookupMiss,
+			"otelcol_k8s_ip_lookup_miss",
+			RecordIDLookupMiss,
 		},
 	}
 


### PR DESCRIPTION

**Description:**
K8s processor metrics refactor:
* replace slashes(/) with underscores(_)
* rename otelsvc prefix for otelcol
* rename lookup miss metric to fit for new mechanism
* add metrics description to doc

Signed-off-by: Patryk Matyjasek <pmatyjasek@sumologic.com>

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2322

**Testing:** 
Unit tests

**Documentation:** 
doc.go file update