### PR TITLE
Removed duplicate code from potential merge issue in Splunk HEC exporter

### DIFF
--- a/exporter/splunkhecexporter/tracedata_to_splunk.go
+++ b/exporter/splunkhecexporter/tracedata_to_splunk.go
@@ -88,17 +88,6 @@ func traceDataToSplunk(logger *zap.Logger, data pdata.Traces, config *Config) ([
 			commonFields[k] = tracetranslator.AttributeValueToString(v)
 			return true
 		})
-
-		if sourceSet, isSet := rs.Resource().Attributes().Get(conventions.AttributeServiceName); isSet {
-			source = sourceSet.StringVal()
-		}
-		if sourcetypeSet, isSet := rs.Resource().Attributes().Get(splunk.SourcetypeLabel); isSet {
-			sourceType = sourcetypeSet.StringVal()
-		}
-		rs.Resource().Attributes().Range(func(k string, v pdata.AttributeValue) bool {
-			commonFields[k] = tracetranslator.AttributeValueToString(v)
-			return true
-		})
 		ilss := rs.InstrumentationLibrarySpans()
 		for sils := 0; sils < ilss.Len(); sils++ {
 			ils := ilss.At(sils)


### PR DESCRIPTION
**Description:**
While developing the Humio exporter, I looked through a number of other exporters for inspiration. I noticed that the `tracedata_to_splunk.go` file from the Splunk HEC exporter contained some odd duplicated code. Upon further investigation, it seems to be a result of a merge conflict gone wrong between #1513 and #1514. This PR removes the duplicated code.

**Link to tracking Issue:**
None

**Testing:**
I reran the Splunk HEC exporter tests, and all tests are still passing.

**Documentation:**
None