### PR TITLE
Use CircleCI contexts to inject secrets into jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,9 +165,13 @@ workflows:
           requires:
             - setup
       - run-stability-tests:
+          context:
+            - github-release-and-issues-api-token
           requires:
             - cross-compile 
       - publish-dev:
+          context:
+            - dockerhub-token
           requires:
             - run-stability-tests
 
@@ -175,6 +179,8 @@ workflows:
     when: << pipeline.parameters.run-build-publish >>
     jobs:
       - windows-test:
+          context:
+            - github-release-and-issues-api-token
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
@@ -201,6 +207,8 @@ workflows:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
       - loadtest:
+          context:
+            - github-release-and-issues-api-token
           requires:
             - cross-compile 
           filters:
@@ -230,6 +238,9 @@ workflows:
             - deb-package
             - rpm-package
       - publish-stable:
+          context:
+            - github-release-and-issues-api-token
+            - dockerhub-token
           requires:
             - lint
             - unit-tests


### PR DESCRIPTION
This will ensure only the jobs that require the secrets get access to
them as opposed to all jobs getting access via environment variables.

Contexts can also be shared between projects so we'll have a single
place to manage secrets for both core and contrib CI jobs.

I'll follow up with another change next week that'll further restrict
access to contexts only to maintainers (or a new publishers group).
