### PR TITLE
[StatsD receiver]Add timing/histogram for statsD receiver as OTLP gauge

### DIFF
--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -21,6 +21,17 @@ The Following settings are optional:
 
 - `enable_metric_type: true`(default value is false): Enable the statsd receiver to be able to emit the metric type(gauge, counter, timer(in the future), histogram(in the future)) as a label.
 
+- `timer_histogram_mapping:`(default value is below): Specify what OTLP type to convert received timing/histogram data to.
+
+// TODO: can add regex support for `match` later.
+
+`"match"`, we only support `"*"` now. 
+
+`"statsd_type"` specifies received Statsd data type. Possible values for this setting are `"timing"`, `"timer"` and `"histogram"`.
+
+`"observer_type"` specifies OTLP data type to convert to. The only supported target data type currently is `"gauge"`, which does not perform any aggregation.
+Support for `"summary"` data type is planned to be added in the future.
+
 Example:
 
 ```yaml
@@ -30,6 +41,13 @@ receivers:
     endpoint: "localhost:8127"
     aggregation_interval: 70s
     enable_metric_type: true
+    timer_histogram_mapping:
+      - match: "*"
+        statsd_type: "histogram"
+        observer_type: "gauge"
+      - match: "*"
+        statsd_type: "timing"
+        observer_type: "gauge"
 ```
 
 The full list of settings exposed for this receiver are documented [here](./config.go)
@@ -75,7 +93,6 @@ General format is:
 `<name>:<value>|c|@<sample-rate>|#<tag1-key>:<tag1-value>`
 
 It supports sample rate.
-TODO: Use OTLP type(Sum data points, with AggregationTemporality=Delta and Monotonic=False) for transferred data types (now we are using OpenCensus types).
 TODO: Need to change the implementation part for sample rate after OTLP supports sample rate as a parameter later.
 
 
@@ -83,11 +100,14 @@ TODO: Need to change the implementation part for sample rate after OTLP supports
 
 `<name>:<value>|g|@<sample-rate>|#<tag1-key>:<tag1-value>`
 
-TODO: Use OTLP type for transferred data types (now we are using OpenCensus types).
 
 ### Timer
 
-TODO: add support for timer and histogram.
+`<name>:<value>|ms|@<sample-rate>|#<tag1-key>:<tag1-value>`
+`<name>:<value>|h|@<sample-rate>|#<tag1-key>:<tag1-value>`
+
+It supports sample rate.
+
 
 ## Testing
 
@@ -99,6 +119,13 @@ receivers:
     endpoint: "localhost:8125" # default
     aggregation_interval: 60s  # default
     enable_metric_type: false   # default
+    timer_histogram_mapping:
+      - match: "*"
+        statsd_type: "histogram"
+        observer_type: "gauge"
+      - match: "*"
+        statsd_type: "timing"
+        observer_type: "gauge"
 
 exporters:
   file:

--- a/receiver/statsdreceiver/factory.go
+++ b/receiver/statsdreceiver/factory.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 )
 
 const (
@@ -53,8 +55,9 @@ func createDefaultConfig() config.Receiver {
 			Endpoint:  defaultBindEndpoint,
 			Transport: defaultTransport,
 		},
-		AggregationInterval: defaultAggregationInterval,
-		EnableMetricType:    defaultEnableMetricType,
+		AggregationInterval:   defaultAggregationInterval,
+		EnableMetricType:      defaultEnableMetricType,
+		TimerHistogramMapping: []protocol.TimerHistogramMapping{{Match: "*", StatsdType: "timer", ObserverType: "gauge"}, {Match: "*", StatsdType: "histogram", ObserverType: "gauge"}},
 	}
 }
 
@@ -65,5 +68,9 @@ func createMetricsReceiver(
 	consumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
 	c := cfg.(*Config)
+	err := c.validate()
+	if err != nil {
+		return nil, err
+	}
 	return New(params.Logger, *c, consumer)
 }

--- a/receiver/statsdreceiver/factory_test.go
+++ b/receiver/statsdreceiver/factory_test.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/protocol"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -40,6 +42,24 @@ func TestCreateReceiver(t *testing.T) {
 	tReceiver, err := createMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, tReceiver, "receiver creation failed")
+}
+
+func TestCreateReceiverWithConfigErr(t *testing.T) {
+	cfg := &Config{
+		AggregationInterval: -1,
+		TimerHistogramMapping: []protocol.TimerHistogramMapping{
+			{Match: "*", StatsdType: "timing", ObserverType: "gauge"},
+		},
+	}
+	receiver, err := createMetricsReceiver(
+		context.Background(),
+		component.ReceiverCreateParams{Logger: zap.NewNop()},
+		cfg,
+		consumertest.NewNop(),
+	)
+	assert.Error(t, err, "aggregation_interval must be a positive duration")
+	assert.Nil(t, receiver)
+
 }
 
 func TestCreateMetricsReceiverWithNilConsumer(t *testing.T) {

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -31,16 +31,31 @@ var (
 )
 
 func getSupportedTypes() []string {
-	return []string{"c", "g"}
+	return []string{"c", "g", "h", "ms"}
 }
 
-const TagMetricType = "metric_type"
+const (
+	tagMetricType   = "metric_type"
+	statsdCounter   = "c"
+	statsdGauge     = "g"
+	statsdHistogram = "h"
+	statsdTiming    = "ms"
+)
+
+type TimerHistogramMapping struct {
+	Match        string `mapstructure:"match"`
+	StatsdType   string `mapstructure:"statsd_type"`
+	ObserverType string `mapstructure:"observer_type"`
+}
 
 // StatsDParser supports the Parse method for parsing StatsD messages with Tags.
 type StatsDParser struct {
-	gauges           map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
-	counters         map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
-	enableMetricType bool
+	gauges                 map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
+	counters               map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
+	timersAndDistributions []pdata.InstrumentationLibraryMetrics
+	enableMetricType       bool
+	observeTimer           string
+	observeHistogram       string
 }
 
 type statsDMetric struct {
@@ -61,10 +76,19 @@ type statsDMetricdescription struct {
 	labels           attribute.Distinct
 }
 
-func (p *StatsDParser) Initialize(enableMetricType bool) error {
+func (p *StatsDParser) Initialize(enableMetricType bool, sendTimerHistogram []TimerHistogramMapping) error {
 	p.gauges = make(map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics)
 	p.counters = make(map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics)
+	p.timersAndDistributions = make([]pdata.InstrumentationLibraryMetrics, 0)
 	p.enableMetricType = enableMetricType
+	for _, eachMap := range sendTimerHistogram {
+		switch eachMap.StatsdType {
+		case "histogram":
+			p.observeHistogram = eachMap.ObserverType
+		case "timer", "timing":
+			p.observeTimer = eachMap.ObserverType
+		}
+	}
 	return nil
 }
 
@@ -82,8 +106,13 @@ func (p *StatsDParser) GetMetrics() pdata.Metrics {
 		metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().Append(metric)
 	}
 
+	for _, metric := range p.timersAndDistributions {
+		metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().Append(metric)
+	}
+
 	p.gauges = make(map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics)
 	p.counters = make(map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics)
+	p.timersAndDistributions = make([]pdata.InstrumentationLibraryMetrics, 0)
 
 	return metrics
 }
@@ -99,7 +128,7 @@ func (p *StatsDParser) Aggregate(line string) error {
 		return err
 	}
 	switch parsedMetric.description.statsdMetricType {
-	case "g":
+	case statsdGauge:
 		_, ok := p.gauges[parsedMetric.description]
 		if !ok {
 			p.gauges[parsedMetric.description] = buildGaugeMetric(parsedMetric, timeNowFunc())
@@ -113,7 +142,7 @@ func (p *StatsDParser) Aggregate(line string) error {
 			}
 		}
 
-	case "c":
+	case statsdCounter:
 		_, ok := p.counters[parsedMetric.description]
 		if !ok {
 			p.counters[parsedMetric.description] = buildCounterMetric(parsedMetric, timeNowFunc())
@@ -121,6 +150,18 @@ func (p *StatsDParser) Aggregate(line string) error {
 			savedValue := p.counters[parsedMetric.description].Metrics().At(0).IntSum().DataPoints().At(0).Value()
 			parsedMetric.intvalue = parsedMetric.intvalue + savedValue
 			p.counters[parsedMetric.description] = buildCounterMetric(parsedMetric, timeNowFunc())
+		}
+
+	case statsdHistogram:
+		switch p.observeHistogram {
+		case "gauge":
+			p.timersAndDistributions = append(p.timersAndDistributions, buildGaugeMetric(parsedMetric, timeNowFunc()))
+		}
+
+	case statsdTiming:
+		switch p.observeTimer {
+		case "gauge":
+			p.timersAndDistributions = append(p.timersAndDistributions, buildGaugeMetric(parsedMetric, timeNowFunc()))
 		}
 	}
 
@@ -153,7 +194,7 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 	}
 
 	result.description.statsdMetricType = parts[1]
-	if !contains(getSupportedTypes(), result.description.statsdMetricType) {
+	if !Contains(getSupportedTypes(), result.description.statsdMetricType) {
 		return result, fmt.Errorf("unsupported metric type: %s", result.description.statsdMetricType)
 	}
 
@@ -193,13 +234,13 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 		}
 	}
 	switch result.description.statsdMetricType {
-	case "g":
+	case statsdGauge:
 		f, err := strconv.ParseFloat(result.value, 64)
 		if err != nil {
 			return result, fmt.Errorf("gauge: parse metric value string: %s", result.value)
 		}
 		result.floatvalue = f
-	case "c":
+	case statsdCounter:
 		f, err := strconv.ParseFloat(result.value, 64)
 		if err != nil {
 			return result, fmt.Errorf("counter: parse metric value string: %s", result.value)
@@ -209,6 +250,15 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 			i = int64(f / result.sampleRate)
 		}
 		result.intvalue = i
+	case statsdHistogram, statsdTiming:
+		f, err := strconv.ParseFloat(result.value, 64)
+		if err != nil {
+			return result, fmt.Errorf("timing/histogram: parse metric value string: %s", result.value)
+		}
+		if 0 < result.sampleRate && result.sampleRate < 1 {
+			f = f / result.sampleRate
+		}
+		result.floatvalue = f
 	}
 
 	// add metric_type dimension for all metrics
@@ -216,15 +266,19 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 	if enableMetricType {
 		var metricType = ""
 		switch result.description.statsdMetricType {
-		case "g":
+		case statsdGauge:
 			metricType = "gauge"
-		case "c":
+		case statsdCounter:
 			metricType = "counter"
+		case statsdTiming:
+			metricType = "timing"
+		case statsdHistogram:
+			metricType = "histogram"
 		}
-		result.labelKeys = append(result.labelKeys, TagMetricType)
+		result.labelKeys = append(result.labelKeys, tagMetricType)
 		result.labelValues = append(result.labelValues, metricType)
 
-		kvs = append(kvs, attribute.String(TagMetricType, metricType))
+		kvs = append(kvs, attribute.String(tagMetricType, metricType))
 	}
 
 	if len(kvs) != 0 {
@@ -233,13 +287,4 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 	}
 
 	return result, nil
-}
-
-func contains(slice []string, element string) bool {
-	for _, val := range slice {
-		if val == element {
-			return true
-		}
-	}
-	return false
 }

--- a/receiver/statsdreceiver/protocol/utils.go
+++ b/receiver/statsdreceiver/protocol/utils.go
@@ -14,13 +14,11 @@
 
 package protocol
 
-import (
-	"go.opentelemetry.io/collector/consumer/pdata"
-)
-
-// Parser is something that can map input StatsD strings to OTLP Metric representations.
-type Parser interface {
-	Initialize(enableMetricType bool, sendTimerHistogram []TimerHistogramMapping) error
-	GetMetrics() pdata.Metrics
-	Aggregate(line string) error
+func Contains(slice []string, element string) bool {
+	for _, val := range slice {
+		if val == element {
+			return true
+		}
+	}
+	return false
 }

--- a/receiver/statsdreceiver/protocol/utils_test.go
+++ b/receiver/statsdreceiver/protocol/utils_test.go
@@ -1,0 +1,64 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Contains(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []string
+		element  string
+		expected bool
+	}{
+		{
+			name: "contain 1",
+			slice: []string{
+				"m",
+				"g",
+			},
+			element:  "m",
+			expected: true,
+		},
+		{
+			name: "contain 2",
+			slice: []string{
+				"m",
+				"g",
+			},
+			element:  "g",
+			expected: true,
+		},
+		{
+			name: "does not contain",
+			slice: []string{
+				"m",
+				"g",
+			},
+			element:  "t",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			answer := Contains(tt.slice, tt.element)
+			assert.Equal(t, tt.expected, answer)
+		})
+	}
+}

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -99,7 +99,7 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 		var transferChan = make(chan string, 10)
 		ticker := time.NewTicker(r.config.AggregationInterval)
 		err = nil
-		r.parser.Initialize(r.config.EnableMetricType)
+		r.parser.Initialize(r.config.EnableMetricType, r.config.TimerHistogramMapping)
 		go func() {
 			err = r.server.ListenAndServe(r.parser, r.nextConsumer, r.reporter, transferChan)
 			if err != nil {

--- a/receiver/statsdreceiver/testdata/config.yaml
+++ b/receiver/statsdreceiver/testdata/config.yaml
@@ -5,6 +5,13 @@ receivers:
     transport: "custom_transport"
     aggregation_interval: 70s
     enable_metric_type: false
+    timer_histogram_mapping:
+      - match: "*"
+        statsd_type: "histogram"
+        observer_type: "gauge"
+      - match: "*"
+        statsd_type: "timing"
+        observer_type: "gauge"
 
 processors:
   nop:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR is for timing/histogram support using OTLP gauge without aggregation. StatsD receiver receives `ms` or `h` StatsD type and transfers to OTLP double gauge. We discussed this approach with community last month. Timing/histogram use OTLP gauge instead of OTLP histogram, because:
* Other preferred downstream AWS EMF exporter requires raw data.
* Histogram OTLP type is changing.

I will implement timing/histogram using OTLP summary data type in the next PR. The user could choose using gauge or summary in config file after the next PR is ready.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2566

**Testing:** <Describe what testing was performed and which tests were added.>
Added unit tests.

**Documentation:** <Describe the documentation added.>