### PR TITLE
docs(exporter/newrelicexporter/README.md): Update the new relic exporter documents

### DIFF
--- a/exporter/newrelicexporter/README.md
+++ b/exporter/newrelicexporter/README.md
@@ -33,21 +33,21 @@ Relic's US data centers. For other use cases refer to
 [OpenTelemetry: Advanced configuration](https://docs.newrelic.com/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-advanced-configuration#h2-change-endpoints).
 
 **Example of overriding options by telemetry signal:**
-  ```yaml
-  exporters:
-    newrelic:
-      apikey: super-secret-api-key
-      timeout: 30s
+```yaml
+exporters:
+  newrelic:
+    apikey: super-secret-api-key
+    timeout: 30s
 
-      # host_override is set to send data to New Relic's EU data centers.
-      traces:
-        host_override: trace-api.eu.newrelic.com
-        timeout: 20s
-      metrics:
-        host_override: metric-api.eu.newrelic.com
-      logs:
-        host_override: log-api.eu.newrelic.com
-  ```
+    # host_override is set to send data to New Relic's EU data centers.
+    traces:
+      host_override: trace-api.eu.newrelic.com
+      timeout: 20s
+    metrics:
+      host_override: metric-api.eu.newrelic.com
+    logs:
+      host_override: log-api.eu.newrelic.com
+```
 
 ## Find and use your data
 

--- a/exporter/newrelicexporter/README.md
+++ b/exporter/newrelicexporter/README.md
@@ -33,21 +33,21 @@ Relic's US data centers. For other use cases refer to
 [OpenTelemetry: Advanced configuration](https://docs.newrelic.com/docs/integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-advanced-configuration#h2-change-endpoints).
 
 **Example of overriding options by telemetry signal:**
-```yaml
-exporters:
-  newrelic:
-    apikey: super-secret-api-key
-    timeout: 30s
+  ```yaml
+  exporters:
+    newrelic:
+      apikey: super-secret-api-key
+      timeout: 30s
 
-  # host_override is set to send data to New Relic's EU data centers.
-    traces:
-      host_override: trace-api.eu.newrelic.com
-      timeout: 20s
-    metrics:
-      host_override: metric-api.eu.newrelic.com
-    logs:
-      host_override: log-api.eu.newrelic.com
-```
+      # host_override is set to send data to New Relic's EU data centers.
+      traces:
+        host_override: trace-api.eu.newrelic.com
+        timeout: 20s
+      metrics:
+        host_override: metric-api.eu.newrelic.com
+      logs:
+        host_override: log-api.eu.newrelic.com
+  ```
 
 ## Find and use your data
 

--- a/exporter/newrelicexporter/README.md
+++ b/exporter/newrelicexporter/README.md
@@ -40,13 +40,13 @@ exporters:
     timeout: 30s
 
   # host_override is set to send data to New Relic's EU data centers.
-  traces:
-    host_override: trace-api.eu.newrelic.com
-    timeout: 20s
-  metrics:
-    host_override: metric-api.eu.newrelic.com
-  logs:
-    host_override: log-api.eu.newrelic.com
+    traces:
+      host_override: trace-api.eu.newrelic.com
+      timeout: 20s
+    metrics:
+      host_override: metric-api.eu.newrelic.com
+    logs:
+      host_override: log-api.eu.newrelic.com
 ```
 
 ## Find and use your data


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Update the new relic exporter's config example.

**Link to tracking Issue:** <Issue number if applicable>
There is no issue for that yet.

**Testing:** <Describe what testing was performed and which tests were added.>
There is no code changes.

**Documentation:** <Describe the documentation added.>
There have a release (0.25.0) had updated the new relic exporter's configuration format. But the new document's config sample is not correct(#3091). The existing documents shows.

```yaml
exporters:
  newrelic:
    apikey: super-secret-api-key
    timeout: 30s

  # host_override is set to send data to New Relic's EU data centers.
  traces:
    host_override: trace-api.eu.newrelic.com
    timeout: 20s
  metrics:
    host_override: metric-api.eu.newrelic.com
  logs:
    host_override: log-api.eu.newrelic.com
```
But the correct format should be

```yaml
exporters:
  newrelic:
    apikey: super-secret-api-key
    timeout: 30s

    # host_override is set to send data to New Relic's EU data centers.
    traces:
      host_override: trace-api.eu.newrelic.com
      timeout: 20s
    metrics:
      host_override: metric-api.eu.newrelic.com
    logs:
      host_override: log-api.eu.newrelic.com
```
