### PR TITLE
Disable unstable Syslog UDP test until it is fixed

### DIFF
--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -101,15 +101,6 @@ func TestLog10kDPS(t *testing.T) {
 			},
 		},
 		{
-			name:     "syslog-udp",
-			sender:   datasenders.NewSyslogWriter("udp", testbed.DefaultHost, testbed.GetAvailablePort(t), 1),
-			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
-			resourceSpec: testbed.ResourceSpec{
-				ExpectedMaxCPU: 80,
-				ExpectedMaxRAM: 150,
-			},
-		},
-		{
 			name:     "syslog-tcp-batch-1",
 			sender:   datasenders.NewTCPUDPWriter("tcp", testbed.DefaultHost, testbed.GetAvailablePort(t), 1),
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),


### PR DESCRIPTION
We have a bug recorded here https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3095

We will re-enable the test when the bug is fixed.
