### PR TITLE
Remove sending_queue from AWS Prometheus Remote Write Exporter

### DIFF
--- a/exporter/awsprometheusremotewriteexporter/config_test.go
+++ b/exporter/awsprometheusremotewriteexporter/config_test.go
@@ -60,11 +60,6 @@ func TestLoadConfig(t *testing.T) {
 				TypeVal: "awsprometheusremotewrite",
 			},
 			TimeoutSettings: exporterhelper.DefaultTimeoutSettings(),
-			QueueSettings: exporterhelper.QueueSettings{
-				Enabled:      true,
-				NumConsumers: 2,
-				QueueSize:    10,
-			},
 			RetrySettings: exporterhelper.RetrySettings{
 				Enabled:         true,
 				InitialInterval: 10 * time.Second,
@@ -81,12 +76,9 @@ func TestLoadConfig(t *testing.T) {
 					},
 					Insecure: false,
 				},
-				ReadBufferSize: 0,
-
+				ReadBufferSize:  0,
 				WriteBufferSize: 512 * 1024,
-
-				Timeout: 5 * time.Second,
-
+				Timeout:         5 * time.Second,
 				Headers: map[string]string{
 					"prometheus-remote-write-version": "0.1.0",
 					"x-scope-orgid":                   "234"},

--- a/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
@@ -8,10 +8,6 @@ exporters:
     awsprometheusremotewrite:
     awsprometheusremotewrite/2:
         namespace: "test-space"
-        sending_queue:
-            enabled: true
-            num_consumers: 2
-            queue_size: 10
         retry_on_failure:
             enabled: true
             initial_interval: 10s


### PR DESCRIPTION
This is a follow up of https://github.com/open-telemetry/opentelemetry-collector/pull/2951.

Fixes #3163.
