### PR TITLE
Fix StatsD drop metrics tags when using summary as observer_type for timer/histogram

### DIFF
--- a/receiver/statsdreceiver/protocol/metric_translator.go
+++ b/receiver/statsdreceiver/protocol/metric_translator.go
@@ -61,28 +61,27 @@ func buildGaugeMetric(parsedMetric statsDMetric, timeNow time.Time) pdata.Instru
 }
 
 func buildSummaryMetric(summaryMetric summaryMetric) pdata.InstrumentationLibraryMetrics {
-	dp := pdata.NewSummaryDataPoint()
+	ilm := pdata.NewInstrumentationLibraryMetrics()
+	nm := ilm.Metrics().AppendEmpty()
+	nm.SetName(summaryMetric.name)
+	nm.SetDataType(pdata.MetricDataTypeSummary)
+
+	dp := nm.Summary().DataPoints().AppendEmpty()
 	dp.SetCount(uint64(len(summaryMetric.summaryPoints)))
 	sum, _ := stats.Sum(summaryMetric.summaryPoints)
 	dp.SetSum(sum)
 	dp.SetTimestamp(pdata.TimestampFromTime(summaryMetric.timeNow))
+	for i, key := range summaryMetric.labelKeys {
+		dp.LabelsMap().Insert(key, summaryMetric.labelValues[i])
+	}
 
 	quantile := []float64{0, 10, 50, 90, 95, 100}
 	for _, v := range quantile {
-		eachQuantile := pdata.NewValueAtQuantile()
+		eachQuantile := dp.QuantileValues().AppendEmpty()
 		eachQuantile.SetQuantile(v)
 		eachQuantileValue, _ := stats.PercentileNearestRank(summaryMetric.summaryPoints, v)
 		eachQuantile.SetValue(eachQuantileValue)
-		dp.QuantileValues().Append(eachQuantile)
 	}
-
-	nm := pdata.NewMetric()
-	nm.SetName(summaryMetric.name)
-	nm.SetDataType(pdata.MetricDataTypeSummary)
-	nm.Summary().DataPoints().Append(dp)
-
-	ilm := pdata.NewInstrumentationLibraryMetrics()
-	ilm.Metrics().Append(nm)
 
 	return ilm
 

--- a/receiver/statsdreceiver/protocol/metric_translator_test.go
+++ b/receiver/statsdreceiver/protocol/metric_translator_test.go
@@ -95,14 +95,16 @@ func TestBuildSummaryMetric(t *testing.T) {
 	expectedMetric.Metrics().At(0).Summary().DataPoints().At(0).SetSum(21)
 	expectedMetric.Metrics().At(0).Summary().DataPoints().At(0).SetCount(6)
 	expectedMetric.Metrics().At(0).Summary().DataPoints().At(0).SetTimestamp(pdata.TimestampFromTime(timeNow))
+	for i, key := range oneSummaryMetric.labelKeys {
+		expectedMetric.Metrics().At(0).Summary().DataPoints().At(0).LabelsMap().Insert(key, oneSummaryMetric.labelValues[i])
+	}
 	quantile := []float64{0, 10, 50, 90, 95, 100}
 	value := []float64{1, 1, 3, 6, 6, 6}
 	for int, v := range quantile {
-		eachQuantile := pdata.NewValueAtQuantile()
+		eachQuantile := expectedMetric.Metrics().At(0).Summary().DataPoints().At(0).QuantileValues().AppendEmpty()
 		eachQuantile.SetQuantile(v)
 		eachQuantileValue := value[int]
 		eachQuantile.SetValue(eachQuantileValue)
-		expectedMetric.Metrics().At(0).Summary().DataPoints().At(0).QuantileValues().Append(eachQuantile)
 	}
 
 	assert.Equal(t, metric, expectedMetric)

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -108,15 +108,15 @@ func (p *StatsDParser) GetMetrics() pdata.Metrics {
 	rm := metrics.ResourceMetrics().AppendEmpty()
 
 	for _, metric := range p.gauges {
-		rm.InstrumentationLibraryMetrics().Append(metric)
+		metric.CopyTo(rm.InstrumentationLibraryMetrics().AppendEmpty())
 	}
 
 	for _, metric := range p.counters {
-		rm.InstrumentationLibraryMetrics().Append(metric)
+		metric.CopyTo(rm.InstrumentationLibraryMetrics().AppendEmpty())
 	}
 
 	for _, metric := range p.timersAndDistributions {
-		rm.InstrumentationLibraryMetrics().Append(metric)
+		metric.CopyTo(rm.InstrumentationLibraryMetrics().AppendEmpty())
 	}
 
 	for _, summaryMetric := range p.summaries {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

- When sending timer/histogram using OTLP summary types, StatsD receiver does not send metrics tags. Add metrics tags when creating OTLP summary. 

- Deprecate `Append` with `AppendEmpty`

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3431

**Testing:** <Describe what testing was performed and which tests were added.>
Added the test part for tags in creating OTLP summary metrics.

**Documentation:** <Describe the documentation added.>