### PR TITLE
Change obsreport receiver calling pattern in carbonreceiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The OpenTelemetry Collector Contrib contains everything in the [opentelemetry-co
 - `groupbytrace` processor: Added workers for queue processing (#2902)
 - `resourcedetection` processor: Add docker detector (#2775)
 - `tailsampling` processor: Support regex on span attribute filtering (#3335_
+- Change obsreport helpers for receiver to use the new pattern created in Collector (#3439,#3443)
 
 ## 🧰 Bug fixes 🧰
 


### PR DESCRIPTION
**Description:** Change obsreport helpers for receiver to use the new pattern created in Collector. Specifically for carbonreceiver.

**Link to tracking Issue:** [Issue #3436](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3436)