### PR TITLE
Disable UDP log perf test

### DIFF
--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -155,15 +155,6 @@ func TestLog10kDPS(t *testing.T) {
 				ExpectedMaxRAM: 150,
 			},
 		},
-		{
-			name:     "udp",
-			sender:   datasenders.NewTCPUDPWriter("udp", testbed.DefaultHost, testbed.GetAvailablePort(t), 1),
-			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
-			resourceSpec: testbed.ResourceSpec{
-				ExpectedMaxCPU: 80,
-				ExpectedMaxRAM: 150,
-			},
-		},
 	}
 
 	processors := map[string]string{


### PR DESCRIPTION
The test is highly unstable, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3730
