### PR TITLE
Fix default dimension value config bug

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -346,16 +346,13 @@ func buildDimensionKVs(serviceName string, span pdata.Span, optionalDims []Dimen
 	dims[spanKindKey] = span.Kind().String()
 	dims[statusCodeKey] = span.Status().Code().String()
 	spanAttr := span.Attributes()
-	var value string
 	for _, d := range optionalDims {
-		// Set the default if configured, otherwise this metric will have no value set for the dimension.
-		if d.Default != nil {
-			value = *d.Default
-		}
 		if attr, ok := spanAttr.Get(d.Name); ok {
-			value = tracetranslator.AttributeValueToString(attr, false)
+			dims[d.Name] = tracetranslator.AttributeValueToString(attr, false)
+		} else if d.Default != nil {
+			// Set the default if configured, otherwise this metric should have no value set for the dimension.
+			dims[d.Name] = *d.Default
 		}
-		dims[d.Name] = value
 	}
 	return dims
 }


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

**Description:** <Describe what has changed.>
Fix bug in spanmetrics processor where the previous default value for a dimension is applied to the next dimension in config if the next dimension's default is unset.

**Link to tracking Issue:** <Issue number if applicable>
Fixes #2888.

**Testing:** <Describe what testing was performed and which tests were added.>
Update unit tests. Improved strictness of existing assertions.

Tested e2e with OTELCol -> M3 -> Grafana using the following spanmetrics otel config:
```
   spanmetrics:
     metrics_exporter: prometheus
     dimensions:
     - name: http.method
       default: GET
     - name: foo
```

**Before**
![Screen Shot 2021-04-27 at 7 47 36 pm](https://user-images.githubusercontent.com/26584478/116222026-86e23400-a791-11eb-9e3a-2f014bbe5530.png)

**After**
![Screen Shot 2021-04-27 at 7 51 24 pm](https://user-images.githubusercontent.com/26584478/116222475-fa844100-a791-11eb-9d00-03842d93c644.png)
