### PR TITLE
Move sarama initialization to scraper start method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 🚀 New components 🚀
+
+- `kafkametricsreceiver` new receiver component for collecting metrics about a kafka cluster - primarily lag and offset. [configuration instructions](receiver/kafkametricsreceiver/README.md)
+
+
 ## v0.24.0
 
 # 🎉 OpenTelemetry Collector Contrib v0.24.0 (Beta) 🎉

--- a/receiver/kafkametricsreceiver/broker_scraper.go
+++ b/receiver/kafkametricsreceiver/broker_scraper.go
@@ -43,7 +43,7 @@ func (s *brokerScraper) Name() string {
 func (s *brokerScraper) start(context.Context, component.Host) error {
 	client, err := newSaramaClient(s.config.Brokers, s.saramaConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create client while starting brokers scraper:%w", err)
+		return fmt.Errorf("failed to create client while starting brokers scraper: %w", err)
 	}
 	s.client = client
 	return nil

--- a/receiver/kafkametricsreceiver/broker_scraper.go
+++ b/receiver/kafkametricsreceiver/broker_scraper.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/consumer/simple"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
@@ -29,13 +30,23 @@ import (
 )
 
 type brokerScraper struct {
-	client sarama.Client
-	logger *zap.Logger
-	config Config
+	client       sarama.Client
+	logger       *zap.Logger
+	config       Config
+	saramaConfig *sarama.Config
 }
 
 func (s *brokerScraper) Name() string {
 	return brokersScraperName
+}
+
+func (s *brokerScraper) start(context.Context, component.Host) error {
+	client, err := newSaramaClient(s.config.Brokers, s.saramaConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create client while starting brokers scraper:%w", err)
+	}
+	s.client = client
+	return nil
 }
 
 func (s *brokerScraper) shutdown(context.Context) error {
@@ -59,19 +70,16 @@ func (s *brokerScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, err
 }
 
 func createBrokerScraper(_ context.Context, config Config, saramaConfig *sarama.Config, logger *zap.Logger) (scraperhelper.ResourceMetricsScraper, error) {
-	client, err := newSaramaClient(config.Brokers, saramaConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create sarama client: %w", err)
-	}
 	s := brokerScraper{
-		client: client,
-		logger: logger,
-		config: config,
+		logger:       logger,
+		config:       config,
+		saramaConfig: saramaConfig,
 	}
 	ms := scraperhelper.NewResourceMetricsScraper(
 		s.Name(),
 		s.scrape,
 		scraperhelper.WithShutdown(s.shutdown),
+		scraperhelper.WithStart(s.start),
 	)
 	return ms, nil
 }

--- a/receiver/kafkametricsreceiver/broker_scraper_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_test.go
@@ -67,14 +67,26 @@ func TestBrokerScraper_createBrokerScraper(t *testing.T) {
 	assert.NotNil(t, ms)
 }
 
-func TestBrokerScraper_createBrokerScraper_handles_client_error(t *testing.T) {
+func TestBrokerScraperStart(t *testing.T) {
+	newSaramaClient = mockNewSaramaClient
+	sc := sarama.NewConfig()
+	ms, err := createBrokerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NotNil(t, ms)
+	assert.Nil(t, err)
+	err = ms.Start(context.Background(), nil)
+	assert.Nil(t, err)
+}
+
+func TestBrokerScraper_startBrokerScraper_handles_client_error(t *testing.T) {
 	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
 		return nil, fmt.Errorf("new client failed")
 	}
 	sc := sarama.NewConfig()
 	ms, err := createBrokerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NotNil(t, ms)
+	assert.Nil(t, err)
+	err = ms.Start(context.Background(), nil)
 	assert.NotNil(t, err)
-	assert.Nil(t, ms)
 }
 
 func TestBrokerScraper_scrape(t *testing.T) {

--- a/receiver/kafkametricsreceiver/broker_scraper_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_test.go
@@ -63,7 +63,7 @@ func TestBrokerScraper_createBrokerScraper(t *testing.T) {
 	sc := sarama.NewConfig()
 	newSaramaClient = mockNewSaramaClient
 	ms, err := createBrokerScraper(context.Background(), Config{}, sc, zap.NewNop())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, ms)
 }
 
@@ -74,7 +74,7 @@ func TestBrokerScraperStart(t *testing.T) {
 	assert.NotNil(t, ms)
 	assert.Nil(t, err)
 	err = ms.Start(context.Background(), nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestBrokerScraper_startBrokerScraper_handles_client_error(t *testing.T) {
@@ -86,7 +86,7 @@ func TestBrokerScraper_startBrokerScraper_handles_client_error(t *testing.T) {
 	assert.NotNil(t, ms)
 	assert.Nil(t, err)
 	err = ms.Start(context.Background(), nil)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestBrokerScraper_scrape(t *testing.T) {
@@ -110,6 +110,6 @@ func TestBrokersScraper_createBrokerScraper(t *testing.T) {
 	sc := sarama.NewConfig()
 	newSaramaClient = mockNewSaramaClient
 	ms, err := createBrokerScraper(context.Background(), Config{}, sc, zap.NewNop())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, ms)
 }

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/consumer/simple"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
@@ -36,11 +37,26 @@ type consumerScraper struct {
 	groupFilter  *regexp.Regexp
 	topicFilter  *regexp.Regexp
 	clusterAdmin sarama.ClusterAdmin
+	saramaConfig *sarama.Config
 	config       Config
 }
 
 func (s *consumerScraper) Name() string {
 	return consumersScraperName
+}
+
+func (s *consumerScraper) start(context.Context, component.Host) error {
+	client, err := newSaramaClient(s.config.Brokers, s.saramaConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create client while starting consumer scraper: %w", err)
+	}
+	clusterAdmin, err := newClusterAdmin(s.config.Brokers, s.saramaConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create cluster admin while starting consumer scraper: %w", err)
+	}
+	s.client = client
+	s.clusterAdmin = clusterAdmin
+	return nil
 }
 
 func (s *consumerScraper) shutdown(_ context.Context) error {
@@ -163,25 +179,17 @@ func createConsumerScraper(_ context.Context, config Config, saramaConfig *saram
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile topic filter: %w", err)
 	}
-	client, err := newSaramaClient(config.Brokers, saramaConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create sarama client: %w", err)
-	}
-	clusterAdmin, err := newClusterAdmin(config.Brokers, saramaConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create sarama cluster admin: %w", err)
-	}
 	s := consumerScraper{
-		client:       client,
 		logger:       logger,
 		groupFilter:  groupFilter,
 		topicFilter:  topicFilter,
-		clusterAdmin: clusterAdmin,
 		config:       config,
+		saramaConfig: saramaConfig,
 	}
 	return scraperhelper.NewResourceMetricsScraper(
 		s.Name(),
 		s.scrape,
 		scraperhelper.WithShutdown(s.shutdown),
+		scraperhelper.WithStart(s.start),
 	), nil
 }

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -52,6 +52,9 @@ func (s *consumerScraper) start(context.Context, component.Host) error {
 	}
 	clusterAdmin, err := newClusterAdmin(s.config.Brokers, s.saramaConfig)
 	if err != nil {
+		if client != nil {
+			_ = client.Close()
+		}
 		return fmt.Errorf("failed to create cluster admin while starting consumer scraper: %w", err)
 	}
 	s.client = client

--- a/receiver/kafkametricsreceiver/consumer_scraper_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_test.go
@@ -78,7 +78,12 @@ func TestConsumerScraper_startScraper_handles_client_error(t *testing.T) {
 }
 
 func TestConsumerScraper_startScraper_handles_clusterAdmin_error(t *testing.T) {
-	newSaramaClient = mockNewSaramaClient
+	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
+		client := newMockClient()
+		client.Mock.
+			On("Close").Return(nil)
+		return client, nil
+	}
 	newClusterAdmin = func(addrs []string, conf *sarama.Config) (sarama.ClusterAdmin, error) {
 		return nil, fmt.Errorf("new cluster admin failed")
 	}

--- a/receiver/kafkametricsreceiver/consumer_scraper_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_test.go
@@ -61,7 +61,7 @@ func TestConsumerScraper_createConsumerScraper(t *testing.T) {
 	newSaramaClient = mockNewSaramaClient
 	newClusterAdmin = mockNewClusterAdmin
 	ms, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, ms)
 }
 
@@ -74,7 +74,7 @@ func TestConsumerScraper_startScraper_handles_client_error(t *testing.T) {
 	assert.NotNil(t, ms)
 	assert.Nil(t, err)
 	err = ms.Start(context.Background(), nil)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestConsumerScraper_startScraper_handles_clusterAdmin_error(t *testing.T) {
@@ -92,7 +92,7 @@ func TestConsumerScraper_startScraper_handles_clusterAdmin_error(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, ms)
 	err = ms.Start(context.Background(), nil)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestConsumerScraperStart(t *testing.T) {
@@ -103,7 +103,7 @@ func TestConsumerScraperStart(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, ms)
 	err = ms.Start(context.Background(), nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestConsumerScraper_createScraper_handles_invalid_topic_match(t *testing.T) {
@@ -113,7 +113,7 @@ func TestConsumerScraper_createScraper_handles_invalid_topic_match(t *testing.T)
 	ms, err := createConsumerScraper(context.Background(), Config{
 		TopicMatch: "[",
 	}, sc, zap.NewNop())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, ms)
 }
 
@@ -124,7 +124,7 @@ func TestConsumerScraper_createScraper_handles_invalid_group_match(t *testing.T)
 	ms, err := createConsumerScraper(context.Background(), Config{
 		GroupMatch: "[",
 	}, sc, zap.NewNop())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, ms)
 }
 
@@ -138,7 +138,7 @@ func TestConsumerScraper_scrape(t *testing.T) {
 		groupFilter:  filter,
 	}
 	ms, err := cs.scrape(context.Background())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, ms)
 }
 
@@ -155,7 +155,7 @@ func TestConsumerScraper_scrape_handlesListTopicError(t *testing.T) {
 		groupFilter:  filter,
 	}
 	_, err := cs.scrape(context.Background())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestConsumerScraper_scrape_handlesListConsumerGroupError(t *testing.T) {
@@ -170,7 +170,7 @@ func TestConsumerScraper_scrape_handlesListConsumerGroupError(t *testing.T) {
 		groupFilter:  filter,
 	}
 	_, err := cs.scrape(context.Background())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestConsumerScraper_scrape_handlesDescribeConsumerError(t *testing.T) {
@@ -185,7 +185,7 @@ func TestConsumerScraper_scrape_handlesDescribeConsumerError(t *testing.T) {
 		groupFilter:  filter,
 	}
 	_, err := cs.scrape(context.Background())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestConsumerScraper_scrape_handlesOffsetPartialError(t *testing.T) {
@@ -203,7 +203,7 @@ func TestConsumerScraper_scrape_handlesOffsetPartialError(t *testing.T) {
 	}
 	s, err := cs.scrape(context.Background())
 	assert.NotNil(t, s)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestConsumerScraper_scrape_handlesPartitionPartialError(t *testing.T) {
@@ -221,5 +221,5 @@ func TestConsumerScraper_scrape_handlesPartitionPartialError(t *testing.T) {
 	}
 	s, err := cs.scrape(context.Background())
 	assert.NotNil(t, s)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/receiver/kafkametricsreceiver/consumer_scraper_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_test.go
@@ -65,25 +65,40 @@ func TestConsumerScraper_createConsumerScraper(t *testing.T) {
 	assert.NotNil(t, ms)
 }
 
-func TestConsumerScraper_createScraper_handles_client_error(t *testing.T) {
+func TestConsumerScraper_startScraper_handles_client_error(t *testing.T) {
 	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
 		return nil, fmt.Errorf("new client failed")
 	}
 	sc := sarama.NewConfig()
 	ms, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NotNil(t, ms)
+	assert.Nil(t, err)
+	err = ms.Start(context.Background(), nil)
 	assert.NotNil(t, err)
-	assert.Nil(t, ms)
 }
 
-func TestConsumerScraper_createScraper_handles_clusterAdmin_error(t *testing.T) {
+func TestConsumerScraper_startScraper_handles_clusterAdmin_error(t *testing.T) {
 	newSaramaClient = mockNewSaramaClient
 	newClusterAdmin = func(addrs []string, conf *sarama.Config) (sarama.ClusterAdmin, error) {
 		return nil, fmt.Errorf("new cluster admin failed")
 	}
 	sc := sarama.NewConfig()
 	ms, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.Nil(t, err)
+	assert.NotNil(t, ms)
+	err = ms.Start(context.Background(), nil)
 	assert.NotNil(t, err)
-	assert.Nil(t, ms)
+}
+
+func TestConsumerScraperStart(t *testing.T) {
+	newSaramaClient = mockNewSaramaClient
+	newClusterAdmin = mockNewClusterAdmin
+	sc := sarama.NewConfig()
+	ms, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.Nil(t, err)
+	assert.NotNil(t, ms)
+	err = ms.Start(context.Background(), nil)
+	assert.Nil(t, err)
 }
 
 func TestConsumerScraper_createScraper_handles_invalid_topic_match(t *testing.T) {

--- a/receiver/kafkametricsreceiver/kafkametrics_e2e_test.go
+++ b/receiver/kafkametricsreceiver/kafkametrics_e2e_test.go
@@ -18,6 +18,7 @@ package kafkametricsreceiver
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func TestIntegrationSingleNode(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		err = receiver.Start(context.Background(), &testHost{t: t})
 		return err == nil
-	}, 30*time.Second, 5*time.Second, "failed to start receiver")
+	}, 30*time.Second, 5*time.Second, fmt.Sprintf("failed to start metrics receiver. %v", err))
 	t.Logf("waiting for metrics...")
 	require.Eventuallyf(t,
 		func() bool {

--- a/receiver/kafkametricsreceiver/kafkametrics_e2e_test.go
+++ b/receiver/kafkametricsreceiver/kafkametrics_e2e_test.go
@@ -68,9 +68,7 @@ func TestIntegrationSingleNode(t *testing.T) {
 	var receiver component.MetricsReceiver
 	var err error
 	receiver, err = f.CreateMetricsReceiver(context.Background(), params, cfg, consumer)
-	if err != nil {
-		t.Errorf("failed to create receiver: %w", err)
-	}
+	require.NoError(t, err, "failed to create receiver")
 	require.Eventuallyf(t, func() bool {
 		err = receiver.Start(context.Background(), &testHost{t: t})
 		return err == nil

--- a/receiver/kafkametricsreceiver/receiver.go
+++ b/receiver/kafkametricsreceiver/receiver.go
@@ -33,8 +33,10 @@ const (
 	consumersScraperName   = "consumers"
 )
 
+type createKafkaScraper = func(context.Context, Config, *sarama.Config, *zap.Logger) (scraperhelper.ResourceMetricsScraper, error)
+
 var (
-	allScrapers = map[string]func(context.Context, Config, *sarama.Config, *zap.Logger) (scraperhelper.ResourceMetricsScraper, error){
+	allScrapers = map[string]createKafkaScraper{
 		brokersScraperName:   createBrokerScraper,
 		topicsScraperName:    createTopicsScraper,
 		consumersScraperName: createConsumerScraper,

--- a/receiver/kafkametricsreceiver/receiver.go
+++ b/receiver/kafkametricsreceiver/receiver.go
@@ -33,7 +33,7 @@ const (
 	consumersScraperName   = "consumers"
 )
 
-type createKafkaScraper = func(context.Context, Config, *sarama.Config, *zap.Logger) (scraperhelper.ResourceMetricsScraper, error)
+type createKafkaScraper func(context.Context, Config, *sarama.Config, *zap.Logger) (scraperhelper.ResourceMetricsScraper, error)
 
 var (
 	allScrapers = map[string]createKafkaScraper{

--- a/receiver/kafkametricsreceiver/topic_scraper.go
+++ b/receiver/kafkametricsreceiver/topic_scraper.go
@@ -46,7 +46,7 @@ func (s *topicScraper) Name() string {
 func (s *topicScraper) start(context.Context, component.Host) error {
 	client, err := newSaramaClient(s.config.Brokers, s.saramaConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create client while starting topics scraper:%w", err)
+		return fmt.Errorf("failed to create client while starting topics scraper: %w", err)
 	}
 	s.client = client
 	return nil

--- a/receiver/kafkametricsreceiver/topic_scraper.go
+++ b/receiver/kafkametricsreceiver/topic_scraper.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/consumer/simple"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
@@ -40,6 +41,15 @@ type topicScraper struct {
 
 func (s *topicScraper) Name() string {
 	return topicsScraperName
+}
+
+func (s *topicScraper) start(context.Context, component.Host) error {
+	client, err := newSaramaClient(s.config.Brokers, s.saramaConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create client while starting topics scraper:%w", err)
+	}
+	s.client = client
+	return nil
 }
 
 func (s *topicScraper) shutdown(context.Context) error {
@@ -118,12 +128,7 @@ func createTopicsScraper(_ context.Context, config Config, saramaConfig *sarama.
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile topic filter: %w", err)
 	}
-	client, err := newSaramaClient(config.Brokers, saramaConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create sarama client: %w", err)
-	}
 	s := topicScraper{
-		client:       client,
 		logger:       logger,
 		topicFilter:  topicFilter,
 		saramaConfig: saramaConfig,
@@ -133,5 +138,6 @@ func createTopicsScraper(_ context.Context, config Config, saramaConfig *sarama.
 		s.Name(),
 		s.scrape,
 		scraperhelper.WithShutdown(s.shutdown),
+		scraperhelper.WithStart(s.start),
 	), nil
 }

--- a/receiver/kafkametricsreceiver/topic_scraper_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_test.go
@@ -70,14 +70,26 @@ func TestTopicScraper_createsScraper(t *testing.T) {
 	assert.NotNil(t, ms)
 }
 
-func TestTopicScraper_createScraperHandlesError(t *testing.T) {
+func TestTopicScraper_startScraperHandlesError(t *testing.T) {
 	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
 		return nil, fmt.Errorf("no scraper here")
 	}
 	sc := sarama.NewConfig()
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NotNil(t, ms)
+	assert.Nil(t, err)
+	err = ms.Start(context.Background(), nil)
 	assert.NotNil(t, err)
-	assert.Nil(t, ms)
+}
+
+func TestTopicScraper_startScraperCreatesClient(t *testing.T) {
+	newSaramaClient = mockNewSaramaClient
+	sc := sarama.NewConfig()
+	ms, err := createTopicsScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NotNil(t, ms)
+	assert.Nil(t, err)
+	err = ms.Start(context.Background(), nil)
+	assert.Nil(t, err)
 }
 
 func TestTopicScraper_createScraperHandles_invalid_topicMatch(t *testing.T) {

--- a/receiver/kafkametricsreceiver/topic_scraper_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_test.go
@@ -66,7 +66,7 @@ func TestTopicScraper_createsScraper(t *testing.T) {
 	sc := sarama.NewConfig()
 	newSaramaClient = mockNewSaramaClient
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, zap.NewNop())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, ms)
 }
 
@@ -79,7 +79,7 @@ func TestTopicScraper_startScraperHandlesError(t *testing.T) {
 	assert.NotNil(t, ms)
 	assert.Nil(t, err)
 	err = ms.Start(context.Background(), nil)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestTopicScraper_startScraperCreatesClient(t *testing.T) {
@@ -87,9 +87,9 @@ func TestTopicScraper_startScraperCreatesClient(t *testing.T) {
 	sc := sarama.NewConfig()
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, zap.NewNop())
 	assert.NotNil(t, ms)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = ms.Start(context.Background(), nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestTopicScraper_createScraperHandles_invalid_topicMatch(t *testing.T) {
@@ -98,7 +98,7 @@ func TestTopicScraper_createScraperHandles_invalid_topicMatch(t *testing.T) {
 	ms, err := createTopicsScraper(context.Background(), Config{
 		TopicMatch: "[",
 	}, sc, zap.NewNop())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, ms)
 }
 
@@ -146,7 +146,7 @@ func TestTopicScraper_scrape_handlesTopicError(t *testing.T) {
 		topicFilter: match,
 	}
 	_, err := scraper.scrape(context.Background())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestTopicScraper_scrape_handlesPartitionError(t *testing.T) {
@@ -160,7 +160,7 @@ func TestTopicScraper_scrape_handlesPartitionError(t *testing.T) {
 		topicFilter: match,
 	}
 	_, err := scraper.scrape(context.Background())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestTopicScraper_scrape_handlesPartialScrapeErrors(t *testing.T) {
@@ -177,5 +177,5 @@ func TestTopicScraper_scrape_handlesPartialScrapeErrors(t *testing.T) {
 		topicFilter: match,
 	}
 	_, err := scraper.scrape(context.Background())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
**Description:** scrapers are updated to initialize sarama client and admin in `Start` instead of the `createMetricsReceiver` method. This way, the receiver is immediately created (instead of contacting broker(s) first). If no brokers are reachable, the receiver will fail to start. [ref](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3084#discussion_r612577152)
- Also updated the CHANGELOG to indicate new component under unreleased changes
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Unit test and integration test updated.

**Documentation:** <Describe the documentation added.>