### PR TITLE
[ecsobserver] Bump time for `TestExtensionStartStop`

### DIFF
--- a/extension/observer/ecsobserver/extension_test.go
+++ b/extension/observer/ecsobserver/extension_test.go
@@ -75,7 +75,7 @@ func (h *inspectErrorHost) getError() error {
 // In that case sd itself does not use timer and relies on caller to trigger List.
 func TestExtensionStartStop(t *testing.T) {
 	settings := component.ExtensionCreateSettings{Logger: zap.NewExample()}
-	refreshInterval := time.Millisecond
+	refreshInterval := 100 * time.Millisecond
 	waitDuration := 2 * refreshInterval
 
 	createTestExt := func(c *ecsmock.Cluster, output string) component.Extension {


### PR DESCRIPTION
**Description:** 

Bump time for `TestExtensionStartStop` test. 

After #4030 we now use Go 1.16 and are thus affected by golang/go#44343 (well, not now but we will be). 
The timers are very unreliable and therefore we need to increase the time for the test to pass.

**Link to tracking Issue:** Fixes #4042 (I think?)