### PR TITLE
[metrics_transform_processor] Add filtering capabilities matching metric label values for applying changes

### DIFF
--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -58,9 +58,9 @@ transforms:
     # match_type specifies whether the include name should be used as a strict match or regexp match, default = strict
     match_type: {strict, regexp}
 
-    # match_labels specifies the label set against which the metric filter will work. If match_labels is specified, transforms will only be applied to those metrics which 
-    # have the provided metric label values. This works for both strict and regexp match_type.
-    match_labels: {<label1>: <label_value1>, <label2>: <label_value2>}
+    # experimental_match_labels specifies the label set against which the metric filter will work. If experimental_match_labels is specified, transforms will only be applied to those metrics which 
+    # have the provided metric label values. This works for both strict and regexp match_type. This is an experimental feature.
+    experimental_match_labels: {<label1>: <label_value1>, <label2>: <label_value2>}
     
     # SPECIFY THE ACTION TO TAKE ON THE MATCHED METRIC(S)
     
@@ -120,7 +120,7 @@ include: host.cpu.usage
 action: insert
 new_name: host.cpu.utilization
 match_type: strict
-match_labels: {"container": "my_container"}
+experimental_match_labels: {"container": "my_container"}
 operations:
   ...
 ```
@@ -132,7 +132,7 @@ include: host.cpu.usage
 action: insert
 new_name: host.cpu.utilization
 match_type: regexp
-match_labels: {"pod": "(.|\\s)*\\S(.|\\s)*"}
+experimental_match_labels: {"pod": "(.|\\s)*\\S(.|\\s)*"}
 operations:
   ...
 ```

--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -57,6 +57,10 @@ transforms:
   - include: <metric_name>
     # match_type specifies whether the include name should be used as a strict match or regexp match, default = strict
     match_type: {strict, regexp}
+
+    # match_labels specifies the label set against which the metric filter will work. If match_labels is specified, transforms will only be applied to those metrics which 
+    # have the provided metric label values. This works for both strict and regexp match_type.
+    match_labels: {<label1>: <label_value1>, <label2>: <label_value2>}
     
     # SPECIFY THE ACTION TO TAKE ON THE MATCHED METRIC(S)
     
@@ -105,6 +109,30 @@ transforms:
 include: host.cpu.usage
 action: insert
 new_name: host.cpu.utilization
+operations:
+  ...
+```
+
+### Create a new metric from an existing metric with matching label values
+```yaml
+# create host.cpu.utilization from host.cpu.usage where we have metric label "container=my_container"
+include: host.cpu.usage
+action: insert
+new_name: host.cpu.utilization
+match_type: strict
+match_labels: {"container": "my_container"}
+operations:
+  ...
+```
+
+### Create a new metric from an existing metric with matching label values with regexp
+```yaml
+# create host.cpu.utilization from host.cpu.usage where we have metric label pod with non-empty values
+include: host.cpu.usage
+action: insert
+new_name: host.cpu.utilization
+match_type: regexp
+match_labels: {"pod": "(.|\\s)*\\S(.|\\s)*"}
 operations:
   ...
 ```

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -113,7 +113,7 @@ type FilterConfig struct {
 
 	// MatchLabels specifies the label set against which the metric filter will work.
 	// This field is optional.
-	MatchLabels map[string]string `mapstructure:"match_labels"`
+	MatchLabels map[string]string `mapstructure:"experimental_match_labels"`
 }
 
 // Operation defines the specific operation performed on the selected metrics.

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -110,6 +110,10 @@ type FilterConfig struct {
 
 	// MatchType determines how the Include string is matched: <strict|regexp>.
 	MatchType MatchType `mapstructure:"match_type"`
+
+	// MatchLabels specifies the label set against which the metric filter will work.
+	// This field is optional.
+	MatchLabels map[string]string `mapstructure:"match_labels"`
 }
 
 // Operation defines the specific operation performed on the selected metrics.

--- a/processor/metricstransformprocessor/config_test.go
+++ b/processor/metricstransformprocessor/config_test.go
@@ -71,6 +71,28 @@ func TestLoadingFullConfig(t *testing.T) {
 					},
 					{
 						MetricIncludeFilter: FilterConfig{
+							Include:   "new_name",
+							MatchType: "strict",
+							MatchLabels: map[string]string{
+								"my_label": "my_value",
+							},
+						},
+						Action:  "insert",
+						NewName: "new_name_copy_1",
+					},
+					{
+						MetricIncludeFilter: FilterConfig{
+							Include:   "new_name",
+							MatchType: "regexp",
+							MatchLabels: map[string]string{
+								"my_label": ".*label",
+							},
+						},
+						Action:  "insert",
+						NewName: "new_name_copy_2",
+					},
+					{
+						MetricIncludeFilter: FilterConfig{
 							Include:   "name2",
 							MatchType: "",
 						},

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -182,7 +182,7 @@ func createFilter(filterConfig FilterConfig) internalFilter {
 	case StrictMatchType:
 		return internalFilterStrict{include: filterConfig.Include, matchLabels: filterConfig.MatchLabels}
 	case RegexpMatchType:
-		return internalFilterRegexp{include: regexp.MustCompile(filterConfig.Include), matchLabels: filterConfig.MatchLabels}
+		return internalFilterRegexp{include: regexp.MustCompile(filterConfig.Include), matchLabels: getFilterRegexpMap(filterConfig.MatchLabels)}
 	}
 
 	return nil
@@ -206,4 +206,13 @@ func sliceToSet(slice []string) map[string]bool {
 		set[s] = true
 	}
 	return set
+}
+
+func getFilterRegexpMap(strMap map[string]string) map[string]*regexp.Regexp {
+	regexpMap := make(map[string]*regexp.Regexp)
+
+	for k, value := range strMap {
+		regexpMap[k] = regexp.MustCompile(value)
+	}
+	return regexpMap
 }

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -180,9 +180,9 @@ func buildHelperConfig(config *Config, version string) []internalTransform {
 func createFilter(filterConfig FilterConfig) internalFilter {
 	switch filterConfig.MatchType {
 	case StrictMatchType:
-		return internalFilterStrict{include: filterConfig.Include}
+		return internalFilterStrict{include: filterConfig.Include, matchLabels: filterConfig.MatchLabels}
 	case RegexpMatchType:
-		return internalFilterRegexp{include: regexp.MustCompile(filterConfig.Include)}
+		return internalFilterRegexp{include: regexp.MustCompile(filterConfig.Include), matchLabels: filterConfig.MatchLabels}
 	}
 
 	return nil

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -105,11 +105,8 @@ func (f internalFilterStrict) labelMatched(metric *metricspb.Metric) bool {
 			}
 
 			keyFound = true
-			for _, timeseries := range metric.Timeseries {
-				if timeseries.LabelValues[idx].Value != value {
-					return false
-				}
-				break
+			if len(metric.Timeseries) > 0 && metric.Timeseries[0].LabelValues[idx].Value != value {
+				return false
 			}
 		}
 
@@ -159,11 +156,8 @@ func (f internalFilterRegexp) labelMatched(metric *metricspb.Metric) bool {
 			}
 
 			keyFound = true
-			for _, timeseries := range metric.Timeseries {
-				if !value.MatchString(timeseries.LabelValues[idx].Value) {
-					return false
-				}
-				break
+			if len(metric.Timeseries) > 0 && !value.MatchString(metric.Timeseries[0].LabelValues[idx].Value) {
+				return false
 			}
 		}
 

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -178,13 +178,3 @@ func BenchmarkMetricsTransformProcessorRenameMetrics(b *testing.B) {
 		mtp.ConsumeMetrics(context.Background(), internaldata.OCToMetrics(md))
 	}
 }
-
-func TestIsEmptyExpTrue(t *testing.T) {
-	check := isEmptyExp("^$")
-	assert.True(t, check)
-}
-
-func TestIsEmptyExpFalse(t *testing.T) {
-	check := isEmptyExp("not_true")
-	assert.False(t, check)
-}

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -178,3 +178,13 @@ func BenchmarkMetricsTransformProcessorRenameMetrics(b *testing.B) {
 		mtp.ConsumeMetrics(context.Background(), internaldata.OCToMetrics(md))
 	}
 }
+
+func TestIsEmptyExpTrue(t *testing.T) {
+	check := isEmptyExp("^$")
+	assert.True(t, check)
+}
+
+func TestIsEmptyExpFalse(t *testing.T) {
+	check := isEmptyExp("not_true")
+	assert.False(t, check)
+}

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -682,7 +682,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": "(.|\\s)*\\S(.|\\s)*"}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("(.|\\s)*\\S(.|\\s)*")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -711,7 +711,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_with_full_value",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": "value1"}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value1")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -764,7 +764,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_negative",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": ".*wrong_ending"}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile(".*wrong_ending")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -788,7 +788,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_missing_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"missing_key": "value1"}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"missing_key": regexp.MustCompile("value1")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -812,7 +812,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_missing_and_present_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": "value1", "missing_key": "value2"}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value1"), "missing_key": regexp.MustCompile("value2")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -836,7 +836,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_missing_key_with_empty_expression",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": "value1", "missing_key": "^$"}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value1"), "missing_key": regexp.MustCompile("^$")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -682,7 +682,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("(.|\\s)*\\S(.|\\s)*")}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile(`(.|\s)*\S(.|\s)*`)}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -650,6 +650,218 @@ var (
 			},
 		},
 		{
+			name: "metric_name_insert_with_match_label_strict",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]string{"label1": "value1"}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+				metricBuilder().setName("new/metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
+			name: "metric_name_insert_with_match_label_regexp",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": "(.|\\s)*\\S(.|\\s)*"}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+				metricBuilder().setName("new/metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
+			name: "metric_name_insert_with_match_label_regexp_with_full_value",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": "value1"}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+				metricBuilder().setName("new/metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
+			name: "metric_name_insert_with_match_label_strict_negative",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]string{"label1": "wrong_value"}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
+			name: "metric_name_insert_with_match_label_regexp_negative",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": ".*wrong_ending"}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
+			name: "metric_name_insert_with_match_label_regexp_missing_key",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"missing_key": "value1"}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
+			name: "metric_name_insert_with_match_label_regexp_missing_and_present_key",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": "value1", "missing_key": "value2"}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
+			name: "metric_name_insert_with_match_label_regexp_missing_key_with_empty_expression",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]string{"label1": "value1", "missing_key": "^$"}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+				metricBuilder().setName("new/metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
 			name: "metric_label_update_with_metric_insert",
 			transforms: []internalTransform{
 				{

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -785,6 +785,30 @@ var (
 			},
 		},
 		{
+			name: "metric_name_insert_with_match_label_strict_missing_key",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]string{"missing_key": "value1"}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
 			name: "metric_name_insert_with_match_label_regexp_missing_key",
 			transforms: []internalTransform{
 				{

--- a/processor/metricstransformprocessor/testdata/config_full.yaml
+++ b/processor/metricstransformprocessor/testdata/config_full.yaml
@@ -19,6 +19,18 @@ processors:
             new_label: my_label
             new_value: my_value
 
+      - include: new_name
+        action: insert
+        new_name: new_name_copy_1
+        match_type: strict
+        match_labels: {"my_label": "my_value"}
+
+      - include: new_name
+        action: insert
+        new_name: new_name_copy_2
+        match_type: regexp
+        match_labels: {"my_label": ".*label"}
+
       - include: name2
         action: update
         operations:

--- a/processor/metricstransformprocessor/testdata/config_full.yaml
+++ b/processor/metricstransformprocessor/testdata/config_full.yaml
@@ -23,13 +23,13 @@ processors:
         action: insert
         new_name: new_name_copy_1
         match_type: strict
-        match_labels: {"my_label": "my_value"}
+        experimental_match_labels: {"my_label": "my_value"}
 
       - include: new_name
         action: insert
         new_name: new_name_copy_2
         match_type: regexp
-        match_labels: {"my_label": ".*label"}
+        experimental_match_labels: {"my_label": ".*label"}
 
       - include: name2
         action: update


### PR DESCRIPTION
**Description:** 
This change adds a new feature which will support to filter metrics and apply changes matching metric names and label values together. Earlier, we were able to filter metrics using only metric names and apply our transforms to all the metrics. This enhanced filtering feature will give a new option to apply changes to a certain set of metrics where we have a match for metric name and specific set of metric labels. 

**Can you share a use case?**
Yes. Using prometheus receiver in Kubernetes, we get same metrics (same name) for containers as well as pods. We can differentiate the metrics using metric label values. In our use cases we need to rename some of the pod level metrics without affecting the container level metrics. Hence, we need an option for applying changes to metircs based on metric names and metric label values together.

**Why did you put this change in metricstransformprocessor?**
Metrics transform processor already have the insert and update functions. It applies changes to metrics matching the metric name. Its super easy and meaningful to add couple of lines to the filtering options to match metrics using metric label values besides metric names.



**Testing:** 
Wrote Unit tests and tested manually on local machine.

**Documentation:** 
Updated README with proper config examples.