### PR TITLE
Create AKS resource detector

### DIFF
--- a/processor/resourcedetectionprocessor/factory.go
+++ b/processor/resourcedetectionprocessor/factory.go
@@ -30,7 +30,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ecs"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/eks"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure/aks"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure/azurevm"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/env"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/gcp/gce"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/gcp/gke"
@@ -56,7 +57,8 @@ type factory struct {
 // NewFactory creates a new factory for ResourceDetection processor.
 func NewFactory() component.ProcessorFactory {
 	resourceProviderFactory := internal.NewProviderFactory(map[internal.DetectorType]internal.DetectorFactory{
-		azure.TypeStr:            azure.NewDetector,
+		aks.TypeStr:              aks.NewDetector,
+		azurevm.TypeStr:          azurevm.NewDetector,
 		ec2.TypeStr:              ec2.NewDetector,
 		ecs.TypeStr:              ecs.NewDetector,
 		eks.TypeStr:              eks.NewDetector,

--- a/processor/resourcedetectionprocessor/internal/azure/aks/aks.go
+++ b/processor/resourcedetectionprocessor/internal/azure/aks/aks.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aks
+
+import (
+	"os"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/translator/conventions"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure"
+)
+
+const TypeStr = "aks"
+
+// NewDetector creates a new Azure AKS detector
+func NewDetector(
+	p component.ProcessorCreateParams,
+	cfg internal.DetectorConfig,
+) (internal.Detector, error) {
+	return azure.NewDetector(
+		p,
+		cfg,
+		conventions.AttributeCloudPlatformAzureAKS,
+		onKubernetes,
+	)
+}
+
+func onKubernetes() bool {
+	// Environment variable that is set when running on Kubernetes
+	const kubernetesServiceHostEnvVar = "KUBERNETES_SERVICE_HOST"
+	return os.Getenv(kubernetesServiceHostEnvVar) != ""
+}

--- a/processor/resourcedetectionprocessor/internal/azure/azure.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azure.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//       http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,51 +16,69 @@ package azure
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
 
-const (
-	// TypeStr is the detector type string
-	TypeStr = "azure"
-)
-
-var _ internal.Detector = (*Detector)(nil)
-
 // Detector is an Azure metadata detector
 type Detector struct {
 	provider azureProvider
+	logger   *zap.Logger
+	platform string
+	envOK    func() bool
 }
 
-// NewDetector creates a new Azure metadata detector
-func NewDetector(component.ProcessorCreateParams, internal.DetectorConfig) (internal.Detector, error) {
-	return &Detector{provider: newProvider()}, nil
+// NewDetector creates a new Azure metadata detector. This is effectively a
+// default constructor called by the constructors in the `aks` and `azurevm`
+// subdirectories.
+func NewDetector(
+	p component.ProcessorCreateParams,
+	_ internal.DetectorConfig,
+	platform string,
+	envOK func() bool,
+) (internal.Detector, error) {
+	return &Detector{
+		provider: newProvider(),
+		logger:   p.Logger,
+		platform: platform,
+		envOK:    envOK,
+	}, nil
 }
 
 // Detect detects system metadata and returns a resource with the available ones
 func (d *Detector) Detect(ctx context.Context) (pdata.Resource, error) {
 	res := pdata.NewResource()
-	attrs := res.Attributes()
 
-	compute, err := d.provider.metadata(ctx)
-	if err != nil {
-		return res, fmt.Errorf("failed getting metadata: %w", err)
+	if !d.envOK() {
+		return res, nil
 	}
 
-	attrs.InsertString(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAzure)
-	attrs.InsertString(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAzureVM)
-	attrs.InsertString(conventions.AttributeHostName, compute.Name)
-	attrs.InsertString(conventions.AttributeCloudRegion, compute.Location)
-	attrs.InsertString(conventions.AttributeHostID, compute.VMID)
-	attrs.InsertString(conventions.AttributeCloudAccount, compute.SubscriptionID)
-	attrs.InsertString("azure.vm.size", compute.VMSize)
-	attrs.InsertString("azure.vm.scaleset.name", compute.VMScaleSetName)
-	attrs.InsertString("azure.resourcegroup.name", compute.ResourceGroupName)
+	metadata, err := d.provider.metadata(ctx)
+	if err != nil {
+		d.logger.Warn("attempt to get Azure metadata failed", zap.Error(err))
+		// don't return an error
+		return res, nil
+	}
+
+	attrs := res.Attributes()
+	attrs.InsertString(conventions.AttributeCloudPlatform, d.platform)
+	insertAttrs(metadata, attrs)
 
 	return res, nil
+}
+
+func insertAttrs(d *computeMetadata, attrs pdata.AttributeMap) {
+	attrs.InsertString(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAzure)
+	attrs.InsertString(conventions.AttributeHostName, d.Name)
+	attrs.InsertString(conventions.AttributeCloudRegion, d.Location)
+	attrs.InsertString(conventions.AttributeHostID, d.VMID)
+	attrs.InsertString(conventions.AttributeCloudAccount, d.SubscriptionID)
+	attrs.InsertString("azure.vm.size", d.VMSize)
+	attrs.InsertString("azure.vm.scaleset.name", d.VMScaleSetName)
+	attrs.InsertString("azure.resourcegroup.name", d.ResourceGroupName)
 }

--- a/processor/resourcedetectionprocessor/internal/azure/azurevm/azurevm.go
+++ b/processor/resourcedetectionprocessor/internal/azure/azurevm/azurevm.go
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azurevm
+
+import (
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/translator/conventions"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure"
+)
+
+const TypeStr = "azurevm"
+
+// NewDetector creates a new Azure VM detector
+func NewDetector(
+	p component.ProcessorCreateParams,
+	cfg internal.DetectorConfig,
+) (internal.Detector, error) {
+	return azure.NewDetector(
+		p,
+		cfg,
+		conventions.AttributeCloudProviderAzure,
+		func() bool { return true },
+	)
+}


### PR DESCRIPTION
This change creates a resource detector for AKS, which is the same as
the previously named `azure` detector, but with a check of the environment
to ensure that it's running on k8s, and a different `cloud.platform` value.
The `azure` detector has been renamed internally to `azurevm`.
