### PR TITLE
build: Handle go install for 1.16 in testbed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,6 @@ commands:
       - run:
           name: Install tools
           command: make install-tools
-      - run:
-          name: Install testbed tools
-          command: make -C testbed install-tools
       - save_module_cache
 
   setup_go:

--- a/testbed/Makefile
+++ b/testbed/Makefile
@@ -19,7 +19,3 @@ list-stability-tests:
 .PHONY: run-stability-tests
 run-stability-tests:
 	TESTCASE_DURATION=1h TEST_ARGS="$${TEST_ARGS} -timeout 70m" TESTS_DIR=stabilitytests ./runtests.sh
-
-.PHONY: install-tools
-install-tools:
-	go install github.com/jstemmer/go-junit-report


### PR DESCRIPTION

**Description:** Selects correct go install syntax for installing in Go 1.16+

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3069

**Testing:** Manually tested on 1.16.3, build will test < 1.16

**Documentation:** N/A