### PR TITLE
Fix example config in README

### DIFF
--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -69,6 +69,7 @@ receivers:
         endpoint: "localhost:55677"
 
 processors:
+  batch:
   spanmetrics:
     metrics_exporter: otlp/spanmetrics
     latency_histogram_buckets: [2ms, 6ms, 10ms, 100ms, 250ms]

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -48,7 +48,13 @@ The following settings can be optionally configured:
   - Default: `[2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]`
 - `dimensions`: the list of dimensions to add together with the default dimensions defined above. Each additional dimension is defined with a `name` which is looked up in the span's collection of attributes. If the `name`d attribute is missing in the span, the optional provided `default` is used. If no `default` is provided, this dimension will be **omitted** from the metric.
 
-Example:
+## Examples
+
+The following is a simple example usage of the spanmetrics processor.
+
+For configuration examples on other use cases, please refer to [More Examples](#more-examples).
+
+The full list of settings exposed for this processor are documented [here](./config.go).
 
 ```yaml
 receivers:
@@ -108,4 +114,6 @@ service:
       exporters: [prometheus]
 ```
 
-The full list of settings exposed for this processor are documented [here](./config.go) with detailed sample configuration [here](./testdata).
+### More Examples
+
+For more example configuration covering various other use cases, please visit the [testdata directory](./testdata).

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -89,21 +89,22 @@ exporters:
     endpoint: "0.0.0.0:8889"
     namespace: promexample
 
-pipelines:
-  traces:
-    receivers: [jaeger]
-    processors: [spanmetrics, batch]
-    exporters: [jaeger]
+service:
+  pipelines:
+    traces:
+      receivers: [jaeger]
+      processors: [spanmetrics, batch]
+      exporters: [jaeger]
 
-  # The exporter name must match the metrics_exporter name.
-  # The receiver is just a dummy and never used; added to pass validation requiring at least one receiver in a pipeline.
-  metrics/spanmetrics:
-    receivers: [otlp/spanmetrics]
-    exporters: [otlp/spanmetrics]
+    # The exporter name must match the metrics_exporter name.
+    # The receiver is just a dummy and never used; added to pass validation requiring at least one receiver in a pipeline.
+    metrics/spanmetrics:
+      receivers: [otlp/spanmetrics]
+      exporters: [otlp/spanmetrics]
 
-  metrics:
-    receivers: [otlp]
-    exporters: [prometheus]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]
 ```
 
 The full list of settings exposed for this processor are documented [here](./config.go) with detailed sample configuration [here](./testdata).

--- a/processor/spanmetricsprocessor/testdata/config-prometheusremotewrite.yaml
+++ b/processor/spanmetricsprocessor/testdata/config-prometheusremotewrite.yaml
@@ -1,0 +1,72 @@
+# This example is practical application of a 3-pipeline configuration for
+# writing to a remote prometheus-compatible write endpoint.
+#
+# The spanmetrics processor will output data on every span batch that is received,
+# that could overwhelm the remote write endpoint.
+#
+# Therefore, a good pattern to follow is to ratelimit the metrics coming out of
+# spanmetrics by adding a prometheus exporter (to expose these metrics as snapshots)
+# and a prometheus receiver to scrape these snapshots at a controlled interval,
+# passing these scraped metrics onto the prometheusremotewrite exporter.
+#
+# The added benefit of this pattern is that it provides a regular "heartbeat" of
+# datapoints that prevents gaps in the timeseries.
+receivers:
+  jaeger:
+    protocols:
+      thrift_http:
+        endpoint: "0.0.0.0:14278"
+
+  # Dummy receiver that's never used, because a pipeline is required to have one.
+  otlp/spanmetrics:
+    protocols:
+      grpc:
+        endpoint: "localhost:12345"
+
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'ratelimiter'
+        scrape_interval: 15s
+        static_configs:
+        - targets: [ "0.0.0.0:8889" ]
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+  jaeger:
+    endpoint: "localhost:14250"
+    insecure: true
+
+  prometheusremotewrite:
+    endpoint: "http://myremotewriteendpoint:1234"
+    headers:
+      Authorization: "Bearer mybearertoken"
+
+processors:
+  batch:
+  spanmetrics:
+    metrics_exporter: prometheus
+
+service:
+  pipelines:
+    traces:
+      receivers: [jaeger]
+      # spanmetrics will pass on span data untouched to next processor
+      # while also accumulating metrics to be sent to the configured 'otlp/spanmetrics' exporter.
+      processors: [spanmetrics, batch]
+      exporters: [jaeger]
+
+    # This pipeline acts as a proxy to the 'metrics' pipeline below,
+    # allowing for further metrics processing if required.
+    metrics/spanmetrics:
+      # This receiver is just a dummy and never used.
+      # Added to pass validation requiring at least one receiver in a pipeline.
+      receivers: [otlp/spanmetrics]
+      exporters: [prometheus]
+
+    metrics:
+      receivers: [prometheus]
+      # The metrics_exporter must be present in this list.
+      exporters: [prometheusremotewrite]


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

- Fix `'' has invalid keys: pipelines` error due to invalid config in README.
- Add config example to demonstrate a prometheusremotewrite pattern.