### PR TITLE
Sentry: Add exception event capture in sentry

### DIFF
--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -42,6 +42,8 @@ var canonicalCodes = [...]sentry.SpanStatus{
 	sentry.SpanStatusOK,
 	sentry.SpanStatusUnknown,
 }
+// exceptionEvents is a mutable slice of exception events in spans recorded as Sentry events.
+var exceptionEvents []*sentry.Event
 
 // SentryExporter defines the Sentry Exporter.
 type SentryExporter struct {
@@ -74,7 +76,9 @@ func (s *SentryExporter) pushTraceData(_ context.Context, td pdata.Traces) error
 
 			spans := ils.Spans()
 			for k := 0; k < spans.Len(); k++ {
-				sentrySpan := convertToSentrySpan(spans.At(k), library, resourceTags)
+				otelSpan := spans.At(k)
+				sentrySpan := convertToSentrySpan(otelSpan, library, resourceTags)
+				convertEventstoSentryExceptions(&exceptionEvents, otelSpan.Events(), sentrySpan)
 
 				// If a span is a root span, we consider it the start of a Sentry transaction.
 				// We should then create a new transaction for that root span, and keep track of it.
@@ -106,7 +110,9 @@ func (s *SentryExporter) pushTraceData(_ context.Context, td pdata.Traces) error
 
 	transactions := generateTransactions(transactionMap, orphanSpans)
 
-	s.transport.SendTransactions(transactions)
+	events := append(transactions, exceptionEvents...)
+
+	s.transport.SendEvents(events)
 
 	return nil
 }
@@ -125,6 +131,67 @@ func generateTransactions(transactionMap map[sentry.SpanID]*sentry.Event, orphan
 	}
 
 	return transactions
+}
+
+// convertEventstoSentryExceptions creates a set of sentry events from exception events present in spans.
+// These events are stored in a mutated eventList
+func convertEventstoSentryExceptions(eventList *[]*sentry.Event, events pdata.SpanEventSlice, sentrySpan *sentry.Span) {
+	for i := 0; i < events.Len(); i++ {
+		event := events.At(i)
+		if event.Name() != "exception" {
+			continue
+		}
+		var exceptionMessage, exceptionStacktrace, exceptionType string
+		event.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
+			switch k {
+			case conventions.AttributeExceptionMessage:
+				exceptionMessage = v.StringVal()
+			case conventions.AttributeExceptionStacktrace:
+				exceptionStacktrace = v.StringVal()
+			case conventions.AttributeExceptionType:
+				exceptionType = v.StringVal()
+			}
+			return true
+		})
+		if exceptionMessage == "" && exceptionType == "" {
+			// `At least one of the following sets of attributes is required:
+			// - exception.type
+			// - exception.message`
+			continue
+		}
+		sentryEvent := eventFromError(exceptionMessage, exceptionType, sentrySpan)
+		*eventList = append(*eventList, sentryEvent)
+	}
+}
+
+// eventFromError creates a sentry event from error event in a span
+func eventFromError(errorMessage, errorType string, span *sentry.Span) *sentry.Event {
+	event := sentry.NewEvent()
+
+	event.Contexts["trace"] = sentry.TraceContext{
+		TraceID: span.TraceID,
+		SpanID:  span.SpanID,
+		Op:      span.Op,
+		Status:  span.Status,
+	}
+
+	event.Type = errorType
+	event.Message = errorMessage
+	event.Level = "error"
+	event.Exception = []sentry.Exception{{
+		Value: errorMessage,
+		Type: errorType,
+	}}
+
+	event.Sdk.Name = otelSentryExporterName
+	event.Sdk.Version = otelSentryExporterVersion
+
+	event.StartTime = span.StartTime
+	event.Tags = span.Tags
+	event.Timestamp = span.EndTime
+	event.Transaction = span.Description
+
+	return event
 }
 
 // classifyAsOrphanSpans iterates through a list of possible orphan spans and tries to associate them

--- a/exporter/sentryexporter/sentry_exporter_test.go
+++ b/exporter/sentryexporter/sentry_exporter_test.go
@@ -17,6 +17,7 @@ package sentryexporter
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"testing"
 
 	"github.com/getsentry/sentry-go"
@@ -168,6 +169,112 @@ func generateOrphanSpansFromSpans(spans ...*sentry.Span) []*sentry.Span {
 	orphanSpans = append(orphanSpans, spans...)
 
 	return orphanSpans
+}
+
+type SpanEventToSentryEventCases struct {
+	testName            string
+	errorMessage        string
+	errorType           string
+	sampleSentrySpan    *sentry.Span
+	expectedSentryEvent *sentry.Event
+	expectedError       error
+}
+
+func TestSpanEventToSentryEvent(t *testing.T) {
+	// Creating expected Sentry Events and Sample Sentry Spans before hand to avoid redundancy
+	sampleSentrySpanForEvent := &sentry.Span{
+		TraceID:      TraceIDFromHex("01020304050607080807060504030201"),
+		SpanID:       SpanIDFromHex("0102030405060708"),
+		ParentSpanID: SpanIDFromHex("0807060504030201"),
+		Description:  "span_name",
+		Op:           "",
+		Tags: map[string]string{
+			"key":             "value",
+			"library_name":    "otel-go",
+			"library_version": "1.4.3",
+			"aws_instance":    "ap-south-1",
+			"unique_id":       "abcd1234",
+			"span_kind":       pdata.SpanKindClient.String(),
+			"status_message":  "message",
+		},
+		StartTime: unixNanoToTime(123),
+		EndTime:   unixNanoToTime(1234567890),
+		Status:    sentry.SpanStatusOK,
+	}
+	sentryEventBase := sentry.Event{
+		Level: "error",
+		Sdk: sentry.SdkInfo{
+			Name:    "sentry.opentelemetry",
+			Version: "0.0.2",
+		},
+		Tags:        sampleSentrySpanForEvent.Tags,
+		Timestamp:   sampleSentrySpanForEvent.EndTime,
+		Transaction: sampleSentrySpanForEvent.Description,
+		Contexts:    map[string]interface{}{},
+		Extra:       map[string]interface{}{},
+		Modules:     map[string]string{},
+		StartTime:   unixNanoToTime(123),
+	}
+	sentryEventBase.Contexts["trace"] = sentry.TraceContext{
+		TraceID: sampleSentrySpanForEvent.TraceID,
+		SpanID:  sampleSentrySpanForEvent.SpanID,
+		Op:      sampleSentrySpanForEvent.Op,
+		Status:  sampleSentrySpanForEvent.Status,
+	}
+	errorType := "mySampleType"
+	errorMessage := "Kernel Panic"
+	testCases := []SpanEventToSentryEventCases{
+		{
+			testName:         "Exception Event with both exception type and message",
+			errorMessage:     errorMessage,
+			errorType:        errorType,
+			sampleSentrySpan: sampleSentrySpanForEvent,
+			expectedSentryEvent: func() *sentry.Event {
+				expectedSentryEventWithTypeAndMessage := sentryEventBase
+				expectedSentryEventWithTypeAndMessage.Type = errorType
+				expectedSentryEventWithTypeAndMessage.Message = errorMessage
+				expectedSentryEventWithTypeAndMessage.Exception = []sentry.Exception{{
+					Value: errorMessage,
+					Type:  errorType,
+				}}
+				return &expectedSentryEventWithTypeAndMessage
+			}(),
+			expectedError: nil,
+		},
+		{
+			testName:         "Exception Event with only exception type",
+			errorMessage:     "",
+			errorType:        errorType,
+			sampleSentrySpan: sampleSentrySpanForEvent,
+			expectedSentryEvent: func() *sentry.Event {
+				expectedSentryEventWithType := sentryEventBase
+				expectedSentryEventWithType.Type = errorType
+				expectedSentryEventWithType.Exception = []sentry.Exception{{
+					Value: "",
+					Type:  errorType,
+				}}
+				return &expectedSentryEventWithType
+			}(),
+			expectedError: nil,
+		},
+		{
+			testName:            "Exception Event with neither exception type nor exception message",
+			errorMessage:        "",
+			errorType:           "",
+			sampleSentrySpan:    sampleSentrySpanForEvent,
+			expectedSentryEvent: nil,
+			expectedError:       errors.New("error type and error message were both empty"),
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.testName, func(t *testing.T) {
+			sentryEvent, err := sentryEventFromError(test.errorMessage, test.errorType, test.sampleSentrySpan)
+			assert.Equal(t, test.expectedError, err)
+			assert.Equal(t, test.expectedSentryEvent, sentryEvent)
+		})
+	}
 }
 
 func TestSpanToSentrySpan(t *testing.T) {

--- a/exporter/sentryexporter/sentry_exporter_test.go
+++ b/exporter/sentryexporter/sentry_exporter_test.go
@@ -499,7 +499,7 @@ type mockTransport struct {
 	transactions []*sentry.Event
 }
 
-func (t *mockTransport) SendTransactions(transactions []*sentry.Event) {
+func (t *mockTransport) SendEvents(transactions []*sentry.Event) {
 	t.transactions = transactions
 	t.called = true
 }

--- a/exporter/sentryexporter/transport.go
+++ b/exporter/sentryexporter/transport.go
@@ -23,7 +23,7 @@ import (
 
 // transport is used by exporter to send events to Sentry
 type transport interface {
-	SendTransactions(transactions []*sentry.Event)
+	SendEvents(events []*sentry.Event)
 	Configure(options sentry.ClientOptions)
 	Flush(ctx context.Context) bool
 }
@@ -53,7 +53,7 @@ func (t *sentryTransport) Flush(ctx context.Context) bool {
 }
 
 // sendTransactions uses a Sentry HTTPTransport to send transaction events to Sentry
-func (t *sentryTransport) SendTransactions(transactions []*sentry.Event) {
+func (t *sentryTransport) SendEvents(transactions []*sentry.Event) {
 	bufferCounter := 0
 	for _, transaction := range transactions {
 		// We should flush all events when we send transactions equal to the transport


### PR DESCRIPTION
Signed-off-by: Uddeshya Singh <singhuddeshyaofficial@gmail.com>

**Description:** <Describe what has changed.>
This commit will iterate through span events and convert the `exception` events to their equivalent sentry error events.

This handling has been inspired by `elastic-exporter` encoding of events enclosed here : https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/9c7c329f0877f72befb36c61c47899d5a4525037/exporter/elasticexporter/internal/translator/elastic/traces.go#L376-L402 

**Link to tracking Issue:**  #3809 

**Testing:** None yet

**Documentation:** None yet