### PR TITLE
f5cloudexporter: export OTLP over gRPC

### DIFF
--- a/exporter/f5cloudexporter/README.md
+++ b/exporter/f5cloudexporter/README.md
@@ -1,6 +1,8 @@
 # F5 Cloud Exporter
 
-Exports data via HTTP to [F5 Cloud](https://portal.cloudservices.f5.com/).
+Exports data via gRPC to [F5 Cloud](https://portal.cloudservices.f5.com/) using [OTLP](
+https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md)
+format. By default, this exporter requires TLS and offers queued retry capabilities.
 
 Supported pipeline types: metrics, traces, logs
 
@@ -10,7 +12,9 @@ Supported pipeline types: metrics, traces, logs
 
 The following settings are required:
 
-- `endpoint` (no default): The URL to send data to. See your F5 Cloud account for details.
+- `endpoint` (no default): host:port to which the exporter is going to send OTLP trace data,
+  using the gRPC protocol. The valid syntax is described
+  [here](https://github.com/grpc/grpc/blob/master/doc/naming.md). See your F5 Cloud account for details.
 - `source` (no default): A unique identifier that is used to distinguish where this data is coming from (e.g. dev_cluster). This is in 
   addition to the pipeline attributes and resources.
 - `auth.credential_file` (no default): Path to the credential file used to authenticate this client. See your F5 
@@ -21,15 +25,11 @@ The following settings can be optionally configured:
 - `auth.audience` (no default): Identifies the recipient that the authentication JWT is intended for. See your F5 Cloud 
   account for details.
 
-- `timeout` (default = 30s): HTTP request time limit. For details see https://golang.org/pkg/net/http/#Client
-- `read_buffer_size` (default = 0): ReadBufferSize for HTTP client.
-- `write_buffer_size` (default = 512 * 1024): WriteBufferSize for HTTP client.
-
 Example:
 
 ```yaml
 f5cloud:
-  endpoint: https://<ENDPOINT_FOUND_IN_F5_CLOUD_PORTAL>
+  endpoint: <ENDPOINT_FOUND_IN_F5_CLOUD_PORTAL>
   source: prod
   auth:
     credential_file: "/etc/creds/key.json"
@@ -40,3 +40,11 @@ configurations [here](./testdata/config.yaml).
 
 This exporter also offers proxy support as documented 
 [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter#proxy-support).
+
+## Advanced Configuration
+
+Several helper files are leveraged to provide additional capabilities automatically:
+
+- [gRPC settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md)
+- [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
+- [Queuing, retry and timeout settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)

--- a/exporter/f5cloudexporter/config.go
+++ b/exporter/f5cloudexporter/config.go
@@ -19,13 +19,13 @@ import (
 	"net/url"
 	"os"
 
-	otlphttp "go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	otlp "go.opentelemetry.io/collector/exporter/otlpexporter"
 )
 
 // Config defines configuration for F5 Cloud exporter.
 type Config struct {
-	// Config represents the OTLP HTTP Exporter configuration.
-	otlphttp.Config `mapstructure:",squash"`
+	// Config represents the OTLP Exporter configuration.
+	otlp.Config `mapstructure:",squash"`
 
 	// Source represents a unique identifier that is used to distinguish where this data is coming from.
 	Source string `mapstructure:"source"`

--- a/exporter/f5cloudexporter/config_test.go
+++ b/exporter/f5cloudexporter/config_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configtest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	otlphttp "go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	otlp "go.opentelemetry.io/collector/exporter/otlpexporter"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -45,7 +45,7 @@ func TestLoadConfig(t *testing.T) {
 	exporter := cfg.Exporters["f5cloud/allsettings"]
 	actualCfg := exporter.(*Config)
 	expectedCfg := &Config{
-		Config: otlphttp.Config{
+		Config: otlp.Config{
 			ExporterSettings: &config.ExporterSettings{
 				NameVal: "f5cloud/allsettings",
 				TypeVal: "f5cloud",
@@ -61,15 +61,15 @@ func TestLoadConfig(t *testing.T) {
 				NumConsumers: 2,
 				QueueSize:    10,
 			},
-			HTTPClientSettings: confighttp.HTTPClientSettings{
-				Endpoint:        "https://f5cloud",
+			GRPCClientSettings: configgrpc.GRPCClientSettings{
+				Endpoint:        "f5cloud:443",
 				ReadBufferSize:  123,
 				WriteBufferSize: 345,
-				Timeout:         time.Second * 10,
 				Headers: map[string]string{
 					"User-Agent": "opentelemetry-collector-contrib {{version}}",
 				},
 			},
+			TimeoutSettings: exporterhelper.TimeoutSettings{Timeout: 5 * time.Second},
 		},
 		Source: "dev",
 		AuthConfig: AuthConfig{
@@ -77,9 +77,6 @@ func TestLoadConfig(t *testing.T) {
 			Audience:       "exampleaudience",
 		},
 	}
-	// testing function equality is not supported in Go hence these will be ignored for this test
-	expectedCfg.HTTPClientSettings.CustomRoundTripper = nil
-	exporter.(*Config).HTTPClientSettings.CustomRoundTripper = nil
 	assert.Equal(t, expectedCfg, actualCfg)
 }
 

--- a/exporter/f5cloudexporter/factory_test.go
+++ b/exporter/f5cloudexporter/factory_test.go
@@ -41,8 +41,8 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	assert.NoError(t, configcheck.ValidateConfig(cfg))
 	ocfg, ok := factory.CreateDefaultConfig().(*Config)
 	assert.True(t, ok)
-	assert.Equal(t, ocfg.HTTPClientSettings.Endpoint, "")
-	assert.Equal(t, ocfg.HTTPClientSettings.Timeout, 30*time.Second, "default timeout is 30 seconds")
+	assert.Equal(t, ocfg.GRPCClientSettings.Endpoint, "")
+	assert.Equal(t, ocfg.Timeout, 5*time.Second, "default timeout is 5 seconds")
 	assert.Equal(t, ocfg.RetrySettings.Enabled, true, "default retry is enabled")
 	assert.Equal(t, ocfg.RetrySettings.MaxElapsedTime, 300*time.Second, "default retry MaxElapsedTime")
 	assert.Equal(t, ocfg.RetrySettings.InitialInterval, 5*time.Second, "default retry InitialInterval")
@@ -53,7 +53,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 func TestFactory_CreateMetricsExporter(t *testing.T) {
 	factory := NewFactoryWithTokenSourceGetter(mockTokenSourceGetter)
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.HTTPClientSettings.Endpoint = "https://" + testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.Source = "tests"
 	cfg.AuthConfig = AuthConfig{
 		CredentialFile: "testdata/empty_credential_file.json",
@@ -86,7 +86,7 @@ func TestFactory_CreateMetricsExporterInvalidConfig(t *testing.T) {
 func TestFactory_CreateTraceExporter(t *testing.T) {
 	factory := NewFactoryWithTokenSourceGetter(mockTokenSourceGetter)
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.HTTPClientSettings.Endpoint = "https://" + testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.Source = "tests"
 	cfg.AuthConfig = AuthConfig{
 		CredentialFile: "testdata/empty_credential_file.json",
@@ -119,7 +119,7 @@ func Test_Factory_CreateTraceExporterInvalidConfig(t *testing.T) {
 func TestFactory_CreateLogsExporter(t *testing.T) {
 	factory := NewFactoryWithTokenSourceGetter(mockTokenSourceGetter)
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.HTTPClientSettings.Endpoint = "https://" + testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.Source = "tests"
 	cfg.AuthConfig = AuthConfig{
 		CredentialFile: "testdata/empty_credential_file.json",
@@ -152,7 +152,7 @@ func TestFactory_CreateLogsExporterInvalidConfig(t *testing.T) {
 func TestFactory_getTokenSourceFromConfig(t *testing.T) {
 	factory := NewFactoryWithTokenSourceGetter(mockTokenSourceGetter)
 	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.HTTPClientSettings.Endpoint = "https://" + testutil.GetAvailableLocalAddress(t)
+	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.Source = "tests"
 	cfg.AuthConfig = AuthConfig{
 		CredentialFile: "testdata/empty_credential_file.json",

--- a/exporter/f5cloudexporter/testdata/config.yaml
+++ b/exporter/f5cloudexporter/testdata/config.yaml
@@ -6,12 +6,12 @@ processors:
 
 exporters:
   f5cloud:
-    endpoint: "https://f5cloud"
+    endpoint: "f5cloud:443"
     source: "dev"
     auth:
       credential_file: "/etc/creds/key.json"
   f5cloud/allsettings:
-    endpoint: "https://f5cloud"
+    endpoint: "f5cloud:443"
     source: "dev"
     auth:
       credential_file: "/etc/creds/key.json"


### PR DESCRIPTION
**Description:**
Updated the f5cloudexporter to use gRPC instead of HTTP. 

This work is pending the following issues to be completed: 
- https://github.com/open-telemetry/opentelemetry-collector/issues/2603
- https://github.com/open-telemetry/opentelemetry-collector/issues/2733
- https://github.com/open-telemetry/opentelemetry-collector/issues/2734
- https://github.com/open-telemetry/opentelemetry-collector/issues/2500

**Link to tracking Issue:**
#3000 

**Testing:**
Unit Tests

**Documentation:**
See code and README.