### PR TITLE
Humio trace exporter

### DIFF
--- a/exporter/humioexporter/README.md
+++ b/exporter/humioexporter/README.md
@@ -3,7 +3,7 @@ Exports data to Humio using JSON over the HTTP [Ingest API](https://docs.humio.c
 
 Supported pipeline types: traces (with metrics and logs to follow soon)
 
-> :construction: This exporter is currently intended for evaluation purposes only!
+> :construction: This exporter is currently intended for evaluation purposes only! It has yet to be enabled in the build.
 
 ## Getting Started
 This exporter requires the following configuration options:

--- a/exporter/humioexporter/README.md
+++ b/exporter/humioexporter/README.md
@@ -6,53 +6,104 @@ Supported pipeline types: traces (with metrics and logs to follow soon)
 > :construction: This exporter is currently intended for evaluation purposes only! It has yet to be enabled in the build.
 
 ## Getting Started
-This exporter requires the following configuration options:
+This exporter provides a set of global configuration options, as well as options specific to each telemetry data type. An example structure is illustrated below:
 
-- `ingest_token` (no default): The token that has been issued in relation to the Humio repository to export data into. This token grants write-only access to a single, specific Humio repository. See [Ingest Tokens](https://docs.humio.com/docs/ingesting-data/ingest-tokens/) for more details.
-- `endpoint` (no default): The base URL on which the Humio backend can be reached, in the form `host:port`. For testing this locally with the Humio Docker image, the endpoint could be `http://localhost:8080/`. For use with the Humio cloud, the URLs are as follows, both of which use port `80`:
+```yaml
+exporters:
+    humio:
+        endpoint: "my-global-endpoint"
+        
+        traces:
+            ingest_token: "my-traces-token"
+```
+
+Required global options must always be specified, while options specific to each type of telemetry data are only required if that telemetry type has been enabled in a pipeline. For instance, the pipeline below will not require configuration options for logs or metrics:
+
+```yaml
+service:
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [humio]
+```
+
+The following sections outline the required and optional settings for both global options as well as options specific to each type of telemetry data.
+
+### Global options
+This exporter requires as a minimum the following global configuration options:
+
+- `endpoint` (no default): The global base URL on which the Humio backend can be reached, in the form `host:port`. For testing this locally with the Humio Docker image, the endpoint could be `http://localhost:8080/`. For use with the Humio cloud, the URLs are as follows, both of which use port `80`:
     - EU: `https://cloud.humio.com/`
     - US: `https://cloud.us.humio.com/`
 
-As defined in the [TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md#tls-configuration-settings), TLS is enabled by default. This can be disabled by overriding the following configuration options:
+In addition, the following optional settings specific to this exporter can be overridden:
+
+- `disable_compression` (default: `false`): Whether to stop compressing payloads with gzip before sending them to Humio. This should only be disabled if compression can be shown to have a negative impact on performance in your specific deployment.
+- `tag` (default: `none`): The strategy to use for tagging telemetry data sent to Humio. By default, tagging is disabled, since it is a complex topic. See [Tagging](#Tagging) for more information, including possible values.
+
+This exporter also supports inherited configuration options as described in [Inherited Options](#Inherited-Options). As defined in the [TLS Configuration Settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md#tls-configuration-settings), TLS is enabled by default. This can be disabled by overriding the following configuration options:
 
 - `insecure` (default: `false`): Whether to enable client transport security for the exporter's HTTP connection. Not recommended for production deployments.
 - `insecure_skip_verify` (default: `false`): Whether to skip verifying the server's certificate chain or not. Not recommended for production deployments.
 
-In addition, the following global configuration options can be overridden:
-
-- `disable_compression` (default: `false`): Whether to stop compressing payloads with gzip before sending them to Humio. This should only be disabled if compression can be shown to have a negative impact on performance in your specific deployment.
-- `tags` (no default): A series of key-value pairs used to target specific Data Sources for storage inside a Humio repository. Refer to [Humio Tagging](https://docs.humio.com/docs/parsers/tagging/) for more details.
-- `disable_service_tag` (default: `false`): By default, the service name will be used to tag all exported events in addition to user-provided tags. If disabled, only the user-provided tags will be used. However, at least one tag _must_ be specified.
-
 ### Traces
-For exporting structured data (traces), the following configuration options are available:
+For exporting traces, the following configuration options are required:
+
+- `ingest_token` (no default): The token that has been issued in relation to the Humio repository to export traces into. This token grants write-only access to a single, specific Humio repository. See [Ingest Tokens](https://docs.humio.com/docs/ingesting-data/ingest-tokens/) for more details.
+
+In addition, the following optional settings can be overridden:
 
 - `unix_timestamps` (default: `false`): Whether to use Unix or ISO 8601 formatted timestamps when exporting data to Humio. If this is set to `true`, timestamps will be represented in milliseconds (Unix time) in UTC, and the time zone of the event is stored separately in the payload sent to Humio.
 
+## Example Configuration
+Below are two examples of configurations specific to this exporter, the first of which is the minimal required configuration for traces. For a more advanced example with all available configuration options, see [This Example](testdata/config.yaml).
+
+```yaml
+exporters:
+    humio:
+        endpoint: "https://cloud.humio.com/"
+        traces:
+            ingest_token: "00000000-0000-0000-0000-0000000000000"
+    humio/advanced:
+        endpoint: "http://localhost:8080/"
+        timeout: 10s
+        disable_compression: true
+        tag: trace_id
+        traces:
+            ingest_token: "00000000-0000-0000-0000-0000000000000"
+            unix_timestamps: true
+```
+
 ## Advaced Configuration
+### Inherited Options
 This exporter, like many others, includes shared configuration helpers for the following advanced settings:
 
 - [HTTP Client Configuration](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp#client-configuration)
 - [TLS Configuration](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md#tls-configuration-settings)
 - [Queueing, Retry, and Timeout Configuration](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md#configuration)
 
-## Example Configuration
-Below are two examples of configurations specific to this exporter. For a more advanced example with all available configuration options, see [This Example](testdata/config.yaml).
+### Tagging
+Tagging is a strategy in Humio to optimize search speeds by sharding ingested data into specific data sources. This allows for making queries that quickly rule out the majority of data to search through. See [Humio Tagging](https://docs.humio.com/docs/parsers/tagging/) for more details.
 
-```yaml
-exporters:
-    humio:
-        ingest_token: "00000000-0000-0000-0000-0000000000000"
-        endpoint: "https://my-humio-host:8080"
-    humio/advanced:
-        ingest_token: "00000000-0000-0000-0000-0000000000000"
-        endpoint: "http://localhost:8080"
-        timeout: 10s
-        disable_compression: true
-        disable_service_tag: true
-        tags:
-            host: "web_server"
-            environment: "production"
-        traces:
-            unix_timestamps: true
+If tagging is disabled on this exporter, Humio will still use its own tags internally to organize the data. One such tag is the `#type` tag, which takes its value from the name of the parser assigned to the [ingest token](https://docs.humio.com/docs/ingesting-data/ingest-tokens/)). This is the only officially recommended tag.
+
+However, due to the nature of OpenTelemetry, the service name or trace ID can make decent tags as well, depending on the intended queries in the backend. For such tags to work well, however, you need to enable tag grouping. See [Tag Grouping](https://docs.humio.com/reference/api/cluster-management-api/#setup-grouping-of-tags) for a thorough discussion.
+
+This exporter supports the following strategies for tags, which thus makes up the legal values for the `tag` option:
+
+| Strategy      | Tag field in Humio |
+| ------------- | ------------------ |
+| none          | -                  |
+| trace_id      | #trace_id          |
+| service_name  | #service_name      |
+
+For instance, to enable the `trace_id` strategy, you must create a tag group as such:
+
+```bash
+curl $YOUR_HUMIO_URL/api/v1/repositories/$REPOSITORY_NAME/taggrouping \
+  -X POST \
+  -H "Authorization: Bearer $YOUR_API_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '[ {"field": "trace_id","modulus": 16} ]'
 ```

--- a/exporter/humioexporter/config.go
+++ b/exporter/humioexporter/config.go
@@ -31,14 +31,47 @@ const (
 	structuredPath   = basePath + "humio-structured"
 )
 
+// Definition of tagging strategies
+type tag string
+
+const (
+	// None disables tagging of payloads to Humio
+	TagNone tag = "none"
+
+	// TraceID tags payloads to Humio using the trace ID, or an empty string if
+	// the trace ID is missing
+	TagTraceID tag = "trace_id"
+
+	// ServiceName tags payloads to Humio using the service name, or an empty
+	// string if it is missing
+	TagServiceName tag = "service_name"
+)
+
+// Tagger represents a tagging strategy understood by the Humio exporter
+type Tagger interface {
+	Tag() tag
+}
+
+// Tag returns the underlying representation of the tagging strategy. This
+// exists to ensure that strategies implement the Tagger interface
+func (t tag) Tag() tag {
+	return t
+}
+
 // LogsConfig represents the Humio configuration settings specific to logs
 type LogsConfig struct {
+	//Ingest token for identifying and authorizing with a Humio repository
+	IngestToken string `mapstructure:"ingest_token"`
+
 	// The name of a custom log parser to use, if no parser is associated with the ingest token
 	LogParser string `mapstructure:"log_parser"`
 }
 
 // TracesConfig represents the Humio configuration settings specific to traces
 type TracesConfig struct {
+	//Ingest token for identifying and authorizing with a Humio repository
+	IngestToken string `mapstructure:"ingest_token"`
+
 	// Whether to use Unix timestamps, or to fall back to ISO 8601 formatted strings
 	UnixTimestamps bool `mapstructure:"unix_timestamps"`
 }
@@ -51,9 +84,6 @@ type Config struct {
 	exporterhelper.QueueSettings  `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"`
 
-	//Ingest token for identifying and authorizing with a Humio repository
-	IngestToken string `mapstructure:"ingest_token"`
-
 	// Endpoint for the unstructured ingest API, created internally
 	unstructuredEndpoint *url.URL
 
@@ -63,11 +93,8 @@ type Config struct {
 	// Whether gzip compression should be disabled when sending data to Humio
 	DisableCompression bool `mapstructure:"disable_compression"`
 
-	// Key-value pairs used to target specific data sources for storage inside Humio
-	Tags map[string]string `mapstructure:"tags,omitempty"`
-
-	// Whether this exporter should automatically add the service name as a tag
-	DisableServiceTag bool `mapstructure:"disable_service_tag"`
+	// Name of tagging strategy used to target specific data sources for storage inside Humio
+	Tag Tagger `mapstructure:"tag"`
 
 	// Configuration options specific to logs
 	Logs LogsConfig `mapstructure:"logs"`
@@ -78,16 +105,12 @@ type Config struct {
 
 // Validate ensures that a valid configuration has been provided, such that we can fail early
 func (c *Config) Validate() error {
-	if c.IngestToken == "" {
-		return errors.New("requires an ingest_token")
-	}
-
 	if c.Endpoint == "" {
 		return errors.New("requires an endpoint")
 	}
 
-	if c.DisableServiceTag && len(c.Tags) == 0 {
-		return errors.New("requires at least one custom tag when disabling service tag")
+	if c.Tag != TagNone && c.Tag != TagTraceID && c.Tag != TagServiceName {
+		return fmt.Errorf("tagging strategy must be one of %s, %s, or %s", TagNone, TagTraceID, TagServiceName)
 	}
 
 	// Ensure that it is possible to construct URLs to access the ingest API
@@ -127,7 +150,6 @@ func (c *Config) sanitize() error {
 	}
 
 	c.Headers["content-type"] = "application/json"
-	c.Headers["authorization"] = "Bearer " + c.IngestToken
 
 	if !c.DisableCompression {
 		c.Headers["content-encoding"] = "gzip"

--- a/exporter/humioexporter/config.go
+++ b/exporter/humioexporter/config.go
@@ -31,33 +31,6 @@ const (
 	structuredPath   = basePath + "humio-structured"
 )
 
-// Definition of tagging strategies
-type tag string
-
-const (
-	// None disables tagging of payloads to Humio
-	TagNone tag = "none"
-
-	// TraceID tags payloads to Humio using the trace ID, or an empty string if
-	// the trace ID is missing
-	TagTraceID tag = "trace_id"
-
-	// ServiceName tags payloads to Humio using the service name, or an empty
-	// string if it is missing
-	TagServiceName tag = "service_name"
-)
-
-// Tagger represents a tagging strategy understood by the Humio exporter
-type Tagger interface {
-	Tag() tag
-}
-
-// Tag returns the underlying representation of the tagging strategy. This
-// exists to ensure that strategies implement the Tagger interface
-func (t tag) Tag() tag {
-	return t
-}
-
 // LogsConfig represents the Humio configuration settings specific to logs
 type LogsConfig struct {
 	//Ingest token for identifying and authorizing with a Humio repository

--- a/exporter/humioexporter/factory.go
+++ b/exporter/humioexporter/factory.go
@@ -53,8 +53,7 @@ func createDefaultConfig() config.Exporter {
 
 		// Settings specific to the Humio exporter
 		DisableCompression: false,
-		Tags:               map[string]string{},
-		DisableServiceTag:  false,
+		Tag:                TagNone,
 		Traces: TracesConfig{
 			UnixTimestamps: false,
 		},
@@ -74,6 +73,11 @@ func createTracesExporter(
 
 	if err := cfg.sanitize(); err != nil {
 		return nil, err
+	}
+
+	// We only require the trace ingest token when the trace exporter is enabled
+	if cfg.Traces.IngestToken == "" {
+		return nil, errors.New("an ingest token for traces is required when enabling the Humio trace exporter")
 	}
 
 	client, err := newHumioClient(cfg, params.Logger)

--- a/exporter/humioexporter/factory_test.go
+++ b/exporter/humioexporter/factory_test.go
@@ -50,9 +50,12 @@ func TestCreateTracesExporter(t *testing.T) {
 			desc: "Valid trace configuration",
 			cfg: &Config{
 				ExporterSettings: config.NewExporterSettings(typeStr),
-				IngestToken:      "00000000-0000-0000-0000-0000000000000",
+				Tag:              TagNone,
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "http://localhost:8080",
+				},
+				Traces: TracesConfig{
+					IngestToken: "00000000-0000-0000-0000-0000000000000",
 				},
 			},
 			wantErr: false,
@@ -61,8 +64,20 @@ func TestCreateTracesExporter(t *testing.T) {
 			desc: "Unsanitizable trace configuration",
 			cfg: &Config{
 				ExporterSettings: config.NewExporterSettings(typeStr),
+				Tag:              TagNone,
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "\n",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "Missing ingest token",
+			cfg: &Config{
+				ExporterSettings: config.NewExporterSettings(typeStr),
+				Tag:              TagNone,
+				HTTPClientSettings: confighttp.HTTPClientSettings{
+					Endpoint: "http://localhost:8080",
 				},
 			},
 			wantErr: true,
@@ -71,7 +86,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			desc: "Invalid client configuration",
 			cfg: &Config{
 				ExporterSettings: config.NewExporterSettings(typeStr),
-				IngestToken:      "00000000-0000-0000-0000-0000000000000",
+				Tag:              TagNone,
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: "http://localhost:8080",
 					TLSSetting: configtls.TLSClientSetting{
@@ -80,6 +95,9 @@ func TestCreateTracesExporter(t *testing.T) {
 							KeyFile:  "key.key",
 						},
 					},
+				},
+				Traces: TracesConfig{
+					IngestToken: "00000000-0000-0000-0000-0000000000000",
 				},
 			},
 			wantErr: true,

--- a/exporter/humioexporter/tag_strategy.go
+++ b/exporter/humioexporter/tag_strategy.go
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package humioexporter
+
+// Definition of tagging strategies
+type tag string
+
+const (
+	// None disables tagging of payloads to Humio
+	TagNone tag = "none"
+
+	// TraceID tags payloads to Humio using the trace ID, or an empty string if
+	// the trace ID is missing
+	TagTraceID tag = "trace_id"
+
+	// ServiceName tags payloads to Humio using the service name, or an empty
+	// string if it is missing
+	TagServiceName tag = "service_name"
+)
+
+// Tagger represents a tagging strategy understood by the Humio exporter
+type Tagger interface {
+	Tag() tag
+}
+
+// Tag returns the underlying representation of the tagging strategy. This
+// exists to ensure that strategies implement the Tagger interface
+func (t tag) Tag() tag {
+	return t
+}
+
+// TagOrganizer represents a type for organizing HumioStructuredEvents by tag
+// while a tree of structured data from OpenTelemetry is being converted into
+// Humio's format. Depending on the tagging strategy, the structure of
+// resource- and instrumentation logs/spans is not necessarily optimal for
+// sending to Humio
+type TagOrganizer struct {
+	evtsByTag map[string][]*HumioStructuredEvent
+	strategy  Tagger
+
+	// getTag should return the tag associated with a certain event, adhering to
+	// the specified taggin strategy
+	getTag func(*HumioStructuredEvent, Tagger) string
+}
+
+func newTagOrganizer(strategy Tagger, getTag func(*HumioStructuredEvent, Tagger) string) *TagOrganizer {
+	return &TagOrganizer{
+		evtsByTag: make(map[string][]*HumioStructuredEvent),
+		strategy:  strategy,
+		getTag:    getTag,
+	}
+}
+
+// Store an event in the group corresponding to the tag of the event. The tag is
+// retrieved using the getTag() callback function, which should adhere to the
+// tagging strategy
+func (t *TagOrganizer) consume(evt *HumioStructuredEvent) {
+	tag := t.getTag(evt, t.strategy)
+
+	if group, ok := t.evtsByTag[tag]; ok {
+		t.evtsByTag[tag] = append(group, evt)
+	} else {
+		t.evtsByTag[tag] = []*HumioStructuredEvent{evt}
+	}
+}
+
+// Converts the currently stored groups into a slice of structured events ready
+// to send to Humio
+func (t *TagOrganizer) asEvents() []*HumioStructuredEvents {
+	evts := make([]*HumioStructuredEvents, 0, len(t.evtsByTag))
+
+	for tag, group := range t.evtsByTag {
+		if tag == "" {
+			evts = append(evts, &HumioStructuredEvents{Events: group})
+		} else {
+			evts = append(evts, &HumioStructuredEvents{
+				Tags: map[string]string{
+					string(t.strategy.Tag()): tag,
+				},
+				Events: group,
+			})
+		}
+	}
+
+	return evts
+}

--- a/exporter/humioexporter/tag_strategy_test.go
+++ b/exporter/humioexporter/tag_strategy_test.go
@@ -13,3 +13,78 @@
 // limitations under the License.
 
 package humioexporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newStructuredEvent(attrs interface{}) *HumioStructuredEvent {
+	return &HumioStructuredEvent{
+		Timestamp:  time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+		AsUnix:     false,
+		Attributes: attrs,
+	}
+}
+
+func TestConsume(t *testing.T) {
+	// Arrange
+	organizer := newTagOrganizer(TagServiceName, func(evt *HumioStructuredEvent, t Tagger) string {
+		return evt.Attributes.(string)
+	})
+
+	// Act
+	organizer.consume(newStructuredEvent("a"))
+	organizer.consume(newStructuredEvent("b"))
+	organizer.consume(newStructuredEvent("c"))
+	organizer.consume(newStructuredEvent("a"))
+	organizer.consume(newStructuredEvent("b"))
+
+	// Assert
+	assert.Len(t, organizer.evtsByTag, 3)
+	assert.Len(t, organizer.evtsByTag["a"], 2)
+	assert.Len(t, organizer.evtsByTag["b"], 2)
+	assert.Len(t, organizer.evtsByTag["c"], 1)
+}
+
+func TestAsEvents(t *testing.T) {
+	// Arrange
+	organizer := newTagOrganizer(TagTraceID, func(evt *HumioStructuredEvent, t Tagger) string {
+		return evt.Attributes.(string)
+	})
+
+	a := newStructuredEvent("123")
+	b := newStructuredEvent("456")
+	c := newStructuredEvent("")
+	d := newStructuredEvent("456")
+
+	organizer.consume(a)
+	organizer.consume(b)
+	organizer.consume(c)
+	organizer.consume(d)
+
+	expected := []*HumioStructuredEvents{
+		{
+			Tags:   map[string]string{"trace_id": "123"},
+			Events: []*HumioStructuredEvent{a},
+		},
+		{
+			Tags:   map[string]string{"trace_id": "456"},
+			Events: []*HumioStructuredEvent{b, d},
+		},
+		{
+			Events: []*HumioStructuredEvent{c},
+		},
+	}
+
+	// Act
+	actual := organizer.asEvents()
+
+	// Assert
+	assert.Len(t, actual, 3)
+	assert.Contains(t, actual, expected[0])
+	assert.Contains(t, actual, expected[1])
+	assert.Contains(t, actual, expected[2])
+}

--- a/exporter/humioexporter/tag_strategy_test.go
+++ b/exporter/humioexporter/tag_strategy_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package humioexporter

--- a/exporter/humioexporter/testdata/config.yaml
+++ b/exporter/humioexporter/testdata/config.yaml
@@ -6,11 +6,11 @@ processors:
 
 exporters:
   humio:
-    ingest_token: "00000000-0000-0000-0000-0000000000000"
-    endpoint: "https://my-humio-host:8080"
+    endpoint: https://cloud.humio.com/
+    traces:
+      ingest_token: 00000000-0000-0000-0000-0000000000000
   humio/allsettings:
-    ingest_token: "00000000-0000-0000-0000-0000000000000"
-    endpoint: "https://my-humio-host:8080"
+    endpoint: http://localhost:8080/
     timeout: 10s
     insecure: false
     insecure_skip_verify: false
@@ -20,13 +20,12 @@ exporters:
     read_buffer_size: 4096
     write_buffer_size: 4096
     disable_compression: true
-    disable_service_tag: true
-    tags:
-      host: "web_server"
-      environment: "production"
+    tag: trace_id
     logs:
-      log_parser: "custom-parser"
+      ingest_token: 00000000-0000-0000-0000-0000000000000
+      log_parser: custom-parser
     traces:
+      ingest_token: 00000000-0000-0000-0000-0000000000001
       unix_timestamps: true
     sending_queue:
       enabled: false

--- a/exporter/humioexporter/testdata/invalid-compression.yaml
+++ b/exporter/humioexporter/testdata/invalid-compression.yaml
@@ -8,11 +8,12 @@ processors:
 
 exporters:
   humio:
-    ingest_token: "00000000-0000-0000-0000-0000000000000"
-    endpoint: "https://my-humio-host:8080"
+    endpoint: https://cloud.humio.com/
     disable_compression: true
     headers:
       Content-Encoding: compress
+    traces:
+      ingest_token: 00000000-0000-0000-0000-0000000000000
 
 
 service:

--- a/exporter/humioexporter/testdata/invalid-tag.yaml
+++ b/exporter/humioexporter/testdata/invalid-tag.yaml
@@ -1,0 +1,22 @@
+# NOTE: This is an invalid configuration used to test that such cases are caught
+# Do not use this configuration
+receivers:
+  nop:
+
+processors:
+  nop:
+
+exporters:
+  humio:
+    endpoint: https://cloud.humio.com/
+    tag: invalid
+    traces:
+      ingest_token: 00000000-0000-0000-0000-0000000000000
+
+
+service:
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [humio]

--- a/exporter/humioexporter/traces_exporter.go
+++ b/exporter/humioexporter/traces_exporter.go
@@ -103,6 +103,7 @@ func (e *humioTracesExporter) tracesToHumioEvents(td pdata.Traces) ([]*HumioStru
 
 		if _, ok := r.Attributes().Get(conventions.AttributeServiceName); !ok {
 			droppedTraces = append(droppedTraces, resSpan)
+			e.logger.Error("skipping export of spans for resource with missing service name, which is required for the Humio exporter")
 			continue
 		}
 
@@ -128,7 +129,7 @@ func (e *humioTracesExporter) tracesToHumioEvents(td pdata.Traces) ([]*HumioStru
 		}
 
 		return results, consumererror.NewTraces(
-			errors.New("unable to serialize spans"),
+			errors.New("unable to serialize spans due to missing required service name for the associated resource"),
 			dropped,
 		)
 	}

--- a/exporter/humioexporter/traces_exporter.go
+++ b/exporter/humioexporter/traces_exporter.go
@@ -188,8 +188,9 @@ func toHumioLinks(pLinks pdata.SpanLinkSlice) []*HumioLink {
 func toHumioAttributes(attrMaps ...pdata.AttributeMap) map[string]interface{} {
 	attr := make(map[string]interface{})
 	for _, attrMap := range attrMaps {
-		attrMap.ForEach(func(k string, v pdata.AttributeValue) {
+		attrMap.Range(func(k string, v pdata.AttributeValue) bool {
 			attr[k] = toHumioAttributeValue(v)
+			return true
 		})
 	}
 	return attr

--- a/exporter/humioexporter/traces_exporter.go
+++ b/exporter/humioexporter/traces_exporter.go
@@ -16,13 +16,34 @@ package humioexporter
 
 import (
 	"context"
-	"errors"
 	"sync"
 
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
 )
+
+type HumioLink struct {
+	TraceId    string `json:"trace_id"`
+	SpanId     string `json:"span_id"`
+	TraceState string `json:"state"`
+}
+
+type HumioSpan struct {
+	TraceId           string            `json:"trace_id"`
+	SpanId            string            `json:"span_id"`
+	ParentSpanId      string            `json:"parent_id,omitempty"`
+	Name              string            `json:"name"`
+	Kind              string            `json:"kind"`
+	Start             int64             `json:"start"`
+	End               int64             `json:"end"`
+	StatusCode        string            `json:"status"`
+	StatusDescription string            `json:"status_descr"`
+	ServiceName       string            `json:"service"`
+	Links             HumioLink         `json:"links"`
+	Attributes        map[string]string `json:"attributes"`
+}
 
 type humioTracesExporter struct {
 	cfg    *Config
@@ -43,10 +64,81 @@ func (e *humioTracesExporter) pushTraceData(ctx context.Context, td pdata.Traces
 	e.wg.Add(1)
 	defer e.wg.Done()
 
-	// TODO: Transform to Humio event structure
-	// TODO: Send events to Humio
+	evts, err := e.tracesToHumioEvents(td)
+	if err != nil {
+		return consumererror.Permanent(err)
+	}
 
-	return consumererror.Permanent(errors.New("Not implemented yet"))
+	err = e.client.sendStructuredEvents(ctx, evts)
+	if consumererror.IsPermanent(err) {
+		return err
+	}
+
+	return consumererror.NewTraces(err, td)
+}
+
+func (e *humioTracesExporter) tracesToHumioEvents(td pdata.Traces) ([]*HumioStructuredEvents, error) {
+	results := make([]*HumioStructuredEvents, 0, td.ResourceSpans().Len())
+
+	// Each resource describes unique origin that generates spans
+	resSpans := td.ResourceSpans()
+	for i := 0; i < resSpans.Len(); i++ {
+		resSpan := resSpans.At(i)
+		r := resSpan.Resource()
+
+		serviceName := ""
+		if sName, ok := r.Attributes().Get(conventions.AttributeServiceName); ok {
+			serviceName = sName.StringVal()
+		}
+		// TODO: All additional attributes should propably be dumped as well
+
+		evts := make([]*HumioStructuredEvent, 0, resSpan.InstrumentationLibrarySpans().Len())
+
+		// For each resource, spans are grouped by the instrumentation library (plugin) that generated them
+		instSpans := resSpan.InstrumentationLibrarySpans()
+		for j := 0; j < instSpans.Len(); j++ {
+			instSpan := instSpans.At(j)
+			// TODO: Use
+			// lib := instSpan.InstrumentationLibrary()
+			// lib.Name()
+			// lib.Version()
+
+			// Lastly, we get access to the actual spans
+			otelSpans := instSpan.Spans()
+			for k := 0; k < otelSpans.Len(); k++ {
+				otelSpan := otelSpans.At(k)
+
+				evts = append(evts, &HumioStructuredEvent{
+					Timestamp: otelSpan.StartTimestamp().AsTime(),
+					AsUnix:    e.cfg.Traces.UnixTimestamps,
+					Attributes: &HumioSpan{
+						TraceId:           otelSpan.TraceID().HexString(),
+						SpanId:            otelSpan.SpanID().HexString(),
+						ParentSpanId:      otelSpan.ParentSpanID().HexString(),
+						Name:              otelSpan.Name(),
+						Kind:              otelSpan.Kind().String(),
+						Start:             otelSpan.StartTimestamp().AsTime().UnixNano(),
+						End:               otelSpan.EndTimestamp().AsTime().UnixNano(),
+						StatusCode:        otelSpan.Status().Code().String(),
+						StatusDescription: otelSpan.Status().Message(),
+						ServiceName:       serviceName,
+						// TODO: Links
+						// TODO: Dump additional attributes
+					},
+				})
+			}
+		}
+
+		// TODO: More user control and adherence to conventions for tags
+		results = append(results, &HumioStructuredEvents{
+			Tags: map[string]string{
+				"service": serviceName,
+			},
+			Events: evts,
+		})
+	}
+
+	return results, nil
 }
 
 func (e *humioTracesExporter) shutdown(context.Context) error {

--- a/exporter/humioexporter/traces_exporter.go
+++ b/exporter/humioexporter/traces_exporter.go
@@ -24,25 +24,27 @@ import (
 	"go.uber.org/zap"
 )
 
+// HumioLink represents a relation between two spans
 type HumioLink struct {
 	TraceId    string `json:"trace_id"`
 	SpanId     string `json:"span_id"`
 	TraceState string `json:"state"`
 }
 
+// HumioSpan represents a span as it is stored inside Humio
 type HumioSpan struct {
-	TraceId           string            `json:"trace_id"`
-	SpanId            string            `json:"span_id"`
-	ParentSpanId      string            `json:"parent_id,omitempty"`
-	Name              string            `json:"name"`
-	Kind              string            `json:"kind"`
-	Start             int64             `json:"start"`
-	End               int64             `json:"end"`
-	StatusCode        string            `json:"status"`
-	StatusDescription string            `json:"status_descr"`
-	ServiceName       string            `json:"service"`
-	Links             HumioLink         `json:"links"`
-	Attributes        map[string]string `json:"attributes"`
+	TraceId           string                 `json:"trace_id"`
+	SpanId            string                 `json:"span_id"`
+	ParentSpanId      string                 `json:"parent_id,omitempty"`
+	Name              string                 `json:"name"`
+	Kind              string                 `json:"kind"`
+	Start             int64                  `json:"start"`
+	End               int64                  `json:"end"`
+	StatusCode        string                 `json:"status"`
+	StatusDescription string                 `json:"status_descr"`
+	ServiceName       string                 `json:"service"`
+	Links             []*HumioLink           `json:"links"`
+	Attributes        map[string]interface{} `json:"attributes"`
 }
 
 type humioTracesExporter struct {
@@ -70,6 +72,10 @@ func (e *humioTracesExporter) pushTraceData(ctx context.Context, td pdata.Traces
 	}
 
 	err = e.client.sendStructuredEvents(ctx, evts)
+	if err == nil {
+		return nil
+	}
+
 	if consumererror.IsPermanent(err) {
 		return err
 	}
@@ -90,7 +96,6 @@ func (e *humioTracesExporter) tracesToHumioEvents(td pdata.Traces) ([]*HumioStru
 		if sName, ok := r.Attributes().Get(conventions.AttributeServiceName); ok {
 			serviceName = sName.StringVal()
 		}
-		// TODO: All additional attributes should propably be dumped as well
 
 		evts := make([]*HumioStructuredEvent, 0, resSpan.InstrumentationLibrarySpans().Len())
 
@@ -98,34 +103,14 @@ func (e *humioTracesExporter) tracesToHumioEvents(td pdata.Traces) ([]*HumioStru
 		instSpans := resSpan.InstrumentationLibrarySpans()
 		for j := 0; j < instSpans.Len(); j++ {
 			instSpan := instSpans.At(j)
-			// TODO: Use
-			// lib := instSpan.InstrumentationLibrary()
-			// lib.Name()
-			// lib.Version()
+			lib := instSpan.InstrumentationLibrary()
 
 			// Lastly, we get access to the actual spans
 			otelSpans := instSpan.Spans()
 			for k := 0; k < otelSpans.Len(); k++ {
 				otelSpan := otelSpans.At(k)
 
-				evts = append(evts, &HumioStructuredEvent{
-					Timestamp: otelSpan.StartTimestamp().AsTime(),
-					AsUnix:    e.cfg.Traces.UnixTimestamps,
-					Attributes: &HumioSpan{
-						TraceId:           otelSpan.TraceID().HexString(),
-						SpanId:            otelSpan.SpanID().HexString(),
-						ParentSpanId:      otelSpan.ParentSpanID().HexString(),
-						Name:              otelSpan.Name(),
-						Kind:              otelSpan.Kind().String(),
-						Start:             otelSpan.StartTimestamp().AsTime().UnixNano(),
-						End:               otelSpan.EndTimestamp().AsTime().UnixNano(),
-						StatusCode:        otelSpan.Status().Code().String(),
-						StatusDescription: otelSpan.Status().Message(),
-						ServiceName:       serviceName,
-						// TODO: Links
-						// TODO: Dump additional attributes
-					},
-				})
+				evts = append(evts, e.spanToHumioEvent(otelSpan, lib, r))
 			}
 		}
 
@@ -139,6 +124,86 @@ func (e *humioTracesExporter) tracesToHumioEvents(td pdata.Traces) ([]*HumioStru
 	}
 
 	return results, nil
+}
+
+func (e *humioTracesExporter) spanToHumioEvent(span pdata.Span, inst pdata.InstrumentationLibrary, res pdata.Resource) *HumioStructuredEvent {
+	attr := toHumioAttributes(span.Attributes(), res.Attributes())
+	attr["instrumentationLibrary.name"] = inst.Name()
+	attr["instrumentationLibrary.version"] = inst.Version()
+
+	serviceName := ""
+	if sName, ok := res.Attributes().Get(conventions.AttributeServiceName); ok {
+		// No need to store the service name in two places
+		delete(attr, conventions.AttributeServiceName)
+		serviceName = sName.StringVal()
+	}
+
+	return &HumioStructuredEvent{
+		Timestamp: span.StartTimestamp().AsTime(),
+		AsUnix:    e.cfg.Traces.UnixTimestamps,
+		Attributes: &HumioSpan{
+			TraceId:           span.TraceID().HexString(),
+			SpanId:            span.SpanID().HexString(),
+			ParentSpanId:      span.ParentSpanID().HexString(),
+			Name:              span.Name(),
+			Kind:              span.Kind().String(),
+			Start:             span.StartTimestamp().AsTime().UnixNano(),
+			End:               span.EndTimestamp().AsTime().UnixNano(),
+			StatusCode:        span.Status().Code().String(),
+			StatusDescription: span.Status().Message(),
+			ServiceName:       serviceName,
+			Links:             toHumioLinks(span.Links()),
+			Attributes:        attr,
+		},
+	}
+}
+
+func toHumioLinks(pLinks pdata.SpanLinkSlice) []*HumioLink {
+	links := make([]*HumioLink, 0, pLinks.Len())
+	for i := 0; i < pLinks.Len(); i++ {
+		link := pLinks.At(i)
+		links = append(links, &HumioLink{
+			TraceId:    link.TraceID().HexString(),
+			SpanId:     link.SpanID().HexString(),
+			TraceState: string(link.TraceState()),
+		})
+	}
+	return links
+}
+
+func toHumioAttributes(attrMaps ...pdata.AttributeMap) map[string]interface{} {
+	attr := make(map[string]interface{}, 0)
+	for _, attrMap := range attrMaps {
+		attrMap.ForEach(func(k string, v pdata.AttributeValue) {
+			attr[k] = toHumioAttributeValue(v)
+		})
+	}
+	return attr
+}
+
+func toHumioAttributeValue(rawVal pdata.AttributeValue) interface{} {
+	switch rawVal.Type() {
+	case pdata.AttributeValueSTRING:
+		return rawVal.StringVal()
+	case pdata.AttributeValueINT:
+		return rawVal.IntVal()
+	case pdata.AttributeValueDOUBLE:
+		return rawVal.DoubleVal()
+	case pdata.AttributeValueBOOL:
+		return rawVal.BoolVal()
+	case pdata.AttributeValueMAP:
+		return toHumioAttributes(rawVal.MapVal())
+	case pdata.AttributeValueARRAY:
+		arrVal := rawVal.ArrayVal()
+		arr := make([]interface{}, 0, arrVal.Len())
+		for i := 0; i < arrVal.Len(); i++ {
+			arr = append(arr, toHumioAttributeValue(arrVal.At(i)))
+		}
+		return arr
+	}
+
+	// Also handles AttributeValueNULL
+	return nil
 }
 
 func (e *humioTracesExporter) shutdown(context.Context) error {

--- a/exporter/humioexporter/traces_exporter_test.go
+++ b/exporter/humioexporter/traces_exporter_test.go
@@ -16,34 +16,379 @@ package humioexporter
 
 import (
 	"context"
+	"encoding/hex"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
 )
 
-func TestPushTraceData(t *testing.T) {
-	// Arrange
-	exp := newTracesExporter(&Config{ExporterSettings: config.NewExporterSettings(typeStr)}, zap.NewNop(), nil)
-
-	// Act
-	err := exp.pushTraceData(context.Background(), pdata.NewTraces())
-
-	// Assert
-	assert.True(t, consumererror.IsPermanent(err))
+func createSpanId(stringVal string) [8]byte {
+	var id [8]byte
+	b, _ := hex.DecodeString(stringVal)
+	copy(id[:], b)
+	return id
 }
 
-func TestShutdown(t *testing.T) {
+func createTraceId(stringVal string) [16]byte {
+	var id [16]byte
+	b, _ := hex.DecodeString(stringVal)
+	copy(id[:], b)
+	return id
+}
+
+// Implement a mock of the client interface for testing
+type clientMock struct {
+	response func() error
+}
+
+func (m *clientMock) sendUnstructuredEvents(ctx context.Context, evts []*HumioUnstructuredEvents) error {
+	return m.response()
+}
+
+func (m *clientMock) sendStructuredEvents(ctx context.Context, evts []*HumioStructuredEvents) error {
+	return m.response()
+}
+
+func TestPushTraceData(t *testing.T) {
 	// Arrange
-	exp := newTracesExporter(&Config{ExporterSettings: config.NewExporterSettings(typeStr)}, zap.NewNop(), nil)
+	testCases := []struct {
+		desc     string
+		client   exporterClient
+		wantErr  bool
+		wantPerm bool
+	}{
+		{
+			desc: "Valid request",
+			client: &clientMock{
+				response: func() error {
+					return nil
+				},
+			},
+			wantErr:  false,
+			wantPerm: false,
+		},
+		{
+			desc: "Forwards transient errors",
+			client: &clientMock{
+				response: func() error {
+					return errors.New("Error")
+				},
+			},
+			wantErr:  true,
+			wantPerm: false,
+		},
+		{
+			desc: "Forwards permanent errors",
+			client: &clientMock{
+				response: func() error {
+					return consumererror.Permanent(errors.New("Error"))
+				},
+			},
+			wantErr:  true,
+			wantPerm: true,
+		},
+	}
 
 	// Act
-	err := exp.shutdown(context.Background())
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			exp := newTracesExporter(&Config{}, zap.NewNop(), tC.client)
+			err := exp.pushTraceData(context.Background(), pdata.NewTraces())
+
+			// Assert
+			if (err != nil) != tC.wantErr {
+				t.Errorf("pushTraceData() error = %v, wantErr %v", err, tC.wantErr)
+			}
+
+			if consumererror.IsPermanent(err) != tC.wantPerm {
+				t.Errorf("pushTraceData() permanent = %v, wantPerm %v",
+					consumererror.IsPermanent(err), tC.wantPerm)
+			}
+		})
+	}
+}
+
+func TestTracesToHumioEvents_OnePerResource(t *testing.T) {
+	// Arrange
+	traces := pdata.NewTraces()
+
+	res1 := pdata.NewResourceSpans()
+	res1.Resource().Attributes().InsertString(conventions.AttributeServiceName, "service1")
+	traces.ResourceSpans().Append(res1)
+
+	res2 := pdata.NewResourceSpans()
+	res2.Resource().Attributes().InsertString(conventions.AttributeServiceName, "service2")
+	traces.ResourceSpans().Append(res2)
+
+	traces.ResourceSpans().Append(pdata.NewResourceSpans())
+
+	exp := newTracesExporter(&Config{}, zap.NewNop(), &clientMock{})
+
+	// Act
+	actual, err := exp.tracesToHumioEvents(traces)
 
 	// Assert
 	require.NoError(t, err)
+	assert.Equal(t, 2, len(actual))
+}
+
+func TestTracesToHumioEvents_CombinesInstrumentation(t *testing.T) {
+	// Arrange
+	traces := pdata.NewTraces()
+
+	res := pdata.NewResourceSpans()
+	res.Resource().Attributes().InsertString(conventions.AttributeServiceName, "service1")
+	traces.ResourceSpans().Append(res)
+
+	inst1 := pdata.NewInstrumentationLibrarySpans()
+	inst1.InstrumentationLibrary().SetName("lib1")
+	inst1.InstrumentationLibrary().SetVersion("1.0")
+	inst1.Spans().Append(pdata.NewSpan())
+	inst1.Spans().Append(pdata.NewSpan())
+	res.InstrumentationLibrarySpans().Append(inst1)
+
+	inst2 := pdata.NewInstrumentationLibrarySpans()
+	inst2.InstrumentationLibrary().SetName("lib2")
+	inst2.InstrumentationLibrary().SetVersion("2.0")
+	inst2.Spans().Append(pdata.NewSpan())
+	res.InstrumentationLibrarySpans().Append(inst2)
+
+	exp := newTracesExporter(&Config{}, zap.NewNop(), &clientMock{})
+
+	// Act
+	actual, err := exp.tracesToHumioEvents(traces)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(actual))
+	assert.Equal(t, map[string]string{
+		"service": "service1",
+	}, actual[0].Tags)
+
+	assert.Equal(t, 3, len(actual[0].Events))
+}
+
+func TestSpanToHumioEvent(t *testing.T) {
+	// Arrange
+	span := pdata.NewSpan()
+	span.SetTraceID(pdata.NewTraceID(createTraceId("10")))
+	span.SetSpanID(pdata.NewSpanID(createSpanId("20")))
+	span.SetName("span")
+	span.SetKind(pdata.SpanKindSERVER)
+	span.SetStartTimestamp(pdata.TimestampFromTime(
+		time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC),
+	))
+	span.SetEndTimestamp(pdata.TimestampFromTime(
+		time.Date(2020, 1, 1, 12, 0, 16, 0, time.UTC),
+	))
+	span.Status().SetCode(pdata.StatusCodeOk)
+	span.Status().SetMessage("done")
+	span.Attributes().InsertString("key", "val")
+
+	inst := pdata.NewInstrumentationLibrary()
+	inst.SetName("otel-test")
+	inst.SetVersion("1.0.0")
+
+	res := pdata.NewResource()
+	res.Attributes().InsertString("service.name", "myapp")
+
+	expected := &HumioStructuredEvent{
+		Timestamp: time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC),
+		AsUnix:    true,
+		Attributes: &HumioSpan{
+			TraceId:           "10000000000000000000000000000000",
+			SpanId:            "2000000000000000",
+			ParentSpanId:      "",
+			Name:              "span",
+			Kind:              "SPAN_KIND_SERVER",
+			Start:             time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano(),
+			End:               time.Date(2020, 1, 1, 12, 0, 16, 0, time.UTC).UnixNano(),
+			StatusCode:        "STATUS_CODE_OK",
+			StatusDescription: "done",
+			ServiceName:       "myapp",
+			Links:             []*HumioLink{},
+			Attributes: map[string]interface{}{
+				"key":                  "val",
+				"otel.library.name":    "otel-test",
+				"otel.library.version": "1.0.0",
+			},
+		},
+	}
+
+	exp := newTracesExporter(&Config{
+		Traces: TracesConfig{
+			UnixTimestamps: true,
+		},
+	}, zap.NewNop(), &clientMock{})
+
+	// Act
+	actual := exp.spanToHumioEvent(span, inst, res)
+
+	// Assert
+	assert.Equal(t, expected, actual)
+}
+
+func TestSpanToHumioEventNoInstrumentation(t *testing.T) {
+	// Arrange
+	span := pdata.NewSpan()
+	inst := pdata.NewInstrumentationLibrary()
+	res := pdata.NewResource()
+
+	exp := newTracesExporter(&Config{
+		Traces: TracesConfig{
+			UnixTimestamps: true,
+		},
+	}, zap.NewNop(), &clientMock{})
+
+	// Act
+	actual := exp.spanToHumioEvent(span, inst, res)
+
+	// Assert
+	require.IsType(t, &HumioSpan{}, actual.Attributes)
+	assert.Empty(t, actual.Attributes.(*HumioSpan).Attributes)
+}
+
+func TestToHumioLinks(t *testing.T) {
+	// Arrange
+	slice := pdata.NewSpanLinkSlice()
+	link1 := pdata.NewSpanLink()
+	link1.SetTraceID(pdata.NewTraceID(createTraceId("11")))
+	link1.SetSpanID(pdata.NewSpanID(createSpanId("22")))
+	link1.SetTraceState("state1")
+	slice.Append(link1)
+
+	link2 := pdata.NewSpanLink()
+	link2.SetTraceID(pdata.NewTraceID(createTraceId("33")))
+	link2.SetSpanID(pdata.NewSpanID(createSpanId("44")))
+	slice.Append(link2)
+
+	expected := []*HumioLink{
+		{
+			TraceId:    "11000000000000000000000000000000",
+			SpanId:     "2200000000000000",
+			TraceState: "state1",
+		},
+		{
+			TraceId:    "33000000000000000000000000000000",
+			SpanId:     "4400000000000000",
+			TraceState: "",
+		},
+	}
+
+	// Act
+	actual := toHumioLinks(slice)
+
+	// Assert
+	assert.Equal(t, expected, actual)
+}
+
+func TestToHumioAttributes(t *testing.T) {
+	// Arrange
+	testCases := []struct {
+		desc     string
+		attr     func() pdata.AttributeMap
+		expected interface{}
+	}{
+		{
+			desc: "Simple types",
+			attr: func() pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.InsertString("string", "val")
+				attrMap.InsertInt("integer", 42)
+				attrMap.InsertDouble("double", 4.2)
+				attrMap.InsertBool("bool", false)
+				return attrMap
+			},
+			expected: map[string]interface{}{
+				"string":  "val",
+				"integer": int64(42),
+				"double":  4.2,
+				"bool":    false,
+			},
+		},
+		{
+			desc: "Nil element",
+			attr: func() pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				attrMap.InsertNull("key")
+				return attrMap
+			},
+			expected: map[string]interface{}{
+				"key": nil,
+			},
+		},
+		{
+			desc: "Array element",
+			attr: func() pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				arr := pdata.NewAttributeValueArray()
+				arr.ArrayVal().Append(pdata.NewAttributeValueString("a"))
+				arr.ArrayVal().Append(pdata.NewAttributeValueString("b"))
+				arr.ArrayVal().Append(pdata.NewAttributeValueInt(4))
+				attrMap.Insert("array", arr)
+				return attrMap
+			},
+			expected: map[string]interface{}{
+				"array": []interface{}{
+					"a", "b", int64(4),
+				},
+			},
+		},
+		{
+			desc: "Nested map",
+			attr: func() pdata.AttributeMap {
+				attrMap := pdata.NewAttributeMap()
+				nested := pdata.NewAttributeValueMap()
+				nested.MapVal().InsertString("key", "val")
+				attrMap.Insert("nested", nested)
+				attrMap.InsertBool("active", true)
+				return attrMap
+			},
+			expected: map[string]interface{}{
+				"nested": map[string]interface{}{
+					"key": "val",
+				},
+				"active": true,
+			},
+		},
+	}
+
+	// Act
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			actual := toHumioAttributes(tC.attr())
+
+			assert.Equal(t, tC.expected, actual)
+		})
+	}
+}
+
+func TestToHumioAttributesShaded(t *testing.T) {
+	// Arrange
+	attrMapA := pdata.NewAttributeMap()
+	attrMapA.InsertString("string", "val")
+	attrMapA.InsertInt("integer", 42)
+
+	attrMapB := pdata.NewAttributeMap()
+	attrMapB.InsertInt("integer", 0)
+	attrMapB.InsertString("key", "val")
+
+	expected := map[string]interface{}{
+		"string":  "val",
+		"integer": int64(0),
+		"key":     "val",
+	}
+
+	// Act
+	actual := toHumioAttributes(attrMapA, attrMapB)
+
+	// Assert
+	assert.Equal(t, expected, actual)
 }

--- a/exporter/humioexporter/traces_exporter_test.go
+++ b/exporter/humioexporter/traces_exporter_test.go
@@ -132,6 +132,7 @@ func TestPushTraceData_PermanentOnCompleteFailure(t *testing.T) {
 	// Assert
 	require.Error(t, err)
 	assert.True(t, consumererror.IsPermanent(err))
+	assert.Contains(t, err.Error(), "unable to serialize spans due to missing required service name for the associated resource")
 }
 
 func TestPushTraceData_TransientOnPartialFailure(t *testing.T) {

--- a/exporter/humioexporter/traces_exporter_test.go
+++ b/exporter/humioexporter/traces_exporter_test.go
@@ -29,14 +29,14 @@ import (
 	"go.uber.org/zap"
 )
 
-func createSpanId(stringVal string) [8]byte {
+func createSpanID(stringVal string) [8]byte {
 	var id [8]byte
 	b, _ := hex.DecodeString(stringVal)
 	copy(id[:], b)
 	return id
 }
 
-func createTraceId(stringVal string) [16]byte {
+func createTraceID(stringVal string) [16]byte {
 	var id [16]byte
 	b, _ := hex.DecodeString(stringVal)
 	copy(id[:], b)
@@ -227,8 +227,8 @@ func TestTracesToHumioEvents_CombinesInstrumentation(t *testing.T) {
 func TestSpanToHumioEvent(t *testing.T) {
 	// Arrange
 	span := pdata.NewSpan()
-	span.SetTraceID(pdata.NewTraceID(createTraceId("10")))
-	span.SetSpanID(pdata.NewSpanID(createSpanId("20")))
+	span.SetTraceID(pdata.NewTraceID(createTraceID("10")))
+	span.SetSpanID(pdata.NewSpanID(createSpanID("20")))
 	span.SetName("span")
 	span.SetKind(pdata.SpanKindSERVER)
 	span.SetStartTimestamp(pdata.TimestampFromTime(
@@ -252,9 +252,9 @@ func TestSpanToHumioEvent(t *testing.T) {
 		Timestamp: time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC),
 		AsUnix:    true,
 		Attributes: &HumioSpan{
-			TraceId:           "10000000000000000000000000000000",
-			SpanId:            "2000000000000000",
-			ParentSpanId:      "",
+			TraceID:           "10000000000000000000000000000000",
+			SpanID:            "2000000000000000",
+			ParentSpanID:      "",
 			Name:              "span",
 			Kind:              "SPAN_KIND_SERVER",
 			Start:             time.Date(2020, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano(),
@@ -308,25 +308,25 @@ func TestToHumioLinks(t *testing.T) {
 	// Arrange
 	slice := pdata.NewSpanLinkSlice()
 	link1 := pdata.NewSpanLink()
-	link1.SetTraceID(pdata.NewTraceID(createTraceId("11")))
-	link1.SetSpanID(pdata.NewSpanID(createSpanId("22")))
+	link1.SetTraceID(pdata.NewTraceID(createTraceID("11")))
+	link1.SetSpanID(pdata.NewSpanID(createSpanID("22")))
 	link1.SetTraceState("state1")
 	slice.Append(link1)
 
 	link2 := pdata.NewSpanLink()
-	link2.SetTraceID(pdata.NewTraceID(createTraceId("33")))
-	link2.SetSpanID(pdata.NewSpanID(createSpanId("44")))
+	link2.SetTraceID(pdata.NewTraceID(createTraceID("33")))
+	link2.SetSpanID(pdata.NewSpanID(createSpanID("44")))
 	slice.Append(link2)
 
 	expected := []*HumioLink{
 		{
-			TraceId:    "11000000000000000000000000000000",
-			SpanId:     "2200000000000000",
+			TraceID:    "11000000000000000000000000000000",
+			SpanID:     "2200000000000000",
 			TraceState: "state1",
 		},
 		{
-			TraceId:    "33000000000000000000000000000000",
-			SpanId:     "4400000000000000",
+			TraceID:    "33000000000000000000000000000000",
+			SpanID:     "4400000000000000",
 			TraceState: "",
 		},
 	}


### PR DESCRIPTION
**Description:**
Adds the capability to export traces to Humio. This has also resulted in some slight configuration changes, since we now:
- Support separate ingest tokens for each telemetry type
- Reworked the tag configuration to make better use of how data is stored in Humio

**Link to tracking Issue:**
#3021

**Testing:**
- `config_test.go`: Tests the new tag and ingest token configurations
- `humio_client_test.go`: Better test coverage for headers
- `tag_strategy_test.go`: Tests grouping of spans by tag, depending on config
- `traces_exporter_test.go`: Tests conversion between OTel spans and the Humio span format

**Documentation:**
Adds documentation on global configurations vs configuration per telemetry type. Also documents the various tagging strategies with references to the Humio docs. Tagging is considered an advanced feature and is disabled by default.