### PR TITLE
Fix ambiguous Config.Validate errors 

### DIFF
--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -97,7 +97,7 @@ type MetricDescriptor struct {
 }
 
 // Validate filters out invalid metricDeclarations and metricDescriptors
-func (config *Config) Validate() {
+func (config *Config) Validate() error {
 	validDeclarations := []*MetricDeclaration{}
 	for _, declaration := range config.MetricDeclarations {
 		err := declaration.Init(config.logger)
@@ -121,6 +121,7 @@ func (config *Config) Validate() {
 		}
 	}
 	config.MetricDescriptors = validDescriptors
+	return nil
 }
 
 func newEMFSupportedUnits() map[string]interface{} {

--- a/extension/observer/k8sobserver/config.go
+++ b/extension/observer/k8sobserver/config.go
@@ -37,3 +37,8 @@ type Config struct {
 	// Then set this value to ${K8S_NODE_NAME} in the configuration.
 	Node string `mapstructure:"node"`
 }
+
+// Validate checks if the extension configuration is valid
+func (cfg *Config) Validate() error {
+	return cfg.APIConfig.Validate()
+}

--- a/extension/observer/k8sobserver/config_test.go
+++ b/extension/observer/k8sobserver/config_test.go
@@ -55,3 +55,21 @@ func TestLoadConfig(t *testing.T) {
 		},
 		ext1)
 }
+
+func TestValidate(t *testing.T) {
+	cfg := &Config{
+		ExtensionSettings: &config.ExtensionSettings{
+			TypeVal: "k8s_observer",
+			NameVal: "k8s_observer/1",
+		},
+		Node:      "node-1",
+		APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeKubeConfig},
+	}
+
+	err := cfg.Validate()
+	require.Nil(t, err)
+
+	cfg.APIConfig.AuthType = "invalid"
+	err = cfg.Validate()
+	require.NotNil(t, err)
+}


### PR DESCRIPTION
**Description:** 
As we're adding `validatable` interface to `config.processor | extension | exporter` in core package. `Contrib` package is failed to be built due to the following errors. This PR is to fix the ambiguous Config.Validate errors.

```
exporter/awsemfexporter/factory.go:40:9: cannot use &Config literal (type *Config) as type config.Exporter in return argument:
	*Config does not implement config.Exporter (wrong type for Validate method)
		have Validate()
		want Validate() error

extension/observer/k8sobserver/factory.go:64:15: Config.Validate is ambiguous

```

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/pull/2898