### PR TITLE
chore: fix influxdbexporter path declaration

### DIFF
--- a/exporter/influxdbexporter/go.mod
+++ b/exporter/influxdbexporter/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxbexporter
+module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
 
 go 1.16
 


### PR DESCRIPTION
**Description:**

Module path has typo: `s/influxbexporter/influxdbexporter`