### PR TITLE
Remove delta adjustment from summaries by default in EMF exporter

### DIFF
--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -272,7 +272,13 @@ func getDataPoints(pmd *pdata.Metric, metadata CWMetricMetadata, logger *zap.Log
 		}
 	case pdata.MetricDataTypeSummary:
 		metric := pmd.Summary()
-		adjusterMetadata.adjustToDelta = true
+		// For summaries coming from the prometheus receiver, the sum and count are cumulative, whereas for summaries
+		// coming from other sources, e.g. SDK, the sum and count are delta by being accumulated and reset periodically.
+		// In order to ensure metrics are sent as deltas, we check the receiver attribute (which can be injected by
+		// attribute processor) from resource metrics. If it exists, and equals to prometheus, the sum and count will be
+		// converted.
+		// For more information: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/prometheusreceiver/DESIGN.md#summary
+		adjusterMetadata.adjustToDelta = metadata.receiver == prometheusReceiver
 		dps = SummaryDataPointSlice{
 			metadata.InstrumentationLibraryName,
 			adjusterMetadata,

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -486,7 +486,7 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 			assert.Equal(t, expectedMetricStats.Max, actualMetricsStats.Max)
 			assert.Equal(t, expectedMetricStats.Min, actualMetricsStats.Min)
 			assert.InDelta(t, expectedMetricStats.Count, actualMetricsStats.Count, 0.1)
-			assert.True(t, expectedMetricStats.Sum-actualMetricsStats.Sum < float64(0.02))
+			assert.InDelta(t, expectedMetricStats.Sum, actualMetricsStats.Sum, 0.02)
 		})
 	}
 }
@@ -536,12 +536,14 @@ func TestGetDataPoints(t *testing.T) {
 		"log-stream",
 	}
 	testCases := []struct {
-		testName           string
-		metric             *metricspb.Metric
-		expectedDataPoints DataPoints
+		testName            string
+		isPrometheusMetrics bool
+		metric              *metricspb.Metric
+		expectedDataPoints  DataPoints
 	}{
 		{
 			"Int gauge",
+			false,
 			generateTestIntGauge("foo"),
 			IntDataPointSlice{
 				metadata.InstrumentationLibraryName,
@@ -551,6 +553,7 @@ func TestGetDataPoints(t *testing.T) {
 		},
 		{
 			"Double gauge",
+			false,
 			generateTestDoubleGauge("foo"),
 			DoubleDataPointSlice{
 				metadata.InstrumentationLibraryName,
@@ -560,6 +563,7 @@ func TestGetDataPoints(t *testing.T) {
 		},
 		{
 			"Int sum",
+			false,
 			generateTestIntSum("foo"),
 			IntDataPointSlice{
 				metadata.InstrumentationLibraryName,
@@ -569,6 +573,7 @@ func TestGetDataPoints(t *testing.T) {
 		},
 		{
 			"Double sum",
+			false,
 			generateTestDoubleSum("foo"),
 			DoubleDataPointSlice{
 				metadata.InstrumentationLibraryName,
@@ -578,6 +583,7 @@ func TestGetDataPoints(t *testing.T) {
 		},
 		{
 			"Double histogram",
+			false,
 			generateTestHistogram("foo"),
 			HistogramDataPointSlice{
 				metadata.InstrumentationLibraryName,
@@ -585,7 +591,18 @@ func TestGetDataPoints(t *testing.T) {
 			},
 		},
 		{
-			"Summary",
+			"Summary from SDK",
+			false,
+			generateTestSummary("foo"),
+			SummaryDataPointSlice{
+				metadata.InstrumentationLibraryName,
+				dmm,
+				pdata.SummaryDataPointSlice{},
+			},
+		},
+		{
+			"Summary from Prometheus",
+			true,
 			generateTestSummary("foo"),
 			SummaryDataPointSlice{
 				metadata.InstrumentationLibraryName,
@@ -607,6 +624,11 @@ func TestGetDataPoints(t *testing.T) {
 		expectedLabels := pdata.NewStringMap().InitFromMap(map[string]string{"label1": "value1"})
 
 		t.Run(tc.testName, func(t *testing.T) {
+			if tc.isPrometheusMetrics {
+				metadata.receiver = prometheusReceiver
+			} else {
+				metadata.receiver = ""
+			}
 			dps := getDataPoints(&metric, metadata, logger)
 			assert.NotNil(t, dps)
 			assert.Equal(t, reflect.TypeOf(tc.expectedDataPoints), reflect.TypeOf(dps))
@@ -636,7 +658,9 @@ func TestGetDataPoints(t *testing.T) {
 				assert.Equal(t, []float64{0, 10}, dp.ExplicitBounds())
 				assert.Equal(t, expectedLabels, dp.LabelsMap())
 			case SummaryDataPointSlice:
+				expectedDPS := tc.expectedDataPoints.(SummaryDataPointSlice)
 				assert.Equal(t, metadata.InstrumentationLibraryName, convertedDPS.instrumentationLibraryName)
+				assert.Equal(t, expectedDPS.deltaMetricMetadata, convertedDPS.deltaMetricMetadata)
 				assert.Equal(t, 1, convertedDPS.Len())
 				dp := convertedDPS.SummaryDataPointSlice.At(0)
 				assert.Equal(t, 15.0, dp.Sum())


### PR DESCRIPTION
**Why do we need it?**
Fixes aws-observability/aws-otel-collector#510.
This is a replacement PR for https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3373.

In CloudWatch, we expect metrics to be sent as delta so the optimization of deltas can be fully utilized. 

Currently, in [prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/prometheusreceiver/DESIGN.md#summary), the `count` and `sum` are not delta:
> The sum and count from Summary are cumulative, however, the quantiles are not. The receiver will again maintain some state to attempt to detect value resets and to set appropriate start timestamps.

On the other hand, in OTEL SDKs, the same type is calculated as delta.

This PR checks whether metrics are tagged with prometheus attribute to decide whether EMF exporter should calculate delta for summaries. 