### PR TITLE
Add semantic conventions to k8s-tagger for pod metadata

### DIFF
--- a/processor/k8sprocessor/config.go
+++ b/processor/k8sprocessor/config.go
@@ -56,8 +56,8 @@ type ExtractConfig struct {
 	// The field accepts a list of strings.
 	//
 	// Metadata fields supported right now are,
-	//   namespace, podName, podUID, deployment, cluster, node and startTime
-	//
+	//   k8s.namespace.name, k8s.pod.name, k8s.pod.uid, k8s.deployment.name, k8s.cluster.name,
+	//   k8s.node.name and k8s.pod.start_time
 	// Specifying anything other than these values will result in an error.
 	// By default all of the fields are extracted and added to spans and metrics.
 	Metadata []string `mapstructure:"metadata"`

--- a/processor/k8sprocessor/config_test.go
+++ b/processor/k8sprocessor/config_test.go
@@ -60,7 +60,7 @@ func TestLoadConfig(t *testing.T) {
 			APIConfig:         k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeKubeConfig},
 			Passthrough:       false,
 			Extract: ExtractConfig{
-				Metadata: []string{"podName", "podUID", "deployment", "cluster", "namespace", "node", "startTime"},
+				Metadata: []string{"k8s.pod.name", "k8s.pod.uid", "k8s.deployment.name", "k8s.cluster.name", "k8s.namespace.name", "k8s.node.name", "k8s.pod.start_time"},
 				Annotations: []FieldExtractConfig{
 					{TagName: "a1", Key: "annotation-one"},
 					{TagName: "a2", Key: "annotation-two", Regex: "field=(?P<value>.+)"},

--- a/processor/k8sprocessor/factory.go
+++ b/processor/k8sprocessor/factory.go
@@ -18,12 +18,11 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/collector/translator/conventions"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"

--- a/processor/k8sprocessor/factory.go
+++ b/processor/k8sprocessor/factory.go
@@ -16,11 +16,15 @@ package k8sprocessor
 
 import (
 	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/translator/conventions"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sprocessor/kube"
@@ -149,6 +153,8 @@ func createKubernetesProcessor(
 ) (*kubernetesprocessor, error) {
 	kp := &kubernetesprocessor{logger: params.Logger}
 
+	warnDeprecatedMetadataConfig(kp.logger, cfg)
+
 	allOptions := append(createProcessorOpts(cfg), options...)
 
 	for _, opt := range allOptions {
@@ -190,4 +196,38 @@ func createProcessorOpts(cfg config.Processor) []Option {
 	opts = append(opts, WithExtractPodAssociations(oCfg.Association...))
 
 	return opts
+}
+
+func warnDeprecatedMetadataConfig(logger *zap.Logger, cfg config.Processor) {
+	oCfg := cfg.(*Config)
+	var oldName, newName string
+
+	for _, field := range oCfg.Extract.Metadata {
+		switch field {
+		case metdataNamespace:
+			oldName = metdataNamespace
+			newName = conventions.AttributeK8sNamespace
+		case metadataPodName:
+			oldName = metadataPodName
+			newName = conventions.AttributeK8sPod
+		case metadataPodUID:
+			oldName = metadataPodUID
+			newName = conventions.AttributeK8sPodUID
+		case metadataStartTime:
+			oldName = metadataStartTime
+			newName = metadataPodStartTime
+		case metadataDeployment:
+			oldName = metadataDeployment
+			newName = conventions.AttributeK8sDeployment
+		case metadataCluster:
+			oldName = metadataCluster
+			newName = conventions.AttributeK8sCluster
+		case metadataNode:
+			oldName = metadataNode
+			newName = conventions.AttributeK8sNodeName
+		}
+		if oldName != "" {
+			logger.Warn(fmt.Sprintf("%s has been deprecated in favor of %s for k8s-tagger processor", oldName, newName))
+		}
+	}
 }

--- a/processor/k8sprocessor/factory.go
+++ b/processor/k8sprocessor/factory.go
@@ -199,9 +199,8 @@ func createProcessorOpts(cfg config.Processor) []Option {
 
 func warnDeprecatedMetadataConfig(logger *zap.Logger, cfg config.Processor) {
 	oCfg := cfg.(*Config)
-	var oldName, newName string
-
 	for _, field := range oCfg.Extract.Metadata {
+		var oldName, newName string
 		switch field {
 		case metdataNamespace:
 			oldName = metdataNamespace

--- a/processor/k8sprocessor/options.go
+++ b/processor/k8sprocessor/options.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"regexp"
 
+	"go.opentelemetry.io/collector/translator/conventions"
 	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
@@ -30,7 +31,7 @@ const (
 	filterOPNotEquals    = "not-equals"
 	filterOPExists       = "exists"
 	filterOPDoesNotExist = "does-not-exist"
-
+	// Used for maintaining backward compatibility
 	metdataNamespace   = "namespace"
 	metadataPodName    = "podName"
 	metadataPodUID     = "podUID"
@@ -38,6 +39,8 @@ const (
 	metadataDeployment = "deployment"
 	metadataCluster    = "cluster"
 	metadataNode       = "node"
+	// Will be removed when new fields get merged to https://github.com/open-telemetry/opentelemetry-collector/blob/main/translator/conventions/opentelemetry.go
+	metadataPodStartTime = "k8s.pod.start_time"
 )
 
 // Option represents a configuration option that can be passes.
@@ -68,30 +71,30 @@ func WithExtractMetadata(fields ...string) Option {
 	return func(p *kubernetesprocessor) error {
 		if len(fields) == 0 {
 			fields = []string{
-				metdataNamespace,
-				metadataPodName,
-				metadataPodUID,
-				metadataStartTime,
-				metadataDeployment,
-				metadataCluster,
-				metadataNode,
+				conventions.AttributeK8sNamespace,
+				conventions.AttributeK8sPod,
+				conventions.AttributeK8sPodUID,
+				metadataPodStartTime,
+				conventions.AttributeK8sDeployment,
+				conventions.AttributeK8sCluster,
+				conventions.AttributeK8sNodeName,
 			}
 		}
 		for _, field := range fields {
 			switch field {
-			case metdataNamespace:
+			case metdataNamespace, conventions.AttributeK8sNamespace:
 				p.rules.Namespace = true
-			case metadataPodName:
+			case metadataPodName, conventions.AttributeK8sPod:
 				p.rules.PodName = true
-			case metadataPodUID:
+			case metadataPodUID, conventions.AttributeK8sPodUID:
 				p.rules.PodUID = true
-			case metadataStartTime:
+			case metadataStartTime, metadataPodStartTime:
 				p.rules.StartTime = true
-			case metadataDeployment:
+			case metadataDeployment, conventions.AttributeK8sDeployment:
 				p.rules.Deployment = true
-			case metadataCluster:
+			case metadataCluster, conventions.AttributeK8sCluster:
 				p.rules.Cluster = true
-			case metadataNode:
+			case metadataNode, conventions.AttributeK8sNodeName:
 				p.rules.Node = true
 			default:
 				return fmt.Errorf("\"%s\" is not a supported metadata field", field)

--- a/processor/k8sprocessor/options.go
+++ b/processor/k8sprocessor/options.go
@@ -83,7 +83,7 @@ func WithExtractMetadata(fields ...string) Option {
 		for _, field := range fields {
 			switch field {
 			// Old conventions handled by the cases metdataNamespace, metadataPodName, metadataPodUID,
-			// metadataStartTime, metadataDeployment, metadataCluster, metadataNode are being supported for backward compatability.
+			// metadataStartTime, metadataDeployment, metadataCluster, metadataNode are being supported for backward compatibility.
 			// These will be removed when new conventions get merged to https://github.com/open-telemetry/opentelemetry-collector/blob/main/translator/conventions/opentelemetry.go
 			case metdataNamespace, conventions.AttributeK8sNamespace:
 				p.rules.Namespace = true

--- a/processor/k8sprocessor/options.go
+++ b/processor/k8sprocessor/options.go
@@ -82,6 +82,9 @@ func WithExtractMetadata(fields ...string) Option {
 		}
 		for _, field := range fields {
 			switch field {
+			// Old conventions handled by the cases metdataNamespace, metadataPodName, metadataPodUID,
+			// metadataStartTime, metadataDeployment, metadataCluster, metadataNode are being supported for backward compatability.
+			// These will be removed when new conventions get merged to https://github.com/open-telemetry/opentelemetry-collector/blob/main/translator/conventions/opentelemetry.go
 			case metdataNamespace, conventions.AttributeK8sNamespace:
 				p.rules.Namespace = true
 			case metadataPodName, conventions.AttributeK8sPod:

--- a/processor/k8sprocessor/options_test.go
+++ b/processor/k8sprocessor/options_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/translator/conventions"
 	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
@@ -216,6 +217,17 @@ func TestWithExtractMetadata(t *testing.T) {
 	assert.True(t, p.rules.Cluster)
 	assert.False(t, p.rules.PodName)
 	assert.False(t, p.rules.PodUID)
+	assert.False(t, p.rules.StartTime)
+	assert.False(t, p.rules.Deployment)
+	assert.False(t, p.rules.Node)
+
+	p = &kubernetesprocessor{}
+
+	assert.NoError(t, WithExtractMetadata(conventions.AttributeK8sNamespace, conventions.AttributeK8sPod, conventions.AttributeK8sPodUID)(p))
+	assert.True(t, p.rules.Namespace)
+	assert.False(t, p.rules.Cluster)
+	assert.True(t, p.rules.PodName)
+	assert.True(t, p.rules.PodUID)
 	assert.False(t, p.rules.StartTime)
 	assert.False(t, p.rules.Deployment)
 	assert.False(t, p.rules.Node)

--- a/processor/k8sprocessor/processor_test.go
+++ b/processor/k8sprocessor/processor_test.go
@@ -323,7 +323,7 @@ func TestProcessorNoAttrs(t *testing.T) {
 		t,
 		NewFactory().CreateDefaultConfig(),
 		nil,
-		WithExtractMetadata(metadataPodName),
+		WithExtractMetadata(conventions.AttributeK8sPod),
 	)
 
 	ctx := client.NewContext(context.Background(), &client.Client{IP: "1.1.1.1"})
@@ -701,7 +701,7 @@ func TestMetricsProcessorHostname(t *testing.T) {
 	p, err := newMetricsProcessor(
 		NewFactory().CreateDefaultConfig(),
 		next,
-		WithExtractMetadata(metadataPodName),
+		WithExtractMetadata(conventions.AttributeK8sPod),
 		withExtractKubernetesProcessorInto(&kp),
 	)
 	require.NoError(t, err)
@@ -771,7 +771,7 @@ func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
 	p, err := newMetricsProcessor(
 		NewFactory().CreateDefaultConfig(),
 		next,
-		WithExtractMetadata(metadataPodName),
+		WithExtractMetadata(conventions.AttributeK8sPod),
 		withExtractKubernetesProcessorInto(&kp),
 	)
 	require.NoError(t, err)

--- a/processor/k8sprocessor/testdata/config.yaml
+++ b/processor/k8sprocessor/testdata/config.yaml
@@ -9,13 +9,21 @@ processors:
     extract:
       metadata:
         # extract the following well-known metadata fields
-        - podName
-        - podUID
-        - deployment
-        - cluster
-        - namespace
-        - node
-        - startTime
+        - k8s.pod.name
+        - k8s.pod.uid
+        - k8s.deployment.name
+        - k8s.cluster.name
+        - k8s.namespace.name
+        - k8s.node.name
+        - k8s.pod.start_time
+        # the following metadata fields configuration options are deprecated
+#        - podName
+#        - podUID
+#        - deployment
+#        - cluster
+#        - namespace
+#        - node
+#        - startTime
 
       annotations:
         - tag_name: a1 # extracts value of annotation with key `annotation-one` and inserts it as a tag with key `a1`


### PR DESCRIPTION
**Description:** Use semantic conventions to specify metadata for k8s-tagger

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3384

**Testing:** Updated unit tests