### PR TITLE
[loadbalancingexporter] Bump time for `TestRollingUpdatesWhenConsumeTraces`

### DIFF
--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -472,7 +472,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	// will still pass due to the 10 secs of sleep that is used to simulate
 	// unreachable backends.
 	go func() {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(300 * time.Millisecond)
 		resolverCh <- struct{}{}
 	}()
 


### PR DESCRIPTION
**Description:** 

Bump time for `TestRollingUpdatesWhenConsumeTraces` test. 

After #4030 we now use Go 1.16 and are thus affected by golang/go#44343. 
The timers are very unreliable and therefore we need to give some more time to the goroutine to consume traces.

**Link to tracking Issue:** Fixes #4043
