### PR TITLE
Add extractors for cpu/mem metrics

### DIFF
--- a/receiver/awscontainerinsightreceiver/go.mod
+++ b/receiver/awscontainerinsightreceiver/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.60
+	github.com/google/cadvisor v0.39.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-00010101000000-000000000000

--- a/receiver/awscontainerinsightreceiver/go.sum
+++ b/receiver/awscontainerinsightreceiver/go.sum
@@ -80,6 +80,7 @@ github.com/HdrHistogram/hdrhistogram-go v0.9.0/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qE
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
+github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -132,6 +133,7 @@ github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:W
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
+github.com/aws/aws-sdk-go v1.35.24/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go v1.38.3/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.52/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.60 h1:MgyEsX0IMwivwth1VwEnesBpH0vxbjp5a0w1lurMOXY=
@@ -144,6 +146,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
@@ -162,9 +165,11 @@ github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -172,8 +177,13 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
 github.com/containerd/containerd v1.4.3 h1:ijQT13JedHSHrQGWFcGEwzcNKrAGIiZ+jSD5QQG07SY=
 github.com/containerd/containerd v1.4.3/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.4.4 h1:rtRG4N6Ct7GNssATwgpvMGfnjnwfjnu/Zs9W3Ikzq+M=
+github.com/containerd/containerd v1.4.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
+github.com/containerd/typeurl v1.0.1/go.mod h1:TB1hUtrpaiO88KEK56ijojHS1+NeF0izUACaJW2mdXg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -184,6 +194,7 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd/v22 v22.3.1/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
@@ -191,8 +202,10 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crossdock/crossdock-go v0.0.0-20160816171116-049aabb0122b/go.mod h1:v9FBN7gdVTpiD/+LZ7Po0UKvROyT87uLVxTHVky/dlQ=
+github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -210,8 +223,10 @@ github.com/digitalocean/godo v1.58.0 h1:Iy8ULTvgCAxH8dlxZ54qRYpm5uTEb2deUqijywLH
 github.com/digitalocean/godo v1.58.0/go.mod h1:p7dOjjtSBqCTUksqtA5Fd3uaKs9kyTq2xcz76ulEJRU=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
+github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v20.10.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.5+incompatible h1:o5WL5onN4awYGwrW7+oTn5x9AF2prw7V0Ox8ZEkoCdg=
 github.com/docker/docker v20.10.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -242,6 +257,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -406,6 +422,7 @@ github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGt
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/gocql/gocql v0.0.0-20200228163523-cd4b606dd2fb/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
+github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0=
@@ -458,6 +475,8 @@ github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/cadvisor v0.39.2 h1:SzgL5IYoMZEFVA9usi0xCy8SXSVXKQ6aL/rYs/kQjXE=
+github.com/google/cadvisor v0.39.2/go.mod h1:kN93gpdevu+bpS227TyHVZyCU5bbqCzTj5T9drl34MI=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -516,7 +535,9 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -651,6 +672,7 @@ github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
+github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -719,10 +741,14 @@ github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsO
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
+github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
+github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
+github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -743,6 +769,7 @@ github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxd
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mjibson/esc v0.2.0/go.mod h1:9Hw9gxxfHulMF5OJKCyhYD7PzlSdhzXyaGEBRPH1OPs=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
+github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 h1:rzf0wL0CHVc8CEsgyygG0Mn9CNCCPZqOPaz8RiiHYQk=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -755,6 +782,7 @@ github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJ
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
+github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -794,6 +822,9 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/runc v1.0.0-rc95/go.mod h1:z+bZxa/+Tz/FmYVWkhUajJdzFeOqjc5vrqskhVyHGUM=
+github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
@@ -879,6 +910,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.0-20190522114515-bc1a522cf7b1/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
@@ -915,6 +947,7 @@ github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210223165440-c65ae3540d44 
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210223165440-c65ae3540d44/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec v0.0.0-20200203094520-d13bb6d2420c/go.mod h1:gp0gaHj0WlmPh9BdsTmo1aq6C27yIPWdxCKGFGdVKBE=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
@@ -931,6 +964,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
@@ -984,6 +1019,7 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
@@ -1004,8 +1040,12 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
+github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2 h1:akYIkZ28e6A96dkWNJQu3nmCzH3YfwMPQExUYDaRv7w=
@@ -1136,6 +1176,7 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1240,6 +1281,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1253,6 +1295,7 @@ golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191115151921-52ab43148777/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1261,10 +1304,12 @@ golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200107162124-548cf772de50/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200120151820-655fe14d7479/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1279,6 +1324,7 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1298,6 +1344,8 @@ golang.org/x/sys v0.0.0-20210316164454-77fc1eacc6aa/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
@@ -1451,6 +1499,7 @@ google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1/go.mod h1:n3cpQtvx
 google.golang.org/genproto v0.0.0-20191230161307-f3c370f40bfb/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200108215221-bd8f9a0ef82f/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200115191322-ca5a22157cba/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
+google.golang.org/genproto v0.0.0-20200117163144-32f20d992d24/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200122232147-0452cf42e150/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200204135345-fa8e72b47b90/go.mod h1:GmwEX6Z4W5gMy59cAlVYjN9JhxgbQH6Gn+gFDQe2lzA=
 google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
@@ -1471,6 +1520,7 @@ google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -1587,6 +1637,7 @@ k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
+k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.4.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/klog/v2 v2.8.0 h1:Q3gmuM9hKEjefWFFYF0Mat+YyFJvsUyYuwyNNJ5C9Ts=
 k8s.io/klog/v2 v2.8.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor.go
@@ -1,0 +1,70 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extractors
+
+import (
+	cInfo "github.com/google/cadvisor/info/v1"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	awsmetrics "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
+)
+
+const (
+	decimalToMillicores = 1000
+)
+
+type CPUMetricExtractor struct {
+	logger         *zap.Logger
+	rateCalculator awsmetrics.MetricCalculator
+}
+
+func (c *CPUMetricExtractor) HasValue(info *cInfo.ContainerInfo) bool {
+	return info.Spec.HasCpu
+}
+
+func (c *CPUMetricExtractor) GetValue(info *cInfo.ContainerInfo, mInfo CPUMemInfoProvider, containerType string) []*CAdvisorMetric {
+	var metrics []*CAdvisorMetric
+	if info.Spec.Labels[containerNameLable] == infraContainerName {
+		return metrics
+	}
+
+	// When there is more than one stats point, always use the last one
+	curStats := GetStats(info)
+	metric := newCadvisorMetric(containerType, c.logger)
+	multiplier := float64(decimalToMillicores)
+	assignRateValueToField(&c.rateCalculator, metric.fields, ci.MetricName(containerType, ci.CPUTotal), info.Name, float64(curStats.Cpu.Usage.Total), curStats.Timestamp, multiplier)
+	assignRateValueToField(&c.rateCalculator, metric.fields, ci.MetricName(containerType, ci.CPUUser), info.Name, float64(curStats.Cpu.Usage.User), curStats.Timestamp, multiplier)
+	assignRateValueToField(&c.rateCalculator, metric.fields, ci.MetricName(containerType, ci.CPUSystem), info.Name, float64(curStats.Cpu.Usage.System), curStats.Timestamp, multiplier)
+
+	numCores := mInfo.GetNumCores()
+	if metric.fields[ci.MetricName(containerType, ci.CPUTotal)] != nil && numCores != 0 {
+		metric.fields[ci.MetricName(containerType, ci.CPUUtilization)] = metric.fields[ci.MetricName(containerType, ci.CPUTotal)].(float64) / float64(numCores*decimalToMillicores) * 100
+	}
+
+	if containerType == ci.TypeNode {
+		metric.fields[ci.MetricName(containerType, ci.CPULimit)] = numCores * decimalToMillicores
+	}
+
+	metrics = append(metrics, metric)
+	return metrics
+}
+
+func NewCPUMetricExtractor(logger *zap.Logger) *CPUMetricExtractor {
+	return &CPUMetricExtractor{
+		logger:         logger,
+		rateCalculator: newFloat64RateCalculator(),
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor_test.go
@@ -24,8 +24,8 @@ import (
 func TestCPUStats(t *testing.T) {
 	MockCPUMemInfo := testutils.MockCPUMemInfo{}
 
-	result := testutils.LoadContainerInfo("./testdata/PreInfoContainer.json")
-	result2 := testutils.LoadContainerInfo("./testdata/CurInfoContainer.json")
+	result := testutils.LoadContainerInfo(t, "./testdata/PreInfoContainer.json")
+	result2 := testutils.LoadContainerInfo(t, "./testdata/CurInfoContainer.json")
 
 	//test container type
 	containerType := TypeContainer

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor_test.go
@@ -1,0 +1,65 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extractors
+
+import (
+	"testing"
+
+	. "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils"
+)
+
+func TestCPUStats(t *testing.T) {
+	MockCPUMemInfo := testutils.MockCPUMemInfo{}
+
+	result := testutils.LoadContainerInfo("./testdata/PreInfoContainer.json")
+	result2 := testutils.LoadContainerInfo("./testdata/CurInfoContainer.json")
+
+	//test container type
+	containerType := TypeContainer
+	extractor := NewCPUMetricExtractor(nil)
+
+	var cMetrics []*CAdvisorMetric
+	if extractor.HasValue(result[0]) {
+		cMetrics = extractor.GetValue(result[0], MockCPUMemInfo, containerType)
+	}
+
+	if extractor.HasValue(result2[0]) {
+		cMetrics = extractor.GetValue(result2[0], MockCPUMemInfo, containerType)
+	}
+
+	AssertContainsTaggedFloat(t, cMetrics[0], "container_cpu_usage_total", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "container_cpu_usage_user", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "container_cpu_usage_system", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "container_cpu_utilization", 0.5, 0)
+
+	//test node type
+	containerType = TypeNode
+	extractor = NewCPUMetricExtractor(nil)
+
+	if extractor.HasValue(result[0]) {
+		cMetrics = extractor.GetValue(result[0], MockCPUMemInfo, containerType)
+	}
+
+	if extractor.HasValue(result2[0]) {
+		cMetrics = extractor.GetValue(result2[0], MockCPUMemInfo, containerType)
+	}
+
+	AssertContainsTaggedFloat(t, cMetrics[0], "node_cpu_usage_total", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "node_cpu_usage_user", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "node_cpu_usage_system", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "node_cpu_utilization", 0.5, 0)
+	AssertContainsTaggedInt(t, cMetrics[0], "node_cpu_limit", 2000)
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor.go
@@ -1,0 +1,172 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extractors
+
+import (
+	"fmt"
+	"time"
+
+	cinfo "github.com/google/cadvisor/info/v1"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	awsmetrics "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
+)
+
+const (
+	containerNameLable = "io.kubernetes.container.name"
+	// TODO: https://github.com/containerd/cri/issues/922#issuecomment-423729537 the container name can be empty on containerd
+	infraContainerName = "POD"
+)
+
+func GetStats(info *cinfo.ContainerInfo) *cinfo.ContainerStats {
+	if len(info.Stats) == 0 {
+		return nil
+	}
+	// When there is more than one stats point, always use the last one
+	return info.Stats[len(info.Stats)-1]
+}
+
+type CPUMemInfoProvider interface {
+	GetNumCores() int64
+	GetMemoryCapacity() int64
+}
+
+type MetricExtractor interface {
+	HasValue(*cinfo.ContainerInfo) bool
+	GetValue(*cinfo.ContainerInfo, CPUMemInfoProvider, string) []*CAdvisorMetric
+}
+
+type CAdvisorMetric struct {
+	//key/value pairs that are typed and contain the metric (numerical) data
+	fields map[string]interface{}
+	//key/value string pairs that are used to identify the metrics
+	tags map[string]string
+
+	logger *zap.Logger
+}
+
+func newCadvisorMetric(mType string, logger *zap.Logger) *CAdvisorMetric {
+	metric := &CAdvisorMetric{
+		fields: make(map[string]interface{}),
+		tags:   make(map[string]string),
+		logger: logger,
+	}
+	metric.tags[ci.MetricType] = mType
+	return metric
+}
+
+func (c *CAdvisorMetric) GetTags() map[string]string {
+	return c.tags
+}
+
+func (c *CAdvisorMetric) GetFields() map[string]interface{} {
+	return c.fields
+}
+
+func (c *CAdvisorMetric) GetMetricType() string {
+	return c.tags[ci.MetricType]
+}
+
+func (c *CAdvisorMetric) AddTags(tags map[string]string) {
+	for k, v := range tags {
+		c.tags[k] = v
+	}
+}
+
+func (c *CAdvisorMetric) Merge(src *CAdvisorMetric) {
+	// If there is any conflict, keep the fields with earlier timestamp
+	for k, v := range src.fields {
+		if _, ok := c.fields[k]; ok {
+			c.logger.Debug(fmt.Sprintf("metric being merged has conflict in fields, src: %v, dest: %v \n", *src, *c))
+			if c.tags[ci.Timestamp] < src.tags[ci.Timestamp] {
+				continue
+			}
+		}
+		c.fields[k] = v
+	}
+}
+
+func newFloat64RateCalculator() awsmetrics.MetricCalculator {
+	return awsmetrics.NewMetricCalculator(func(prev *awsmetrics.MetricValue, val interface{}, timestamp time.Time) (interface{}, bool) {
+		if prev != nil {
+			deltaNs := timestamp.Sub(prev.Timestamp)
+			deltaValue := val.(float64) - prev.RawValue.(float64)
+			if deltaNs > ci.MinTimeDiff && deltaValue >= 0 {
+				return deltaValue / float64(deltaNs), true
+			}
+		}
+		return float64(0), false
+	})
+}
+
+func assignRateValueToField(rateCalculator *awsmetrics.MetricCalculator, fields map[string]interface{}, metricName string,
+	cinfoName string, curVal interface{}, curTime time.Time, multiplier float64) {
+	key := cinfoName + metricName
+	if val, ok := rateCalculator.Calculate(key, nil, curVal, curTime); ok {
+		fields[metricName] = val.(float64) * multiplier
+	}
+}
+
+// MergeMetrics merges an array of cadvisor metrics based on common metric keys
+func MergeMetrics(metrics []*CAdvisorMetric) []*CAdvisorMetric {
+	var result []*CAdvisorMetric
+	metricMap := make(map[string]*CAdvisorMetric)
+	for _, metric := range metrics {
+		if metricKey := getMetricKey(metric); metricKey != "" {
+			if mergedMetric, ok := metricMap[metricKey]; ok {
+				mergedMetric.Merge(metric)
+			} else {
+				metricMap[metricKey] = metric
+			}
+		} else {
+			// this metric cannot be merged
+			result = append(result, metric)
+		}
+	}
+	for _, metric := range metricMap {
+		result = append(result, metric)
+	}
+	return result
+}
+
+// return MetricKey for merge-able metrics
+func getMetricKey(metric *CAdvisorMetric) string {
+	metricType := metric.GetMetricType()
+	metricKey := ""
+	switch metricType {
+	case ci.TypeInstance:
+		// merge cpu, memory, net metric for type Instance
+		metricKey = fmt.Sprintf("metricType:%s", ci.TypeInstance)
+	case ci.TypeNode:
+		// merge cpu, memory, net metric for type Node
+		metricKey = fmt.Sprintf("metricType:%s", ci.TypeNode)
+	case ci.TypePod:
+		// merge cpu, memory, net metric for type Pod
+		metricKey = fmt.Sprintf("metricType:%s,podId:%s", ci.TypePod, metric.GetTags()[ci.PodIDKey])
+	case ci.TypeContainer:
+		// merge cpu, memory metric for type Container
+		metricKey = fmt.Sprintf("metricType:%s,podId:%s,containerName:%s", ci.TypeContainer, metric.GetTags()[ci.PodIDKey], metric.GetTags()[ci.ContainerNamekey])
+	case ci.TypeInstanceDiskIO:
+		// merge io_serviced, io_service_bytes for type InstanceDiskIO
+		metricKey = fmt.Sprintf("metricType:%s,device:%s", ci.TypeInstanceDiskIO, metric.GetTags()[ci.DiskDev])
+	case ci.TypeNodeDiskIO:
+		// merge io_serviced, io_service_bytes for type NodeDiskIO
+		metricKey = fmt.Sprintf("metricType:%s,device:%s", ci.TypeNodeDiskIO, metric.GetTags()[ci.DiskDev])
+	default:
+		metricKey = ""
+	}
+	return metricKey
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor_helpers_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor_helpers_test.go
@@ -1,0 +1,112 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extractors
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertContainsTaggedFloat(
+	t *testing.T,
+	cadvisorMetric *CAdvisorMetric,
+	field string,
+	expectedValue float64,
+	delta float64,
+) {
+	var actualValue float64
+	fields := cadvisorMetric.GetFields()
+	if val, ok := fields[field]; ok {
+		if val, ok := val.(float64); ok {
+			actualValue = val
+			if (val >= expectedValue-delta) && (val <= expectedValue+delta) {
+				//Found the point, return without failing
+				return
+			}
+		} else {
+			assert.Fail(t, fmt.Sprintf("Field \"%s\" does not have type float64", field))
+		}
+	}
+	msg := fmt.Sprintf(
+		"Could not find field \"%s\" with requested tags within %f of %f, Actual: %f",
+		field, delta, expectedValue, actualValue)
+	assert.Fail(t, msg)
+}
+
+func AssertContainsTaggedInt(
+	t *testing.T,
+	cadvisorMetric *CAdvisorMetric,
+	field string,
+	expectedValue int64,
+) {
+	var actualValue int64
+	fields := cadvisorMetric.GetFields()
+	if val, ok := fields[field]; ok {
+		var isOK bool
+		if actualValue, isOK = val.(int64); isOK {
+			return
+		}
+	}
+	msg := fmt.Sprintf(
+		"Could not find field \"%s\" with requested tags with value: %v, Actual: %v",
+		field, expectedValue, actualValue)
+	assert.Fail(t, msg)
+}
+
+func AssertContainsTaggedUint(
+	t *testing.T,
+	cadvisorMetric *CAdvisorMetric,
+	field string,
+	expectedValue uint64,
+) {
+	var actualValue uint64
+	fields := cadvisorMetric.GetFields()
+	if val, ok := fields[field]; ok {
+		var isOK bool
+		if _, isOK = val.(uint64); isOK {
+			return
+		}
+	}
+	msg := fmt.Sprintf(
+		"Could not find field \"%s\" with requested tags with value: %v, Actual: %v",
+		field, expectedValue, actualValue)
+	assert.Fail(t, msg)
+}
+
+func AssertContainsTaggedField(
+	t *testing.T,
+	cadvisorMetric *CAdvisorMetric,
+	expectedFields map[string]interface{},
+	expectedTags map[string]string,
+) {
+
+	actualFields := cadvisorMetric.GetFields()
+	actualTags := cadvisorMetric.GetTags()
+	if !reflect.DeepEqual(expectedTags, actualTags) {
+		msg := fmt.Sprintf("No field exists for metric %v\n", *cadvisorMetric)
+		msg += fmt.Sprintf("expected: %v\n", expectedTags)
+		msg += fmt.Sprintf("actual: %v\n", actualTags)
+		assert.Fail(t, msg)
+	}
+	if len(actualFields) > 0 {
+		assert.Equal(t, expectedFields, actualFields)
+		return
+	}
+	msg := fmt.Sprintf("No field exists for metric %v", *cadvisorMetric)
+	assert.Fail(t, msg)
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor_test.go
@@ -1,0 +1,135 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extractors
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+)
+
+func TestCAdvisorMetric_Merge(t *testing.T) {
+	src := &CAdvisorMetric{
+		fields: map[string]interface{}{"value1": 1, "value2": 2},
+		tags:   map[string]string{ci.Timestamp: "1586331559882"},
+		logger: zap.NewNop(),
+	}
+	dest := &CAdvisorMetric{
+		fields: map[string]interface{}{"value1": 3, "value3": 3},
+		tags:   map[string]string{ci.Timestamp: "1586331559973"},
+		logger: zap.NewNop(),
+	}
+	src.Merge(dest)
+	assert.Equal(t, 3, len(src.fields))
+	assert.Equal(t, 1, src.fields["value1"].(int))
+}
+
+func TestGetMetricKey(t *testing.T) {
+	c := &CAdvisorMetric{
+		tags: map[string]string{
+			ci.MetricType: ci.TypeInstance,
+		},
+	}
+	assert.Equal(t, "metricType:Instance", getMetricKey(c))
+
+	c = &CAdvisorMetric{
+		tags: map[string]string{
+			ci.MetricType: ci.TypeNode,
+		},
+	}
+	assert.Equal(t, "metricType:Node", getMetricKey(c))
+
+	c = &CAdvisorMetric{
+		tags: map[string]string{
+			ci.MetricType: ci.TypePod,
+			ci.PodIDKey:   "podID",
+		},
+	}
+	assert.Equal(t, "metricType:Pod,podId:podID", getMetricKey(c))
+
+	c = &CAdvisorMetric{
+		tags: map[string]string{
+			ci.MetricType:       ci.TypeContainer,
+			ci.PodIDKey:         "podID",
+			ci.ContainerNamekey: "containerName",
+		},
+	}
+	assert.Equal(t, "metricType:Container,podId:podID,containerName:containerName", getMetricKey(c))
+
+	c = &CAdvisorMetric{
+		tags: map[string]string{
+			ci.MetricType: ci.TypeInstanceDiskIO,
+			ci.DiskDev:    "/abc",
+		},
+	}
+	assert.Equal(t, "metricType:InstanceDiskIO,device:/abc", getMetricKey(c))
+
+	c = &CAdvisorMetric{
+		tags: map[string]string{
+			ci.MetricType: ci.TypeNodeDiskIO,
+			ci.DiskDev:    "/abc",
+		},
+	}
+	assert.Equal(t, "metricType:NodeDiskIO,device:/abc", getMetricKey(c))
+
+	c = &CAdvisorMetric{}
+	assert.Equal(t, "", getMetricKey(c))
+}
+
+func TestMergeMetrics(t *testing.T) {
+	cpuMetrics := &CAdvisorMetric{
+		fields: map[string]interface{}{
+			"node_cpu_usage_total": float64(10),
+			"node_cpu_usage_user":  float64(10),
+		},
+		tags: map[string]string{
+			ci.MetricType: ci.TypeNode,
+		},
+	}
+
+	memMetrics := &CAdvisorMetric{
+		fields: map[string]interface{}{
+			"node_memory_cache": uint(25645056),
+		},
+		tags: map[string]string{
+			ci.MetricType: ci.TypeNode,
+		},
+	}
+
+	metrics := []*CAdvisorMetric{
+		cpuMetrics,
+		memMetrics,
+	}
+
+	expected := &CAdvisorMetric{
+		fields: map[string]interface{}{
+			"node_cpu_usage_total": float64(10),
+			"node_cpu_usage_user":  float64(10),
+			"node_memory_cache":    uint(25645056),
+		},
+		tags: map[string]string{
+			ci.MetricType: ci.TypeNode,
+		},
+	}
+	mergedMetrics := MergeMetrics(metrics)
+	assert.Equal(t, 1, len(mergedMetrics))
+	assert.True(t, reflect.DeepEqual(expected.GetTags(), mergedMetrics[0].GetTags()))
+	assert.True(t, reflect.DeepEqual(expected.GetFields(), mergedMetrics[0].GetFields()))
+
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor.go
@@ -1,0 +1,82 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extractors
+
+import (
+	"time"
+
+	cinfo "github.com/google/cadvisor/info/v1"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	awsmetrics "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics"
+)
+
+type MemMetricExtractor struct {
+	logger         *zap.Logger
+	rateCalculator awsmetrics.MetricCalculator
+}
+
+func (m *MemMetricExtractor) HasValue(info *cinfo.ContainerInfo) bool {
+	return info.Spec.HasMemory
+}
+
+func (m *MemMetricExtractor) GetValue(info *cinfo.ContainerInfo, mInfo CPUMemInfoProvider, containerType string) []*CAdvisorMetric {
+	var metrics []*CAdvisorMetric
+	if info.Spec.Labels[containerNameLable] == infraContainerName {
+		return metrics
+	}
+
+	metric := newCadvisorMetric(containerType, m.logger)
+	curStats := GetStats(info)
+
+	metric.fields[ci.MetricName(containerType, ci.MemUsage)] = curStats.Memory.Usage
+	metric.fields[ci.MetricName(containerType, ci.MemCache)] = curStats.Memory.Cache
+	metric.fields[ci.MetricName(containerType, ci.MemRss)] = curStats.Memory.RSS
+	metric.fields[ci.MetricName(containerType, ci.MemMaxusage)] = curStats.Memory.MaxUsage
+	metric.fields[ci.MetricName(containerType, ci.MemSwap)] = curStats.Memory.Swap
+	metric.fields[ci.MetricName(containerType, ci.MemFailcnt)] = curStats.Memory.Failcnt
+	metric.fields[ci.MetricName(containerType, ci.MemMappedfile)] = curStats.Memory.MappedFile
+	metric.fields[ci.MetricName(containerType, ci.MemWorkingset)] = curStats.Memory.WorkingSet
+
+	multiplier := float64(time.Second)
+	assignRateValueToField(&m.rateCalculator, metric.fields, ci.MetricName(containerType, ci.MemPgfault), info.Name,
+		float64(curStats.Memory.ContainerData.Pgfault), curStats.Timestamp, multiplier)
+	assignRateValueToField(&m.rateCalculator, metric.fields, ci.MetricName(containerType, ci.MemPgmajfault), info.Name,
+		float64(curStats.Memory.ContainerData.Pgmajfault), curStats.Timestamp, multiplier)
+	assignRateValueToField(&m.rateCalculator, metric.fields, ci.MetricName(containerType, ci.MemHierarchicalPgfault), info.Name,
+		float64(curStats.Memory.HierarchicalData.Pgfault), curStats.Timestamp, multiplier)
+	assignRateValueToField(&m.rateCalculator, metric.fields, ci.MetricName(containerType, ci.MemHierarchicalPgmajfault), info.Name,
+		float64(curStats.Memory.HierarchicalData.Pgmajfault), curStats.Timestamp, multiplier)
+
+	memoryCapacity := mInfo.GetMemoryCapacity()
+	if metric.fields[ci.MetricName(containerType, ci.MemWorkingset)] != nil && memoryCapacity != 0 {
+		metric.fields[ci.MetricName(containerType, ci.MemUtilization)] = float64(metric.fields[ci.MetricName(containerType, ci.MemWorkingset)].(uint64)) / float64(memoryCapacity) * 100
+	}
+
+	if containerType == ci.TypeNode {
+		metric.fields[ci.MetricName(containerType, ci.MemLimit)] = memoryCapacity
+	}
+
+	metrics = append(metrics, metric)
+	return metrics
+}
+
+func NewMemMetricExtractor(logger *zap.Logger) *MemMetricExtractor {
+	return &MemMetricExtractor{
+		logger:         logger,
+		rateCalculator: newFloat64RateCalculator(),
+	}
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor_test.go
@@ -15,7 +15,6 @@
 package extractors
 
 import (
-	"log"
 	"testing"
 
 	. "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
@@ -24,8 +23,8 @@ import (
 
 func TestMemStats(t *testing.T) {
 	MockCPUMemInfo := testutils.MockCPUMemInfo{}
-	result := testutils.LoadContainerInfo("./testdata/PreInfoContainer.json")
-	result2 := testutils.LoadContainerInfo("./testdata/CurInfoContainer.json")
+	result := testutils.LoadContainerInfo(t, "./testdata/PreInfoContainer.json")
+	result2 := testutils.LoadContainerInfo(t, "./testdata/CurInfoContainer.json")
 
 	containerType := TypeContainer
 	extractor := NewMemMetricExtractor(nil)
@@ -37,10 +36,6 @@ func TestMemStats(t *testing.T) {
 
 	if extractor.HasValue(result2[0]) {
 		cMetrics = extractor.GetValue(result2[0], MockCPUMemInfo, containerType)
-	}
-
-	for _, cadvisorMetric := range cMetrics {
-		log.Printf("cadvisor Metrics received:\n %v \n", *cadvisorMetric)
 	}
 
 	AssertContainsTaggedUint(t, cMetrics[0], "container_memory_cache", 25645056)
@@ -67,10 +62,6 @@ func TestMemStats(t *testing.T) {
 
 	if extractor.HasValue(result2[0]) {
 		cMetrics = extractor.GetValue(result2[0], MockCPUMemInfo, containerType)
-	}
-
-	for _, cadvisorMetric := range cMetrics {
-		log.Printf("cadvisor Metrics received:\n %v \n", *cadvisorMetric)
 	}
 
 	AssertContainsTaggedUint(t, cMetrics[0], "node_memory_cache", 25645056)

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor_test.go
@@ -1,0 +1,92 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extractors
+
+import (
+	"log"
+	"testing"
+
+	. "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils"
+)
+
+func TestMemStats(t *testing.T) {
+	MockCPUMemInfo := testutils.MockCPUMemInfo{}
+	result := testutils.LoadContainerInfo("./testdata/PreInfoContainer.json")
+	result2 := testutils.LoadContainerInfo("./testdata/CurInfoContainer.json")
+
+	containerType := TypeContainer
+	extractor := NewMemMetricExtractor(nil)
+
+	var cMetrics []*CAdvisorMetric
+	if extractor.HasValue(result[0]) {
+		cMetrics = extractor.GetValue(result[0], MockCPUMemInfo, containerType)
+	}
+
+	if extractor.HasValue(result2[0]) {
+		cMetrics = extractor.GetValue(result2[0], MockCPUMemInfo, containerType)
+	}
+
+	for _, cadvisorMetric := range cMetrics {
+		log.Printf("cadvisor Metrics received:\n %v \n", *cadvisorMetric)
+	}
+
+	AssertContainsTaggedUint(t, cMetrics[0], "container_memory_cache", 25645056)
+	AssertContainsTaggedUint(t, cMetrics[0], "container_memory_rss", 221184)
+	AssertContainsTaggedUint(t, cMetrics[0], "container_memory_max_usage", 90775552)
+	AssertContainsTaggedUint(t, cMetrics[0], "container_memory_mapped_file", 0)
+	AssertContainsTaggedUint(t, cMetrics[0], "container_memory_usage", 29728768)
+	AssertContainsTaggedUint(t, cMetrics[0], "container_memory_swap", 0)
+	AssertContainsTaggedUint(t, cMetrics[0], "container_memory_failcnt", 0)
+	AssertContainsTaggedUint(t, cMetrics[0], "container_memory_working_set", 28844032)
+
+	AssertContainsTaggedFloat(t, cMetrics[0], "container_memory_pgfault", 1000, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "container_memory_hierarchical_pgfault", 1000, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "container_memory_pgmajfault", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "container_memory_hierarchical_pgmajfault", 10, 0)
+
+	// for node type
+	containerType = TypeNode
+	extractor = NewMemMetricExtractor(nil)
+
+	if extractor.HasValue(result[0]) {
+		cMetrics = extractor.GetValue(result[0], MockCPUMemInfo, containerType)
+	}
+
+	if extractor.HasValue(result2[0]) {
+		cMetrics = extractor.GetValue(result2[0], MockCPUMemInfo, containerType)
+	}
+
+	for _, cadvisorMetric := range cMetrics {
+		log.Printf("cadvisor Metrics received:\n %v \n", *cadvisorMetric)
+	}
+
+	AssertContainsTaggedUint(t, cMetrics[0], "node_memory_cache", 25645056)
+	AssertContainsTaggedUint(t, cMetrics[0], "node_memory_rss", 221184)
+	AssertContainsTaggedUint(t, cMetrics[0], "node_memory_max_usage", 90775552)
+	AssertContainsTaggedUint(t, cMetrics[0], "node_memory_mapped_file", 0)
+	AssertContainsTaggedUint(t, cMetrics[0], "node_memory_usage", 29728768)
+	AssertContainsTaggedUint(t, cMetrics[0], "node_memory_swap", 0)
+	AssertContainsTaggedUint(t, cMetrics[0], "node_memory_failcnt", 0)
+	AssertContainsTaggedUint(t, cMetrics[0], "node_memory_working_set", 28844032)
+	AssertContainsTaggedInt(t, cMetrics[0], "node_memory_limit", 1073741824)
+
+	AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_pgfault", 1000, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_hierarchical_pgfault", 1000, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_pgmajfault", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_hierarchical_pgmajfault", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_utilization", 2.68630981, 1.0e-8)
+
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
@@ -1,0 +1,68 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+
+	cinfo "github.com/google/cadvisor/info/v1"
+)
+
+func LoadContainerInfo(file string) []*cinfo.ContainerInfo {
+	info, err := ioutil.ReadFile(file)
+	if err != nil {
+		log.Printf("Fail to read file content: %s", err)
+	}
+
+	var result []*cinfo.ContainerInfo
+	containers := map[string]*cinfo.ContainerInfo{}
+	err = json.Unmarshal(info, &containers)
+
+	if err != nil {
+		log.Printf("Fail to parse json string: %s", err)
+	}
+
+	for _, containerInfo := range containers {
+		result = append(result, containerInfo)
+	}
+
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.Encode(result)
+	return result
+}
+
+type MockCPUMemInfo struct {
+}
+
+func (m MockCPUMemInfo) GetNumCores() int64 {
+	return 2
+}
+
+func (m MockCPUMemInfo) GetMemoryCapacity() int64 {
+	return 1073741824
+}
+
+type MockHostInfo struct {
+	MockCPUMemInfo
+	ClusterName string
+}
+
+func (m MockHostInfo) GetClusterName() string {
+	return m.ClusterName
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
@@ -18,24 +18,20 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
-	"log"
+	"testing"
 
 	cinfo "github.com/google/cadvisor/info/v1"
+	"github.com/stretchr/testify/assert"
 )
 
-func LoadContainerInfo(file string) []*cinfo.ContainerInfo {
+func LoadContainerInfo(t *testing.T, file string) []*cinfo.ContainerInfo {
 	info, err := ioutil.ReadFile(file)
-	if err != nil {
-		log.Printf("Fail to read file content: %s", err)
-	}
+	assert.Nil(t, err, "Fail to read file content")
 
 	var result []*cinfo.ContainerInfo
 	containers := map[string]*cinfo.ContainerInfo{}
 	err = json.Unmarshal(info, &containers)
-
-	if err != nil {
-		log.Printf("Fail to parse json string: %s", err)
-	}
+	assert.Nil(t, err, "Fail to parse json string")
 
 	for _, containerInfo := range containers {
 		result = append(result, containerInfo)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
To reduce the size of the PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3414, I create a separate PR to add the extractors for cpu/mem metrics. 

The extractors take the container stats generated by cadvisor as input and do some processing (e.g. rate calculation) to produce the metrics for Container Insights. 

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2307

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests.
