### PR TITLE
[receivers/redis] Remove service_name config and type datapoint label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The OpenTelemetry Collector Contrib contains everything in the [opentelemetry-co
 
 - `f5cloud` exporter (#3509):
   - Renamed the config 'auth' field to 'f5cloud_auth'. This will prevent a config field name collision when [Support for Custom Exporter Authenticators as Extensions](https://github.com/open-telemetry/opentelemetry-collector/pull/3128) is ready to be integrated.
+- `redis` receiver (#3808)
+  - removed configuration `service_name`. Use resource processor or `resource_attributes` setting if using `receivercreator`
+  - removed `type` label and set instrumentation library name to `otelcol/redis` as other receivers do
 
 ## 💡 Enhancements 💡
 

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -153,7 +153,10 @@ receivers:
           # Static receiver-specific config.
           password: secret
           # Dynamic configuration value.
-          service_name: `pod.labels["service_name"]`
+          collection_interval: `pod.annotations["collection_interval"]`
+      resource_attributes:
+          # Dynamic configuration value.
+          service.name: `pod.labels["service_name"]`
 
       redis/2:
         # Set a resource attribute based on endpoint value.
@@ -170,9 +173,8 @@ receivers:
       redis/on_host:
         # If this rule matches an instance of this receiver will be started.
         rule: type == "port" && port == 6379 && is_ipv6 == true
-        config:
-          service_name: redis_on_host
-
+        resource_attributes:
+          service.name: redis_on_host
 
 processors:
   exampleprocessor:

--- a/receiver/redisreceiver/README.md
+++ b/receiver/redisreceiver/README.md
@@ -44,9 +44,6 @@ The following settings are required:
 
 - `endpoint` (no default): The hostname and port of the Redis instance,
 separated by a colon.
-- `service_name` (no default): The logical name of the Redis server. This
-value will be added as a `service_name` Resource label and may end up as a
-dimension on exported metrics, depending on the exporter.
 
 The following settings are optional:
 
@@ -66,7 +63,6 @@ Example:
 receivers:
   redis:
     endpoint: "localhost:6379"
-    service_name: "my-test-redis"
     collection_interval: 10s
     password: $REDIS_PASSWORD
 ```
@@ -80,7 +76,6 @@ configuration like the following:
 receivers:
   redis:
     endpoint: "localhost:6379"
-    service_name: "my-test-redis"
     collection_interval: 10s
     password: $REDIS_PASSWORD
 ```

--- a/receiver/redisreceiver/config.go
+++ b/receiver/redisreceiver/config.go
@@ -27,9 +27,6 @@ type Config struct {
 	Endpoint string `mapstructure:"endpoint"`
 	// The duration between Redis metric fetches.
 	CollectionInterval time.Duration `mapstructure:"collection_interval"`
-	// The logical name of the Redis server. This value will be added as a
-	// "service.name" Resource label.
-	ServiceName string `mapstructure:"service_name"`
 
 	// TODO allow users to add additional resource key value pairs?
 

--- a/receiver/redisreceiver/pdata.go
+++ b/receiver/redisreceiver/pdata.go
@@ -18,18 +18,6 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 )
 
-func newResourceMetrics(ms pdata.MetricSlice, serviceName string) pdata.ResourceMetrics {
-	rm := pdata.NewResourceMetrics()
-	r := rm.Resource()
-	rattrs := r.Attributes()
-	rattrs.Insert("type", pdata.NewAttributeValueString(typeStr))
-	rattrs.Insert("service.name", pdata.NewAttributeValueString(serviceName))
-	ilm := pdata.NewInstrumentationLibraryMetrics()
-	rm.InstrumentationLibraryMetrics().Append(ilm)
-	ms.CopyTo(ilm.Metrics())
-	return rm
-}
-
 func buildKeyspaceTriplet(k *keyspace, t *timeBundle) pdata.MetricSlice {
 	ms := pdata.NewMetricSlice()
 	ms.Resize(3)

--- a/receiver/redisreceiver/receiver.go
+++ b/receiver/redisreceiver/receiver.go
@@ -50,7 +50,7 @@ func (r *redisReceiver) Start(ctx context.Context, host component.Host) error {
 		Addr:     r.config.Endpoint,
 		Password: r.config.Password,
 	})
-	redisRunnable := newRedisRunnable(ctx, r.config.ID(), c, r.config.ServiceName, r.consumer, r.logger)
+	redisRunnable := newRedisRunnable(ctx, r.config.ID(), c, r.consumer, r.logger)
 	r.intervalRunner = interval.NewRunner(r.config.CollectionInterval, redisRunnable)
 
 	go func() {


### PR DESCRIPTION
This makes the receiver behave more like newer receivers that have been added.
service_name can be added with a processor or with `resource_attributes` option
in `receiver_creator`.

Resolves #2227