### PR TITLE
Identify the Amazon Prometheus region from the endpoint

### DIFF
--- a/exporter/awsprometheusremotewriteexporter/auth_test.go
+++ b/exporter/awsprometheusremotewriteexporter/auth_test.go
@@ -288,6 +288,44 @@ func TestCloneRequest(t *testing.T) {
 	}
 }
 
+func TestParseEndpointRegion(t *testing.T) {
+	tests := []struct {
+		name       string
+		endpoint   string
+		wantRegion string
+		wantErr    bool
+	}{
+		{
+			name:     "empty",
+			endpoint: "",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid",
+			endpoint: "https://aps-workspaces.us-east-1",
+			wantErr:  true,
+		},
+		{
+			name:       "valid",
+			endpoint:   "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write",
+			wantRegion: "us-east-1",
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRegion, err := parseEndpointRegion(tt.endpoint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseEndpointRegion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotRegion != tt.wantRegion {
+				t.Errorf("parseEndpointRegion() = %v, want %v", gotRegion, tt.wantRegion)
+			}
+		})
+	}
+}
+
 func fetchMockCredentials() *credentials.Credentials {
 	return credentials.NewStaticCredentials(
 		"MOCK_AWS_ACCESS_KEY",

--- a/exporter/awsprometheusremotewriteexporter/config_test.go
+++ b/exporter/awsprometheusremotewriteexporter/config_test.go
@@ -68,7 +68,7 @@ func TestLoadConfig(t *testing.T) {
 			Namespace:      "test-space",
 			ExternalLabels: map[string]string{"key1": "value1", "key2": "value2"},
 			HTTPClientSettings: confighttp.HTTPClientSettings{
-				Endpoint: "http://localhost:9009",
+				Endpoint: "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write",
 				TLSSetting: configtls.TLSClientSetting{
 					TLSSetting: configtls.TLSSetting{
 						CAFile: "/var/lib/mycert.pem",

--- a/exporter/awsprometheusremotewriteexporter/factory.go
+++ b/exporter/awsprometheusremotewriteexporter/factory.go
@@ -57,7 +57,7 @@ func (af *awsFactory) CreateDefaultConfig() config.Exporter {
 	cfg.TypeVal = typeStr
 	cfg.NameVal = typeStr
 	cfg.HTTPClientSettings.CustomRoundTripper = func(next http.RoundTripper) (http.RoundTripper, error) {
-		return newSigningRoundTripper(cfg.AuthConfig, next)
+		return newSigningRoundTripper(cfg, next)
 	}
 
 	return cfg

--- a/exporter/awsprometheusremotewriteexporter/factory_test.go
+++ b/exporter/awsprometheusremotewriteexporter/factory_test.go
@@ -76,11 +76,6 @@ func TestCreateMetricsExporter(t *testing.T) {
 		params      component.ExporterCreateParams
 		returnError bool
 	}{
-		{"success_case_default",
-			af.CreateDefaultConfig(),
-			component.ExporterCreateParams{Logger: zap.NewNop()},
-			false,
-		},
 		{"success_case_with_auth",
 			validConfigWithAuth,
 			component.ExporterCreateParams{Logger: zap.NewNop()},
@@ -97,7 +92,6 @@ func TestCreateMetricsExporter(t *testing.T) {
 			true,
 		},
 	}
-	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := af.CreateMetricsExporter(context.Background(), tt.params, tt.cfg)

--- a/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
@@ -13,7 +13,7 @@ exporters:
             initial_interval: 10s
             max_interval: 60s
             max_elapsed_time: 10m
-        endpoint: "http://localhost:9009"
+        endpoint: "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write"
         ca_file: "/var/lib/mycert.pem"
         write_buffer_size: 524288
         headers:


### PR DESCRIPTION
This change allows users to skip setting aws_auth in their configuration and make sure SigV4 is scoping to the region user's workspace is in.

Fixes #3162.