### PR TITLE
[extension/ecsobserver] Add task definition, ec2 and service fetcher

### DIFF
--- a/extension/observer/ecsobserver/fetcher.go
+++ b/extension/observer/ecsobserver/fetcher.go
@@ -21,19 +21,27 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/golang-lru/simplelru"
 	"go.uber.org/zap"
+)
+
+const (
+	// ECS Service Quota: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-quotas.html
+	taskDefCacheSize = 2000
 )
 
 // ecsClient includes API required by taskFetcher.
 type ecsClient interface {
 	ListTasksWithContext(ctx context.Context, input *ecs.ListTasksInput, opts ...request.Option) (*ecs.ListTasksOutput, error)
 	DescribeTasksWithContext(ctx context.Context, input *ecs.DescribeTasksInput, opts ...request.Option) (*ecs.DescribeTasksOutput, error)
+	DescribeTaskDefinitionWithContext(ctx context.Context, input *ecs.DescribeTaskDefinitionInput, opts ...request.Option) (*ecs.DescribeTaskDefinitionOutput, error)
 }
 
 type taskFetcher struct {
-	logger  *zap.Logger
-	ecs     ecsClient
-	cluster string
+	logger       *zap.Logger
+	ecs          ecsClient
+	cluster      string
+	taskDefCache simplelru.LRUCache
 }
 
 type taskFetcherOptions struct {
@@ -46,10 +54,17 @@ type taskFetcherOptions struct {
 }
 
 func newTaskFetcher(opts taskFetcherOptions) (*taskFetcher, error) {
+	// Init cache
+	taskDefCache, err := simplelru.NewLRU(taskDefCacheSize, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	fetcher := taskFetcher{
-		logger:  opts.Logger,
-		ecs:     opts.ecsOverride,
-		cluster: opts.Cluster,
+		logger:       opts.Logger,
+		ecs:          opts.ecsOverride,
+		cluster:      opts.Cluster,
+		taskDefCache: taskDefCache,
 	}
 	// Return early if clients are mocked
 	if fetcher.ecs != nil {
@@ -85,4 +100,43 @@ func (f *taskFetcher) GetAllTasks(ctx context.Context) ([]*ecs.Task, error) {
 		req.NextToken = listRes.NextToken
 	}
 	return tasks, nil
+}
+
+// AttachTaskDefinition converts ecs.Task into a annotated Task to include its ecs.TaskDefinition.
+func (f *taskFetcher) AttachTaskDefinition(ctx context.Context, tasks []*ecs.Task) ([]*Task, error) {
+	svc := f.ecs
+	// key is task definition arn
+	arn2Def := make(map[string]*ecs.TaskDefinition)
+	for _, t := range tasks {
+		arn2Def[aws.StringValue(t.TaskDefinitionArn)] = nil
+	}
+
+	for arn := range arn2Def {
+		if arn == "" {
+			continue
+		}
+		var def *ecs.TaskDefinition
+		if cached, ok := f.taskDefCache.Get(arn); ok {
+			def = cached.(*ecs.TaskDefinition)
+		} else {
+			res, err := svc.DescribeTaskDefinitionWithContext(ctx, &ecs.DescribeTaskDefinitionInput{
+				TaskDefinition: aws.String(arn),
+			})
+			if err != nil {
+				return nil, err
+			}
+			f.taskDefCache.Add(arn, res.TaskDefinition)
+			def = res.TaskDefinition
+		}
+		arn2Def[arn] = def
+	}
+
+	var tasksWithDef []*Task
+	for _, t := range tasks {
+		tasksWithDef = append(tasksWithDef, &Task{
+			Task:       t,
+			Definition: arn2Def[aws.StringValue(t.TaskDefinitionArn)],
+		})
+	}
+	return tasksWithDef, nil
 }

--- a/extension/observer/ecsobserver/fetcher_test.go
+++ b/extension/observer/ecsobserver/fetcher_test.go
@@ -28,6 +28,44 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver/internal/ecsmock"
 )
 
+func TestFetcher_FetchAndDecorate(t *testing.T) {
+	c := ecsmock.NewCluster()
+	f, err := newTaskFetcher(taskFetcherOptions{
+		Logger:      zap.NewExample(),
+		Cluster:     "not used",
+		Region:      "not used",
+		ecsOverride: c,
+		ec2Override: c,
+	})
+	require.NoError(t, err)
+	// Create 1 task def and 10 tasks, 8 running on ec2, first 3 runs on fargate
+	// TODO: they will be changed to include service etc.
+	nTasks := 11
+	nInstances := 2
+	nFargateInstances := 3
+	c.SetTaskDefinitions(ecsmock.GenTaskDefinitions("d", 1, 1, nil))
+	c.SetTasks(ecsmock.GenTasks("t", nTasks, func(i int, task *ecs.Task) {
+		ins := i % nInstances
+		if i < nFargateInstances {
+			task.LaunchType = aws.String(ecs.LaunchTypeFargate)
+		} else {
+			task.LaunchType = aws.String(ecs.LaunchTypeEc2)
+			task.ContainerInstanceArn = aws.String(fmt.Sprintf("ci%d", ins))
+		}
+		task.TaskDefinitionArn = aws.String("d0:1")
+	}))
+	// Setting container instance and ec2 is same as previous sub test
+	c.SetContainerInstances(ecsmock.GenContainerInstances("ci", nInstances, func(i int, ci *ecs.ContainerInstance) {
+		ci.Ec2InstanceId = aws.String(fmt.Sprintf("i-%d", i))
+	}))
+	c.SetEc2Instances(ecsmock.GenEc2Instances("i-", nInstances, nil))
+
+	ctx := context.Background()
+	tasks, err := f.fetchAndDecorate(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, nTasks, len(tasks))
+}
+
 func TestFetcher_GetAllTasks(t *testing.T) {
 	c := ecsmock.NewCluster()
 	f, err := newTaskFetcher(taskFetcherOptions{
@@ -40,7 +78,7 @@ func TestFetcher_GetAllTasks(t *testing.T) {
 	const nTasks = 203
 	c.SetTasks(ecsmock.GenTasks("p", nTasks, nil))
 	ctx := context.Background()
-	tasks, err := f.GetAllTasks(ctx)
+	tasks, err := f.getAllTasks(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, nTasks, len(tasks))
 }
@@ -64,19 +102,19 @@ func TestFetcher_AttachTaskDefinitions(t *testing.T) {
 	c.SetTaskDefinitions(ecsmock.GenTaskDefinitions("pdef", nTasks, 1, nil))
 
 	// no cache
-	tasks, err := f.GetAllTasks(ctx)
+	tasks, err := f.getAllTasks(ctx)
 	require.NoError(t, err)
-	attached, err := f.AttachTaskDefinition(ctx, tasks)
+	attached, err := f.attachTaskDefinition(ctx, tasks)
 	stats := c.Stats()
 	require.NoError(t, err)
 	assert.Equal(t, len(tasks), len(attached))
 	assert.Equal(t, nTasks, stats.DescribeTaskDefinition.Called)
 
 	// all cached
-	tasks, err = f.GetAllTasks(ctx)
+	tasks, err = f.getAllTasks(ctx)
 	require.NoError(t, err)
 	// do it again to trigger cache logic
-	attached, err = f.AttachTaskDefinition(ctx, tasks)
+	attached, err = f.attachTaskDefinition(ctx, tasks)
 	stats = c.Stats()
 	require.NoError(t, err)
 	assert.Equal(t, len(tasks), len(attached))
@@ -87,10 +125,98 @@ func TestFetcher_AttachTaskDefinitions(t *testing.T) {
 		task.TaskDefinitionArn = aws.String(fmt.Sprintf("pdef%d:1", i))
 	}))
 	c.SetTaskDefinitions(ecsmock.GenTaskDefinitions("pdef", nTasks+1, 1, nil))
-	tasks, err = f.GetAllTasks(ctx)
+	tasks, err = f.getAllTasks(ctx)
 	require.NoError(t, err)
-	_, err = f.AttachTaskDefinition(ctx, tasks)
+	_, err = f.attachTaskDefinition(ctx, tasks)
 	stats = c.Stats()
 	require.NoError(t, err)
 	assert.Equal(t, nTasks+1, stats.DescribeTaskDefinition.Called) // +1 for new task
+}
+
+func TestFetcher_AttachContainerInstance(t *testing.T) {
+	t.Run("ec2 only", func(t *testing.T) {
+		c := ecsmock.NewCluster()
+		f, err := newTaskFetcher(taskFetcherOptions{
+			Logger:      zap.NewExample(),
+			Cluster:     "not used",
+			Region:      "not used",
+			ecsOverride: c,
+			ec2Override: c,
+		})
+		require.NoError(t, err)
+		// Create 1 task def and 11 tasks running on 2 ec2 instances
+		nTasks := 11
+		nInstances := 2
+		c.SetTaskDefinitions(ecsmock.GenTaskDefinitions("d", 1, 1, nil))
+		c.SetTasks(ecsmock.GenTasks("t", nTasks, func(i int, task *ecs.Task) {
+			ins := i % nInstances
+			task.LaunchType = aws.String(ecs.LaunchTypeEc2)
+			task.TaskDefinitionArn = aws.String("d0:1")
+			task.ContainerInstanceArn = aws.String(fmt.Sprintf("ci%d", ins))
+		}))
+		c.SetContainerInstances(ecsmock.GenContainerInstances("ci", nInstances, func(i int, ci *ecs.ContainerInstance) {
+			ci.Ec2InstanceId = aws.String(fmt.Sprintf("i-%d", i))
+		}))
+		c.SetEc2Instances(ecsmock.GenEc2Instances("i-", nInstances, nil))
+
+		ctx := context.Background()
+		rawTasks, err := f.getAllTasks(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, nTasks, len(rawTasks))
+
+		tasks, err := f.attachTaskDefinition(ctx, rawTasks)
+		require.NoError(t, err)
+		assert.Equal(t, "d0:1", aws.StringValue(tasks[0].Definition.TaskDefinitionArn))
+
+		err = f.attachContainerInstance(ctx, tasks)
+		require.NoError(t, err)
+		assert.Equal(t, "i-0", aws.StringValue(tasks[0].EC2.InstanceId))
+	})
+
+	t.Run("mixed cluster", func(t *testing.T) {
+		c := ecsmock.NewCluster()
+		f, err := newTaskFetcher(taskFetcherOptions{
+			Logger:      zap.NewExample(),
+			Cluster:     "not used",
+			Region:      "not used",
+			ecsOverride: c,
+			ec2Override: c,
+		})
+		require.NoError(t, err)
+		// Create 1 task def and 10 tasks, 8 running on ec2, first 3 runs on fargate
+		nTasks := 11
+		nInstances := 2
+		nFargateInstances := 3
+		c.SetTaskDefinitions(ecsmock.GenTaskDefinitions("d", 1, 1, nil))
+		c.SetTasks(ecsmock.GenTasks("t", nTasks, func(i int, task *ecs.Task) {
+			ins := i % nInstances
+			if i < nFargateInstances {
+				task.LaunchType = aws.String(ecs.LaunchTypeFargate)
+			} else {
+				task.LaunchType = aws.String(ecs.LaunchTypeEc2)
+				task.ContainerInstanceArn = aws.String(fmt.Sprintf("ci%d", ins))
+			}
+			task.TaskDefinitionArn = aws.String("d0:1")
+		}))
+		// Setting container instance and ec2 is same as previous sub test
+		c.SetContainerInstances(ecsmock.GenContainerInstances("ci", nInstances, func(i int, ci *ecs.ContainerInstance) {
+			ci.Ec2InstanceId = aws.String(fmt.Sprintf("i-%d", i))
+		}))
+		c.SetEc2Instances(ecsmock.GenEc2Instances("i-", nInstances, nil))
+
+		ctx := context.Background()
+		rawTasks, err := f.getAllTasks(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, nTasks, len(rawTasks))
+
+		tasks, err := f.attachTaskDefinition(ctx, rawTasks)
+		require.NoError(t, err)
+		assert.Equal(t, "d0:1", aws.StringValue(tasks[0].Definition.TaskDefinitionArn))
+
+		err = f.attachContainerInstance(ctx, tasks)
+		require.NoError(t, err)
+		assert.Nil(t, tasks[0].EC2)
+		// task instance pattern is  0 1 0 1 ..., nFargateInstances = 3 so the 4th task is running on instance 1
+		assert.Equal(t, "i-1", aws.StringValue(tasks[nFargateInstances].EC2.InstanceId))
+	})
 }

--- a/extension/observer/ecsobserver/go.mod
+++ b/extension/observer/ecsobserver/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.55
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.27.1-0.20210608105628-44a4ae746c3c
 	go.uber.org/multierr v1.7.0

--- a/extension/observer/ecsobserver/go.sum
+++ b/extension/observer/ecsobserver/go.sum
@@ -489,6 +489,7 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=


### PR DESCRIPTION
**Description:**

- get ECS task definition
- get EC2 instance if it's ECS EC2
- get ECS service and map them to tasks

Most code is in the mock and they looks very similar. Not sure if there is a better way when it comes to generating mock data of specific struct(s) in a for loop. 

**Link to tracking Issue:**

- Feature request #1395 

Pending PRs

- Service matcher https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3386
- Exporter https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3333

Previous PRs

- Fetch Task https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3284
- Docker Label Matcher https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3276
- Task IP and Port https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3133
- Target and Task definition (merged) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2939
- Config PR (merged) https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2377
- Original PR (closed) #2734 

**Testing:** 

unit test

**Documentation:** 

No new doc. See [existing doc](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/observer/ecsobserver/README.md)