### PR TITLE
Use the correct default for aws_auth.service for the AWS PRW exporter

### DIFF
--- a/exporter/awsprometheusremotewriteexporter/README.md
+++ b/exporter/awsprometheusremotewriteexporter/README.md
@@ -59,13 +59,14 @@ exporters:
         max_interval: 60s
         max_elapsed_time: 10m
     endpoint: "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write"
-    aws_auth:
-        region: "us-east-1" # need to match workspace region
-        role_arn: "arn:aws:iam::123456789012:role/aws-service-role/access"
     ca_file: "/var/lib/mycert.pem"
     write_buffer_size: 524288
     headers:
         X-Scope-OrgID: 234
+    aws_auth:
+        region: "us-east-1" # need to match workspace region
+        service: "aps"
+        role_arn: "arn:aws:iam::123456789012:role/aws-service-role/access"
     external_labels:
         key1: value1
         key2: value2

--- a/exporter/awsprometheusremotewriteexporter/README.md
+++ b/exporter/awsprometheusremotewriteexporter/README.md
@@ -59,14 +59,14 @@ exporters:
         max_interval: 60s
         max_elapsed_time: 10m
     endpoint: "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write"
-    ca_file: "/var/lib/mycert.pem"
-    write_buffer_size: 524288
-    headers:
-        X-Scope-OrgID: 234
     aws_auth:
         region: "us-east-1" # need to match workspace region
         service: "aps"
         role_arn: "arn:aws:iam::123456789012:role/aws-service-role/access"
+    ca_file: "/var/lib/mycert.pem"
+    write_buffer_size: 524288
+    headers:
+        X-Scope-OrgID: 234
     external_labels:
         key1: value1
         key2: value2

--- a/exporter/awsprometheusremotewriteexporter/config.go
+++ b/exporter/awsprometheusremotewriteexporter/config.go
@@ -27,12 +27,12 @@ type Config struct {
 	AuthConfig AuthConfig `mapstructure:"aws_auth"`
 }
 
-// AuthConfig defines AWS authentication configurations for SigningRoundTripper
+// AuthConfig defines AWS authentication configurations for SigningRoundTripper.
 type AuthConfig struct {
 	// Region is the AWS region for AWS SigV4.
 	Region string `mapstructure:"region"`
 
-	// Service is the AWS service for AWS SigV4, this is by default "aps".
+	// Service is the AWS service for AWS SigV4, this is by default "aps". Optional.
 	Service string `mapstructure:"service"`
 
 	// Amazon Resource Name (ARN) of a role to assume. Optional.

--- a/exporter/awsprometheusremotewriteexporter/config.go
+++ b/exporter/awsprometheusremotewriteexporter/config.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package awsprometheusremotewriteexporter provides a Prometheus Remote Write Exporter with AWS Sigv4 authentication
 package awsprometheusremotewriteexporter
 
 import (
@@ -21,19 +20,21 @@ import (
 
 // Config defines configuration for Remote Write exporter.
 type Config struct {
-	// Config represents the Prometheus Remote Write Exporter configuration
+	// Config represents the Prometheus Remote Write Exporter configuration.
 	prw.Config `mapstructure:",squash"`
 
-	// AuthConfig represents the AWS Sig V4 configuration options
+	// AuthConfig represents the AWS SigV4 configuration options.
 	AuthConfig AuthConfig `mapstructure:"aws_auth"`
 }
 
 // AuthConfig defines AWS authentication configurations for SigningRoundTripper
 type AuthConfig struct {
-	// Region is the AWS region for AWS Sig v4.
+	// Region is the AWS region for AWS SigV4.
 	Region string `mapstructure:"region"`
-	// Service is the service name for AWS Sig v4
+
+	// Service is the AWS service for AWS SigV4, this is by default "aps".
 	Service string `mapstructure:"service"`
-	// Amazon Resource Name (ARN) of a role to assume
+
+	// Amazon Resource Name (ARN) of a role to assume. Optional.
 	RoleArn string `mapstructure:"role_arn"`
 }

--- a/exporter/awsprometheusremotewriteexporter/config_test.go
+++ b/exporter/awsprometheusremotewriteexporter/config_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package awsprometheusremotewriteexporter provides a Prometheus Remote Write Exporter with AWS Sigv4 authentication
 package awsprometheusremotewriteexporter
 
 import (
@@ -31,7 +30,7 @@ import (
 	prw "go.opentelemetry.io/collector/exporter/prometheusremotewriteexporter"
 )
 
-// TestLoadConfig checks whether yaml configuration can be loaded correctly
+// TestLoadConfig checks whether yaml configuration can be loaded correctly.
 func TestLoadConfig(t *testing.T) {
 	factories, err := componenttest.NopFactories()
 	assert.NoError(t, err)

--- a/exporter/awsprometheusremotewriteexporter/factory.go
+++ b/exporter/awsprometheusremotewriteexporter/factory.go
@@ -17,7 +17,6 @@ package awsprometheusremotewriteexporter
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"go.opentelemetry.io/collector/component"
@@ -50,25 +49,16 @@ func (af *awsFactory) CreateDefaultConfig() config.Exporter {
 		Config: *af.ExporterFactory.CreateDefaultConfig().(*prw.Config),
 		AuthConfig: AuthConfig{
 			Region:  "",
-			Service: "",
+			Service: defaultAMPSigV4Service,
 			RoleArn: "",
 		},
 	}
 
 	cfg.TypeVal = typeStr
 	cfg.NameVal = typeStr
-
 	cfg.HTTPClientSettings.CustomRoundTripper = func(next http.RoundTripper) (http.RoundTripper, error) {
-		if !isAuthConfigValid(cfg.AuthConfig) {
-			return nil, errors.New("invalid authentication configuration")
-		}
-
 		return newSigningRoundTripper(cfg.AuthConfig, next)
 	}
 
 	return cfg
-}
-
-func isAuthConfigValid(params AuthConfig) bool {
-	return !(params.Region != "" && params.Service == "" || params.Region == "" && params.Service != "")
 }

--- a/exporter/awsprometheusremotewriteexporter/factory_test.go
+++ b/exporter/awsprometheusremotewriteexporter/factory_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package awsprometheusremotewriteexporter provides a Prometheus Remote Write Exporter with AWS Sigv4 authentication
 package awsprometheusremotewriteexporter
 
 import (
@@ -86,11 +85,6 @@ func TestCreateMetricsExporter(t *testing.T) {
 			validConfigWithAuth,
 			component.ExporterCreateParams{Logger: zap.NewNop()},
 			false,
-		},
-		{"invalid_auth_case",
-			invalidConfigWithAuth,
-			component.ExporterCreateParams{Logger: zap.NewNop()},
-			true,
 		},
 		{"invalid_config_case",
 			invalidConfig,


### PR DESCRIPTION
"aps" is currently the only value that is acceptable for this field. We should have never provided it as a configuration setting but we can't remove and break the existing users. This change is setting it to "aps" by default.

A follow-up change will be provided to automatically parse the region from the workspace remote write endpoint.

