### PR TITLE
Replace `golint` with `revive`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,7 @@ linters-settings:
     disable:
       - fieldalignment
 
-  golint:
+  revive:
     # minimal confidence for issues, default is 0.8
     min-confidence: 0.8
   gofmt:
@@ -100,10 +100,10 @@ linters:
     - exportloopref
     - gofmt
     - goimports
-    - golint
     - gosec
     - govet
     - misspell
+    - revive
     - staticcheck
     - unconvert
     - unparam

--- a/exporter/awsprometheusremotewriteexporter/auth_test.go
+++ b/exporter/awsprometheusremotewriteexporter/auth_test.go
@@ -35,7 +35,7 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 )
 
-var sdkInformation string = fmt.Sprintf("%s/%s (%s; %s; %s)", aws.SDKName, aws.SDKVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+var sdkInformation = fmt.Sprintf("%s/%s (%s; %s; %s)", aws.SDKName, aws.SDKVersion, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 
 func TestRequestSignature(t *testing.T) {
 	// Some form of AWS credentials must be set up for tests to succeed

--- a/exporter/datadogexporter/metadata/system/host_unix.go
+++ b/exporter/datadogexporter/metadata/system/host_unix.go
@@ -24,7 +24,7 @@ import (
 )
 
 // keep as var for testing
-var hostnamePath string = "/bin/hostname"
+var hostnamePath = "/bin/hostname"
 
 func getSystemFQDN() (string, error) {
 	// Go does not provide a way to get the full hostname

--- a/exporter/datadogexporter/metrics_translator_test.go
+++ b/exporter/datadogexporter/metrics_translator_test.go
@@ -31,10 +31,10 @@ import (
 
 func TestMetricValue(t *testing.T) {
 	var (
-		name  string   = "name"
-		value float64  = math.Pi
-		ts    uint64   = uint64(time.Now().UnixNano())
-		tags  []string = []string{"tool:opentelemetry", "version:0.1.0"}
+		name  = "name"
+		value = math.Pi
+		ts    = uint64(time.Now().UnixNano())
+		tags  = []string{"tool:opentelemetry", "version:0.1.0"}
 	)
 
 	metric := metrics.NewGauge(name, ts, value, tags)

--- a/exporter/datadogexporter/utils/http.go
+++ b/exporter/datadogexporter/utils/http.go
@@ -25,11 +25,11 @@ import (
 )
 
 var (
-	JSONHeaders map[string]string = map[string]string{
+	JSONHeaders = map[string]string{
 		"Content-Type":     "application/json",
 		"Content-Encoding": "gzip",
 	}
-	ProtobufHeaders map[string]string = map[string]string{
+	ProtobufHeaders = map[string]string{
 		"Content-Type":     "application/x-protobuf",
 		"Content-Encoding": "identity",
 	}

--- a/exporter/dynatraceexporter/metrics_exporter.go
+++ b/exporter/dynatraceexporter/metrics_exporter.go
@@ -132,7 +132,7 @@ func (e *exporter) serializeMetrics(md pdata.Metrics) ([]string, int) {
 	return lines, dropped
 }
 
-var lastLog int64 = 0
+var lastLog int64
 
 // send sends a serialized metric batch to Dynatrace.
 // Returns the number of lines rejected by Dynatrace.

--- a/exporter/elasticexporter/internal/translator/elastic/traces.go
+++ b/exporter/elasticexporter/internal/translator/elastic/traces.go
@@ -91,10 +91,7 @@ func EncodeSpan(
 		}
 		w.RawString("}\n")
 	}
-	if err := encodeSpanEvents(otlpSpan.Events(), otlpResource, traceID, spanID, w); err != nil {
-		return err
-	}
-	return nil
+	return encodeSpanEvents(otlpSpan.Events(), otlpResource, traceID, spanID, w)
 }
 
 func setTransactionProperties(

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -101,11 +101,7 @@ func newLoadBalancer(params component.ExporterCreateParams, cfg config.Exporter,
 func (lb *loadBalancerImp) Start(ctx context.Context, host component.Host) error {
 	lb.res.onChange(lb.onBackendChanges)
 	lb.host = host
-	if err := lb.res.start(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return lb.res.start(ctx)
 }
 
 func (lb *loadBalancerImp) onBackendChanges(resolved []string) {

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -73,11 +73,7 @@ func (e *logExporterImp) Capabilities() consumer.Capabilities {
 }
 
 func (e *logExporterImp) Start(ctx context.Context, host component.Host) error {
-	if err := e.loadBalancer.Start(ctx, host); err != nil {
-		return err
-	}
-
-	return nil
+	return e.loadBalancer.Start(ctx, host)
 }
 
 func (e *logExporterImp) Shutdown(context.Context) error {

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -84,11 +84,7 @@ func (e *traceExporterImp) Capabilities() consumer.Capabilities {
 }
 
 func (e *traceExporterImp) Start(ctx context.Context, host component.Host) error {
-	if err := e.loadBalancer.Start(ctx, host); err != nil {
-		return err
-	}
-
-	return nil
+	return e.loadBalancer.Start(ctx, host)
 }
 
 func (e *traceExporterImp) Shutdown(context.Context) error {

--- a/exporter/lokiexporter/config.go
+++ b/exporter/lokiexporter/config.go
@@ -43,11 +43,7 @@ func (c *Config) validate() error {
 		return fmt.Errorf("\"endpoint\" must be a valid URL")
 	}
 
-	if err := c.Labels.validate(); err != nil {
-		return err
-	}
-
-	return nil
+	return c.Labels.validate()
 }
 
 // LabelsConfig defines the labels-related configuration

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -299,7 +299,7 @@ func subLogs(ld *pdata.Logs, from *logIndex) *pdata.Logs {
 				k = from.record
 			}
 
-			for kSub := 0; k < logs.Len(); k++ {
+			for kSub := 0; k < logs.Len(); k++ { //revive:disable-line:var-naming
 				logsSub.AppendEmpty()
 				logs.At(k).CopyTo(logsSub.At(kSub))
 				kSub++

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -790,7 +790,7 @@ func TestSubLogs(t *testing.T) {
 	logs := createLogData(2, 2, 3)
 
 	// Logs subset from leftmost index (resource 0, library 0, record 0).
-	_0_0_0 := &logIndex{resource: 0, library: 0, record: 0}
+	_0_0_0 := &logIndex{resource: 0, library: 0, record: 0} //revive:disable-line:var-naming
 	got := subLogs(&logs, _0_0_0)
 
 	// Number of logs in subset should equal original logs.
@@ -802,7 +802,7 @@ func TestSubLogs(t *testing.T) {
 	assert.Equal(t, "1_1_2", got.ResourceLogs().At(1).InstrumentationLibraryLogs().At(1).Logs().At(2).Name())
 
 	// Logs subset from some mid index (resource 0, library 1, log 2).
-	_0_1_2 := &logIndex{resource: 0, library: 1, record: 2}
+	_0_1_2 := &logIndex{resource: 0, library: 1, record: 2} //revive:disable-line:var-naming
 	got = subLogs(&logs, _0_1_2)
 
 	assert.Equal(t, 7, got.LogRecordCount())
@@ -813,7 +813,7 @@ func TestSubLogs(t *testing.T) {
 	assert.Equal(t, "1_1_2", got.ResourceLogs().At(1).InstrumentationLibraryLogs().At(1).Logs().At(2).Name())
 
 	// Logs subset from rightmost index (resource 1, library 1, log 2).
-	_1_1_2 := &logIndex{resource: 1, library: 1, record: 2}
+	_1_1_2 := &logIndex{resource: 1, library: 1, record: 2} //revive:disable-line:var-naming
 	got = subLogs(&logs, _1_1_2)
 
 	// Number of logs in subset should be 1.

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -214,11 +214,7 @@ func (p *processorImp) ConsumeTraces(ctx context.Context, traces pdata.Traces) e
 	}
 
 	// Forward trace data unmodified.
-	if err := p.nextConsumer.ConsumeTraces(ctx, traces); err != nil {
-		return err
-	}
-
-	return nil
+	return p.nextConsumer.ConsumeTraces(ctx, traces)
 }
 
 // buildMetrics collects the computed raw metrics data, builds the metrics object and

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -190,7 +190,7 @@ func (tsp *tailSamplingSpanProcessor) samplingPolicyOnTick() {
 
 func (tsp *tailSamplingSpanProcessor) makeDecision(id pdata.TraceID, trace *sampling.TraceData, metrics *policyMetrics) (sampling.Decision, *Policy) {
 	finalDecision := sampling.NotSampled
-	var matchingPolicy *Policy = nil
+	var matchingPolicy *Policy
 
 	for i, policy := range tsp.policies {
 		policyEvaluateStartTime := time.Now()

--- a/receiver/carbonreceiver/config.go
+++ b/receiver/carbonreceiver/config.go
@@ -76,9 +76,5 @@ func (cfg *Config) Unmarshal(componentParser *config.Parser) error {
 	}
 
 	// Unmarshal exact to validate the config keys.
-	if err := componentParser.UnmarshalExact(cfg); err != nil {
-		return err
-	}
-
-	return nil
+	return componentParser.UnmarshalExact(cfg)
 }

--- a/receiver/carbonreceiver/protocol/config.go
+++ b/receiver/carbonreceiver/protocol/config.go
@@ -87,9 +87,5 @@ func LoadParserConfig(cp *config.Parser, cfg *Config) error {
 		return errSub
 	}
 
-	if err := vParserCfg.UnmarshalExact(cfg.Config); err != nil {
-		return err
-	}
-
-	return nil
+	return vParserCfg.UnmarshalExact(cfg.Config)
 }

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -147,8 +147,8 @@ func (s *consumerScraper) scrape(context.Context) (pdata.ResourceMetricsSlice, e
 			}
 			grpTopicMetrics := grpMetrics.WithLabels(map[string]string{metadata.L.Topic: topic})
 			if isConsumed {
-				var lagSum int64 = 0
-				var offsetSum int64 = 0
+				var lagSum int64
+				var offsetSum int64
 				for partition, block := range partitions {
 					grpPartitionMetrics := grpTopicMetrics.WithLabels(map[string]string{metadata.L.Partition: string(partition)})
 					consumerOffset := block.Offset


### PR DESCRIPTION
**Description:** 

Switch golint linter to revive. golint has been deprecated (see golang/go#38968). golangci-lint recommends revive as a replacement.

Fix lint issues discovered by revive but not by golint.

Follow up to open-telemetry/opentelemetry-collector#3182

**Link to tracking Issue:** n/a
