### PR TITLE
Include the response in returned 400 errors

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
 	"sync"
 
@@ -113,7 +115,7 @@ func (c *client) sendSplunkEvents(ctx context.Context, splunkEvents []*splunk.Ev
 	return c.postEvents(ctx, body, compressed)
 }
 
-func (c *client) pushLogData(ctx context.Context, ld pdata.Logs) (err error) {
+func (c *client) pushLogData(ctx context.Context, ld pdata.Logs) error {
 	c.wg.Add(1)
 	defer c.wg.Done()
 
@@ -151,7 +153,7 @@ func (c *client) pushLogData(ctx context.Context, ld pdata.Logs) (err error) {
 // pushLogDataInBatches sends batches of Splunk events in JSON format.
 // The batch content length is restricted to MaxContentLengthLogs.
 // ld log records are parsed to Splunk events.
-func (c *client) pushLogDataInBatches(ctx context.Context, ld pdata.Logs, send func(context.Context, *bytes.Buffer) error) (err error) {
+func (c *client) pushLogDataInBatches(ctx context.Context, ld pdata.Logs, send func(context.Context, *bytes.Buffer) error) error {
 	// Length of retained bytes in buffer after truncation.
 	var bufLen int
 	// Buffer capacity.
@@ -186,7 +188,7 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld pdata.Logs, send f
 				// Parsing log record to Splunk event.
 				event := mapLogRecordToSplunkEvent(res, logs.At(k), c.config, c.logger)
 				// JSON encoding event and writing to buffer.
-				if err = encoder.Encode(event); err != nil {
+				if err := encoder.Encode(event); err != nil {
 					permanentErrors = append(permanentErrors, consumererror.Permanent(fmt.Errorf("dropped log event: %v, error: %v", event, err)))
 					continue
 				}
@@ -214,7 +216,7 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld pdata.Logs, send f
 				// Truncating buffer at tracked length below capacity and sending.
 				buf.Truncate(bufLen)
 				if buf.Len() > 0 {
-					if err = send(ctx, buf); err != nil {
+					if err := send(ctx, buf); err != nil {
 						return consumererror.NewLogs(err, *subLogs(&ld, bufFront))
 					}
 				}
@@ -229,7 +231,7 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld pdata.Logs, send f
 	}
 
 	if buf.Len() > 0 {
-		if err = send(ctx, buf); err != nil {
+		if err := send(ctx, buf); err != nil {
 			return consumererror.NewLogs(err, *subLogs(&ld, bufFront))
 		}
 	}
@@ -259,7 +261,22 @@ func (c *client) postEvents(ctx context.Context, events io.Reader, compressed bo
 	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
 
-	return splunk.HandleHTTPCode(resp)
+	if err = splunk.HandleHTTPCode(resp); err != nil && resp.StatusCode == http.StatusBadRequest {
+		var err2 error
+
+		if req.Body, err2 = req.GetBody(); err2 != nil {
+			log.Fatal(err2)
+		}
+		defer req.Body.Close()
+
+		var dump []byte
+		if dump, err2 = httputil.DumpRequestOut(req, true); err2 != nil {
+			log.Fatal(err2)
+		}
+		err = fmt.Errorf("%w for request %q", err, dump)
+	}
+
+	return err
 }
 
 // subLogs returns a subset of `ld` starting from index `from` to the end.


### PR DESCRIPTION
**Description:** Include the response in the returned error for response status code 400. That way when the error is logged it will contain the response which is helpful for troubleshooting.

**Testing:** Test_pushLogData_ShouldAddResponseTo400Error