### PR TITLE
Fix timestamp value for cumulative metrics.

### DIFF
--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -326,7 +326,7 @@ func (t *transformer) Metric(m pdata.Metric) ([]telemetry.Metric, error) {
 					Name:       m.Name(),
 					Attributes: attributes,
 					Value:      float64(point.Value()),
-					Timestamp:  point.StartTimestamp().AsTime(),
+					Timestamp:  point.Timestamp().AsTime(),
 				}
 				output = append(output, nrMetric)
 			} else {
@@ -362,7 +362,7 @@ func (t *transformer) Metric(m pdata.Metric) ([]telemetry.Metric, error) {
 					Name:       m.Name(),
 					Attributes: attributes,
 					Value:      point.Value(),
-					Timestamp:  point.StartTimestamp().AsTime(),
+					Timestamp:  point.Timestamp().AsTime(),
 				}
 				output = append(output, nrMetric)
 			} else {

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -633,7 +633,7 @@ func TestTransformSum(t *testing.T) {
 		telemetry.Gauge{
 			Name:      "sum",
 			Value:     42.0,
-			Timestamp: start.AsTime(),
+			Timestamp: end.AsTime(),
 			Attributes: map[string]interface{}{
 				"unit":        "1",
 				"description": "description",


### PR DESCRIPTION
**Description:** We used the wrong timestamp for cumulative metrics 🤦 