### PR TITLE
[small bug fix] [metrics transform processor] check all data points for matching metric label values

### DIFF
--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -180,7 +180,7 @@ func buildHelperConfig(config *Config, version string) []internalTransform {
 func createFilter(filterConfig FilterConfig) internalFilter {
 	switch filterConfig.MatchType {
 	case StrictMatchType:
-		return internalFilterStrict{include: filterConfig.Include, matchLabels: filterConfig.MatchLabels}
+		return internalFilterStrict{include: filterConfig.Include, matchLabels: getFilterStrictMatcherMap(filterConfig.MatchLabels)}
 	case RegexpMatchType:
 		return internalFilterRegexp{include: regexp.MustCompile(filterConfig.Include), matchLabels: getFilterRegexpMap(filterConfig.MatchLabels)}
 	}
@@ -215,4 +215,13 @@ func getFilterRegexpMap(strMap map[string]string) map[string]*regexp.Regexp {
 		regexpMap[k] = regexp.MustCompile(value)
 	}
 	return regexpMap
+}
+
+func getFilterStrictMatcherMap(strMap map[string]string) map[string]strictMatcher {
+	strictMatcherMap := make(map[string]strictMatcher)
+
+	for k, value := range strMap {
+		strictMatcherMap[k] = strictMatcher(value)
+	}
+	return strictMatcherMap
 }

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -58,7 +58,11 @@ func createMetricsProcessor(
 		return nil, err
 	}
 
-	metricsProcessor := newMetricsTransformProcessor(params.Logger, buildHelperConfig(oCfg, params.BuildInfo.Version))
+	hCfg, err := buildHelperConfig(oCfg, params.BuildInfo.Version)
+	if err != nil {
+		return nil, err
+	}
+	metricsProcessor := newMetricsTransformProcessor(params.Logger, hCfg)
 
 	return processorhelper.NewMetricsProcessor(
 		cfg,
@@ -134,7 +138,7 @@ func validateConfiguration(config *Config) error {
 }
 
 // buildHelperConfig constructs the maps that will be useful for the operations
-func buildHelperConfig(config *Config, version string) []internalTransform {
+func buildHelperConfig(config *Config, version string) ([]internalTransform, error) {
 	helperDataTransforms := make([]internalTransform, len(config.Transforms))
 	for i, t := range config.Transforms {
 
@@ -147,8 +151,13 @@ func buildHelperConfig(config *Config, version string) []internalTransform {
 			t.MetricIncludeFilter.MatchType = StrictMatchType
 		}
 
+		filter, err := createFilter(t.MetricIncludeFilter)
+		if err != nil {
+			return nil, err
+		}
+
 		helperT := internalTransform{
-			MetricIncludeFilter: createFilter(t.MetricIncludeFilter),
+			MetricIncludeFilter: filter,
 			Action:              t.Action,
 			NewName:             t.NewName,
 			GroupResourceLabels: t.GroupResourceLabels,
@@ -174,18 +183,26 @@ func buildHelperConfig(config *Config, version string) []internalTransform {
 		}
 		helperDataTransforms[i] = helperT
 	}
-	return helperDataTransforms
+	return helperDataTransforms, nil
 }
 
-func createFilter(filterConfig FilterConfig) internalFilter {
+func createFilter(filterConfig FilterConfig) (internalFilter, error) {
 	switch filterConfig.MatchType {
 	case StrictMatchType:
-		return internalFilterStrict{include: filterConfig.Include, matchLabels: getFilterStrictMatcherMap(filterConfig.MatchLabels)}
+		matchers, err := getMatcherMap(filterConfig.MatchLabels, func(str string) (StringMatcher, error) { return strictMatcher(str), nil })
+		if err != nil {
+			return nil, err
+		}
+		return internalFilterStrict{include: filterConfig.Include, matchLabels: matchers}, nil
 	case RegexpMatchType:
-		return internalFilterRegexp{include: regexp.MustCompile(filterConfig.Include), matchLabels: getFilterRegexpMap(filterConfig.MatchLabels)}
+		matchers, err := getMatcherMap(filterConfig.MatchLabels, func(str string) (StringMatcher, error) { return regexp.Compile(str) })
+		if err != nil {
+			return nil, err
+		}
+		return internalFilterRegexp{include: regexp.MustCompile(filterConfig.Include), matchLabels: matchers}, nil
 	}
 
-	return nil
+	return nil, fmt.Errorf("invalid match type: %v", filterConfig.MatchType)
 }
 
 // createLabelValueMapping creates the labelValue rename mappings based on the valueActions
@@ -208,20 +225,14 @@ func sliceToSet(slice []string) map[string]bool {
 	return set
 }
 
-func getFilterRegexpMap(strMap map[string]string) map[string]*regexp.Regexp {
-	regexpMap := make(map[string]*regexp.Regexp)
-
-	for k, value := range strMap {
-		regexpMap[k] = regexp.MustCompile(value)
+func getMatcherMap(strMap map[string]string, ctor func(string) (StringMatcher, error)) (map[string]StringMatcher, error) {
+	out := make(map[string]StringMatcher)
+	for k, v := range strMap {
+		matcher, err := ctor(v)
+		if err != nil {
+			return nil, err
+		}
+		out[k] = matcher
 	}
-	return regexpMap
-}
-
-func getFilterStrictMatcherMap(strMap map[string]string) map[string]strictMatcher {
-	strictMatcherMap := make(map[string]strictMatcher)
-
-	for k, value := range strMap {
-		strictMatcherMap[k] = strictMatcher(value)
-	}
-	return strictMatcherMap
+	return out, nil
 }

--- a/processor/metricstransformprocessor/factory_test.go
+++ b/processor/metricstransformprocessor/factory_test.go
@@ -289,7 +289,8 @@ func TestCreateProcessorsFilledData(t *testing.T) {
 		},
 	}
 
-	internalTransforms := buildHelperConfig(oCfg, "v0.0.1")
+	internalTransforms, err := buildHelperConfig(oCfg, "v0.0.1")
+	assert.NoError(t, err)
 
 	for i, expTr := range expData {
 		mtpT := internalTransforms[i]

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -60,7 +60,6 @@ type internalOperation struct {
 type internalFilter interface {
 	getMatches(toMatch metricNameMapping) []*match
 	getSubexpNames() []string
-	labelMatched(metric *metricspb.Metric) *metricspb.Metric
 }
 
 type match struct {
@@ -69,16 +68,31 @@ type match struct {
 	submatches []int
 }
 
+type StringMatcher interface {
+	MatchString(string) bool
+}
+
+type strictMatcher string
+
+func (s strictMatcher) MatchString(cmp string) bool {
+	return string(s) == cmp
+}
+
 type internalFilterStrict struct {
 	include     string
-	matchLabels map[string]string
+	matchLabels map[string]strictMatcher
 }
 
 func (f internalFilterStrict) getMatches(toMatch metricNameMapping) []*match {
+
 	if metrics, ok := toMatch[f.include]; ok {
 		matches := make([]*match, 0, 10)
+		stringMatcherMap := make(map[string]StringMatcher)
+		for k, v := range f.matchLabels {
+			stringMatcherMap[k] = v
+		}
 		for _, metric := range metrics {
-			matchedMetric := f.labelMatched(metric)
+			matchedMetric := labelMatched(stringMatcherMap, metric)
 			if matchedMetric != nil {
 				matches = append(matches, &match{metric: matchedMetric})
 			}
@@ -93,55 +107,6 @@ func (f internalFilterStrict) getSubexpNames() []string {
 	return nil
 }
 
-func (f internalFilterStrict) labelMatched(metric *metricspb.Metric) *metricspb.Metric {
-	metricWithMatchedLabel := proto.Clone(metric).(*metricspb.Metric)
-	var timeSeriesWithMatchedLabel []*metricspb.TimeSeries
-	labelIndexValueMap := make(map[int]string)
-
-	if len(f.matchLabels) == 0 {
-		return metric
-	}
-
-	for key, value := range f.matchLabels {
-		keyFound := false
-
-		for idx, label := range metric.MetricDescriptor.LabelKeys {
-			if label.Key != key {
-				continue
-			}
-
-			keyFound = true
-			labelIndexValueMap[idx] = value
-		}
-
-		// if a label-key is not found then return nil only if the given label-value is non-empty. If a given label-value is empty
-		// and the key is not found then move forward. In this approach we can make sure certain key is not present which is a valid use case.
-		if !keyFound && value != "" {
-			return nil
-		}
-	}
-
-	for _, timeseries := range metric.Timeseries {
-		allValuesMatched := true
-		for index, value := range labelIndexValueMap {
-			if timeseries.LabelValues[index].Value != value {
-				allValuesMatched = false
-				break
-			}
-		}
-		if allValuesMatched {
-			timeSeriesWithMatchedLabel = append(timeSeriesWithMatchedLabel, timeseries)
-		}
-	}
-
-	if len(timeSeriesWithMatchedLabel) == 0 {
-		return nil
-	}
-
-	metricWithMatchedLabel.Timeseries = timeSeriesWithMatchedLabel
-	return metricWithMatchedLabel
-}
-
 type internalFilterRegexp struct {
 	include     *regexp.Regexp
 	matchLabels map[string]*regexp.Regexp
@@ -149,10 +114,15 @@ type internalFilterRegexp struct {
 
 func (f internalFilterRegexp) getMatches(toMatch metricNameMapping) []*match {
 	matches := make([]*match, 0, 10)
+	stringMatcherMap := make(map[string]StringMatcher)
+	for k, v := range f.matchLabels {
+		stringMatcherMap[k] = v
+	}
+
 	for name, metrics := range toMatch {
 		if submatches := f.include.FindStringSubmatchIndex(name); submatches != nil {
 			for _, metric := range metrics {
-				matchedMetric := f.labelMatched(metric)
+				matchedMetric := labelMatched(stringMatcherMap, metric)
 				if matchedMetric != nil {
 					matches = append(matches, &match{metric: matchedMetric, pattern: f.include, submatches: submatches})
 				}
@@ -166,16 +136,19 @@ func (f internalFilterRegexp) getSubexpNames() []string {
 	return f.include.SubexpNames()
 }
 
-func (f internalFilterRegexp) labelMatched(metric *metricspb.Metric) *metricspb.Metric {
-	metricWithMatchedLabel := proto.Clone(metric).(*metricspb.Metric)
-	var timeSeriesWithMatchedLabel []*metricspb.TimeSeries
-	labelIndexValueMap := make(map[int]*regexp.Regexp)
-
-	if len(f.matchLabels) == 0 {
+func labelMatched(matchLabels map[string]StringMatcher, metric *metricspb.Metric) *metricspb.Metric {
+	if len(matchLabels) == 0 {
 		return metric
 	}
 
-	for key, value := range f.matchLabels {
+	metricWithMatchedLabel := &metricspb.Metric{}
+	metricWithMatchedLabel.MetricDescriptor = proto.Clone(metric.MetricDescriptor).(*metricspb.MetricDescriptor)
+	metricWithMatchedLabel.Resource = proto.Clone(metric.Resource).(*resourcepb.Resource)
+
+	var timeSeriesWithMatchedLabel []*metricspb.TimeSeries
+	labelIndexValueMap := make(map[int]StringMatcher)
+
+	for key, value := range matchLabels {
 		keyFound := false
 
 		for idx, label := range metric.MetricDescriptor.LabelKeys {

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -80,19 +80,15 @@ func (s strictMatcher) MatchString(cmp string) bool {
 
 type internalFilterStrict struct {
 	include     string
-	matchLabels map[string]strictMatcher
+	matchLabels map[string]StringMatcher
 }
 
 func (f internalFilterStrict) getMatches(toMatch metricNameMapping) []*match {
 
 	if metrics, ok := toMatch[f.include]; ok {
-		matches := make([]*match, 0, 10)
-		stringMatcherMap := make(map[string]StringMatcher)
-		for k, v := range f.matchLabels {
-			stringMatcherMap[k] = v
-		}
+		matches := make([]*match, 0)
 		for _, metric := range metrics {
-			matchedMetric := labelMatched(stringMatcherMap, metric)
+			matchedMetric := labelMatched(f.matchLabels, metric)
 			if matchedMetric != nil {
 				matches = append(matches, &match{metric: matchedMetric})
 			}
@@ -109,20 +105,15 @@ func (f internalFilterStrict) getSubexpNames() []string {
 
 type internalFilterRegexp struct {
 	include     *regexp.Regexp
-	matchLabels map[string]*regexp.Regexp
+	matchLabels map[string]StringMatcher
 }
 
 func (f internalFilterRegexp) getMatches(toMatch metricNameMapping) []*match {
-	matches := make([]*match, 0, 10)
-	stringMatcherMap := make(map[string]StringMatcher)
-	for k, v := range f.matchLabels {
-		stringMatcherMap[k] = v
-	}
-
+	matches := make([]*match, 0)
 	for name, metrics := range toMatch {
 		if submatches := f.include.FindStringSubmatchIndex(name); submatches != nil {
 			for _, metric := range metrics {
-				matchedMetric := labelMatched(stringMatcherMap, metric)
+				matchedMetric := labelMatched(f.matchLabels, metric)
 				if matchedMetric != nil {
 					matches = append(matches, &match{metric: matchedMetric, pattern: f.include, submatches: submatches})
 				}

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -653,7 +653,7 @@ var (
 			name: "metric_name_insert_with_match_label_strict",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]strictMatcher{"label1": "value1"}},
+					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]StringMatcher{"label1": strictMatcher("value1")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -682,7 +682,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile(`(.|\s)*\S(.|\s)*`)}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile(`(.|\s)*\S(.|\s)*`)}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -711,7 +711,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_two_datapoints_positive",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value3")}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value3")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -744,7 +744,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_two_datapoints_negative",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value3")}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value3")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -772,7 +772,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_with_full_value",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value1")}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value1")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -801,7 +801,7 @@ var (
 			name: "metric_name_insert_with_match_label_strict_negative",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]strictMatcher{"label1": "wrong_value"}},
+					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]StringMatcher{"label1": strictMatcher("wrong_value")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -825,7 +825,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_negative",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile(".*wrong_ending")}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile(".*wrong_ending")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -849,7 +849,7 @@ var (
 			name: "metric_name_insert_with_match_label_strict_missing_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]strictMatcher{"missing_key": "value1"}},
+					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]StringMatcher{"missing_key": strictMatcher("value1")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -873,7 +873,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_missing_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"missing_key": regexp.MustCompile("value1")}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"missing_key": regexp.MustCompile("value1")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -897,7 +897,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_missing_and_present_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value1"), "missing_key": regexp.MustCompile("value2")}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value1"), "missing_key": regexp.MustCompile("value2")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -921,7 +921,7 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_missing_key_with_empty_expression",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value1"), "missing_key": regexp.MustCompile("^$")}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value1"), "missing_key": regexp.MustCompile("^$")}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -653,7 +653,7 @@ var (
 			name: "metric_name_insert_with_match_label_strict",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]string{"label1": "value1"}},
+					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]strictMatcher{"label1": "value1"}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -801,7 +801,7 @@ var (
 			name: "metric_name_insert_with_match_label_strict_negative",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]string{"label1": "wrong_value"}},
+					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]strictMatcher{"label1": "wrong_value"}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},
@@ -849,7 +849,7 @@ var (
 			name: "metric_name_insert_with_match_label_strict_missing_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]string{"missing_key": "value1"}},
+					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]strictMatcher{"missing_key": "value1"}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -708,6 +708,67 @@ var (
 			},
 		},
 		{
+			name: "metric_name_insert_with_match_label_regexp_two_datapoints_positive",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value3")}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addTimeseries(2, []string{"value3", "value4"}).
+					addInt64Point(0, 3, 2).
+					addInt64Point(1, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addTimeseries(2, []string{"value3", "value4"}).
+					addInt64Point(0, 3, 2).
+					addInt64Point(1, 3, 2).build(),
+				metricBuilder().setName("new/metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(2, []string{"value3", "value4"}).
+					addInt64Point(0, 3, 2).build(),
+			},
+		},
+		{
+			name: "metric_name_insert_with_match_label_regexp_two_datapoints_negative",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]*regexp.Regexp{"label1": regexp.MustCompile("value3")}},
+					Action:              Insert,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addTimeseries(2, []string{"value11", "value22"}).
+					addInt64Point(0, 3, 2).
+					addInt64Point(1, 3, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setLabels([]string{"label1", "label2"}).
+					setDataType(metricspb.MetricDescriptor_GAUGE_INT64).
+					addTimeseries(1, []string{"value1", "value2"}).
+					addTimeseries(2, []string{"value11", "value22"}).
+					addInt64Point(0, 3, 2).
+					addInt64Point(1, 3, 2).build(),
+			},
+		},
+		{
 			name: "metric_name_insert_with_match_label_regexp_with_full_value",
 			transforms: []internalTransform{
 				{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This change fixes a small bug for newly added `experimental_match_label` feature in the metricstransform processor. Earlier we used to check only the first datapoint while matching the metric label values. But that case is not always true and the feature is not working to support our use case. This change checks all the data points and search for proper metric label value match.


**Testing:** 
Unit tests added.
Manually tested.

**Documentation:** 
README