### PR TITLE
Add breaking change for signalfx exporter to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 🛑 Breaking changes 🛑
+
+- `signalfx` exporter (#3207):
+  - Additional metrics excluded by default by signalfx exporter
+    - system.disk.io_time
+    - system.disk.operation_time
+    - system.disk.weighted_io_time
+    - system.network.connections
+    - system.processes.count
+    - system.processes.created
+
 ## v0.25.0
 
 # 🎉 OpenTelemetry Collector Contrib v0.25.0 (Beta) 🎉


### PR DESCRIPTION
These metrics no longer being emitted is a potentially breaking change for current users that were relying on them.