### PR TITLE
Remove propagation of error from xray exporter on shutdown

### DIFF
--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -90,7 +90,8 @@ func newTraceExporter(
 			return err
 		},
 		exporterhelper.WithShutdown(func(context.Context) error {
-			return logger.Sync()
+			_ = logger.Sync()
+			return nil
 		}),
 	)
 }

--- a/exporter/awsxrayexporter/awsxray_test.go
+++ b/exporter/awsxrayexporter/awsxray_test.go
@@ -36,6 +36,8 @@ func TestTraceExport(t *testing.T) {
 	td := constructSpanData()
 	err := traceExporter.ConsumeTraces(ctx, td)
 	assert.NotNil(t, err)
+	err = traceExporter.Shutdown(ctx)
+	assert.Nil(t, err)
 }
 
 func BenchmarkForTraceExporter(b *testing.B) {


### PR DESCRIPTION
**Description:** 

Fix error thrown when the awsxray exporter is shutting down, which causes the process to exit with a non 0 exit code. 

See https://github.com/uber-go/zap/issues/370

**Link to tracking Issue:**

https://github.com/aws-observability/aws-otel-collector/issues/419

**Testing:**

Ran a custom built container which does not exit with code 1
