### PR TITLE
[exporter/signalfx] add info log for host metadata properties update

### DIFF
--- a/exporter/signalfxexporter/hostmetadata/metadata.go
+++ b/exporter/signalfxexporter/hostmetadata/metadata.go
@@ -72,6 +72,8 @@ func (s *Syncer) syncOnResource(res pdata.Resource) {
 	}
 
 	metadataUpdate := s.prepareMetadataUpdate(props, hostID)
+	s.logger.Info("Preparing to sync host properties to host dimension", zap.String("dimension_key", string(hostID.Key)),
+		zap.String("dimension_value", hostID.ID), zap.Any("properties", props))
 	err := s.dimClient.PushMetadata([]*metadata.MetadataUpdate{metadataUpdate})
 	if err != nil {
 		s.logger.Error("Failed to push host metadata update", zap.Error(err))


### PR DESCRIPTION
Results in a log like:
```
2021-05-07T15:34:33.517Z	info	hostmetadata/metadata.go:85	Preparing host metadata update	{"kind": "exporter", "name": "signalfx", "dimension_key": "host.name", "dimension_value": "192.168.0.0", "properties": {"host_cpu_cores":"2","host_cpu_model":"Intel(R) Core(TM) i7-8850H CPU @ 2.60GHz","host_kernel_name":"linux","host_kernel_release":"4.19.150","host_kernel_version":"#1 SMP Fri Nov 6 15:58:07 PST 2020","host_linux_version":"","host_logical_cpus":"2","host_machine":"x86_64","host_mem_total":"5952388","host_os_name":"","host_physical_cpus":"2","host_processor":"x86_64"}}
```

I decided to make this an Info log over debug because it should only log once per start up, and this info will be useful for support.