### PR TITLE
Enrich tailsamplingprocessor string-attribute-filter to support regex on span attribute filtering

### DIFF
--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -14,7 +14,7 @@ The following configuration options are required:
 Multiple policies exist today and it is straight forward to add more. These include:
 - `always_sample`: Sample all traces
 - `numeric_attribute`: Sample based on number attributes
-- `string_attribute`: Sample based on string attributes
+- `string_attribute`: Sample based on string attributes value matches, both exact and regex value matches are supported
 - `rate_limiting`: Sample based on rate
 
 The following configuration options can also be modified:
@@ -45,6 +45,11 @@ processors:
             name: test-policy-3,
             type: string_attribute,
             string_attribute: {key: key2, values: [value1, value2]}
+          },
+          {
+            name: test-policy-3,
+            type: string_attribute,
+            string_attribute: {key: key2, values: [value1, val*], enabled_regex_matching: true, cache_max_size: 10}
           },
           {
             name: test-policy-4,

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -66,8 +66,15 @@ type NumericAttributeCfg struct {
 type StringAttributeCfg struct {
 	// Tag that the filter is going to be matching against.
 	Key string `mapstructure:"key"`
-	// Values is the set of attribute values that if any is equal to the actual attribute value to be considered a match.
+	// Values indicate the set of values or regular expressions to use when matching against attribute values.
+	// StringAttribute Policy will apply exact value match on Values unless EnabledRegexMatching is true.
 	Values []string `mapstructure:"values"`
+	// EnabledRegexMatching determines whether match attribute values by regexp string.
+	EnabledRegexMatching bool `mapstructure:"enabled_regex_matching"`
+	// CacheMaxSize is the maximum number of attribute entries of LRU Cache that stores the matched result
+	// from the regular expressions defined in Values.
+	// CacheMaxSize will not be used if EnabledRegexMatching is set to false.
+	CacheMaxSize int `mapstructure:"cache_max_size"`
 }
 
 // RateLimitingCfg holds the configurable settings to create a rate limiting

--- a/processor/tailsamplingprocessor/go.mod
+++ b/processor/tailsamplingprocessor/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/armon/go-metrics v0.3.3 // indirect
 	github.com/gogo/googleapis v1.3.0 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-immutable-radix v1.2.0 // indirect
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -122,7 +122,7 @@ func getPolicyEvaluator(logger *zap.Logger, cfg *PolicyCfg) (sampling.PolicyEval
 		return sampling.NewNumericAttributeFilter(logger, nafCfg.Key, nafCfg.MinValue, nafCfg.MaxValue), nil
 	case StringAttribute:
 		safCfg := cfg.StringAttributeCfg
-		return sampling.NewStringAttributeFilter(logger, safCfg.Key, safCfg.Values), nil
+		return sampling.NewStringAttributeFilter(logger, safCfg.Key, safCfg.Values, safCfg.EnabledRegexMatching, safCfg.CacheMaxSize), nil
 	case RateLimiting:
 		rlfCfg := cfg.RateLimitingCfg
 		return sampling.NewRateLimiting(logger, rlfCfg.SpansPerSecond), nil

--- a/processor/tailsamplingprocessor/sampling/string_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/sampling/string_tag_filter_test.go
@@ -22,54 +22,117 @@ import (
 	"go.uber.org/zap"
 )
 
+// TestStringAttributeCfg is replicated with StringAttributeCfg
+type TestStringAttributeCfg struct {
+	Key                  string
+	Values               []string
+	EnabledRegexMatching bool
+	CacheMaxSize         int
+}
+
 func TestStringTagFilter(t *testing.T) {
 
 	var empty = map[string]pdata.AttributeValue{}
-	filter := NewStringAttributeFilter(zap.NewNop(), "example", []string{"value"})
 
 	cases := []struct {
-		Desc     string
-		Trace    *TraceData
-		Decision Decision
+		Desc      string
+		Trace     *TraceData
+		filterCfg *TestStringAttributeCfg
+		Decision  Decision
 	}{
 		{
-			Desc:     "nonmatching node attribute key",
-			Trace:    newTraceStringAttrs(map[string]pdata.AttributeValue{"non_matching": pdata.NewAttributeValueString("value")}, "", ""),
-			Decision: NotSampled,
+			Desc:      "nonmatching node attribute key",
+			Trace:     newTraceStringAttrs(map[string]pdata.AttributeValue{"non_matching": pdata.NewAttributeValueString("value")}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
 		},
 		{
-			Desc:     "nonmatching node attribute value",
-			Trace:    newTraceStringAttrs(map[string]pdata.AttributeValue{"example": pdata.NewAttributeValueString("non_matching")}, "", ""),
-			Decision: NotSampled,
+			Desc:      "nonmatching node attribute value",
+			Trace:     newTraceStringAttrs(map[string]pdata.AttributeValue{"example": pdata.NewAttributeValueString("non_matching")}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
 		},
 		{
-			Desc:     "matching node attribute",
-			Trace:    newTraceStringAttrs(map[string]pdata.AttributeValue{"example": pdata.NewAttributeValueString("value")}, "", ""),
-			Decision: Sampled,
+			Desc:      "matching node attribute",
+			Trace:     newTraceStringAttrs(map[string]pdata.AttributeValue{"example": pdata.NewAttributeValueString("value")}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  Sampled,
 		},
 		{
-			Desc:     "nonmatching span attribute key",
-			Trace:    newTraceStringAttrs(empty, "nonmatching", "value"),
-			Decision: NotSampled,
+			Desc:      "nonmatching span attribute key",
+			Trace:     newTraceStringAttrs(empty, "nonmatching", "value"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
 		},
 		{
-			Desc:     "nonmatching span attribute value",
-			Trace:    newTraceStringAttrs(empty, "example", "nonmatching"),
-			Decision: NotSampled,
+			Desc:      "nonmatching span attribute value",
+			Trace:     newTraceStringAttrs(empty, "example", "nonmatching"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
 		},
 		{
-			Desc:     "matching span attribute",
-			Trace:    newTraceStringAttrs(empty, "example", "value"),
-			Decision: Sampled,
+			Desc:      "matching span attribute",
+			Trace:     newTraceStringAttrs(empty, "example", "value"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: false, CacheMaxSize: defaultCacheSize},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "matching span attribute with regex",
+			Trace:     newTraceStringAttrs(empty, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[0-9]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "nonmatching span attribute with regex",
+			Trace:     newTraceStringAttrs(empty, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[a-z]+.HealthCheck$"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize},
+			Decision:  NotSampled,
+		},
+		{
+			Desc:      "matching span attribute with regex without CacheSize provided in config",
+			Trace:     newTraceStringAttrs(empty, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"v[0-9]+.HealthCheck$"}, EnabledRegexMatching: true},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "matching plain text node attribute in regex",
+			Trace:     newTraceStringAttrs(map[string]pdata.AttributeValue{"example": pdata.NewAttributeValueString("value")}, "", ""),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{"value"}, EnabledRegexMatching: true, CacheMaxSize: defaultCacheSize},
+			Decision:  Sampled,
+		},
+		{
+			Desc:      "nonmatching span attribute on empty filter list",
+			Trace:     newTraceStringAttrs(empty, "example", "grpc.health.v1.HealthCheck"),
+			filterCfg: &TestStringAttributeCfg{Key: "example", Values: []string{}, EnabledRegexMatching: true},
+			Decision:  NotSampled,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.Desc, func(t *testing.T) {
+			filter := NewStringAttributeFilter(zap.NewNop(), c.filterCfg.Key, c.filterCfg.Values, c.filterCfg.EnabledRegexMatching, c.filterCfg.CacheMaxSize)
 			decision, err := filter.Evaluate(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), c.Trace)
 			assert.NoError(t, err)
 			assert.Equal(t, decision, c.Decision)
 		})
+	}
+}
+
+func BenchmarkStringTagFilterEvaluatePlainText(b *testing.B) {
+	trace := newTraceStringAttrs(map[string]pdata.AttributeValue{"example": pdata.NewAttributeValueString("value")}, "", "")
+	filter := NewStringAttributeFilter(zap.NewNop(), "example", []string{"value"}, false, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		filter.Evaluate(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), trace)
+	}
+}
+
+func BenchmarkStringTagFilterEvaluateRegex(b *testing.B) {
+	trace := newTraceStringAttrs(map[string]pdata.AttributeValue{"example": pdata.NewAttributeValueString("grpc.health.v1.HealthCheck")}, "", "")
+	filter := NewStringAttributeFilter(zap.NewNop(), "example", []string{"v[0-9]+.HealthCheck$"}, true, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		filter.Evaluate(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}), trace)
 	}
 }
 
@@ -92,7 +155,7 @@ func newTraceStringAttrs(nodeAttrs map[string]pdata.AttributeValue, spanAttrKey 
 }
 
 func TestOnLateArrivingSpans_StringAttribute(t *testing.T) {
-	filter := NewStringAttributeFilter(zap.NewNop(), "example", []string{"value"})
+	filter := NewStringAttributeFilter(zap.NewNop(), "example", []string{"value"}, false, defaultCacheSize)
 	err := filter.OnLateArrivingSpans(NotSampled, nil)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Allow `string-attribute-filter` in `tailsamplingprocessor`  to support both plain text and `regex` rule when filtering the span attribute by matching the value. 
This is a task in P2 milestone list.

New Config Example,
```
processors:
  tail_sampling:
    decision_wait: 10s
    num_traces: 100
    expected_new_traces_per_sec: 10
    policies:
       [
          {
               name: test-policy-3,
               type: string_attribute,
               string_attribute: {key: "key", values: ["v[0-9]+\.Health\.Check$", "plain_text"]}
          }
      ]
```
### Benchmark
**Before,**
```
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/sampling
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
**BenchmarkStringTagFilterEvaluatePlainText**
BenchmarkStringTagFilterEvaluatePlainText-8   	29896698	        40.31 ns/op
```
**After,**
```
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/sampling
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkStringTagFilterEvaluatePlainText
BenchmarkStringTagFilterEvaluatePlainText-8   	30917172	        41.27 ns/op

pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/sampling
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkStringTagFilterEvaluateRegex
BenchmarkStringTagFilterEvaluateRegex-8   	18788356	        63.94 ns/op
```

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30155

**Testing:**
`make all`
**Documentation:** 
README