### PR TITLE
Update README.md to specify the endpoint correctly

### DIFF
--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -53,7 +53,7 @@ port but the port needs to be set inside endpoint. You could do:
 
 ```yaml
 config:
-   endpoint: `endpoint`:8080
+   endpoint: '`endpoint`:8080'
 ```
 
 **receivers.&lt;receiver_type/id&gt;.resource_attributes**


### PR DESCRIPTION
Without the single quotes, the backticks cause an error when you run the otel-collector

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>