### PR TITLE
Revert part of CHANGELOG as #3754 was not released in v0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 💡 Enhancements 💡
+
+- `tailsampling` processor: Add new policy `status_code` (#3754)
+
 ## v0.29.0
 
 # 🎉 OpenTelemetry Collector Contrib v0.29.0 (Beta) 🎉


### PR DESCRIPTION
**Description:**
Fixes the CHANGELOG: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3754 was merged after v0.29 was released, so it should not be under the v0.29 section.
