### PR TITLE
Print Splunk HEC error message

### DIFF
--- a/internal/splunk/httprequest.go
+++ b/internal/splunk/httprequest.go
@@ -35,9 +35,8 @@ func HandleHTTPCode(resp *http.Response) error {
 	}
 
 	err := fmt.Errorf(
-		"HTTP %d %q",
-		resp.StatusCode,
-		http.StatusText(resp.StatusCode))
+		"HTTP %q",
+		resp.Status)
 
 	switch resp.StatusCode {
 	// Check for responses that may include "Retry-After" header.


### PR DESCRIPTION
**Description:** 
When response code is not 2xx from HEC, show helpful text that HEC returns. 
https://docs.splunk.com/Documentation/Splunk/8.2.0/Data/TroubleshootHTTPEventCollector

It will print messages from HEC like "HTTP 400 Invalid data format" instead of just general HTTP status code. 