### PR TITLE
[extension/ecsobserver] Add exporter to convert task to target

### DIFF
--- a/extension/observer/ecsobserver/error.go
+++ b/extension/observer/ecsobserver/error.go
@@ -28,9 +28,8 @@ import (
 // for log and metrics that can be used for debugging.
 
 const (
-	errKeyTask      = "task"
-	errKeyContainer = "container"
-	errKeyTarget    = "target"
+	errKeyTask   = "task"
+	errKeyTarget = "target"
 )
 
 type errWithAttributes interface {
@@ -73,7 +72,9 @@ func extractErrorFields(err error) ([]zap.Field, string) {
 	fields = errAttr.zapFields()
 	v, ok := errctx.ValueFrom(err, errKeyTask)
 	if ok {
-		if task, ok := v.(*Task); ok {
+		// Rename ok to tok because linter says it shadows outer ok.
+		// Though the linter seems to allow the similar block to shadow...
+		if task, tok := v.(*Task); tok {
 			fields = append(fields, zap.String("TaskArn", aws.StringValue(task.Task.TaskArn)))
 			scope = "Task"
 		}

--- a/extension/observer/ecsobserver/error.go
+++ b/extension/observer/ecsobserver/error.go
@@ -1,0 +1,148 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecsobserver
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+// error.go defines common error interfaces and util methods for generating reports
+// for log and metrics that can be used for debugging.
+
+type errWithAttributes interface {
+	// message does not include attributes like task arn etc.
+	// and expect the caller extract them using getters.
+	message() string
+	// zapFields will be logged as json attribute and allows searching and filter backend like cloudwatch.
+	// For example { $.ErrScope == "Target" } list all the error whose scope is a (scrape) target.
+	zapFields() []zap.Field
+}
+
+type taskError interface {
+	errWithAttributes
+	setTask(t *Task)
+	getTask() *Task
+}
+
+// baseTaskError can be embedded into error that happens at task level or below.
+type baseTaskError struct {
+	t *Task
+}
+
+func (be *baseTaskError) setTask(t *Task) {
+	be.t = t
+}
+
+func (be *baseTaskError) getTask() *Task {
+	return be.t
+}
+
+func setErrTask(err error, t *Task) {
+	e, ok := err.(taskError)
+	if !ok {
+		return
+	}
+	e.setTask(t)
+}
+
+type containerError interface {
+	taskError
+	setContainerIndex(j int)
+	getContainerIndex() int
+}
+
+func setErrContainer(err error, containerIndex int, task *Task) {
+	e, ok := err.(containerError)
+	if !ok {
+		return
+	}
+	setErrTask(err, task)
+	e.setContainerIndex(containerIndex)
+}
+
+type targetError interface {
+	containerError
+	setTarget(t MatchedTarget)
+	getTarget() MatchedTarget
+}
+
+func setErrTarget(err error, target MatchedTarget, containerIndex int, task *Task) {
+	e, ok := err.(targetError)
+	if !ok {
+		return
+	}
+	setErrContainer(err, containerIndex, task)
+	e.setTarget(target)
+}
+
+func printErrors(logger *zap.Logger, err error) {
+	merr := multierr.Errors(err)
+	if merr == nil {
+		return
+	}
+
+	for _, err := range merr {
+		m := err.Error()
+		serr, ok := err.(errWithAttributes)
+		if ok {
+			m = serr.message()
+		}
+		fields, scope := extractErrorFields(err)
+		fields = append(fields, zap.String("ErrScope", scope))
+		logger.Error(m, fields...)
+	}
+}
+
+func extractErrorFields(err error) ([]zap.Field, string) {
+	var fields []zap.Field
+	scope := "Unknown"
+	errAttr, ok := err.(errWithAttributes)
+	if !ok {
+		return fields, scope
+	}
+	fields = errAttr.zapFields()
+
+	taskErr, ok := err.(taskError)
+	if !ok {
+		return fields, scope
+	}
+	scope = "Task"
+	task := taskErr.getTask()
+	fields = append(fields, zap.String("TaskArn", aws.StringValue(task.Task.TaskArn)))
+
+	containerErr, ok := err.(containerError)
+	if !ok {
+		return fields, scope
+	}
+	scope = "Container"
+	container := task.Task.Containers[containerErr.getContainerIndex()]
+	fields = append(fields, zap.String("ContainerName", aws.StringValue(container.Name)))
+	if !ok {
+		return fields, scope
+	}
+
+	targetErr, ok := err.(targetError)
+	if !ok {
+		return fields, scope
+	}
+	scope = "Target"
+	target := targetErr.getTarget()
+	// TODO: change to string once another PR for matcher got merged
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3386 defines Stringer
+	fields = append(fields, zap.Int("MatcherType", int(target.MatcherType)))
+	return fields, scope
+}

--- a/extension/observer/ecsobserver/error_test.go
+++ b/extension/observer/ecsobserver/error_test.go
@@ -15,16 +15,14 @@
 package ecsobserver
 
 import (
-	"fmt"
 	"testing"
 
 	"go.uber.org/zap"
 )
 
 func TestSetInvalidError(t *testing.T) {
-	err := fmt.Errorf("std")
-	setErrTask(err, nil)
-	setErrContainer(err, 0, nil)
-	setErrTarget(err, MatchedTarget{}, 0, nil)
-	printErrors(zap.NewExample(), nil)
+	printErrors(zap.NewExample(), nil) // you know, for coverage
+	// The actual test cen be found in the following locations:
+	//
+	// exporter_test.go where we filter logs by error scope
 }

--- a/extension/observer/ecsobserver/error_test.go
+++ b/extension/observer/ecsobserver/error_test.go
@@ -1,0 +1,30 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecsobserver
+
+import (
+	"fmt"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestSetInvalidError(t *testing.T) {
+	err := fmt.Errorf("std")
+	setErrTask(err, nil)
+	setErrContainer(err, 0, nil)
+	setErrTarget(err, MatchedTarget{}, 0, nil)
+	printErrors(zap.NewExample(), nil)
+}

--- a/extension/observer/ecsobserver/exporter.go
+++ b/extension/observer/ecsobserver/exporter.go
@@ -14,7 +14,17 @@
 
 package ecsobserver
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultMetricsPath = "/metrics"
+)
 
 // CommonExporterConfig should be embedded into filter config.
 // They set labels like job, metrics_path etc. that can override prometheus default.
@@ -44,4 +54,98 @@ type commonExportSetting struct {
 
 func (s *commonExportSetting) hasContainerPort(containerPort int) bool {
 	return s.metricsPorts[containerPort]
+}
+
+// TaskExporter converts annotated Task into PrometheusECSTarget.
+type TaskExporter struct {
+	logger  *zap.Logger
+	cluster string
+}
+
+func newTaskExporter(logger *zap.Logger, cluster string) *TaskExporter {
+	return &TaskExporter{
+		logger:  logger,
+		cluster: cluster,
+	}
+}
+
+// ExportTasks loops a list of tasks and export prometheus scrape targets.
+// It keeps track of error but does NOT stop when error occurs.
+// The returned targets are all valid and the error(s) are mainly for generating metrics.
+func (e *TaskExporter) ExportTasks(tasks []*Task) ([]PrometheusECSTarget, error) {
+	var merr error
+	var allTargets []PrometheusECSTarget
+	for _, t := range tasks {
+		targets, err := e.ExportTask(t)
+		multierr.AppendInto(&merr, err) // if err == nil, AppendInto does nothing
+		// Even if there are error, returned targets are still valid.
+		allTargets = append(allTargets, targets...)
+	}
+	return allTargets, merr
+}
+
+// ExportTask exports all the matched container within a single task.
+// One task can contain multiple containers. One container can have more than one target
+// if there are multiple ports in `metrics_port`.
+func (e *TaskExporter) ExportTask(task *Task) ([]PrometheusECSTarget, error) {
+	// All targets in one task shares same IP.
+	privateIP, err := task.PrivateIP()
+	if err != nil {
+		return nil, err
+	}
+
+	// Base for all the containers in this task, most attributes are same.
+	baseTarget := PrometheusECSTarget{
+		Source:                 aws.StringValue(task.Task.TaskArn),
+		MetricsPath:            defaultMetricsPath,
+		ClusterName:            e.cluster,
+		TaskDefinitionFamily:   aws.StringValue(task.Definition.Family),
+		TaskDefinitionRevision: int(aws.Int64Value(task.Definition.Revision)),
+		TaskStartedBy:          aws.StringValue(task.Task.StartedBy),
+		TaskLaunchType:         aws.StringValue(task.Task.LaunchType),
+		TaskGroup:              aws.StringValue(task.Task.Group),
+		TaskTags:               task.TaskTags(),
+		HealthStatus:           aws.StringValue(task.Task.HealthStatus),
+	}
+	if task.Service != nil {
+		baseTarget.ServiceName = aws.StringValue(task.Service.ServiceName)
+	}
+	if task.EC2 != nil {
+		ec2 := task.EC2
+		baseTarget.EC2InstanceID = aws.StringValue(ec2.InstanceId)
+		baseTarget.EC2InstanceType = aws.StringValue(ec2.InstanceType)
+		baseTarget.EC2Tags = task.EC2Tags()
+		baseTarget.EC2VpcID = aws.StringValue(ec2.VpcId)
+		baseTarget.EC2SubnetID = aws.StringValue(ec2.SubnetId)
+		baseTarget.EC2PrivateIP = privateIP
+		baseTarget.EC2PublicIP = aws.StringValue(ec2.PublicIpAddress)
+	}
+
+	var targetsInTask []PrometheusECSTarget
+	var merr error
+	for _, m := range task.Matched {
+		container := task.Definition.ContainerDefinitions[m.ContainerIndex]
+		// Shallow copy task level attributes
+		containerTarget := baseTarget
+		// Add container specific info
+		containerTarget.ContainerName = aws.StringValue(container.Name)
+		containerTarget.ContainerLabels = task.ContainerLabels(m.ContainerIndex)
+		// Multiple targets for a single container
+		for _, matchedTarget := range m.Targets {
+			// Shallow copy from container
+			target := containerTarget
+			mappedPort, err := task.MappedPort(container, int64(matchedTarget.Port))
+			// Skip this target and keep track of port error, does not abort.
+			if multierr.AppendInto(&merr, err) {
+				continue
+			}
+			target.Address = fmt.Sprintf("%s:%d", privateIP, mappedPort)
+			if matchedTarget.MetricsPath != "" {
+				target.MetricsPath = matchedTarget.MetricsPath
+			}
+			target.Job = matchedTarget.Job
+			targetsInTask = append(targetsInTask, target)
+		}
+	}
+	return targetsInTask, merr
 }

--- a/extension/observer/ecsobserver/exporter.go
+++ b/extension/observer/ecsobserver/exporter.go
@@ -56,14 +56,14 @@ func (s *commonExportSetting) hasContainerPort(containerPort int) bool {
 	return s.metricsPorts[containerPort]
 }
 
-// TaskExporter converts annotated Task into PrometheusECSTarget.
-type TaskExporter struct {
+// taskExporter converts annotated Task into PrometheusECSTarget.
+type taskExporter struct {
 	logger  *zap.Logger
 	cluster string
 }
 
-func newTaskExporter(logger *zap.Logger, cluster string) *TaskExporter {
-	return &TaskExporter{
+func newTaskExporter(logger *zap.Logger, cluster string) *taskExporter {
+	return &taskExporter{
 		logger:  logger,
 		cluster: cluster,
 	}
@@ -72,7 +72,7 @@ func newTaskExporter(logger *zap.Logger, cluster string) *TaskExporter {
 // ExportTasks loops a list of tasks and export prometheus scrape targets.
 // It keeps track of error but does NOT stop when error occurs.
 // The returned targets are all valid and the error(s) are mainly for generating metrics.
-func (e *TaskExporter) ExportTasks(tasks []*Task) ([]PrometheusECSTarget, error) {
+func (e *taskExporter) ExportTasks(tasks []*Task) ([]PrometheusECSTarget, error) {
 	var merr error
 	var allTargets []PrometheusECSTarget
 	for _, t := range tasks {
@@ -87,7 +87,7 @@ func (e *TaskExporter) ExportTasks(tasks []*Task) ([]PrometheusECSTarget, error)
 // ExportTask exports all the matched container within a single task.
 // One task can contain multiple containers. One container can have more than one target
 // if there are multiple ports in `metrics_port`.
-func (e *TaskExporter) ExportTask(task *Task) ([]PrometheusECSTarget, error) {
+func (e *taskExporter) ExportTask(task *Task) ([]PrometheusECSTarget, error) {
 	// All targets in one task shares same IP.
 	privateIP, err := task.PrivateIP()
 	if err != nil {

--- a/extension/observer/ecsobserver/exporter_test.go
+++ b/extension/observer/ecsobserver/exporter_test.go
@@ -1,0 +1,230 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecsobserver
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+func TestTaskExporter(t *testing.T) {
+	exp := newTaskExporter(zap.NewExample(), "ecs-cluster-1")
+
+	t.Run("invalid ip", func(t *testing.T) {
+		_, err := exp.ExportTask(&Task{
+			Task:       &ecs.Task{},
+			Definition: &ecs.TaskDefinition{},
+		})
+		assert.Error(t, err)
+		assert.IsType(t, &ErrPrivateIPNotFound{}, err)
+	})
+
+	awsVpcTask := &ecs.Task{
+		TaskArn:           aws.String("arn:task:t2"),
+		TaskDefinitionArn: aws.String("t2"),
+		Attachments: []*ecs.Attachment{
+			{
+				Type: aws.String("ElasticNetworkInterface"),
+				Details: []*ecs.KeyValuePair{
+					{
+						Name:  aws.String("privateIPv4Address"),
+						Value: aws.String("172.168.1.1"),
+					},
+				},
+			},
+		},
+	}
+	awsVpcTaskDef := &ecs.TaskDefinition{
+		ContainerDefinitions: []*ecs.ContainerDefinition{
+			{
+				PortMappings: []*ecs.PortMapping{
+					{
+						ContainerPort: aws.Int64(2112),
+						HostPort:      aws.Int64(2113),
+					},
+				},
+			},
+		},
+		NetworkMode: aws.String(ecs.NetworkModeAwsvpc),
+	}
+	t.Run("single target", func(t *testing.T) {
+		task := &Task{
+			Task:       awsVpcTask,
+			Definition: awsVpcTaskDef,
+			Matched: []MatchedContainer{
+				{
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeDockerLabel,
+							Port:        2112,
+							Job:         "PROM_JOB_1",
+						},
+					},
+				},
+			},
+		}
+
+		targets, err := exp.ExportTask(task)
+		require.NoError(t, err)
+		assert.Len(t, targets, 1)
+		assert.Equal(t, "172.168.1.1:2113", targets[0].Address)
+	})
+
+	t.Run("multiple target in one container", func(t *testing.T) {
+		task := &Task{
+			Task:       awsVpcTask,
+			Definition: awsVpcTaskDef,
+			Service:    &ecs.Service{ServiceName: aws.String("svc-1")},
+			Matched: []MatchedContainer{
+				{
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeDockerLabel,
+							Port:        2112,
+							Job:         "PROM_JOB_1",
+						},
+						{
+							Port: 404, // invalid in the middle, but shouldn't stop the export
+						},
+						{
+							MatcherType: MatcherTypeService,
+							Port:        2112,
+							Job:         "PROM_JOB_Service",
+							MetricsPath: "/service_metrics",
+						},
+					},
+				},
+			},
+		}
+
+		targets, err := exp.ExportTask(task)
+		require.Error(t, err)
+		merr := multierr.Errors(err)
+		require.Len(t, merr, 1)
+		assert.IsType(t, &ErrMappedPortNotFound{}, merr[0])
+		assert.Len(t, targets, 2)
+	})
+
+	t.Run("ec2", func(t *testing.T) {
+		task := &Task{
+			Task: &ecs.Task{
+				TaskArn:           aws.String("arn:task:t2"),
+				TaskDefinitionArn: aws.String("t2"),
+				Containers: []*ecs.Container{
+					{
+						Name: aws.String("c1"),
+						NetworkBindings: []*ecs.NetworkBinding{
+							{
+								ContainerPort: aws.Int64(2112),
+								HostPort:      aws.Int64(2114),
+							},
+						},
+					},
+				},
+			},
+			Definition: &ecs.TaskDefinition{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("c1"),
+						PortMappings: []*ecs.PortMapping{
+							{
+								ContainerPort: aws.Int64(2112),
+							},
+						},
+					},
+				},
+				NetworkMode: aws.String(ecs.NetworkModeBridge),
+			},
+			EC2: &ec2.Instance{PrivateIpAddress: aws.String("172.168.1.2")},
+			Matched: []MatchedContainer{
+				{
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeDockerLabel,
+							Port:        2112,
+							Job:         "PROM_JOB_1",
+						},
+					},
+				},
+			},
+		}
+
+		targets, err := exp.ExportTask(task)
+		require.NoError(t, err)
+		assert.Len(t, targets, 1)
+		assert.Equal(t, "172.168.1.2:2114", targets[0].Address)
+	})
+
+	validMatched := []MatchedContainer{
+		{
+			Targets: []MatchedTarget{
+				{
+					MatcherType: MatcherTypeDockerLabel,
+					Port:        2112,
+					Job:         "PROM_JOB_1",
+				},
+			},
+		},
+	}
+	invalidMatched := []MatchedContainer{
+		{
+			Targets: []MatchedTarget{
+				{
+					MatcherType: MatcherTypeDockerLabel,
+					Port:        404,
+					Job:         "PROM_JOB_1",
+				},
+				{
+					MatcherType: MatcherTypeDockerLabel,
+					Port:        405,
+					Job:         "PROM_JOB_1",
+				},
+			},
+		},
+	}
+	validTask := &Task{
+		Task:       awsVpcTask,
+		Definition: awsVpcTaskDef,
+		Matched:    validMatched,
+	}
+	invalidTask := &Task{
+		Task:       awsVpcTask,
+		Definition: awsVpcTaskDef,
+		Matched:    invalidMatched,
+	}
+	t.Run("all valid tasks", func(t *testing.T) {
+		// Just make sure the for loop is right, done care about the content, they are tested in previous cases
+		targets, err := exp.ExportTasks([]*Task{validTask, validTask})
+		assert.NoError(t, err)
+		assert.Len(t, targets, 2)
+	})
+
+	t.Run("invalid tasks", func(t *testing.T) {
+		targets, err := exp.ExportTasks([]*Task{validTask, invalidTask, validTask, invalidTask, invalidTask})
+		require.Error(t, err)
+		assert.Len(t, targets, 2)
+		merr := multierr.Errors(err)
+		// each invalid task has two invalid match, we have 3 invalid tasks
+		// multierr flatten multierr when appending
+		assert.Len(t, merr, 2*3)
+	})
+}

--- a/extension/observer/ecsobserver/go.sum
+++ b/extension/observer/ecsobserver/go.sum
@@ -63,7 +63,6 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/HdrHistogram/hdrhistogram-go v0.9.0/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qEclQKK70g0KxO61gFFZD4=
-github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/extension/observer/ecsobserver/internal/errctx/doc.go
+++ b/extension/observer/ecsobserver/internal/errctx/doc.go
@@ -1,0 +1,19 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package errctx allow attaching values to an error in a structural way
+// using WithValue and read the value out using ValueFrom.
+// It is inspired by context package and works along with error wrapping
+// introduced in go 1.13.
+package errctx

--- a/extension/observer/ecsobserver/internal/errctx/value.go
+++ b/extension/observer/ecsobserver/internal/errctx/value.go
@@ -67,7 +67,7 @@ func WithValue(err error, key string, val interface{}) error {
 	}
 }
 
-// WithValues attaches multiple key value pairs. The behaviour is similar to WithValue.
+// WithValues attaches multiple key value pairs. The behavior is similar to WithValue.
 func WithValues(err error, kvs map[string]interface{}) error {
 	if err == nil {
 		return nil

--- a/extension/observer/ecsobserver/internal/errctx/value.go
+++ b/extension/observer/ecsobserver/internal/errctx/value.go
@@ -1,0 +1,162 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errctx
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ErrorWithValue indicates the error has some (could be just one) key value pairs
+// attached to it during error wrapping.
+type ErrorWithValue interface {
+	error
+	// Value returns a value attached to the error by key.
+	// If the key does not exists, it returns nil, false.
+	// The value saved can be nil, so it can also returns nil, true
+	// to indicates a key exists but its value is nil.
+	//
+	// It does NOT do recursive Value calls (like context.Context).
+	// For getting value from entire error chain, use ValueFrom.
+	Value(key string) (v interface{}, ok bool)
+}
+
+// WithValue attaches a single key value pair to a non nil error.
+// If err is nil, it does nothing and return nil.
+// key has to be a non empty string otherwise it will panic.
+// val can be nil, and the existence of a key with nil value
+// can be distinguished using the bool return value in Value/ValueFrom call.
+//
+// It is a good practice to define the key as a constant strange instead of inline literal.
+//
+// 	const taskErrKey = "task"
+// 	return errctx.WithValue(taskErrKey, myTask)
+//  task, ok := errctx.ValueFrom(err, taskErrKey)
+func WithValue(err error, key string, val interface{}) error {
+	if err == nil {
+		return nil
+	}
+	// panic because this should not happen and there is no good way to return error when dealing w/ error.
+	// This is also how context.WithValue is implemented.
+	if key == "" {
+		panic("empty key in WithValue")
+	}
+	// NOTE: we don't check if the value is nil because unlike context.Context
+	// our value methods return a bool to indicates if the key exists or not
+	// so we can allow user to save key with nil value, user's error inspection logic
+	// need to be aware of that.
+
+	return &valueError{
+		key:   key,
+		val:   val,
+		inner: err,
+	}
+}
+
+// WithValues attaches multiple key value pairs. The behaviour is similar to WithValue.
+func WithValues(err error, kvs map[string]interface{}) error {
+	if err == nil {
+		return nil
+	}
+	// make a shallow copy, and hope the values in map are not map ...
+	m := make(map[string]interface{})
+	for k, v := range kvs {
+		if k == "" {
+			panic("empty key in WithValues")
+		}
+		m[k] = v
+	}
+	return &valuesError{
+		values: m,
+		inner:  err,
+	}
+}
+
+// ValueFrom traverse entire error chain and returns the value
+// from the first ErrorWithValue that contains the key.
+// e.g. for an error created using errctx.WithValue(errctx.WithValue(base, "k", "v1"), "k", "v2")
+// ValueFrom(err, "k") returns "v2".
+func ValueFrom(err error, key string) (interface{}, bool) {
+	if err == nil {
+		return nil, false
+	}
+	verr, ok := err.(ErrorWithValue)
+	if ok {
+		v, vok := verr.Value(key)
+		if vok {
+			return v, vok
+		}
+	}
+
+	// Check if this is a wrapped error
+	// I guess tail recursion should be optimized by compiler so we don't need to unroll it into for loop.
+	return ValueFrom(errors.Unwrap(err), key)
+}
+
+// valueError only contains one pair, which is common
+type valueError struct {
+	key   string
+	val   interface{}
+	inner error
+}
+
+func (e *valueError) Error() string {
+	return fmt.Sprintf("%s %s=%v", e.inner.Error(), e.key, e.val)
+}
+
+func (e *valueError) Value(key string) (interface{}, bool) {
+	if key == e.key {
+		return e.val, true
+	}
+	return nil, false
+}
+
+func (e *valueError) Unwrap() error {
+	return e.inner
+}
+
+// valuesError contains multiple pairs
+type valuesError struct {
+	values map[string]interface{}
+	inner  error
+}
+
+func (e *valuesError) Error() string {
+	// NOTE: in order to have a consistent output, we sort the keys
+	var keys []string
+	for k := range e.values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	sb.WriteString(e.inner.Error())
+	for _, k := range keys {
+		v := e.values[k]
+		sb.WriteString(fmt.Sprintf(" %s=%v", k, v))
+	}
+	return sb.String()
+}
+
+func (e *valuesError) Value(key string) (interface{}, bool) {
+	v, ok := e.values[key]
+	return v, ok
+}
+
+func (e *valuesError) Unwrap() error {
+	return e.inner
+}

--- a/extension/observer/ecsobserver/internal/errctx/value_test.go
+++ b/extension/observer/ecsobserver/internal/errctx/value_test.go
@@ -1,0 +1,98 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errctx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithValue(t *testing.T) {
+	assert.Nil(t, WithValue(nil, "a", "b"))
+	assert.Panics(t, func() {
+		WithValue(fmt.Errorf("base"), "", nil)
+	})
+
+	e1 := WithValue(fmt.Errorf("base"), "a", "b")
+	assert.Equal(t, "base a=b", e1.Error())
+	v1, ok := ValueFrom(e1, "a")
+	assert.True(t, ok)
+	assert.Equal(t, "b", v1)
+
+	// No exists
+	v2, ok := ValueFrom(e1, "404")
+	assert.False(t, ok)
+	assert.Nil(t, v2)
+
+	// Allow nil
+	e2 := WithValue(e1, "nilval", nil)
+	v3, ok := ValueFrom(e2, "nilval")
+	assert.True(t, ok)
+	assert.Nil(t, v3)
+}
+
+func TestWithValues(t *testing.T) {
+	assert.Nil(t, WithValues(nil, map[string]interface{}{"a": "b"}))
+	assert.Panics(t, func() {
+		WithValues(fmt.Errorf("base"), map[string]interface{}{"": "123"})
+	})
+
+	e1 := WithValues(fmt.Errorf("base"), map[string]interface{}{"a": "b", "c": 123})
+	// NOTE: we sort the key in the impl so the test is not flaky
+	assert.Equal(t, "base a=b c=123", e1.Error())
+	v1, ok := ValueFrom(e1, "a")
+	assert.True(t, ok)
+	assert.Equal(t, "b", v1)
+
+	v2, ok := ValueFrom(e1, "404")
+	assert.False(t, ok)
+	assert.Nil(t, v2)
+}
+
+func TestValueFrom(t *testing.T) {
+	v, ok := ValueFrom(nil, "a")
+	assert.Nil(t, v)
+	assert.False(t, ok)
+
+	// Chained with value in the middle
+	t.Run("chained", func(t *testing.T) {
+		e1 := fmt.Errorf("base")
+		e2 := WithValue(e1, "a", "b")
+		e3 := fmt.Errorf("l2 %w", e2)
+
+		v, ok = ValueFrom(e3, "a")
+		assert.True(t, ok)
+		assert.Equal(t, "b", v)
+	})
+
+	// When there is duplication in the chain, the first one comes out got picked up.
+	t.Run("duplication", func(t *testing.T) {
+		e1 := fmt.Errorf("base")
+		e2 := WithValue(e1, "a", "e2")
+		e3 := fmt.Errorf("e3 %w", e2)
+		e4 := WithValue(e3, "a", "e4")
+
+		v, ok = ValueFrom(e4, "a")
+		assert.True(t, ok)
+		assert.Equal(t, "e4", v)
+
+		v, ok = ValueFrom(e2, "a")
+		assert.True(t, ok)
+		assert.Equal(t, "e2", v)
+	})
+
+}

--- a/extension/observer/ecsobserver/target.go
+++ b/extension/observer/ecsobserver/target.go
@@ -81,7 +81,9 @@ const (
 	labelEC2PublicIP            = labelPrefix + "ec2_public_ip"
 )
 
-func TargetToLabels(t PrometheusECSTarget) map[string]string {
+// ToLabels converts fields in the target to map.
+// It also sanitize label name because the requirements on AWS tags and Prometheus are different.
+func (t *PrometheusECSTarget) ToLabels() map[string]string {
 	labels := map[string]string{
 		labelSource:                 t.Source,
 		labelAddress:                t.Address,

--- a/extension/observer/ecsobserver/target_test.go
+++ b/extension/observer/ecsobserver/target_test.go
@@ -28,7 +28,7 @@ func TestTargetToLabels(t *testing.T) {
 				"ab":  "same",
 			},
 		}
-		m := TargetToLabels(pt)
+		m := pt.ToLabels()
 		assert.Equal(t, "sanitized", m["__meta_ecs_task_tags_a_b"])
 		assert.Equal(t, "same", m["__meta_ecs_task_tags_ab"])
 	})

--- a/extension/observer/ecsobserver/task.go
+++ b/extension/observer/ecsobserver/task.go
@@ -87,8 +87,6 @@ type ErrPrivateIPNotFound struct {
 	TaskArn     string
 	NetworkMode string
 	Extra       string // extra message
-	// detail error report
-	baseTaskError
 }
 
 func (e *ErrPrivateIPNotFound) Error() string {
@@ -156,10 +154,6 @@ type ErrMappedPortNotFound struct {
 	NetworkMode   string
 	ContainerName string
 	ContainerPort int64
-	// detail error report
-	baseTaskError
-	containerIndex int
-	target         MatchedTarget
 }
 
 func (e *ErrMappedPortNotFound) Error() string {
@@ -171,22 +165,6 @@ func (e *ErrMappedPortNotFound) Error() string {
 
 func (e *ErrMappedPortNotFound) message() string {
 	return "mapped port not found"
-}
-
-func (e *ErrMappedPortNotFound) setContainerIndex(i int) {
-	e.containerIndex = i
-}
-
-func (e *ErrMappedPortNotFound) getContainerIndex() int {
-	return e.containerIndex
-}
-
-func (e *ErrMappedPortNotFound) setTarget(t MatchedTarget) {
-	e.target = t
-}
-
-func (e *ErrMappedPortNotFound) getTarget() MatchedTarget {
-	return e.target
 }
 
 func (e *ErrMappedPortNotFound) zapFields() []zap.Field {


### PR DESCRIPTION
**Description:** 

Export discovered ECS task as Prometheus scrape targets.

**Link to tracking Issue:**

- Feature request #1395 

Pending PRs

- Task fetcher and ECS mock https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3284
- Docker Label Matcher (approved) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3276

Previous PRs

- Task IP and Port (merged) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3133
- Target and Task definition (merged) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2939
- Config PR (merged) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2377
- Original PR (closed) #2734 

**Testing:** 

unit test

**Documentation:** 

No new doc. See [existing doc](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/observer/ecsobserver/README.md)