### PR TITLE
HTTP client for Humio exporter

### DIFF
--- a/exporter/humioexporter/README.md
+++ b/exporter/humioexporter/README.md
@@ -20,6 +20,7 @@ As defined in the [TLS Configuration Settings](https://github.com/open-telemetry
 
 In addition, the following global configuration options can be overridden:
 
+- `disable_compression` (default: `false`): Whether to stop compressing payloads with gzip before sending them to Humio. This should only be disabled if compression can be shown to have a negative impact on performance in your specific deployment.
 - `tags` (no default): A series of key-value pairs used to target specific Data Sources for storage inside a Humio repository. Refer to [Humio Tagging](https://docs.humio.com/docs/parsers/tagging/) for more details.
 - `disable_service_tag` (default: `false`): By default, the service name will be used to tag all exported events in addition to user-provided tags. If disabled, only the user-provided tags will be used. However, at least one tag _must_ be specified.
 
@@ -48,6 +49,7 @@ exporters:
         ingest_token: "00000000-0000-0000-0000-0000000000000"
         endpoint: "http://localhost:8080"
         timeout: 10s
+        disable_compression: true
         disable_service_tag: true
         tags:
             host: "web_server"

--- a/exporter/humioexporter/README.md
+++ b/exporter/humioexporter/README.md
@@ -52,8 +52,6 @@ exporters:
         tags:
             host: "web_server"
             environment: "production"
-        logs:
-            log_parser: "custom-parser"
         traces:
             unix_timestamps: true
             timezone: "Europe/Copenhagen"

--- a/exporter/humioexporter/README.md
+++ b/exporter/humioexporter/README.md
@@ -27,8 +27,7 @@ In addition, the following global configuration options can be overridden:
 ### Traces
 For exporting structured data (traces), the following configuration options are available:
 
-- `unix_timestamps` (default: `false`): Whether to use Unix or ISO 8601 formatted timestamps when exporting data to Humio. If this is set to `true`, timestamps will be represented in milliseconds (Unix time) in UTC.
-- `timezone` (default: host timezone): When using Unix timestamps, this option can be provided to specify the local timezone of the events. If not specified, the local time zone of the host is used instead. An example is `Europe/Copenhagen`.
+- `unix_timestamps` (default: `false`): Whether to use Unix or ISO 8601 formatted timestamps when exporting data to Humio. If this is set to `true`, timestamps will be represented in milliseconds (Unix time) in UTC, and the time zone of the event is stored separately in the payload sent to Humio.
 
 ## Advaced Configuration
 This exporter, like many others, includes shared configuration helpers for the following advanced settings:
@@ -56,5 +55,4 @@ exporters:
             environment: "production"
         traces:
             unix_timestamps: true
-            timezone: "Europe/Copenhagen"
 ```

--- a/exporter/humioexporter/config.go
+++ b/exporter/humioexporter/config.go
@@ -129,6 +129,13 @@ func (c *Config) Validate() error {
 	}
 	c.Headers["Authorization"] = "Bearer " + c.IngestToken
 
+	if enc, ok := c.Headers["Content-Encoding"]; ok && (c.DisableCompression || enc != "gzip") {
+		return errors.New("the Content-Encoding header must be gzip when using compression, and empty when compression is disabled")
+	}
+	if !c.DisableCompression {
+		c.Headers["Content-Encoding"] = "gzip"
+	}
+
 	// Fallback User-Agent if not overridden by user
 	if _, ok := c.Headers["User-Agent"]; !ok {
 		c.Headers["User-Agent"] = "opentelemetry-collector-contrib Humio"

--- a/exporter/humioexporter/config.go
+++ b/exporter/humioexporter/config.go
@@ -96,15 +96,15 @@ func (c *Config) Validate() error {
 	}
 
 	// We require these headers, which should not be overwritten by the user
-	if contentType, ok := c.Headers["Content-Type"]; ok && contentType != "application/json" {
+	if contentType, ok := c.Headers["content-type"]; ok && contentType != "application/json" {
 		return errors.New("the Content-Type must be application/json, which is also the default for this header")
 	}
 
-	if _, ok := c.Headers["Authorization"]; ok {
+	if _, ok := c.Headers["authorization"]; ok {
 		return errors.New("the Authorization header must not be overwritten, since it is automatically generated from the ingest token")
 	}
 
-	if enc, ok := c.Headers["Content-Encoding"]; ok && (c.DisableCompression || enc != "gzip") {
+	if enc, ok := c.Headers["content-encoding"]; ok && (c.DisableCompression || enc != "gzip") {
 		return errors.New("the Content-Encoding header must be gzip when using compression, and empty when compression is disabled")
 	}
 
@@ -126,15 +126,15 @@ func (c *Config) sanitize() error {
 		c.Headers = make(map[string]string)
 	}
 
-	c.Headers["Content-Type"] = "application/json"
-	c.Headers["Authorization"] = "Bearer " + c.IngestToken
+	c.Headers["content-type"] = "application/json"
+	c.Headers["authorization"] = "Bearer " + c.IngestToken
 
 	if !c.DisableCompression {
-		c.Headers["Content-Encoding"] = "gzip"
+		c.Headers["content-encoding"] = "gzip"
 	}
 
-	if _, ok := c.Headers["User-Agent"]; !ok {
-		c.Headers["User-Agent"] = "opentelemetry-collector-contrib Humio"
+	if _, ok := c.Headers["user-agent"]; !ok {
+		c.Headers["user-agent"] = "opentelemetry-collector-contrib Humio"
 	}
 
 	return nil

--- a/exporter/humioexporter/config.go
+++ b/exporter/humioexporter/config.go
@@ -40,9 +40,6 @@ type LogsConfig struct {
 type TracesConfig struct {
 	// Whether to use Unix timestamps, or to fall back to ISO 8601 formatted strings
 	UnixTimestamps bool `mapstructure:"unix_timestamps"`
-
-	// The time zone to use when representing timestamps in Unix time
-	TimeZone string `mapstructure:"timezone"`
 }
 
 // Config represents the Humio configuration settings
@@ -90,10 +87,6 @@ func (c *Config) Validate() error {
 
 	if c.DisableServiceTag && len(c.Tags) == 0 {
 		return errors.New("requires at least one custom tag when disabling service tag")
-	}
-
-	if c.Traces.UnixTimestamps && c.Traces.TimeZone == "" {
-		return errors.New("requires a time zone when using Unix timestamps")
 	}
 
 	// Ensure that it is possible to construct a URL to access the unstructured ingest API

--- a/exporter/humioexporter/config.go
+++ b/exporter/humioexporter/config.go
@@ -62,6 +62,9 @@ type Config struct {
 	// Endpoint for the structured ingest API, created internally
 	structuredEndpoint *url.URL
 
+	// Whether gzip compression should be disabled when sending data to Humio
+	DisableCompression bool `mapstructure:"disable_compression"`
+
 	// Key-value pairs used to target specific data sources for storage inside Humio
 	Tags map[string]string `mapstructure:"tags,omitempty"`
 

--- a/exporter/humioexporter/config_test.go
+++ b/exporter/humioexporter/config_test.go
@@ -115,7 +115,6 @@ func TestLoadAllSettings(t *testing.T) {
 		},
 		Traces: TracesConfig{
 			UnixTimestamps: true,
-			TimeZone:       "Europe/Copenhagen",
 		},
 	}
 
@@ -264,7 +263,7 @@ func TestValidateErrors(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			desc: "Unix with time zone",
+			desc: "Unix time",
 			config: &Config{
 				ExporterSettings: config.NewExporterSettings(typeStr),
 				IngestToken:      "t",
@@ -273,24 +272,9 @@ func TestValidateErrors(t *testing.T) {
 				},
 				Traces: TracesConfig{
 					UnixTimestamps: true,
-					TimeZone:       "z",
 				},
 			},
 			wantErr: false,
-		},
-		{
-			desc: "Missing time zone",
-			config: &Config{
-				ExporterSettings: config.NewExporterSettings(typeStr),
-				IngestToken:      "t",
-				HTTPClientSettings: confighttp.HTTPClientSettings{
-					Endpoint: "e",
-				},
-				Traces: TracesConfig{
-					UnixTimestamps: true,
-				},
-			},
-			wantErr: true,
 		},
 		{
 			desc: "Error creating URLs",

--- a/exporter/humioexporter/config_test.go
+++ b/exporter/humioexporter/config_test.go
@@ -103,8 +103,9 @@ func TestLoadAllSettings(t *testing.T) {
 			},
 		},
 
-		IngestToken:       "00000000-0000-0000-0000-0000000000000",
-		DisableServiceTag: true,
+		IngestToken:        "00000000-0000-0000-0000-0000000000000",
+		DisableCompression: true,
+		DisableServiceTag:  true,
 		Tags: map[string]string{
 			"host":        "web_server",
 			"environment": "production",

--- a/exporter/humioexporter/config_test.go
+++ b/exporter/humioexporter/config_test.go
@@ -61,6 +61,19 @@ func TestLoadWithDefaults(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestLoadInvalid(t *testing.T) {
+	// Initialize exporter factory
+	factories, err := componenttest.NopFactories()
+	require.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Exporters[config.Type(typeStr)] = factory
+
+	// Load configurations
+	_, err = configtest.LoadConfigFile(t, path.Join(".", "testdata", "invalid.yaml"), factories)
+	require.Error(t, err)
+}
+
 func TestLoadAllSettings(t *testing.T) {
 	// Arrange
 	expected := &Config{
@@ -147,9 +160,9 @@ func TestValidate(t *testing.T) {
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "http://localhost:8080",
 					Headers: map[string]string{
-						"User-Agent":       "Humio",
-						"Content-Type":     "application/json",
-						"Content-Encoding": "gzip",
+						"user-agent":       "Humio",
+						"content-type":     "application/json",
+						"content-encoding": "gzip",
 					},
 				},
 			},
@@ -247,7 +260,7 @@ func TestValidate(t *testing.T) {
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "e",
 					Headers: map[string]string{
-						"Content-Type": "text/plain",
+						"content-type": "text/plain",
 					},
 				},
 			},
@@ -261,7 +274,7 @@ func TestValidate(t *testing.T) {
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "e",
 					Headers: map[string]string{
-						"Authorization": "Bearer mytoken",
+						"authorization": "Bearer mytoken",
 					},
 				},
 			},
@@ -275,7 +288,7 @@ func TestValidate(t *testing.T) {
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "e",
 					Headers: map[string]string{
-						"Content-Encoding": "compress",
+						"content-encoding": "compress",
 					},
 				},
 			},
@@ -290,7 +303,7 @@ func TestValidate(t *testing.T) {
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "e",
 					Headers: map[string]string{
-						"Content-Encoding": "gzip",
+						"content-encoding": "gzip",
 					},
 				},
 			},
@@ -332,10 +345,10 @@ func TestSanitizeValid(t *testing.T) {
 	assert.Equal(t, structuredPath, cfg.structuredEndpoint.Path)
 
 	assert.Equal(t, map[string]string{
-		"Content-Type":     "application/json",
-		"Content-Encoding": "gzip",
-		"Authorization":    "Bearer token",
-		"User-Agent":       "opentelemetry-collector-contrib Humio",
+		"content-type":     "application/json",
+		"content-encoding": "gzip",
+		"authorization":    "Bearer token",
+		"user-agent":       "opentelemetry-collector-contrib Humio",
 	}, cfg.Headers)
 }
 
@@ -347,9 +360,9 @@ func TestSanitizeCustomHeaders(t *testing.T) {
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint: "http://localhost:8080",
 			Headers: map[string]string{
-				"User-Agent":       "Humio",
-				"Content-Type":     "application/json",
-				"Content-Encoding": "gzip",
+				"user-agent":       "Humio",
+				"content-type":     "application/json",
+				"content-encoding": "gzip",
 			},
 		},
 	}
@@ -360,10 +373,10 @@ func TestSanitizeCustomHeaders(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
-		"Content-Type":     "application/json",
-		"Content-Encoding": "gzip",
-		"Authorization":    "Bearer token",
-		"User-Agent":       "Humio",
+		"content-type":     "application/json",
+		"content-encoding": "gzip",
+		"authorization":    "Bearer token",
+		"user-agent":       "Humio",
 	}, cfg.Headers)
 }
 
@@ -384,9 +397,9 @@ func TestSanitizeNoCompression(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{
-		"Content-Type":  "application/json",
-		"Authorization": "Bearer token",
-		"User-Agent":    "opentelemetry-collector-contrib Humio",
+		"content-type":  "application/json",
+		"authorization": "Bearer token",
+		"user-agent":    "opentelemetry-collector-contrib Humio",
 	}, cfg.Headers)
 }
 

--- a/exporter/humioexporter/factory.go
+++ b/exporter/humioexporter/factory.go
@@ -72,8 +72,7 @@ func createTracesExporter(
 	}
 	cfg := config.(*Config)
 
-	// Fail fast if the configurations are invalid
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.sanitize(); err != nil {
 		return nil, err
 	}
 

--- a/exporter/humioexporter/factory.go
+++ b/exporter/humioexporter/factory.go
@@ -17,7 +17,6 @@ package humioexporter
 import (
 	"context"
 	"errors"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -36,9 +35,6 @@ func NewFactory() component.ExporterFactory {
 		typeStr,
 		createDefaultConfig,
 		exporterhelper.WithTraces(createTracesExporter),
-		// To be added over time
-		// exporterhelper.WithMetrics(createMetricsExporter),
-		// exporterhelper.WithLogs(createLogsExporter),
 	)
 }
 
@@ -61,7 +57,6 @@ func createDefaultConfig() config.Exporter {
 		DisableServiceTag:  false,
 		Traces: TracesConfig{
 			UnixTimestamps: false,
-			TimeZone:       time.Local.String(),
 		},
 	}
 }

--- a/exporter/humioexporter/factory.go
+++ b/exporter/humioexporter/factory.go
@@ -81,7 +81,12 @@ func createTracesExporter(
 		return nil, err
 	}
 
-	exporter := newTracesExporter(cfg, params.Logger)
+	client, err := newHumioClient(cfg, params.Logger)
+	if err != nil {
+		return nil, err
+	}
+
+	exporter := newTracesExporter(cfg, params.Logger, client)
 
 	return exporterhelper.NewTracesExporter(
 		cfg,

--- a/exporter/humioexporter/factory.go
+++ b/exporter/humioexporter/factory.go
@@ -56,8 +56,9 @@ func createDefaultConfig() config.Exporter {
 		},
 
 		// Settings specific to the Humio exporter
-		Tags:              map[string]string{},
-		DisableServiceTag: false,
+		DisableCompression: false,
+		Tags:               map[string]string{},
+		DisableServiceTag:  false,
 		Traces: TracesConfig{
 			UnixTimestamps: false,
 			TimeZone:       time.Local.String(),

--- a/exporter/humioexporter/factory_test.go
+++ b/exporter/humioexporter/factory_test.go
@@ -43,12 +43,12 @@ func TestCreateTracesExporter(t *testing.T) {
 	factory := newHumioFactory(t)
 	testCases := []struct {
 		desc    string
-		config  config.Exporter
+		cfg     config.Exporter
 		wantErr bool
 	}{
 		{
 			desc: "Valid trace configuration",
-			config: &Config{
+			cfg: &Config{
 				ExporterSettings: config.NewExporterSettings(typeStr),
 				IngestToken:      "00000000-0000-0000-0000-0000000000000",
 				HTTPClientSettings: confighttp.HTTPClientSettings{
@@ -58,18 +58,18 @@ func TestCreateTracesExporter(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			desc: "Invalid trace configuration",
-			config: &Config{
+			desc: "Unsanitizable trace configuration",
+			cfg: &Config{
 				ExporterSettings: config.NewExporterSettings(typeStr),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
-					Endpoint: "http://localhost:8080",
+					Endpoint: "\n",
 				},
 			},
 			wantErr: true,
 		},
 		{
 			desc: "Invalid client configuration",
-			config: &Config{
+			cfg: &Config{
 				ExporterSettings: config.NewExporterSettings(typeStr),
 				IngestToken:      "00000000-0000-0000-0000-0000000000000",
 				HTTPClientSettings: confighttp.HTTPClientSettings{
@@ -86,7 +86,7 @@ func TestCreateTracesExporter(t *testing.T) {
 		},
 		{
 			desc:    "Missing configuration",
-			config:  nil,
+			cfg:     nil,
 			wantErr: true,
 		},
 	}
@@ -97,7 +97,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			exp, err := factory.CreateTracesExporter(
 				context.Background(),
 				component.ExporterCreateParams{Logger: zap.NewNop()},
-				tC.config,
+				tC.cfg,
 			)
 
 			if (err != nil) != tC.wantErr {

--- a/exporter/humioexporter/factory_test.go
+++ b/exporter/humioexporter/factory_test.go
@@ -70,7 +70,8 @@ func TestCreateTracesExporter(t *testing.T) {
 		{
 			desc: "Invalid client configuration",
 			config: &Config{
-				IngestToken: "00000000-0000-0000-0000-0000000000000",
+				ExporterSettings: config.NewExporterSettings(typeStr),
+				IngestToken:      "00000000-0000-0000-0000-0000000000000",
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "http://localhost:8080",
 					TLSSetting: configtls.TLSClientSetting{

--- a/exporter/humioexporter/factory_test.go
+++ b/exporter/humioexporter/factory_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
 )
 
@@ -62,6 +63,22 @@ func TestCreateTracesExporter(t *testing.T) {
 				ExporterSettings: config.NewExporterSettings(typeStr),
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "http://localhost:8080",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "Invalid client configuration",
+			config: &Config{
+				IngestToken: "00000000-0000-0000-0000-0000000000000",
+				HTTPClientSettings: confighttp.HTTPClientSettings{
+					Endpoint: "http://localhost:8080",
+					TLSSetting: configtls.TLSClientSetting{
+						TLSSetting: configtls.TLSSetting{
+							CertFile: "",
+							KeyFile:  "key.key",
+						},
+					},
 				},
 			},
 			wantErr: true,

--- a/exporter/humioexporter/humio_client.go
+++ b/exporter/humioexporter/humio_client.go
@@ -62,9 +62,6 @@ type HumioStructuredEvent struct {
 
 	// The event payload
 	Attributes interface{}
-
-	// A representation of this event as a string, may be empty to ignore
-	RawString string
 }
 
 // Formats the timestamp in a HumioStructuredEvent as either an ISO string or a
@@ -75,22 +72,18 @@ func (e *HumioStructuredEvent) MarshalJSON() ([]byte, error) {
 			Timestamp  int64       `json:"timestamp"`
 			TimeZone   string      `json:"timezone"`
 			Attributes interface{} `json:"attributes,omitempty"`
-			RawString  string      `json:"rawstring,omitempty"`
 		}{
 			Timestamp:  e.Timestamp.Local().UnixNano() * int64(time.Nanosecond) / int64(time.Millisecond),
 			TimeZone:   e.Timestamp.Location().String(),
 			Attributes: e.Attributes,
-			RawString:  e.RawString,
 		})
 	} else {
 		return json.Marshal(struct {
 			Timestamp  time.Time   `json:"timestamp"`
 			Attributes interface{} `json:"attributes,omitempty"`
-			RawString  string      `json:"rawstring,omitempty"`
 		}{
 			Timestamp:  e.Timestamp,
 			Attributes: e.Attributes,
-			RawString:  e.RawString,
 		})
 	}
 }

--- a/exporter/humioexporter/humio_client.go
+++ b/exporter/humioexporter/humio_client.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"sync"
 	"time"
@@ -159,7 +160,7 @@ func (h *humioClient) sendEvents(ctx context.Context, evts interface{}, url stri
 	}
 	// Response body needs to both be read to EOF and closed to avoid leaks
 	defer res.Body.Close()
-	io.Copy(io.Discard, res.Body)
+	io.Copy(ioutil.Discard, res.Body)
 
 	// If an error has occurred, determine if it would make sense to retry
 	// This check is not exhaustive, but should cover the most common cases

--- a/exporter/humioexporter/humio_client.go
+++ b/exporter/humioexporter/humio_client.go
@@ -1,0 +1,133 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package humioexporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/zap"
+)
+
+// Describes a payload of unstructured events to send to Humio
+type HumioUnstructuredEvents struct {
+	Fields   map[string]string `json:"fields,omitempty"`
+	Tags     map[string]string `json:"tags,omitempty"`
+	Type     string            `json:"type,omitempty"`
+	Messages []string          `json:"messages"`
+}
+
+// Describes a payload of structured events to send to Humio
+type HumioStructuredEvents struct {
+	Tags   map[string]string      `json:"tags,omitempty"`
+	Events []HumioStructuredEvent `json:"events"`
+}
+
+// Describes a single structured event to send to Humio
+type HumioStructuredEvent struct {
+	TimeStamp  time.Time         `json:"timestamp"`          // TODO: Handle both ISO and Unix
+	TimeZone   string            `json:"timezone,omitempty"` // TODO: Does Go have a time zone struct we can use?
+	Attributes map[string]string `json:"attributes,omitempty"`
+	RawString  string            `json:"rawstring,omitempty"`
+}
+
+// An HTTP client for sending unstructured and structured events to Humio
+type humioClient struct {
+	config *Config
+	client *http.Client
+	logger *zap.Logger
+}
+
+// Constructs a new HTTP client for sending payloads to Humio
+func newHumioClient(config *Config, logger *zap.Logger) (*humioClient, error) {
+	client, err := config.HTTPClientSettings.ToClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return &humioClient{
+		config: config,
+		client: client,
+		logger: logger,
+	}, nil
+}
+
+func (h *humioClient) sendUnstructuredEvents(ctx context.Context, evts []*HumioUnstructuredEvents) error {
+	return h.sendEvents(ctx, evts, h.config.unstructuredEndpoint)
+}
+
+func (h *humioClient) sendStructuredEvents(ctx context.Context, evts []*HumioStructuredEvents) error {
+	return h.sendEvents(ctx, evts, h.config.structuredEndpoint)
+}
+
+func (h *humioClient) sendEvents(ctx context.Context, evts interface{}, u *url.URL) error {
+	body, err := encodeBody(evts)
+	if err != nil {
+		return consumererror.Permanent(err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		"POST",
+		u.String(),
+		body,
+	)
+	if err != nil {
+		return consumererror.Permanent(err)
+	}
+
+	for h, v := range h.config.Headers {
+		req.Header.Set(h, v)
+	}
+
+	res, err := h.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// If an error has occured, determine if it would make sense to retry
+	// This check is not exhaustive, but should cover the most common cases
+	if res.StatusCode < http.StatusOK ||
+		res.StatusCode >= http.StatusMultipleChoices {
+		err = errors.New("unable to export events to Humio, got " + res.Status)
+
+		// These indicate a programming or configuration error
+		if res.StatusCode == http.StatusBadRequest ||
+			res.StatusCode == http.StatusUnauthorized ||
+			res.StatusCode == http.StatusForbidden {
+			return consumererror.Permanent(err)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func encodeBody(body interface{}) (io.Reader, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes.NewReader(b), nil
+}

--- a/exporter/humioexporter/humio_client_test.go
+++ b/exporter/humioexporter/humio_client_test.go
@@ -92,7 +92,6 @@ func makeStructuredEvents(unix bool) []*HumioStructuredEvents {
 						"attr1": "attrval1",
 						"attr2": "attrval2",
 					},
-					RawString: "str1",
 				},
 			},
 		},
@@ -173,7 +172,7 @@ func TestSendUnstructuredEvents(t *testing.T) {
 
 func TestSendStructuredEventsIso(t *testing.T) {
 	// Arrange
-	expected := `[{"tags":{"tag1":"tagval1","tag2":"tagval2"},"events":[{"timestamp":"2021-03-28T12:30:15+02:00","attributes":{"attr1":"attrval1","attr2":"attrval2"},"rawstring":"str1"}]},{"events":[{"timestamp":"2021-03-28T12:30:15+02:00"},{"timestamp":"2021-03-28T12:30:15+02:00"}]}]`
+	expected := `[{"tags":{"tag1":"tagval1","tag2":"tagval2"},"events":[{"timestamp":"2021-03-28T12:30:15+02:00","attributes":{"attr1":"attrval1","attr2":"attrval2"}}]},{"events":[{"timestamp":"2021-03-28T12:30:15+02:00"},{"timestamp":"2021-03-28T12:30:15+02:00"}]}]`
 	evts := makeStructuredEvents(false)
 
 	// Act
@@ -190,7 +189,7 @@ func TestSendStructuredEventsIso(t *testing.T) {
 
 func TestSendStructuredEventsUnix(t *testing.T) {
 	// Arrange
-	expected := `[{"tags":{"tag1":"tagval1","tag2":"tagval2"},"events":[{"timestamp":1616927415000,"timezone":"Europe/Copenhagen","attributes":{"attr1":"attrval1","attr2":"attrval2"},"rawstring":"str1"}]},{"events":[{"timestamp":1616927415000,"timezone":"Europe/Copenhagen"},{"timestamp":1616927415000,"timezone":"Europe/Copenhagen"}]}]`
+	expected := `[{"tags":{"tag1":"tagval1","tag2":"tagval2"},"events":[{"timestamp":1616927415000,"timezone":"Europe/Copenhagen","attributes":{"attr1":"attrval1","attr2":"attrval2"}}]},{"events":[{"timestamp":1616927415000,"timezone":"Europe/Copenhagen"},{"timestamp":1616927415000,"timezone":"Europe/Copenhagen"}]}]`
 	evts := makeStructuredEvents(true)
 
 	// Act

--- a/exporter/humioexporter/humio_client_test.go
+++ b/exporter/humioexporter/humio_client_test.go
@@ -46,6 +46,9 @@ func makeClient(t *testing.T, host string, compression bool) exporterClient {
 	err := cfg.Validate()
 	require.NoError(t, err)
 
+	err = cfg.sanitize()
+	require.NoError(t, err)
+
 	client, err := newHumioClient(cfg, zap.NewNop())
 	require.NoError(t, err)
 	return client

--- a/exporter/humioexporter/humio_client_test.go
+++ b/exporter/humioexporter/humio_client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021, OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,19 +25,21 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.uber.org/zap"
 )
 
-func makeClient(t *testing.T, host string) client {
+func makeClient(t *testing.T, host string) exporterClient {
 	cfg := &Config{
-		IngestToken: "token",
+		ExporterSettings: config.NewExporterSettings(typeStr),
+		IngestToken:      "token",
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint: host,
 		},
 	}
-	err := cfg.sanitize()
+	err := cfg.Validate()
 	require.NoError(t, err)
 
 	client, err := newHumioClient(cfg, zap.NewNop())
@@ -221,7 +223,7 @@ func TestSendEventsBadParameters(t *testing.T) {
 	humio := makeClient(t, "https://localhost:8080")
 
 	// Act
-	err := humio.sendStructuredEvents(nil, nil)
+	err := humio.(*humioClient).sendEvents(context.Background(), nil, "\n")
 
 	// Assert
 	require.Error(t, err)

--- a/exporter/humioexporter/humio_client_test.go
+++ b/exporter/humioexporter/humio_client_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -132,7 +132,7 @@ func executeRequest(fn func(s *httptest.Server) error) (result requestData) {
 	// store it in "result"
 	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		result.Path = r.URL.Path
-		body, err := io.ReadAll(r.Body)
+		body, err := ioutil.ReadAll(r.Body)
 
 		if err != nil {
 			result.Error = err

--- a/exporter/humioexporter/humio_client_test.go
+++ b/exporter/humioexporter/humio_client_test.go
@@ -1,0 +1,237 @@
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package humioexporter
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/zap"
+)
+
+func makeClient(t *testing.T, host string) *humioClient {
+	cfg := &Config{
+		IngestToken: "token",
+		HTTPClientSettings: confighttp.HTTPClientSettings{
+			Endpoint: host,
+		},
+	}
+	err := cfg.sanitize()
+	require.NoError(t, err)
+
+	client, err := newHumioClient(cfg, zap.NewNop())
+	require.NoError(t, err)
+	return client
+}
+
+func makeUnstructuredEvents() []*HumioUnstructuredEvents {
+	return []*HumioUnstructuredEvents{
+		// Fully specified
+		{
+			Fields: map[string]string{
+				"field1": "fieldval1",
+			},
+			Tags: map[string]string{
+				"tag1": "tagval1",
+				"tag2": "tagval2",
+			},
+			Type: "custom-parser",
+			Messages: []string{
+				"msg1",
+				"msg2",
+				"msg3",
+			},
+		},
+		// Only required fields
+		{
+			Messages: []string{
+				"msg1",
+				"msg2",
+			},
+		},
+	}
+}
+
+func makeStructuredEvents(unix bool) []*HumioStructuredEvents {
+	var timestamp = time.Date(2021, 3, 28, 12, 30, 15, 0, time.UTC)
+	var timeZone = ""
+	if unix {
+		timeZone = "Europe/Copenhagen"
+	}
+
+	return []*HumioStructuredEvents{
+		// Fully specified
+		{
+			Tags: map[string]string{
+				"tag1": "tagval1",
+				"tag2": "tagval2",
+			},
+			Events: []*HumioStructuredEvent{
+				{
+					TimeStamp: timestamp,
+					TimeZone:  timeZone,
+					Attributes: map[string]string{
+						"attr1": "attrval1",
+						"attr2": "attrval2",
+					},
+					RawString: "str1",
+				},
+			},
+		},
+		// Only required fields
+		{
+			Events: []*HumioStructuredEvent{
+				{
+					TimeStamp: timestamp,
+					TimeZone:  timeZone,
+				},
+				{
+					TimeStamp: timestamp,
+					TimeZone:  timeZone,
+				},
+			},
+		},
+	}
+}
+
+type requestData struct {
+	Path  string
+	Body  string
+	Error error
+}
+
+// Helper function to intercept information from HTTP requests.
+// The caller provides a closure from which it is possible to access the address
+// of the mock server. The HTTP request must also be performed from within this
+// closure.
+func executeRequest(fn func(s *httptest.Server) error) (result requestData) {
+	// Create a mock server that will intercept information from the request and
+	// store it in "result"
+	s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		result.Path = r.URL.Path
+		body, err := io.ReadAll(r.Body)
+
+		if err != nil {
+			result.Error = err
+		} else {
+			result.Body = string(body)
+			defer r.Body.Close()
+		}
+	}))
+	defer s.Close()
+
+	// Call the closure to execute the request
+	err := fn(s)
+	if err != nil {
+		result.Error = err
+	}
+
+	return result
+}
+
+func TestNewHumioClient(t *testing.T) {
+	// Arrange / Act
+	humio := makeClient(t, "http://localhost:8080")
+
+	// Assert
+	assert.NotNil(t, humio)
+	assert.NotNil(t, humio.client)
+}
+
+func TestSendUnstructuredEvents(t *testing.T) {
+	// Arrange
+	expected := `[{"fields":{"field1":"fieldval1"},"tags":{"tag1":"tagval1","tag2":"tagval2"},"type":"custom-parser","messages":["msg1","msg2","msg3"]},{"messages":["msg1","msg2"]}]`
+	evts := makeUnstructuredEvents()
+
+	// Act
+	result := executeRequest(func(s *httptest.Server) error {
+		humio := makeClient(t, s.URL)
+		return humio.sendUnstructuredEvents(context.Background(), evts)
+	})
+
+	// Assert
+	require.NoError(t, result.Error)
+	assert.Equal(t, "/api/v1/ingest/humio-unstructured", result.Path)
+	assert.Equal(t, expected, result.Body)
+}
+
+func TestSendStructuredEventsIso(t *testing.T) {
+	// Arrange
+	expected := `[{"tags":{"tag1":"tagval1","tag2":"tagval2"},"events":[{"timestamp":"2021-03-28T12:30:15Z","attributes":{"attr1":"attrval1","attr2":"attrval2"},"rawstring":"str1"}]},{"events":[{"timestamp":"2021-03-28T12:30:15Z"},{"timestamp":"2021-03-28T12:30:15Z"}]}]`
+	evts := makeStructuredEvents(false)
+
+	// Act
+	result := executeRequest(func(s *httptest.Server) error {
+		humio := makeClient(t, s.URL)
+		return humio.sendStructuredEvents(context.Background(), evts)
+	})
+
+	// Assert
+	require.NoError(t, result.Error)
+	assert.Equal(t, "/api/v1/ingest/humio-structured", result.Path)
+	assert.Equal(t, expected, result.Body)
+}
+
+func TestSendStructuredEventsUnix(t *testing.T) {
+	// Arrange
+	expected := `[{"tags":{"tag1":"tagval1","tag2":"tagval2"},"events":[{"timestamp":"1616927415","timezone":"Europe/Copenhagen","attributes":{"attr1":"attrval1","attr2":"attrval2"},"rawstring":"str1"}]},{"events":[{"timestamp":"1616927415","timezone":"Europe/Copenhagen"},{"timestamp":"1616927415","timezone":"Europe/Copenhagen"}]}]`
+	evts := makeStructuredEvents(true)
+
+	// Act
+	result := executeRequest(func(s *httptest.Server) error {
+		humio := makeClient(t, s.URL)
+		return humio.sendStructuredEvents(context.Background(), evts)
+	})
+
+	// Assert
+	require.NoError(t, result.Error)
+	assert.Equal(t, "/api/v1/ingest/humio-structured", result.Path)
+	assert.Equal(t, expected, result.Body)
+}
+
+func TestSendEventsNoConnection(t *testing.T) {
+	// Arrange
+	humio := makeClient(t, "https://localhost:8080")
+
+	// Act
+	err := humio.sendStructuredEvents(context.Background(), makeStructuredEvents(false))
+
+	// Assert
+	require.Error(t, err)
+	assert.False(t, consumererror.IsPermanent(err))
+}
+
+func TestSendEventsBadParameters(t *testing.T) {
+	// Arrange
+	humio := makeClient(t, "https://localhost:8080")
+
+	// Act
+	err := humio.sendStructuredEvents(nil, nil)
+
+	// Assert
+	require.Error(t, err)
+	assert.True(t, consumererror.IsPermanent(err))
+}
+
+// TODO: Test JSON marshal error?
+// TODO: Test error codes with test cases

--- a/exporter/humioexporter/humio_client_test.go
+++ b/exporter/humioexporter/humio_client_test.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func makeClient(t *testing.T, host string) *humioClient {
+func makeClient(t *testing.T, host string) client {
 	cfg := &Config{
 		IngestToken: "token",
 		HTTPClientSettings: confighttp.HTTPClientSettings{
@@ -148,11 +148,10 @@ func executeRequest(fn func(s *httptest.Server) error) (result requestData) {
 
 func TestNewHumioClient(t *testing.T) {
 	// Arrange / Act
-	humio := makeClient(t, "http://localhost:8080")
+	c := makeClient(t, "http://localhost:8080")
 
 	// Assert
-	assert.NotNil(t, humio)
-	assert.NotNil(t, humio.client)
+	assert.NotNil(t, c)
 }
 
 func TestSendUnstructuredEvents(t *testing.T) {
@@ -315,7 +314,7 @@ func TestSendEventsStatusCodes(t *testing.T) {
 
 			// Assert
 			if consumererror.IsPermanent(err) != tC.wantPerm {
-				t.Errorf("SendEvents() permanent = %v, wantPerm %v",
+				t.Errorf("sendEvents() permanent = %v, wantPerm %v",
 					consumererror.IsPermanent(err), tC.wantPerm)
 			}
 		})

--- a/exporter/humioexporter/testdata/config.yaml
+++ b/exporter/humioexporter/testdata/config.yaml
@@ -28,7 +28,6 @@ exporters:
       log_parser: "custom-parser"
     traces:
       unix_timestamps: true
-      timezone: "Europe/Copenhagen"
     sending_queue:
       enabled: false
       num_consumers: 20

--- a/exporter/humioexporter/testdata/config.yaml
+++ b/exporter/humioexporter/testdata/config.yaml
@@ -19,6 +19,7 @@ exporters:
     key_file: client.key
     read_buffer_size: 4096
     write_buffer_size: 4096
+    disable_compression: true
     disable_service_tag: true
     tags:
       host: "web_server"

--- a/exporter/humioexporter/testdata/invalid.yaml
+++ b/exporter/humioexporter/testdata/invalid.yaml
@@ -1,0 +1,23 @@
+# NOTE: This is an invalid configuration used to test that such cases are caught
+# Do not use this configuration
+receivers:
+  nop:
+
+processors:
+  nop:
+
+exporters:
+  humio:
+    ingest_token: "00000000-0000-0000-0000-0000000000000"
+    endpoint: "https://my-humio-host:8080"
+    disable_compression: true
+    headers:
+      Content-Encoding: compress
+
+
+service:
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [humio]

--- a/exporter/humioexporter/traces_exporter.go
+++ b/exporter/humioexporter/traces_exporter.go
@@ -25,11 +25,11 @@ import (
 type humioTracesExporter struct {
 	config *Config
 	logger *zap.Logger
-	client *humioClient
+	client client
 	wg     sync.WaitGroup
 }
 
-func newTracesExporter(config *Config, logger *zap.Logger, client *humioClient) *humioTracesExporter {
+func newTracesExporter(config *Config, logger *zap.Logger, client client) *humioTracesExporter {
 	return &humioTracesExporter{
 		config: config,
 		logger: logger,

--- a/exporter/humioexporter/traces_exporter.go
+++ b/exporter/humioexporter/traces_exporter.go
@@ -16,8 +16,10 @@ package humioexporter
 
 import (
 	"context"
+	"errors"
 	"sync"
 
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 )
@@ -25,11 +27,11 @@ import (
 type humioTracesExporter struct {
 	config *Config
 	logger *zap.Logger
-	client client
+	client exporterClient
 	wg     sync.WaitGroup
 }
 
-func newTracesExporter(config *Config, logger *zap.Logger, client client) *humioTracesExporter {
+func newTracesExporter(config *Config, logger *zap.Logger, client exporterClient) *humioTracesExporter {
 	return &humioTracesExporter{
 		config: config,
 		logger: logger,
@@ -42,8 +44,9 @@ func (e *humioTracesExporter) pushTraceData(ctx context.Context, td pdata.Traces
 	defer e.wg.Done()
 
 	// TODO: Transform to Humio event structure
+	// TODO: Send events to Humio
 
-	return e.client.sendStructuredEvents(ctx, nil)
+	return consumererror.Permanent(errors.New("Not implemented yet"))
 }
 
 func (e *humioTracesExporter) shutdown(context.Context) error {

--- a/exporter/humioexporter/traces_exporter.go
+++ b/exporter/humioexporter/traces_exporter.go
@@ -16,10 +16,8 @@ package humioexporter
 
 import (
 	"context"
-	"errors"
 	"sync"
 
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 )
@@ -27,13 +25,15 @@ import (
 type humioTracesExporter struct {
 	config *Config
 	logger *zap.Logger
+	client *humioClient
 	wg     sync.WaitGroup
 }
 
-func newTracesExporter(config *Config, logger *zap.Logger) *humioTracesExporter {
+func newTracesExporter(config *Config, logger *zap.Logger, client *humioClient) *humioTracesExporter {
 	return &humioTracesExporter{
 		config: config,
 		logger: logger,
+		client: client,
 	}
 }
 
@@ -42,9 +42,8 @@ func (e *humioTracesExporter) pushTraceData(ctx context.Context, td pdata.Traces
 	defer e.wg.Done()
 
 	// TODO: Transform to Humio event structure
-	// TODO: Send events to Humio
 
-	return consumererror.Permanent(errors.New("Not implemented yet"))
+	return e.client.sendStructuredEvents(ctx, nil)
 }
 
 func (e *humioTracesExporter) shutdown(context.Context) error {

--- a/exporter/humioexporter/traces_exporter.go
+++ b/exporter/humioexporter/traces_exporter.go
@@ -25,15 +25,15 @@ import (
 )
 
 type humioTracesExporter struct {
-	config *Config
+	cfg    *Config
 	logger *zap.Logger
 	client exporterClient
 	wg     sync.WaitGroup
 }
 
-func newTracesExporter(config *Config, logger *zap.Logger, client exporterClient) *humioTracesExporter {
+func newTracesExporter(cfg *Config, logger *zap.Logger, client exporterClient) *humioTracesExporter {
 	return &humioTracesExporter{
-		config: config,
+		cfg:    cfg,
 		logger: logger,
 		client: client,
 	}

--- a/exporter/humioexporter/traces_exporter_test.go
+++ b/exporter/humioexporter/traces_exporter_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestPushTraceData(t *testing.T) {
 	// Arrange
-	exp := newTracesExporter(&Config{ExporterSettings: config.NewExporterSettings(typeStr)}, zap.NewNop())
+	exp := newTracesExporter(&Config{ExporterSettings: config.NewExporterSettings(typeStr)}, zap.NewNop(), nil)
 
 	// Act
 	err := exp.pushTraceData(context.Background(), pdata.NewTraces())
@@ -39,7 +39,7 @@ func TestPushTraceData(t *testing.T) {
 
 func TestShutdown(t *testing.T) {
 	// Arrange
-	exp := newTracesExporter(&Config{ExporterSettings: config.NewExporterSettings(typeStr)}, zap.NewNop())
+	exp := newTracesExporter(&Config{ExporterSettings: config.NewExporterSettings(typeStr)}, zap.NewNop(), nil)
 
 	// Act
 	err := exp.shutdown(context.Background())


### PR DESCRIPTION
**Description:**
Added an HTTP client for the Humio exporter. The client contains definitions of types for calling the Humio API, which contains separate endpoints for structured data such as traces, and unstructured data such as logs.

This PR also adds a new configuration option to toggle gzip compression, which is supported by the HTTP client.

Lastly, this PR removes the time zone configuration, since the timestamps on spans seem to be using UTC (at least this is what I could gather from the documentation). I figured that time zone conversion should not be the responsibility of an exporter, but it can rather depend on the information in timestamps to be correct?

I have excluded the trace exporter for now to get closer to the 500 line limit on pull requests.

**Link to tracking Issue:**
#3021

**Testing:**
- `config_test.go`: Added tests for compression settings, and removed tests for time zone.
- `humio_client_test.go`: Tests that events are correctly serialized and/or compressed. Also tests that the client raises the proper errors for retrying when possible.

**Documentation:**
Removed documentation for time zones, and added documentation for gzip compression. Updated examples as appropriate.