### PR TITLE
Remove translation to HTTP status from OC status.

### DIFF
--- a/exporter/awsxrayexporter/translator/http.go
+++ b/exporter/awsxrayexporter/translator/http.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	semconventions "go.opentelemetry.io/collector/translator/conventions"
-	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/awsxray"
 )
@@ -117,11 +116,6 @@ func makeHTTP(span pdata.Span) (map[string]string, *awsxray.HTTPData) {
 		} else {
 			info.Request.URL = awsxray.String(constructClientURL(urlParts))
 		}
-	}
-
-	if info.Response.Status == nil {
-		// TODO(anuraaga): Replace with direct translator of StatusCode without casting to int
-		info.Response.Status = aws.Int64(int64(tracetranslator.HTTPStatusCodeFromOCStatus(int32(span.Status().Code()))))
 	}
 
 	info.Response.ContentLength = aws.Int64(extractResponseSizeFromEvents(span))

--- a/exporter/awsxrayexporter/translator/http_test.go
+++ b/exporter/awsxrayexporter/translator/http_test.go
@@ -245,25 +245,6 @@ func TestServerSpanWithSchemeNamePortTargetAttributes(t *testing.T) {
 	assert.True(t, strings.Contains(jsonStr, "http://kb234.example.com:8080/users/junit"))
 }
 
-func TestHttpStatusFromSpanStatus(t *testing.T) {
-	attributes := make(map[string]interface{})
-	attributes[semconventions.AttributeHTTPMethod] = "GET"
-	attributes[semconventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
-	span := constructHTTPClientSpan(attributes)
-
-	filtered, httpData := makeHTTP(span)
-
-	assert.NotNil(t, httpData)
-	assert.NotNil(t, filtered)
-	w := testWriters.borrow()
-	if err := w.Encode(httpData); err != nil {
-		assert.Fail(t, "invalid json")
-	}
-	jsonStr := w.String()
-	testWriters.release(w)
-	assert.True(t, strings.Contains(jsonStr, "200"))
-}
-
 func TestSpanWithNotEnoughHTTPRequestURLAttributes(t *testing.T) {
 	attributes := make(map[string]interface{})
 	attributes[semconventions.AttributeHTTPMethod] = "GET"


### PR DESCRIPTION
**Description:** Remove compatibility adapter for OC for mapping HTTP status.

**Link to tracking Issue:** Fixes #2940

**Testing:** Unit tests

This was here to give time for OC users to migrate instrumentation - if @kbrockhoff is ok with it, we can delete it now.