### PR TITLE
processor/*: Eliminate use of .Append()

### DIFF
--- a/processor/groupbyattrsprocessor/processor.go
+++ b/processor/groupbyattrsprocessor/processor.go
@@ -54,7 +54,8 @@ func (gap *groupByAttrsProcessor) ProcessTraces(ctx context.Context, td pdata.Tr
 				// Lets combine the base resource attributes + the extracted (grouped) attributes
 				// and keep them in the grouping entry
 				groupedSpans := extractedGroups.attributeGroup(rs.Resource(), groupedAttrMap)
-				matchingInstrumentationLibrarySpans(groupedSpans, ils.InstrumentationLibrary()).Spans().Append(span)
+				sp := matchingInstrumentationLibrarySpans(groupedSpans, ils.InstrumentationLibrary()).Spans().AppendEmpty()
+				span.CopyTo(sp)
 			}
 		}
 	}
@@ -93,7 +94,8 @@ func (gap *groupByAttrsProcessor) ProcessLogs(ctx context.Context, ld pdata.Logs
 				// Lets combine the base resource attributes + the extracted (grouped) attributes
 				// and keep them in the grouping entry
 				groupedLogs := extractedGroups.attributeGroup(ls.Resource(), groupedAttrMap)
-				matchingInstrumentationLibraryLogs(groupedLogs, ill.InstrumentationLibrary()).Logs().Append(log)
+				lr := matchingInstrumentationLibraryLogs(groupedLogs, ill.InstrumentationLibrary()).Logs().AppendEmpty()
+				log.CopyTo(lr)
 			}
 		}
 

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -56,6 +56,10 @@ func prepareResource(attrMap pdata.AttributeMap, selectedKeys []string) pdata.Re
 
 func filterAttributeMap(attrMap pdata.AttributeMap, selectedKeys []string) pdata.AttributeMap {
 	filteredAttrMap := pdata.NewAttributeMap()
+	if len(selectedKeys) == 0 {
+		return filteredAttrMap
+	}
+
 	filteredAttrMap.EnsureCapacity(10)
 	for _, key := range selectedKeys {
 		val, _ := attrMap.Get(key)

--- a/processor/groupbytraceprocessor/processor.go
+++ b/processor/groupbytraceprocessor/processor.go
@@ -213,7 +213,8 @@ func (sp *groupByTraceProcessor) markAsReleased(traceID pdata.TraceID, fire func
 func (sp *groupByTraceProcessor) onTraceReleased(rss []pdata.ResourceSpans) error {
 	trace := pdata.NewTraces()
 	for _, rs := range rss {
-		trace.ResourceSpans().Append(rs)
+		trs := trace.ResourceSpans().AppendEmpty()
+		rs.CopyTo(trs)
 	}
 	stats.Record(context.Background(),
 		mReleasedSpans.M(int64(trace.SpanCount())),
@@ -294,7 +295,8 @@ func splitByTrace(rs pdata.ResourceSpans) []*singleTraceBatch {
 			}
 
 			// there is only one instrumentation library per batch
-			batches[sTraceID].rs.InstrumentationLibrarySpans().At(0).Spans().Append(span)
+			sp := batches[sTraceID].rs.InstrumentationLibrarySpans().At(0).Spans().AppendEmpty()
+			span.CopyTo(sp)
 		}
 	}
 

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
@@ -131,7 +131,8 @@ func Test_ecsDetectV4(t *testing.T) {
 	for i, field := range attribFields {
 		ava := pdata.NewAttributeValueArray()
 		av := ava.ArrayVal()
-		av.Append(pdata.NewAttributeValueString(attribVals[i]))
+		avs := av.AppendEmpty()
+		pdata.NewAttributeValueString(attribVals[i]).CopyTo(avs)
 		attr.Insert(field, ava)
 	}
 

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -388,7 +388,8 @@ func prepareTraceBatch(rss pdata.ResourceSpans, spans []*pdata.Span) pdata.Trace
 	rss.Resource().CopyTo(rs.Resource())
 	ils := rs.InstrumentationLibrarySpans().AppendEmpty()
 	for _, span := range spans {
-		ils.Spans().Append(*span)
+		sp := ils.Spans().AppendEmpty()
+		span.CopyTo(sp)
 	}
 	return traceTd
 }


### PR DESCRIPTION
**Description:**  Removes use of `.Append()` on `pdata` types in processor modules.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/2488

**Testing:** Unit tests were executed for affected modules.