### PR TITLE
Refactor AWS Kinesis exporter to allow for extended types of encoding

### DIFF
--- a/exporter/awskinesisexporter/encoding/encoder.go
+++ b/exporter/awskinesisexporter/encoding/encoder.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	// ErrUnsupportedEncodedType is used when the encoder type does not the type of encoding
 	ErrUnsupportedEncodedType = errors.New("unsupported type to encode")
 )
 

--- a/exporter/awskinesisexporter/encoding/encoder.go
+++ b/exporter/awskinesisexporter/encoding/encoder.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ErrUnsupportedEncodedType = errors.New("unsupport type to encode")
+	ErrUnsupportedEncodedType = errors.New("unsupported type to encode")
 )
 
 // Encoder allows for the internal types to be converted to an consumable

--- a/exporter/awskinesisexporter/encoding/encoder.go
+++ b/exporter/awskinesisexporter/encoding/encoder.go
@@ -1,0 +1,21 @@
+package encoding
+
+import (
+	"errors"
+
+	"go.opentelemetry.io/collector/consumer/pdata"
+)
+
+var (
+	ErrUnsupportedEncodedType = errors.New("unsupport type to encode")
+)
+
+// Encoder allows for the internal types to be converted to an consumable
+// exported type which is written to the kinesis stream
+type Encoder interface {
+	EncodeMetrics(md pdata.Metrics) error
+
+	EncodeTraces(td pdata.Traces) error
+
+	EncodeLogs(ld pdata.Logs) error
+}

--- a/exporter/awskinesisexporter/encoding/encoder.go
+++ b/exporter/awskinesisexporter/encoding/encoder.go
@@ -1,3 +1,17 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package encoding
 
 import (

--- a/exporter/awskinesisexporter/encoding/encoder.go
+++ b/exporter/awskinesisexporter/encoding/encoder.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	// ErrUnsupportedEncodedType is used when the encoder type does not the type of encoding
+	// ErrUnsupportedEncodedType is used when the encoder type does not support the type of encoding
 	ErrUnsupportedEncodedType = errors.New("unsupported type to encode")
 )
 

--- a/exporter/awskinesisexporter/encoding/encoder_jaeger.go
+++ b/exporter/awskinesisexporter/encoding/encoder_jaeger.go
@@ -38,5 +38,4 @@ func (j *jaeger) EncodeTraces(td pdata.Traces) error {
 }
 
 func (j *jaeger) EncodeMetrics(_ pdata.Metrics) error { return ErrUnsupportedEncodedType }
-
-func (j *jaeger) EncodeLogs(_ pdata.Logs) error { return ErrUnsupportedEncodedType }
+func (j *jaeger) EncodeLogs(_ pdata.Logs) error       { return ErrUnsupportedEncodedType }

--- a/exporter/awskinesisexporter/encoding/encoder_jaeger.go
+++ b/exporter/awskinesisexporter/encoding/encoder_jaeger.go
@@ -1,0 +1,42 @@
+package encoding
+
+import (
+	awskinesis "github.com/signalfx/opencensus-go-exporter-kinesis"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	jaegertranslator "go.opentelemetry.io/collector/translator/trace/jaeger"
+)
+
+type jaeger struct {
+	kinesis *awskinesis.Exporter
+}
+
+// Ensure the jaeger encoder meets the interface at compile time.
+var _ Encoder = (*jaeger)(nil)
+
+func Jaeger(kinesis *awskinesis.Exporter) Encoder {
+	return &jaeger{kinesis: kinesis}
+}
+
+func (j *jaeger) EncodeTraces(td pdata.Traces) error {
+	traces, err := jaegertranslator.InternalTracesToJaegerProto(td)
+	if err != nil {
+		return err
+	}
+
+	for _, trace := range traces {
+		for _, span := range trace.GetSpans() {
+			if span.Process == nil {
+				span.Process = trace.Process
+			}
+			if err := j.kinesis.ExportSpan(span); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (j *jaeger) EncodeMetrics(_ pdata.Metrics) error { return ErrUnsupportedEncodedType }
+
+func (j *jaeger) EncodeLogs(_ pdata.Logs) error { return ErrUnsupportedEncodedType }

--- a/exporter/awskinesisexporter/encoding/encoder_jaeger.go
+++ b/exporter/awskinesisexporter/encoding/encoder_jaeger.go
@@ -1,3 +1,17 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package encoding
 
 import (

--- a/exporter/awskinesisexporter/encoding/encoder_jaeger_test.go
+++ b/exporter/awskinesisexporter/encoding/encoder_jaeger_test.go
@@ -1,0 +1,28 @@
+package encoding_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/encoding"
+)
+
+func TestEncodingTraceData(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, encoding.Jaeger(nil).EncodeTraces(pdata.NewTraces()), "Must not error when processing spans")
+}
+
+func TestEncodingMetricData(t *testing.T) {
+	t.Parallel()
+
+	assert.Error(t, encoding.Jaeger(nil).EncodeMetrics(pdata.NewMetrics()), "Must error when trying to encode unsupported type")
+}
+
+func TestEncodingLogData(t *testing.T) {
+	t.Parallel()
+
+	assert.Error(t, encoding.Jaeger(nil).EncodeLogs(pdata.NewLogs()), "Must error when trying to encode unsupported type")
+}

--- a/exporter/awskinesisexporter/encoding/encoder_jaeger_test.go
+++ b/exporter/awskinesisexporter/encoding/encoder_jaeger_test.go
@@ -1,3 +1,17 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package encoding_test
 
 import (

--- a/exporter/awskinesisexporter/exporter.go
+++ b/exporter/awskinesisexporter/exporter.go
@@ -20,15 +20,16 @@ import (
 	awskinesis "github.com/signalfx/opencensus-go-exporter-kinesis"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/pdata"
-	jaegertranslator "go.opentelemetry.io/collector/translator/trace/jaeger"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/encoding"
 )
 
 // Exporter implements an OpenTelemetry trace exporter that exports all spans to AWS Kinesis
 type Exporter struct {
 	awskinesis *awskinesis.Exporter
+	encoder    encoding.Encoder
 	logger     *zap.Logger
 }
 
@@ -55,24 +56,9 @@ func (e Exporter) Shutdown(context.Context) error {
 
 // ConsumeTraces receives a span batch and exports it to AWS Kinesis
 func (e Exporter) ConsumeTraces(_ context.Context, td pdata.Traces) error {
-	pBatches, err := jaegertranslator.InternalTracesToJaegerProto(td)
+	err := e.encoder.EncodeTraces(td)
 	if err != nil {
-		e.logger.Error("error translating span batch", zap.Error(err))
-		return consumererror.Permanent(err)
+		e.logger.Error("Unable to write jaeger traces to kinesis", zap.Error(err))
 	}
-	// TODO: Use a multi error type
-	var exportErr error
-	for _, pBatch := range pBatches {
-		for _, span := range pBatch.GetSpans() {
-			if span.Process == nil {
-				span.Process = pBatch.Process
-			}
-			err := e.awskinesis.ExportSpan(span)
-			if err != nil {
-				e.logger.Error("error exporting span to awskinesis", zap.Error(err))
-				exportErr = err
-			}
-		}
-	}
-	return exportErr
+	return err
 }

--- a/exporter/awskinesisexporter/factory.go
+++ b/exporter/awskinesisexporter/factory.go
@@ -17,6 +17,7 @@ package awskinesisexporter
 import (
 	"context"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/encoding"
 	awskinesis "github.com/signalfx/opencensus-go-exporter-kinesis"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -93,5 +94,9 @@ func createTracesExporter(
 		return nil, err
 	}
 
-	return Exporter{k, params.Logger}, nil
+	return Exporter{
+		awskinesis: k,
+		encoder:    encoding.Jaeger(k),
+		logger:     params.Logger,
+	}, nil
 }

--- a/exporter/awskinesisexporter/factory.go
+++ b/exporter/awskinesisexporter/factory.go
@@ -17,11 +17,12 @@ package awskinesisexporter
 import (
 	"context"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/encoding"
 	awskinesis "github.com/signalfx/opencensus-go-exporter-kinesis"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/encoding"
 )
 
 const (


### PR DESCRIPTION
**Description:** Moving to encoding type model for exporting data to kinesis while maintaining backwards comparability. Ref https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1310  

**Link to tracking Issue:** We have split up the work needed for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1305 as per @owais' comments on the PR linked above.

**Testing:** I have added rather trivial tests to get this shipped and to make sure it doing what it says on the tin (so to speak).

**Documentation:** No behaviour changes are being made here, just a change in implementation detail. Any follow up PRs that extend the ability of this exporter will joined with documentation. 