### PR TITLE
[metrics_generation_processor] Add metrics generation logic

### DIFF
--- a/processor/metricsgenerationprocessor/README.md
+++ b/processor/metricsgenerationprocessor/README.md
@@ -26,6 +26,9 @@ processors:
               # Name of the new metric. This is a required field.
             - name: <new_metric_name>
 
+              # Unit for the new metric being generated.
+              unit: <new_metric_unit>
+
               # type describes how the new metric will be generated. It can be one of `calculate` or `scale`.  calculate generates a metric applying the given operation on two operand metrics. scale operates only on operand1 metric to generate the new metric.
               type: {calculate, scale}
 
@@ -57,6 +60,7 @@ rules:
 # create pod.memory.usage.bytes from pod.memory.usage.megabytes
 rules:
     - name: pod.memory.usage.bytes
+      unit: Bytes
       type: scale
       metric1: pod.memory.usage.megabytes
       operation: multiply

--- a/processor/metricsgenerationprocessor/config.go
+++ b/processor/metricsgenerationprocessor/config.go
@@ -53,6 +53,9 @@ type Rule struct {
 	// Name of the new metric being generated. This is a required field.
 	Name string `mapstructure:"name"`
 
+	// Unit for the new metric being generated.
+	Unit string `mapstructure:"unit"`
+
 	// The rule type following which the new metric will be generated. This is a required field.
 	Type GenerationType `mapstructure:"type"`
 

--- a/processor/metricsgenerationprocessor/config_test.go
+++ b/processor/metricsgenerationprocessor/config_test.go
@@ -38,6 +38,7 @@ func TestLoadingFullConfig(t *testing.T) {
 				Rules: []Rule{
 					{
 						Name:      "new_metric",
+						Unit:      "percent",
 						Type:      "calculate",
 						Metric1:   "metric1",
 						Metric2:   "metric2",
@@ -45,6 +46,7 @@ func TestLoadingFullConfig(t *testing.T) {
 					},
 					{
 						Name:      "new_metric",
+						Unit:      "unit",
 						Type:      "scale",
 						Metric1:   "metric1",
 						ScaleBy:   1000,

--- a/processor/metricsgenerationprocessor/factory.go
+++ b/processor/metricsgenerationprocessor/factory.go
@@ -73,6 +73,7 @@ func buildInternalConfig(config *Config) []internalRule {
 	for i, rule := range config.Rules {
 		customRule := internalRule{
 			name:      rule.Name,
+			unit:      rule.Unit,
 			ruleType:  string(rule.Type),
 			metric1:   rule.Metric1,
 			metric2:   rule.Metric2,

--- a/processor/metricsgenerationprocessor/processor.go
+++ b/processor/metricsgenerationprocessor/processor.go
@@ -64,28 +64,26 @@ func (mgp *metricsGenerationProcessor) ProcessMetrics(_ context.Context, md pdat
 			operand2 := float64(0)
 			_, ok := nameToMetricMap[rule.metric1]
 			if !ok {
-				mgp.logger.Debug("Missing first metric:" + rule.metric1)
+				mgp.logger.Debug("Missing first metric", zap.String("metric_name", rule.metric1))
 				continue
 			}
 
 			if rule.ruleType == string(calculate) {
 				metric2, ok := nameToMetricMap[rule.metric2]
 				if !ok {
-					mgp.logger.Debug("Missing second metric:" + rule.metric2)
+					mgp.logger.Debug("Missing second metric", zap.String("metric_name", rule.metric2))
 					continue
 				}
-				operand2 = getMetricValue(metric2[0])
+				operand2 = getMetricValue(metric2)
 				if operand2 <= 0 {
 					continue
 				}
-				generateMetrics(rm, operand2, rule)
-			}
 
-			if rule.ruleType == string(scale) {
-				generateMetrics(rm, rule.scaleBy, rule)
+			} else if rule.ruleType == string(scale) {
+				operand2 = rule.scaleBy
 			}
+			generateMetrics(rm, operand2, rule, mgp.logger)
 		}
-
 	}
 	return md, nil
 }

--- a/processor/metricsgenerationprocessor/processor.go
+++ b/processor/metricsgenerationprocessor/processor.go
@@ -32,6 +32,7 @@ var _ processorhelper.MProcessor = (*metricsGenerationProcessor)(nil)
 
 type internalRule struct {
 	name      string
+	unit      string
 	ruleType  string
 	metric1   string
 	metric2   string
@@ -53,6 +54,39 @@ func (mgp *metricsGenerationProcessor) Start(context.Context, component.Host) er
 
 // ProcessMetrics implements the MProcessor interface.
 func (mgp *metricsGenerationProcessor) ProcessMetrics(_ context.Context, md pdata.Metrics) (pdata.Metrics, error) {
+	resourceMetricsSlice := md.ResourceMetrics()
+
+	for i := 0; i < resourceMetricsSlice.Len(); i++ {
+		rm := resourceMetricsSlice.At(i)
+		nameToMetricMap := getNameToMetricMap(rm)
+
+		for _, rule := range mgp.rules {
+			operand2 := float64(0)
+			_, ok := nameToMetricMap[rule.metric1]
+			if !ok {
+				mgp.logger.Debug("Missing first metric:" + rule.metric1)
+				continue
+			}
+
+			if rule.ruleType == string(calculate) {
+				metric2, ok := nameToMetricMap[rule.metric2]
+				if !ok {
+					mgp.logger.Debug("Missing second metric:" + rule.metric2)
+					continue
+				}
+				operand2 = getMetricValue(metric2[0])
+				if operand2 <= 0 {
+					continue
+				}
+				generateMetrics(rm, operand2, rule)
+			}
+
+			if rule.ruleType == string(scale) {
+				generateMetrics(rm, rule.scaleBy, rule)
+			}
+		}
+
+	}
 	return md, nil
 }
 

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -1,0 +1,402 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricsgenerationprocessor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+type testMetric struct {
+	metricNames  []string
+	metricValues [][]float64
+}
+
+type testMetricIntGauge struct {
+	metricNames  []string
+	metricValues [][]int64
+}
+
+type metricsGenerationTest struct {
+	name       string
+	rules      []Rule
+	inMetrics  pdata.Metrics
+	outMetrics pdata.Metrics
+}
+
+var (
+	testCases = []metricsGenerationTest{
+		{
+			name:  "metrics_generation_expect_all",
+			rules: nil,
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+		},
+		{
+			name: "metrics_generation_rule_scale",
+			rules: []Rule{
+				{
+					Name:      "metric_1_scaled",
+					Type:      "scale",
+					Metric1:   "metric_1",
+					Operation: "multiply",
+					ScaleBy:   5,
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2", "metric_1_scaled"},
+				metricValues: [][]float64{{100}, {4}, {500}},
+			}),
+		},
+		{
+			name: "metrics_generation_missing_first_metric",
+			rules: []Rule{
+				{
+					Name:      "metric_1_scaled",
+					Type:      "scale",
+					Operation: "multiply",
+					ScaleBy:   5,
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+		},
+		{
+			name: "metrics_generation_rule_calculate_divide",
+			rules: []Rule{
+				{
+					Name:      "metric_1_calculated_divide",
+					Type:      "calculate",
+					Metric1:   "metric_1",
+					Metric2:   "metric_2",
+					Operation: "divide",
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_divide"},
+				metricValues: [][]float64{{100}, {4}, {25}},
+			}),
+		},
+		{
+			name: "metrics_generation_rule_calculate_multiply",
+			rules: []Rule{
+				{
+					Name:      "metric_1_calculated_multiply",
+					Type:      "calculate",
+					Metric1:   "metric_1",
+					Metric2:   "metric_2",
+					Operation: "multiply",
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_multiply"},
+				metricValues: [][]float64{{100}, {4}, {400}},
+			}),
+		},
+		{
+			name: "metrics_generation_rule_calculate_add",
+			rules: []Rule{
+				{
+					Name:      "metric_1_calculated_add",
+					Type:      "calculate",
+					Metric1:   "metric_1",
+					Metric2:   "metric_2",
+					Operation: "add",
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_add"},
+				metricValues: [][]float64{{100}, {4}, {104}},
+			}),
+		},
+		{
+			name: "metrics_generation_rule_calculate_subtract",
+			rules: []Rule{
+				{
+					Name:      "metric_1_calculated_subtract",
+					Type:      "calculate",
+					Metric1:   "metric_1",
+					Metric2:   "metric_2",
+					Operation: "subtract",
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_subtract"},
+				metricValues: [][]float64{{100}, {4}, {96}},
+			}),
+		},
+		{
+			name: "metrics_generation_rule_calculate_percent",
+			rules: []Rule{
+				{
+					Name:      "metric_1_calculated_percent",
+					Type:      "calculate",
+					Metric1:   "metric_1",
+					Metric2:   "metric_2",
+					Operation: "percent",
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{20}, {200}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_percent"},
+				metricValues: [][]float64{{20}, {200}, {10}},
+			}),
+		},
+		{
+			name: "metrics_generation_rule_calculate_missing_2nd_metric",
+			rules: []Rule{
+				{
+					Name:      "metric_1_calculated_multiply",
+					Type:      "calculate",
+					Metric1:   "metric_1",
+					Operation: "multiply",
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {4}},
+			}),
+		},
+		{
+			name: "metrics_generation_rule_calculate_divide_op2_zero",
+			rules: []Rule{
+				{
+					Name:      "metric_1_calculated_divide",
+					Type:      "calculate",
+					Metric1:   "metric_1",
+					Metric2:   "metric_2",
+					Operation: "divide",
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {0}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {0}},
+			}),
+		},
+		{
+			name: "metrics_generation_rule_calculate_invalid_operation",
+			rules: []Rule{
+				{
+					Name:      "metric_1_calculated_invalid",
+					Type:      "calculate",
+					Metric1:   "metric_1",
+					Metric2:   "metric_2",
+					Operation: "invalid",
+				},
+			},
+			inMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {0}},
+			}),
+			outMetrics: generateTestMetrics(testMetric{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]float64{{100}, {0}},
+			}),
+		},
+		{
+			name: "metrics_generation_test_int_gauge_add",
+			rules: []Rule{
+				{
+					Name:      "metric_calculated",
+					Type:      "calculate",
+					Metric1:   "metric_1",
+					Metric2:   "metric_2",
+					Operation: "add",
+				},
+			},
+			inMetrics: generateTestMetricsWithIntDatapoint(testMetricIntGauge{
+				metricNames:  []string{"metric_1", "metric_2"},
+				metricValues: [][]int64{{100}, {5}},
+			}),
+			outMetrics: getOutputForIntGaugeTest(),
+		},
+	}
+)
+
+func TestMetricsGenerationProcessor(t *testing.T) {
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			// next stores the results of the filter metric processor
+			next := new(consumertest.MetricsSink)
+			cfg := &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewID(typeStr)),
+				Rules:             test.rules,
+			}
+			factory := NewFactory()
+			mgp, err := factory.CreateMetricsProcessor(
+				context.Background(),
+				componenttest.NewNopProcessorCreateSettings(),
+				cfg,
+				next,
+			)
+			assert.NotNil(t, mgp)
+			assert.Nil(t, err)
+
+			caps := mgp.Capabilities()
+			assert.True(t, caps.MutatesData)
+			ctx := context.Background()
+			require.NoError(t, mgp.Start(ctx, nil))
+
+			cErr := mgp.ConsumeMetrics(context.Background(), test.inMetrics)
+			assert.Nil(t, cErr)
+			got := next.AllMetrics()
+
+			require.Equal(t, 1, len(got))
+			require.Equal(t, test.outMetrics.ResourceMetrics().Len(), got[0].ResourceMetrics().Len())
+
+			expectedMetrics := test.outMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+			actualMetrics := got[0].ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+
+			require.Equal(t, expectedMetrics.Len(), actualMetrics.Len())
+
+			for i := 0; i < expectedMetrics.Len(); i++ {
+				eM := expectedMetrics.At(i)
+				aM := actualMetrics.At(i)
+
+				require.Equal(t, eM.Name(), aM.Name())
+
+				if eM.DataType() == pdata.MetricDataTypeDoubleGauge {
+					eDataPoints := eM.DoubleGauge().DataPoints()
+					aDataPoints := aM.DoubleGauge().DataPoints()
+					require.Equal(t, eDataPoints.Len(), aDataPoints.Len())
+
+					for j := 0; j < eDataPoints.Len(); j++ {
+						require.Equal(t, eDataPoints.At(j).Value(), aDataPoints.At(j).Value())
+					}
+				}
+
+				if eM.DataType() == pdata.MetricDataTypeIntGauge {
+					eDataPoints := eM.IntGauge().DataPoints()
+					aDataPoints := aM.IntGauge().DataPoints()
+					require.Equal(t, eDataPoints.Len(), aDataPoints.Len())
+
+					for j := 0; j < eDataPoints.Len(); j++ {
+						require.Equal(t, eDataPoints.At(j).Value(), aDataPoints.At(j).Value())
+					}
+				}
+				
+			}
+
+			require.NoError(t, mgp.Shutdown(ctx))
+		})
+	}
+}
+
+func generateTestMetrics(tm testMetric) pdata.Metrics {
+	md := pdata.NewMetrics()
+	now := time.Now()
+
+	rm := md.ResourceMetrics().AppendEmpty()
+	ms := rm.InstrumentationLibraryMetrics().AppendEmpty().Metrics()
+	for i, name := range tm.metricNames {
+		m := ms.AppendEmpty()
+		m.SetName(name)
+		m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+		for _, value := range tm.metricValues[i] {
+			dp := m.DoubleGauge().DataPoints().AppendEmpty()
+			dp.SetTimestamp(pdata.TimestampFromTime(now.Add(10 * time.Second)))
+			dp.SetValue(value)
+		}
+	}
+
+	return md
+}
+
+
+func generateTestMetricsWithIntDatapoint(tm testMetricIntGauge) pdata.Metrics {
+	md := pdata.NewMetrics()
+	now := time.Now()
+
+	rm := md.ResourceMetrics().AppendEmpty()
+	ms := rm.InstrumentationLibraryMetrics().AppendEmpty().Metrics()
+	for i, name := range tm.metricNames {
+		m := ms.AppendEmpty()
+		m.SetName(name)
+		m.SetDataType(pdata.MetricDataTypeIntGauge)
+		for _, value := range tm.metricValues[i] {
+			dp := m.IntGauge().DataPoints().AppendEmpty()
+			dp.SetTimestamp(pdata.TimestampFromTime(now.Add(10 * time.Second)))
+			dp.SetValue(value)
+		}
+	}
+
+	return md
+}
+
+func getOutputForIntGaugeTest() pdata.Metrics {
+	intGaugeOutputMetrics := generateTestMetricsWithIntDatapoint(testMetricIntGauge{
+		metricNames:  []string{"metric_1", "metric_2"},
+		metricValues: [][]int64{{100}, {5}},
+	})
+	ilm := intGaugeOutputMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
+	doubleMetric := ilm.AppendEmpty()
+	doubleMetric.SetDataType(pdata.MetricDataTypeDoubleGauge)
+	doubleMetric.SetName("metric_calculated")
+	neweDoubleDataPoint := doubleMetric.DoubleGauge().DataPoints().AppendEmpty()
+	neweDoubleDataPoint.SetValue(105)
+
+	return intGaugeOutputMetrics
+}

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -337,7 +337,7 @@ func TestMetricsGenerationProcessor(t *testing.T) {
 						require.Equal(t, eDataPoints.At(j).Value(), aDataPoints.At(j).Value())
 					}
 				}
-				
+
 			}
 
 			require.NoError(t, mgp.Shutdown(ctx))
@@ -364,7 +364,6 @@ func generateTestMetrics(tm testMetric) pdata.Metrics {
 
 	return md
 }
-
 
 func generateTestMetricsWithIntDatapoint(tm testMetricIntGauge) pdata.Metrics {
 	md := pdata.NewMetrics()

--- a/processor/metricsgenerationprocessor/testdata/config_full.yaml
+++ b/processor/metricsgenerationprocessor/testdata/config_full.yaml
@@ -5,11 +5,13 @@ processors:
   experimental_metricsgeneration:
     rules:
       - name: new_metric
+        unit: percent
         type: calculate
         metric1: metric1
         metric2: metric2
         operation: percent
       - name: new_metric
+        unit: unit
         type: scale
         metric1: metric1
         scale_by: 1000

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -15,7 +15,7 @@
 package metricsgenerationprocessor
 
 import (
-	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
 )
 

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -16,18 +16,19 @@ package metricsgenerationprocessor
 
 import (
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
 )
 
-func getNameToMetricMap(rm pdata.ResourceMetrics) map[string][]pdata.Metric {
+func getNameToMetricMap(rm pdata.ResourceMetrics) map[string]pdata.Metric {
 	ilms := rm.InstrumentationLibraryMetrics()
-	metricMap := make(map[string][]pdata.Metric)
+	metricMap := make(map[string]pdata.Metric)
 
 	for i := 0; i < ilms.Len(); i++ {
 		ilm := ilms.At(i)
 		metricSlice := ilm.Metrics()
 		for j := 0; j < metricSlice.Len(); j++ {
 			metric := metricSlice.At(j)
-			metricMap[metric.Name()] = append(metricMap[metric.Name()], metric)
+			metricMap[metric.Name()] = metric
 		}
 	}
 	return metricMap
@@ -55,7 +56,7 @@ func getMetricValue(metric pdata.Metric) float64 {
 // generateMetrics creates a new metric based on the given rule and add it to the Resource Metric.
 // The value for newly calculated metrics is always a floting point number and the dataType is set
 // as MetricDataTypeDoubleGauge.
-func generateMetrics(rm pdata.ResourceMetrics, operand2 float64, rule internalRule) {
+func generateMetrics(rm pdata.ResourceMetrics, operand2 float64, rule internalRule, logger *zap.Logger) {
 	ilms := rm.InstrumentationLibraryMetrics()
 	for i := 0; i < ilms.Len(); i++ {
 		ilm := ilms.At(i)
@@ -65,21 +66,20 @@ func generateMetrics(rm pdata.ResourceMetrics, operand2 float64, rule internalRu
 			if metric.Name() == rule.metric1 {
 				newMetric := appendMetric(ilm, rule.name, rule.unit)
 				newMetric.SetDataType(pdata.MetricDataTypeDoubleGauge)
-				addDoubleGaugeDataPoints(metric, newMetric, operand2, rule.operation)
+				addDoubleGaugeDataPoints(metric, newMetric, operand2, rule.operation, logger)
 			}
 		}
 	}
 }
 
-func addDoubleGaugeDataPoints(from pdata.Metric, to pdata.Metric, operand2 float64, operation string) {
+func addDoubleGaugeDataPoints(from pdata.Metric, to pdata.Metric, operand2 float64, operation string, logger *zap.Logger) {
 	if from.DataType() == pdata.MetricDataTypeIntGauge {
 		dataPoints := from.IntGauge().DataPoints()
 		for i := 0; i < dataPoints.Len(); i++ {
 			fromDataPoint := dataPoints.At(i)
 			operand1 := float64(fromDataPoint.Value())
 			neweDoubleDataPoint := to.DoubleGauge().DataPoints().AppendEmpty()
-			value := calculateValue(operand1, operand2, operation)
-
+			value := calculateValue(operand1, operand2, operation, logger, to.Name())
 			neweDoubleDataPoint.SetValue(value)
 			fromDataPoint.LabelsMap().CopyTo(neweDoubleDataPoint.LabelsMap())
 			neweDoubleDataPoint.SetStartTimestamp(fromDataPoint.StartTimestamp())
@@ -92,7 +92,7 @@ func addDoubleGaugeDataPoints(from pdata.Metric, to pdata.Metric, operand2 float
 			operand1 := fromDataPoint.Value()
 			neweDoubleDataPoint := to.DoubleGauge().DataPoints().AppendEmpty()
 			fromDataPoint.CopyTo(neweDoubleDataPoint)
-			value := calculateValue(operand1, operand2, operation)
+			value := calculateValue(operand1, operand2, operation, logger, to.Name())
 			neweDoubleDataPoint.SetValue(value)
 		}
 	}
@@ -106,7 +106,7 @@ func appendMetric(ilm pdata.InstrumentationLibraryMetrics, name, unit string) pd
 	return metric
 }
 
-func calculateValue(operand1 float64, operand2 float64, operation string) float64 {
+func calculateValue(operand1 float64, operand2 float64, operation string, logger *zap.Logger, metricName string) float64 {
 	switch operation {
 	case string(add):
 		return operand1 + operand2
@@ -115,8 +115,16 @@ func calculateValue(operand1 float64, operand2 float64, operation string) float6
 	case string(multiply):
 		return operand1 * operand2
 	case string(divide):
+		if operand2 == 0 {
+			logger.Debug("Divide by zero was attempted while calculating metric", zap.String("metric_name", metricName))
+			return 0
+		}
 		return operand1 / operand2
 	case string(percent):
+		if operand2 == 0 {
+			logger.Debug("Divide by zero was attempted while calculating metric", zap.String("metric_name", metricName))
+			return 0
+		}
 		return (operand1 / operand2) * 100
 	}
 	return 0

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -1,0 +1,123 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricsgenerationprocessor
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+func getNameToMetricMap(rm pdata.ResourceMetrics) map[string][]pdata.Metric {
+	ilms := rm.InstrumentationLibraryMetrics()
+	metricMap := make(map[string][]pdata.Metric)
+
+	for i := 0; i < ilms.Len(); i++ {
+		ilm := ilms.At(i)
+		metricSlice := ilm.Metrics()
+		for j := 0; j < metricSlice.Len(); j++ {
+			metric := metricSlice.At(j)
+			metricMap[metric.Name()] = append(metricMap[metric.Name()], metric)
+		}
+	}
+	return metricMap
+}
+
+// getMetricValue returns the value of the first data point from the given metric.
+func getMetricValue(metric pdata.Metric) float64 {
+	if metric.DataType() == pdata.MetricDataTypeIntGauge {
+		dataPoints := metric.IntGauge().DataPoints()
+		if dataPoints.Len() > 0 {
+			return float64(dataPoints.At(0).Value())
+		}
+		return 0
+	}
+	if metric.DataType() == pdata.MetricDataTypeDoubleGauge {
+		dataPoints := metric.DoubleGauge().DataPoints()
+		if dataPoints.Len() > 0 {
+			return dataPoints.At(0).Value()
+		}
+		return 0
+	}
+	return 0
+}
+
+// generateMetrics creates a new metric based on the given rule and add it to the Resource Metric.
+// The value for newly calculated metrics is always a floting point number and the dataType is set
+// as MetricDataTypeDoubleGauge.
+func generateMetrics(rm pdata.ResourceMetrics, operand2 float64, rule internalRule) {
+	ilms := rm.InstrumentationLibraryMetrics()
+	for i := 0; i < ilms.Len(); i++ {
+		ilm := ilms.At(i)
+		metricSlice := ilm.Metrics()
+		for j := 0; j < metricSlice.Len(); j++ {
+			metric := metricSlice.At(j)
+			if metric.Name() == rule.metric1 {
+				newMetric := appendMetric(ilm, rule.name, rule.unit)
+				newMetric.SetDataType(pdata.MetricDataTypeDoubleGauge)
+				addDoubleGaugeDataPoints(metric, newMetric, operand2, rule.operation)
+			}
+		}
+	}
+}
+
+func addDoubleGaugeDataPoints(from pdata.Metric, to pdata.Metric, operand2 float64, operation string) {
+	if from.DataType() == pdata.MetricDataTypeIntGauge {
+		dataPoints := from.IntGauge().DataPoints()
+		for i := 0; i < dataPoints.Len(); i++ {
+			fromDataPoint := dataPoints.At(i)
+			operand1 := float64(fromDataPoint.Value())
+			neweDoubleDataPoint := to.DoubleGauge().DataPoints().AppendEmpty()
+			value := calculateValue(operand1, operand2, operation)
+
+			neweDoubleDataPoint.SetValue(value)
+			fromDataPoint.LabelsMap().CopyTo(neweDoubleDataPoint.LabelsMap())
+			neweDoubleDataPoint.SetStartTimestamp(fromDataPoint.StartTimestamp())
+			neweDoubleDataPoint.SetTimestamp(fromDataPoint.Timestamp())
+		}
+	} else if from.DataType() == pdata.MetricDataTypeDoubleGauge {
+		dataPoints := from.DoubleGauge().DataPoints()
+		for i := 0; i < dataPoints.Len(); i++ {
+			fromDataPoint := dataPoints.At(i)
+			operand1 := fromDataPoint.Value()
+			neweDoubleDataPoint := to.DoubleGauge().DataPoints().AppendEmpty()
+			fromDataPoint.CopyTo(neweDoubleDataPoint)
+			value := calculateValue(operand1, operand2, operation)
+			neweDoubleDataPoint.SetValue(value)
+		}
+	}
+}
+
+func appendMetric(ilm pdata.InstrumentationLibraryMetrics, name, unit string) pdata.Metric {
+	metric := ilm.Metrics().AppendEmpty()
+	metric.SetName(name)
+	metric.SetUnit(unit)
+
+	return metric
+}
+
+func calculateValue(operand1 float64, operand2 float64, operation string) float64 {
+	switch operation {
+	case string(add):
+		return operand1 + operand2
+	case string(subtract):
+		return operand1 - operand2
+	case string(multiply):
+		return operand1 * operand2
+	case string(divide):
+		return operand1 / operand2
+	case string(percent):
+		return (operand1 / operand2) * 100
+	}
+	return 0
+}

--- a/processor/metricsgenerationprocessor/utils_test.go
+++ b/processor/metricsgenerationprocessor/utils_test.go
@@ -17,9 +17,9 @@ package metricsgenerationprocessor
 import (
 	"testing"
 
-	"go.uber.org/zap"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
 )
 
 func TestCalculateValue(t *testing.T) {

--- a/processor/metricsgenerationprocessor/utils_test.go
+++ b/processor/metricsgenerationprocessor/utils_test.go
@@ -1,0 +1,62 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricsgenerationprocessor
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestCalculateValue(t *testing.T) {
+	value := calculateValue(100.0, 5.0, "add", zap.NewNop(), "test_metric")
+	require.Equal(t, 105.0, value)
+
+	value = calculateValue(100.0, 5.0, "subtract", zap.NewNop(), "test_metric")
+	require.Equal(t, 95.0, value)
+
+	value = calculateValue(100.0, 5.0, "multiply", zap.NewNop(), "test_metric")
+	require.Equal(t, 500.0, value)
+
+	value = calculateValue(100.0, 5.0, "divide", zap.NewNop(), "test_metric")
+	require.Equal(t, 20.0, value)
+
+	value = calculateValue(10.0, 200.0, "percent", zap.NewNop(), "test_metric")
+	require.Equal(t, 5.0, value)
+
+	value = calculateValue(100.0, 0, "divide", zap.NewNop(), "test_metric")
+	require.Equal(t, 0.0, value)
+
+	value = calculateValue(100.0, 0, "percent", zap.NewNop(), "test_metric")
+	require.Equal(t, 0.0, value)
+
+	value = calculateValue(100.0, 0, "invalid", zap.NewNop(), "test_metric")
+	require.Equal(t, 0.0, value)
+}
+
+func TestGetMetricValueWithNoDataPoint(t *testing.T) {
+	md := pdata.NewMetrics()
+
+	rm := md.ResourceMetrics().AppendEmpty()
+	ms := rm.InstrumentationLibraryMetrics().AppendEmpty().Metrics()
+	m := ms.AppendEmpty()
+	m.SetName("metric_1")
+	m.SetDataType(pdata.MetricDataTypeDoubleGauge)
+
+	value := getMetricValue(md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0))
+	require.Equal(t, 0.0, value)
+}


### PR DESCRIPTION
**Description:** 
This PR adds the actual metrics generation logic based on configured rules in the `experimental_metrics_generation` processor.

**Link to tracking Issue:** <Issue number if applicable>
#2722 

**Testing:** 
Manually tested.
I am adding unit tests to improve coverage. Created the PR to have some early feedback.

**Documentation:**
README updated.