### PR TITLE
Report raw cumulative metric value under non container insights prome…

### DIFF
--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -224,6 +224,8 @@ func getDataPoints(pmd *pdata.Metric, metadata CWMetricMetadata, logger *zap.Log
 		return
 	}
 
+	// We only calculate delta when metrics are generated for container insights prometheus
+	isContainerInsightsPromMetric := metadata.receiver == containerInsightsPrometheusReceiver
 	adjusterMetadata := deltaMetricMetadata{
 		false,
 		pmd.Name(),
@@ -250,7 +252,8 @@ func getDataPoints(pmd *pdata.Metric, metadata CWMetricMetadata, logger *zap.Log
 		}
 	case pdata.MetricDataTypeIntSum:
 		metric := pmd.IntSum()
-		adjusterMetadata.adjustToDelta = metric.AggregationTemporality() == pdata.AggregationTemporalityCumulative
+		adjusterMetadata.adjustToDelta = metric.AggregationTemporality() == pdata.AggregationTemporalityCumulative &&
+			isContainerInsightsPromMetric
 		dps = IntDataPointSlice{
 			metadata.InstrumentationLibraryName,
 			adjusterMetadata,
@@ -258,7 +261,8 @@ func getDataPoints(pmd *pdata.Metric, metadata CWMetricMetadata, logger *zap.Log
 		}
 	case pdata.MetricDataTypeDoubleSum:
 		metric := pmd.DoubleSum()
-		adjusterMetadata.adjustToDelta = metric.AggregationTemporality() == pdata.AggregationTemporalityCumulative
+		adjusterMetadata.adjustToDelta = metric.AggregationTemporality() == pdata.AggregationTemporalityCumulative &&
+			isContainerInsightsPromMetric
 		dps = DoubleDataPointSlice{
 			metadata.InstrumentationLibraryName,
 			adjusterMetadata,
@@ -272,7 +276,7 @@ func getDataPoints(pmd *pdata.Metric, metadata CWMetricMetadata, logger *zap.Log
 		}
 	case pdata.MetricDataTypeSummary:
 		metric := pmd.Summary()
-		adjusterMetadata.adjustToDelta = true
+		adjusterMetadata.adjustToDelta = isContainerInsightsPromMetric
 		dps = SummaryDataPointSlice{
 			metadata.InstrumentationLibraryName,
 			adjusterMetadata,

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -335,7 +335,14 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 			"w/ 2nd delta calculation",
 			false,
 			float64(0.5),
-			float64(0.1),
+			float64(0.5),
+		},
+		{
+			"w/ 3nd delta calculation",
+			true,
+			float64(0.6),
+			// 2nd is not stored in cache as it's skipped
+			float64(0.2),
 		},
 	}
 
@@ -369,7 +376,7 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 
 			assert.Equal(t, 1, dps.Len())
 			dp := dps.At(0)
-			assert.True(t, (expectedDP.Value.(float64)-dp.Value.(float64)) < 0.002)
+			assert.InDelta(t, expectedDP.Value.(float64), dp.Value.(float64), 0.002)
 		})
 	}
 }
@@ -517,6 +524,7 @@ func TestGetDataPoints(t *testing.T) {
 			LogStream:   "log-stream",
 		},
 		InstrumentationLibraryName: "cloudwatch-otel",
+		receiver:                   containerInsightsPrometheusReceiver,
 	}
 
 	dmm := deltaMetricMetadata{

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -34,9 +34,9 @@ const (
 	zeroAndSingleDimensionRollup = "ZeroAndSingleDimensionRollup"
 	singleDimensionRollupOnly    = "SingleDimensionRollupOnly"
 
-	prometheusReceiver        = "prometheus"
-	attributeReceiver         = "receiver"
-	fieldPrometheusMetricType = "prom_metric_type"
+	containerInsightsPrometheusReceiver = "container_insights_prometheus"
+	attributeReceiver                   = "receiver"
+	fieldPrometheusMetricType           = "prom_metric_type"
 )
 
 var fieldPrometheusTypes = map[pdata.MetricDataType]string{
@@ -146,8 +146,8 @@ func translateGroupedMetricToCWMetric(groupedMetric *GroupedMetric, config *Conf
 	labels := groupedMetric.Labels
 	fieldsLength := len(labels) + len(groupedMetric.Metrics)
 
-	isPrometheusMetric := groupedMetric.Metadata.receiver == prometheusReceiver
-	if isPrometheusMetric {
+	isContainerInsightsPromMetric := groupedMetric.Metadata.receiver == containerInsightsPrometheusReceiver
+	if isContainerInsightsPromMetric {
 		fieldsLength++
 	}
 	fields := make(map[string]interface{}, fieldsLength)
@@ -160,7 +160,7 @@ func translateGroupedMetricToCWMetric(groupedMetric *GroupedMetric, config *Conf
 	for metricName, metricInfo := range groupedMetric.Metrics {
 		fields[metricName] = metricInfo.Value
 	}
-	if isPrometheusMetric {
+	if isContainerInsightsPromMetric {
 		fields[fieldPrometheusMetricType] = fieldPrometheusTypes[groupedMetric.Metadata.metricDataType]
 	}
 

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -52,7 +52,7 @@ func createMetricTestData() internaldata.MetricsData {
 			Labels: map[string]string{
 				conventions.AttributeServiceName:      "myServiceName",
 				conventions.AttributeServiceNamespace: "myServiceNS",
-				attributeReceiver:                     prometheusReceiver,
+				attributeReceiver:                     containerInsightsPrometheusReceiver,
 			},
 		},
 		Metrics: []*metricspb.Metric{
@@ -832,7 +832,7 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 						Namespace:   namespace,
 						TimestampMs: timestamp,
 					},
-					receiver:       prometheusReceiver,
+					receiver:       containerInsightsPrometheusReceiver,
 					metricDataType: pdata.MetricDataTypeDoubleGauge,
 				},
 			},


### PR DESCRIPTION
**Why do we need it?**
Fixes https://github.com/aws-observability/aws-otel-collector/issues/510.

This PR checks whether metrics are tagged with `prometheus` attribute (which only exists when metrics are used for container insights prometheus) to decide whether EMF exporter should calculate delta for cumulative metrics or not.