### PR TITLE
#3665 add events exporting logic for azure monitor

### DIFF
--- a/exporter/azuremonitorexporter/event_to_envelope.go
+++ b/exporter/azuremonitorexporter/event_to_envelope.go
@@ -1,0 +1,54 @@
+package azuremonitorexporter
+
+// Contains code common to both trace and metrics exporters
+import (
+	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.uber.org/zap"
+)
+
+// Wraps a telemetry item in an envelope with the information found in this  context.
+func  eventToEnvelope(span pdata.Span,item  pdata.SpanEvent, logger *zap.Logger) *contracts.Envelope {
+
+	eventData := NewEventData(item)
+	data := contracts.NewData()
+	data.BaseType = eventData.BaseType()
+	data.BaseData = eventData
+
+	envelope := contracts.NewEnvelope()
+	envelope.Name = eventData.EnvelopeName(item.Name())//context.nameIKey)
+	envelope.Data = data
+
+	timestamp := item.Timestamp()
+	
+	envelope.Time = timestamp.AsTime().UTC().Format("2006-01-02T15:04:05.999999Z")
+	envelope.Tags = make(contracts.ContextTags)
+	envelope.Tags[contracts.OperationId] = span.TraceID().HexString()
+	envelope.Tags[contracts.OperationParentId] = span.SpanID().HexString()
+
+	// copy attributes to envelope
+    attrMap := item.Attributes()
+		attrMap.Range(func(k string, v pdata.AttributeValue) bool {
+			eventData.Properties[k] =  v.StringVal()
+			return true
+		})
+
+	// Sanitize.
+	for _, warningMsg := range eventData.Sanitize() {
+		logger.Warn("Telemetry data warning: "+ warningMsg)
+	}
+	for _, warningMsg := range contracts.SanitizeTags(envelope.Tags) {
+		logger.Warn("Telemetry tag warning: "+ warningMsg)
+	}
+
+	return envelope
+}
+
+func NewEventData(event pdata.SpanEvent) *contracts.EventData {
+	data := contracts.NewEventData()
+	data.Name = event.Name() 
+	data.Properties = make(map[string]string) 
+	data.Measurements = make(map[string]float64)
+
+	return data
+}

--- a/exporter/azuremonitorexporter/traceexporter.go
+++ b/exporter/azuremonitorexporter/traceexporter.go
@@ -55,6 +55,15 @@ func (v *traceVisitor) visit(
 	v.exporter.transportChannel.Send(envelope)
 	v.processed++
 
+    // Export events
+	for i := 0; i < span.Events().Len(); i++ {
+		event := span.Events().At(i)
+		eventEnvelope :=  eventToEnvelope(span,event,v.exporter.logger)
+		eventEnvelope.IKey = v.exporter.config.InstrumentationKey
+		v.exporter.transportChannel.Send(eventEnvelope)
+		v.processed++
+	}
+
 	return true
 }
 


### PR DESCRIPTION
**Description:** 
Azure monitor exporter did not export events from spans.

It basically loops over the events in each span and  creates an envelope that contains an azure monitor event data  with EventData item attributes attached as properties to the event data.

**Link to tracking Issue:** #3665

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:**  No documena