### PR TITLE
Add cadvisor to aws container insight receiver

### DIFF
--- a/receiver/awscontainerinsightreceiver/go.sum
+++ b/receiver/awscontainerinsightreceiver/go.sum
@@ -146,6 +146,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
@@ -165,10 +166,12 @@ github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/checkpoint-restore/go-criu/v5 v5.0.0 h1:TW8f/UvntYoVDMN1K2HlT82qH1rb0sOjpGw3m6Ym+i4=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cilium/ebpf v0.5.0 h1:E1KshmrMEtkMP2UjlWzfmUV1owWY+BnbL5FxxuatnrU=
 github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -177,12 +180,15 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/containerd/console v1.0.2 h1:Pi6D+aZXM+oUw1czuKgH5IJ+y0jhYcwBJfx5/Ghn9dE=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
 github.com/containerd/containerd v1.4.3 h1:ijQT13JedHSHrQGWFcGEwzcNKrAGIiZ+jSD5QQG07SY=
 github.com/containerd/containerd v1.4.3/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.4 h1:rtRG4N6Ct7GNssATwgpvMGfnjnwfjnu/Zs9W3Ikzq+M=
 github.com/containerd/containerd v1.4.4/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/ttrpc v1.0.2 h1:2/O3oTZN36q2xRolk0a2WWGgh7/Vf/liElg5hFYLX9U=
 github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8httJEt98Y=
+github.com/containerd/typeurl v1.0.1 h1:PvuK4E3D5S5q6IqsPDCy928FhP0LUIGcmZ/Yhgp5Djw=
 github.com/containerd/typeurl v1.0.1/go.mod h1:TB1hUtrpaiO88KEK56ijojHS1+NeF0izUACaJW2mdXg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -193,7 +199,9 @@ github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHo
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd/v22 v22.3.1 h1:7OO2CXWMYNDdaAzP51t4lCCZWwpQHmvPbm9sxWjm3So=
 github.com/coreos/go-systemd/v22 v22.3.1/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -205,6 +213,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crossdock/crossdock-go v0.0.0-20160816171116-049aabb0122b/go.mod h1:v9FBN7gdVTpiD/+LZ7Po0UKvROyT87uLVxTHVky/dlQ=
+github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -257,6 +266,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/euank/go-kmsg-parser v2.0.0+incompatible h1:cHD53+PLQuuQyLZeriD1V/esuG4MuU0Pjs5y6iknohY=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -422,6 +432,7 @@ github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGt
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/gocql/gocql v0.0.0-20200228163523-cd4b606dd2fb/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
+github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -672,6 +683,7 @@ github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
 github.com/karrick/godirwalk v1.8.0/go.mod h1:H5KPZjojv4lE+QYImBI8xVtrBRgYrIVsaRPx4tDPEn4=
 github.com/karrick/godirwalk v1.10.3/go.mod h1:RoGL9dQei4vP9ilrpETWE8CLOZ1kiN0LhBygSwrAsHA=
+github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -747,7 +759,9 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
+github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989 h1:PS1dLCGtD8bb9RPKJrc8bS7qHL6JnW1CZvwzH9dPoUs=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
+github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible h1:aKW/4cBs+yK6gpqU3K/oIwk9Q/XICqd3zOX/UFuvqmk=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
@@ -769,6 +783,7 @@ github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxd
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mjibson/esc v0.2.0/go.mod h1:9Hw9gxxfHulMF5OJKCyhYD7PzlSdhzXyaGEBRPH1OPs=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
+github.com/moby/sys/mountinfo v0.4.1 h1:1O+1cHA1aujwEwwVMa2Xm2l+gIpUHyd3+D+d7LZh1kM=
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 h1:rzf0wL0CHVc8CEsgyygG0Mn9CNCCPZqOPaz8RiiHYQk=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
@@ -782,6 +797,7 @@ github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJ
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:SrKMQvPiws7F7iqYp8/TX+IhxCYhzr6N/1yb8cwHsGk=
+github.com/mrunalp/fileutils v0.5.0 h1:NKzVxiH7eSk+OQ4M+ZYW1K6h27RUV3MI6NUTsHhU6Z4=
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -822,8 +838,11 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/runc v1.0.0-rc95 h1:RMuWVfY3E1ILlVsC3RhIq38n4sJtlOFwU9gfFZSqrd0=
 github.com/opencontainers/runc v1.0.0-rc95/go.mod h1:z+bZxa/+Tz/FmYVWkhUajJdzFeOqjc5vrqskhVyHGUM=
+github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/selinux v1.8.0 h1:+77ba4ar4jsCbL1GLbFL8fFM57w6suPfSS9PDLDY7KM=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
@@ -947,6 +966,7 @@ github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210223165440-c65ae3540d44 
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210223165440-c65ae3540d44/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/seccomp/libseccomp-golang v0.9.1 h1:NJjM5DNFOs0s3kYE1WUOr6G8V97sdt46rlXTMfXGWBo=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec v0.0.0-20200203094520-d13bb6d2420c/go.mod h1:gp0gaHj0WlmPh9BdsTmo1aq6C27yIPWdxCKGFGdVKBE=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
@@ -1019,6 +1039,7 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
@@ -1040,11 +1061,14 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
+github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
@@ -17,24 +17,207 @@
 package cadvisor
 
 import (
+	"errors"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/google/cadvisor/cache/memory"
+	cadvisormetrics "github.com/google/cadvisor/container"
+	"github.com/google/cadvisor/container/containerd"
+	"github.com/google/cadvisor/container/crio"
+	"github.com/google/cadvisor/container/docker"
+	"github.com/google/cadvisor/container/systemd"
+	cInfo "github.com/google/cadvisor/info/v1"
+	"github.com/google/cadvisor/manager"
+	"github.com/google/cadvisor/utils/sysfs"
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/host"
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
 )
 
+// The amount of time for which to keep stats in memory.
+const statsCacheDuration = 2 * time.Minute
+
+// Max collection interval, it is not meaningful if allowDynamicHousekeeping = false
+var maxHousekeepingInterval = 15 * time.Second
+
+// When allowDynamicHousekeeping is true, the collection interval is floating between 1s(default) to maxHousekeepingInterval
+var allowDynamicHousekeeping = true
+
+const defaultHousekeepingInterval = 10 * time.Second
+
+// define the interface for cadvisor manager so that we can mock it in tests.
+// For detailed information about these APIs, see https://github.com/google/cadvisor/blob/release-v0.39/manager/manager.go
+type cadvisorManager interface {
+	// Start the manager. Calling other manager methods before this returns
+	// may produce undefined behavior.
+	Start() error
+
+	// Get information about all subcontainers of the specified container (includes self).
+	SubcontainersInfo(containerName string, query *cInfo.ContainerInfoRequest) ([]*cInfo.ContainerInfo, error)
+}
+
+// define a function type for creating a cadvisor manager
+type createCadvisorManager func(*memory.InMemoryCache, sysfs.SysFs, manager.HouskeepingConfig, cadvisormetrics.MetricSet, *http.Client,
+	[]string, string) (cadvisorManager, error)
+
+// this is the default function that are used in production code to create a cadvisor manager
+// We define defaultCreateManager and use it as a field value for Cadvisor mainly for the purpose of
+// unit testing. Ideally we should just replace the cadvisor manager with a mock in unit tests instead of calling
+// createCadvisorManager() to create a mock. However this means that we will not be able
+// to unit test the code in `initManager(...)`. For now, I will leave code as it is. Hopefully we can find
+// a better way to mock the cadvisor related part in the future.
+var defaultCreateManager = func(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, houskeepingConfig manager.HouskeepingConfig,
+	includedMetricsSet cadvisormetrics.MetricSet, collectorHTTPClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string,
+	perfEventsFile string) (cadvisorManager, error) {
+	return manager.New(memoryCache, sysfs, houskeepingConfig, includedMetricsSet, collectorHTTPClient, rawContainerCgroupPathPrefixWhiteList, perfEventsFile)
+}
+
+type cadvisorOption func(*Cadvisor)
+
+func cadvisorManagerCreator(f createCadvisorManager) cadvisorOption {
+	return func(c *Cadvisor) {
+		c.createCadvisorManager = f
+	}
+}
+
+type hostInfo interface {
+	GetNumCores() int64
+	GetMemoryCapacity() int64
+	GetClusterName() string
+}
+
 type Cadvisor struct {
-	// TODO: add proper field for Cadvisor
+	logger                *zap.Logger
+	nodeName              string //get the value from downward API
+	createCadvisorManager createCadvisorManager
+	manager               cadvisorManager
+	version               string
+	hostInfo              hostInfo
+	containerOrchestrator string
+}
+
+func init() {
+	// Override the default cAdvisor housekeeping interval.
+	// We should use a proper way to configure once the issue is resolved: https://github.com/google/cadvisor/issues/2886
+	*manager.HousekeepingInterval = defaultHousekeepingInterval
 }
 
 // New creates a Cadvisor struct which can generate metrics from embedded cadvisor lib
-func New(containerOrchestrator string, machineInfo *host.Info, logger *zap.Logger) *Cadvisor {
-	// TODO: initialize the cadvisor
-	return &Cadvisor{}
+func New(containerOrchestrator string, hostInfo hostInfo, logger *zap.Logger, options ...cadvisorOption) (*Cadvisor, error) {
+	nodeName := os.Getenv("HOST_NAME")
+	if nodeName == "" {
+		return nil, errors.New("missing environment variable HOST_NAME. Please check your deployment YAML config")
+	}
+
+	c := &Cadvisor{
+		logger:                logger,
+		nodeName:              nodeName,
+		version:               "0",
+		createCadvisorManager: defaultCreateManager,
+		containerOrchestrator: containerOrchestrator,
+	}
+
+	// apply additional options
+	for _, option := range options {
+		option(c)
+	}
+
+	if err := c.initManager(c.createCadvisorManager); err != nil {
+		return nil, err
+	}
+
+	c.hostInfo = hostInfo
+	return c, nil
+}
+
+var metricsExtractors = []extractors.MetricExtractor{}
+
+func GetMetricsExtractors() []extractors.MetricExtractor {
+	return metricsExtractors
 }
 
 // GetMetrics generates metrics from cadvisor
 func (c *Cadvisor) GetMetrics() []pdata.Metrics {
-	// TODO: add the logic to generate the metrics from cadvisor
-	return []pdata.Metrics{}
+	c.logger.Debug("collect data from cadvisor...")
+	var result []pdata.Metrics
+	var containerinfos []*cInfo.ContainerInfo
+	var err error
+
+	//don't emit metrics if the cluster name is not detected
+	clusterName := c.hostInfo.GetClusterName()
+	if clusterName == "" {
+		c.logger.Warn("Failed to detect cluster name. Drop all metrics")
+		return result
+	}
+
+	req := &cInfo.ContainerInfoRequest{
+		NumStats: 1,
+	}
+
+	containerinfos, err = c.manager.SubcontainersInfo("/", req)
+	if err != nil {
+		c.logger.Warn("GetContainerInfo failed", zap.Error(err))
+		return result
+	}
+
+	c.logger.Debug("cadvisor containers stats", zap.Int("size", len(containerinfos)))
+	results := processContainers(containerinfos, c.hostInfo, c.containerOrchestrator, c.logger)
+
+	for _, cadvisorMetric := range results {
+		md := ci.ConvertToOTLPMetrics(cadvisorMetric.GetFields(), cadvisorMetric.GetTags(), c.logger)
+		result = append(result, md)
+	}
+
+	return result
+}
+
+// initManager accepts a function of type createCadvisorManager which can be used
+// to create a cadvisor manager
+func (c *Cadvisor) initManager(createManager createCadvisorManager) error {
+	sysFs := sysfs.NewRealSysFs()
+	includedMetrics := cadvisormetrics.MetricSet{
+		cadvisormetrics.CpuUsageMetrics:     struct{}{},
+		cadvisormetrics.MemoryUsageMetrics:  struct{}{},
+		cadvisormetrics.DiskIOMetrics:       struct{}{},
+		cadvisormetrics.NetworkUsageMetrics: struct{}{},
+		cadvisormetrics.DiskUsageMetrics:    struct{}{},
+	}
+	var cgroupRoots []string
+	if c.containerOrchestrator == ci.EKS {
+		cgroupRoots = []string{"/kubepods"}
+	}
+
+	houseKeepingConfig := manager.HouskeepingConfig{
+		Interval:     &maxHousekeepingInterval,
+		AllowDynamic: &allowDynamicHousekeeping,
+	}
+	// Create and start the cAdvisor container manager.
+	m, err := createManager(memory.New(statsCacheDuration, nil), sysFs, houseKeepingConfig, includedMetrics, http.DefaultClient, cgroupRoots, "")
+	if err != nil {
+		c.logger.Error("cadvisor manager allocate failed, ", zap.Error(err))
+		return err
+	}
+	cadvisormetrics.RegisterPlugin("containerd", containerd.NewPlugin())
+	cadvisormetrics.RegisterPlugin("crio", crio.NewPlugin())
+	cadvisormetrics.RegisterPlugin("docker", docker.NewPlugin())
+	cadvisormetrics.RegisterPlugin("systemd", systemd.NewPlugin())
+	c.manager = m
+	err = c.manager.Start()
+	if err != nil {
+		c.logger.Error("cadvisor manager start failed", zap.Error(err))
+		return err
+	}
+
+	metricsExtractors = []extractors.MetricExtractor{}
+	metricsExtractors = append(metricsExtractors, extractors.NewCPUMetricExtractor(c.logger))
+	metricsExtractors = append(metricsExtractors, extractors.NewMemMetricExtractor(c.logger))
+	metricsExtractors = append(metricsExtractors, extractors.NewDiskIOMetricExtractor(c.logger))
+	metricsExtractors = append(metricsExtractors, extractors.NewNetMetricExtractor(c.logger))
+	metricsExtractors = append(metricsExtractors, extractors.NewFileSystemMetricExtractor(c.logger))
+
+	return nil
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
@@ -19,19 +19,23 @@ package cadvisor
 import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/host"
 )
 
 // cadvisor doesn't support windows, define the dummy functions
+
+type hostInfo interface {
+	GetNumCores() int64
+	GetMemoryCapacity() int64
+	GetClusterName() string
+}
 
 // Cadvisor is a dummy struct for windows
 type Cadvisor struct {
 }
 
 // New is a dummy function to construct a dummy Cadvisor struct for windows
-func New(containerOrchestrator string, machineInfo *host.Info, logger *zap.Logger) *Cadvisor {
-	return &Cadvisor{}
+func New(containerOrchestrator string, hostInfo hostInfo, logger *zap.Logger) (*Cadvisor, error) {
+	return &Cadvisor{}, nil
 }
 
 // GetMetrics is a dummy function that always returns empty metrics for windows

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor.go
@@ -1,0 +1,218 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package cadvisor
+
+import (
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+
+	cInfo "github.com/google/cadvisor/info/v1"
+	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
+)
+
+const (
+	// TODO: https://github.com/containerd/cri/issues/922#issuecomment-423729537 the container name can be empty on containerd
+	infraContainerName = "POD"
+	podNameLabel       = "io.kubernetes.pod.name"
+	namespaceLabel     = "io.kubernetes.pod.namespace"
+	podIDLabel         = "io.kubernetes.pod.uid"
+	containerNameLabel = "io.kubernetes.container.name"
+)
+
+// podKey contains information of a pod extracted from containers owned by it.
+// containers has label information for a pod and their cgroup path is one level deeper.
+type podKey struct {
+	cgroupPath   string
+	podID        string
+	containerIds []string
+	podName      string
+	namespace    string
+}
+
+func processContainers(cInfos []*cInfo.ContainerInfo, mInfo extractors.CPUMemInfoProvider, containerOrchestrator string, logger *zap.Logger) []*extractors.CAdvisorMetric {
+	var metrics []*extractors.CAdvisorMetric
+	podKeys := make(map[string]podKey)
+
+	// first iteration of container infos processes individual container info and
+	// gather pod related info for the second iteration which generate pod metric
+	for _, info := range cInfos {
+		if len(info.Stats) == 0 {
+			continue
+		}
+		outMetrics, outPodKey, err := processContainer(info, mInfo, containerOrchestrator, logger)
+		if err != nil {
+			logger.Warn("drop some container info", zap.Error(err))
+			continue
+		}
+		metrics = append(metrics, outMetrics...)
+		// Save pod cgroup path we collected from containers under it.
+		if outPodKey != nil {
+			if key, ok := podKeys[outPodKey.cgroupPath]; !ok {
+				podKeys[outPodKey.cgroupPath] = *outPodKey
+			} else {
+				//collect the container ids associated with a pod
+				key.containerIds = append(key.containerIds, outPodKey.containerIds...)
+			}
+		}
+	}
+
+	beforePod := len(metrics)
+
+	// second iteration of container infos generates pod metrics based on the info
+	// gathered from the first iteration
+	for _, info := range cInfos {
+		if len(info.Stats) == 0 {
+			continue
+		}
+
+		metrics = append(metrics, processPod(info, mInfo, podKeys, logger)...)
+	}
+
+	// This happens when our cgroup path based pod detection logic is not working.
+	if len(metrics) == beforePod {
+		logger.Warn("No pod metric collected", zap.Any("metrics count", beforePod))
+	}
+
+	metrics = extractors.MergeMetrics(metrics)
+
+	return metrics
+}
+
+// processContainers get metrics for individual container and gather information for pod so we can look it up later.
+func processContainer(info *cInfo.ContainerInfo, mInfo extractors.CPUMemInfoProvider, containerOrchestrator string, logger *zap.Logger) ([]*extractors.CAdvisorMetric, *podKey, error) {
+	var result []*extractors.CAdvisorMetric
+	var pKey *podKey
+
+	if isContainerInContainer(info.Name) {
+		return result, pKey, fmt.Errorf("drop metric because it's nested container, name: %s", info.Name)
+	}
+
+	tags := map[string]string{}
+
+	var containerType string
+	if info.Name != "/" {
+		// Only a container has all these three labels set.
+		containerName := info.Spec.Labels[containerNameLabel]
+		namespace := info.Spec.Labels[namespaceLabel]
+		podName := info.Spec.Labels[podNameLabel]
+		podID := info.Spec.Labels[podIDLabel]
+		if containerName == "" || namespace == "" || podName == "" {
+			logger.Debug("Container labels are missing",
+				zap.String("containerName", containerName),
+				zap.String("namespace", namespace),
+				zap.String("podName", podName),
+				zap.String("podId", podID),
+			)
+			return result, pKey, nil
+		}
+
+		// Pod's cgroup path is parent for a container.
+		// container name: /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod04d39715_075e_4c7c_b128_67f7897c05b7.slice/docker-57b3dabd69b94beb462244a0c15c244b509adad0940cdcc67ca079b8208ec1f2.scope
+		// pod name:       /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod04d39715_075e_4c7c_b128_67f7897c05b7.slice/
+		podPath := path.Dir(info.Name)
+		pKey = &podKey{cgroupPath: podPath, podName: podName, podID: podID, namespace: namespace}
+
+		tags[ci.PodIDKey] = podID
+		tags[ci.K8sPodNameKey] = podName
+		tags[ci.K8sNamespace] = namespace
+		if containerName != infraContainerName {
+			tags[ci.ContainerNamekey] = containerName
+			containerID := path.Base(info.Name)
+			tags[ci.ContainerIDkey] = containerID
+			pKey.containerIds = []string{containerID}
+			containerType = ci.TypeContainer
+		} else {
+			// NOTE: the pod here is only used by NetMetricExtractor,
+			// other pod info like CPU, Mem are dealt within in processPod.
+			containerType = ci.TypePod
+		}
+	} else {
+		containerType = ci.TypeNode
+		if containerOrchestrator == ci.ECS {
+			containerType = ci.TypeInstance
+		}
+	}
+
+	tags[ci.Timestamp] = strconv.FormatInt(extractors.GetStats(info).Timestamp.UnixNano(), 10)
+
+	for _, extractor := range GetMetricsExtractors() {
+		if extractor.HasValue(info) {
+			result = append(result, extractor.GetValue(info, mInfo, containerType)...)
+		}
+	}
+
+	for _, ele := range result {
+		ele.AddTags(tags)
+	}
+	return result, pKey, nil
+}
+
+func processPod(info *cInfo.ContainerInfo, mInfo extractors.CPUMemInfoProvider, podKeys map[string]podKey, logger *zap.Logger) []*extractors.CAdvisorMetric {
+	var result []*extractors.CAdvisorMetric
+	if isContainerInContainer(info.Name) {
+		logger.Debug("drop metric because it's nested container", zap.String("name", info.Name))
+		return result
+	}
+
+	podKey, ok := podKeys[info.Name]
+	if !ok {
+		return result
+	}
+
+	tags := map[string]string{}
+	tags[ci.PodIDKey] = podKey.podID
+	tags[ci.K8sPodNameKey] = podKey.podName
+	tags[ci.K8sNamespace] = podKey.namespace
+
+	tags[ci.Timestamp] = strconv.FormatInt(extractors.GetStats(info).Timestamp.UnixNano(), 10)
+
+	for _, extractor := range GetMetricsExtractors() {
+		if extractor.HasValue(info) {
+			result = append(result, extractor.GetValue(info, mInfo, ci.TypePod)...)
+		}
+	}
+
+	for _, ele := range result {
+		ele.AddTags(tags)
+	}
+	return result
+}
+
+// Check if it's a container running inside container, caller will drop the metric when return value is true.
+// The validation is based on ContainerReference.Name, which is essentially cgroup path.
+// The first version is from https://github.com/aws/amazon-cloudwatch-agent/commit/e8daa5f5926c5a5f38e0ceb746c141be463e11e4#diff-599185154c116b295172b56311729990d20672f6659500870997c018ce072100
+// But the logic no longer works when docker is using systemd as cgroup driver, because a prefix like `kubepods` is attached to each segment.
+// The new name pattern with systemd is
+// - Guaranteed /kubepods.slice/kubepods-podc8f7bb69_65f2_4b61_ae5a_9b19ac47a239.slice/docker-523b624a86a2a74c2bedf586d8448c86887ef7858a8dec037d6559e5ad3fccb5.scope
+// - Burstable /kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podab0e310c_0bdb_48e8_ac87_81a701514645.slice/docker-caa8a5e51cd6610f8f0110b491e8187d23488b9635acccf0355a7975fd3ff158.scope
+// - Docker in Docker /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podc9adcee4_c874_4dad_8bc8_accdbd67ac3a.slice/docker-e58cfbc8b67f6e1af458efdd31cb2a8abdbf9f95db64f4c852b701285a09d40e.scope/docker/fb651068cfbd4bf3d45fb092ec9451f8d1a36b3753687bbaa0a9920617eae5b9
+// So we check the number of segements within the cgroup path to determine if it's a container running in container.
+func isContainerInContainer(p string) bool {
+	segs := strings.Split(strings.TrimLeft(p, "/"), "/")
+	// Without nested container, the number of segments (regardless of cgroupfs/systemd) are either 3 or 4 (depends on QoS)
+	// /kubepods/pod_id/docker_id
+	// /kubepods/qos/pod_id/docker_id
+	// With nested container, the number of segments are either 5 or 6
+	// /kubepods/pod_id/docker_id/docker/docker_id
+	// /kubepods/qos/pod_id/docker_id/docker/docker_id
+	return len(segs) > 4
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor_test.go
@@ -1,0 +1,82 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package cadvisor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils"
+)
+
+func TestIsContainerInContainer(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		dind bool
+	}{
+		{
+			"guaranteed",
+			"/kubepods.slice/kubepods-podc8f7bb69_65f2_4b61_ae5a_9b19ac47a239.slice/docker-523b624a86a2a74c2bedf586d8448c86887ef7858a8dec037d6559e5ad3fccb5.scope",
+			false,
+		},
+		{
+			"guaranteed-dind",
+			"/kubepods.slice/kubepods-burstable-podc9adcee4_c874_4dad_8bc8_accdbd67ac3a.slice/docker-e58cfbc8b67f6e1af458efdd31cb2a8abdbf9f95db64f4c852b701285a09d40e.scope/docker/fb651068cfbd4bf3d45fb092ec9451f8d1a36b3753687bbaa0a9920617eae5b9",
+			true,
+		},
+		{
+			"burstable",
+			"/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podab0e310c_0bdb_48e8_ac87_81a701514645.slice/docker-caa8a5e51cd6610f8f0110b491e8187d23488b9635acccf0355a7975fd3ff158.scope",
+			false,
+		},
+		{
+			"burstable-dind",
+			"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podc9adcee4_c874_4dad_8bc8_accdbd67ac3a.slice/docker-e58cfbc8b67f6e1af458efdd31cb2a8abdbf9f95db64f4c852b701285a09d40e.scope/docker/fb651068cfbd4bf3d45fb092ec9451f8d1a36b3753687bbaa0a9920617eae5b9",
+			true,
+		},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.dind, isContainerInContainer(c.path), c.name)
+	}
+}
+
+func TestProcessContainers(t *testing.T) {
+	// set the metrics extractors for testing
+	originalMetricsExtractors := metricsExtractors
+	metricsExtractors = []extractors.MetricExtractor{}
+	metricsExtractors = append(metricsExtractors, extractors.NewCPUMetricExtractor(zap.NewNop()))
+	metricsExtractors = append(metricsExtractors, extractors.NewMemMetricExtractor(zap.NewNop()))
+	metricsExtractors = append(metricsExtractors, extractors.NewDiskIOMetricExtractor(zap.NewNop()))
+	metricsExtractors = append(metricsExtractors, extractors.NewNetMetricExtractor(zap.NewNop()))
+	metricsExtractors = append(metricsExtractors, extractors.NewFileSystemMetricExtractor(zap.NewNop()))
+
+	containerInfos := testutils.LoadContainerInfo(t, "./extractors/testdata/CurInfoContainer.json")
+	podInfos := testutils.LoadContainerInfo(t, "./extractors/testdata/InfoPod.json")
+	containerInfos = append(containerInfos, podInfos...)
+	containerInContainerInfos := testutils.LoadContainerInfo(t, "./extractors/testdata/ContainerInContainer.json")
+	containerInfos = append(containerInfos, containerInContainerInfos...)
+	mInfo := testutils.MockCPUMemInfo{}
+	metrics := processContainers(containerInfos, mInfo, "eks", zap.NewNop())
+	assert.Equal(t, 3, len(metrics))
+
+	// restore the original value of metrics extractors
+	metricsExtractors = originalMetricsExtractors
+}

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -68,7 +68,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 	ctx, acir.cancel = context.WithCancel(obsreport.ReceiverContext(ctx, acir.config.ID(), "http"))
 	//ignore the error for now, will address it in later PR
 	machineInfo, _ := hostInfo.NewInfo(acir.config.CollectionInterval, acir.logger)
-	acir.cadvisor = cadvisor.New(acir.config.ContainerOrchestrator, machineInfo, acir.logger)
+	acir.cadvisor, _ = cadvisor.New(acir.config.ContainerOrchestrator, machineInfo, acir.logger)
 	acir.k8sapiserver, _ = k8sapiserver.New(machineInfo, acir.logger)
 
 	// TODO: add more intialization code

--- a/receiver/awscontainerinsightreceiver/receiver_test.go
+++ b/receiver/awscontainerinsightreceiver/receiver_test.go
@@ -91,6 +91,7 @@ func TestCollectData(t *testing.T) {
 	r.Start(context.Background(), nil)
 	ctx := context.Background()
 	r.k8sapiserver = &MockK8sAPIServer{}
+	r.cadvisor = &MockCadvisor{}
 	err = r.collectData(ctx)
 	require.Nil(t, err)
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
To reduce the size of the original PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3414, I create the current PR for setting up cadvisor:
* embed cadvisor lib inside and use it collect container stats
* use extractors to generate metrics based on container stats

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2307

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests.