### PR TITLE
[exporter/datadog]: add note about version v28

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -1,5 +1,9 @@
 # Datadog Exporter
 
+<div class="alert alert-warning">
+The Datadog exporter version v0.28.0 (the current latest version at time of writing) has reports of an <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3786">unintended issue</a> that may cause Traces exported to Datadog to not be retained past 15 minutes. This may cause unexpected behavior in the Datadog UI. This issued should be resolved in the next release (v0.29.0), but at present the current recommended version of the Datadog Exporter is <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.27.0">v0.27.0</a>. Please <a href="https://docs.datadoghq.com/help/">Reach out to Datadog support</a> if it doesn't work as you expect.
+</div>
+
 This exporter sends metric and trace data to [Datadog](https://datadoghq.com). For environment specific setup instructions visit the [Datadog Documentation](https://docs.datadoghq.com/tracing/setup_overview/open_standards/#opentelemetry-collector-datadog-exporter).
 
 > Please review the Collector's [security

--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -1,8 +1,6 @@
 # Datadog Exporter
 
-<div class="alert alert-warning">
-The Datadog exporter version v0.28.0 (the current latest version at time of writing) has reports of an <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3786">unintended issue</a> that may cause Traces exported to Datadog to not be retained past 15 minutes. This may cause unexpected behavior in the Datadog UI. This issued should be resolved in the next release (v0.29.0), but at present the current recommended version of the Datadog Exporter is <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.27.0">v0.27.0</a>. Please <a href="https://docs.datadoghq.com/help/">Reach out to Datadog support</a> if it doesn't work as you expect.
-</div>
+> :warning: The Datadog exporter version v0.28.0 (the current latest version at time of writing) has reports of an [unintended issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3786) that may cause Traces exported to Datadog to not be retained past 15 minutes. This may cause unexpected behavior in the Datadog UI. This issued should be resolved in the next release (v0.29.0), but at present the current recommended version of the Datadog Exporter is [v0.27.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.27.0). Please [Reach out to Datadog support](https://docs.datadoghq.com/help/) if it doesn't work as you expect.
 
 This exporter sends metric and trace data to [Datadog](https://datadoghq.com). For environment specific setup instructions visit the [Datadog Documentation](https://docs.datadoghq.com/tracing/setup_overview/open_standards/#opentelemetry-collector-datadog-exporter).
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adds a warning to opentelemetry onboarding documentation with warning to users about v0.28.0, which has user reports of emitting spans that are not retained by the backend.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.> n/a

**Documentation:** <Describe the documentation added.> Updated docs

cc @mx-psi @KSerrania 