### PR TITLE
Splunk HEC exporter: remove mentions of `insecure` config option 

### DIFF
--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -56,13 +56,11 @@ exporters:
     timeout: 10s
     # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
     insecure_skip_verify: false
-    # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
-    insecure: false
-    # Path to the CA cert to verify the server being connected to. Should only be used if `insecure` is set to false.
+    # Path to the CA cert to verify the server being connected to.
     ca_file: /certs/ExampleCA.crt
-    # Path to the TLS cert to use for client connections when TLS client auth is required. Should only be used if `insecure` is set to false.
+    # Path to the TLS cert to use for client connections when TLS client auth is required.
     cert_file: /certs/HECclient.crt
-    # Path to the TLS key to use for TLS required connections. Should only be used if `insecure` is set to false.
+    # Path to the TLS key to use for TLS required connections.
     key_file: /certs/HECclient.key
     # Application name is used to track telemetry information for Splunk App's using HEC by App name.
     splunk_app_name: "OpenTelemetry-Collector Splunk Exporter"

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -83,7 +83,6 @@ func TestLoadConfig(t *testing.T) {
 				CertFile: "",
 				KeyFile:  "",
 			},
-			Insecure:           true,
 			InsecureSkipVerify: false,
 		},
 	}

--- a/exporter/splunkhecexporter/exporter_test.go
+++ b/exporter/splunkhecexporter/exporter_test.go
@@ -71,7 +71,6 @@ func TestNew(t *testing.T) {
 				CertFile: "file-not-found",
 				KeyFile:  "file-not-found",
 			},
-			Insecure:           false,
 			InsecureSkipVerify: false,
 		},
 	}

--- a/exporter/splunkhecexporter/testdata/config.yaml
+++ b/exporter/splunkhecexporter/testdata/config.yaml
@@ -15,7 +15,6 @@ exporters:
     sourcetype: "otel"
     index: "metrics"
     insecure_skip_verify: false
-    insecure: true
     ca_file: ""
     cert_file: ""
     key_file: ""


### PR DESCRIPTION
`insecure_skip_verify` and `insecure` both have the same description in README, but `insecure` is applicable only for GRPC and is no-op for HEC requests. This commit removes mentions of `insecure` config option.