### PR TITLE
[exporter/datadog]: improve mappings for span kind dd span type

### DIFF
--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -43,9 +43,13 @@ const (
 	currentILNameTag    string = "otel.library.name"
 	errorCode           int32  = 1
 	okCode              int32  = 0
-	httpKind            string = "http"
-	webKind             string = "web"
-	customKind          string = "custom"
+	kindDb              string = "db"
+	kindHTTP            string = "http"
+	kindWeb             string = "web"
+	kindCustom          string = "custom"
+	kindCache           string = "cache"
+	kindMemcached       string = "memcached"
+	kindRedis           string = "redis"
 	grpcPath            string = "grpc.path"
 	eventsTag           string = "events"
 	eventNameTag        string = "name"
@@ -282,7 +286,7 @@ func spanToDatadogSpan(s pdata.Span,
 		Duration: duration,
 		Metrics:  map[string]float64{},
 		Meta:     make(map[string]string, len(tags)),
-		Type:     spanKindToDatadogType(s.Kind()),
+		Type:     inferDatadogType(s.Kind(), tags),
 		Error:    isSpanError,
 	}
 
@@ -376,16 +380,31 @@ func buildDatadogContainerTags(spanTags map[string]string) string {
 	return strings.TrimSuffix(b.String(), ",")
 }
 
-// TODO: some clients send SPAN_KIND_UNSPECIFIED for valid kinds
-// we also need a more formal mapping for cache and db types
-func spanKindToDatadogType(kind pdata.SpanKind) string {
+// inferDatadogTypes returns a string for the datadog type based on metadata
+// in the otel span. DB semantic conventions state that what datadog
+// would mark as a db or cache span type, otel marks as a CLIENT span kind, but
+// has a required attribute 'db.system'. This is the only required attribute for
+// db or cache spans, so we can reliably use it as a heuristic for infering the
+// difference between client, db, and cache span types. The only "cache" spans
+// in datadog currently are redis and memcached, so those are the only two db.system
+// attribute values we have to check to determine whether it's a db or cache span
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#semantic-conventions-for-database-client-calls
+func inferDatadogType(kind pdata.SpanKind, datadogTags map[string]string) string {
 	switch kind {
 	case pdata.SpanKindCLIENT:
-		return httpKind
+		if dbSysOtlp, okDbSysOtlp := datadogTags[conventions.AttributeDBSystem]; okDbSysOtlp {
+			if dbSysOtlp == kindRedis || dbSysOtlp == kindMemcached {
+				return kindCache
+			}
+
+			return kindDb
+		}
+
+		return kindHTTP
 	case pdata.SpanKindSERVER:
-		return webKind
+		return kindWeb
 	default:
-		return customKind
+		return kindCustom
 	}
 }
 

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -392,7 +392,7 @@ func buildDatadogContainerTags(spanTags map[string]string) string {
 func inferDatadogType(kind pdata.SpanKind, datadogTags map[string]string) string {
 	switch kind {
 	case pdata.SpanKindCLIENT:
-		if dbSysOtlp, okDbSysOtlp := datadogTags[conventions.AttributeDBSystem]; okDbSysOtlp {
+		if dbSysOtlp, ok := datadogTags[conventions.AttributeDBSystem]; ok {
 			if dbSysOtlp == kindRedis || dbSysOtlp == kindMemcached {
 				return kindCache
 			}

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -1058,13 +1058,26 @@ func TestSpanNameNormalization(t *testing.T) {
 
 // ensure that the datadog span type gets mapped from span kind
 func TestSpanTypeTranslation(t *testing.T) {
-	spanTypeClient := spanKindToDatadogType(pdata.SpanKindCLIENT)
-	spanTypeServer := spanKindToDatadogType(pdata.SpanKindSERVER)
-	spanTypeCustom := spanKindToDatadogType(pdata.SpanKindUNSPECIFIED)
+	spanTypeClient := inferDatadogType(pdata.SpanKindCLIENT, map[string]string{})
+	spanTypeServer := inferDatadogType(pdata.SpanKindSERVER, map[string]string{})
+	spanTypeCustom := inferDatadogType(pdata.SpanKindUNSPECIFIED, map[string]string{})
+
+	ddTagsDb := map[string]string{
+		"db.system": "postgres",
+	}
+
+	ddTagsCache := map[string]string{
+		"db.system": "redis",
+	}
+
+	spanTypeDb := inferDatadogType(pdata.SpanKindCLIENT, ddTagsDb)
+	spanTypeCache := inferDatadogType(pdata.SpanKindCLIENT, ddTagsCache)
 
 	assert.Equal(t, "http", spanTypeClient)
 	assert.Equal(t, "web", spanTypeServer)
 	assert.Equal(t, "custom", spanTypeCustom)
+	assert.Equal(t, "db", spanTypeDb)
+	assert.Equal(t, "cache", spanTypeCache)
 
 }
 

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -1063,22 +1063,27 @@ func TestSpanTypeTranslation(t *testing.T) {
 	spanTypeCustom := inferDatadogType(pdata.SpanKindUNSPECIFIED, map[string]string{})
 
 	ddTagsDb := map[string]string{
-		"db.system": "postgres",
+		"db.system": "postgresql",
 	}
 
 	ddTagsCache := map[string]string{
 		"db.system": "redis",
 	}
 
+	ddTagsCacheAlt := map[string]string{
+		"db.system": "memcached",
+	}
+
 	spanTypeDb := inferDatadogType(pdata.SpanKindCLIENT, ddTagsDb)
 	spanTypeCache := inferDatadogType(pdata.SpanKindCLIENT, ddTagsCache)
+	spanTypeCacheAlt := inferDatadogType(pdata.SpanKindCLIENT, ddTagsCacheAlt)
 
 	assert.Equal(t, "http", spanTypeClient)
 	assert.Equal(t, "web", spanTypeServer)
 	assert.Equal(t, "custom", spanTypeCustom)
 	assert.Equal(t, "db", spanTypeDb)
 	assert.Equal(t, "cache", spanTypeCache)
-
+	assert.Equal(t, "cache", spanTypeCacheAlt)
 }
 
 // ensure that the IL Tags extraction handles nil case


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This PR Adds some additional mappings between opentelemetry span kind and datadog span type, that allow users to see more specialized UIs and representation of traces properly marked `db` or `cache` whereas previously they were all `custom`

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.> updated unit tests

**Documentation:** <Describe the documentation added.>