### PR TITLE
Add TLS certs verification for Splunk HEC exporter

### DIFF
--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -22,6 +22,9 @@ The following configuration options can also be configured:
 - `disable_compression` (default: false): Whether to disable gzip compression over HTTP.
 - `timeout` (default: 10s): HTTP timeout when sending data.
 - `insecure_skip_verify` (default: false): Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS.
+- `ca_file` (no default) Path to the CA cert to verify the server being connected to.
+- `cert_file` (no default) Path to the TLS cert to use for client connections when TLS client auth is required.
+- `key_file` (no default) Path to the TLS key to use for TLS required connections.
 - `max_content_length_logs` (default: 2097152): Maximum log data size in bytes per HTTP post limited to 2097152 bytes (2 MiB).
 
 In addition, this exporter offers queued retry which is enabled by default.
@@ -51,6 +54,14 @@ exporters:
     timeout: 10s
     # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
     insecure_skip_verify: false
+    # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
+    insecure: false
+    # Path to the CA cert to verify the server being connected to. Should only be used if `insecure` is set to false.
+    ca_file: /certs/ExampleCA.crt
+    # Path to the TLS cert to use for client connections when TLS client auth is required. Should only be used if `insecure` is set to false.
+    cert_file: /certs/HECclient.crt
+    # Path to the TLS key to use for TLS required connections. Should only be used if `insecure` is set to false.
+    key_file: /certs/HECclient.key
 ```
 
 The full list of settings exposed for this exporter are documented [here](config.go)

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -21,6 +21,7 @@ import (
 	"path"
 
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
@@ -59,11 +60,11 @@ type Config struct {
 	// Disable GZip compression. Defaults to false.
 	DisableCompression bool `mapstructure:"disable_compression"`
 
-	// insecure_skip_verify skips checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
-	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify"`
-
 	// Maximum log data size in bytes per HTTP post. Defaults to the backend limit of 2097152 bytes (2MiB).
 	MaxContentLengthLogs uint `mapstructure:"max_content_length_logs"`
+
+	// TLSSetting struct exposes TLS client configuration.
+	TLSSetting configtls.TLSClientSetting `mapstructure:",squash"`
 }
 
 func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
 )
@@ -78,6 +79,15 @@ func TestLoadConfig(t *testing.T) {
 			Enabled:      true,
 			NumConsumers: 2,
 			QueueSize:    10,
+		},
+		TLSSetting: configtls.TLSClientSetting{
+			TLSSetting: configtls.TLSSetting{
+				CAFile:   "",
+				CertFile: "",
+				KeyFile:  "",
+			},
+			Insecure:           true,
+			InsecureSkipVerify: false,
 		},
 	}
 	assert.Equal(t, &expectedCfg, e1)

--- a/exporter/splunkhecexporter/exporter_test.go
+++ b/exporter/splunkhecexporter/exporter_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/testutil/metricstestutil"
@@ -56,6 +57,24 @@ func TestNew(t *testing.T) {
 	got, err = createExporter(config, zap.NewNop())
 	assert.NoError(t, err)
 	require.NotNil(t, got)
+
+	config = &Config{
+		Token:           "someToken",
+		Endpoint:        "https://example.com:8088",
+		TimeoutSettings: exporterhelper.TimeoutSettings{Timeout: 1 * time.Second},
+		TLSSetting: configtls.TLSClientSetting{
+			TLSSetting: configtls.TLSSetting{
+				CAFile:   "file-not-found",
+				CertFile: "file-not-found",
+				KeyFile:  "file-not-found",
+			},
+			Insecure:           false,
+			InsecureSkipVerify: false,
+		},
+	}
+	got, err = createExporter(config, zap.NewNop())
+	assert.Error(t, err)
+	require.Nil(t, got)
 }
 
 func TestConsumeMetricsData(t *testing.T) {
@@ -147,7 +166,8 @@ func TestConsumeMetricsData(t *testing.T) {
 			config.Token = "1234"
 			config.Index = "test_index"
 
-			sender := buildClient(options, config, zap.NewNop())
+			sender, err := buildClient(options, config, zap.NewNop())
+			assert.NoError(t, err)
 
 			md := internaldata.OCToMetrics(tt.md)
 			err = sender.pushMetricsData(context.Background(), md)
@@ -292,7 +312,8 @@ func TestConsumeLogsData(t *testing.T) {
 			config.Token = "1234"
 			config.Index = "test_index"
 
-			sender := buildClient(options, config, zap.NewNop())
+			sender, err := buildClient(options, config, zap.NewNop())
+			assert.NoError(t, err)
 
 			err = sender.pushLogData(context.Background(), tt.ld)
 			if tt.wantErr {

--- a/exporter/splunkhecexporter/testdata/config.yaml
+++ b/exporter/splunkhecexporter/testdata/config.yaml
@@ -14,6 +14,11 @@ exporters:
     source: "otel"
     sourcetype: "otel"
     index: "metrics"
+    insecure_skip_verify: false
+    insecure: true
+    ca_file: ""
+    cert_file: ""
+    key_file: ""
     timeout: 10s
     sending_queue:
       enabled: true

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -581,7 +581,6 @@ func Test_Logs_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 				Token:              "ignored",
 				SourceType:         "defaultsourcetype",
 				Index:              "defaultindex",
-				InsecureSkipVerify: true,
 				DisableCompression: true,
 				Endpoint:           endServer.URL,
 			}
@@ -680,7 +679,6 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 				Token:              "ignored",
 				SourceType:         "defaultsourcetype",
 				Index:              "defaultindex",
-				InsecureSkipVerify: true,
 				DisableCompression: true,
 				Endpoint:           endServer.URL,
 			}


### PR DESCRIPTION
**Description:** Adds support for TLS certificate verification while use splunk hec exporter

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3015

**Testing:** Tested on localhost

**Documentation:** Add documentation for new/replaced configuration options