### PR TITLE
exporter/splunkhec: Mark permanent errors to avoid futile retries

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -86,16 +86,7 @@ func (c *client) pushMetricsData(
 	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
 
-	// Splunk accepts all 2XX codes.
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		err = fmt.Errorf(
-			"HTTP %d %q",
-			resp.StatusCode,
-			http.StatusText(resp.StatusCode))
-		return err
-	}
-
-	return nil
+	return splunk.HandleHTTPCode(resp)
 }
 
 func (c *client) pushTraceData(
@@ -268,15 +259,7 @@ func (c *client) postEvents(ctx context.Context, events io.Reader, compressed bo
 	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
 
-	// Splunk accepts all 2XX codes.
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		err = fmt.Errorf(
-			"HTTP %d %q",
-			resp.StatusCode,
-			http.StatusText(resp.StatusCode))
-		return err
-	}
-	return nil
+	return splunk.HandleHTTPCode(resp)
 }
 
 // subLogs returns a subset of `ld` starting from index `from` to the end.

--- a/internal/splunk/httprequest.go
+++ b/internal/splunk/httprequest.go
@@ -28,7 +28,7 @@ const HeaderRetryAfter = "Retry-After"
 
 // HandleHTTPCode handles an http response and returns the right type of error in case of a failure.
 func HandleHTTPCode(resp *http.Response) error {
-	// SignalFx accepts all 2XX codes.
+	// Splunk accepts all 2XX codes.
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		return nil
 	}


### PR DESCRIPTION
**Description:** Mark permanent errors to avoid futile retries using the [helper](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/splunk/httprequest.go) in internal.