### PR TITLE
Users shouldn't set the aws_auth.service for the AWS PRW exporter

### DIFF
--- a/exporter/awsprometheusremotewriteexporter/README.md
+++ b/exporter/awsprometheusremotewriteexporter/README.md
@@ -30,7 +30,6 @@ The following settings can be optionally configured:
 - `write_buffer_size` (default = 512 * 1024): WriteBufferSize for HTTP client.
 - `aws_auth`: specify if each request should be signed with AWS Sig v4. The following settings must be configured:
     - `region`: region of the AWS service being exported to.
-    - `service`: AWS service being exported to.
     - `role_arn`: Amazon Resource Name of the role to assume.
 
 #### Examples:
@@ -64,7 +63,6 @@ exporters:
         X-Scope-OrgID: 234
     aws_auth:
         region: "us-west-2"
-        service: "service-name"
     external_labels:
         key1: value1
         key2: value2

--- a/exporter/awsprometheusremotewriteexporter/config.go
+++ b/exporter/awsprometheusremotewriteexporter/config.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package awsprometheusremotewriteexporter provides a Prometheus Remote Write Exporter with AWS Sigv4 authentication
 package awsprometheusremotewriteexporter
 
 import (
@@ -32,8 +31,7 @@ type Config struct {
 type AuthConfig struct {
 	// Region is the AWS region for AWS Sig v4.
 	Region string `mapstructure:"region"`
-	// Service is the service name for AWS Sig v4
-	Service string `mapstructure:"service"`
+
 	// Amazon Resource Name (ARN) of a role to assume
 	RoleArn string `mapstructure:"role_arn"`
 }

--- a/exporter/awsprometheusremotewriteexporter/config_test.go
+++ b/exporter/awsprometheusremotewriteexporter/config_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package awsprometheusremotewriteexporter provides a Prometheus Remote Write Exporter with AWS Sigv4 authentication
 package awsprometheusremotewriteexporter
 
 import (
@@ -94,7 +93,6 @@ func TestLoadConfig(t *testing.T) {
 		},
 		AuthConfig: AuthConfig{
 			Region:  "us-west-2",
-			Service: "service-name",
 			RoleArn: "arn:aws:iam::123456789012:role/IAMRole",
 		},
 	}

--- a/exporter/awsprometheusremotewriteexporter/factory.go
+++ b/exporter/awsprometheusremotewriteexporter/factory.go
@@ -17,7 +17,6 @@ package awsprometheusremotewriteexporter
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"go.opentelemetry.io/collector/component"
@@ -50,7 +49,6 @@ func (af *awsFactory) CreateDefaultConfig() config.Exporter {
 		Config: *af.ExporterFactory.CreateDefaultConfig().(*prw.Config),
 		AuthConfig: AuthConfig{
 			Region:  "",
-			Service: "",
 			RoleArn: "",
 		},
 	}
@@ -59,16 +57,7 @@ func (af *awsFactory) CreateDefaultConfig() config.Exporter {
 	cfg.NameVal = typeStr
 
 	cfg.HTTPClientSettings.CustomRoundTripper = func(next http.RoundTripper) (http.RoundTripper, error) {
-		if !isAuthConfigValid(cfg.AuthConfig) {
-			return nil, errors.New("invalid authentication configuration")
-		}
-
 		return newSigningRoundTripper(cfg.AuthConfig, next)
 	}
-
 	return cfg
-}
-
-func isAuthConfigValid(params AuthConfig) bool {
-	return !(params.Region != "" && params.Service == "" || params.Region == "" && params.Service != "")
 }

--- a/exporter/awsprometheusremotewriteexporter/factory_test.go
+++ b/exporter/awsprometheusremotewriteexporter/factory_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package awsprometheusremotewriteexporter provides a Prometheus Remote Write Exporter with AWS Sigv4 authentication
 package awsprometheusremotewriteexporter
 
 import (
@@ -46,7 +45,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateMetricsExporter(t *testing.T) {
 	af := NewFactory()
 	validConfigWithAuth := af.CreateDefaultConfig().(*Config)
-	validConfigWithAuth.AuthConfig = AuthConfig{Region: "region", Service: "service"}
+	validConfigWithAuth.AuthConfig = AuthConfig{Region: "region"}
 
 	// Some form of AWS credentials chain required to test valid auth case
 	// This is a set of mock credentials strictly for testing purposes. Users
@@ -55,7 +54,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "mock_value2")
 
 	invalidConfigWithAuth := af.CreateDefaultConfig().(*Config)
-	invalidConfigWithAuth.AuthConfig = AuthConfig{Region: "", Service: "service"}
+	invalidConfigWithAuth.AuthConfig = AuthConfig{}
 
 	invalidConfig := af.CreateDefaultConfig().(*Config)
 	invalidConfig.HTTPClientSettings = confighttp.HTTPClientSettings{}
@@ -87,11 +86,6 @@ func TestCreateMetricsExporter(t *testing.T) {
 			component.ExporterCreateParams{Logger: zap.NewNop()},
 			false,
 		},
-		{"invalid_auth_case",
-			invalidConfigWithAuth,
-			component.ExporterCreateParams{Logger: zap.NewNop()},
-			true,
-		},
 		{"invalid_config_case",
 			invalidConfig,
 			component.ExporterCreateParams{Logger: zap.NewNop()},
@@ -103,7 +97,6 @@ func TestCreateMetricsExporter(t *testing.T) {
 			true,
 		},
 	}
-	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := af.CreateMetricsExporter(context.Background(), tt.params, tt.cfg)

--- a/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
@@ -25,7 +25,6 @@ exporters:
             X-Scope-OrgID: 234
         aws_auth:
             region: "us-west-2"
-            service: "service-name"
             role_arn: "arn:aws:iam::123456789012:role/IAMRole"
         external_labels:
             key1: value1


### PR DESCRIPTION
The service is always "aps", removing the configuration setting that allows to set this field and making it default.
