### PR TITLE
[exporter/signalfx] add a few more default excluded metrics to exporter

### DIFF
--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -265,7 +265,7 @@ func TestCreateMetricsExporterWithDefaultExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 10, len(config.ExcludeMetrics))
+	assert.Equal(t, 11, len(config.ExcludeMetrics))
 }
 
 func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
@@ -285,7 +285,7 @@ func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 11, len(config.ExcludeMetrics))
+	assert.Equal(t, 12, len(config.ExcludeMetrics))
 }
 
 func TestCreateMetricsExporterWithEmptyExcludeMetrics(t *testing.T) {

--- a/exporter/signalfxexporter/translation/default_metrics.go
+++ b/exporter/signalfxexporter/translation/default_metrics.go
@@ -132,13 +132,22 @@ exclude_metrics:
   - system.disk.merged
   - system.disk.io
   - system.disk.time
+  - system.disk.io_time
+  - system.disk.operation_time
   - system.disk.pending_operations
+  - system.disk.weighted_io_time
 
 # Network-IO metrics.
 - metric_names:
   - system.network.packets
   - system.network.dropped
   - system.network.tcp_connections
+  - system.network.connections
+
+# Processes metrics
+- metric_names:
+  - system.processes.count
+  - system.processes.created
 
 # Virtual memory metrics.
 - metric_names:


### PR DESCRIPTION
These metrics are being categorized as custom metrics in our backend, so we should not emit them unless explicitly configured to do so.