### PR TITLE
Map summary metrics to Splunk hec metrics

### DIFF
--- a/exporter/splunkhecexporter/metricdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk_test.go
@@ -528,6 +528,80 @@ func Test_metricDataToSplunk(t *testing.T) {
 			},
 		},
 		{
+			name: "summary",
+			metricsDataFn: func() pdata.Metrics {
+				metrics := newMetricsWithResources()
+				ilm := metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0)
+				summary := ilm.Metrics().AppendEmpty()
+				summary.SetName("summary")
+				summary.SetDataType(pdata.MetricDataTypeSummary)
+				doubleDataPt := summary.Summary().DataPoints().AppendEmpty()
+				doubleDataPt.SetTimestamp(ts)
+				doubleDataPt.SetStartTimestamp(ts)
+				doubleDataPt.SetCount(2)
+				doubleDataPt.SetSum(42)
+				qt1 := doubleDataPt.QuantileValues().AppendEmpty()
+				qt1.SetQuantile(0.5)
+				qt1.SetValue(34)
+				qt2 := doubleDataPt.QuantileValues().AppendEmpty()
+				qt2.SetQuantile(0.6)
+				qt2.SetValue(45)
+				return metrics
+			},
+			wantSplunkMetrics: []*splunk.Event{
+				{
+					Host:       "unknown",
+					Source:     "",
+					SourceType: "",
+					Event:      "metric",
+					Time:       tsMSecs,
+					Fields: map[string]interface{}{
+						"k0":                      "v0",
+						"k1":                      "v1",
+						"metric_name:summary_sum": float64(42),
+					},
+				},
+				{
+					Host:       "unknown",
+					Source:     "",
+					SourceType: "",
+					Event:      "metric",
+					Time:       tsMSecs,
+					Fields: map[string]interface{}{
+						"k0":                        "v0",
+						"k1":                        "v1",
+						"metric_name:summary_count": uint64(2),
+					},
+				},
+				{
+					Host:       "unknown",
+					Source:     "",
+					SourceType: "",
+					Event:      "metric",
+					Time:       tsMSecs,
+					Fields: map[string]interface{}{
+						"k0":                      "v0",
+						"k1":                      "v1",
+						"qt":                      "0.5",
+						"metric_name:summary_0.5": float64(34),
+					},
+				},
+				{
+					Host:       "unknown",
+					Source:     "",
+					SourceType: "",
+					Event:      "metric",
+					Time:       tsMSecs,
+					Fields: map[string]interface{}{
+						"k0":                      "v0",
+						"k1":                      "v1",
+						"qt":                      "0.6",
+						"metric_name:summary_0.6": float64(45),
+					},
+				},
+			},
+		},
+		{
 			name: "unknown_type",
 			metricsDataFn: func() pdata.Metrics {
 				metrics := newMetricsWithResources()
@@ -545,6 +619,7 @@ func Test_metricDataToSplunk(t *testing.T) {
 			md := tt.metricsDataFn()
 			gotMetrics, gotNumDroppedTimeSeries := metricDataToSplunk(logger, md, &Config{})
 			assert.Equal(t, tt.wantNumDroppedTimeseries, gotNumDroppedTimeSeries)
+			assert.Equal(t, len(gotMetrics), len(tt.wantSplunkMetrics))
 			for i, want := range tt.wantSplunkMetrics {
 				assert.Equal(t, want, gotMetrics[i])
 			}

--- a/exporter/splunkhecexporter/metricdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk_test.go
@@ -619,7 +619,6 @@ func Test_metricDataToSplunk(t *testing.T) {
 			md := tt.metricsDataFn()
 			gotMetrics, gotNumDroppedTimeSeries := metricDataToSplunk(logger, md, &Config{})
 			assert.Equal(t, tt.wantNumDroppedTimeseries, gotNumDroppedTimeSeries)
-			assert.Equal(t, len(gotMetrics), len(tt.wantSplunkMetrics))
 			for i, want := range tt.wantSplunkMetrics {
 				assert.Equal(t, want, gotMetrics[i])
 			}


### PR DESCRIPTION
**Description:** 
Adds mapping of the summary data type to Splunk HEC metrics.

**Link to tracking Issue:** 
#3319 

**Testing:** 
One unit test.