### PR TITLE
Fix awsutil unit test which was failing when run on EC2 instance deve…

### DIFF
--- a/internal/aws/awsutil/conn_test.go
+++ b/internal/aws/awsutil/conn_test.go
@@ -124,6 +124,7 @@ func TestNewAWSSessionWithErr(t *testing.T) {
 	region := "fake_region"
 	env := stashEnv()
 	defer popEnv(env)
+	os.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	os.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 	conn := &Conn{}
 	se, err := conn.newAWSSession(logger, roleArn, region)


### PR DESCRIPTION
…lopment environment.

The test assumed that the EC2 Instance Metadata Service would not be accessible.  Now disable it via environment
variable to enforce that assumption.

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** #3526

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>