### PR TITLE
Add ability to specify name in file extension client

### DIFF
--- a/extension/storage/README.md
+++ b/extension/storage/README.md
@@ -4,7 +4,7 @@ A storage extension persists state beyond the collector process. Other component
 
 The `storage.Extension` interface extends `component.Extension` by adding the following method:
 ```
-GetClient(component.Kind, component.Kind, config.ComponentID, string) (Client, error)
+GetClient(context.Context, component.Kind, config.ComponentID, string) (Client, error)
 ```
 
 The `storage.Client` interface contains the following methods:

--- a/extension/storage/README.md
+++ b/extension/storage/README.md
@@ -4,7 +4,7 @@ A storage extension persists state beyond the collector process. Other component
 
 The `storage.Extension` interface extends `component.Extension` by adding the following method:
 ```
-GetClient(component.Kind, component.Kind, config.ComponentID) (Client, error)
+GetClient(component.Kind, component.Kind, config.ComponentID, string) (Client, error)
 ```
 
 The `storage.Client` interface contains the following methods:

--- a/extension/storage/filestorage/extension.go
+++ b/extension/storage/filestorage/extension.go
@@ -63,8 +63,13 @@ func (lfs *localFileStorage) Shutdown(context.Context) error {
 }
 
 // GetClient returns a storage client for an individual component
-func (lfs *localFileStorage) GetClient(ctx context.Context, kind component.Kind, ent config.ComponentID) (storage.Client, error) {
-	rawName := fmt.Sprintf("%s_%s_%s", kindString(kind), ent.Type(), ent.Name())
+func (lfs *localFileStorage) GetClient(ctx context.Context, kind component.Kind, ent config.ComponentID, name string) (storage.Client, error) {
+	var rawName string
+	if name == "" {
+		rawName = fmt.Sprintf("%s_%s_%s", kindString(kind), ent.Type(), ent.Name())
+	} else {
+		rawName = fmt.Sprintf("%s_%s_%s_%s", kindString(kind), ent.Type(), ent.Name(), name)
+	}
 	// TODO sanitize rawName
 	absoluteName := filepath.Join(lfs.directory, rawName)
 	return newClient(absoluteName, lfs.timeout)

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -52,7 +52,7 @@ func TestExtensionIntegrity(t *testing.T) {
 	// Make a client for each component
 	clients := make(map[config.ComponentID]storage.Client)
 	for _, c := range components {
-		client, err := se.GetClient(ctx, c.kind, c.name)
+		client, err := se.GetClient(ctx, c.kind, c.name, "")
 		require.NoError(t, err)
 		clients[c.name] = client
 	}
@@ -110,6 +110,7 @@ func TestClientHandlesSimpleCases(t *testing.T) {
 		ctx,
 		component.KindReceiver,
 		newTestEntity("my_component"),
+		"",
 	)
 
 	myBytes := []byte("value")
@@ -181,6 +182,7 @@ func TestGetClientErrorsOnDeletedDirectory(t *testing.T) {
 		ctx,
 		component.KindReceiver,
 		newTestEntity("my_component"),
+		"",
 	)
 
 	require.Error(t, err)

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -156,6 +156,46 @@ func TestNewExtensionErrorsOnMissingDirectory(t *testing.T) {
 	require.Nil(t, extension)
 }
 
+func TestTwoClientsWithDifferentNames(t *testing.T) {
+	ctx := context.Background()
+	se := newTestExtension(t)
+
+	client1, err := se.GetClient(
+		ctx,
+		component.KindReceiver,
+		newTestEntity("my_component"),
+		"foo",
+	)
+	require.NoError(t, err)
+
+	client2, err := se.GetClient(
+		ctx,
+		component.KindReceiver,
+		newTestEntity("my_component"),
+		"bar",
+	)
+	require.NoError(t, err)
+
+	myBytes1 := []byte("value1")
+	myBytes2 := []byte("value2")
+
+	// Set the data
+	err = client1.Set(ctx, "key", myBytes1)
+	require.NoError(t, err)
+
+	err = client2.Set(ctx, "key", myBytes2)
+	require.NoError(t, err)
+
+	// Check it was associated accordingly
+	data, err := client1.Get(ctx, "key")
+	require.NoError(t, err)
+	require.Equal(t, myBytes1, data)
+
+	data, err = client2.Get(ctx, "key")
+	require.NoError(t, err)
+	require.Equal(t, myBytes2, data)
+}
+
 func TestGetClientErrorsOnDeletedDirectory(t *testing.T) {
 	ctx := context.Background()
 

--- a/extension/storage/storage.go
+++ b/extension/storage/storage.go
@@ -27,7 +27,7 @@ type Extension interface {
 
 	// GetClient will create a client for use by the specified component.
 	// The component can use the client to manage state
-	GetClient(context.Context, component.Kind, config.ComponentID) (Client, error)
+	GetClient(context.Context, component.Kind, config.ComponentID, string) (Client, error)
 }
 
 // Client is the interface that storage clients must implement

--- a/internal/stanza/storage.go
+++ b/internal/stanza/storage.go
@@ -40,7 +40,7 @@ func (r *receiver) setStorageClient(ctx context.Context, host component.Host) er
 		return nil
 	}
 
-	client, err := storageExtension.GetClient(ctx, component.KindReceiver, r.id)
+	client, err := storageExtension.GetClient(ctx, component.KindReceiver, r.id, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:** 

This is a proposal how to make File Extension more generic. When used e.g. for WAL purposes this will allow to have separate client for each signal type