### PR TITLE
Support sub-millisecond latency buckets

### DIFF
--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -78,7 +78,7 @@ processors:
   batch:
   spanmetrics:
     metrics_exporter: otlp/spanmetrics
-    latency_histogram_buckets: [5ns, 8us, 2ms, 6ms, 10ms, 100ms, 250ms]
+    latency_histogram_buckets: [100us, 1ms, 2ms, 6ms, 10ms, 100ms, 250ms]
     dimensions:
       - name: http.method
         default: GET

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -78,7 +78,7 @@ processors:
   batch:
   spanmetrics:
     metrics_exporter: otlp/spanmetrics
-    latency_histogram_buckets: [2ms, 6ms, 10ms, 100ms, 250ms]
+    latency_histogram_buckets: [5ns, 8us, 2ms, 6ms, 10ms, 100ms, 250ms]
     dimensions:
       - name: http.method
         default: GET

--- a/processor/spanmetricsprocessor/config_test.go
+++ b/processor/spanmetricsprocessor/config_test.go
@@ -46,6 +46,8 @@ func TestLoadConfig(t *testing.T) {
 			configFile:          "config-full.yaml",
 			wantMetricsExporter: "otlp/spanmetrics",
 			wantLatencyHistogramBuckets: []time.Duration{
+				5 * time.Nanosecond,
+				8 * time.Microsecond,
 				2 * time.Millisecond,
 				6 * time.Millisecond,
 				10 * time.Millisecond,

--- a/processor/spanmetricsprocessor/config_test.go
+++ b/processor/spanmetricsprocessor/config_test.go
@@ -46,8 +46,8 @@ func TestLoadConfig(t *testing.T) {
 			configFile:          "config-full.yaml",
 			wantMetricsExporter: "otlp/spanmetrics",
 			wantLatencyHistogramBuckets: []time.Duration{
-				5 * time.Nanosecond,
-				8 * time.Microsecond,
+				100 * time.Microsecond,
+				1 * time.Millisecond,
 				2 * time.Millisecond,
 				6 * time.Millisecond,
 				10 * time.Millisecond,

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -136,6 +136,27 @@ func TestProcessorShutdown(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestConfigureLatencyBounds(t *testing.T) {
+	// Prepare
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.LatencyHistogramBuckets = []time.Duration{
+		3 * time.Nanosecond,
+		3 * time.Microsecond,
+		3 * time.Millisecond,
+		3 * time.Second,
+	}
+
+	// Test
+	next := new(consumertest.TracesSink)
+	p, err := newProcessor(zap.NewNop(), cfg, next)
+
+	// Verify
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+	assert.Equal(t, []float64{0.000003, 0.003, 3, 3000, maxDurationMs}, p.latencyBounds)
+}
+
 func TestProcessorCapabilities(t *testing.T) {
 	// Prepare
 	factory := NewFactory()

--- a/processor/spanmetricsprocessor/testdata/config-full.yaml
+++ b/processor/spanmetricsprocessor/testdata/config-full.yaml
@@ -34,7 +34,7 @@ processors:
   batch:
   spanmetrics:
     metrics_exporter: otlp/spanmetrics
-    latency_histogram_buckets: [2ms, 6ms, 10ms, 100ms, 250ms]
+    latency_histogram_buckets: [5ns, 8us, 2ms, 6ms, 10ms, 100ms, 250ms]
 
     # Additional list of dimensions on top of:
     # - service.name

--- a/processor/spanmetricsprocessor/testdata/config-full.yaml
+++ b/processor/spanmetricsprocessor/testdata/config-full.yaml
@@ -34,7 +34,7 @@ processors:
   batch:
   spanmetrics:
     metrics_exporter: otlp/spanmetrics
-    latency_histogram_buckets: [5ns, 8us, 2ms, 6ms, 10ms, 100ms, 250ms]
+    latency_histogram_buckets: [100us, 1ms, 2ms, 6ms, 10ms, 100ms, 250ms]
 
     # Additional list of dimensions on top of:
     # - service.name


### PR DESCRIPTION
Signed-off-by: albertteoh <albert.teoh@logz.io>

**Description:** 
Fixes the lack of support for sub-millisecond latency buckets.

**Link to tracking Issue:** Fixes #4051

**Testing:** 
Updated unit tests to fail, then implement fix to pass.

Integration tested locally with prometheus exporter. The output from the otel collector's `/metrics` endpoint:
```
# HELP latency 
# TYPE latency histogram
latency_bucket{operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="5e-06"} 0
latency_bucket{operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="0.008"} 0
latency_bucket{operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="2"} 1
latency_bucket{operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="6"} 1
...
```
**Documentation:** 
Update example `config-full.yaml` file and README to contain a 5ns and 8us buckets.