### PR TITLE
HTTP forwarder should not report  ErrServerClosed

### DIFF
--- a/extension/httpforwarder/extension.go
+++ b/extension/httpforwarder/extension.go
@@ -47,7 +47,7 @@ func (h *httpForwarder) Start(_ context.Context, host component.Host) error {
 
 	h.server = h.config.Ingress.ToServer(handler)
 	go func() {
-		if err := h.server.Serve(listener); err != nil {
+		if err := h.server.Serve(listener); err != http.ErrServerClosed {
 			host.ReportFatalError(err)
 		}
 	}()


### PR DESCRIPTION
The HTTP forwarder reports ErrServerClosed when shutting down the service. This error is expected and should not be reported.