### PR TITLE
receiver/[k8scluster/kubeletstats]: Replace package constansts in favor of constants from conventions in core

### DIFF
--- a/receiver/k8sclusterreceiver/collection/collector.go
+++ b/receiver/k8sclusterreceiver/collection/collector.go
@@ -43,14 +43,12 @@ const (
 	containerType = "container"
 
 	// Resource labels keys for UID.
-	k8sKeyNodeUID                  = "k8s.node.uid"
 	k8sKeyNamespaceUID             = "k8s.namespace.uid"
 	k8sKeyReplicationControllerUID = "k8s.replicationcontroller.uid"
 	k8sKeyHPAUID                   = "k8s.hpa.uid"
 	k8sKeyResourceQuotaUID         = "k8s.resourcequota.uid"
 
 	// Resource labels keys for Name.
-	k8sKeyNodeName                  = "k8s.node.name"
 	k8sKeyReplicationControllerName = "k8s.replicationcontroller.name"
 	k8sKeyHPAName                   = "k8s.hpa.name"
 	k8sKeyResourceQuotaName         = "k8s.resourcequota.name"

--- a/receiver/k8sclusterreceiver/collection/nodes.go
+++ b/receiver/k8sclusterreceiver/collection/nodes.go
@@ -70,9 +70,9 @@ func getResourceForNode(node *corev1.Node) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: k8sType,
 		Labels: map[string]string{
-			k8sKeyNodeUID:                   string(node.UID),
-			k8sKeyNodeName:                  node.Name,
-			conventions.AttributeK8sCluster: node.ClusterName,
+			conventions.AttributeK8sNodeUID:  string(node.UID),
+			conventions.AttributeK8sNodeName: node.Name,
+			conventions.AttributeK8sCluster:  node.ClusterName,
 		},
 	}
 }
@@ -97,13 +97,13 @@ func nodeConditionValue(node *corev1.Node, condType corev1.NodeConditionType) in
 func getMetadataForNode(node *corev1.Node) map[metadataPkg.ResourceID]*KubernetesMetadata {
 	metadata := util.MergeStringMaps(map[string]string{}, node.Labels)
 
-	metadata[k8sKeyNodeName] = node.Name
+	metadata[conventions.AttributeK8sNodeName] = node.Name
 	metadata[nodeCreationTime] = node.GetCreationTimestamp().Format(time.RFC3339)
 
 	nodeID := metadataPkg.ResourceID(node.UID)
 	return map[metadataPkg.ResourceID]*KubernetesMetadata{
 		nodeID: {
-			resourceIDKey: k8sKeyNodeUID,
+			resourceIDKey: conventions.AttributeK8sNodeUID,
 			resourceID:    nodeID,
 			metadata:      metadata,
 		},

--- a/receiver/k8sclusterreceiver/collection/pods.go
+++ b/receiver/k8sclusterreceiver/collection/pods.go
@@ -116,7 +116,7 @@ func getResourceForPod(pod *corev1.Pod) *resourcepb.Resource {
 		Labels: map[string]string{
 			conventions.AttributeK8sPodUID:    string(pod.UID),
 			conventions.AttributeK8sPod:       pod.Name,
-			k8sKeyNodeName:                    pod.Spec.NodeName,
+			conventions.AttributeK8sNodeName:  pod.Spec.NodeName,
 			conventions.AttributeK8sNamespace: pod.Namespace,
 			conventions.AttributeK8sCluster:   pod.ClusterName,
 		},

--- a/receiver/kubeletstatsreceiver/kubelet/conventions.go
+++ b/receiver/kubeletstatsreceiver/kubelet/conventions.go
@@ -15,7 +15,6 @@
 package kubelet
 
 const (
-	labelNodeName                  = "k8s.node.name"
 	labelPersistentVolumeClaimName = "k8s.persistentvolumeclaim.name"
 	labelVolumeName                = "k8s.volume.name"
 	labelVolumeType                = "k8s.volume.type"

--- a/receiver/kubeletstatsreceiver/kubelet/resource.go
+++ b/receiver/kubeletstatsreceiver/kubelet/resource.go
@@ -26,7 +26,7 @@ func nodeResource(s stats.NodeStats) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: "k8s", // k8s/node
 		Labels: map[string]string{
-			labelNodeName: s.NodeName,
+			conventions.AttributeK8sNodeName: s.NodeName,
 		},
 	}
 }


### PR DESCRIPTION
**Description:** Use constants from `go.opentelemetry.io/collector/translator/conventions`