### PR TITLE
EMF: Store the initial value for cumulative metrics

### DIFF
--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -16,7 +16,6 @@ package awsemfexporter
 
 import (
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -86,60 +85,68 @@ func generateTestDoubleGauge(name string) *metricspb.Metric {
 	}
 }
 
-func generateTestIntSum(name string) *metricspb.Metric {
-	return &metricspb.Metric{
-		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name: name,
-			Type: metricspb.MetricDescriptor_CUMULATIVE_INT64,
-			Unit: "Count",
-			LabelKeys: []*metricspb.LabelKey{
-				{Key: "label1"},
-			},
-		},
-		Timeseries: []*metricspb.TimeSeries{
-			{
-				LabelValues: []*metricspb.LabelValue{
-					{Value: "value1", HasValue: true},
-					{Value: "value2", HasValue: true},
+func generateTestIntSum(name string) []*metricspb.Metric {
+	var metrics []*metricspb.Metric
+	for i := 0; i < 2; i++ {
+		metrics = append(metrics, &metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name: name,
+				Type: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+				Unit: "Count",
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "label1"},
 				},
-				Points: []*metricspb.Point{
-					{
-						Value: &metricspb.Point_Int64Value{
-							Int64Value: 1,
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "value1", HasValue: true},
+						{Value: "value2", HasValue: true},
+					},
+					Points: []*metricspb.Point{
+						{
+							Value: &metricspb.Point_Int64Value{
+								Int64Value: int64(i),
+							},
 						},
 					},
 				},
 			},
-		},
+		})
 	}
+	return metrics
 }
 
-func generateTestDoubleSum(name string) *metricspb.Metric {
-	return &metricspb.Metric{
-		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name: name,
-			Type: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
-			Unit: "Count",
-			LabelKeys: []*metricspb.LabelKey{
-				{Key: "label1"},
-			},
-		},
-		Timeseries: []*metricspb.TimeSeries{
-			{
-				LabelValues: []*metricspb.LabelValue{
-					{Value: "value1", HasValue: true},
-					{Value: "value2", HasValue: true},
+func generateTestDoubleSum(name string) []*metricspb.Metric {
+	var metrics []*metricspb.Metric
+	for i := 0; i < 2; i++ {
+		metrics = append(metrics, &metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name: name,
+				Type: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
+				Unit: "Count",
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "label1"},
 				},
-				Points: []*metricspb.Point{
-					{
-						Value: &metricspb.Point_DoubleValue{
-							DoubleValue: 0.1,
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "value1", HasValue: true},
+						{Value: "value2", HasValue: true},
+					},
+					Points: []*metricspb.Point{
+						{
+							Value: &metricspb.Point_DoubleValue{
+								DoubleValue: float64(i) * 0.1,
+							},
 						},
 					},
 				},
 			},
-		},
+		})
 	}
+	return metrics
 }
 
 func generateTestHistogram(name string) *metricspb.Metric {
@@ -191,46 +198,49 @@ func generateTestHistogram(name string) *metricspb.Metric {
 	}
 }
 
-func generateTestSummary(name string) *metricspb.Metric {
-	return &metricspb.Metric{
-		MetricDescriptor: &metricspb.MetricDescriptor{
-			Name: name,
-			Type: metricspb.MetricDescriptor_SUMMARY,
-			Unit: "Seconds",
-			LabelKeys: []*metricspb.LabelKey{
-				{Key: "label1"},
-			},
-		},
-		Timeseries: []*metricspb.TimeSeries{
-			{
-				LabelValues: []*metricspb.LabelValue{
-					{Value: "value1", HasValue: true},
+func generateTestSummary(name string) []*metricspb.Metric {
+	var metrics []*metricspb.Metric
+	for i := 0; i < 2; i++ {
+		metrics = append(metrics, &metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name: name,
+				Type: metricspb.MetricDescriptor_SUMMARY,
+				Unit: "Seconds",
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "label1"},
 				},
-				Points: []*metricspb.Point{
-					{
-						Value: &metricspb.Point_SummaryValue{
-							SummaryValue: &metricspb.SummaryValue{
-								Sum: &wrappers.DoubleValue{
-									Value: 15.0,
-								},
-								Count: &wrappers.Int64Value{
-									Value: 5,
-								},
-								Snapshot: &metricspb.SummaryValue_Snapshot{
-									Count: &wrappers.Int64Value{
-										Value: 5,
-									},
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "value1", HasValue: true},
+					},
+					Points: []*metricspb.Point{
+						{
+							Value: &metricspb.Point_SummaryValue{
+								SummaryValue: &metricspb.SummaryValue{
 									Sum: &wrappers.DoubleValue{
-										Value: 15.0,
+										Value: float64(i * 15.0),
 									},
-									PercentileValues: []*metricspb.SummaryValue_Snapshot_ValueAtPercentile{
-										{
-											Percentile: 0.0,
-											Value:      1,
+									Count: &wrappers.Int64Value{
+										Value: int64(i * 5),
+									},
+									Snapshot: &metricspb.SummaryValue_Snapshot{
+										Count: &wrappers.Int64Value{
+											Value: 5,
 										},
-										{
-											Percentile: 100.0,
-											Value:      5,
+										Sum: &wrappers.DoubleValue{
+											Value: 15.0,
+										},
+										PercentileValues: []*metricspb.SummaryValue_Snapshot_ValueAtPercentile{
+											{
+												Percentile: 0.0,
+												Value:      1,
+											},
+											{
+												Percentile: 100.0,
+												Value:      5,
+											},
 										},
 									},
 								},
@@ -239,8 +249,9 @@ func generateTestSummary(name string) *metricspb.Metric {
 					},
 				},
 			},
-		},
+		})
 	}
+	return metrics
 }
 
 func setupDataPointCache() {
@@ -264,17 +275,23 @@ func TestIntDataPointSliceAt(t *testing.T) {
 			"w/ 1st delta calculation",
 			true,
 			int64(-17),
-			float64(-17),
+			float64(0),
 		},
 		{
-			"w/ 2st delta calculation",
+			"w/ 2nd delta calculation",
 			true,
 			int64(1),
 			float64(18),
 		},
+		{
+			"w/o delta calculation",
+			false,
+			int64(10),
+			float64(10),
+		},
 	}
 
-	for _, tc := range testDeltaCases {
+	for i, tc := range testDeltaCases {
 		t.Run(tc.testName, func(t *testing.T) {
 			testDPS := pdata.NewIntDataPointSlice()
 			testDP := testDPS.AppendEmpty()
@@ -303,11 +320,11 @@ func TestIntDataPointSliceAt(t *testing.T) {
 			}
 
 			assert.Equal(t, 1, dps.Len())
-			dp := dps.At(0)
-			if strings.Contains(tc.testName, "2nd rate") {
+			dp, retained := dps.At(0)
+			assert.Equal(t, i > 0, retained)
+			if retained {
+				assert.Equal(t, expectedDP.Labels, dp.Labels)
 				assert.InDelta(t, expectedDP.Value.(float64), dp.Value.(float64), 0.02)
-			} else {
-				assert.Equal(t, expectedDP, dp)
 			}
 		})
 	}
@@ -333,13 +350,19 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 		},
 		{
 			"w/ 2nd delta calculation",
+			true,
+			0.8,
+			0.4,
+		},
+		{
+			"w/o delta calculation",
 			false,
 			0.5,
-			0.1,
+			0.5,
 		},
 	}
 
-	for _, tc := range testDeltaCases {
+	for i, tc := range testDeltaCases {
 		t.Run(tc.testName, func(t *testing.T) {
 			testDPS := pdata.NewDoubleDataPointSlice()
 			testDP := testDPS.AppendEmpty()
@@ -360,8 +383,11 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 			}
 
 			assert.Equal(t, 1, dps.Len())
-			dp := dps.At(0)
-			assert.True(t, (tc.calculatedValue.(float64)-dp.Value.(float64)) < 0.002)
+			dp, retained := dps.At(0)
+			assert.Equal(t, i > 0, retained)
+			if retained {
+				assert.InDelta(t, tc.calculatedValue.(float64), dp.Value.(float64), 0.002)
+			}
 		})
 	}
 }
@@ -395,7 +421,7 @@ func TestHistogramDataPointSliceAt(t *testing.T) {
 	}
 
 	assert.Equal(t, 1, dps.Len())
-	dp := dps.At(0)
+	dp, _ := dps.At(0)
 	assert.Equal(t, expectedDP, dp)
 }
 
@@ -414,7 +440,7 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 		{
 			"1st summary count calculation",
 			[]interface{}{17.3, uint64(17)},
-			[]interface{}{17.3, uint64(17)},
+			[]interface{}{float64(0), uint64(0)},
 		},
 		{
 			"2nd summary count calculation",
@@ -428,7 +454,7 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 		},
 	}
 
-	for _, tt := range testCases {
+	for i, tt := range testCases {
 		t.Run(tt.testName, func(t *testing.T) {
 			testDPS := pdata.NewSummaryDataPointSlice()
 			testDP := testDPS.AppendEmpty()
@@ -471,14 +497,17 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 			}
 
 			assert.Equal(t, 1, dps.Len())
-			dp := dps.At(0)
-			expectedMetricStats := expectedDP.Value.(*CWMetricStats)
-			actualMetricsStats := dp.Value.(*CWMetricStats)
-			assert.Equal(t, expectedDP.Labels, dp.Labels)
-			assert.Equal(t, expectedMetricStats.Max, actualMetricsStats.Max)
-			assert.Equal(t, expectedMetricStats.Min, actualMetricsStats.Min)
-			assert.InDelta(t, expectedMetricStats.Count, actualMetricsStats.Count, 0.1)
-			assert.InDelta(t, expectedMetricStats.Sum, actualMetricsStats.Sum, 0.02)
+			dp, retained := dps.At(0)
+			assert.Equal(t, i > 0, retained)
+			if retained {
+				expectedMetricStats := expectedDP.Value.(*CWMetricStats)
+				actualMetricsStats := dp.Value.(*CWMetricStats)
+				assert.Equal(t, expectedDP.Labels, dp.Labels)
+				assert.Equal(t, expectedMetricStats.Max, actualMetricsStats.Max)
+				assert.Equal(t, expectedMetricStats.Min, actualMetricsStats.Min)
+				assert.InDelta(t, expectedMetricStats.Count, actualMetricsStats.Count, 0.1)
+				assert.InDelta(t, expectedMetricStats.Sum, actualMetricsStats.Sum, 0.02)
+			}
 		})
 	}
 }
@@ -556,7 +585,7 @@ func TestGetDataPoints(t *testing.T) {
 		{
 			"Int sum",
 			false,
-			generateTestIntSum("foo"),
+			generateTestIntSum("foo")[1],
 			IntDataPointSlice{
 				metadata.InstrumentationLibraryName,
 				cumulativeDmm,
@@ -566,7 +595,7 @@ func TestGetDataPoints(t *testing.T) {
 		{
 			"Double sum",
 			false,
-			generateTestDoubleSum("foo"),
+			generateTestDoubleSum("foo")[1],
 			DoubleDataPointSlice{
 				metadata.InstrumentationLibraryName,
 				cumulativeDmm,
@@ -585,7 +614,7 @@ func TestGetDataPoints(t *testing.T) {
 		{
 			"Summary from SDK",
 			false,
-			generateTestSummary("foo"),
+			generateTestSummary("foo")[1],
 			SummaryDataPointSlice{
 				metadata.InstrumentationLibraryName,
 				dmm,
@@ -595,7 +624,7 @@ func TestGetDataPoints(t *testing.T) {
 		{
 			"Summary from Prometheus",
 			true,
-			generateTestSummary("foo"),
+			generateTestSummary("foo")[1],
 			SummaryDataPointSlice{
 				metadata.InstrumentationLibraryName,
 				cumulativeDmm,
@@ -616,6 +645,8 @@ func TestGetDataPoints(t *testing.T) {
 		expectedLabels := pdata.NewStringMap().InitFromMap(map[string]string{"label1": "value1"})
 
 		t.Run(tc.testName, func(t *testing.T) {
+			setupDataPointCache()
+
 			if tc.isPrometheusMetrics {
 				metadata.receiver = prometheusReceiver
 			} else {
@@ -701,11 +732,11 @@ func BenchmarkGetDataPoints(b *testing.B) {
 	ocMetrics := []*metricspb.Metric{
 		generateTestIntGauge("int-gauge"),
 		generateTestDoubleGauge("double-gauge"),
-		generateTestIntSum("int-sum"),
-		generateTestDoubleSum("double-sum"),
 		generateTestHistogram("double-histogram"),
-		generateTestSummary("summary"),
 	}
+	ocMetrics = append(ocMetrics, generateTestIntSum("int-sum")...)
+	ocMetrics = append(ocMetrics, generateTestDoubleSum("double-sum")...)
+	ocMetrics = append(ocMetrics, generateTestSummary("summary")...)
 	rms := internaldata.OCToMetrics(nil, nil, ocMetrics).ResourceMetrics()
 	metrics := rms.At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	numMetrics := metrics.Len()
@@ -755,7 +786,7 @@ func TestIntDataPointSlice_At(t *testing.T) {
 				deltaMetricMetadata:        tt.fields.deltaMetricMetadata,
 				IntDataPointSlice:          tt.fields.IntDataPointSlice,
 			}
-			if got := dps.At(tt.args.i); !reflect.DeepEqual(got, tt.want) {
+			if got, _ := dps.At(tt.args.i); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("At() = %v, want %v", got, tt.want)
 			}
 		})

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -86,38 +86,40 @@ func TestConsumeMetrics(t *testing.T) {
 				"resource": "R1",
 			},
 		},
-		Metrics: []*metricspb.Metric{
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
+		Metrics: []*metricspb.Metric{},
+	}
+	for i := 0; i < 2; i++ {
+		m := &metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        "spanCounter",
+				Description: "Counting all the spans",
+				Unit:        "Count",
+				Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "spanName"},
+					{Key: "isItAnError"},
 				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan"},
-							{Value: "false"},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 0,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "testSpan"},
+						{Value: "false"},
+					},
+					Points: []*metricspb.Point{
+						{
+							Timestamp: &timestamp.Timestamp{
+								Seconds: int64(i),
+							},
+							Value: &metricspb.Point_Int64Value{
+								Int64Value: 1,
 							},
 						},
 					},
 				},
 			},
-		},
+		}
+		mdata.Metrics = append(mdata.Metrics, m)
 	}
 	md := internaldata.OCToMetrics(mdata.Node, mdata.Resource, mdata.Metrics)
 	require.Error(t, exp.ConsumeMetrics(ctx, md))
@@ -207,39 +209,42 @@ func TestConsumeMetricsWithLogGroupStreamConfig(t *testing.T) {
 				"resource": "R1",
 			},
 		},
-		Metrics: []*metricspb.Metric{
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
+		Metrics: []*metricspb.Metric{},
+	}
+	for i := 0; i < 2; i++ {
+		m := &metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        "spanCounter",
+				Description: "Counting all the spans",
+				Unit:        "Count",
+				Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "spanName"},
+					{Key: "isItAnError"},
 				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan"},
-							{Value: "false"},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 0,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "testSpan"},
+						{Value: "false"},
+					},
+					Points: []*metricspb.Point{
+						{
+							Timestamp: &timestamp.Timestamp{
+								Seconds: int64(i),
+							},
+							Value: &metricspb.Point_Int64Value{
+								Int64Value: int64(i),
 							},
 						},
 					},
 				},
 			},
-		},
+		}
+		mdata.Metrics = append(mdata.Metrics, m)
 	}
+
 	md := internaldata.OCToMetrics(mdata.Node, mdata.Resource, mdata.Metrics)
 	require.NoError(t, exp.Start(ctx, nil))
 	require.Error(t, exp.ConsumeMetrics(ctx, md))
@@ -275,39 +280,40 @@ func TestConsumeMetricsWithLogGroupStreamValidPlaceholder(t *testing.T) {
 				"aws.ecs.task.id":      "test-task-id",
 			},
 		},
-		Metrics: []*metricspb.Metric{
-
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
+		Metrics: []*metricspb.Metric{},
+	}
+	for i := 0; i < 2; i++ {
+		m := &metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        "spanCounter",
+				Description: "Counting all the spans",
+				Unit:        "Count",
+				Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "spanName"},
+					{Key: "isItAnError"},
 				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan"},
-							{Value: "false"},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 0,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "testSpan"},
+						{Value: "false"},
+					},
+					Points: []*metricspb.Point{
+						{
+							Timestamp: &timestamp.Timestamp{
+								Seconds: int64(i),
+							},
+							Value: &metricspb.Point_Int64Value{
+								Int64Value: int64(i),
 							},
 						},
 					},
 				},
 			},
-		},
+		}
+		mdata.Metrics = append(mdata.Metrics, m)
 	}
 	md := internaldata.OCToMetrics(mdata.Node, mdata.Resource, mdata.Metrics)
 	require.NoError(t, exp.Start(ctx, nil))
@@ -344,39 +350,40 @@ func TestConsumeMetricsWithOnlyLogStreamPlaceholder(t *testing.T) {
 				"aws.ecs.task.id":      "test-task-id",
 			},
 		},
-		Metrics: []*metricspb.Metric{
-
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
+		Metrics: []*metricspb.Metric{},
+	}
+	for i := 0; i < 2; i++ {
+		m := &metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        "spanCounter",
+				Description: "Counting all the spans",
+				Unit:        "Count",
+				Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "spanName"},
+					{Key: "isItAnError"},
 				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan"},
-							{Value: "false"},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 0,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "testSpan"},
+						{Value: "false"},
+					},
+					Points: []*metricspb.Point{
+						{
+							Timestamp: &timestamp.Timestamp{
+								Seconds: int64(i),
+							},
+							Value: &metricspb.Point_Int64Value{
+								Int64Value: int64(i),
 							},
 						},
 					},
 				},
 			},
-		},
+		}
+		mdata.Metrics = append(mdata.Metrics, m)
 	}
 	md := internaldata.OCToMetrics(mdata.Node, mdata.Resource, mdata.Metrics)
 	require.NoError(t, exp.Start(ctx, nil))
@@ -413,39 +420,40 @@ func TestConsumeMetricsWithWrongPlaceholder(t *testing.T) {
 				"aws.ecs.task.id":      "test-task-id",
 			},
 		},
-		Metrics: []*metricspb.Metric{
-
-			{
-				MetricDescriptor: &metricspb.MetricDescriptor{
-					Name:        "spanCounter",
-					Description: "Counting all the spans",
-					Unit:        "Count",
-					Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
-					LabelKeys: []*metricspb.LabelKey{
-						{Key: "spanName"},
-						{Key: "isItAnError"},
-					},
+		Metrics: []*metricspb.Metric{},
+	}
+	for i := 0; i < 2; i++ {
+		m := &metricspb.Metric{
+			MetricDescriptor: &metricspb.MetricDescriptor{
+				Name:        "spanCounter",
+				Description: "Counting all the spans",
+				Unit:        "Count",
+				Type:        metricspb.MetricDescriptor_CUMULATIVE_INT64,
+				LabelKeys: []*metricspb.LabelKey{
+					{Key: "spanName"},
+					{Key: "isItAnError"},
 				},
-				Timeseries: []*metricspb.TimeSeries{
-					{
-						LabelValues: []*metricspb.LabelValue{
-							{Value: "testSpan"},
-							{Value: "false"},
-						},
-						Points: []*metricspb.Point{
-							{
-								Timestamp: &timestamp.Timestamp{
-									Seconds: 0,
-								},
-								Value: &metricspb.Point_Int64Value{
-									Int64Value: 1,
-								},
+			},
+			Timeseries: []*metricspb.TimeSeries{
+				{
+					LabelValues: []*metricspb.LabelValue{
+						{Value: "testSpan"},
+						{Value: "false"},
+					},
+					Points: []*metricspb.Point{
+						{
+							Timestamp: &timestamp.Timestamp{
+								Seconds: int64(i),
+							},
+							Value: &metricspb.Point_Int64Value{
+								Int64Value: int64(i),
 							},
 						},
 					},
 				},
 			},
-		},
+		}
+		mdata.Metrics = append(mdata.Metrics, m)
 	}
 	md := internaldata.OCToMetrics(mdata.Node, mdata.Resource, mdata.Metrics)
 	require.NoError(t, exp.Start(ctx, nil))

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -47,7 +47,11 @@ func addToGroupedMetric(pmd *pdata.Metric, groupedMetrics map[interface{}]*Group
 	}
 
 	for i := 0; i < dps.Len(); i++ {
-		dp := dps.At(i)
+		dp, retained := dps.At(i)
+		if !retained {
+			continue
+		}
+
 		labels := dp.Labels
 		metric := &MetricInfo{
 			Value: dp.Value,

--- a/internal/aws/metrics/metric_calculator.go
+++ b/internal/aws/metrics/metric_calculator.go
@@ -35,12 +35,11 @@ func NewFloat64DeltaCalculator() MetricCalculator {
 }
 
 func calculateDelta(prev *MetricValue, val interface{}, timestamp time.Time) (interface{}, bool) {
-	deltaValue := val.(float64)
+	var deltaValue float64
 	if prev != nil {
-		deltaValue = deltaValue - prev.RawValue.(float64)
-		if deltaValue < 0 {
-			return float64(0), true
-		}
+		deltaValue = val.(float64) - prev.RawValue.(float64)
+	} else {
+		return deltaValue, false
 	}
 	return deltaValue, true
 }

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -80,9 +80,9 @@ func TestFloat64DeltaCalculator(t *testing.T) {
 	testCases := []float64{0.1, 0.1, 0.5, 1.3, 1.9, 2.5, 5, 24.2, 103}
 	for i, f := range testCases {
 		r, ok := c.Calculate(MetricMetadata, nil, f, initTime)
-		assert.True(t, ok)
+		assert.Equal(t, i > 0, ok)
 		if i == 0 {
-			assert.Equal(t, f, r)
+			assert.Equal(t, float64(0), r)
 		} else {
 			assert.InDelta(t, f-testCases[i-1], r, f/10)
 		}
@@ -97,12 +97,9 @@ func TestFloat64DeltaCalculatorWithDecreasingValues(t *testing.T) {
 	testCases := []float64{108, 106, 56.2, 28.8, 10, 10, 3, -1, -100}
 	for i, f := range testCases {
 		r, ok := c.Calculate(MetricMetadata, nil, f, initTime)
-		if i == 0 {
-			assert.True(t, ok)
-			assert.Equal(t, f, r)
-		} else {
-			assert.True(t, ok)
-			assert.Equal(t, float64(0), r)
+		assert.Equal(t, i > 0, ok)
+		if ok {
+			assert.Equal(t, testCases[i]-testCases[i-1], r)
 		}
 	}
 }


### PR DESCRIPTION
**Why do we need it?**
This is a follow-up PR of https://github.com/open-telemetry/opentelemetry-collector/pull/3047.

In this PR, EMF exporter changes its strategy when handling cumulative metric values such as counters, and prometheus summaries - it stores the first scraped records as initial value in cache, and skip sending them to the backend. As a result, the deltas calculated from the second are treated as the first values that EMF exporter will export.

For example, if counter metrics are received in the following order:
```
1st batch: request_total {code=400, value=100}
2nd batch: request_total {code=400, value=101}
3rd batch: request_total {code=400, value=102}
```

The metrics will be sent by EMF as:
~~1st batch: SKIP~~
~~2nd batch: request_total {code=400, value=1}~~
~~3rd batch: request_total {code=400, value=2}~~

```
1st batch: SKIP
2nd batch: request_total {code=400, value=1}
3rd batch: request_total {code=400, value=1}
```