### PR TITLE
Update JMX Receiver for latest snapshot and header support

### DIFF
--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -12,7 +12,7 @@ Status: alpha
 
 This receiver will launch a child JRE process running the JMX Metric Gatherer configured with your specified JMX
 connection information and target Groovy script.  It then reports metrics to an implicitly created OTLP receiver.
-In order to use you will need to download the most [recent release](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/opentelemetry/contrib/opentelemetry-java-contrib-jmx-metrics/)
+In order to use you will need to download the most [recent release](https://oss.sonatype.org/content/repositories/snapshots/io/opentelemetry/contrib/opentelemetry-java-contrib-jmx-metrics)
 of the JMX Metric Gatherer JAR and configure the receiver with its path.  It is assumed that the JRE is
 available on your system.
 

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -16,6 +16,7 @@ package jmxreceiver
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -68,6 +69,24 @@ type otlpExporterConfig struct {
 	exporterhelper.TimeoutSettings `mapstructure:",squash"`
 	// The headers to include in OTLP metric submission requests.
 	Headers map[string]string `mapstructure:"headers"`
+}
+
+func (oec otlpExporterConfig) headersToString() string {
+	// sort for reliable testing
+	headers := make([]string, 0, len(oec.Headers))
+	for k := range oec.Headers {
+		headers = append(headers, k)
+	}
+	sort.Strings(headers)
+
+	headerString := ""
+	for _, k := range headers {
+		v := oec.Headers[k]
+		headerString += fmt.Sprintf("%s=%v,", k, v)
+	}
+	// remove trailing comma
+	headerString = headerString[0 : len(headerString)-1]
+	return headerString
 }
 
 func (c *Config) validate() error {

--- a/receiver/jmxreceiver/integration_test.go
+++ b/receiver/jmxreceiver/integration_test.go
@@ -60,7 +60,7 @@ func (suite *JMXIntegrationSuite) TearDownSuite() {
 }
 
 func downloadJMXMetricGathererJAR() (string, error) {
-	url := "https://oss.jfrog.org/artifactory/list/oss-snapshot-local/io/opentelemetry/contrib/opentelemetry-java-contrib-jmx-metrics/0.0.1-SNAPSHOT/opentelemetry-java-contrib-jmx-metrics-0.0.1-20201110.155252-5.jar"
+	url := "https://oss.sonatype.org/content/repositories/snapshots/io/opentelemetry/contrib/opentelemetry-java-contrib-jmx-metrics/1.0.0-alpha-SNAPSHOT/opentelemetry-java-contrib-jmx-metrics-1.0.0-alpha-20210429.213723-5.jar"
 	resp, err := http.Get(url)
 	if err != nil {
 		return "", err
@@ -191,7 +191,7 @@ func (suite *JMXIntegrationSuite) TestJMXReceiverHappyPath() {
 
 		ilm := rm.InstrumentationLibraryMetrics().At(0)
 		require.Equal(t, "io.opentelemetry.contrib.jmxmetrics", ilm.InstrumentationLibrary().Name())
-		require.Equal(t, "0.0.1", ilm.InstrumentationLibrary().Version())
+		require.Equal(t, "1.0.0-alpha", ilm.InstrumentationLibrary().Version())
 
 		met := ilm.Metrics().At(0)
 
@@ -229,5 +229,5 @@ func TestJMXReceiverInvalidOTLPEndpointIntegration(t *testing.T) {
 	}()
 
 	err := receiver.Start(context.Background(), componenttest.NewNopHost())
-	require.EqualError(t, err, "listen tcp: lookup <invalid>: no such host")
+	require.Contains(t, err.Error(), "listen tcp: lookup <invalid>:")
 }

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -158,10 +158,19 @@ otel.jmx.interval.milliseconds = %v
 		javaConfig += fmt.Sprintf("otel.jmx.groovy.script = %v\n", jmx.config.GroovyScript)
 	}
 
-	javaConfig += fmt.Sprintf(`otel.exporter = otlp
+	endpoint := jmx.config.OTLPExporterConfig.Endpoint
+	if !strings.HasPrefix(endpoint, "http") {
+		endpoint = fmt.Sprintf("http://%s", endpoint)
+	}
+
+	javaConfig += fmt.Sprintf(`otel.metrics.exporter = otlp
 otel.exporter.otlp.endpoint = %v
-otel.exporter.otlp.metric.timeout = %v
-`, jmx.config.OTLPExporterConfig.Endpoint, jmx.config.OTLPExporterConfig.Timeout.Milliseconds())
+otel.exporter.otlp.timeout = %v
+`, endpoint, jmx.config.OTLPExporterConfig.Timeout.Milliseconds())
+
+	if len(jmx.config.OTLPExporterConfig.Headers) > 0 {
+		javaConfig += fmt.Sprintf("otel.exporter.otlp.headers = %s\n", jmx.config.OTLPExporterConfig.headersToString())
+	}
 
 	if jmx.config.Username != "" {
 		javaConfig += fmt.Sprintf("otel.jmx.username = %v\n", jmx.config.Username)

--- a/receiver/jmxreceiver/receiver_test.go
+++ b/receiver/jmxreceiver/receiver_test.go
@@ -71,9 +71,9 @@ func TestBuildJMXMetricGathererConfig(t *testing.T) {
 			`otel.jmx.service.url = service:jmx:rmi///jndi/rmi://myservice:12345/jmxrmi/
 otel.jmx.interval.milliseconds = 123000
 otel.jmx.target.system = mytargetsystem
-otel.exporter = otlp
-otel.exporter.otlp.endpoint = myotlpendpoint
-otel.exporter.otlp.metric.timeout = 234000
+otel.metrics.exporter = otlp
+otel.exporter.otlp.endpoint = http://myotlpendpoint
+otel.exporter.otlp.timeout = 234000
 `, "",
 		},
 		{
@@ -83,7 +83,7 @@ otel.exporter.otlp.metric.timeout = 234000
 				GroovyScript:       "mygroovyscript",
 				CollectionInterval: 123 * time.Second,
 				OTLPExporterConfig: otlpExporterConfig{
-					Endpoint: "myotlpendpoint",
+					Endpoint: "http://myotlpendpoint",
 					TimeoutSettings: exporterhelper.TimeoutSettings{
 						Timeout: 234 * time.Second,
 					},
@@ -92,9 +92,9 @@ otel.exporter.otlp.metric.timeout = 234000
 			`otel.jmx.service.url = service:jmx:rmi///jndi/rmi://myservice:12345/jmxrmi/
 otel.jmx.interval.milliseconds = 123000
 otel.jmx.groovy.script = mygroovyscript
-otel.exporter = otlp
-otel.exporter.otlp.endpoint = myotlpendpoint
-otel.exporter.otlp.metric.timeout = 234000
+otel.metrics.exporter = otlp
+otel.exporter.otlp.endpoint = http://myotlpendpoint
+otel.exporter.otlp.timeout = 234000
 `, "",
 		},
 		{
@@ -105,18 +105,23 @@ otel.exporter.otlp.metric.timeout = 234000
 				GroovyScript:       "mygroovyscript",
 				CollectionInterval: 123 * time.Second,
 				OTLPExporterConfig: otlpExporterConfig{
-					Endpoint: "myotlpendpoint",
+					Endpoint: "https://myotlpendpoint",
 					TimeoutSettings: exporterhelper.TimeoutSettings{
 						Timeout: 234 * time.Second,
+					},
+					Headers: map[string]string{
+						"one":   "two",
+						"three": "four",
 					},
 				},
 			},
 			`otel.jmx.service.url = service:jmx:rmi:///jndi/rmi://myhost:12345/jmxrmi
 otel.jmx.interval.milliseconds = 123000
 otel.jmx.target.system = mytargetsystem
-otel.exporter = otlp
-otel.exporter.otlp.endpoint = myotlpendpoint
-otel.exporter.otlp.metric.timeout = 234000
+otel.metrics.exporter = otlp
+otel.exporter.otlp.endpoint = https://myotlpendpoint
+otel.exporter.otlp.timeout = 234000
+otel.exporter.otlp.headers = one=two,three=four
 `, "",
 		},
 		{

--- a/receiver/jmxreceiver/testdata/script.groovy
+++ b/receiver/jmxreceiver/testdata/script.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import io.opentelemetry.api.common.Labels
+import io.opentelemetry.api.metrics.common.Labels
 
 def loadMatches = otel.queryJmx("org.apache.cassandra.metrics:type=Storage,name=Load")
 if (loadMatches.size() > 0) {


### PR DESCRIPTION
**Description:**
These changes move the tested snapshot to OSSRH in light of the deprecation of Bintray.  They also add* OTLP exporter header support that was previously missing.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:**
Updated unit and integration tests

**Documentation:**
Updated snapshot link until new JMX Metric Gatherer version is released (upcoming).