### PR TITLE
Fix DataDog exporter unit test which was failing when run on EC2 inst…

### DIFF
--- a/exporter/datadogexporter/metadata/host_test.go
+++ b/exporter/datadogexporter/metadata/host_test.go
@@ -48,6 +48,14 @@ func TestHost(t *testing.T) {
 	})
 	assert.Equal(t, host, "test-host-2")
 
+	// Disable EC2 Metadata service to prevent fetching hostname from there,
+	// in case the test is running on an EC2 instance
+	const awsEc2MetadataDisabled = "AWS_EC2_METADATA_DISABLED"
+	curr := os.Getenv(awsEc2MetadataDisabled)
+	err := os.Setenv(awsEc2MetadataDisabled, "true")
+	require.NoError(t, err)
+	defer os.Setenv(awsEc2MetadataDisabled, curr)
+
 	host = GetHost(logger, &config.Config{})
 	osHostname, err := os.Hostname()
 	require.NoError(t, err)


### PR DESCRIPTION
…ance development environment.

The test assumed that the EC2 Instance Metadata Service would not be accessible.  Now disable it via environment
variable to enforce that assumption.

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** #3526

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>