### PR TITLE
[exporter/datadogexporter] Add note about metrics stability

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -7,7 +7,7 @@ This exporter sends metric and trace data to [Datadog](https://datadoghq.com). F
 > which contains recommendations on securing sensitive information such as the
 > API key required by this exporter.
 
-> **Note**: Metrics exporting is not considered stable yet and may suffer breaking changes.
+> **Note**: The metrics exporter is not considered stable yet and may suffer breaking changes.
 
 ## Configuration
 

--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -7,6 +7,8 @@ This exporter sends metric and trace data to [Datadog](https://datadoghq.com). F
 > which contains recommendations on securing sensitive information such as the
 > API key required by this exporter.
 
+> **Note**: Metrics exporting is not considered stable yet and may suffer breaking changes.
+
 ## Configuration
 
 The only required setting is a [Datadog API key](https://app.datadoghq.com/account/settings#api).


### PR DESCRIPTION
**Description:** 

Add note on metrics stability for Datadog exporter. We want to wait at least until all parts of the data model specification are clarified.