### PR TITLE
Remove locking only used on startup/shutdown

### DIFF
--- a/internal/stanza/receiver.go
+++ b/internal/stanza/receiver.go
@@ -30,8 +30,7 @@ import (
 )
 
 type receiver struct {
-	id config.ComponentID
-	sync.Mutex
+	id     config.ComponentID
 	wg     sync.WaitGroup
 	cancel context.CancelFunc
 
@@ -48,8 +47,6 @@ var _ component.LogsReceiver = (*receiver)(nil)
 
 // Start tells the receiver to start
 func (r *receiver) Start(ctx context.Context, host component.Host) error {
-	r.Lock()
-	defer r.Unlock()
 	rctx, cancel := context.WithCancel(ctx)
 	r.cancel = cancel
 	r.logger.Info("Starting stanza receiver")
@@ -138,9 +135,6 @@ func (r *receiver) consumerLoop(ctx context.Context) {
 
 // Shutdown is invoked during service shutdown
 func (r *receiver) Shutdown(ctx context.Context) error {
-	r.Lock()
-	defer r.Unlock()
-
 	r.logger.Info("Stopping stanza receiver")
 	agentErr := r.agent.Stop()
 	r.converter.Stop()

--- a/receiver/collectdreceiver/receiver.go
+++ b/receiver/collectdreceiver/receiver.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
@@ -36,7 +35,6 @@ var _ component.MetricsReceiver = (*collectdReceiver)(nil)
 
 // collectdReceiver implements the component.MetricsReceiver for CollectD protocol.
 type collectdReceiver struct {
-	sync.Mutex
 	logger             *zap.Logger
 	addr               string
 	server             *http.Server
@@ -72,9 +70,6 @@ func newCollectdReceiver(
 
 // Start starts an HTTP server that can process CollectD JSON requests.
 func (cdr *collectdReceiver) Start(_ context.Context, host component.Host) error {
-	cdr.Lock()
-	defer cdr.Unlock()
-
 	go func() {
 		if err := cdr.server.ListenAndServe(); err != http.ErrServerClosed {
 			host.ReportFatalError(fmt.Errorf("error starting collectd receiver: %v", err))
@@ -85,9 +80,6 @@ func (cdr *collectdReceiver) Start(_ context.Context, host component.Host) error
 
 // Shutdown stops the CollectD receiver.
 func (cdr *collectdReceiver) Shutdown(context.Context) error {
-	cdr.Lock()
-	defer cdr.Unlock()
-
 	return cdr.server.Shutdown(context.Background())
 }
 

--- a/receiver/sapmreceiver/trace_receiver.go
+++ b/receiver/sapmreceiver/trace_receiver.go
@@ -43,8 +43,6 @@ var gzipWriterPool = &sync.Pool{
 
 // sapmReceiver receives spans in the Splunk SAPM format over HTTP
 type sapmReceiver struct {
-	// mu protects the fields of this type
-	mu     sync.Mutex
 	logger *zap.Logger
 
 	config *Config
@@ -161,9 +159,6 @@ func (sr *sapmReceiver) HTTPHandlerFunc(rw http.ResponseWriter, req *http.Reques
 
 // Start starts the sapmReceiver's server.
 func (sr *sapmReceiver) Start(_ context.Context, host component.Host) error {
-	sr.mu.Lock()
-	defer sr.mu.Unlock()
-
 	// set up the listener
 	ln, err := sr.config.HTTPServerSettings.ToListener()
 	if err != nil {
@@ -188,9 +183,6 @@ func (sr *sapmReceiver) Start(_ context.Context, host component.Host) error {
 
 // Shutdown stops the the sapmReceiver's server.
 func (sr *sapmReceiver) Shutdown(context.Context) error {
-	sr.mu.Lock()
-	defer sr.mu.Unlock()
-
 	return sr.server.Close()
 }
 

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -35,7 +34,6 @@ var _ component.MetricsReceiver = (*statsdReceiver)(nil)
 
 // statsdReceiver implements the component.MetricsReceiver for StatsD protocol.
 type statsdReceiver struct {
-	sync.Mutex
 	logger *zap.Logger
 	config *Config
 
@@ -88,9 +86,6 @@ func buildTransportServer(config Config) (transport.Server, error) {
 
 // Start starts a UDP server that can process StatsD messages.
 func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
-	r.Lock()
-	defer r.Unlock()
-
 	ctx, r.cancel = context.WithCancel(ctx)
 	var transferChan = make(chan string, 10)
 	ticker := time.NewTicker(r.config.AggregationInterval)
@@ -122,9 +117,6 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 
 // Shutdown stops the StatsD receiver.
 func (r *statsdReceiver) Shutdown(context.Context) error {
-	r.Lock()
-	defer r.Unlock()
-
 	err := r.server.Close()
 	r.cancel()
 	return err


### PR DESCRIPTION
This removes locking that is only used for calls to Startup/Shutdown. These
functions are run in the same goroutine so there should be no
memory-inconsistency in calls to Startup and Shutdown.

Fixes open-telemetry/opentelemetry-collector#3041