### PR TITLE
Bump go to 1.16 on Windows CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ commands:
       - run:
           name: Upgrade golang
           command: |
-            choco upgrade golang --version=1.15
+            choco upgrade golang --version=1.16
             refreshenv
       - run:
           name: Unit tests


### PR DESCRIPTION
**Description:** 

Bump Windows to 1.16 on CircleCI. 

**Link to tracking Issue:** fixes #4029
