### PR TITLE
Update Datadog attributes to tags mapping

### DIFF
--- a/exporter/datadogexporter/attributes/attributes.go
+++ b/exporter/datadogexporter/attributes/attributes.go
@@ -26,9 +26,16 @@ var (
 	// and Datadog Agent conventions
 	conventionsMapping = map[string]string{
 		// Datadog conventions
+		// https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/
 		conventions.AttributeDeploymentEnvironment: "env",
-		conventions.AttributeServiceName: "service",
-		conventions.AttributeServiceVersion: "version",
+		conventions.AttributeServiceName:           "service",
+		conventions.AttributeServiceVersion:        "version",
+
+		// Cloud conventions
+		// https://www.datadoghq.com/blog/tagging-best-practices/
+		conventions.AttributeCloudProvider:         "cloud_provider",
+		conventions.AttributeCloudRegion:           "region",
+		conventions.AttributeCloudAvailabilityZone: "zone",
 
 		// ECS conventions
 		// https://github.com/DataDog/datadog-agent/blob/e081bed/pkg/tagger/collectors/ecs_extract.go

--- a/exporter/datadogexporter/attributes/attributes.go
+++ b/exporter/datadogexporter/attributes/attributes.go
@@ -25,6 +25,11 @@ var (
 	// conventionsMappings defines the mapping between OpenTelemetry semantic conventions
 	// and Datadog Agent conventions
 	conventionsMapping = map[string]string{
+		// Datadog conventions
+		conventions.AttributeDeploymentEnvironment: "env",
+		conventions.AttributeServiceName: "service",
+		conventions.AttributeServiceVersion: "version",
+
 		// ECS conventions
 		// https://github.com/DataDog/datadog-agent/blob/e081bed/pkg/tagger/collectors/ecs_extract.go
 		conventions.AttributeAWSECSTaskFamily: "task_family",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Attributes that are mapped for traces are not being mapped for metrics.

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/f853a99d3be25aa6436e9c89f5453169c62efc82/exporter/datadogexporter/translate_traces.go#L143
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/f853a99d3be25aa6436e9c89f5453169c62efc82/exporter/datadogexporter/translate_traces.go#L321-L330
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/f853a99d3be25aa6436e9c89f5453169c62efc82/exporter/datadogexporter/translate_traces.go#L238

I [don]'t understand why the code for doing attributes -> tags is different between metrics and traces?
