### PR TITLE
[exporter/datadog]: ensure top level spans are computed

### DIFF
--- a/exporter/datadogexporter/stats.go
+++ b/exporter/datadogexporter/stats.go
@@ -37,6 +37,7 @@ func computeAPMStats(tracePayload *pb.TracePayload, pushTime int64) *stats.Paylo
 	bucketTS := pushTime - statsBucketDuration
 	for _, trace := range tracePayload.Traces {
 		spans := getAnalyzedSpans(trace.Spans)
+
 		for _, span := range spans {
 
 			// TODO: While this is hardcoded to assume a single 10s buckets for now,

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/exportable/traceutil"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
@@ -207,6 +208,9 @@ func resourceSpansToDatadogSpans(rs pdata.ResourceSpans, hostname string, cfg *c
 		// appends a specific piece of metadata to these spans marking them as analyzed
 		// TODO: allow users to configure specific spans to be marked as an analyzed spans for app analytics
 		top := getAnalyzedSpans(apiTrace.Spans)
+
+		// https://github.com/DataDog/datadog-agent/blob/443930a00bced1ea87d0067fc2f1fc3f98a48ba1/pkg/trace/agent/agent.go#L241-L243
+		traceutil.ComputeTopLevel(apiTrace.Spans)
 
 		payload.Transactions = append(payload.Transactions, top...)
 		payload.Traces = append(payload.Traces, apiTrace)

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -278,7 +278,7 @@ func TestBasicTracesTranslation(t *testing.T) {
 
 	// ensure that span.meta and span.metrics pick up attributes, instrumentation ibrary and resource attribs
 	assert.Equal(t, 10, len(datadogPayload.Traces[0].Spans[0].Meta))
-	assert.Equal(t, 0, len(datadogPayload.Traces[0].Spans[0].Metrics))
+	assert.Equal(t, 1, len(datadogPayload.Traces[0].Spans[0].Metrics))
 
 	// ensure that span error is based on otlp span status
 	assert.Equal(t, int32(0), datadogPayload.Traces[0].Spans[0].Error)
@@ -800,7 +800,7 @@ func TestTracesTranslationServicePeerName(t *testing.T) {
 
 	// ensure that span.meta and span.metrics pick up attributes, instrumentation ibrary and resource attribs
 	assert.Equal(t, 11, len(datadogPayload.Traces[0].Spans[0].Meta))
-	assert.Equal(t, 0, len(datadogPayload.Traces[0].Spans[0].Metrics))
+	assert.Equal(t, 1, len(datadogPayload.Traces[0].Spans[0].Metrics))
 
 	// ensure that span error is based on otlp span status
 	assert.Equal(t, int32(0), datadogPayload.Traces[0].Spans[0].Error)
@@ -875,7 +875,7 @@ func TestTracesTranslationTruncatetag(t *testing.T) {
 
 	// ensure that span.meta and span.metrics pick up attributes, instrumentation ibrary and resource attribs
 	assert.Equal(t, 11, len(datadogPayload.Traces[0].Spans[0].Meta))
-	assert.Equal(t, 0, len(datadogPayload.Traces[0].Spans[0].Metrics))
+	assert.Equal(t, 1, len(datadogPayload.Traces[0].Spans[0].Metrics))
 
 	// ensure that span error is based on otlp span status
 	assert.Equal(t, int32(0), datadogPayload.Traces[0].Spans[0].Error)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

A previous PR accidentally dropped top level span computation, (here: https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/269678310105311d8eb652d60f66fdd66eceb396#diff-b98fa670a9a811a13714fe4ce9bb4b3c5c6442c05638eb156a61e5480e8aa8faL82) which has caused an unintended effect of causing a large number of spans to not be retained. This PR reverts that change

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

updated unit tests

**Documentation:** <Describe the documentation added.>