### PR TITLE
Improvements to the awsprometheusremotewriteexporter

### DIFF
--- a/exporter/awsprometheusremotewriteexporter/README.md
+++ b/exporter/awsprometheusremotewriteexporter/README.md
@@ -1,24 +1,29 @@
 # AWS Prometheus Remote Write Exporter
 
-This Exporter sends metrics data in Prometheus TimeSeries format to a Prometheus Remote Write Backend and signs each outgoing HTTP request following
-the AWS Signature Version 4 signing process. AWS region and service must be provided in the configuration file, and AWS
-credentials are retrieved from the [default credential chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials)
-of the AWS SDK for Go.
+AWS Prometheus Remote Write Exporter sends metrics in remote write format to
+[Amazon Managed Service for Prometheus](https://aws.amazon.com/prometheus/).
+The exporter uses AWS Signature Version 4 signing process for authentication
+and uses credentials from the 
+[default credential chain](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).
 
-Note: this exporter imports and uses the [Prometheus remote write exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/prometheusremotewriteexporter)
-from upstream, and simply wraps it in Sigv4 authentication logic
+Note: This exporter is similar to [Prometheus remote write exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/prometheusremotewriteexporter)
+and it only adds SigV4 support to it.
 
-Same as the Prometheus remote write exporter, this exporter checks the temporality and the type of each incoming metric
+Similar to the Prometheus remote write exporter, the exporter checks the
+temporality and the type of each incoming metric
 and only exports the following combination:
 
 - Int64 or Double type with any temporality
 - MonotonicInt64, MonotonicDouble, Histogram, or Summary with only Cumulative temporality.
 
 ## Configuration
+
 The following settings are required:
+
 - `endpoint`: protocol:host:port to which the exporter is going to send traces or metrics, using the HTTP/HTTPS protocol.
 
 The following settings can be optionally configured:
+
 - `namespace`: prefix attached to each exported metric name.
 - `headers`: additional headers attached to each HTTP request. If `X-Prometheus-Remote-Write-Version` is set by user, its value must be `0.1.0`
 - `insecure` (default = false): whether to enable client transport security for the exporter's connection.
@@ -32,36 +37,35 @@ The following settings can be optionally configured:
     - `region`: region of the AWS service being exported to.
     - `role_arn`: Amazon Resource Name of the role to assume.
 
-#### Examples:
+### Examples
 
 Simplest configuration:
+
 ```yaml
 exporters:
   awsprometheusremotewrite:
-    endpoint: "http://some.url:9411/api/prom/push"
+    endpoint: "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write"
 ```
 
 All configurations:
+
 ```yaml
 exporters:
   awsprometheusremotewrite:
     namespace: "test-space"
-    sending_queue:
-        enabled: true
-        num_consumers: 2
-        queue_size: 10
     retry_on_failure:
         enabled: true
         initial_interval: 10s
         max_interval: 60s
         max_elapsed_time: 10m
-    endpoint: "http://localhost:9009"
+    endpoint: "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write"
+    aws_auth:
+        region: "us-east-1" # need to match workspace region
+        role_arn: "arn:aws:iam::123456789012:role/aws-service-role/access"
     ca_file: "/var/lib/mycert.pem"
     write_buffer_size: 524288
     headers:
         X-Scope-OrgID: 234
-    aws_auth:
-        region: "us-west-2"
     external_labels:
         key1: value1
         key2: value2

--- a/exporter/awsprometheusremotewriteexporter/README.md
+++ b/exporter/awsprometheusremotewriteexporter/README.md
@@ -30,7 +30,6 @@ The following settings can be optionally configured:
 - `write_buffer_size` (default = 512 * 1024): WriteBufferSize for HTTP client.
 - `aws_auth`: specify if each request should be signed with AWS Sig v4. The following settings must be configured:
     - `region`: region of the AWS service being exported to.
-    - `service`: AWS service being exported to.
     - `role_arn`: Amazon Resource Name of the role to assume.
 
 #### Examples:
@@ -60,11 +59,9 @@ exporters:
     ca_file: "/var/lib/mycert.pem"
     write_buffer_size: 524288
     headers:
-        Prometheus-Remote-Write-Version: "0.1.0"
         X-Scope-OrgID: 234
     aws_auth:
         region: "us-west-2"
-        service: "service-name"
     external_labels:
         key1: value1
         key2: value2

--- a/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
@@ -8,10 +8,6 @@ exporters:
     awsprometheusremotewrite:
     awsprometheusremotewrite/2:
         namespace: "test-space"
-        sending_queue:
-            enabled: true
-            num_consumers: 2
-            queue_size: 10
         retry_on_failure:
             enabled: true
             initial_interval: 10s

--- a/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
@@ -8,6 +8,10 @@ exporters:
     awsprometheusremotewrite:
     awsprometheusremotewrite/2:
         namespace: "test-space"
+        sending_queue:
+            enabled: true
+            num_consumers: 2
+            queue_size: 10
         retry_on_failure:
             enabled: true
             initial_interval: 10s


### PR DESCRIPTION
- Improvements to language and formatting
- Providing a realistic workspace URL
- Removing sending_queue due to lack of support
- aws_auth.service has to be always "aps", removing it from documentation
- Adding a note that aws_auth.region has to match the workspace region
- Documenting aws_auth.role_arn

Related to https://github.com/open-telemetry/opentelemetry-collector/pull/2951