### PR TITLE
Install issuegenerator on windows before running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,11 @@ commands:
             choco upgrade golang --version=1.16
             refreshenv
       - run:
+          name: Install issue generator
+          command: |
+            cd internal\tools
+            go install go.opentelemetry.io/collector/cmd/issuegenerator
+      - run:
           name: Unit tests
           command: (Get-Childitem -Include go.mod -Recurse) | ForEach-Object { cd (Split-Path $_ -Parent); go test ./...; if ($LastExitCode -gt 0) { exit $LastExitCode } }
       - save_module_cache


### PR DESCRIPTION
Windows tests are unable to report issues back to Github right now as issuegenerator is not installed. This patch makes sure issue generator is installed on windows before running tests.