### PR TITLE
Add implementation of Tanzu Observability exporter

### DIFF
--- a/exporter/tanzuobservabilityexporter/README.md
+++ b/exporter/tanzuobservabilityexporter/README.md
@@ -22,7 +22,7 @@ This exporter supports sending traces to [Tanzu Observability](https://tanzu.vmw
     - `application` is set to "defaultApp".
     - `service` is set to "defaultService".
 
-## Exporter Configuration
+## Example Configuration
 
 ```yaml
 receivers:

--- a/exporter/tanzuobservabilityexporter/config.go
+++ b/exporter/tanzuobservabilityexporter/config.go
@@ -16,6 +16,7 @@ package tanzuobservabilityexporter
 
 import (
 	"fmt"
+	"net/url"
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -36,6 +37,9 @@ type Config struct {
 func (c *Config) Validate() error {
 	if c.Traces.Endpoint == "" {
 		return fmt.Errorf("A non-empty traces.endpoint is required")
+	}
+	if _, err := url.Parse(c.Traces.Endpoint); err != nil {
+		return fmt.Errorf("invalid traces.endpoint %s", err)
 	}
 	return nil
 }

--- a/exporter/tanzuobservabilityexporter/config_test.go
+++ b/exporter/tanzuobservabilityexporter/config_test.go
@@ -17,7 +17,7 @@ package tanzuobservabilityexporter
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
 )
@@ -30,5 +30,16 @@ func TestConfigRequiresNonEmptyEndpoint(t *testing.T) {
 		},
 	}
 
-	require.Error(t, c.Validate())
+	assert.Error(t, c.Validate())
+}
+
+func TestConfigRequiresValidEndpointUrl(t *testing.T) {
+	c := &Config{
+		ExporterSettings: config.ExporterSettings{},
+		Traces: TracesConfig{
+			HTTPClientSettings: confighttp.HTTPClientSettings{Endpoint: "http#$%^&#$%&#"},
+		},
+	}
+
+	assert.Error(t, c.Validate())
 }

--- a/exporter/tanzuobservabilityexporter/exporter.go
+++ b/exporter/tanzuobservabilityexporter/exporter.go
@@ -1,0 +1,166 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tanzuobservabilityexporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/wavefronthq/wavefront-sdk-go/senders"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultApplicationName = "defaultApp"
+	defaultServiceName     = "defaultService"
+	labelApplication       = "application"
+	labelError             = "error"
+	labelEventName         = "name"
+	labelService           = "service"
+	labelSpanKind          = "span.kind"
+	labelStatusMessage     = "status.message"
+	labelStatusCode        = "status.code"
+)
+
+// spanSender Interface for sending tracing spans to Tanzu Observability
+type spanSender interface {
+	// SendSpan sends a tracing span to Tanzu Observability.
+	// traceId, spanId, parentIds and preceding spanIds are expected to be UUID strings.
+	// parents and preceding spans can be empty for a root span.
+	// span tag keys can be repeated (example: "user"="foo" and "user"="bar")
+	// span logs are currently omitted
+	SendSpan(name string, startMillis, durationMillis int64, source, traceID, spanID string, parents, followsFrom []string, tags []senders.SpanTag, spanLogs []senders.SpanLog) error
+	Flush() error
+	Close()
+}
+
+type exporter struct {
+	cfg    *Config
+	sender spanSender
+	logger *zap.Logger
+}
+
+func newExporter(l *zap.Logger, c config.Exporter) (*exporter, error) {
+	cfg, ok := c.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config: %#v", c)
+	}
+
+	l.Info("Creating Tanzu Observability exporter", zap.String("tracing_endpoint", cfg.Traces.Endpoint))
+	endpoint, err := url.Parse(cfg.Traces.Endpoint)
+	if nil != err {
+		return nil, err
+	}
+	tracingPort, err := strconv.Atoi(endpoint.Port())
+	if nil != err {
+		return nil, err
+	}
+
+	s, err := senders.NewProxySender(&senders.ProxyConfiguration{
+		Host:                 endpoint.Hostname(),
+		MetricsPort:          2878,
+		TracingPort:          tracingPort,
+		FlushIntervalSeconds: 1,
+	})
+	if nil != err {
+		return nil, err
+	}
+
+	return &exporter{
+		cfg:    cfg,
+		sender: s,
+		logger: l,
+	}, nil
+}
+
+func (e exporter) pushTraceData(ctx context.Context, td pdata.Traces) error {
+	var errs []error
+
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		rspans := td.ResourceSpans().At(i)
+		resource := rspans.Resource()
+		for j := 0; j < rspans.InstrumentationLibrarySpans().Len(); j++ {
+			ispans := rspans.InstrumentationLibrarySpans().At(j)
+			transform := newTraceTransformer(resource, e.cfg)
+			for k := 0; k < ispans.Spans().Len(); k++ {
+				select {
+				case <-ctx.Done():
+					return consumererror.Combine(append(errs, errors.New("context canceled")))
+				default:
+					transformedSpan, err := transform.Span(ispans.Spans().At(k))
+					if err != nil {
+						errs = append(errs, err)
+						continue
+					}
+
+					if err := e.RecordSpan(transformedSpan); err != nil {
+						errs = append(errs, err)
+						continue
+					}
+				}
+			}
+		}
+	}
+
+	return consumererror.Combine(errs)
+}
+
+func (e exporter) Shutdown(_ context.Context) error {
+	e.sender.Close()
+	return nil
+}
+
+func (e exporter) RecordSpan(span Span) error {
+	var parents []string
+	if span.ParentSpanID != uuid.Nil {
+		parents = []string{span.ParentSpanID.String()}
+	}
+
+	err := e.sender.SendSpan(
+		span.Name,
+		span.StartMillis,
+		span.DurationMillis,
+		"",
+		span.TraceID.String(),
+		span.SpanID.String(),
+		parents,
+		nil,
+		mapToSpanTags(span.Tags),
+		span.SpanLogs,
+	)
+
+	if err != nil {
+		return err
+	}
+	return e.sender.Flush()
+}
+
+func mapToSpanTags(tags map[string]string) []senders.SpanTag {
+	var spanTags []senders.SpanTag
+	for k, v := range tags {
+		spanTags = append(spanTags, senders.SpanTag{
+			Key:   k,
+			Value: v,
+		})
+	}
+	return spanTags
+}

--- a/exporter/tanzuobservabilityexporter/exporter.go
+++ b/exporter/tanzuobservabilityexporter/exporter.go
@@ -65,14 +65,13 @@ func newExporter(l *zap.Logger, c config.Exporter) (*exporter, error) {
 		return nil, fmt.Errorf("invalid config: %#v", c)
 	}
 
-	l.Info("Creating Tanzu Observability exporter", zap.String("tracing_endpoint", cfg.Traces.Endpoint))
 	endpoint, err := url.Parse(cfg.Traces.Endpoint)
 	if nil != err {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse traces endpoint: %v", err)
 	}
 	tracingPort, err := strconv.Atoi(endpoint.Port())
 	if nil != err {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse traces port: %v", err)
 	}
 
 	s, err := senders.NewProxySender(&senders.ProxyConfiguration{
@@ -82,7 +81,7 @@ func newExporter(l *zap.Logger, c config.Exporter) (*exporter, error) {
 		FlushIntervalSeconds: 1,
 	})
 	if nil != err {
-		return nil, err
+		return nil, fmt.Errorf("failed to create proxy sender: %v", err)
 	}
 
 	return &exporter{

--- a/exporter/tanzuobservabilityexporter/exporter.go
+++ b/exporter/tanzuobservabilityexporter/exporter.go
@@ -65,21 +65,24 @@ func newTracesExporter(l *zap.Logger, c config.Exporter) (*tracesExporter, error
 	}
 
 	endpoint, err := url.Parse(cfg.Traces.Endpoint)
-	if nil != err {
-		return nil, fmt.Errorf("failed to parse traces endpoint: %v", err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse traces.endpoint: %v", err)
 	}
 	tracingPort, err := strconv.Atoi(endpoint.Port())
-	if nil != err {
-		return nil, fmt.Errorf("failed to parse traces port: %v", err)
+	if err != nil {
+		// the port is empty, otherwise url.Parse would have failed above
+		return nil, fmt.Errorf("traces.endpoint requires a port")
 	}
 
+	// we specify a MetricsPort so the SDK can report its internal metrics
+	// but don't currently export any metrics from the pipeline
 	s, err := senders.NewProxySender(&senders.ProxyConfiguration{
 		Host:                 endpoint.Hostname(),
 		MetricsPort:          2878,
 		TracingPort:          tracingPort,
 		FlushIntervalSeconds: 1,
 	})
-	if nil != err {
+	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy sender: %v", err)
 	}
 

--- a/exporter/tanzuobservabilityexporter/exporter_test.go
+++ b/exporter/tanzuobservabilityexporter/exporter_test.go
@@ -224,7 +224,7 @@ func consumeTraces(ptrace pdata.Traces) ([]*Span, error) {
 	sender := &mockSender{}
 
 	cfg := createDefaultConfig()
-	exp := exporter{
+	exp := tracesExporter{
 		cfg:    cfg.(*Config),
 		sender: sender,
 		logger: zap.NewNop(),

--- a/exporter/tanzuobservabilityexporter/exporter_test.go
+++ b/exporter/tanzuobservabilityexporter/exporter_test.go
@@ -88,7 +88,7 @@ func TestExportTraceDataFullTrace(t *testing.T) {
 		pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 2}),
 		rootSpan.SpanID(),
 	)
-	clientSpan.SetKind(pdata.SpanKindCLIENT)
+	clientSpan.SetKind(pdata.SpanKindClient)
 	event := pdata.NewSpanEvent()
 	event.SetName("client-event")
 	event.CopyTo(clientSpan.Events().AppendEmpty())
@@ -108,7 +108,7 @@ func TestExportTraceDataFullTrace(t *testing.T) {
 		pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 3}),
 		clientSpan.SpanID(),
 	)
-	serverSpan.SetKind(pdata.SpanKindSERVER)
+	serverSpan.SetKind(pdata.SpanKindServer)
 	serverSpan.SetTraceState("key=val")
 	serverAttrs := pdata.NewAttributeMap()
 	serverAttrs.InsertString(conventions.AttributeServiceName, "the-server")
@@ -214,7 +214,7 @@ func constructTraces(spans []pdata.Span) pdata.Traces {
 	rs.InstrumentationLibrarySpans().Resize(1)
 	ils := rs.InstrumentationLibrarySpans().At(0)
 	for _, span := range spans {
-		ils.Spans().Append(span)
+		span.CopyTo(ils.Spans().AppendEmpty())
 	}
 	return traces
 }

--- a/exporter/tanzuobservabilityexporter/exporter_test.go
+++ b/exporter/tanzuobservabilityexporter/exporter_test.go
@@ -1,0 +1,286 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tanzuobservabilityexporter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wavefronthq/wavefront-sdk-go/senders"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/translator/conventions"
+	"go.uber.org/zap"
+)
+
+func TestSpansRequireTraceAndSpanIDs(t *testing.T) {
+	spanWithNoTraceID := pdata.NewSpan()
+	spanWithNoTraceID.SetSpanID(pdata.NewSpanID([8]byte{9, 9, 9, 9, 9, 9, 9, 9}))
+	spanWithNoSpanID := pdata.NewSpan()
+	spanWithNoSpanID.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	traces := constructTraces([]pdata.Span{spanWithNoTraceID, spanWithNoSpanID})
+
+	_, err := consumeTraces(traces)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), errInvalidSpanID.Error()))
+	assert.True(t, strings.Contains(err.Error(), errInvalidTraceID.Error()))
+}
+
+func TestExportTraceDataMinimum(t *testing.T) {
+	// <operationName> source=<source> <spanTags> <start_milliseconds> <duration_milliseconds>
+	// getAllUsers source=localhost traceId=7b3bf470-9456-11e8-9eb6-529269fb1459 spanId=0313bafe-9457-11e8-9eb6-529269fb1459 parent=2f64e538-9457-11e8-9eb6-529269fb1459 application=Wavefront service=auth cluster=us-west-2 shard=secondary http.method=GET 1552949776000 343
+	span := createSpan(
+		"root",
+		pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),
+		pdata.NewSpanID([8]byte{9, 9, 9, 9, 9, 9, 9, 9}),
+		pdata.SpanID{},
+	)
+	traces := constructTraces([]pdata.Span{span})
+
+	expected := []*Span{{
+		Name:    "root",
+		TraceID: uuid.MustParse("01010101-0101-0101-0101-010101010101"),
+		SpanID:  uuid.MustParse("00000000-0000-0000-0909-090909090909"),
+		Tags: map[string]string{
+			labelApplication: "defaultApp",
+			labelService:     "defaultService",
+		},
+	}}
+
+	validateTraces(t, expected, traces)
+}
+
+/*
+ TODO logging?
+ TODO InstrumentationLibrary tags (see DD translate_traces)
+ TODO Trace Semantic Conventions: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/README.md
+*/
+
+func TestExportTraceDataFullTrace(t *testing.T) {
+	traceID := pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1})
+
+	rootSpan := createSpan(
+		"root",
+		traceID,
+		pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}),
+		pdata.SpanID{},
+	)
+
+	clientSpan := createSpan(
+		"client",
+		traceID,
+		pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 2}),
+		rootSpan.SpanID(),
+	)
+	clientSpan.SetKind(pdata.SpanKindCLIENT)
+	event := pdata.NewSpanEvent()
+	event.SetName("client-event")
+	event.CopyTo(clientSpan.Events().AppendEmpty())
+
+	status := pdata.NewSpanStatus()
+	status.SetCode(pdata.StatusCodeError)
+	status.SetMessage("an error event occurred")
+	status.CopyTo(clientSpan.Status())
+
+	clientAttrs := pdata.NewAttributeMap()
+	clientAttrs.InsertString(labelApplication, "test-app")
+	clientAttrs.CopyTo(clientSpan.Attributes())
+
+	serverSpan := createSpan(
+		"server",
+		traceID,
+		pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 3}),
+		clientSpan.SpanID(),
+	)
+	serverSpan.SetKind(pdata.SpanKindSERVER)
+	serverSpan.SetTraceState("key=val")
+	serverAttrs := pdata.NewAttributeMap()
+	serverAttrs.InsertString(conventions.AttributeServiceName, "the-server")
+	serverAttrs.InsertString(conventions.AttributeHTTPMethod, "POST")
+	serverAttrs.InsertInt(conventions.AttributeHTTPStatusCode, 403)
+	serverAttrs.CopyTo(serverSpan.Attributes())
+
+	traces := constructTraces([]pdata.Span{rootSpan, clientSpan, serverSpan})
+	resourceAttrs := pdata.NewAttributeMap()
+	resourceAttrs.InsertString("resource", "R1")
+	resourceAttrs.InsertString(conventions.AttributeServiceName, "test-service")
+	resourceAttrs.CopyTo(traces.ResourceSpans().At(0).Resource().Attributes())
+
+	expected := []*Span{
+		{
+			Name:    "root",
+			SpanID:  uuid.MustParse("00000000000000000000000000000001"),
+			TraceID: uuid.MustParse("01010101010101010101010101010101"),
+			Tags: map[string]string{
+				"resource":       "R1",
+				labelApplication: "defaultApp",
+				labelService:     "test-service",
+				labelStatusCode:  "0",
+			},
+		},
+		{
+			Name:         "client",
+			SpanID:       uuid.MustParse("00000000000000000000000000000002"),
+			TraceID:      uuid.MustParse("01010101010101010101010101010101"),
+			ParentSpanID: uuid.MustParse("00000000000000000000000000000001"),
+			Tags: map[string]string{
+				"resource":         "R1",
+				labelApplication:   "test-app",
+				labelService:       "test-service",
+				labelStatusCode:    "2",
+				labelStatusMessage: "an error event occurred",
+				"error":            "true",
+				labelSpanKind:      "client",
+			},
+			SpanLogs: []senders.SpanLog{{
+				Fields: map[string]string{labelEventName: "client-event"},
+			}},
+		},
+		{
+			Name:         "server",
+			SpanID:       uuid.MustParse("00000000000000000000000000000003"),
+			TraceID:      uuid.MustParse("01010101010101010101010101010101"),
+			ParentSpanID: uuid.MustParse("00000000000000000000000000000002"),
+			Tags: map[string]string{
+				"resource":                          "R1",
+				labelApplication:                    "defaultApp",
+				labelService:                        "the-server",
+				labelStatusCode:                     "0",
+				labelSpanKind:                       "server",
+				conventions.AttributeHTTPStatusCode: "403",
+				conventions.AttributeHTTPMethod:     "POST",
+				"w3c.tracestate":                    "key=val",
+			},
+		},
+	}
+
+	validateTraces(t, expected, traces)
+}
+
+func validateTraces(t *testing.T, expected []*Span, traces pdata.Traces) {
+	actual, err := consumeTraces(traces)
+	require.NoError(t, err)
+	require.Equal(t, len(expected), len(actual))
+	for i := 0; i < len(expected); i++ {
+		assert.Equal(t, expected[i].Name, actual[i].Name)
+		assert.Equal(t, expected[i].TraceID, actual[i].TraceID)
+		assert.Equal(t, expected[i].SpanID, actual[i].SpanID)
+		assert.Equal(t, expected[i].ParentSpanID, actual[i].ParentSpanID)
+		for k, v := range expected[i].Tags {
+			a, ok := actual[i].Tags[k]
+			assert.True(t, ok, "tag '"+k+"' not found")
+			assert.Equal(t, v, a)
+		}
+		assert.Equal(t, expected[i].StartMillis, actual[i].StartMillis)
+		assert.Equal(t, expected[i].DurationMillis, actual[i].DurationMillis)
+		assert.Equal(t, expected[i].SpanLogs, actual[i].SpanLogs)
+	}
+}
+
+func createSpan(
+	name string,
+	traceID pdata.TraceID,
+	spanID pdata.SpanID,
+	parentSpanID pdata.SpanID,
+) pdata.Span {
+	span := pdata.NewSpan()
+	span.SetName(name)
+	span.SetTraceID(traceID)
+	span.SetSpanID(spanID)
+	span.SetParentSpanID(parentSpanID)
+	return span
+}
+
+func constructTraces(spans []pdata.Span) pdata.Traces {
+	traces := pdata.NewTraces()
+	traces.ResourceSpans().Resize(1)
+	rs := traces.ResourceSpans().At(0)
+	rs.InstrumentationLibrarySpans().Resize(1)
+	ils := rs.InstrumentationLibrarySpans().At(0)
+	for _, span := range spans {
+		ils.Spans().Append(span)
+	}
+	return traces
+}
+
+func consumeTraces(ptrace pdata.Traces) ([]*Span, error) {
+	ctx := context.Background()
+	sender := &mockSender{}
+
+	cfg := createDefaultConfig()
+	exp := exporter{
+		cfg:    cfg.(*Config),
+		sender: sender,
+		logger: zap.NewNop(),
+	}
+	mockOTelTracesExporter, err := exporterhelper.NewTracesExporter(
+		cfg,
+		zap.NewNop(),
+		exp.pushTraceData,
+		exporterhelper.WithShutdown(exp.Shutdown),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	if err := mockOTelTracesExporter.ConsumeTraces(ctx, ptrace); err != nil {
+		return nil, err
+	}
+	if err := mockOTelTracesExporter.Shutdown(ctx); err != nil {
+		return nil, err
+	}
+	return sender.spans, nil
+}
+
+// implements the spanSender interface
+type mockSender struct {
+	spans []*Span
+}
+
+func (m *mockSender) SendSpan(
+	name string,
+	startMillis, durationMillis int64,
+	source, traceID, spanID string,
+	parents, followsFrom []string,
+	spanTags []senders.SpanTag,
+	spanLogs []senders.SpanLog,
+) error {
+	var parentSpanID uuid.UUID
+	if len(parents) == 1 {
+		parentSpanID = uuid.MustParse(parents[0])
+	}
+	tags := map[string]string{}
+	for _, pair := range spanTags {
+		tags[pair.Key] = pair.Value
+	}
+	span := &Span{
+		Name:           name,
+		TraceID:        uuid.MustParse(traceID),
+		SpanID:         uuid.MustParse(spanID),
+		ParentSpanID:   parentSpanID,
+		Tags:           tags,
+		StartMillis:    startMillis,
+		DurationMillis: durationMillis,
+		SpanLogs:       spanLogs,
+	}
+	m.spans = append(m.spans, span)
+	return nil
+}
+func (m *mockSender) Flush() error { return nil }
+func (m *mockSender) Close()       {}

--- a/exporter/tanzuobservabilityexporter/factory.go
+++ b/exporter/tanzuobservabilityexporter/factory.go
@@ -51,7 +51,7 @@ func createTraceExporter(
 	params component.ExporterCreateParams,
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
-	exp, err := newExporter(params.Logger, cfg)
+	exp, err := newTracesExporter(params.Logger, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/tanzuobservabilityexporter/factory.go
+++ b/exporter/tanzuobservabilityexporter/factory.go
@@ -15,6 +15,8 @@
 package tanzuobservabilityexporter
 
 import (
+	"context"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -28,7 +30,7 @@ func NewFactory() component.ExporterFactory {
 	return exporterhelper.NewFactory(
 		exporterType,
 		createDefaultConfig,
-		//exporterhelper.WithTraces(createTraceExporter),
+		exporterhelper.WithTraces(createTraceExporter),
 	)
 }
 
@@ -40,4 +42,24 @@ func createDefaultConfig() config.Exporter {
 		ExporterSettings: config.NewExporterSettings(config.NewID(exporterType)),
 		Traces:           tracesCfg,
 	}
+}
+
+// createTraceExporter implements exporterhelper.CreateTracesExporter and creates
+// an exporter for traces using this configuration
+func createTraceExporter(
+	_ context.Context,
+	params component.ExporterCreateParams,
+	cfg config.Exporter,
+) (component.TracesExporter, error) {
+	exp, err := newExporter(params.Logger, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return exporterhelper.NewTracesExporter(
+		cfg,
+		params.Logger,
+		exp.pushTraceData,
+		exporterhelper.WithShutdown(exp.Shutdown),
+	)
 }

--- a/exporter/tanzuobservabilityexporter/factory_test.go
+++ b/exporter/tanzuobservabilityexporter/factory_test.go
@@ -15,16 +15,19 @@
 package tanzuobservabilityexporter
 
 import (
+	"context"
 	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.uber.org/zap"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -42,8 +45,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	factory := NewFactory()
-	// TODO come back to config.Type
-	factories.Exporters[config.Type(exporterType)] = factory
+	factories.Exporters[exporterType] = factory
 	cfg, err := configtest.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)
 
 	require.NoError(t, err)
@@ -58,4 +60,20 @@ func TestLoadConfig(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, actual)
+}
+
+func TestCreateExporter(t *testing.T) {
+	defaultConfig := createDefaultConfig()
+	cfg := defaultConfig.(*Config)
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+
+	te, err := createTraceExporter(context.Background(), params, cfg)
+	assert.Nil(t, err)
+	assert.NotNil(t, te, "failed to create trace exporter")
+}
+
+func TestCreateTraceExporterNilConfigError(t *testing.T) {
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+	_, err := createTraceExporter(context.Background(), params, nil)
+	assert.Error(t, err)
 }

--- a/exporter/tanzuobservabilityexporter/factory_test.go
+++ b/exporter/tanzuobservabilityexporter/factory_test.go
@@ -77,3 +77,30 @@ func TestCreateTraceExporterNilConfigError(t *testing.T) {
 	_, err := createTraceExporter(context.Background(), params, nil)
 	assert.Error(t, err)
 }
+
+func TestCreateTraceExporterInvalidEndpointError(t *testing.T) {
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+	defaultConfig := createDefaultConfig()
+	cfg := defaultConfig.(*Config)
+	cfg.Traces.Endpoint = "http:#$%^&#$%&#"
+	_, err := createTraceExporter(context.Background(), params, cfg)
+	assert.Error(t, err)
+}
+
+func TestCreateTraceExporterMissingPortError(t *testing.T) {
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+	defaultConfig := createDefaultConfig()
+	cfg := defaultConfig.(*Config)
+	cfg.Traces.Endpoint = "http://localhost"
+	_, err := createTraceExporter(context.Background(), params, cfg)
+	assert.Error(t, err)
+}
+
+func TestCreateTraceExporterInvalidPortError(t *testing.T) {
+	params := component.ExporterCreateParams{Logger: zap.NewNop()}
+	defaultConfig := createDefaultConfig()
+	cfg := defaultConfig.(*Config)
+	cfg.Traces.Endpoint = "http://localhost:c42a"
+	_, err := createTraceExporter(context.Background(), params, cfg)
+	assert.Error(t, err)
+}

--- a/exporter/tanzuobservabilityexporter/go.mod
+++ b/exporter/tanzuobservabilityexporter/go.mod
@@ -3,6 +3,9 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tanzuo
 go 1.15
 
 require (
+	github.com/google/uuid v1.2.0
 	github.com/stretchr/testify v1.7.0
+	github.com/wavefronthq/wavefront-sdk-go v0.9.8
 	go.opentelemetry.io/collector v0.27.1-0.20210524201935-86ea0a131fb2
+	go.uber.org/zap v1.16.0
 )

--- a/exporter/tanzuobservabilityexporter/go.sum
+++ b/exporter/tanzuobservabilityexporter/go.sum
@@ -143,6 +143,8 @@ github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+Wji
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bsm/sarama-cluster v2.1.13+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
+github.com/caio/go-tdigest v3.1.0+incompatible h1:uoVMJ3Q5lXmVLCCqaMGHLBWnbGoN6Lpu7OAUPR60cds=
+github.com/caio/go-tdigest v3.1.0+incompatible/go.mod h1:sHQM/ubZStBUmF1WbB8FAm8q9GjDajLC5T7ydxE3JHI=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
@@ -666,6 +668,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353 h1:X/79QL0b4YJVO5+OsPH9rF2u428CIrGL/jLmPsoOQQ4=
+github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353/go.mod h1:N0SVk0uhy+E1PZ3C9ctsPRlvOPAFPkCNlcPBDkt0N3U=
 github.com/leoluk/perflib_exporter v0.1.0 h1:fXe/mDaf9jR+Zk8FjFlcCSksACuIj2VNN4GyKHmQqtA=
 github.com/leoluk/perflib_exporter v0.1.0/go.mod h1:rpV0lYj7lemdTm31t7zpCqYqPnw7xs86f+BaaNBVYFM=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -995,6 +999,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
+github.com/wavefronthq/wavefront-sdk-go v0.9.8 h1:6U1HW/sovO1ASbjU8f7iEZEKphDEehaDhdZ5nabb550=
+github.com/wavefronthq/wavefront-sdk-go v0.9.8/go.mod h1:JTGsu+KKgxx+GitC65VVdftN2iep1nVpQi/8EGR6v4Y=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xdg-go/scram v0.0.0-20180814205039-7eeb5667e42c h1:Wm21TPasVdeOUTg1m/uNkRdMuvI+jIeYfTIwq98Z2V0=
 github.com/xdg-go/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:FV1RpvYFmF8wnKtr3ArzkC0b+tAySCbw8eP7QSIvLKM=
@@ -1093,6 +1099,7 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5 h1:FR+oGxGfbQu1d+jglI3rCkjAjUnhRSZcUxr+DqlDLNo=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -1381,7 +1388,10 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.6.0/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=
+gonum.org/v1/gonum v0.7.0 h1:Hdks0L0hgznZLG9nzXb8vZ0rRvqNvAcgAp84y7Mwkgw=
+gonum.org/v1/gonum v0.7.0/go.mod h1:L02bwd0sqlsvRv41G7wGWFCsVNZFv/k1xzGIxeANHGM=
 gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
+gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=

--- a/exporter/tanzuobservabilityexporter/transformer.go
+++ b/exporter/tanzuobservabilityexporter/transformer.go
@@ -101,17 +101,17 @@ func (t *traceTransformer) Span(orig pdata.Span) (Span, error) {
 
 func spanKind(span pdata.Span) string {
 	switch span.Kind() {
-	case pdata.SpanKindCLIENT:
+	case pdata.SpanKindClient:
 		return "client"
-	case pdata.SpanKindSERVER:
+	case pdata.SpanKindServer:
 		return "server"
-	case pdata.SpanKindPRODUCER:
+	case pdata.SpanKindProducer:
 		return "producer"
-	case pdata.SpanKindCONSUMER:
+	case pdata.SpanKindConsumer:
 		return "consumer"
-	case pdata.SpanKindINTERNAL:
+	case pdata.SpanKindInternal:
 		return "internal"
-	case pdata.SpanKindUNSPECIFIED:
+	case pdata.SpanKindUnspecified:
 		return "unspecified"
 	default:
 		return "unknown"
@@ -162,7 +162,7 @@ func attributesToTags(attributes ...pdata.AttributeMap) map[string]string {
 	tags := map[string]string{}
 
 	extractTag := func(k string, v pdata.AttributeValue) bool {
-		tags[k] = tracetranslator.AttributeValueToString(v, false)
+		tags[k] = tracetranslator.AttributeValueToString(v)
 		return true
 	}
 

--- a/exporter/tanzuobservabilityexporter/transformer.go
+++ b/exporter/tanzuobservabilityexporter/transformer.go
@@ -120,8 +120,8 @@ func spanKind(span pdata.Span) string {
 
 func (t *traceTransformer) setRequiredTags(tags map[string]string) {
 	if _, ok := tags[labelService]; !ok {
-		if _, svcNameOk := tags[conventions.AttributeServiceName]; svcNameOk {
-			tags[labelService] = tags[conventions.AttributeServiceName]
+		if svcName, svcNameOk := tags[conventions.AttributeServiceName]; svcNameOk {
+			tags[labelService] = svcName
 			delete(tags, conventions.AttributeServiceName)
 		} else {
 			tags[labelService] = defaultServiceName
@@ -185,7 +185,7 @@ func errorTagsFromStatus(status pdata.SpanStatus) map[string]string {
 	tags[labelError] = "true"
 	if status.Message() != "" {
 		msg := status.Message()
-		maxLength := 255 - len(labelStatusMessage+"=")
+		const maxLength = 255 - len(labelStatusMessage+"=")
 		if len(msg) > maxLength {
 			msg = msg[:maxLength]
 		}

--- a/exporter/tanzuobservabilityexporter/transformer.go
+++ b/exporter/tanzuobservabilityexporter/transformer.go
@@ -1,0 +1,228 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tanzuobservabilityexporter
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/wavefronthq/wavefront-sdk-go/senders"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
+)
+
+type traceTransformer struct {
+	ResourceAttributes pdata.AttributeMap
+	Config             *Config
+}
+
+func newTraceTransformer(resource pdata.Resource, cfg *Config) *traceTransformer {
+	t := &traceTransformer{
+		ResourceAttributes: resource.Attributes(),
+		Config:             cfg,
+	}
+	return t
+}
+
+var (
+	errInvalidSpanID  = errors.New("SpanID is invalid")
+	errInvalidTraceID = errors.New("TraceID is invalid")
+)
+
+type Span struct {
+	Name           string
+	TraceID        uuid.UUID
+	SpanID         uuid.UUID
+	ParentSpanID   uuid.UUID
+	Tags           map[string]string
+	StartMillis    int64
+	DurationMillis int64
+	SpanLogs       []senders.SpanLog
+}
+
+func (t *traceTransformer) Span(orig pdata.Span) (Span, error) {
+	traceID, err := traceIDtoUUID(orig.TraceID())
+	if err != nil {
+		return Span{}, errInvalidTraceID
+	}
+
+	spanID, err := spanIDtoUUID(orig.SpanID())
+	if err != nil {
+		return Span{}, errInvalidSpanID
+	}
+
+	parentSpanID, err := parentSpanIDtoUUID(orig.ParentSpanID())
+	if err != nil {
+		return Span{}, errInvalidSpanID
+	}
+
+	startMillis, durationMillis := calculateTimes(orig)
+
+	tags := attributesToTags(t.ResourceAttributes, orig.Attributes())
+	t.setRequiredTags(tags)
+
+	tags[labelSpanKind] = spanKind(orig)
+
+	errorTags := errorTagsFromStatus(orig.Status())
+	for k, v := range errorTags {
+		tags[k] = v
+	}
+
+	if len(orig.TraceState()) > 0 {
+		tags[tracetranslator.TagW3CTraceState] = string(orig.TraceState())
+	}
+
+	return Span{
+		Name:           orig.Name(),
+		TraceID:        traceID,
+		SpanID:         spanID,
+		ParentSpanID:   parentSpanID,
+		Tags:           tags,
+		StartMillis:    startMillis,
+		DurationMillis: durationMillis,
+		SpanLogs:       eventsToLogs(orig.Events()),
+	}, nil
+}
+
+func spanKind(span pdata.Span) string {
+	switch span.Kind() {
+	case pdata.SpanKindCLIENT:
+		return "client"
+	case pdata.SpanKindSERVER:
+		return "server"
+	case pdata.SpanKindPRODUCER:
+		return "producer"
+	case pdata.SpanKindCONSUMER:
+		return "consumer"
+	case pdata.SpanKindINTERNAL:
+		return "internal"
+	case pdata.SpanKindUNSPECIFIED:
+		return "unspecified"
+	default:
+		return "unknown"
+	}
+}
+
+func (t *traceTransformer) setRequiredTags(tags map[string]string) {
+	if _, ok := tags[labelService]; !ok {
+		if _, svcNameOk := tags[conventions.AttributeServiceName]; svcNameOk {
+			tags[labelService] = tags[conventions.AttributeServiceName]
+			delete(tags, conventions.AttributeServiceName)
+		} else {
+			tags[labelService] = defaultServiceName
+		}
+	}
+	if _, ok := tags[labelApplication]; !ok {
+		tags[labelApplication] = defaultApplicationName
+	}
+}
+
+func eventsToLogs(events pdata.SpanEventSlice) []senders.SpanLog {
+	var result []senders.SpanLog
+	for i := 0; i < events.Len(); i++ {
+		e := events.At(i)
+		fields := attributesToTags(e.Attributes())
+		fields[labelEventName] = e.Name()
+		result = append(result, senders.SpanLog{
+			Timestamp: int64(e.Timestamp()) / time.Microsecond.Nanoseconds(), // Timestamp is in microseconds
+			Fields:    fields,
+		})
+	}
+
+	return result
+}
+
+func calculateTimes(span pdata.Span) (int64, int64) {
+	startMillis := int64(span.StartTimestamp()) / time.Millisecond.Nanoseconds()
+	endMillis := int64(span.EndTimestamp()) / time.Millisecond.Nanoseconds()
+	durationMillis := endMillis - startMillis
+	// it's possible end time is unset, so default to 0 rather than using a negative number
+	if span.EndTimestamp() == 0 {
+		durationMillis = 0
+	}
+	return startMillis, durationMillis
+}
+
+func attributesToTags(attributes ...pdata.AttributeMap) map[string]string {
+	tags := map[string]string{}
+
+	extractTag := func(k string, v pdata.AttributeValue) bool {
+		tags[k] = tracetranslator.AttributeValueToString(v, false)
+		return true
+	}
+
+	// Since AttributeMaps are processed in the order received, later values overwrite earlier ones
+	for _, att := range attributes {
+		att.Range(extractTag)
+	}
+
+	return tags
+}
+
+func errorTagsFromStatus(status pdata.SpanStatus) map[string]string {
+	tags := map[string]string{
+		labelStatusCode: fmt.Sprintf("%d", status.Code()),
+	}
+	if status.Code() != pdata.StatusCodeError {
+		return tags
+	}
+
+	tags[labelError] = "true"
+	if status.Message() != "" {
+		msg := status.Message()
+		maxLength := 255 - len(labelStatusMessage+"=")
+		if len(msg) > maxLength {
+			msg = msg[:maxLength]
+		}
+		tags[labelStatusMessage] = msg
+	}
+	return tags
+}
+
+func traceIDtoUUID(id pdata.TraceID) (uuid.UUID, error) {
+	formatted, err := uuid.Parse(id.HexString())
+	if err != nil || id.IsEmpty() {
+		return uuid.Nil, errInvalidTraceID
+	}
+	return formatted, nil
+}
+
+func spanIDtoUUID(id pdata.SpanID) (uuid.UUID, error) {
+	formatted, err := uuid.FromBytes(padTo16Bytes(id.Bytes()))
+	if err != nil || id.IsEmpty() {
+		return uuid.Nil, errInvalidSpanID
+	}
+	return formatted, nil
+}
+
+func parentSpanIDtoUUID(id pdata.SpanID) (uuid.UUID, error) {
+	if id.IsEmpty() {
+		return uuid.Nil, nil
+	}
+	formatted, err := uuid.FromBytes(padTo16Bytes(id.Bytes()))
+	if err != nil {
+		return uuid.Nil, errInvalidSpanID
+	}
+	return formatted, nil
+}
+
+func padTo16Bytes(b [8]byte) []byte {
+	as16bytes := make([]byte, 16)
+	copy(as16bytes[16-len(b):], b[:])
+	return as16bytes
+}

--- a/exporter/tanzuobservabilityexporter/transformer_test.go
+++ b/exporter/tanzuobservabilityexporter/transformer_test.go
@@ -183,37 +183,37 @@ func TestSpanEventsAreTranslatedToSpanLogs(t *testing.T) {
 func TestSpanKindIsTranslatedToTag(t *testing.T) {
 	transform := transformerFromAttributes(pdata.NewAttributeMap())
 
-	internalSpan, err := transform.Span(spanWithKind(pdata.SpanKindINTERNAL))
+	internalSpan, err := transform.Span(spanWithKind(pdata.SpanKindInternal))
 	require.NoError(t, err, "transforming span to wavefront format")
 	kind, ok := internalSpan.Tags["span.kind"]
 	assert.True(t, ok)
 	assert.Equal(t, "internal", kind)
 
-	serverSpan, err := transform.Span(spanWithKind(pdata.SpanKindSERVER))
+	serverSpan, err := transform.Span(spanWithKind(pdata.SpanKindServer))
 	require.NoError(t, err, "transforming span to wavefront format")
 	kind, ok = serverSpan.Tags["span.kind"]
 	assert.True(t, ok)
 	assert.Equal(t, "server", kind)
 
-	clientSpan, err := transform.Span(spanWithKind(pdata.SpanKindCLIENT))
+	clientSpan, err := transform.Span(spanWithKind(pdata.SpanKindClient))
 	require.NoError(t, err, "transforming span to wavefront format")
 	kind, ok = clientSpan.Tags["span.kind"]
 	assert.True(t, ok)
 	assert.Equal(t, "client", kind)
 
-	consumerSpan, err := transform.Span(spanWithKind(pdata.SpanKindCONSUMER))
+	consumerSpan, err := transform.Span(spanWithKind(pdata.SpanKindConsumer))
 	require.NoError(t, err, "transforming span to wavefront format")
 	kind, ok = consumerSpan.Tags["span.kind"]
 	assert.True(t, ok)
 	assert.Equal(t, "consumer", kind)
 
-	producerSpan, err := transform.Span(spanWithKind(pdata.SpanKindPRODUCER))
+	producerSpan, err := transform.Span(spanWithKind(pdata.SpanKindProducer))
 	require.NoError(t, err, "transforming span to wavefront format")
 	kind, ok = producerSpan.Tags["span.kind"]
 	assert.True(t, ok)
 	assert.Equal(t, "producer", kind)
 
-	unspecifiedSpan, err := transform.Span(spanWithKind(pdata.SpanKindUNSPECIFIED))
+	unspecifiedSpan, err := transform.Span(spanWithKind(pdata.SpanKindUnspecified))
 	require.NoError(t, err, "transforming span to wavefront format")
 	kind, ok = unspecifiedSpan.Tags["span.kind"]
 	assert.True(t, ok)

--- a/exporter/tanzuobservabilityexporter/transformer_test.go
+++ b/exporter/tanzuobservabilityexporter/transformer_test.go
@@ -1,0 +1,272 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tanzuobservabilityexporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func TestSpanStartTimeIsConvertedToMilliseconds(t *testing.T) {
+	inNanos := int64(50000000)
+	att := pdata.NewAttributeMap()
+	transform := transformerFromAttributes(att)
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	span.SetStartTimestamp(pdata.Timestamp(inNanos))
+
+	actual, err := transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	assert.Equal(t, inNanos/time.Millisecond.Nanoseconds(), actual.StartMillis)
+}
+
+func TestSpanDurationIsCalculatedFromStartAndEndTimes(t *testing.T) {
+	startNanos := int64(50000000)
+	endNanos := int64(60000000)
+	att := pdata.NewAttributeMap()
+	transform := transformerFromAttributes(att)
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	span.SetStartTimestamp(pdata.Timestamp(startNanos))
+	span.SetEndTimestamp(pdata.Timestamp(endNanos))
+
+	actual, err := transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	assert.Equal(t, int64(10), actual.DurationMillis)
+}
+
+func TestSpanDurationIsZeroIfEndTimeIsUnset(t *testing.T) {
+	startNanos := int64(50000000)
+	att := pdata.NewAttributeMap()
+	transform := transformerFromAttributes(att)
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	span.SetStartTimestamp(pdata.Timestamp(startNanos))
+
+	actual, err := transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	assert.Equal(t, int64(0), actual.DurationMillis)
+}
+
+func TestSpanStatusCodeErrorAddsErrorTag(t *testing.T) {
+	transform := transformerFromAttributes(pdata.NewAttributeMap())
+	actual, err := transform.Span(spanWithStatus(pdata.StatusCodeError, ""))
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	errorTag, ok := actual.Tags["error"]
+	assert.True(t, ok)
+	assert.Equal(t, "true", errorTag)
+
+	code, ok := actual.Tags[labelStatusCode]
+	assert.True(t, ok)
+	assert.Equal(t, "2", code)
+}
+
+func TestSpanStatusCodeOkDoesNotAddErrorTag(t *testing.T) {
+	transform := transformerFromAttributes(pdata.NewAttributeMap())
+	actual, err := transform.Span(spanWithStatus(pdata.StatusCodeOk, ""))
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	_, ok := actual.Tags["error"]
+	assert.False(t, ok)
+
+	code, ok := actual.Tags[labelStatusCode]
+	assert.True(t, ok)
+	assert.Equal(t, "1", code)
+}
+
+func TestSpanStatusCodeUnsetDoesNotAddErrorTag(t *testing.T) {
+	transform := transformerFromAttributes(pdata.NewAttributeMap())
+	actual, err := transform.Span(spanWithStatus(pdata.StatusCodeUnset, ""))
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	_, ok := actual.Tags["error"]
+	assert.False(t, ok)
+
+	code, ok := actual.Tags[labelStatusCode]
+	assert.True(t, ok)
+	assert.Equal(t, "0", code)
+}
+
+func TestSpanStatusMessageIsConvertedToTag(t *testing.T) {
+	transform := transformerFromAttributes(pdata.NewAttributeMap())
+	message := "some error message"
+	actual, err := transform.Span(spanWithStatus(pdata.StatusCodeError, message))
+
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	msgVal, ok := actual.Tags["status.message"]
+	assert.True(t, ok)
+	assert.Equal(t, message, msgVal)
+}
+
+func TestSpanStatusMessageIsIgnoredIfStatusIsNotError(t *testing.T) {
+	transform := transformerFromAttributes(pdata.NewAttributeMap())
+	actual, err := transform.Span(spanWithStatus(pdata.StatusCodeOk, "not a real error message"))
+
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	_, ok := actual.Tags["status.message"]
+	assert.False(t, ok)
+}
+
+func TestSpanStatusMessageIsTruncatedToValidLength(t *testing.T) {
+	/*
+	 * Maximum allowed length for a combination of a point tag key and value is 254 characters
+	 * (255 including the "=" separating key and value). If the value is longer, the point is rejected and logged.
+	 * Keep the number of distinct time series per metric and host to under 1000.
+	 * -- https://docs.wavefront.com/wavefront_data_format.html
+	 */
+	transform := transformerFromAttributes(pdata.NewAttributeMap())
+	message := "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+	message += "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+	message += "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+	actual, err := transform.Span(spanWithStatus(pdata.StatusCodeError, message))
+
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	msgVal, ok := actual.Tags["status.message"]
+	assert.True(t, ok)
+	assert.Equal(t, 255-1-len("status.message"), len(msgVal), "message value truncated")
+}
+
+func TestSpanEventsAreTranslatedToSpanLogs(t *testing.T) {
+	transform := transformerFromAttributes(pdata.NewAttributeMap())
+	now := time.Now()
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	event := pdata.NewSpanEvent()
+	event.SetName("eventName")
+	event.SetTimestamp(pdata.TimestampFromTime(now))
+	eventAttrs := pdata.NewAttributeMap()
+	eventAttrs.InsertString("attrKey", "attrVal")
+	eventAttrs.CopyTo(event.Attributes())
+	event.CopyTo(span.Events().AppendEmpty())
+
+	result, err := transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+
+	require.Equal(t, 1, len(result.SpanLogs))
+	actual := result.SpanLogs[0]
+	assert.Equal(t, now.UnixNano()/time.Microsecond.Nanoseconds(), actual.Timestamp)
+	name, ok := actual.Fields[labelEventName]
+	assert.True(t, ok)
+	assert.Equal(t, "eventName", name)
+	attrVal, ok := actual.Fields["attrKey"]
+	assert.True(t, ok)
+	assert.Equal(t, "attrVal", attrVal)
+}
+
+func TestSpanKindIsTranslatedToTag(t *testing.T) {
+	transform := transformerFromAttributes(pdata.NewAttributeMap())
+
+	internalSpan, err := transform.Span(spanWithKind(pdata.SpanKindINTERNAL))
+	require.NoError(t, err, "transforming span to wavefront format")
+	kind, ok := internalSpan.Tags["span.kind"]
+	assert.True(t, ok)
+	assert.Equal(t, "internal", kind)
+
+	serverSpan, err := transform.Span(spanWithKind(pdata.SpanKindSERVER))
+	require.NoError(t, err, "transforming span to wavefront format")
+	kind, ok = serverSpan.Tags["span.kind"]
+	assert.True(t, ok)
+	assert.Equal(t, "server", kind)
+
+	clientSpan, err := transform.Span(spanWithKind(pdata.SpanKindCLIENT))
+	require.NoError(t, err, "transforming span to wavefront format")
+	kind, ok = clientSpan.Tags["span.kind"]
+	assert.True(t, ok)
+	assert.Equal(t, "client", kind)
+
+	consumerSpan, err := transform.Span(spanWithKind(pdata.SpanKindCONSUMER))
+	require.NoError(t, err, "transforming span to wavefront format")
+	kind, ok = consumerSpan.Tags["span.kind"]
+	assert.True(t, ok)
+	assert.Equal(t, "consumer", kind)
+
+	producerSpan, err := transform.Span(spanWithKind(pdata.SpanKindPRODUCER))
+	require.NoError(t, err, "transforming span to wavefront format")
+	kind, ok = producerSpan.Tags["span.kind"]
+	assert.True(t, ok)
+	assert.Equal(t, "producer", kind)
+
+	unspecifiedSpan, err := transform.Span(spanWithKind(pdata.SpanKindUNSPECIFIED))
+	require.NoError(t, err, "transforming span to wavefront format")
+	kind, ok = unspecifiedSpan.Tags["span.kind"]
+	assert.True(t, ok)
+	assert.Equal(t, "unspecified", kind)
+}
+
+func TestTraceStateTranslatedToTag(t *testing.T) {
+	transform := transformerFromAttributes(pdata.NewAttributeMap())
+
+	spanWithState, err := transform.Span(spanWithTraceState("key=val"))
+	require.NoError(t, err, "transforming span to wavefront format")
+	stateVal, ok := spanWithState.Tags["w3c.tracestate"]
+	assert.True(t, ok)
+	assert.Equal(t, "key=val", stateVal)
+
+	spanWithEmptyState, err := transform.Span(spanWithTraceState(""))
+	require.NoError(t, err, "transforming span to wavefront format")
+	_, ok = spanWithEmptyState.Tags["w3c.tracestate"]
+	assert.False(t, ok)
+}
+
+func spanWithKind(kind pdata.SpanKind) pdata.Span {
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	span.SetKind(kind)
+	return span
+}
+
+func spanWithTraceState(state pdata.TraceState) pdata.Span {
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	span.SetTraceState(state)
+	return span
+}
+
+func transformerFromAttributes(att pdata.AttributeMap) *traceTransformer {
+	return &traceTransformer{
+		ResourceAttributes: att,
+		Config:             createDefaultConfig().(*Config),
+	}
+}
+
+func spanWithStatus(statusCode pdata.StatusCode, message string) pdata.Span {
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	status := pdata.NewSpanStatus()
+	status.SetCode(statusCode)
+	if message != "" {
+		status.SetMessage(message)
+	}
+	status.CopyTo(span.Status())
+	return span
+}


### PR DESCRIPTION
**Description:** This is the implementation of a traces exporter for Tanzu Observability (Wavefront).

**Link to tracking Issue:** This is a continuation of #3393.

**Testing:** Unit tests.

**Documentation:** #3393 included a README with documentation.

@thepeterstone and @oppegard are responsible for this PR submission.