### PR TITLE
Add albertteoh as approver for spanmetricsprocessor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,6 +59,7 @@ processor/metricstransformprocessor/                 @open-telemetry/collector-c
 processor/resourcedetectionprocessor/                @open-telemetry/collector-contrib-approvers @jrcamp @pmm-sumo @anuraaga @dashpole
 processor/resourcedetectionprocessor/internal/azure  @open-telemetry/collector-contrib-approvers @mx-psi
 processor/routingprocessor/                          @open-telemetry/collector-contrib-approvers @jpkrohling
+processor/spanmetricsprocessor/                      @open-telemetry/collector-contrib-approvers @albertteoh
 processor/tailsamplingprocessor/                     @open-telemetry/collector-contrib-approvers @jpkrohling
 
 receiver/awsecscontainermetricsreceiver/             @open-telemetry/collector-contrib-approvers @kbrockhoff @anuraaga


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

As requested by @bogdandrutu in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3040#pullrequestreview-635902024.