### PR TITLE
Change New Relic version key to allow for user-agent only modification.

### DIFF
--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -54,7 +54,7 @@ func newTransformer(logger *zap.Logger, buildInfo *component.BuildInfo, details 
 	overrideAttributes := make(map[string]interface{})
 	if buildInfo != nil {
 		overrideAttributes[collectorNameKey] = buildInfo.Command
-		if buildInfo.Version != "" {
+		if strings.HasPrefix(buildInfo.Version, "v") {
 			overrideAttributes[collectorVersionKey] = buildInfo.Version
 		}
 	}


### PR DESCRIPTION
**Description:** This PR allows for a compile to disable adding the version attribute. The reason for this is at New Relic we want the ability to modify the user agent without adding additional attributes to customer data.

There should be no impact to any official builds of the collector.

**Testing:** Unit tests.
