### PR TITLE
Create new client with new AWS session if aws token is expired

### DIFF
--- a/exporter/awsemfexporter/pusher_test.go
+++ b/exporter/awsemfexporter/pusher_test.go
@@ -65,7 +65,7 @@ func TestConcurrentPushAndFlush(t *testing.T) {
 }
 
 func newMockPusherWithEventCheck(check func(msg string)) (Pusher, string) {
-	logger := zap.NewNop()
+	emf := &emfExporter{}
 	tmpfolder, _ := ioutil.TempDir("", "")
 	svc := NewAlwaysPassMockLogClient(func(args mock.Arguments) {
 		input := args.Get(0).(*cloudwatchlogs.PutLogEventsInput)
@@ -74,7 +74,9 @@ func newMockPusherWithEventCheck(check func(msg string)) (Pusher, string) {
 			check(eventMsg)
 		}
 	})
-	p := newPusher(&logGroup, &logStreamName, svc, logger)
+	emf.logger = zap.NewNop()
+	emf.svcStructuredLog = svc
+	p := newPusher(&logGroup, &logStreamName, emf)
 	return p, tmpfolder
 }
 
@@ -175,10 +177,12 @@ func TestLogEventBatch_sortLogEvents(t *testing.T) {
 
 // Need to remove the tmp state folder after testing.
 func newMockPusher() (*pusher, string) {
-	logger := zap.NewNop()
+	emf := &emfExporter{}
 	tmpfolder, _ := ioutil.TempDir("", "")
 	svc := NewAlwaysPassMockLogClient(func(args mock.Arguments) {})
-	p := newPusher(&logGroup, &logStreamName, svc, logger)
+	emf.logger = zap.NewNop()
+	emf.svcStructuredLog = svc
+	p := newPusher(&logGroup, &logStreamName, emf)
 	return p, tmpfolder
 }
 

--- a/extension/storage/go.sum
+++ b/extension/storage/go.sum
@@ -108,6 +108,7 @@ github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:W
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
+github.com/aws/aws-sdk-go v1.37.8 h1:9kywcbuz6vQuTf+FD+U7FshafrHzmqUCjgAEiLuIJ8U=
 github.com/aws/aws-sdk-go v1.37.8/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/internal/aws/awsutil/conn.go
+++ b/internal/aws/awsutil/conn.go
@@ -34,6 +34,11 @@ import (
 	"golang.org/x/net/http2"
 )
 
+const (
+	ErrCodeThrottlingException   = "ThrottlingException"
+	ErrCodeExpiredTokenException = "ExpiredTokenException"
+)
+
 type ConnAttr interface {
 	newAWSSession(logger *zap.Logger, roleArn string, region string) (*session.Session, error)
 	getEC2Region(s *session.Session) (string, error)


### PR DESCRIPTION
**Description:** 
In `awsxray` and `awsemf` exporters, both of these two components create aws sessions for the request sender clients at the component initialization time. If customer has rotated/expired the existing credential/tokens. OTel collector will keep failing the request until it is reboot again. 

In this fix, The data send client will be refreshed with new AWS session if the response returns `ExpiredTokenException` from AWS backends. 

**Link to tracking Issue:** 
https://github.com/aws-observability/aws-otel-collector/issues/408

**Testing:** 
Locally e2e testing & `make all`

