### PR TITLE
Update New Relic exporter error conditions.

### DIFF
--- a/exporter/newrelicexporter/errors.go
+++ b/exporter/newrelicexporter/errors.go
@@ -15,6 +15,7 @@
 package newrelicexporter
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -63,7 +64,7 @@ type httpError struct {
 	Response *http.Response
 }
 
-func (e *httpError) Error() string { return "New Relic HTTP call failed" }
+func (e *httpError) Error() string { return fmt.Sprintf("New Relic HTTP call failed. Status Code: %d", e.Response.StatusCode) }
 
 func (e *httpError) GRPCStatus() *grpcStatus.Status {
 	mapEntry, ok := httpGrpcMapping[e.Response.StatusCode]

--- a/exporter/newrelicexporter/errors.go
+++ b/exporter/newrelicexporter/errors.go
@@ -64,7 +64,9 @@ type httpError struct {
 	Response *http.Response
 }
 
-func (e *httpError) Error() string { return fmt.Sprintf("New Relic HTTP call failed. Status Code: %d", e.Response.StatusCode) }
+func (e *httpError) Error() string {
+	return fmt.Sprintf("New Relic HTTP call failed. Status Code: %d", e.Response.StatusCode)
+}
 
 func (e *httpError) GRPCStatus() *grpcStatus.Status {
 	mapEntry, ok := httpGrpcMapping[e.Response.StatusCode]

--- a/exporter/newrelicexporter/errors_test.go
+++ b/exporter/newrelicexporter/errors_test.go
@@ -90,7 +90,7 @@ func TestHttpError_GRPCStatus(t *testing.T) {
 
 func TestHttpError_Error(t *testing.T) {
 	httpError := &httpError{Response: responseOf(http.StatusTeapot)}
-	assert.Equal(t, httpError.Error(), "New Relic HTTP call failed")
+	assert.Equal(t, httpError.Error(), "New Relic HTTP call failed. Status Code: 418")
 }
 
 func responseOf(statusCode int) *http.Response {

--- a/exporter/newrelicexporter/newrelic.go
+++ b/exporter/newrelicexporter/newrelic.go
@@ -131,7 +131,7 @@ func (e exporter) pushTraceData(ctx context.Context, td pdata.Traces) (outputErr
 func (e exporter) buildTraceBatch(details *exportMetadata, td pdata.Traces) ([]telemetry.Batch, error) {
 	var errs []error
 
-	transform := newTransformer(e.buildInfo, details)
+	transform := newTransformer(e.logger, e.buildInfo, details)
 	batches := make([]telemetry.Batch, 0, calcSpanBatches(td))
 
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
@@ -184,7 +184,7 @@ func (e exporter) pushLogData(ctx context.Context, ld pdata.Logs) (outputErr err
 func (e exporter) buildLogBatch(details *exportMetadata, ld pdata.Logs) ([]telemetry.Batch, error) {
 	var errs []error
 
-	transform := newTransformer(e.buildInfo, details)
+	transform := newTransformer(e.logger, e.buildInfo, details)
 	batches := make([]telemetry.Batch, 0, calcLogBatches(ld))
 
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
@@ -237,7 +237,7 @@ func (e exporter) pushMetricData(ctx context.Context, md pdata.Metrics) (outputE
 func (e exporter) buildMetricBatch(details *exportMetadata, md pdata.Metrics) ([]telemetry.Batch, error) {
 	var errs []error
 
-	transform := newTransformer(e.buildInfo, details)
+	transform := newTransformer(e.logger, e.buildInfo, details)
 	batches := make([]telemetry.Batch, 0, calcMetricBatches(md))
 
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {


### PR DESCRIPTION
**Description:** This PR updates the New Relic exporter "error" conditions in a couple of key ways:
* Cumulative Sum metrics are now exported as gauges
* The HTTP status error message now contains the status code.

**Testing:** Yes

Fixes: #3315