### PR TITLE
[system detector] Correctly report `DRAGONFLYBSD` value

### DIFF
--- a/processor/resourcedetectionprocessor/internal/system/metadata.go
+++ b/processor/resourcedetectionprocessor/internal/system/metadata.go
@@ -31,8 +31,17 @@ type systemMetadata interface {
 
 type systemMetadataImpl struct{}
 
+// goosToOSType maps a runtime.GOOS-like value to os.type style.
+func goosToOSType(goos string) string {
+	switch goos {
+	case "dragonfly":
+		return "DRAGONFLYBSD"
+	}
+	return strings.ToUpper(goos)
+}
+
 func (*systemMetadataImpl) OSType() (string, error) {
-	return strings.ToUpper(runtime.GOOS), nil
+	return goosToOSType(runtime.GOOS), nil
 }
 
 func (*systemMetadataImpl) FQDN() (string, error) {

--- a/processor/resourcedetectionprocessor/internal/system/metadata_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/metadata_test.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package system
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGOOSToOsType(t *testing.T) {
+	assert.Equal(t, "DARWIN", goosToOSType("darwin"))
+	assert.Equal(t, "LINUX", goosToOSType("linux"))
+	assert.Equal(t, "WINDOWS", goosToOSType("windows"))
+	assert.Equal(t, "DRAGONFLYBSD", goosToOSType("dragonfly"))
+}


### PR DESCRIPTION
**Description:**

- Fixes incorrect mapping when OS is of the `dragonfly` family. Not sure if the Collector would even build correctly on Dragonfly BSD but this is technically a bug 😄 

**Link to tracking Issue:** Relates to open-telemetry/opentelemetry-specification#1572

**Testing:** Added unit test
