### PR TITLE
Update New Relic version info to allow for user-agent only modification.

### DIFF
--- a/exporter/newrelicexporter/newrelic.go
+++ b/exporter/newrelicexporter/newrelic.go
@@ -36,6 +36,9 @@ const (
 	product = "NewRelic-OpenTelemetry-Collector"
 )
 
+// GitHash may be replaced at compile time in order to update the UserAgent
+var GitHash = ""
+
 // exporter exports OpenTelemetry Collector data to New Relic.
 type exporter struct {
 	buildInfo      *component.BuildInfo
@@ -61,6 +64,8 @@ func clientOptions(info *component.BuildInfo, apiKey string, apiKeyHeader string
 	userAgent := product
 	if info.Version != "" {
 		userAgent += "/" + info.Version
+	} else if GitHash != "" {
+		userAgent += "/" + GitHash
 	}
 	userAgent += " " + info.Command
 	options := []telemetry.ClientOption{telemetry.WithUserAgent(userAgent)}

--- a/exporter/newrelicexporter/newrelic_test.go
+++ b/exporter/newrelicexporter/newrelic_test.go
@@ -728,10 +728,12 @@ func TestExportLogs(t *testing.T) {
 }
 
 func TestCreatesClientOptionWithVersionInUserAgent(t *testing.T) {
-	testUserAgentContainsCollectorInfo(t, testCollectorVersion, testCollectorName, "NewRelic-OpenTelemetry-Collector/v1.2.3 TestCollector")
+	testUserAgentContainsCollectorInfo(t, "", "", testCollectorName, "NewRelic-OpenTelemetry-Collector TestCollector")
+	testUserAgentContainsCollectorInfo(t, "abcdef", "", testCollectorName, "NewRelic-OpenTelemetry-Collector/abcdef TestCollector")
+	testUserAgentContainsCollectorInfo(t, "", testCollectorVersion, testCollectorName, "NewRelic-OpenTelemetry-Collector/v1.2.3 TestCollector")
 }
 
-func testUserAgentContainsCollectorInfo(t *testing.T, version string, exeName string, expectedUserAgentSubstring string) {
+func testUserAgentContainsCollectorInfo(t *testing.T, gitHash string, version string, exeName string, expectedUserAgentSubstring string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -763,6 +765,11 @@ func testUserAgentContainsCollectorInfo(t *testing.T, version string, exeName st
 		Command: exeName,
 		Version: version,
 	}}
+
+	cleanupHash := GitHash
+	GitHash = gitHash
+	t.Cleanup(func() { GitHash = cleanupHash })
+
 	exp, err := f.CreateTracesExporter(context.Background(), params, c)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Description:** 

There are cases where the exporter would like a git hash transmitted via the user agent string without also modifying attributes on user data. In that case, a compile-time attribute can be set.

**Testing:** Unit tests