### PR TITLE
Disable unstable k8sprocessor TestMetrics

### DIFF
--- a/processor/k8sprocessor/observability/observability_test.go
+++ b/processor/k8sprocessor/observability/observability_test.go
@@ -87,6 +87,9 @@ func TestMetrics(t *testing.T) {
 	}
 	go metricReader.ReadAndExport(e)
 
+	// TODO: fix this test: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1093
+	t.Skipf("Skipped because unstable.")
+
 	var data []*metricdata.Metric
 	select {
 	case <-time.After(time.Second * 2):


### PR DESCRIPTION
The test is unstable and keeps failing on CircleCI.

Issue is open to fix the test https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1093
