### PR TITLE
Check if fluent-bit is in PATH when starting testbed

### DIFF
--- a/testbed/datasenders/fluentbit.go
+++ b/testbed/datasenders/fluentbit.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"strconv"
 	"time"
 
@@ -62,6 +63,10 @@ func NewFluentBitFileLogWriter(host string, port int) *FluentBitFileLogWriter {
 }
 
 func (f *FluentBitFileLogWriter) Start() error {
+	if _, err := exec.LookPath("fluent-bit"); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Description:** When fluent-bit is missing from system's PATH there's no error reported mentioning this in testbed tests.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3037

This PR tries to address that by returning an error in `Start()` method of `FluentBitFileLogWriter`.

This will make the test to explicitly mention that `fluent-bit` is missing but it won't abort the test hence the user still needs to wait the full test duration.

```
=== RUN   TestLog10kDPS/FluentBitToOTLP
2021/04/10 10:15:47 Starting mock backend...
2021/04/10 10:15:47 Starting Agent (/Users/pmalek/code/opentelemetry/opentelemetry-collector-contrib-rebase/bin/otelcontribcol_darwin_amd64)
2021/04/10 10:15:47 Writing Agent log to /Users/pmalek/code/opentelemetry/opentelemetry-collector-contrib-rebase/testbed/tests/results/TestLog10kDPS/FluentBitToOTLP/agent.log
2021/04/10 10:15:47 Agent running, pid=187
2021/04/10 10:15:48 Starting load generator at 10000 items/sec.
2021/04/10 10:15:48 Cannot start sender: failed to find fluent-bit in PATH: exec: "fluent-bit": executable file not found in $PATH
2021/04/10 10:15:50 Agent RAM (RES):   0 MiB, CPU: 0.0% | Sent:         0 items | Received:         0 items (0/sec)
2021/04/10 10:15:53 Agent RAM (RES):  35 MiB, CPU: 2.3% | Sent:         0 items | Received:         0 items (0/sec)
2021/04/10 10:15:56 Agent RAM (RES):  35 MiB, CPU: 0.3% | Sent:         0 items | Received:         0 items (0/sec)
2021/04/10 10:15:59 Agent RAM (RES):  35 MiB, CPU: 0.0% | Sent:         0 items | Received:         0 items (0/sec)
2021/04/10 10:16:02 Agent RAM (RES):  35 MiB, CPU: 0.3% | Sent:         0 items | Received:         0 items (0/sec)
2021/04/10 10:16:03 Stopped generator. Sent:         0 items
2021/04/10 10:16:05 Agent RAM (RES):  35 MiB, CPU: 0.3% | Sent:         0 items | Received:         0 items (0/sec)
2021/04/10 10:16:08 Agent RAM (RES):  35 MiB, CPU: 0.0% | Sent:         0 items | Received:         0 items (0/sec)
2021/04/10 10:16:11 Agent RAM (RES):  35 MiB, CPU: 0.3% | Sent:         0 items | Received:         0 items (0/sec)
    test_case.go:312: Time out waiting for [load generator started]
2021/04/10 10:16:13 Gracefully terminating Agent pid=187, sending SIGTEM...
2021/04/10 10:16:13 Stopping process monitor.
2021/04/10 10:16:14 Agent RAM (RES):  35 MiB, CPU: 0.0% | Sent:         0 items | Received:         0 items (0/sec)
2021/04/10 10:16:17 Agent RAM (RES):  35 MiB, CPU: 0.0% | Sent:         0 items | Received:         0 items (0/sec)
2021/04/10 10:16:18 Agent process stopped, exit code=0
2021/04/10 10:16:18 Sent and received data matches.
2021/04/10 10:16:18 Stopping mock backend...
2021/04/10 10:16:18 Stopped backend. Received:         0 items (0/sec)
--- FAIL: TestLog10kDPS (31.61s)
    --- FAIL: TestLog10kDPS/FluentBitToOTLP (31.60s)
FAIL
exit status 1
FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/testbed/tests 32.519s
```