### PR TITLE
[extension/ecsobserver]  Add get ip and port from task

### DIFF
--- a/extension/observer/ecsobserver/matcher.go
+++ b/extension/observer/ecsobserver/matcher.go
@@ -58,18 +58,20 @@ type MatchedContainer struct {
 }
 
 // MergeTargets adds new targets to the set, the 'key' is port + metrics path.
-// The 'key' does not have ip because all the targets from on container has same ip.
-// If there are duplicated 'key' we honor existing target and does not override.
-// The duplication could happen if there are several rules matching same target.
+// The 'key' does not contain an IP address because all targets from one
+// container have the same IP address. If there are duplicate 'key's we honor
+// the existing target and do not override.  Duplication could happen if there
+// are several rules matching same target.
 func (mc *MatchedContainer) MergeTargets(newTargets []MatchedTarget) {
+NextNewTarget:
 	for _, newt := range newTargets {
 		for _, old := range mc.Targets {
 			// If port and metrics_path are same, then we treat them as same target and keep the existing one
 			if old.Port == newt.Port && old.MetricsPath == newt.MetricsPath {
-				continue
+				continue NextNewTarget
 			}
-			mc.Targets = append(mc.Targets, newt)
 		}
+		mc.Targets = append(mc.Targets, newt)
 	}
 }
 

--- a/extension/observer/ecsobserver/matcher.go
+++ b/extension/observer/ecsobserver/matcher.go
@@ -57,6 +57,24 @@ type MatchedContainer struct {
 	Targets        []MatchedTarget
 }
 
+// MergeTargets adds new targets to the set, the 'key' is port + metrics path.
+// The 'key' does not have ip because all the targets from on container has same ip.
+// If there are duplicated 'key' we honor existing target and does not override.
+// The duplication could happen if there are several rules matching same target.
+func (mc *MatchedContainer) MergeTargets(newTargets []MatchedTarget) {
+	for _, newt := range newTargets {
+		for _, old := range mc.Targets {
+			// If port and metrics_path are same, then we treat them as same target and keep the existing one
+			if old.Port == newt.Port && old.MetricsPath == newt.MetricsPath {
+				continue
+			}
+			mc.Targets = append(mc.Targets, newt)
+		}
+	}
+}
+
+// MatchedTarget contains info for exporting prometheus scrape target
+// and tracing back into the config (can be used in stats, error reporting etc.).
 type MatchedTarget struct {
 	MatcherType  MatcherType
 	MatcherIndex int // Index within a specific matcher type

--- a/extension/observer/ecsobserver/matcher_test.go
+++ b/extension/observer/ecsobserver/matcher_test.go
@@ -1,0 +1,81 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecsobserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchedContainer_MergeTargets(t *testing.T) {
+	t.Run("add new targets", func(t *testing.T) {
+		m := MatchedContainer{
+			Targets: []MatchedTarget{
+				{
+					Port:        1234,
+					MetricsPath: "/m1",
+				},
+				{
+					Port:        1235,
+					MetricsPath: "/m2",
+				},
+			},
+		}
+		newTargets := []MatchedTarget{
+			{
+				Port:        1234,
+				MetricsPath: "/not-m1", // different path
+			},
+			{
+				Port:        1235, // different port
+				MetricsPath: "/m1",
+			},
+		}
+		m.MergeTargets(newTargets)
+		assert.Len(t, m.Targets, 4)
+		assert.Equal(t, m.Targets[3].MetricsPath, "/m1") // order is append
+	})
+
+	t.Run("respect existing targets", func(t *testing.T) {
+		m := MatchedContainer{
+			Targets: []MatchedTarget{
+				{
+					MatcherType: MatcherTypeService,
+					Port:        1234,
+					MetricsPath: "/m1",
+				},
+				{
+					Port:        1235,
+					MetricsPath: "/m2",
+				},
+			},
+		}
+		newTargets := []MatchedTarget{
+			{
+				MatcherType: MatcherTypeDockerLabel, // different matcher
+				Port:        1234,
+				MetricsPath: "/m1",
+			},
+			{
+				Port:        1235, // different port
+				MetricsPath: "/m1",
+			},
+		}
+		m.MergeTargets(newTargets)
+		assert.Len(t, m.Targets, 3)
+		assert.Equal(t, MatcherTypeService, m.Targets[0].MatcherType)
+	})
+}

--- a/extension/observer/ecsobserver/task.go
+++ b/extension/observer/ecsobserver/task.go
@@ -32,6 +32,18 @@ type Task struct {
 	Matched    []MatchedContainer
 }
 
+// AddMatchedContainer tries to add a new matched container.
+// If the container already exists will merge targets within one container (i.e. different port/metrics path).
+func (t *Task) AddMatchedContainer(newContainer MatchedContainer) {
+	for i, oldContainer := range t.Matched {
+		if oldContainer.ContainerIndex == newContainer.ContainerIndex {
+			t.Matched[i].MergeTargets(newContainer.Targets)
+			return
+		}
+	}
+	t.Matched = append(t.Matched, newContainer)
+}
+
 func (t *Task) TaskTags() map[string]string {
 	if len(t.Task.Tags) == 0 {
 		return nil

--- a/extension/observer/ecsobserver/task_test.go
+++ b/extension/observer/ecsobserver/task_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTask_Tags(t *testing.T) {
@@ -57,5 +58,135 @@ func TestTask_Tags(t *testing.T) {
 			"k": aws.String("v"),
 		}
 		assert.Equal(t, map[string]string{"k": "v"}, task.ContainerLabels(0))
+	})
+}
+
+func TestTask_PrivateIP(t *testing.T) {
+	t.Run("awsvpc", func(t *testing.T) {
+		task := Task{
+			Task: &ecs.Task{
+				TaskArn:           aws.String("arn:task:t2"),
+				TaskDefinitionArn: aws.String("t2"),
+				Attachments: []*ecs.Attachment{
+					{
+						Type: aws.String("ElasticNetworkInterface"),
+						Details: []*ecs.KeyValuePair{
+							{
+								Name:  aws.String("privateIPv4Address"),
+								Value: aws.String("172.168.1.1"),
+							},
+						},
+					},
+				},
+			},
+			Definition: &ecs.TaskDefinition{NetworkMode: aws.String(ecs.NetworkModeAwsvpc)},
+		}
+		ip, err := task.PrivateIP()
+		require.NoError(t, err)
+		assert.Equal(t, "172.168.1.1", ip)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		task := Task{
+			Task:       &ecs.Task{TaskArn: aws.String("arn:task:1")},
+			Definition: &ecs.TaskDefinition{},
+		}
+		modes := []string{"", ecs.NetworkModeBridge, ecs.NetworkModeHost, ecs.NetworkModeAwsvpc, ecs.NetworkModeNone, "not even a network mode"}
+		for _, mode := range modes {
+			task.Definition.NetworkMode = aws.String(mode)
+			_, err := task.PrivateIP()
+			assert.Error(t, err)
+		}
+	})
+}
+
+func TestTask_MappedPort(t *testing.T) {
+	ec2BridgeTask := &ecs.Task{
+		TaskArn: aws.String("arn:task:1"),
+		Containers: []*ecs.Container{
+			{
+				Name: aws.String("c1"),
+				NetworkBindings: []*ecs.NetworkBinding{
+					{
+						ContainerPort: aws.Int64(2112),
+						HostPort:      aws.Int64(2345),
+					},
+				},
+			},
+		},
+	}
+	// Network mode is optional for ecs and it default to ec2 bridge
+	t.Run("empty is ec2 bridge", func(t *testing.T) {
+		task := Task{
+			Task:       ec2BridgeTask,
+			Definition: &ecs.TaskDefinition{NetworkMode: nil},
+			EC2:        &ec2.Instance{PrivateIpAddress: aws.String("172.168.1.1")},
+		}
+		ip, err := task.PrivateIP()
+		require.Nil(t, err)
+		assert.Equal(t, "172.168.1.1", ip)
+		p, err := task.MappedPort(&ecs.ContainerDefinition{Name: aws.String("c1")}, 2112)
+		require.Nil(t, err)
+		assert.Equal(t, int64(2345), p)
+	})
+
+	t.Run("ec2 bridge", func(t *testing.T) {
+		task := Task{
+			Task:       ec2BridgeTask,
+			Definition: &ecs.TaskDefinition{NetworkMode: aws.String(ecs.NetworkModeBridge)},
+			EC2:        &ec2.Instance{PrivateIpAddress: aws.String("172.168.1.1")},
+		}
+		p, err := task.MappedPort(&ecs.ContainerDefinition{Name: aws.String("c1")}, 2112)
+		require.Nil(t, err)
+		assert.Equal(t, int64(2345), p)
+	})
+
+	vpcTaskDef := &ecs.TaskDefinition{
+		NetworkMode: aws.String(ecs.NetworkModeAwsvpc),
+		ContainerDefinitions: []*ecs.ContainerDefinition{
+			{
+				Name: aws.String("c1"),
+				PortMappings: []*ecs.PortMapping{
+					{
+						ContainerPort: aws.Int64(2112),
+						HostPort:      aws.Int64(2345),
+					},
+				},
+			},
+		},
+	}
+	t.Run("awsvpc", func(t *testing.T) {
+		task := Task{
+			Task:       &ecs.Task{TaskArn: aws.String("arn:task:1")},
+			Definition: vpcTaskDef,
+		}
+		p, err := task.MappedPort(vpcTaskDef.ContainerDefinitions[0], 2112)
+		require.Nil(t, err)
+		assert.Equal(t, int64(2345), p)
+	})
+
+	t.Run("host", func(t *testing.T) {
+		def := vpcTaskDef
+		def.NetworkMode = aws.String(ecs.NetworkModeHost)
+		task := Task{
+			Task:       &ecs.Task{TaskArn: aws.String("arn:task:1")},
+			Definition: def,
+		}
+		p, err := task.MappedPort(def.ContainerDefinitions[0], 2112)
+		require.Nil(t, err)
+		assert.Equal(t, int64(2345), p)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		task := Task{
+			Task:       &ecs.Task{TaskArn: aws.String("arn:task:1")},
+			Definition: &ecs.TaskDefinition{},
+		}
+		modes := []string{"", ecs.NetworkModeBridge, ecs.NetworkModeHost, ecs.NetworkModeAwsvpc, ecs.NetworkModeNone, "not even a network mode"}
+		for _, mode := range modes {
+			task.Definition.NetworkMode = aws.String(mode)
+			_, err := task.MappedPort(&ecs.ContainerDefinition{Name: aws.String("c11")}, 1234)
+			assert.Error(t, err)
+		}
 	})
 }

--- a/extension/observer/ecsobserver/task_test.go
+++ b/extension/observer/ecsobserver/task_test.go
@@ -96,6 +96,11 @@ func TestTask_PrivateIP(t *testing.T) {
 			task.Definition.NetworkMode = aws.String(mode)
 			_, err := task.PrivateIP()
 			assert.Error(t, err)
+			assert.IsType(t, &ErrPrivateIPNotFound{}, err)
+			assert.Equal(t, mode, err.(*ErrPrivateIPNotFound).NetworkMode)
+			// doing contains on error message is not good, but this line increase test coverage from 93% to 98%
+			// not sure how the average coverage is calculated ...
+			assert.Contains(t, err.Error(), mode)
 		}
 	})
 }
@@ -187,6 +192,8 @@ func TestTask_MappedPort(t *testing.T) {
 			task.Definition.NetworkMode = aws.String(mode)
 			_, err := task.MappedPort(&ecs.ContainerDefinition{Name: aws.String("c11")}, 1234)
 			assert.Error(t, err)
+			assert.Equal(t, mode, err.(*ErrMappedPortNotFound).NetworkMode)
+			assert.Contains(t, err.Error(), mode) // for coverage
 		}
 	})
 }

--- a/extension/observer/ecsobserver/task_test.go
+++ b/extension/observer/ecsobserver/task_test.go
@@ -190,3 +190,130 @@ func TestTask_MappedPort(t *testing.T) {
 		}
 	})
 }
+
+func TestTask_AddMatchedContainer(t *testing.T) {
+	t.Run("different container", func(t *testing.T) {
+		task := Task{
+			Matched: []MatchedContainer{
+				{
+					ContainerIndex: 0,
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeService,
+							Port:        1,
+						},
+					},
+				},
+			},
+		}
+
+		task.AddMatchedContainer(MatchedContainer{
+			ContainerIndex: 1,
+			Targets: []MatchedTarget{
+				{
+					MatcherType: MatcherTypeDockerLabel,
+					Port:        2,
+				},
+			},
+		})
+		assert.Equal(t, []MatchedContainer{
+			{
+				ContainerIndex: 0,
+				Targets: []MatchedTarget{
+					{
+						MatcherType: MatcherTypeService,
+						Port:        1,
+					},
+				},
+			},
+			{
+				ContainerIndex: 1,
+				Targets: []MatchedTarget{
+					{
+						MatcherType: MatcherTypeDockerLabel,
+						Port:        2,
+					},
+				},
+			},
+		}, task.Matched)
+	})
+
+	t.Run("same container different metris path", func(t *testing.T) {
+		task := Task{
+			Matched: []MatchedContainer{
+				{
+					ContainerIndex: 0,
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeService,
+							Port:        1,
+						},
+					},
+				},
+			},
+		}
+		task.AddMatchedContainer(MatchedContainer{
+			ContainerIndex: 0,
+			Targets: []MatchedTarget{
+				{
+					MatcherType: MatcherTypeTaskDefinition,
+					Port:        1,
+					MetricsPath: "/metrics2",
+				},
+			},
+		})
+		assert.Equal(t, []MatchedContainer{
+			{
+				ContainerIndex: 0,
+				Targets: []MatchedTarget{
+					{
+						MatcherType: MatcherTypeService,
+						Port:        1,
+					},
+					{
+						MatcherType: MatcherTypeTaskDefinition,
+						Port:        1,
+						MetricsPath: "/metrics2",
+					},
+				},
+			},
+		}, task.Matched)
+	})
+
+	t.Run("same container same metrics path", func(t *testing.T) {
+		task := Task{
+			Matched: []MatchedContainer{
+				{
+					ContainerIndex: 0,
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeService,
+							Port:        1,
+						},
+					},
+				},
+			},
+		}
+		task.AddMatchedContainer(MatchedContainer{
+			ContainerIndex: 0,
+			Targets: []MatchedTarget{
+				{
+					MatcherType: MatcherTypeTaskDefinition,
+					Port:        1,
+					MetricsPath: "",
+				},
+			},
+		})
+		assert.Equal(t, []MatchedContainer{
+			{
+				ContainerIndex: 0,
+				Targets: []MatchedTarget{
+					{
+						MatcherType: MatcherTypeService,
+						Port:        1,
+					},
+				},
+			},
+		}, task.Matched)
+	})
+}


### PR DESCRIPTION
**Description:** 

Follow up on #2734  Add get private ip and mapped port from ecs task

**Link to tracking Issue:**

- Feature request #1395 

Previous PRs

- Target and Task definition (merged) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2939
- Config PR (merged) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2377
- Original PR (closed) #2734 

**Testing:** 

unit test

**Documentation:** 

No new doc. See [existing doc](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/observer/ecsobserver/README.md)