### PR TITLE
[extension/ecsobserver] Add service and task definition based matcher

### DIFF
--- a/extension/observer/ecsobserver/config.go
+++ b/extension/observer/ecsobserver/config.go
@@ -53,7 +53,8 @@ type Config struct {
 	DockerLabels []DockerLabelConfig `mapstructure:"docker_labels" yaml:"docker_labels"`
 }
 
-// Validate overrides the embedded noop validation.
+// Validate overrides the embedded noop validation so that load config can trigger
+// our own validation logic.
 func (c *Config) Validate() error {
 	if c.ClusterName == "" {
 		// TODO: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3188
@@ -61,17 +62,17 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("must specify ECS cluster name directly")
 	}
 	for _, s := range c.Services {
-		if err := s.Validate(); err != nil {
+		if err := s.validate(); err != nil {
 			return err
 		}
 	}
 	for _, t := range c.TaskDefinitions {
-		if err := t.Validate(); err != nil {
+		if err := t.validate(); err != nil {
 			return err
 		}
 	}
 	for _, d := range c.DockerLabels {
-		if err := d.Validate(); err != nil {
+		if err := d.validate(); err != nil {
 			return err
 		}
 	}

--- a/extension/observer/ecsobserver/config.go
+++ b/extension/observer/ecsobserver/config.go
@@ -15,6 +15,7 @@
 package ecsobserver
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -50,6 +51,31 @@ type Config struct {
 	TaskDefinitions []TaskDefinitionConfig `mapstructure:"task_definitions" yaml:"task_definitions"`
 	// DockerLabels is a list of docker labels for filtering containers within tasks.
 	DockerLabels []DockerLabelConfig `mapstructure:"docker_labels" yaml:"docker_labels"`
+}
+
+// Validate overrides the embedded noop validation.
+func (c *Config) Validate() error {
+	if c.ClusterName == "" {
+		// TODO: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3188
+		// would allow auto detect cluster name in extension
+		return fmt.Errorf("must specify ECS cluster name directly")
+	}
+	for _, s := range c.Services {
+		if err := s.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, t := range c.TaskDefinitions {
+		if err := t.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, d := range c.DockerLabels {
+		if err := d.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // DefaultConfig only applies docker label

--- a/extension/observer/ecsobserver/docker_label.go
+++ b/extension/observer/ecsobserver/docker_label.go
@@ -39,23 +39,29 @@ type DockerLabelConfig struct {
 	MetricsPathLabel string `mapstructure:"metrics_path_label" yaml:"metrics_path_label"`
 }
 
-func (d *DockerLabelConfig) Init() error {
+func (d *DockerLabelConfig) Validate() error {
+	_, err := d.NewMatcher(MatcherOptions{})
+	return err
+}
+
+func (d *DockerLabelConfig) NewMatcher(options MatcherOptions) (Matcher, error) {
 	// It's possible to support it in the future, but for now just fail at config,
 	// so user don't need to wonder which port is used in the exported target.
 	if len(d.MetricsPorts) != 0 {
-		return fmt.Errorf("metrics_ports is not supported in docker_labels, got %v", d.MetricsPorts)
+		return nil, fmt.Errorf("metrics_ports is not supported in docker_labels, got %v", d.MetricsPorts)
 	}
 	if d.PortLabel == "" {
-		return fmt.Errorf("port_label is empty")
+		return nil, fmt.Errorf("port_label is empty")
 	}
-	return nil
-}
-
-func (d *DockerLabelConfig) NewMatcher(options MatcherOptions) Matcher {
+	expSetting, err := d.newExportSetting()
+	if err != nil {
+		return nil, err
+	}
 	return &dockerLabelMatcher{
-		logger: options.Logger,
-		cfg:    *d,
-	}
+		logger:        options.Logger,
+		cfg:           *d,
+		exportSetting: expSetting,
+	}, nil
 }
 
 func dockerLabelConfigToMatchers(cfgs []DockerLabelConfig) []MatcherConfig {
@@ -71,8 +77,9 @@ func dockerLabelConfigToMatchers(cfgs []DockerLabelConfig) []MatcherConfig {
 // dockerLabelMatcher implements Matcher interface.
 // It checks PortLabel from config and only matches if the label value is a valid number.
 type dockerLabelMatcher struct {
-	logger *zap.Logger
-	cfg    DockerLabelConfig
+	logger        *zap.Logger
+	cfg           DockerLabelConfig
+	exportSetting *commonExportSetting
 }
 
 func (d *dockerLabelMatcher) Type() MatcherType {

--- a/extension/observer/ecsobserver/docker_label.go
+++ b/extension/observer/ecsobserver/docker_label.go
@@ -39,12 +39,12 @@ type DockerLabelConfig struct {
 	MetricsPathLabel string `mapstructure:"metrics_path_label" yaml:"metrics_path_label"`
 }
 
-func (d *DockerLabelConfig) Validate() error {
-	_, err := d.NewMatcher(MatcherOptions{})
+func (d *DockerLabelConfig) validate() error {
+	_, err := d.newMatcher(MatcherOptions{})
 	return err
 }
 
-func (d *DockerLabelConfig) NewMatcher(options MatcherOptions) (Matcher, error) {
+func (d *DockerLabelConfig) newMatcher(options MatcherOptions) (Matcher, error) {
 	// It's possible to support it in the future, but for now just fail at config,
 	// so user don't need to wonder which port is used in the exported target.
 	if len(d.MetricsPorts) != 0 {
@@ -64,8 +64,8 @@ func (d *DockerLabelConfig) NewMatcher(options MatcherOptions) (Matcher, error) 
 	}, nil
 }
 
-func dockerLabelConfigToMatchers(cfgs []DockerLabelConfig) []MatcherConfig {
-	var matchers []MatcherConfig
+func dockerLabelConfigToMatchers(cfgs []DockerLabelConfig) []matcherConfig {
+	var matchers []matcherConfig
 	for _, cfg := range cfgs {
 		// NOTE: &cfg points to the temp var, whose value would end up be the last one in the slice.
 		copied := cfg

--- a/extension/observer/ecsobserver/docker_label.go
+++ b/extension/observer/ecsobserver/docker_label.go
@@ -51,11 +51,21 @@ func (d *DockerLabelConfig) Init() error {
 	return nil
 }
 
-func (d *DockerLabelConfig) NewMatcher(options MatcherOptions) (Matcher, error) {
+func (d *DockerLabelConfig) NewMatcher(options MatcherOptions) Matcher {
 	return &dockerLabelMatcher{
 		logger: options.Logger,
 		cfg:    *d,
-	}, nil
+	}
+}
+
+func dockerLabelConfigToMatchers(cfgs []DockerLabelConfig) []MatcherConfig {
+	var matchers []MatcherConfig
+	for _, cfg := range cfgs {
+		// NOTE: &cfg points to the temp var, whose value would end up be the last one in the slice.
+		copied := cfg
+		matchers = append(matchers, &copied)
+	}
+	return matchers
 }
 
 // dockerLabelMatcher implements Matcher interface.

--- a/extension/observer/ecsobserver/docker_label_test.go
+++ b/extension/observer/ecsobserver/docker_label_test.go
@@ -27,7 +27,7 @@ import (
 func TestDockerLabelMatcher_Match(t *testing.T) {
 	t.Run("must set port label", func(t *testing.T) {
 		var cfg DockerLabelConfig
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 	})
 
 	t.Run("metrics_ports not supported", func(t *testing.T) {
@@ -37,21 +37,21 @@ func TestDockerLabelMatcher_Match(t *testing.T) {
 				MetricsPorts: []int{404},
 			},
 		}
-		assert.Error(t, cfg.Validate())
+		assert.Error(t, cfg.validate())
 	})
 
 	t.Run("invalid export config", func(t *testing.T) {
 		cfg := DockerLabelConfig{PortLabel: "foo", CommonExporterConfig: CommonExporterConfig{
 			MetricsPorts: []int{8080, 8080},
 		}}
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 	})
 
 	t.Run("valid", func(t *testing.T) {
 		cfg := DockerLabelConfig{
 			PortLabel: "PORT_PROM",
 		}
-		assert.NoError(t, cfg.Validate())
+		assert.NoError(t, cfg.validate())
 	})
 
 	portLabel := "MY_PROMETHEUS_PORT"

--- a/extension/observer/ecsobserver/docker_label_test.go
+++ b/extension/observer/ecsobserver/docker_label_test.go
@@ -27,24 +27,31 @@ import (
 func TestDockerLabelMatcher_Match(t *testing.T) {
 	t.Run("must set port label", func(t *testing.T) {
 		var cfg DockerLabelConfig
-		require.Error(t, cfg.Init())
+		require.Error(t, cfg.Validate())
 	})
 
 	t.Run("metrics_ports not supported", func(t *testing.T) {
 		cfg := DockerLabelConfig{
 			PortLabel: "foo",
 			CommonExporterConfig: CommonExporterConfig{
-				MetricsPorts: []int{404}, // they should be ignored
+				MetricsPorts: []int{404},
 			},
 		}
-		assert.Error(t, cfg.Init())
+		assert.Error(t, cfg.Validate())
+	})
+
+	t.Run("invalid export config", func(t *testing.T) {
+		cfg := DockerLabelConfig{PortLabel: "foo", CommonExporterConfig: CommonExporterConfig{
+			MetricsPorts: []int{8080, 8080},
+		}}
+		require.Error(t, cfg.Validate())
 	})
 
 	t.Run("valid", func(t *testing.T) {
 		cfg := DockerLabelConfig{
 			PortLabel: "PORT_PROM",
 		}
-		assert.NoError(t, cfg.Init())
+		assert.NoError(t, cfg.Validate())
 	})
 
 	portLabel := "MY_PROMETHEUS_PORT"

--- a/extension/observer/ecsobserver/matcher.go
+++ b/extension/observer/ecsobserver/matcher.go
@@ -58,7 +58,7 @@ type MatchResult struct {
 
 type MatchedContainer struct {
 	TaskIndex      int // Index in task list
-	ContainerIndex int // Index within a tasks defintion's container list
+	ContainerIndex int // Index within a tasks definition's container list
 	Targets        []MatchedTarget
 }
 
@@ -138,7 +138,7 @@ func matchContainers(tasks []*Task, matcher Matcher, matcherIndex int) (*MatchRe
 	}, merr
 }
 
-// matchContainerByName is used by TaskDefinitionMatcher and serviceMatcher.
+// matchContainerByName is used by taskDefinitionMatcher and serviceMatcher.
 // The only exception is DockerLabelMatcher because it get ports from docker label.
 func matchContainerByName(nameRegex *regexp.Regexp, expCfg CommonExporterConfig, container *ecs.ContainerDefinition) ([]MatchedTarget, error) {
 	if nameRegex != nil && !nameRegex.MatchString(aws.StringValue(container.Name)) {

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -38,9 +38,7 @@ func TestNewDiscovery(t *testing.T) {
 
 func newMatcher(t *testing.T, cfg MatcherConfig) Matcher {
 	require.NoError(t, cfg.Init())
-	m, err := cfg.NewMatcher(testMatcherOptions())
-	require.NoError(t, err)
-	return m
+	return cfg.NewMatcher(testMatcherOptions())
 }
 
 func newMatcherAndMatch(t *testing.T, cfg MatcherConfig, tasks []*Task) *MatchResult {

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -36,13 +36,13 @@ func TestNewDiscovery(t *testing.T) {
 
 // Util Start
 
-func newMatcher(t *testing.T, cfg MatcherConfig) Matcher {
-	m, err := cfg.NewMatcher(testMatcherOptions())
+func newMatcher(t *testing.T, cfg matcherConfig) Matcher {
+	m, err := cfg.newMatcher(testMatcherOptions())
 	require.NoError(t, err)
 	return m
 }
 
-func newMatcherAndMatch(t *testing.T, cfg MatcherConfig, tasks []*Task) *MatchResult {
+func newMatcherAndMatch(t *testing.T, cfg matcherConfig, tasks []*Task) *MatchResult {
 	m := newMatcher(t, cfg)
 	res, err := matchContainers(tasks, m, 0)
 	require.NoError(t, err)

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -37,8 +37,9 @@ func TestNewDiscovery(t *testing.T) {
 // Util Start
 
 func newMatcher(t *testing.T, cfg MatcherConfig) Matcher {
-	require.NoError(t, cfg.Init())
-	return cfg.NewMatcher(testMatcherOptions())
+	m, err := cfg.NewMatcher(testMatcherOptions())
+	require.NoError(t, err)
+	return m
 }
 
 func newMatcherAndMatch(t *testing.T, cfg MatcherConfig, tasks []*Task) *MatchResult {

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -38,13 +38,6 @@ type ServiceConfig struct {
 	containerNameRegex *regexp.Regexp
 }
 
-func (s *ServiceConfig) NewMatcher(opts MatcherOptions) (Matcher, error) {
-	return &serviceMatcher{
-		logger: opts.Logger,
-		cfg:    *s,
-	}, nil
-}
-
 func (s *ServiceConfig) Init() error {
 	if s.NamePattern == "" {
 		return fmt.Errorf("name_pattern is empty")
@@ -63,6 +56,23 @@ func (s *ServiceConfig) Init() error {
 		s.containerNameRegex = r
 	}
 	return nil
+}
+
+func (s *ServiceConfig) NewMatcher(opts MatcherOptions) Matcher {
+	return &serviceMatcher{
+		logger: opts.Logger,
+		cfg:    *s,
+	}
+}
+
+func serviceConfigsToMatchers(cfgs []ServiceConfig) []MatcherConfig {
+	var matchers []MatcherConfig
+	for _, cfg := range cfgs {
+		// NOTE: &cfg points to the temp var, whose value would end up be the last one in the slice.
+		copied := cfg
+		matchers = append(matchers, &copied)
+	}
+	return matchers
 }
 
 type serviceMatcher struct {

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -33,12 +33,12 @@ type ServiceConfig struct {
 	ContainerNamePattern string `mapstructure:"container_name_pattern" yaml:"container_name_pattern"`
 }
 
-func (s *ServiceConfig) Validate() error {
-	_, err := s.NewMatcher(MatcherOptions{})
+func (s *ServiceConfig) validate() error {
+	_, err := s.newMatcher(MatcherOptions{})
 	return err
 }
 
-func (s *ServiceConfig) NewMatcher(opts MatcherOptions) (Matcher, error) {
+func (s *ServiceConfig) newMatcher(opts MatcherOptions) (Matcher, error) {
 	if s.NamePattern == "" {
 		return nil, fmt.Errorf("name_pattern is empty")
 	}
@@ -67,8 +67,8 @@ func (s *ServiceConfig) NewMatcher(opts MatcherOptions) (Matcher, error) {
 	}, nil
 }
 
-func serviceConfigsToMatchers(cfgs []ServiceConfig) []MatcherConfig {
-	var matchers []MatcherConfig
+func serviceConfigsToMatchers(cfgs []ServiceConfig) []matcherConfig {
+	var matchers []matcherConfig
 	for _, cfg := range cfgs {
 		// NOTE: &cfg points to the temp var, whose value would end up be the last one in the slice.
 		copied := cfg

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -84,6 +84,6 @@ func (s *serviceMatcher) MatchTargets(t *Task, c *ecs.ContainerDefinition) ([]Ma
 	if !s.cfg.nameRegex.MatchString(aws.StringValue(t.Service.ServiceName)) {
 		return nil, errNotMatched
 	}
-	// The rest is same as TaskDefinitionMatcher
+	// The rest is same as taskDefinitionMatcher
 	return matchContainerByName(s.cfg.containerNameRegex, s.cfg.CommonExporterConfig, c)
 }

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -14,12 +14,76 @@
 
 package ecsobserver
 
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"go.uber.org/zap"
+)
+
 type ServiceConfig struct {
 	CommonExporterConfig `mapstructure:",squash" yaml:",inline"`
 
-	// NamePattern is mandetory, empty string means service name based match is skipped.
+	// NamePattern is mandatory.
 	NamePattern string `mapstructure:"name_pattern" yaml:"name_pattern"`
 	// ContainerNamePattern is optional, empty string means all containers in that service would be exported.
 	// Otherwise both service and container name petterns need to metch.
 	ContainerNamePattern string `mapstructure:"container_name_pattern" yaml:"container_name_pattern"`
+
+	// should never be nil because Init must reject it and caller should stop
+	nameRegex *regexp.Regexp
+	// if nil, matches all the container in the task (whose service name is matched by nameRegex)
+	containerNameRegex *regexp.Regexp
+}
+
+func (s *ServiceConfig) NewMatcher(opts MatcherOptions) (Matcher, error) {
+	return &serviceMatcher{
+		logger: opts.Logger,
+		cfg:    *s,
+	}, nil
+}
+
+func (s *ServiceConfig) Init() error {
+	if s.NamePattern == "" {
+		return fmt.Errorf("name_pattern is empty")
+	}
+
+	r, err := regexp.Compile(s.NamePattern)
+	if err != nil {
+		return fmt.Errorf("invalid name pattern %w", err)
+	}
+	s.nameRegex = r
+	if s.ContainerNamePattern != "" {
+		r, err = regexp.Compile(s.ContainerNamePattern)
+		if err != nil {
+			return fmt.Errorf("invalid container name pattern %w", err)
+		}
+		s.containerNameRegex = r
+	}
+	return nil
+}
+
+type serviceMatcher struct {
+	logger *zap.Logger
+	cfg    ServiceConfig
+}
+
+func (s *serviceMatcher) Type() MatcherType {
+	return MatcherTypeService
+}
+
+func (s *serviceMatcher) MatchTargets(t *Task, c *ecs.ContainerDefinition) ([]MatchedTarget, error) {
+	// Service info is only attached for tasks whose services are included in config.
+	// However, Match is called on tasks so we need to guard nil pointer.
+	if t.Service == nil {
+		return nil, errNotMatched
+	}
+	// nameRegex should never be nil
+	if !s.cfg.nameRegex.MatchString(aws.StringValue(t.Service.ServiceName)) {
+		return nil, errNotMatched
+	}
+	// The rest is same as TaskDefinitionMatcher
+	return matchContainerByName(s.cfg.containerNameRegex, s.cfg.CommonExporterConfig, c)
 }

--- a/extension/observer/ecsobserver/service_test.go
+++ b/extension/observer/ecsobserver/service_test.go
@@ -1,0 +1,145 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecsobserver
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceMatcher(t *testing.T) {
+	t.Run("must set name pattern", func(t *testing.T) {
+		var cfg ServiceConfig
+		require.Error(t, cfg.Init())
+	})
+
+	t.Run("invalid regex", func(t *testing.T) {
+		invalidRegex := "*" //  missing argument to repetition operator: `*`
+		cfg := ServiceConfig{NamePattern: invalidRegex}
+		require.Error(t, cfg.Init())
+
+		cfg = ServiceConfig{NamePattern: "valid", ContainerNamePattern: invalidRegex}
+		require.Error(t, cfg.Init())
+	})
+
+	emptyDef := &ecs.TaskDefinition{
+		ContainerDefinitions: []*ecs.ContainerDefinition{
+			{
+				Name: aws.String("I got nothing, just to trigger the for loop ~~for coverage~~"),
+			},
+		},
+	}
+	genTasks := func() []*Task {
+		return []*Task{
+			{
+				Service: &ecs.Service{ServiceName: aws.String("nginx-service")},
+				Definition: &ecs.TaskDefinition{
+					ContainerDefinitions: []*ecs.ContainerDefinition{
+						{
+							Name: aws.String("port-2112"),
+							PortMappings: []*ecs.PortMapping{
+								{
+									ContainerPort: aws.Int64(2112),
+									HostPort:      aws.Int64(2113), // doesn't matter for matcher test
+								},
+							},
+						},
+						{
+							Name: aws.String("port-2114"),
+							PortMappings: []*ecs.PortMapping{
+								{
+									ContainerPort: aws.Int64(2113 + 1), // a different port
+									HostPort:      aws.Int64(2113),     // doesn't matter for matcher test
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Service:    &ecs.Service{ServiceName: aws.String("memcached-service")},
+				Definition: emptyDef,
+			},
+			{
+				// No service
+				Definition: emptyDef,
+			},
+		}
+	}
+
+	t.Run("service name only", func(t *testing.T) {
+		cfg := ServiceConfig{
+			NamePattern: "nginx",
+			CommonExporterConfig: CommonExporterConfig{
+				JobName:      "CONFIG_PROM_JOB",
+				MetricsPorts: []int{2112},
+			},
+		}
+		res := newMatcherAndMatch(t, &cfg, genTasks())
+		assert.Equal(t, &MatchResult{
+			Tasks: []int{0},
+			Containers: []MatchedContainer{
+				{
+					TaskIndex:      0,
+					ContainerIndex: 0,
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeService,
+							Port:        2112,
+							Job:         "CONFIG_PROM_JOB",
+						},
+					},
+				},
+				{
+					TaskIndex:      0,
+					ContainerIndex: 1,
+					Targets:        nil, // the container itself is matched, but it has no matching port
+				},
+			},
+		}, res)
+	})
+
+	t.Run("container name", func(t *testing.T) {
+		cfg := ServiceConfig{
+			NamePattern:          "nginx",
+			ContainerNamePattern: ".*-2114",
+			CommonExporterConfig: CommonExporterConfig{
+				JobName:      "CONFIG_PROM_JOB",
+				MetricsPorts: []int{2112, 2114},
+			},
+		}
+		res := newMatcherAndMatch(t, &cfg, genTasks())
+		assert.Equal(t, &MatchResult{
+			Tasks: []int{0},
+			Containers: []MatchedContainer{
+				{
+					TaskIndex:      0,
+					ContainerIndex: 1,
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeService,
+							Port:        2114,
+							Job:         "CONFIG_PROM_JOB",
+						},
+					},
+				},
+			},
+		}, res)
+	})
+}

--- a/extension/observer/ecsobserver/service_test.go
+++ b/extension/observer/ecsobserver/service_test.go
@@ -26,23 +26,23 @@ import (
 func TestServiceMatcher(t *testing.T) {
 	t.Run("must set name pattern", func(t *testing.T) {
 		var cfg ServiceConfig
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 	})
 
 	t.Run("invalid regex", func(t *testing.T) {
 		invalidRegex := "*" //  missing argument to repetition operator: `*`
 		cfg := ServiceConfig{NamePattern: invalidRegex}
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 
 		cfg = ServiceConfig{NamePattern: "valid", ContainerNamePattern: invalidRegex}
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 	})
 
 	t.Run("invalid export config", func(t *testing.T) {
 		cfg := ServiceConfig{NamePattern: "valid", CommonExporterConfig: CommonExporterConfig{
 			MetricsPorts: []int{8080, 8080},
 		}}
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 	})
 
 	emptyDef := &ecs.TaskDefinition{

--- a/extension/observer/ecsobserver/service_test.go
+++ b/extension/observer/ecsobserver/service_test.go
@@ -26,16 +26,23 @@ import (
 func TestServiceMatcher(t *testing.T) {
 	t.Run("must set name pattern", func(t *testing.T) {
 		var cfg ServiceConfig
-		require.Error(t, cfg.Init())
+		require.Error(t, cfg.Validate())
 	})
 
 	t.Run("invalid regex", func(t *testing.T) {
 		invalidRegex := "*" //  missing argument to repetition operator: `*`
 		cfg := ServiceConfig{NamePattern: invalidRegex}
-		require.Error(t, cfg.Init())
+		require.Error(t, cfg.Validate())
 
 		cfg = ServiceConfig{NamePattern: "valid", ContainerNamePattern: invalidRegex}
-		require.Error(t, cfg.Init())
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("invalid export config", func(t *testing.T) {
+		cfg := ServiceConfig{NamePattern: "valid", CommonExporterConfig: CommonExporterConfig{
+			MetricsPorts: []int{8080, 8080},
+		}}
+		require.Error(t, cfg.Validate())
 	})
 
 	emptyDef := &ecs.TaskDefinition{

--- a/extension/observer/ecsobserver/task_definition.go
+++ b/extension/observer/ecsobserver/task_definition.go
@@ -33,12 +33,12 @@ type TaskDefinitionConfig struct {
 	ContainerNamePattern string `mapstructure:"container_name_pattern" yaml:"container_name_pattern"`
 }
 
-func (t *TaskDefinitionConfig) Validate() error {
-	_, err := t.NewMatcher(MatcherOptions{})
+func (t *TaskDefinitionConfig) validate() error {
+	_, err := t.newMatcher(MatcherOptions{})
 	return err
 }
 
-func (t *TaskDefinitionConfig) NewMatcher(opts MatcherOptions) (Matcher, error) {
+func (t *TaskDefinitionConfig) newMatcher(opts MatcherOptions) (Matcher, error) {
 	if t.ArnPattern == "" {
 		return nil, fmt.Errorf("arn_pattern is empty")
 	}
@@ -67,8 +67,8 @@ func (t *TaskDefinitionConfig) NewMatcher(opts MatcherOptions) (Matcher, error) 
 	}, nil
 }
 
-func taskDefinitionConfigsToMatchers(cfgs []TaskDefinitionConfig) []MatcherConfig {
-	var matchers []MatcherConfig
+func taskDefinitionConfigsToMatchers(cfgs []TaskDefinitionConfig) []matcherConfig {
+	var matchers []matcherConfig
 	for _, cfg := range cfgs {
 		// NOTE: &cfg points to the temp var, whose value would end up be the last one in the slice.
 		copied := cfg

--- a/extension/observer/ecsobserver/task_definition.go
+++ b/extension/observer/ecsobserver/task_definition.go
@@ -58,11 +58,21 @@ func (t *TaskDefinitionConfig) Init() error {
 	return nil
 }
 
-func (t *TaskDefinitionConfig) NewMatcher(opts MatcherOptions) (Matcher, error) {
+func (t *TaskDefinitionConfig) NewMatcher(opts MatcherOptions) Matcher {
 	return &taskDefinitionMatcher{
 		logger: opts.Logger,
 		cfg:    *t,
-	}, nil
+	}
+}
+
+func taskDefinitionConfigsToMatchers(cfgs []TaskDefinitionConfig) []MatcherConfig {
+	var matchers []MatcherConfig
+	for _, cfg := range cfgs {
+		// NOTE: &cfg points to the temp var, whose value would end up be the last one in the slice.
+		copied := cfg
+		matchers = append(matchers, &copied)
+	}
+	return matchers
 }
 
 type taskDefinitionMatcher struct {

--- a/extension/observer/ecsobserver/task_definition_test.go
+++ b/extension/observer/ecsobserver/task_definition_test.go
@@ -1,0 +1,145 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecsobserver
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskDefinitionMatcher(t *testing.T) {
+	t.Run("must set arn pattern", func(t *testing.T) {
+		var cfg TaskDefinitionConfig
+		require.Error(t, cfg.Init())
+	})
+
+	t.Run("invalid regex", func(t *testing.T) {
+		invalidRegex := "*" //  missing argument to repetition operator: `*`
+		cfg := TaskDefinitionConfig{ArnPattern: invalidRegex}
+		require.Error(t, cfg.Init())
+
+		cfg = TaskDefinitionConfig{ArnPattern: "arn:is:valid:regexp", ContainerNamePattern: invalidRegex}
+		require.Error(t, cfg.Init())
+	})
+
+	emptyTask := &Task{
+		Task: &ecs.Task{TaskDefinitionArn: aws.String("arn:that:never:matches")},
+		Definition: &ecs.TaskDefinition{
+			TaskDefinitionArn: aws.String("arn:that:never:matches"),
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("I got nothing, just to trigger the for loop ~~for coverage~~"),
+				},
+			},
+		},
+	}
+	genTasks := func() []*Task {
+		return []*Task{
+			{
+				Task: &ecs.Task{
+					TaskDefinitionArn: aws.String("arn:alike:nginx-latest"),
+				},
+				Definition: &ecs.TaskDefinition{
+					TaskDefinitionArn: aws.String("arn:alike:nginx-latest"),
+					ContainerDefinitions: []*ecs.ContainerDefinition{
+						{
+							Name: aws.String("port-2112"),
+							PortMappings: []*ecs.PortMapping{
+								{
+									ContainerPort: aws.Int64(2112),
+									HostPort:      aws.Int64(2113), // doesn't matter for matcher test
+								},
+							},
+						},
+						{
+							Name: aws.String("port-2114"),
+							PortMappings: []*ecs.PortMapping{
+								{
+									ContainerPort: aws.Int64(2113 + 1), // a different port
+									HostPort:      aws.Int64(2113),     // doesn't matter for matcher test
+								},
+							},
+						},
+					},
+				},
+			},
+			emptyTask,
+		}
+	}
+
+	t.Run("arn only", func(t *testing.T) {
+		cfg := TaskDefinitionConfig{
+			ArnPattern: "nginx",
+			CommonExporterConfig: CommonExporterConfig{
+				JobName:      "CONFIG_PROM_JOB",
+				MetricsPorts: []int{2112},
+			},
+		}
+		res := newMatcherAndMatch(t, &cfg, genTasks())
+		assert.Equal(t, &MatchResult{
+			Tasks: []int{0},
+			Containers: []MatchedContainer{
+				{
+					TaskIndex:      0,
+					ContainerIndex: 0,
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeTaskDefinition,
+							Port:        2112,
+							Job:         "CONFIG_PROM_JOB",
+						},
+					},
+				},
+				{
+					TaskIndex:      0,
+					ContainerIndex: 1,
+					Targets:        nil, // the container itself is matched, but it has no matching port
+				},
+			},
+		}, res)
+	})
+
+	t.Run("container name", func(t *testing.T) {
+		cfg := TaskDefinitionConfig{
+			ArnPattern:           "nginx",
+			ContainerNamePattern: ".*-2114",
+			CommonExporterConfig: CommonExporterConfig{
+				JobName:      "CONFIG_PROM_JOB",
+				MetricsPorts: []int{2112, 2114},
+			},
+		}
+		res := newMatcherAndMatch(t, &cfg, genTasks())
+		assert.Equal(t, &MatchResult{
+			Tasks: []int{0},
+			Containers: []MatchedContainer{
+				{
+					TaskIndex:      0,
+					ContainerIndex: 1,
+					Targets: []MatchedTarget{
+						{
+							MatcherType: MatcherTypeTaskDefinition,
+							Port:        2114,
+							Job:         "CONFIG_PROM_JOB",
+						},
+					},
+				},
+			},
+		}, res)
+	})
+}

--- a/extension/observer/ecsobserver/task_definition_test.go
+++ b/extension/observer/ecsobserver/task_definition_test.go
@@ -26,23 +26,23 @@ import (
 func TestTaskDefinitionMatcher(t *testing.T) {
 	t.Run("must set arn pattern", func(t *testing.T) {
 		var cfg TaskDefinitionConfig
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 	})
 
 	t.Run("invalid regex", func(t *testing.T) {
 		invalidRegex := "*" //  missing argument to repetition operator: `*`
 		cfg := TaskDefinitionConfig{ArnPattern: invalidRegex}
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 
 		cfg = TaskDefinitionConfig{ArnPattern: "arn:is:valid:regexp", ContainerNamePattern: invalidRegex}
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 	})
 
 	t.Run("invalid export config", func(t *testing.T) {
 		cfg := TaskDefinitionConfig{ArnPattern: "a", CommonExporterConfig: CommonExporterConfig{
 			MetricsPorts: []int{8080, 8080},
 		}}
-		require.Error(t, cfg.Validate())
+		require.Error(t, cfg.validate())
 	})
 
 	emptyTask := &Task{

--- a/extension/observer/ecsobserver/task_definition_test.go
+++ b/extension/observer/ecsobserver/task_definition_test.go
@@ -26,16 +26,23 @@ import (
 func TestTaskDefinitionMatcher(t *testing.T) {
 	t.Run("must set arn pattern", func(t *testing.T) {
 		var cfg TaskDefinitionConfig
-		require.Error(t, cfg.Init())
+		require.Error(t, cfg.Validate())
 	})
 
 	t.Run("invalid regex", func(t *testing.T) {
 		invalidRegex := "*" //  missing argument to repetition operator: `*`
 		cfg := TaskDefinitionConfig{ArnPattern: invalidRegex}
-		require.Error(t, cfg.Init())
+		require.Error(t, cfg.Validate())
 
 		cfg = TaskDefinitionConfig{ArnPattern: "arn:is:valid:regexp", ContainerNamePattern: invalidRegex}
-		require.Error(t, cfg.Init())
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("invalid export config", func(t *testing.T) {
+		cfg := TaskDefinitionConfig{ArnPattern: "a", CommonExporterConfig: CommonExporterConfig{
+			MetricsPorts: []int{8080, 8080},
+		}}
+		require.Error(t, cfg.Validate())
 	})
 
 	emptyTask := &Task{

--- a/extension/observer/ecsobserver/testdata/config_invalid.yaml
+++ b/extension/observer/ecsobserver/testdata/config_invalid.yaml
@@ -1,0 +1,24 @@
+extensions:
+  ecs_observer:
+    cluster_name: 'ecs-sd-test-1'
+    cluster_region: 'us-west-2'
+    result_file: '/etc/ecs_sd_targets.yaml'
+    refresh_interval: 15s
+    services:
+      - name_pattern: '*' # invalid regex
+
+service:
+  extensions: [ ecs_observer ]
+  pipelines:
+    traces:
+      receivers: [ nop ]
+      processors: [ nop ]
+      exporters: [ nop ]
+
+# Data pipeline is required to load the config.
+receivers:
+  nop:
+processors:
+  nop:
+exporters:
+  nop:


### PR DESCRIPTION
**Description:**

- Implement match task by service name (like k8s deployment name)
- Implement match task by task definition (btw: it is not same as service name, like pod template 'name')

**Link to tracking Issue:**

- Feature request #1395 

Pending PRs

- Exporter https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3333

Previous PRs

- Fetch Task https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3284
- Docker Label Matcher https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3276
- Task IP and Port https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3133
- Target and Task definition (merged) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2939
- Config PR (merged) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2377
- Original PR (closed) #2734 

**Testing:** 

unit test

**Documentation:** 

No new doc. See [existing doc](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/observer/ecsobserver/README.md)