### PR TITLE
collectd receiver should not report ErrServerClosed

### DIFF
--- a/receiver/collectdreceiver/receiver.go
+++ b/receiver/collectdreceiver/receiver.go
@@ -88,7 +88,7 @@ func (cdr *collectdReceiver) Start(_ context.Context, host component.Host) error
 		err = nil
 		go func() {
 			err = cdr.server.ListenAndServe()
-			if err != nil {
+			if err != http.ErrServerClosed {
 				host.ReportFatalError(fmt.Errorf("error starting collectd receiver: %v", err))
 			}
 		}()


### PR DESCRIPTION
The collectord receiver reports ErrServerClosed when shutting down the service. This error is expected and should not be reported.