### PR TITLE
[extension/ecsobserver] Write discovered targets as Prometheus file sd

### DIFF
--- a/extension/observer/ecsobserver/README.md
+++ b/extension/observer/ecsobserver/README.md
@@ -419,10 +419,13 @@ otel's own /metrics.
 
 ### Error Handling
 
-- Auth error will be logged, but the extension will not fail as the IAM role can be updated and take effect without
-  restarting the ECS task.
-- If errors happen in the middle (e.g. rate limit), the discovery result will be merged with previous success runs to
-  avoid discarding active targets, though it may keep some stale targets as well.
+- Auth and cluster not found error will cause the extension to stop (calling `host.ReportFatalError`). Although IAM role
+  can be updated at runtime without restarting the collector, it's better to fail to make the problem obvious. Same
+  applies to cluster not found. In the future we can add config to downgrade those errors if user want to monitor an ECS
+  cluster with collector running outside the cluster, the collector can run anywhere as long as it can reach scrape
+  targets and AWS API.
+- If we have non-critical error, we overwrite existing file with whatever targets we have, we might not have all the
+  targets due to throttle etc.
 
 ### Unit Test
 

--- a/extension/observer/ecsobserver/config.go
+++ b/extension/observer/ecsobserver/config.go
@@ -51,6 +51,9 @@ type Config struct {
 	TaskDefinitions []TaskDefinitionConfig `mapstructure:"task_definitions" yaml:"task_definitions"`
 	// DockerLabels is a list of docker labels for filtering containers within tasks.
 	DockerLabels []DockerLabelConfig `mapstructure:"docker_labels" yaml:"docker_labels"`
+
+	// test override
+	fetcher *taskFetcher
 }
 
 // Validate overrides the embedded noop validation so that load config can trigger

--- a/extension/observer/ecsobserver/config.go
+++ b/extension/observer/ecsobserver/config.go
@@ -51,9 +51,6 @@ type Config struct {
 	TaskDefinitions []TaskDefinitionConfig `mapstructure:"task_definitions" yaml:"task_definitions"`
 	// DockerLabels is a list of docker labels for filtering containers within tasks.
 	DockerLabels []DockerLabelConfig `mapstructure:"docker_labels" yaml:"docker_labels"`
-
-	// test override
-	fetcher *taskFetcher
 }
 
 // Validate overrides the embedded noop validation so that load config can trigger

--- a/extension/observer/ecsobserver/error.go
+++ b/extension/observer/ecsobserver/error.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
@@ -39,6 +41,32 @@ type errWithAttributes interface {
 	// zapFields will be logged as json attribute and allows searching and filter backend like cloudwatch.
 	// For example { $.ErrScope == "Target" } list all the error whose scope is a (scrape) target.
 	zapFields() []zap.Field
+}
+
+// hasCriticalError returns first critical error.
+// Currently only access error and cluster not found are treated as critical.
+func hasCriticalError(logger *zap.Logger, err error) error {
+	merr := multierr.Errors(err)
+	if merr == nil {
+		merr = []error{err} // fake a multi error
+	}
+	for _, err := range merr {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
+			// NOTE: we don't use zap.Error because the stack trace is quite useless here
+			// We print the error after entire fetch and match loop is done, and source
+			// of these error are from user config, wrong IAM, typo in cluster name etc.
+			switch awsErr.Code() {
+			case ecs.ErrCodeAccessDeniedException:
+				logger.Error("AccessDenied", zap.String("ErrMessage", awsErr.Message()))
+				return awsErr
+			case ecs.ErrCodeClusterNotFoundException:
+				logger.Error("Cluster NotFound", zap.String("ErrMessage", awsErr.Message()))
+				return awsErr
+			}
+		}
+	}
+	return nil
 }
 
 func printErrors(logger *zap.Logger, err error) {
@@ -82,9 +110,7 @@ func extractErrorFields(err error) ([]zap.Field, string) {
 	v, ok = errctx.ValueFrom(err, errKeyTarget)
 	if ok {
 		if target, ok := v.(MatchedTarget); ok {
-			// TODO: change to string once another PR for matcher got merged
-			// https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3386 defines Stringer
-			fields = append(fields, zap.Int("MatcherType", int(target.MatcherType)))
+			fields = append(fields, zap.String("MatcherType", target.MatcherType.String()))
 			scope = "Target"
 		}
 	}

--- a/extension/observer/ecsobserver/extension.go
+++ b/extension/observer/ecsobserver/extension.go
@@ -26,7 +26,7 @@ var _ component.Extension = (*ecsObserver)(nil)
 // ecsObserver implements component.ServiceExtension interface.
 type ecsObserver struct {
 	logger *zap.Logger
-	sd     *ServiceDiscovery
+	sd     *serviceDiscovery
 
 	// for Shutdown
 	cancel func()
@@ -39,7 +39,7 @@ func (e *ecsObserver) Start(_ context.Context, host component.Host) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	e.cancel = cancel
 	go func() {
-		if err := e.sd.RunAndWriteFile(ctx); err != nil {
+		if err := e.sd.runAndWriteFile(ctx); err != nil {
 			e.logger.Error("ECSDiscovery stopped by error", zap.Error(err))
 		}
 	}()

--- a/extension/observer/ecsobserver/extension.go
+++ b/extension/observer/ecsobserver/extension.go
@@ -32,7 +32,7 @@ type ecsObserver struct {
 	cancel func()
 }
 
-// Start runs the service discovery in backeground
+// Start runs the service discovery in background
 func (e *ecsObserver) Start(_ context.Context, host component.Host) error {
 	e.logger.Info("Starting ECSDiscovery")
 	// Ignore the ctx parameter as it is not for long running operation
@@ -41,6 +41,8 @@ func (e *ecsObserver) Start(_ context.Context, host component.Host) error {
 	go func() {
 		if err := e.sd.runAndWriteFile(ctx); err != nil {
 			e.logger.Error("ECSDiscovery stopped by error", zap.Error(err))
+			// Stop the collector
+			host.ReportFatalError(err)
 		}
 	}()
 	return nil

--- a/extension/observer/ecsobserver/extension_test.go
+++ b/extension/observer/ecsobserver/extension_test.go
@@ -74,7 +74,6 @@ func (h *inspectErrorHost) getError() error {
 // Simply start and stop, the actual test logic is in sd_test.go until we implement the ListWatcher interface.
 // In that case sd itself does not use timer and relies on caller to trigger List.
 func TestExtensionStartStop(t *testing.T) {
-	ctx := context.TODO()
 	settings := component.ExtensionCreateSettings{Logger: zap.NewExample()}
 	refreshInterval := time.Millisecond
 	waitDuration := 2 * refreshInterval
@@ -83,10 +82,9 @@ func TestExtensionStartStop(t *testing.T) {
 		f := newTestTaskFetcher(t, c)
 		cfg := createDefaultConfig()
 		sdCfg := cfg.(*Config)
-		sdCfg.fetcher = f
 		sdCfg.RefreshInterval = refreshInterval
 		sdCfg.ResultFile = output
-		ext, err := createExtension(ctx, settings, cfg)
+		ext, err := createExtensionWithFetcher(settings, sdCfg, f)
 		require.NoError(t, err)
 		return ext
 	}

--- a/extension/observer/ecsobserver/extension_test.go
+++ b/extension/observer/ecsobserver/extension_test.go
@@ -30,13 +30,7 @@ import (
 // In that case sd itself does not use timer and relies on caller to trigger List.
 func TestExtensionStartStop(t *testing.T) {
 	c := ecsmock.NewCluster()
-	f, err := newTaskFetcher(taskFetcherOptions{
-		Logger:      zap.NewExample(),
-		Cluster:     "not used",
-		Region:      "not used",
-		ecsOverride: c,
-	})
-	require.NoError(t, err)
+	f := newTestTaskFetcher(t, c)
 	ctx := context.WithValue(context.TODO(), ctxFetcherOverrideKey, f)
 	ext, err := createExtension(ctx, component.ExtensionCreateSettings{Logger: zap.NewExample()}, createDefaultConfig())
 	require.NoError(t, err)

--- a/extension/observer/ecsobserver/extension_test.go
+++ b/extension/observer/ecsobserver/extension_test.go
@@ -31,8 +31,11 @@ import (
 func TestExtensionStartStop(t *testing.T) {
 	c := ecsmock.NewCluster()
 	f := newTestTaskFetcher(t, c)
-	ctx := context.WithValue(context.TODO(), ctxFetcherOverrideKey, f)
-	ext, err := createExtension(ctx, component.ExtensionCreateSettings{Logger: zap.NewExample()}, createDefaultConfig())
+
+	ctx := context.TODO()
+	cfg := createDefaultConfig()
+	cfg.(*Config).fetcher = f
+	ext, err := createExtension(ctx, component.ExtensionCreateSettings{Logger: zap.NewExample()}, cfg)
 	require.NoError(t, err)
 	require.IsType(t, &ecsObserver{}, ext)
 	require.NoError(t, ext.Start(context.TODO(), componenttest.NewNopHost()))

--- a/extension/observer/ecsobserver/extension_test.go
+++ b/extension/observer/ecsobserver/extension_test.go
@@ -16,7 +16,9 @@ package ecsobserver
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -26,18 +28,88 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver/internal/ecsmock"
 )
 
+// inspectErrorHost implements component.Host.
+// btw: I only find assertNoErrorHost in other components, seems there is no exported util struct.
+type inspectErrorHost struct {
+	component.Host
+
+	// Why we need a mutex here? Our extension only has one go routine so it seems
+	// we don't need to protect the error as our extension is the only component for this 'host'.
+	// But without the lock the test actually fails on race detector.
+	// There is no actual concurrency in our test, when we read the error in test assertion,
+	// we know the extension has already stopped because we provided invalided config and waited long enough.
+	// However, (I assume) from race detector's perspective, race between a stopped goroutine and a running one
+	// is same as two running goroutines. A goroutine's stop condition is uncertain at runtime, and the data
+	// access order may varies, goroutine A can stop before B in first run and reverse in next run.
+	// As long as there is some read/write of one memory area without protection from multiple go routines,
+	// it means the code can have data race, but it does not mean this race always happen.
+	// In our case, the race never happens because we hard coded the sleep time of two go routines.
+	//
+	// btw: assertNoErrorHost does not have mutex because it never saves the error. Its ReportFatalError
+	// just call assertion and forget about nil error. For unexpected error it call helpers to fail the test
+	// and those helper func all have mutex. https://golang.org/src/testing/testing.go
+	mu  sync.Mutex
+	err error
+}
+
+func newInspectErrorHost() component.Host {
+	return &inspectErrorHost{
+		Host: componenttest.NewNopHost(),
+	}
+}
+
+func (h *inspectErrorHost) ReportFatalError(err error) {
+	h.mu.Lock()
+	h.err = err
+	h.mu.Unlock()
+}
+
+func (h *inspectErrorHost) getError() error {
+	h.mu.Lock()
+	cp := h.err
+	h.mu.Unlock()
+	return cp
+}
+
 // Simply start and stop, the actual test logic is in sd_test.go until we implement the ListWatcher interface.
 // In that case sd itself does not use timer and relies on caller to trigger List.
 func TestExtensionStartStop(t *testing.T) {
-	c := ecsmock.NewCluster()
-	f := newTestTaskFetcher(t, c)
-
 	ctx := context.TODO()
-	cfg := createDefaultConfig()
-	cfg.(*Config).fetcher = f
-	ext, err := createExtension(ctx, component.ExtensionCreateSettings{Logger: zap.NewExample()}, cfg)
-	require.NoError(t, err)
-	require.IsType(t, &ecsObserver{}, ext)
-	require.NoError(t, ext.Start(context.TODO(), componenttest.NewNopHost()))
-	require.NoError(t, ext.Shutdown(context.TODO()))
+	settings := component.ExtensionCreateSettings{Logger: zap.NewExample()}
+	refreshInterval := time.Millisecond
+	waitDuration := 2 * refreshInterval
+
+	createTestExt := func(c *ecsmock.Cluster, output string) component.Extension {
+		f := newTestTaskFetcher(t, c)
+		cfg := createDefaultConfig()
+		sdCfg := cfg.(*Config)
+		sdCfg.fetcher = f
+		sdCfg.RefreshInterval = refreshInterval
+		sdCfg.ResultFile = output
+		ext, err := createExtension(ctx, settings, cfg)
+		require.NoError(t, err)
+		return ext
+	}
+
+	t.Run("noop", func(t *testing.T) {
+		c := ecsmock.NewCluster()
+		ext := createTestExt(c, "testdata/ut_ext_noop.actual.yaml")
+		require.IsType(t, &ecsObserver{}, ext)
+		host := newInspectErrorHost()
+		require.NoError(t, ext.Start(context.TODO(), host))
+		time.Sleep(waitDuration)
+		require.NoError(t, host.(*inspectErrorHost).getError())
+		require.NoError(t, ext.Shutdown(context.TODO()))
+	})
+
+	t.Run("critical error", func(t *testing.T) {
+		c := ecsmock.NewClusterWithName("different than default config")
+		ext := createTestExt(c, "testdata/ut_ext_critical_error.actual.yaml")
+		host := newInspectErrorHost()
+		require.NoError(t, ext.Start(context.TODO(), host))
+		time.Sleep(waitDuration)
+		err := host.(*inspectErrorHost).getError()
+		require.Error(t, err)
+		require.Error(t, hasCriticalError(zap.NewExample(), err))
+	})
 }

--- a/extension/observer/ecsobserver/factory.go
+++ b/extension/observer/ecsobserver/factory.go
@@ -43,18 +43,16 @@ func createDefaultConfig() config.Extension {
 
 func createExtension(ctx context.Context, params component.ExtensionCreateSettings, cfg config.Extension) (component.Extension, error) {
 	sdCfg := cfg.(*Config)
-	opt := serviceDiscoveryOptions{Logger: params.Logger}
-	// Create actual AWS client or use overridden config in unit test,
-	if sdCfg.fetcher == nil {
-		fetcher, err := newTaskFetcherFromConfig(*sdCfg, params.Logger)
-		if err != nil {
-			return nil, fmt.Errorf("init fetcher failed: %w", err)
-		}
-		opt.Fetcher = fetcher
-	} else {
-		opt.Fetcher = sdCfg.fetcher
+	fetcher, err := newTaskFetcherFromConfig(*sdCfg, params.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("init fetcher failed: %w", err)
 	}
-	sd, err := newDiscovery(*sdCfg, opt)
+	return createExtensionWithFetcher(params, sdCfg, fetcher)
+}
+
+// fetcher is mock in unit test or AWS API client
+func createExtensionWithFetcher(params component.ExtensionCreateSettings, sdCfg *Config, fetcher *taskFetcher) (component.Extension, error) {
+	sd, err := newDiscovery(*sdCfg, serviceDiscoveryOptions{Logger: params.Logger, Fetcher: fetcher})
 	if err != nil {
 		return nil, err
 	}

--- a/extension/observer/ecsobserver/factory.go
+++ b/extension/observer/ecsobserver/factory.go
@@ -45,13 +45,13 @@ func createDefaultConfig() config.Extension {
 
 func createExtension(ctx context.Context, params component.ExtensionCreateSettings, cfg config.Extension) (component.Extension, error) {
 	sdCfg := cfg.(*Config)
-	opt := ServiceDiscoveryOptions{Logger: params.Logger}
+	opt := serviceDiscoveryOptions{Logger: params.Logger}
 	// Only for test
 	fetcher := ctx.Value(ctxFetcherOverrideKey)
 	if fetcher != nil {
 		opt.FetcherOverride = fetcher.(*taskFetcher)
 	}
-	sd, err := NewDiscovery(*sdCfg, opt)
+	sd, err := newDiscovery(*sdCfg, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/extension/observer/ecsobserver/fetcher.go
+++ b/extension/observer/ecsobserver/fetcher.go
@@ -109,6 +109,9 @@ func newTaskFetcher(opts taskFetcherOptions) (*taskFetcher, error) {
 	if fetcher.ecs != nil || fetcher.ec2 != nil {
 		return &fetcher, nil
 	}
+	if opts.Cluster == "" {
+		return nil, fmt.Errorf("missing ECS cluster for task fetcher")
+	}
 	if opts.Region == "" {
 		return nil, fmt.Errorf("missing aws region for task fetcher")
 	}

--- a/extension/observer/ecsobserver/fetcher.go
+++ b/extension/observer/ecsobserver/fetcher.go
@@ -77,6 +77,19 @@ type taskFetcherOptions struct {
 	ec2Override ec2Client
 }
 
+func newTaskFetcherFromConfig(cfg Config, logger *zap.Logger) (*taskFetcher, error) {
+	svcNameFilter, err := serviceConfigsToFilter(cfg.Services)
+	if err != nil {
+		return nil, fmt.Errorf("init serivce name filter failed: %w", err)
+	}
+	return newTaskFetcher(taskFetcherOptions{
+		Logger:            logger,
+		Region:            cfg.ClusterRegion,
+		Cluster:           cfg.ClusterName,
+		serviceNameFilter: svcNameFilter,
+	})
+}
+
 func newTaskFetcher(opts taskFetcherOptions) (*taskFetcher, error) {
 	// Init cache
 	taskDefCache, err := simplelru.NewLRU(taskDefCacheSize, nil)

--- a/extension/observer/ecsobserver/fetcher.go
+++ b/extension/observer/ecsobserver/fetcher.go
@@ -98,12 +98,10 @@ func newTaskFetcher(opts taskFetcherOptions) (*taskFetcher, error) {
 		ec2Cache:          ec2Cache,
 		serviceNameFilter: opts.serviceNameFilter,
 	}
-	// Match all the services for test. For production if there is no service related config,
-	// we don't describe any service, see serviceConfigsToFilter for detail.
+	// Even if user didn't specify any service related config, we still generates a valid filter
+	// that matches nothing. See service.go serviceConfigsToFilter.
 	if fetcher.serviceNameFilter == nil {
-		fetcher.serviceNameFilter = func(name string) bool {
-			return true
-		}
+		return nil, fmt.Errorf("serviceNameFilter can't be nil")
 	}
 	// Return early if any clients are mocked, caller should overrides all the clients when mocking.
 	if fetcher.ecs != nil || fetcher.ec2 != nil {

--- a/extension/observer/ecsobserver/fetcher_test.go
+++ b/extension/observer/ecsobserver/fetcher_test.go
@@ -23,21 +23,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver/internal/ecsmock"
 )
 
 func TestFetcher_FetchAndDecorate(t *testing.T) {
 	c := ecsmock.NewCluster()
-	f, err := newTaskFetcher(taskFetcherOptions{
-		Logger:      zap.NewExample(),
-		Cluster:     "not used",
-		Region:      "not used",
-		ecsOverride: c,
-		ec2Override: c,
-	})
-	require.NoError(t, err)
+	f := newTestTaskFetcher(t, c)
 	// Create 1 task def, 2 services and 10 tasks, 8 running on ec2, first 3 runs on fargate
 	nTasks := 11
 	nInstances := 2
@@ -90,13 +82,7 @@ func TestFetcher_FetchAndDecorate(t *testing.T) {
 
 func TestFetcher_GetAllTasks(t *testing.T) {
 	c := ecsmock.NewCluster()
-	f, err := newTaskFetcher(taskFetcherOptions{
-		Logger:      zap.NewExample(),
-		Cluster:     "not used",
-		Region:      "not used",
-		ecsOverride: c,
-	})
-	require.NoError(t, err)
+	f := newTestTaskFetcher(t, c)
 	const nTasks = 203
 	c.SetTasks(ecsmock.GenTasks("p", nTasks, nil))
 	ctx := context.Background()
@@ -107,13 +93,7 @@ func TestFetcher_GetAllTasks(t *testing.T) {
 
 func TestFetcher_AttachTaskDefinitions(t *testing.T) {
 	c := ecsmock.NewCluster()
-	f, err := newTaskFetcher(taskFetcherOptions{
-		Logger:      zap.NewExample(),
-		Cluster:     "not used",
-		Region:      "not used",
-		ecsOverride: c,
-	})
-	require.NoError(t, err)
+	f := newTestTaskFetcher(t, c)
 
 	const nTasks = 5
 	ctx := context.Background()
@@ -158,14 +138,7 @@ func TestFetcher_AttachTaskDefinitions(t *testing.T) {
 func TestFetcher_AttachContainerInstance(t *testing.T) {
 	t.Run("ec2 only", func(t *testing.T) {
 		c := ecsmock.NewCluster()
-		f, err := newTaskFetcher(taskFetcherOptions{
-			Logger:      zap.NewExample(),
-			Cluster:     "not used",
-			Region:      "not used",
-			ecsOverride: c,
-			ec2Override: c,
-		})
-		require.NoError(t, err)
+		f := newTestTaskFetcher(t, c)
 		// Create 1 task def and 11 tasks running on 2 ec2 instances
 		nTasks := 11
 		nInstances := 2
@@ -197,14 +170,7 @@ func TestFetcher_AttachContainerInstance(t *testing.T) {
 
 	t.Run("mixed cluster", func(t *testing.T) {
 		c := ecsmock.NewCluster()
-		f, err := newTaskFetcher(taskFetcherOptions{
-			Logger:      zap.NewExample(),
-			Cluster:     "not used",
-			Region:      "not used",
-			ecsOverride: c,
-			ec2Override: c,
-		})
-		require.NoError(t, err)
+		f := newTestTaskFetcher(t, c)
 		// Create 1 task def and 10 tasks, 8 running on ec2, first 3 runs on fargate
 		nTasks := 11
 		nInstances := 2
@@ -245,13 +211,7 @@ func TestFetcher_AttachContainerInstance(t *testing.T) {
 
 func TestFetcher_GetAllServices(t *testing.T) {
 	c := ecsmock.NewCluster()
-	f, err := newTaskFetcher(taskFetcherOptions{
-		Logger:      zap.NewExample(),
-		Cluster:     "not used",
-		Region:      "not used",
-		ecsOverride: c,
-	})
-	require.NoError(t, err)
+	f := newTestTaskFetcher(t, c)
 	const nServices = 101
 	c.SetServices(ecsmock.GenServices("s", nServices, nil))
 	ctx := context.Background()
@@ -262,13 +222,7 @@ func TestFetcher_GetAllServices(t *testing.T) {
 
 func TestFetcher_AttachService(t *testing.T) {
 	c := ecsmock.NewCluster()
-	f, err := newTaskFetcher(taskFetcherOptions{
-		Logger:      zap.NewExample(),
-		Cluster:     "not used",
-		Region:      "not used",
-		ecsOverride: c,
-	})
-	require.NoError(t, err)
+	f := newTestTaskFetcher(t, c)
 	const nServices = 10
 	c.SetServices(ecsmock.GenServices("s", nServices, func(i int, s *ecs.Service) {
 		s.Deployments = []*ecs.Deployment{

--- a/extension/observer/ecsobserver/filter.go
+++ b/extension/observer/ecsobserver/filter.go
@@ -1,0 +1,74 @@
+package ecsobserver
+
+import (
+	"sort"
+
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+type taskFilter struct {
+	logger   *zap.Logger
+	matchers map[MatcherType][]Matcher
+}
+
+func newTaskFilter(logger *zap.Logger, matchers map[MatcherType][]Matcher) *taskFilter {
+	return &taskFilter{
+		logger:   logger,
+		matchers: matchers,
+	}
+}
+
+// Filter run all the matchers and return all the tasks that including at least one matched container.
+func (f *taskFilter) filter(tasks []*Task) ([]*Task, error) {
+	// Group result by matcher type, each type can have multiple configs.
+	matched := make(map[MatcherType][]*MatchResult)
+	var merr error
+	for tpe, matchers := range f.matchers { // for each type of matchers
+		for index, matcher := range matchers { // for individual matchers of same type
+			res, err := matchContainers(tasks, matcher, index)
+			// NOTE: we continue the loop even if there is error because some tasks can has invalid labels.
+			// matchContainers always return non nil result even if there are errors during matching.
+			if err != nil {
+				multierr.AppendInto(&merr, err)
+			}
+
+			// TODO: print out the pattern to include both pattern and port
+			f.logger.Debug("matched",
+				zap.String("MatcherType", tpe.String()), zap.Int("MatcherIndex", index),
+				zap.Int("Tasks", len(tasks)), zap.Int("MatchedTasks", len(res.Tasks)),
+				zap.Int("MatchedContainers", len(res.Containers)))
+			matched[tpe] = append(matched[tpe], res)
+		}
+	}
+
+	// Attach match result to tasks, do it in matcherOrders.
+	// AddMatchedContainer will merge in new targets if it is not already matched by other matchers.
+	matchedTasks := make(map[int]struct{})
+	for _, tpe := range matcherOrders() {
+		for _, res := range matched[tpe] {
+			for _, container := range res.Containers {
+				matchedTasks[container.TaskIndex] = struct{}{}
+				task := tasks[container.TaskIndex]
+				task.AddMatchedContainer(container)
+			}
+		}
+	}
+
+	// Sort by task index so the output is consistent.
+	var taskIndexes []int
+	for k := range matchedTasks {
+		taskIndexes = append(taskIndexes, k)
+	}
+	sort.Ints(taskIndexes)
+	var sortedTasks []*Task
+	for _, i := range taskIndexes {
+		task := tasks[i]
+		// Sort containers within a task
+		sort.Slice(task.Matched, func(i, j int) bool {
+			return task.Matched[i].ContainerIndex < task.Matched[j].ContainerIndex
+		})
+		sortedTasks = append(sortedTasks, task)
+	}
+	return sortedTasks, merr
+}

--- a/extension/observer/ecsobserver/filter.go
+++ b/extension/observer/ecsobserver/filter.go
@@ -1,3 +1,17 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ecsobserver
 
 import (

--- a/extension/observer/ecsobserver/filter_test.go
+++ b/extension/observer/ecsobserver/filter_test.go
@@ -1,3 +1,17 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ecsobserver
 
 import (

--- a/extension/observer/ecsobserver/filter_test.go
+++ b/extension/observer/ecsobserver/filter_test.go
@@ -1,0 +1,190 @@
+package ecsobserver
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
+)
+
+func TestFilter(t *testing.T) {
+	cfgTaskDefOnly := Config{
+		TaskDefinitions: []TaskDefinitionConfig{
+			{
+				ArnPattern: "arn:alike:nginx-.*",
+				CommonExporterConfig: CommonExporterConfig{
+					JobName:      "CONFIG_PROM_JOB",
+					MetricsPorts: []int{2112},
+				},
+			},
+		},
+	}
+	t.Run("nil", func(t *testing.T) {
+		f := newTestFilter(t, cfgTaskDefOnly)
+		res, err := f.filter(nil)
+		require.NoError(t, err)
+		assert.Nil(t, res)
+	})
+
+	emptyTask := &Task{
+		Task: &ecs.Task{TaskDefinitionArn: aws.String("arn:that:never:matches")},
+		Definition: &ecs.TaskDefinition{
+			TaskDefinitionArn: aws.String("arn:that:never:matches"),
+			ContainerDefinitions: []*ecs.ContainerDefinition{
+				{
+					Name: aws.String("I got nothing, just to trigger the for loop ~~for coverage~~"),
+				},
+			},
+		},
+	}
+	portLabelWithInvalidValue := "MY_PROMETHEUS_PORT_IS_INVALID"
+	genTasks := func() []*Task {
+		return []*Task{
+			{
+				Task: &ecs.Task{
+					TaskDefinitionArn: aws.String("arn:alike:nginx-latest"),
+				},
+				Service: &ecs.Service{ServiceName: aws.String("nginx-service")},
+				Definition: &ecs.TaskDefinition{
+					TaskDefinitionArn: aws.String("arn:alike:nginx-latest"),
+					ContainerDefinitions: []*ecs.ContainerDefinition{
+						{
+							Name: aws.String("port-2112"),
+							PortMappings: []*ecs.PortMapping{
+								{
+									ContainerPort: aws.Int64(2112),
+									HostPort:      aws.Int64(2113), // doesn't matter for matcher test
+								},
+							},
+						},
+						{
+							Name: aws.String("port-2114"),
+							PortMappings: []*ecs.PortMapping{
+								{
+									ContainerPort: aws.Int64(2113 + 1), // a different port
+									HostPort:      aws.Int64(2113),     // doesn't matter for matcher test
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Task: &ecs.Task{
+					TaskDefinitionArn: aws.String("not used"),
+				},
+				Definition: &ecs.TaskDefinition{
+					ContainerDefinitions: []*ecs.ContainerDefinition{
+						{
+							Name: aws.String("port-label"),
+							DockerLabels: map[string]*string{
+								portLabelWithInvalidValue: aws.String("not a numeric string"),
+							},
+						},
+					},
+				},
+			},
+			emptyTask,
+		}
+	}
+
+	t.Run("task definition", func(t *testing.T) {
+		f := newTestFilter(t, cfgTaskDefOnly)
+		res, err := f.filter(genTasks())
+		require.NoError(t, err)
+		assert.Len(t, res, 1)
+		assert.Equal(t, []MatchedContainer{
+			{
+				TaskIndex:      0,
+				ContainerIndex: 0,
+				Targets: []MatchedTarget{
+					{
+						MatcherType: MatcherTypeTaskDefinition,
+						Port:        2112,
+						Job:         "CONFIG_PROM_JOB",
+					},
+				},
+			},
+			{
+				TaskIndex:      0,
+				ContainerIndex: 1,
+				Targets:        nil, // the container itself is matched, but it has no matching port
+			},
+		}, res[0].Matched)
+	})
+
+	cfgServiceTaskDef := Config{
+		Services: []ServiceConfig{
+			{
+				NamePattern: "^nginx-.*$",
+				CommonExporterConfig: CommonExporterConfig{
+					JobName:      "CONFIG_PROM_JOB_BY_SERVICE",
+					MetricsPorts: []int{2112},
+				},
+			},
+		},
+		TaskDefinitions: []TaskDefinitionConfig{
+			{
+				ArnPattern: "arn:alike:nginx-.*",
+				CommonExporterConfig: CommonExporterConfig{
+					JobName:      "CONFIG_PROM_JOB",
+					MetricsPorts: []int{2112},
+				},
+			},
+		},
+	}
+
+	t.Run("match order", func(t *testing.T) {
+		f := newTestFilter(t, cfgServiceTaskDef)
+		res, err := f.filter(genTasks())
+		require.NoError(t, err)
+		assert.Len(t, res, 1)
+		assert.Equal(t, []MatchedContainer{
+			{
+				TaskIndex:      0,
+				ContainerIndex: 0,
+				Targets: []MatchedTarget{
+					{
+						MatcherType: MatcherTypeService,
+						Port:        2112,
+						Job:         "CONFIG_PROM_JOB_BY_SERVICE",
+					},
+				},
+			},
+			{
+				TaskIndex:      0,
+				ContainerIndex: 1,
+				Targets:        nil, // the container itself is matched, but it has no matching port
+			},
+		}, res[0].Matched)
+	})
+
+	cfgServiceDockerLabel := Config{
+		Services: []ServiceConfig{
+			{
+				NamePattern: "^nginx-.*$",
+				CommonExporterConfig: CommonExporterConfig{
+					JobName:      "CONFIG_PROM_JOB_BY_SERVICE",
+					MetricsPorts: []int{2112},
+				},
+			},
+		},
+		DockerLabels: []DockerLabelConfig{
+			{
+				PortLabel: portLabelWithInvalidValue,
+			},
+		},
+	}
+
+	t.Run("invalid docker label", func(t *testing.T) {
+		f := newTestFilter(t, cfgServiceDockerLabel)
+		res, err := f.filter(genTasks())
+		require.Error(t, err)
+		merr := multierr.Errors(err)
+		require.Len(t, merr, 1)
+		assert.Len(t, res, 1)
+	})
+}

--- a/extension/observer/ecsobserver/filter_test.go
+++ b/extension/observer/ecsobserver/filter_test.go
@@ -37,7 +37,7 @@ func TestFilter(t *testing.T) {
 		},
 	}
 	t.Run("nil", func(t *testing.T) {
-		f := newTestFilter(t, cfgTaskDefOnly)
+		f := newTestTaskFilter(t, cfgTaskDefOnly)
 		res, err := f.filter(nil)
 		require.NoError(t, err)
 		assert.Nil(t, res)
@@ -106,7 +106,7 @@ func TestFilter(t *testing.T) {
 	}
 
 	t.Run("task definition", func(t *testing.T) {
-		f := newTestFilter(t, cfgTaskDefOnly)
+		f := newTestTaskFilter(t, cfgTaskDefOnly)
 		res, err := f.filter(genTasks())
 		require.NoError(t, err)
 		assert.Len(t, res, 1)
@@ -152,7 +152,7 @@ func TestFilter(t *testing.T) {
 	}
 
 	t.Run("match order", func(t *testing.T) {
-		f := newTestFilter(t, cfgServiceTaskDef)
+		f := newTestTaskFilter(t, cfgServiceTaskDef)
 		res, err := f.filter(genTasks())
 		require.NoError(t, err)
 		assert.Len(t, res, 1)
@@ -194,7 +194,7 @@ func TestFilter(t *testing.T) {
 	}
 
 	t.Run("invalid docker label", func(t *testing.T) {
-		f := newTestFilter(t, cfgServiceDockerLabel)
+		f := newTestTaskFilter(t, cfgServiceDockerLabel)
 		res, err := f.filter(genTasks())
 		require.Error(t, err)
 		merr := multierr.Errors(err)

--- a/extension/observer/ecsobserver/go.mod
+++ b/extension/observer/ecsobserver/go.mod
@@ -9,4 +9,5 @@ require (
 	go.opentelemetry.io/collector v0.29.1-0.20210628130708-ec64689277a6
 	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.18.1
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/extension/observer/ecsobserver/matcher.go
+++ b/extension/observer/ecsobserver/matcher.go
@@ -77,7 +77,7 @@ type MatchResult struct {
 }
 
 type MatchedContainer struct {
-	TaskIndex      int // Index in task list
+	TaskIndex      int // Index in task list before filter, i.e. after fetch and decorate
 	ContainerIndex int // Index within a tasks definition's container list
 	Targets        []MatchedTarget
 }
@@ -108,6 +108,14 @@ type MatchedTarget struct {
 	Port         int
 	MetricsPath  string
 	Job          string
+}
+
+func matcherOrders() []MatcherType {
+	return []MatcherType{
+		MatcherTypeService,
+		MatcherTypeTaskDefinition,
+		MatcherTypeDockerLabel,
+	}
 }
 
 func newMatchers(c Config, mOpt MatcherOptions) (map[MatcherType][]Matcher, error) {
@@ -144,7 +152,7 @@ var errNotMatched = fmt.Errorf("container not matched")
 
 // matchContainers apply one matcher to a list of tasks and returns MatchResult.
 // It does not modify the task in place, the attaching match result logic is
-// performed by TaskFilter at later stage.
+// performed by taskFilter at later stage.
 func matchContainers(tasks []*Task, matcher Matcher, matcherIndex int) (*MatchResult, error) {
 	var (
 		matchedTasks      []int

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -70,7 +70,7 @@ func TestNewDiscovery(t *testing.T) {
 		ec2Override:       c,
 	})
 	require.NoError(t, err)
-	opts := ServiceDiscoveryOptions{Logger: logger, FetcherOverride: fetcher}
+	opts := serviceDiscoveryOptions{Logger: logger, FetcherOverride: fetcher}
 
 	// Create 1 task def, 2 services and 11 tasks, 8 running on ec2, first 3 runs on fargate
 	nTasks := 11
@@ -173,12 +173,12 @@ func TestNewDiscovery(t *testing.T) {
 	}))
 
 	t.Run("success", func(t *testing.T) {
-		sd, err := NewDiscovery(cfg, opts)
+		sd, err := newDiscovery(cfg, opts)
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithTimeout(context.Background(), cfg.RefreshInterval*2)
 		defer cancel()
-		err = sd.RunAndWriteFile(ctx)
+		err = sd.runAndWriteFile(ctx)
 		require.NoError(t, err)
 
 		assert.FileExists(t, outputFile)
@@ -192,9 +192,9 @@ func TestNewDiscovery(t *testing.T) {
 	t.Run("fail to write file", func(t *testing.T) {
 		cfg2 := cfg
 		cfg2.ResultFile = "testdata/folder/does/not/exists/ut_targets.yaml"
-		sd, err := NewDiscovery(cfg2, opts)
+		sd, err := newDiscovery(cfg2, opts)
 		require.NoError(t, err)
-		require.Error(t, sd.RunAndWriteFile(context.TODO()))
+		require.Error(t, sd.runAndWriteFile(context.TODO()))
 	})
 
 	t.Run("critical error in discovery", func(t *testing.T) {
@@ -209,24 +209,24 @@ func TestNewDiscovery(t *testing.T) {
 			ec2Override:       c,
 		})
 		require.NoError(t, err)
-		opts2 := ServiceDiscoveryOptions{Logger: logger, FetcherOverride: fetcher2}
-		sd, err := NewDiscovery(cfg2, opts2)
+		opts2 := serviceDiscoveryOptions{Logger: logger, FetcherOverride: fetcher2}
+		sd, err := newDiscovery(cfg2, opts2)
 		require.NoError(t, err)
-		require.Error(t, sd.RunAndWriteFile(context.TODO()))
+		require.Error(t, sd.runAndWriteFile(context.TODO()))
 	})
 
 	t.Run("invalid fetcher config", func(t *testing.T) {
 		cfg2 := cfg
 		cfg2.ClusterName = ""
-		opts2 := ServiceDiscoveryOptions{Logger: logger}
-		_, err := NewDiscovery(cfg2, opts2)
+		opts2 := serviceDiscoveryOptions{Logger: logger}
+		_, err := newDiscovery(cfg2, opts2)
 		require.Error(t, err)
 	})
 }
 
 // Util Start
 
-func newTestFilter(t *testing.T, cfg Config) *taskFilter {
+func newTestTaskFilter(t *testing.T, cfg Config) *taskFilter {
 	logger := zap.NewExample()
 	m, err := newMatchers(cfg, MatcherOptions{Logger: logger})
 	require.NoError(t, err)

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -65,7 +65,7 @@ func TestNewDiscovery(t *testing.T) {
 		options.Cluster = cfg.ClusterName
 		options.serviceNameFilter = svcNameFilter
 	})
-	opts := serviceDiscoveryOptions{Logger: logger, FetcherOverride: fetcher}
+	opts := serviceDiscoveryOptions{Logger: logger, Fetcher: fetcher}
 
 	// Create 1 task def, 2 services and 11 tasks, 8 running on ec2, first 3 runs on fargate
 	nTasks := 11
@@ -199,7 +199,7 @@ func TestNewDiscovery(t *testing.T) {
 			options.Cluster = cfg2.ClusterName
 			options.serviceNameFilter = svcNameFilter
 		})
-		opts2 := serviceDiscoveryOptions{Logger: logger, FetcherOverride: fetcher2}
+		opts2 := serviceDiscoveryOptions{Logger: logger, Fetcher: fetcher2}
 		sd, err := newDiscovery(cfg2, opts2)
 		require.NoError(t, err)
 		require.Error(t, sd.runAndWriteFile(context.TODO()))

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -15,7 +15,6 @@
 package ecsobserver
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,18 +22,18 @@ import (
 )
 
 func TestNewDiscovery(t *testing.T) {
-	t.Run("empty impl", func(t *testing.T) {
-		_, err := NewDiscovery(ExampleConfig(), ServiceDiscoveryOptions{})
-		require.NoError(t, err)
-	})
-	t.Run("for the coverage", func(t *testing.T) {
-		d := ServiceDiscovery{}
-		_, err := d.Discover(context.TODO())
-		require.Error(t, err)
-	})
+
 }
 
 // Util Start
+
+func newTestFilter(t *testing.T, cfg Config) *taskFilter {
+	logger := zap.NewExample()
+	m, err := newMatchers(cfg, MatcherOptions{Logger: logger})
+	require.NoError(t, err)
+	f := newTaskFilter(logger, m)
+	return f
+}
 
 func newMatcher(t *testing.T, cfg matcherConfig) Matcher {
 	m, err := cfg.newMatcher(testMatcherOptions())

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -15,14 +15,213 @@
 package ecsobserver
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver/internal/ecsmock"
 )
 
 func TestNewDiscovery(t *testing.T) {
+	logger := zap.NewExample()
+	outputFile := "testdata/ut_targets.actual.yaml"
+	cfg := Config{
+		ClusterName:     "ut-cluster-1",
+		ClusterRegion:   "us-test-2",
+		RefreshInterval: 10 * time.Millisecond,
+		ResultFile:      outputFile,
+		JobLabelName:    defaultJobLabelName,
+		DockerLabels: []DockerLabelConfig{
+			{
+				PortLabel:        "PROMETHEUS_PORT",
+				JobNameLabel:     "MY_JOB_NAME",
+				MetricsPathLabel: "MY_METRICS_PATH",
+			},
+		},
+		Services: []ServiceConfig{
+			{
+				NamePattern: "s1",
+				CommonExporterConfig: CommonExporterConfig{
+					MetricsPorts: []int{2112},
+				},
+			},
+		},
+	}
+	svcNameFilter, err := serviceConfigsToFilter(cfg.Services)
+	assert.True(t, svcNameFilter("s1"))
+	require.NoError(t, err)
+	c := ecsmock.NewClusterWithName(cfg.ClusterName)
+	fetcher, err := newTaskFetcher(taskFetcherOptions{
+		Logger:            logger,
+		Cluster:           cfg.ClusterName,
+		Region:            cfg.ClusterRegion,
+		serviceNameFilter: svcNameFilter,
+		ecsOverride:       c,
+		ec2Override:       c,
+	})
+	require.NoError(t, err)
+	opts := ServiceDiscoveryOptions{Logger: logger, FetcherOverride: fetcher}
 
+	// Create 1 task def, 2 services and 11 tasks, 8 running on ec2, first 3 runs on fargate
+	nTasks := 11
+	nInstances := 2
+	nFargateInstances := 3
+	c.SetTaskDefinitions(ecsmock.GenTaskDefinitions("d", 2, 1, func(i int, def *ecs.TaskDefinition) {
+		if i == 0 {
+			def.NetworkMode = aws.String(ecs.NetworkModeAwsvpc)
+		} else {
+			def.NetworkMode = aws.String(ecs.NetworkModeBridge)
+		}
+		def.ContainerDefinitions = []*ecs.ContainerDefinition{
+			{
+				Name: aws.String("c1"),
+				DockerLabels: map[string]*string{
+					"PROMETHEUS_PORT": aws.String("2112"),
+					"MY_JOB_NAME":     aws.String("PROM_JOB_1"),
+					"MY_METRICS_PATH": aws.String("/new/metrics"),
+				},
+				PortMappings: []*ecs.PortMapping{
+					{
+						ContainerPort: aws.Int64(2112),
+						HostPort:      aws.Int64(2113), // doesn't matter for matcher test
+					},
+				},
+			},
+		}
+	}))
+	c.SetTasks(ecsmock.GenTasks("t", nTasks, func(i int, task *ecs.Task) {
+		if i < nFargateInstances {
+			task.TaskDefinitionArn = aws.String("d0:1")
+			task.LaunchType = aws.String(ecs.LaunchTypeFargate)
+			task.StartedBy = aws.String("deploy0")
+			task.Attachments = []*ecs.Attachment{
+				{
+					Type: aws.String("ElasticNetworkInterface"),
+					Details: []*ecs.KeyValuePair{
+						{
+							Name:  aws.String("privateIPv4Address"),
+							Value: aws.String(fmt.Sprintf("172.168.1.%d", i)),
+						},
+					},
+				},
+			}
+			// Pretend this fargate task does not have private ip to trigger print non critical error.
+			if i == (nFargateInstances - 1) {
+				task.Attachments = nil
+			}
+		} else {
+			ins := i % nInstances
+			task.TaskDefinitionArn = aws.String("d1:1")
+			task.LaunchType = aws.String(ecs.LaunchTypeEc2)
+			task.ContainerInstanceArn = aws.String(fmt.Sprintf("ci%d", ins))
+			task.StartedBy = aws.String("deploy1")
+			task.Containers = []*ecs.Container{
+				{
+					Name: aws.String("c1"),
+					NetworkBindings: []*ecs.NetworkBinding{
+						{
+							ContainerPort: aws.Int64(2112),
+							HostPort:      aws.Int64(2114 + int64(i)),
+						},
+					},
+				},
+			}
+		}
+	}))
+	// Setting container instance and ec2 is same as previous sub test
+	c.SetContainerInstances(ecsmock.GenContainerInstances("ci", nInstances, func(i int, ci *ecs.ContainerInstance) {
+		ci.Ec2InstanceId = aws.String(fmt.Sprintf("i-%d", i))
+	}))
+	c.SetEc2Instances(ecsmock.GenEc2Instances("i-", nInstances, func(i int, ins *ec2.Instance) {
+		ins.PrivateIpAddress = aws.String(fmt.Sprintf("172.168.2.%d", i))
+		ins.Tags = []*ec2.Tag{
+			{
+				Key:   aws.String("aws:cloudformation:instance"),
+				Value: aws.String(fmt.Sprintf("cfni%d", i)),
+			},
+		}
+	}))
+	// Service
+	c.SetServices(ecsmock.GenServices("s", 2, func(i int, s *ecs.Service) {
+		if i == 0 {
+			s.LaunchType = aws.String(ecs.LaunchTypeEc2)
+			s.Deployments = []*ecs.Deployment{
+				{
+					Status: aws.String("ACTIVE"),
+					Id:     aws.String("deploy0"),
+				},
+			}
+		} else {
+			s.LaunchType = aws.String(ecs.LaunchTypeFargate)
+			s.Deployments = []*ecs.Deployment{
+				{
+					Status: aws.String("ACTIVE"),
+					Id:     aws.String("deploy1"),
+				},
+			}
+		}
+	}))
+
+	t.Run("success", func(t *testing.T) {
+		sd, err := NewDiscovery(cfg, opts)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.RefreshInterval*2)
+		defer cancel()
+		err = sd.RunAndWriteFile(ctx)
+		require.NoError(t, err)
+
+		assert.FileExists(t, outputFile)
+		expectedFile := "testdata/ut_targets.expected.yaml"
+		// workaround for windows git checkout autocrlf
+		// https://circleci.com/blog/circleci-config-teardown-how-we-write-our-circleci-config-at-circleci/#main:~:text=Line%20endings
+		expectedContent := bytes.ReplaceAll(mustReadFile(t, expectedFile), []byte("\r\n"), []byte("\n"))
+		assert.Equal(t, string(expectedContent), string(mustReadFile(t, outputFile)))
+	})
+
+	t.Run("fail to write file", func(t *testing.T) {
+		cfg2 := cfg
+		cfg2.ResultFile = "testdata/folder/does/not/exists/ut_targets.yaml"
+		sd, err := NewDiscovery(cfg2, opts)
+		require.NoError(t, err)
+		require.Error(t, sd.RunAndWriteFile(context.TODO()))
+	})
+
+	t.Run("critical error in discovery", func(t *testing.T) {
+		cfg2 := cfg
+		cfg2.ClusterName += "not_right_anymore"
+		fetcher2, err := newTaskFetcher(taskFetcherOptions{
+			Logger:            logger,
+			Cluster:           cfg2.ClusterName,
+			Region:            cfg2.ClusterRegion,
+			serviceNameFilter: svcNameFilter,
+			ecsOverride:       c,
+			ec2Override:       c,
+		})
+		require.NoError(t, err)
+		opts2 := ServiceDiscoveryOptions{Logger: logger, FetcherOverride: fetcher2}
+		sd, err := NewDiscovery(cfg2, opts2)
+		require.NoError(t, err)
+		require.Error(t, sd.RunAndWriteFile(context.TODO()))
+	})
+
+	t.Run("invalid fetcher config", func(t *testing.T) {
+		cfg2 := cfg
+		cfg2.ClusterName = ""
+		opts2 := ServiceDiscoveryOptions{Logger: logger}
+		_, err := NewDiscovery(cfg2, opts2)
+		require.Error(t, err)
+	})
 }
 
 // Util Start
@@ -52,6 +251,12 @@ func testMatcherOptions() MatcherOptions {
 	return MatcherOptions{
 		Logger: zap.NewExample(),
 	}
+}
+
+func mustReadFile(t *testing.T, p string) []byte {
+	b, err := ioutil.ReadFile(p)
+	require.NoError(t, err, p)
+	return b
 }
 
 // Util End

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -113,9 +113,6 @@ func serviceConfigsToFilter(cfgs []ServiceConfig) (serviceNameFilter, error) {
 	}
 	var regs []*regexp.Regexp
 	for _, cfg := range cfgs {
-		if cfg.NamePattern == "" {
-			continue
-		}
 		r, err := regexp.Compile(cfg.NamePattern)
 		if err != nil {
 			return nil, fmt.Errorf("invalid service name pattern %q: %w", cfg.NamePattern, err)

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -102,3 +102,32 @@ func (s *serviceMatcher) MatchTargets(t *Task, c *ecs.ContainerDefinition) ([]Ma
 	// The rest is same as taskDefinitionMatcher
 	return matchContainerByName(s.containerNameRegex, s.exportSetting, c)
 }
+
+// serviceConfigsToFilter reduce number of describe service API call
+func serviceConfigsToFilter(cfgs []ServiceConfig) (serviceNameFilter, error) {
+	// If no service config, don't describe any services
+	if len(cfgs) == 0 {
+		return func(name string) bool {
+			return false
+		}, nil
+	}
+	var regs []*regexp.Regexp
+	for _, cfg := range cfgs {
+		if cfg.NamePattern == "" {
+			continue
+		}
+		r, err := regexp.Compile(cfg.NamePattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid service name pattern %q: %w", cfg.NamePattern, err)
+		}
+		regs = append(regs, r)
+	}
+	return func(name string) bool {
+		for _, r := range regs {
+			if r.MatchString(name) {
+				return true
+			}
+		}
+		return false
+	}, nil
+}

--- a/extension/observer/ecsobserver/service_test.go
+++ b/extension/observer/ecsobserver/service_test.go
@@ -34,6 +34,9 @@ func TestServiceMatcher(t *testing.T) {
 		cfg := ServiceConfig{NamePattern: invalidRegex}
 		require.Error(t, cfg.validate())
 
+		_, err := serviceConfigsToFilter([]ServiceConfig{cfg})
+		require.Error(t, err)
+
 		cfg = ServiceConfig{NamePattern: "valid", ContainerNamePattern: invalidRegex}
 		require.Error(t, cfg.validate())
 	})
@@ -148,5 +151,20 @@ func TestServiceMatcher(t *testing.T) {
 				},
 			},
 		}, res)
+	})
+}
+
+func TestServiceNameFilter(t *testing.T) {
+	t.Run("match nothing when empty", func(t *testing.T) {
+		f, err := serviceConfigsToFilter(nil)
+		require.NoError(t, err)
+		require.False(t, f("should not match"))
+	})
+
+	t.Run("invalid regex", func(t *testing.T) {
+		invalidRegex := "*" //  missing argument to repetition operator: `*`
+		cfg := ServiceConfig{NamePattern: invalidRegex}
+		_, err := serviceConfigsToFilter([]ServiceConfig{cfg})
+		require.Error(t, err)
 	})
 }

--- a/extension/observer/ecsobserver/target.go
+++ b/extension/observer/ecsobserver/target.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -108,6 +109,7 @@ func (t *PrometheusECSTarget) ToLabels() map[string]string {
 		labelEC2PrivateIP:           t.EC2PrivateIP,
 		labelEC2PublicIP:            t.EC2PublicIP,
 	}
+	trimEmptyValueByKeyPrefix(labels, labelPrefix+"ec2_")
 	addTagsToLabels(t.TaskTags, labelPrefixTaskTags, labels)
 	addTagsToLabels(t.ContainerLabels, labelPrefixContainerLabels, labels)
 	addTagsToLabels(t.EC2Tags, labelPrefixEC2Tags, labels)
@@ -119,6 +121,14 @@ func (t *PrometheusECSTarget) ToLabels() map[string]string {
 func addTagsToLabels(tags map[string]string, labelNamePrefix string, labels map[string]string) {
 	for k, v := range tags {
 		labels[labelNamePrefix+"_"+sanitizeLabelName(k)] = v
+	}
+}
+
+func trimEmptyValueByKeyPrefix(m map[string]string, prefix string) {
+	for k, v := range m {
+		if v == "" && strings.HasPrefix(k, prefix) {
+			delete(m, k)
+		}
 	}
 }
 

--- a/extension/observer/ecsobserver/target.go
+++ b/extension/observer/ecsobserver/target.go
@@ -162,7 +162,14 @@ func targetsToFileSDTargets(targets []PrometheusECSTarget, jobLabelName string) 
 				delete(labels, k)
 			}
 		}
-		// Rename job label as a workaround for https://github.com/open-telemetry/opentelemetry-collector/issues/575
+		// Rename job label as a workaround for https://github.com/open-telemetry/opentelemetry-collector/issues/575#issuecomment-814558584
+		// In order to keep similar behaviour as cloudwatch agent's discovery implementation,
+		// we support getting job name from docker label. However, prometheus receiver is using job and __name__
+		// labels to get metric type, and it believes the job specified in prom config is always the same as
+		// the job label attached to metrics. Prometheus itself allows discovery to provide job names.
+		//
+		// We can't relabel it using prometheus's relabel config as it would cause the same problem on receiver.
+		// We 'relabel' it to job outside prometheus receiver using other processors in collector's pipeline.
 		job := labels[labelJob]
 		if job != "" && jobLabelName != labelJob {
 			delete(labels, labelJob)

--- a/extension/observer/ecsobserver/target.go
+++ b/extension/observer/ecsobserver/target.go
@@ -163,7 +163,7 @@ func targetsToFileSDTargets(targets []PrometheusECSTarget, jobLabelName string) 
 			}
 		}
 		// Rename job label as a workaround for https://github.com/open-telemetry/opentelemetry-collector/issues/575#issuecomment-814558584
-		// In order to keep similar behaviour as cloudwatch agent's discovery implementation,
+		// In order to keep similar behavior as cloudwatch agent's discovery implementation,
 		// we support getting job name from docker label. However, prometheus receiver is using job and __name__
 		// labels to get metric type, and it believes the job specified in prom config is always the same as
 		// the job label attached to metrics. Prometheus itself allows discovery to provide job names.

--- a/extension/observer/ecsobserver/testdata/ut_targets.expected.yaml
+++ b/extension/observer/ecsobserver/testdata/ut_targets.expected.yaml
@@ -1,0 +1,362 @@
+- targets:
+  - 172.168.1.0:2113
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_health_status: ""
+    __meta_ecs_source: t0
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: FARGATE
+    __meta_ecs_task_started_by: deploy0
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1
+- targets:
+  - 172.168.1.1:2113
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_health_status: ""
+    __meta_ecs_source: t1
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: FARGATE
+    __meta_ecs_task_started_by: deploy0
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1
+- targets:
+  - 172.168.2.1:2117
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t3
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.1:2117
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t3
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1
+- targets:
+  - 172.168.2.0:2118
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t4
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.0:2118
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t4
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1
+- targets:
+  - 172.168.2.1:2119
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t5
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.1:2119
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t5
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1
+- targets:
+  - 172.168.2.0:2120
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t6
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.0:2120
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t6
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1
+- targets:
+  - 172.168.2.1:2121
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t7
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.1:2121
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t7
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1
+- targets:
+  - 172.168.2.0:2122
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t8
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.0:2122
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t8
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1
+- targets:
+  - 172.168.2.1:2123
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t9
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.1:2123
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-1
+    __meta_ecs_ec2_private_ip: 172.168.2.1
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni1
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t9
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1
+- targets:
+  - 172.168.2.0:2124
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t10
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /metrics
+- targets:
+  - 172.168.2.0:2124
+  labels:
+    __meta_ecs_cluster_name: ut-cluster-1
+    __meta_ecs_container_labels_MY_JOB_NAME: PROM_JOB_1
+    __meta_ecs_container_labels_MY_METRICS_PATH: /new/metrics
+    __meta_ecs_container_labels_PROMETHEUS_PORT: "2112"
+    __meta_ecs_container_name: c1
+    __meta_ecs_ec2_instance_id: i-0
+    __meta_ecs_ec2_private_ip: 172.168.2.0
+    __meta_ecs_ec2_tags_aws_cloudformation_instance: cfni0
+    __meta_ecs_health_status: ""
+    __meta_ecs_service_name: s1
+    __meta_ecs_source: t10
+    __meta_ecs_task_definition_family: ""
+    __meta_ecs_task_definition_revision: "0"
+    __meta_ecs_task_group: ""
+    __meta_ecs_task_launch_type: EC2
+    __meta_ecs_task_started_by: deploy1
+    __metrics_path__: /new/metrics
+    prometheus_job: PROM_JOB_1


### PR DESCRIPTION
**Description:**

- Glue all pieces using `serviceDiscovery` and support real AWS client
- Write output in prometheus file sd format
- Filter ECS service based on config to reduce API calls

**Link to tracking Issue:**

- Feature request #1395 

Previous PRs

- Fetch EC2, Service https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3503
- Service matcher https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3386
- Exporter https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3333
- Fetch Task https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3284
- Docker Label Matcher https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3276
- Task IP and Port https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3133
- Target and Task definition https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2939
- Config PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2377
- Original PR #2734 

**Testing:** 

- unit test
- e2e test using https://github.com/pingleig/aws-otel-collector/commit/d30c480e45073ec72dff51612a884d475d899b81

**Documentation:** 

No new doc. See [existing doc](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/observer/ecsobserver/README.md)