### PR TITLE
[datadogexporter] Add support for summary datatype

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -86,3 +86,4 @@ There are a number of optional settings for configuring how to send your metrics
 |-|-|-|
 | `send_monotonic_counters` | Cumulative monotonic metrics are sent as deltas between successive measurements. Disable this flag to send get the raw, monotonically increasing value. | `true` |
 | `delta_ttl` | Maximum number of seconds values from cumulative monotonic metrics are kept in memory. | 3600 |
+| `report_quantiles` | Whether to report quantile values for summary type metrics. | `true` |

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -63,6 +63,10 @@ type MetricsConfig struct {
 	// Buckets states whether to report buckets from distribution metrics
 	Buckets bool `mapstructure:"report_buckets"`
 
+	// Quantiles states whether to report quantiles from summary metrics.
+	// By default, the minimum, maximum and average are reported.
+	Quantiles bool `mapstructure:"report_quantiles"`
+
 	// SendMonotonic states whether to report cumulative monotonic metrics as counters
 	// or gauges
 	SendMonotonic bool `mapstructure:"send_monotonic_counter"`

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -66,6 +66,7 @@ func createDefaultConfig() config.Exporter {
 			},
 			SendMonotonic: true,
 			DeltaTTL:      3600,
+			Quantiles:     true,
 			ExporterConfig: ddconfig.MetricsExporterConfig{
 				ResourceAttributesAsTags: false,
 			},

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -57,6 +57,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 			},
 			DeltaTTL:      3600,
 			SendMonotonic: true,
+			Quantiles:     true,
 		},
 
 		Traces: ddconfig.TracesConfig{
@@ -121,6 +122,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 			DeltaTTL:      3600,
 			SendMonotonic: true,
+			Quantiles:     true,
 		},
 
 		Traces: ddconfig.TracesConfig{
@@ -160,6 +162,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 			SendMonotonic: true,
 			DeltaTTL:      3600,
+			Quantiles:     true,
 		},
 
 		Traces: ddconfig.TracesConfig{
@@ -241,6 +244,7 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 				Endpoint: "https://api.datadoghq.test",
 			},
 			SendMonotonic: true,
+			Quantiles:     false,
 			DeltaTTL:      3600,
 		},
 
@@ -285,6 +289,7 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 			},
 			SendMonotonic: true,
 			DeltaTTL:      3600,
+			Quantiles:     true,
 		},
 
 		Traces: ddconfig.TracesConfig{

--- a/exporter/datadogexporter/metrics_translator.go
+++ b/exporter/datadogexporter/metrics_translator.go
@@ -270,7 +270,7 @@ func getQuantileTag(quantile float64) string {
 
 // mapSummaryMetrics maps summary datapoints into Datadog metrics
 func mapSummaryMetrics(name string, slice pdata.SummaryDataPointSlice, quantiles bool, attrTags []string) []datadog.Metric {
-	// Allocate assuming none are nil and no percentiles
+	// Allocate assuming none are nil and no quantiles
 	ms := make([]datadog.Metric, 0, 2*slice.Len())
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)

--- a/exporter/datadogexporter/metrics_translator.go
+++ b/exporter/datadogexporter/metrics_translator.go
@@ -17,6 +17,7 @@ package datadogexporter
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -251,6 +252,52 @@ func mapHistogramMetrics(name string, slice pdata.HistogramDataPointSlice, bucke
 	return ms
 }
 
+// getQuantileTag returns the quantile tag for summary types.
+// Since the summary type is provided as a compatibility feature, we try to format the float number as close as possible to what
+// we do on the Datadog Agent Python OpenMetrics check, which, in turn, tries to
+// follow https://github.com/OpenObservability/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#considerations-canonical-numbers
+func getQuantileTag(quantile float64) string {
+	// We handle 0 and 1 separately since they are special
+	if quantile == 0 {
+		// we do this differently on our check
+		return "quantile:0"
+	} else if quantile == 1.0 {
+		// it needs to have a '.0' added at the end according to the spec
+		return "quantile:1.0"
+	}
+	return fmt.Sprintf("quantile:%s", strconv.FormatFloat(quantile, 'g', -1, 64))
+}
+
+// mapSummaryMetrics maps summary datapoints into Datadog metrics
+func mapSummaryMetrics(name string, slice pdata.SummaryDataPointSlice, quantiles bool, attrTags []string) []datadog.Metric {
+	// Allocate assuming none are nil and no percentiles
+	ms := make([]datadog.Metric, 0, 2*slice.Len())
+	for i := 0; i < slice.Len(); i++ {
+		p := slice.At(i)
+		ts := uint64(p.Timestamp())
+		tags := getTags(p.LabelsMap())
+		tags = append(tags, attrTags...)
+
+		ms = append(ms,
+			metrics.NewGauge(fmt.Sprintf("%s.count", name), ts, float64(p.Count()), tags),
+			metrics.NewGauge(fmt.Sprintf("%s.sum", name), ts, p.Sum(), tags),
+		)
+
+		if quantiles {
+			fullName := fmt.Sprintf("%s.quantile", name)
+			quantiles := p.QuantileValues()
+			for i := 0; i < quantiles.Len(); i++ {
+				q := quantiles.At(i)
+				quantileTags := append(tags, getQuantileTag(q.Quantile()))
+				ms = append(ms,
+					metrics.NewGauge(fullName, ts, q.Value(), quantileTags),
+				)
+			}
+		}
+	}
+	return ms
+}
+
 // mapMetrics maps OTLP metrics into the DataDog format
 func mapMetrics(logger *zap.Logger, cfg config.MetricsConfig, prevPts *ttlmap.TTLMap, fallbackHost string, md pdata.Metrics, buildInfo component.BuildInfo) (series []datadog.Metric, droppedTimeSeries int) {
 	pushTime := uint64(time.Now().UTC().UnixNano())
@@ -301,6 +348,8 @@ func mapMetrics(logger *zap.Logger, cfg config.MetricsConfig, prevPts *ttlmap.TT
 					datapoints = mapIntHistogramMetrics(md.Name(), md.IntHistogram().DataPoints(), cfg.Buckets, attributeTags)
 				case pdata.MetricDataTypeHistogram:
 					datapoints = mapHistogramMetrics(md.Name(), md.Histogram().DataPoints(), cfg.Buckets, attributeTags)
+				case pdata.MetricDataTypeSummary:
+					datapoints = mapSummaryMetrics(md.Name(), md.Summary().DataPoints(), cfg.Quantiles, attributeTags)
 				default: // pdata.MetricDataTypeNone or any other not supported type
 					logger.Debug("Unknown or unsupported metric type", zap.String("metric name", md.Name()), zap.Any("data type", md.DataType()))
 					continue

--- a/exporter/datadogexporter/testdata/config.yaml
+++ b/exporter/datadogexporter/testdata/config.yaml
@@ -36,6 +36,7 @@ exporters:
 
     metrics:
       endpoint: https://api.datadoghq.test
+      report_quantiles: false
 
     traces:
       sample_rate: 1


### PR DESCRIPTION
**Description:** 

Add support for summary datatype to the Datadog exporter.

Since this is a datatype that is used mostly for compatibility with OpenMetrics, the implementation largely follows the features on our existing OpenMetrics base check on the Datadog Agent.

**Link to tracking Issue:** Fixes #3154

**Testing:** Added unit tests.

**Documentation:** Documented `report_quantiles` flag
