### PR TITLE
Include dropped attributes and events counts

### DIFF
--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -28,21 +28,22 @@ import (
 )
 
 const (
-	unitAttrKey               = "unit"
-	descriptionAttrKey        = "description"
-	collectorNameKey          = "collector.name"
-	collectorVersionKey       = "collector.version"
-	instrumentationNameKey    = "instrumentation.name"
-	instrumentationVersionKey = "instrumentation.version"
-	droppedAttributesCountKey = "otel.dropped_attributes_count"
-	droppedEventsCountKey     = "otel.dropped_events_count"
-	statusCodeKey             = "otel.status_code"
-	statusDescriptionKey      = "otel.status_description"
-	spanKindKey               = "span.kind"
-	spanIDKey                 = "span.id"
-	traceIDKey                = "trace.id"
-	logSeverityTextKey        = "log.level"
-	logSeverityNumKey         = "log.levelNum"
+	unitAttrKey                     = "unit"
+	descriptionAttrKey              = "description"
+	collectorNameKey                = "collector.name"
+	collectorVersionKey             = "collector.version"
+	instrumentationNameKey          = "instrumentation.name"
+	instrumentationVersionKey       = "instrumentation.version"
+	droppedAttributesCountKey       = "otel.dropped_attributes_count"
+	droppedEventsCountKey           = "otel.dropped_events_count"
+	eventsDroppedAttributesCountKey = "otel.event.dropped_attributes_count"
+	statusCodeKey                   = "otel.status_code"
+	statusDescriptionKey            = "otel.status_description"
+	spanKindKey                     = "span.kind"
+	spanIDKey                       = "span.id"
+	traceIDKey                      = "trace.id"
+	logSeverityTextKey              = "log.level"
+	logSeverityNumKey               = "log.levelNum"
 )
 
 type transformer struct {
@@ -238,7 +239,7 @@ func (t *transformer) SpanEvents(span pdata.Span) []telemetry.Event {
 		}
 
 		if droppedAttributesCount := event.DroppedAttributesCount(); droppedAttributesCount > 0 {
-			events[i].Attributes[droppedAttributesCountKey] = droppedAttributesCount
+			events[i].Attributes[eventsDroppedAttributesCountKey] = droppedAttributesCount
 		}
 
 		t.TrackAttributes(attributeLocationSpanEvent, eventAttrs)

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -34,6 +34,8 @@ const (
 	collectorVersionKey       = "collector.version"
 	instrumentationNameKey    = "instrumentation.name"
 	instrumentationVersionKey = "instrumentation.version"
+	droppedAttributesCountKey = "otel.dropped_attributes_count"
+	droppedEventsCountKey     = "otel.dropped_events_count"
 	statusCodeKey             = "otel.status_code"
 	statusDescriptionKey      = "otel.status_description"
 	spanKindKey               = "span.kind"
@@ -151,6 +153,10 @@ func (t *transformer) Log(log pdata.LogRecord) (telemetry.Log, error) {
 		attrs[logSeverityNumKey] = int32(log.SeverityNumber())
 	}
 
+	if droppedAttributesCount := log.DroppedAttributesCount(); droppedAttributesCount > 0 {
+		attrs[droppedAttributesCountKey] = droppedAttributesCount
+	}
+
 	return telemetry.Log{
 		Message:    message,
 		Timestamp:  log.Timestamp().AsTime(),
@@ -194,6 +200,14 @@ func (t *transformer) SpanAttributes(span pdata.Span) map[string]interface{} {
 		attrs[spanKindKey] = strings.ToLower(kind)
 	}
 
+	if droppedAttributesCount := span.DroppedAttributesCount(); droppedAttributesCount > 0 {
+		attrs[droppedAttributesCountKey] = droppedAttributesCount
+	}
+
+	if droppedEventsCount := span.DroppedEventsCount(); droppedEventsCount > 0 {
+		attrs[droppedEventsCountKey] = droppedEventsCount
+	}
+
 	for k, v := range tracetranslator.AttributeMapToMap(spanAttrs) {
 		// Only include attribute if not an override attribute
 		if _, isOverrideKey := t.OverrideAttributes[k]; !isOverrideKey {
@@ -222,6 +236,11 @@ func (t *transformer) SpanEvents(span pdata.Span) []telemetry.Event {
 			Timestamp:  event.Timestamp().AsTime(),
 			Attributes: tracetranslator.AttributeMapToMap(eventAttrs),
 		}
+
+		if droppedAttributesCount := event.DroppedAttributesCount(); droppedAttributesCount > 0 {
+			events[i].Attributes[droppedAttributesCountKey] = droppedAttributesCount
+		}
+
 		t.TrackAttributes(attributeLocationSpanEvent, eventAttrs)
 	}
 	return events

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -28,22 +28,21 @@ import (
 )
 
 const (
-	unitAttrKey                     = "unit"
-	descriptionAttrKey              = "description"
-	collectorNameKey                = "collector.name"
-	collectorVersionKey             = "collector.version"
-	instrumentationNameKey          = "instrumentation.name"
-	instrumentationVersionKey       = "instrumentation.version"
-	droppedAttributesCountKey       = "otel.dropped_attributes_count"
-	droppedEventsCountKey           = "otel.dropped_events_count"
-	eventsDroppedAttributesCountKey = "otel.event.dropped_attributes_count"
-	statusCodeKey                   = "otel.status_code"
-	statusDescriptionKey            = "otel.status_description"
-	spanKindKey                     = "span.kind"
-	spanIDKey                       = "span.id"
-	traceIDKey                      = "trace.id"
-	logSeverityTextKey              = "log.level"
-	logSeverityNumKey               = "log.levelNum"
+	unitAttrKey               = "unit"
+	descriptionAttrKey        = "description"
+	collectorNameKey          = "collector.name"
+	collectorVersionKey       = "collector.version"
+	instrumentationNameKey    = "instrumentation.name"
+	instrumentationVersionKey = "instrumentation.version"
+	droppedAttributesCountKey = "otel.dropped_attributes_count"
+	droppedEventsCountKey     = "otel.dropped_events_count"
+	statusCodeKey             = "otel.status_code"
+	statusDescriptionKey      = "otel.status_description"
+	spanKindKey               = "span.kind"
+	spanIDKey                 = "span.id"
+	traceIDKey                = "trace.id"
+	logSeverityTextKey        = "log.level"
+	logSeverityNumKey         = "log.levelNum"
 )
 
 type transformer struct {
@@ -239,7 +238,7 @@ func (t *transformer) SpanEvents(span pdata.Span) []telemetry.Event {
 		}
 
 		if droppedAttributesCount := event.DroppedAttributesCount(); droppedAttributesCount > 0 {
-			events[i].Attributes[eventsDroppedAttributesCountKey] = droppedAttributesCount
+			events[i].Attributes[droppedAttributesCountKey] = droppedAttributesCount
 		}
 
 		t.TrackAttributes(attributeLocationSpanEvent, eventAttrs)

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -512,7 +512,7 @@ func TestTransformSpan(t *testing.T) {
 						EventType: "this is the event name",
 						Timestamp: now.UTC(),
 						Attributes: map[string]interface{}{
-							droppedAttributesCountKey: uint32(1),
+							eventsDroppedAttributesCountKey: uint32(1),
 						},
 					},
 				},

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -512,7 +512,7 @@ func TestTransformSpan(t *testing.T) {
 						EventType: "this is the event name",
 						Timestamp: now.UTC(),
 						Attributes: map[string]interface{}{
-							eventsDroppedAttributesCountKey: uint32(1),
+							droppedAttributesCountKey: uint32(1),
 						},
 					},
 				},

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -442,6 +442,82 @@ func TestTransformSpan(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with dropped attributes",
+			spanFunc: func() pdata.Span {
+				s := pdata.NewSpan()
+				s.SetTraceID(pdata.NewTraceID([...]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+				s.SetSpanID(pdata.NewSpanID([...]byte{0, 0, 0, 0, 0, 0, 0, 8}))
+				s.SetName("with dropped attributes")
+				s.SetDroppedAttributesCount(2)
+				return s
+			},
+			want: telemetry.Span{
+				ID:        "0000000000000008",
+				TraceID:   "01010101010101010101010101010101",
+				Name:      "with dropped attributes",
+				Timestamp: time.Unix(0, 0).UTC(),
+				Attributes: map[string]interface{}{
+					droppedAttributesCountKey: uint32(2),
+				},
+				Events: nil,
+			},
+		},
+		{
+			name: "with dropped events",
+			spanFunc: func() pdata.Span {
+				s := pdata.NewSpan()
+				s.SetTraceID(pdata.NewTraceID([...]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+				s.SetSpanID(pdata.NewSpanID([...]byte{0, 0, 0, 0, 0, 0, 0, 9}))
+				s.SetName("with dropped events")
+				s.SetDroppedEventsCount(3)
+				return s
+			},
+			want: telemetry.Span{
+				ID:        "0000000000000009",
+				TraceID:   "01010101010101010101010101010101",
+				Name:      "with dropped events",
+				Timestamp: time.Unix(0, 0).UTC(),
+				Attributes: map[string]interface{}{
+					droppedEventsCountKey: uint32(3),
+				},
+				Events: nil,
+			},
+		},
+		{
+			name: "with dropped attributes on events",
+			spanFunc: func() pdata.Span {
+				s := pdata.NewSpan()
+				s.SetTraceID(pdata.NewTraceID([...]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+				s.SetSpanID(pdata.NewSpanID([...]byte{0, 0, 0, 0, 0, 0, 0, 10}))
+				s.SetName("with dropped attributes on events")
+
+				ev := pdata.NewSpanEventSlice()
+				ev.Resize(1)
+				event := ev.At(0)
+				event.SetName("this is the event name")
+				event.SetTimestamp(pdata.TimestampFromTime(now))
+				event.SetDroppedAttributesCount(1)
+				s.Events().Append(event)
+				return s
+			},
+			want: telemetry.Span{
+				ID:         "000000000000000a",
+				TraceID:    "01010101010101010101010101010101",
+				Name:       "with dropped attributes on events",
+				Timestamp:  time.Unix(0, 0).UTC(),
+				Attributes: map[string]interface{}{},
+				Events: []telemetry.Event{
+					{
+						EventType: "this is the event name",
+						Timestamp: now.UTC(),
+						Attributes: map[string]interface{}{
+							droppedAttributesCountKey: uint32(1),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -830,6 +906,24 @@ func TestTransformer_Log(t *testing.T) {
 					"name":     "",
 					"trace.id": "01010101010101010101010101010101",
 					"span.id":  "0000000000000001",
+				},
+			},
+		},
+		{
+			name: "With dropped attribute count",
+			logFunc: func() pdata.LogRecord {
+				log := pdata.NewLogRecord()
+				timestamp := pdata.TimestampFromTime(time.Unix(0, 0).UTC())
+				log.SetTimestamp(timestamp)
+				log.SetDroppedAttributesCount(4)
+				return log
+			},
+			want: telemetry.Log{
+				Message:   "",
+				Timestamp: time.Unix(0, 0).UTC(),
+				Attributes: map[string]interface{}{
+					"name":                    "",
+					droppedAttributesCountKey: uint32(4),
 				},
 			},
 		},


### PR DESCRIPTION
**Description:** 
New features:
- Includes `otel.dropped_attributes_count` on exported spans, events, and logs when the value is greater than 0.
- Includes `otel.dropped_events_count` on exported events when the value is greater than 0.

**Testing:** Unit tests updated

**Documentation:** No changes required