### PR TITLE
Remove the OTLP receiver legacy gRPC port(55680) references

### DIFF
--- a/examples/tracing/docker-compose.yml
+++ b/examples/tracing/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "8889:8889"   # Prometheus exporter metrics
       - "13133:13133" # health_check extension
       - "9411"   # Zipkin receiver
-      - "55680:55679" # zpages extension
+      - "55670:55679" # zpages extension
     depends_on:
       - jaeger
       - zipkin

--- a/examples/tracing/docker-compose.yml
+++ b/examples/tracing/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "8889:8889"   # Prometheus exporter metrics
       - "13133:13133" # health_check extension
       - "9411"   # Zipkin receiver
-      - "55670:55679" # zpages extension
+      - "55679:55679" # zpages extension
     depends_on:
       - jaeger
       - zipkin

--- a/exporter/datadogexporter/example/example_k8s_manifest.yaml
+++ b/exporter/datadogexporter/example/example_k8s_manifest.yaml
@@ -32,7 +32,7 @@ data:
       zipkin:
     exporters:
       otlp:
-        endpoint: "otel-collector.default:55680"
+        endpoint: "otel-collector.default:4317"
         insecure: true
     processors:
       batch:
@@ -113,7 +113,7 @@ spec:
         - containerPort: 9411 # Default endpoint for Zipkin receiver.
         - containerPort: 14250 # Default endpoint for Jaeger gRPC receiver.
         - containerPort: 14268 # Default endpoint for Jaeger HTTP receiver.
-        - containerPort: 55680 # Default OpenTelemetry gRPC receiver port.
+        - containerPort: 4317 # Default OpenTelemetry gRPC receiver port.
         - containerPort: 55681 # Default OpenTelemetry HTTP receiver port.
         env:
            # Get pod ip so that k8s_tagger can tag resources
@@ -190,9 +190,9 @@ metadata:
 spec:
   ports:
   - name: otlp # Default endpoint for OpenTelemetry receiver.
-    port: 55680
+    port: 4317
     protocol: TCP
-    targetPort: 55680
+    targetPort: 4317
   - name: metrics # Default endpoint for querying metrics.
     port: 8888
   selector:
@@ -235,7 +235,7 @@ spec:
             memory: 400Mi
         ports:
         - containerPort: 55679 # Default endpoint for ZPages.
-        - containerPort: 55680 # Default endpoint for OpenTelemetry receiver.
+        - containerPort: 4317 # Default endpoint for OpenTelemetry receiver.
         - containerPort: 8888  # Default endpoint for querying metrics.
         volumeMounts:
         - name: otel-collector-config-vol

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -85,7 +85,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:55680
+        endpoint: 0.0.0.0:4317
 exporters:
   dynatrace:
     endpoint: https://ab12345.live.dynatrace.com

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -19,7 +19,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `otlp` property configures the template used for building the OTLP exporter. Refer to the OTLP Exporter documentation for information on which options are available. Note that the `endpoint` property should not be set and will be overridden by this exporter with the backend endpoint.
 * The `resolver` accepts either a `static` node, or a `dns`. If both are specified, `dns` takes precedence.
 * The `hostname` property inside a `dns` node specifies the hostname to query in order to obtain the list of IP addresses.
-* The `dns` node also accepts an optional property `port` to specify the port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 55680 is used.
+* The `dns` node also accepts an optional property `port` to specify the port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 4317 is used.
 
 
 Simple example
@@ -28,7 +28,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: localhost:55680
+        endpoint: localhost:4317
 
 processors:
 
@@ -43,10 +43,10 @@ exporters:
     resolver:
       static:
         hostnames:
-        - backend-1:55680
-        - backend-2:55680
-        - backend-3:55680
-        - backend-4:55680
+        - backend-1:4317
+        - backend-2:4317
+        - backend-3:4317
+        - backend-4:4317
 
 service:
   pipelines:
@@ -70,7 +70,7 @@ receivers:
   otlp/loadbalancer:
     protocols:
       grpc:
-        endpoint: localhost:55680
+        endpoint: localhost:4317
   otlp/backend-1:
     protocols:
       grpc:

--- a/exporter/loadbalancingexporter/testdata/config.yaml
+++ b/exporter/loadbalancingexporter/testdata/config.yaml
@@ -14,7 +14,7 @@ exporters:
     resolver:
       static:
         hostnames:
-        - endpoint-1 # assumes 55680 as the default port
+        - endpoint-1 # assumes 4317 as the default port
         - endpoint-2:55678
   loadbalancing/2:
     protocol:
@@ -23,7 +23,7 @@ exporters:
     # how to get the list of backends: DNS
     resolver:
       dns:
-        hostname: service-1 # assumes 55680 as the default port for the resolved IP addresses
+        hostname: service-1 # assumes 4317 as the default port for the resolved IP addresses
   loadbalancing/3:
     protocol:
       otlp:

--- a/exporter/lokiexporter/example/docker-compose.yml
+++ b/exporter/lokiexporter/example/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "1888:1888"   # pprof extension
       - "8888:8888"   # Prometheus metrics exposed by the collector
       - "13133:13133" # health_check extension
-      - "55670:55679" # zpages extension
+      - "55679:55679" # zpages extension
       - "24224:24224" # fluentforwarder
       - "24224:24224/udp" # fluentforwarder
     depends_on:

--- a/exporter/lokiexporter/example/docker-compose.yml
+++ b/exporter/lokiexporter/example/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "1888:1888"   # pprof extension
       - "8888:8888"   # Prometheus metrics exposed by the collector
       - "13133:13133" # health_check extension
-      - "55680:55679" # zpages extension
+      - "55670:55679" # zpages extension
       - "24224:24224" # fluentforwarder
       - "24224:24224/udp" # fluentforwarder
     depends_on:

--- a/exporter/sapmexporter/examples/signalfx-k8s.yaml
+++ b/exporter/sapmexporter/examples/signalfx-k8s.yaml
@@ -155,7 +155,7 @@ spec:
           value: # set your token here
         ports:
         - containerPort: 55679 # Default endpoint for ZPages.
-        - containerPort: 55680 # Default endpoint for OpenTelemetry receiver.
+        - containerPort: 4317 # Default endpoint for OpenTelemetry receiver.
         - containerPort: 6060  # Default endpoint for HTTP Forwarder extension.
         - containerPort: 7276  # Default endpoint for SignalFx APM receiver.
         - containerPort: 8888  # Default endpoint for querying metrics.

--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -31,7 +31,7 @@ receivers:
     collection_interval: 10s
     # optional: the same as specifying OTLP receiver endpoint.
     otlp:
-      endpoint: mycollectorotlpreceiver:55680
+      endpoint: mycollectorotlpreceiver:4317
     username: my_jmx_username
     # determined by the environment variable value
     password: $MY_JMX_PASSWORD

--- a/tracegen/README.md
+++ b/tracegen/README.md
@@ -17,7 +17,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: localhost:55680
+        endpoint: localhost:4317
 
 processors:
 

--- a/tracegen/internal/tracegen/config.go
+++ b/tracegen/internal/tracegen/config.go
@@ -50,7 +50,7 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 	fs.StringVar(&c.ServiceName, "service", "tracegen", "Service name to use")
 
 	// unfortunately, at this moment, the otel-go client doesn't support configuring OTLP via env vars
-	fs.StringVar(&c.Endpoint, "otlp-endpoint", "localhost:55680", "Target to which the exporter is going to send spans or metrics. This MAY be configured to include a path (e.g. example.com/v1/traces)")
+	fs.StringVar(&c.Endpoint, "otlp-endpoint", "localhost:4317", "Target to which the exporter is going to send spans or metrics. This MAY be configured to include a path (e.g. example.com/v1/traces)")
 	fs.BoolVar(&c.Insecure, "otlp-insecure", false, "Whether to enable client transport security for the exporter's grpc or http connection")
 }
 


### PR DESCRIPTION
**Description:**
Replace the legacy gRPC port(`55680`) to `4317` and will disable `55680` in the core repo later.

Submitted CRs to remove `55680` from all of the OTEL SDKs and website/documentations. (track in the issue below)

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2565