### PR TITLE
[extension/ecsobserver] Reduce exported types

### DIFF
--- a/extension/observer/ecsobserver/config.go
+++ b/extension/observer/ecsobserver/config.go
@@ -96,9 +96,9 @@ func DefaultConfig() Config {
 	}
 }
 
-// ExampleConfig returns an example instance that matches testdata/config_example.yaml.
+// exampleConfig returns an example instance that matches testdata/config_example.yaml.
 // It can be used to validate if the struct tags like mapstructure, yaml are working properly.
-func ExampleConfig() Config {
+func exampleConfig() Config {
 	return Config{
 		ClusterName:     "ecs-sd-test-1",
 		ClusterRegion:   "us-west-2",

--- a/extension/observer/ecsobserver/config_test.go
+++ b/extension/observer/ecsobserver/config_test.go
@@ -50,7 +50,7 @@ func TestLoadConfig(t *testing.T) {
 
 	// Example Config
 	ext2 := cfg.Extensions[config.NewIDWithName(typeStr, "2")]
-	ext2Expected := ExampleConfig()
+	ext2Expected := exampleConfig()
 	ext2Expected.ExtensionSettings = config.NewExtensionSettings(config.NewIDWithName(typeStr, "2"))
 	assert.Equal(t, &ext2Expected, ext2)
 

--- a/extension/observer/ecsobserver/docker_label_test.go
+++ b/extension/observer/ecsobserver/docker_label_test.go
@@ -60,8 +60,8 @@ func TestDockerLabelMatcher_Match(t *testing.T) {
 	jobLabel := "MY_PROMETHEUS_JOB"
 	metricsPathLabel := "MY_METRICS_PATH"
 
-	genTasks := func() []*Task {
-		return []*Task{
+	genTasks := func() []*taskAnnotated {
+		return []*taskAnnotated{
 			{
 				Definition: &ecs.TaskDefinition{
 					ContainerDefinitions: []*ecs.ContainerDefinition{
@@ -119,15 +119,15 @@ func TestDockerLabelMatcher_Match(t *testing.T) {
 			JobNameLabel: jobLabel,
 		}
 		res := newMatcherAndMatch(t, &cfg, genTasks())
-		assert.Equal(t, &MatchResult{
+		assert.Equal(t, &matchResult{
 			Tasks: []int{0},
-			Containers: []MatchedContainer{
+			Containers: []matchedContainer{
 				{
 					TaskIndex:      0,
 					ContainerIndex: 0,
-					Targets: []MatchedTarget{
+					Targets: []matchedTarget{
 						{
-							MatcherType: MatcherTypeDockerLabel,
+							MatcherType: matcherTypeDockerLabel,
 							Port:        2112,
 							Job:         "PROM_JOB_1",
 						},
@@ -143,7 +143,7 @@ func TestDockerLabelMatcher_Match(t *testing.T) {
 		}
 		m := newMatcher(t, &cfg)
 		// Direct match has error
-		_, err := m.MatchTargets(genTasks()[0], genTasks()[0].Definition.ContainerDefinitions[2])
+		_, err := m.matchTargets(genTasks()[0], genTasks()[0].Definition.ContainerDefinitions[2])
 		require.Error(t, err)
 
 		// errNotMatched is ignored
@@ -169,15 +169,15 @@ func TestDockerLabelMatcher_Match(t *testing.T) {
 			MetricsPathLabel: metricsPathLabel,
 		}
 		res := newMatcherAndMatch(t, &cfg, genTasks())
-		assert.Equal(t, &MatchResult{
+		assert.Equal(t, &matchResult{
 			Tasks: []int{0},
-			Containers: []MatchedContainer{
+			Containers: []matchedContainer{
 				{
 					TaskIndex:      0,
 					ContainerIndex: 0,
-					Targets: []MatchedTarget{
+					Targets: []matchedTarget{
 						{
-							MatcherType: MatcherTypeDockerLabel,
+							MatcherType: matcherTypeDockerLabel,
 							Port:        2112,
 							MetricsPath: "/new/metrics",
 						},
@@ -196,15 +196,15 @@ func TestDockerLabelMatcher_Match(t *testing.T) {
 			},
 		}
 		res := newMatcherAndMatch(t, &cfg, genTasks())
-		assert.Equal(t, &MatchResult{
+		assert.Equal(t, &matchResult{
 			Tasks: []int{0},
-			Containers: []MatchedContainer{
+			Containers: []matchedContainer{
 				{
 					TaskIndex:      0,
 					ContainerIndex: 0,
-					Targets: []MatchedTarget{
+					Targets: []matchedTarget{
 						{
-							MatcherType: MatcherTypeDockerLabel,
+							MatcherType: matcherTypeDockerLabel,
 							Port:        2112,
 							Job:         "override docker label",
 						},

--- a/extension/observer/ecsobserver/error.go
+++ b/extension/observer/ecsobserver/error.go
@@ -102,15 +102,15 @@ func extractErrorFields(err error) ([]zap.Field, string) {
 	if ok {
 		// Rename ok to tok because linter says it shadows outer ok.
 		// Though the linter seems to allow the similar block to shadow...
-		if task, tok := v.(*Task); tok {
+		if task, tok := v.(*taskAnnotated); tok {
 			fields = append(fields, zap.String("TaskArn", aws.StringValue(task.Task.TaskArn)))
-			scope = "Task"
+			scope = "taskAnnotated"
 		}
 	}
 	v, ok = errctx.ValueFrom(err, errKeyTarget)
 	if ok {
-		if target, ok := v.(MatchedTarget); ok {
-			fields = append(fields, zap.String("MatcherType", target.MatcherType.String()))
+		if target, ok := v.(matchedTarget); ok {
+			fields = append(fields, zap.String("matcherType", target.MatcherType.String()))
 			scope = "Target"
 		}
 	}

--- a/extension/observer/ecsobserver/filter.go
+++ b/extension/observer/ecsobserver/filter.go
@@ -23,10 +23,10 @@ import (
 
 type taskFilter struct {
 	logger   *zap.Logger
-	matchers map[MatcherType][]Matcher
+	matchers map[matcherType][]targetMatcher
 }
 
-func newTaskFilter(logger *zap.Logger, matchers map[MatcherType][]Matcher) *taskFilter {
+func newTaskFilter(logger *zap.Logger, matchers map[matcherType][]targetMatcher) *taskFilter {
 	return &taskFilter{
 		logger:   logger,
 		matchers: matchers,
@@ -34,9 +34,9 @@ func newTaskFilter(logger *zap.Logger, matchers map[MatcherType][]Matcher) *task
 }
 
 // Filter run all the matchers and return all the tasks that including at least one matched container.
-func (f *taskFilter) filter(tasks []*Task) ([]*Task, error) {
+func (f *taskFilter) filter(tasks []*taskAnnotated) ([]*taskAnnotated, error) {
 	// Group result by matcher type, each type can have multiple configs.
-	matched := make(map[MatcherType][]*MatchResult)
+	matched := make(map[matcherType][]*matchResult)
 	var merr error
 	for tpe, matchers := range f.matchers { // for each type of matchers
 		for index, matcher := range matchers { // for individual matchers of same type
@@ -49,7 +49,7 @@ func (f *taskFilter) filter(tasks []*Task) ([]*Task, error) {
 
 			// TODO: print out the pattern to include both pattern and port
 			f.logger.Debug("matched",
-				zap.String("MatcherType", tpe.String()), zap.Int("MatcherIndex", index),
+				zap.String("matcherType", tpe.String()), zap.Int("MatcherIndex", index),
 				zap.Int("Tasks", len(tasks)), zap.Int("MatchedTasks", len(res.Tasks)),
 				zap.Int("MatchedContainers", len(res.Containers)))
 			matched[tpe] = append(matched[tpe], res)
@@ -75,7 +75,7 @@ func (f *taskFilter) filter(tasks []*Task) ([]*Task, error) {
 		taskIndexes = append(taskIndexes, k)
 	}
 	sort.Ints(taskIndexes)
-	var sortedTasks []*Task
+	var sortedTasks []*taskAnnotated
 	for _, i := range taskIndexes {
 		task := tasks[i]
 		// Sort containers within a task

--- a/extension/observer/ecsobserver/filter_test.go
+++ b/extension/observer/ecsobserver/filter_test.go
@@ -43,7 +43,7 @@ func TestFilter(t *testing.T) {
 		assert.Nil(t, res)
 	})
 
-	emptyTask := &Task{
+	emptyTask := &taskAnnotated{
 		Task: &ecs.Task{TaskDefinitionArn: aws.String("arn:that:never:matches")},
 		Definition: &ecs.TaskDefinition{
 			TaskDefinitionArn: aws.String("arn:that:never:matches"),
@@ -55,8 +55,8 @@ func TestFilter(t *testing.T) {
 		},
 	}
 	portLabelWithInvalidValue := "MY_PROMETHEUS_PORT_IS_INVALID"
-	genTasks := func() []*Task {
-		return []*Task{
+	genTasks := func() []*taskAnnotated {
+		return []*taskAnnotated{
 			{
 				Task: &ecs.Task{
 					TaskDefinitionArn: aws.String("arn:alike:nginx-latest"),
@@ -110,13 +110,13 @@ func TestFilter(t *testing.T) {
 		res, err := f.filter(genTasks())
 		require.NoError(t, err)
 		assert.Len(t, res, 1)
-		assert.Equal(t, []MatchedContainer{
+		assert.Equal(t, []matchedContainer{
 			{
 				TaskIndex:      0,
 				ContainerIndex: 0,
-				Targets: []MatchedTarget{
+				Targets: []matchedTarget{
 					{
-						MatcherType: MatcherTypeTaskDefinition,
+						MatcherType: matcherTypeTaskDefinition,
 						Port:        2112,
 						Job:         "CONFIG_PROM_JOB",
 					},
@@ -156,13 +156,13 @@ func TestFilter(t *testing.T) {
 		res, err := f.filter(genTasks())
 		require.NoError(t, err)
 		assert.Len(t, res, 1)
-		assert.Equal(t, []MatchedContainer{
+		assert.Equal(t, []matchedContainer{
 			{
 				TaskIndex:      0,
 				ContainerIndex: 0,
-				Targets: []MatchedTarget{
+				Targets: []matchedTarget{
 					{
-						MatcherType: MatcherTypeService,
+						MatcherType: matcherTypeService,
 						Port:        2112,
 						Job:         "CONFIG_PROM_JOB_BY_SERVICE",
 					},

--- a/extension/observer/ecsobserver/matcher.go
+++ b/extension/observer/ecsobserver/matcher.go
@@ -24,11 +24,12 @@ import (
 	"go.uber.org/zap"
 )
 
-type Matcher interface {
-	Type() MatcherType
-	// MatchTargets returns targets fond from the specific container.
+type targetMatcher interface {
+	// type() won't parse
+	matcherType() matcherType
+	// matchTargets returns targets fond from the specific container.
 	// One container can have multiple targets because it may have multiple ports.
-	MatchTargets(task *Task, container *ecs.ContainerDefinition) ([]MatchedTarget, error)
+	matchTargets(task *taskAnnotated, container *ecs.ContainerDefinition) ([]matchedTarget, error)
 }
 
 // matcherConfig should be implemented by all the matcher config structs
@@ -37,31 +38,31 @@ type matcherConfig interface {
 	// validate calls NewMatcher and only returns the error, it can be used in test
 	// and the new config validator interface.
 	validate() error
-	// newMatcher validates config and creates a Matcher implementation.
+	// newMatcher validates config and creates a targetMatcher implementation.
 	// The error is a config validation error
-	newMatcher(options MatcherOptions) (Matcher, error)
+	newMatcher(options matcherOptions) (targetMatcher, error)
 }
 
-type MatcherOptions struct {
+type matcherOptions struct {
 	Logger *zap.Logger
 }
 
-type MatcherType int
+type matcherType int
 
-// Values for enum MatcherType.
+// Values for enum matcherType.
 const (
-	MatcherTypeService MatcherType = iota + 1
-	MatcherTypeTaskDefinition
-	MatcherTypeDockerLabel
+	matcherTypeService matcherType = iota + 1
+	matcherTypeTaskDefinition
+	matcherTypeDockerLabel
 )
 
-func (t MatcherType) String() string {
+func (t matcherType) String() string {
 	switch t {
-	case MatcherTypeService:
+	case matcherTypeService:
 		return "service"
-	case MatcherTypeTaskDefinition:
+	case matcherTypeTaskDefinition:
 		return "task_definition"
-	case MatcherTypeDockerLabel:
+	case matcherTypeDockerLabel:
 		return "docker_label"
 	default:
 		// Give it a _matcher_type suffix so people can find it by string search.
@@ -69,17 +70,17 @@ func (t MatcherType) String() string {
 	}
 }
 
-type MatchResult struct {
+type matchResult struct {
 	// Tasks are index for tasks that include matched containers
 	Tasks []int
 	// Containers are index for matched containers. containers should show up in the original order of the task list and container definitions.
-	Containers []MatchedContainer
+	Containers []matchedContainer
 }
 
-type MatchedContainer struct {
+type matchedContainer struct {
 	TaskIndex      int // Index in task list before filter, i.e. after fetch and decorate
 	ContainerIndex int // Index within a tasks definition's container list
-	Targets        []MatchedTarget
+	Targets        []matchedTarget
 }
 
 // MergeTargets adds new targets to the set, the 'key' is port + metrics path.
@@ -87,7 +88,7 @@ type MatchedContainer struct {
 // container have the same IP address. If there are duplicate 'key's we honor
 // the existing target and do not override.  Duplication could happen if there
 // are several rules matching same target.
-func (mc *MatchedContainer) MergeTargets(newTargets []MatchedTarget) {
+func (mc *matchedContainer) MergeTargets(newTargets []matchedTarget) {
 NextNewTarget:
 	for _, newt := range newTargets {
 		for _, old := range mc.Targets {
@@ -100,34 +101,34 @@ NextNewTarget:
 	}
 }
 
-// MatchedTarget contains info for exporting prometheus scrape target
+// matchedTarget contains info for exporting prometheus scrape target
 // and tracing back into the config (can be used in stats, error reporting etc.).
-type MatchedTarget struct {
-	MatcherType  MatcherType
+type matchedTarget struct {
+	MatcherType  matcherType
 	MatcherIndex int // Index within a specific matcher type
 	Port         int
 	MetricsPath  string
 	Job          string
 }
 
-func matcherOrders() []MatcherType {
-	return []MatcherType{
-		MatcherTypeService,
-		MatcherTypeTaskDefinition,
-		MatcherTypeDockerLabel,
+func matcherOrders() []matcherType {
+	return []matcherType{
+		matcherTypeService,
+		matcherTypeTaskDefinition,
+		matcherTypeDockerLabel,
 	}
 }
 
-func newMatchers(c Config, mOpt MatcherOptions) (map[MatcherType][]Matcher, error) {
+func newMatchers(c Config, mOpt matcherOptions) (map[matcherType][]targetMatcher, error) {
 	// We can have a registry or factory methods etc. but we only have three type of matchers
 	// and likely not going to add anymore in forseable future, just hard code the map here.
 	// All the XXXConfigToMatchers looks like copy pasted funcs, but there is no generic way to do it.
-	matcherConfigs := map[MatcherType][]matcherConfig{
-		MatcherTypeService:        serviceConfigsToMatchers(c.Services),
-		MatcherTypeTaskDefinition: taskDefinitionConfigsToMatchers(c.TaskDefinitions),
-		MatcherTypeDockerLabel:    dockerLabelConfigToMatchers(c.DockerLabels),
+	matcherConfigs := map[matcherType][]matcherConfig{
+		matcherTypeService:        serviceConfigsToMatchers(c.Services),
+		matcherTypeTaskDefinition: taskDefinitionConfigsToMatchers(c.TaskDefinitions),
+		matcherTypeDockerLabel:    dockerLabelConfigToMatchers(c.DockerLabels),
 	}
-	matchers := make(map[MatcherType][]Matcher)
+	matchers := make(map[matcherType][]targetMatcher)
 	matcherCount := 0
 	for mType, cfgs := range matcherConfigs {
 		for i, cfg := range cfgs {
@@ -150,20 +151,20 @@ func newMatchers(c Config, mOpt MatcherOptions) (map[MatcherType][]Matcher, erro
 // to help user debug. e.g. type ^ngix-*$ does not match nginx-service.
 var errNotMatched = fmt.Errorf("container not matched")
 
-// matchContainers apply one matcher to a list of tasks and returns MatchResult.
+// matchContainers apply one matcher to a list of tasks and returns matchResult.
 // It does not modify the task in place, the attaching match result logic is
 // performed by taskFilter at later stage.
-func matchContainers(tasks []*Task, matcher Matcher, matcherIndex int) (*MatchResult, error) {
+func matchContainers(tasks []*taskAnnotated, matcher targetMatcher, matcherIndex int) (*matchResult, error) {
 	var (
 		matchedTasks      []int
-		matchedContainers []MatchedContainer
+		matchedContainers []matchedContainer
 	)
 	var merr error
-	tpe := matcher.Type()
+	tpe := matcher.matcherType()
 	for tIndex, t := range tasks {
-		var matched []MatchedContainer
+		var matched []matchedContainer
 		for cIndex, c := range t.Definition.ContainerDefinitions {
-			targets, err := matcher.MatchTargets(t, c)
+			targets, err := matcher.matchTargets(t, c)
 			// NOTE: we don't stop when there is an error because it could be one task having invalid docker label.
 			if err != nil {
 				// Keep track of unexpected error
@@ -176,7 +177,7 @@ func matchContainers(tasks []*Task, matcher Matcher, matcherIndex int) (*MatchRe
 				targets[i].MatcherType = tpe
 				targets[i].MatcherIndex = matcherIndex
 			}
-			matched = append(matched, MatchedContainer{
+			matched = append(matched, matchedContainer{
 				TaskIndex:      tIndex,
 				ContainerIndex: cIndex,
 				Targets:        targets,
@@ -187,7 +188,7 @@ func matchContainers(tasks []*Task, matcher Matcher, matcherIndex int) (*MatchRe
 			matchedContainers = append(matchedContainers, matched...)
 		}
 	}
-	return &MatchResult{
+	return &matchResult{
 		Tasks:      matchedTasks,
 		Containers: matchedContainers,
 	}, merr
@@ -195,17 +196,17 @@ func matchContainers(tasks []*Task, matcher Matcher, matcherIndex int) (*MatchRe
 
 // matchContainerByName is used by taskDefinitionMatcher and serviceMatcher.
 // The only exception is DockerLabelMatcher because it get ports from docker label.
-func matchContainerByName(nameRegex *regexp.Regexp, expSetting *commonExportSetting, container *ecs.ContainerDefinition) ([]MatchedTarget, error) {
+func matchContainerByName(nameRegex *regexp.Regexp, expSetting *commonExportSetting, container *ecs.ContainerDefinition) ([]matchedTarget, error) {
 	if nameRegex != nil && !nameRegex.MatchString(aws.StringValue(container.Name)) {
 		return nil, errNotMatched
 	}
 	// Match based on port
-	var targets []MatchedTarget
+	var targets []matchedTarget
 	// Only export container if it has at least one matching port.
 	for _, portMapping := range container.PortMappings {
 		port := int(aws.Int64Value(portMapping.ContainerPort))
 		if expSetting.hasContainerPort(port) {
-			targets = append(targets, MatchedTarget{
+			targets = append(targets, matchedTarget{
 				Port:        port,
 				MetricsPath: expSetting.MetricsPath,
 				Job:         expSetting.JobName,

--- a/extension/observer/ecsobserver/matcher_test.go
+++ b/extension/observer/ecsobserver/matcher_test.go
@@ -23,10 +23,10 @@ import (
 )
 
 func TestMatcherType(t *testing.T) {
-	m := map[MatcherType]string{
-		MatcherTypeService:        "service",
-		MatcherTypeTaskDefinition: "task_definition",
-		MatcherTypeDockerLabel:    "docker_label",
+	m := map[matcherType]string{
+		matcherTypeService:        "service",
+		matcherTypeTaskDefinition: "task_definition",
+		matcherTypeDockerLabel:    "docker_label",
 		-1:                        "unknown_matcher_type",
 	}
 	for k, v := range m {
@@ -37,7 +37,7 @@ func TestMatcherType(t *testing.T) {
 func TestNewMatchers(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		var c Config
-		_, err := newMatchers(c, MatcherOptions{})
+		_, err := newMatchers(c, matcherOptions{})
 		require.Error(t, err)
 	})
 
@@ -49,7 +49,7 @@ func TestNewMatchers(t *testing.T) {
 				},
 			},
 		}
-		_, err := newMatchers(c, MatcherOptions{})
+		_, err := newMatchers(c, matcherOptions{})
 		require.Error(t, err)
 	})
 
@@ -71,7 +71,7 @@ func TestNewMatchers(t *testing.T) {
 				},
 			},
 		}
-		m, err := newMatchers(c, MatcherOptions{Logger: zap.NewExample()})
+		m, err := newMatchers(c, matcherOptions{Logger: zap.NewExample()})
 		require.NoError(t, err)
 		assert.Len(t, m, 3)
 	})
@@ -79,8 +79,8 @@ func TestNewMatchers(t *testing.T) {
 
 func TestMatchedContainer_MergeTargets(t *testing.T) {
 	t.Run("add new targets", func(t *testing.T) {
-		m := MatchedContainer{
-			Targets: []MatchedTarget{
+		m := matchedContainer{
+			Targets: []matchedTarget{
 				{
 					Port:        1234,
 					MetricsPath: "/m1",
@@ -91,7 +91,7 @@ func TestMatchedContainer_MergeTargets(t *testing.T) {
 				},
 			},
 		}
-		newTargets := []MatchedTarget{
+		newTargets := []matchedTarget{
 			{
 				Port:        1234,
 				MetricsPath: "/not-m1", // different path
@@ -107,10 +107,10 @@ func TestMatchedContainer_MergeTargets(t *testing.T) {
 	})
 
 	t.Run("respect existing targets", func(t *testing.T) {
-		m := MatchedContainer{
-			Targets: []MatchedTarget{
+		m := matchedContainer{
+			Targets: []matchedTarget{
 				{
-					MatcherType: MatcherTypeService,
+					MatcherType: matcherTypeService,
 					Port:        1234,
 					MetricsPath: "/m1",
 				},
@@ -120,9 +120,9 @@ func TestMatchedContainer_MergeTargets(t *testing.T) {
 				},
 			},
 		}
-		newTargets := []MatchedTarget{
+		newTargets := []matchedTarget{
 			{
-				MatcherType: MatcherTypeDockerLabel, // different matcher
+				MatcherType: matcherTypeDockerLabel, // different matcher
 				Port:        1234,
 				MetricsPath: "/m1",
 			},
@@ -133,6 +133,6 @@ func TestMatchedContainer_MergeTargets(t *testing.T) {
 		}
 		m.MergeTargets(newTargets)
 		assert.Len(t, m.Targets, 3)
-		assert.Equal(t, MatcherTypeService, m.Targets[0].MatcherType)
+		assert.Equal(t, matcherTypeService, m.Targets[0].MatcherType)
 	})
 }

--- a/extension/observer/ecsobserver/sd.go
+++ b/extension/observer/ecsobserver/sd.go
@@ -23,6 +23,8 @@ import (
 	"go.uber.org/zap"
 )
 
+// serviceDiscovery runs the discovery loop.
+// It writes discovered targets as prometheus file sd format (for now).
 type serviceDiscovery struct {
 	logger   *zap.Logger
 	cfg      Config
@@ -40,7 +42,7 @@ func newDiscovery(cfg Config, opts serviceDiscoveryOptions) (*serviceDiscovery, 
 	if opts.Fetcher == nil {
 		return nil, fmt.Errorf("fetcher is nil")
 	}
-	matchers, err := newMatchers(cfg, MatcherOptions{Logger: opts.Logger})
+	matchers, err := newMatchers(cfg, matcherOptions{Logger: opts.Logger})
 	if err != nil {
 		return nil, fmt.Errorf("init matchers failed: %w", err)
 	}
@@ -100,7 +102,7 @@ func (s *serviceDiscovery) runAndWriteFile(ctx context.Context) error {
 }
 
 // discover fetch tasks, filter by matching result and export them.
-func (s *serviceDiscovery) discover(ctx context.Context) ([]PrometheusECSTarget, error) {
+func (s *serviceDiscovery) discover(ctx context.Context) ([]prometheusECSTarget, error) {
 	tasks, err := s.fetcher.fetchAndDecorate(ctx)
 	if err != nil {
 		return nil, err

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -218,7 +218,7 @@ func TestNewDiscovery(t *testing.T) {
 
 func newTestTaskFilter(t *testing.T, cfg Config) *taskFilter {
 	logger := zap.NewExample()
-	m, err := newMatchers(cfg, MatcherOptions{Logger: logger})
+	m, err := newMatchers(cfg, matcherOptions{Logger: logger})
 	require.NoError(t, err)
 	f := newTaskFilter(logger, m)
 	return f
@@ -243,21 +243,21 @@ func newTestTaskFetcher(t *testing.T, c *ecsmock.Cluster, opts ...func(options *
 	return f
 }
 
-func newMatcher(t *testing.T, cfg matcherConfig) Matcher {
+func newMatcher(t *testing.T, cfg matcherConfig) targetMatcher {
 	m, err := cfg.newMatcher(testMatcherOptions())
 	require.NoError(t, err)
 	return m
 }
 
-func newMatcherAndMatch(t *testing.T, cfg matcherConfig, tasks []*Task) *MatchResult {
+func newMatcherAndMatch(t *testing.T, cfg matcherConfig, tasks []*taskAnnotated) *matchResult {
 	m := newMatcher(t, cfg)
 	res, err := matchContainers(tasks, m, 0)
 	require.NoError(t, err)
 	return res
 }
 
-func testMatcherOptions() MatcherOptions {
-	return MatcherOptions{
+func testMatcherOptions() matcherOptions {
+	return matcherOptions{
 		Logger: zap.NewExample(),
 	}
 }

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -34,11 +34,11 @@ type ServiceConfig struct {
 }
 
 func (s *ServiceConfig) validate() error {
-	_, err := s.newMatcher(MatcherOptions{})
+	_, err := s.newMatcher(matcherOptions{})
 	return err
 }
 
-func (s *ServiceConfig) newMatcher(opts MatcherOptions) (Matcher, error) {
+func (s *ServiceConfig) newMatcher(opts matcherOptions) (targetMatcher, error) {
 	if s.NamePattern == "" {
 		return nil, fmt.Errorf("name_pattern is empty")
 	}
@@ -86,11 +86,11 @@ type serviceMatcher struct {
 	exportSetting      *commonExportSetting
 }
 
-func (s *serviceMatcher) Type() MatcherType {
-	return MatcherTypeService
+func (s *serviceMatcher) matcherType() matcherType {
+	return matcherTypeService
 }
 
-func (s *serviceMatcher) MatchTargets(t *Task, c *ecs.ContainerDefinition) ([]MatchedTarget, error) {
+func (s *serviceMatcher) matchTargets(t *taskAnnotated, c *ecs.ContainerDefinition) ([]matchedTarget, error) {
 	// Service info is only attached for tasks whose services are included in config.
 	// However, Match is called on tasks so we need to guard nil pointer.
 	if t.Service == nil {

--- a/extension/observer/ecsobserver/service_test.go
+++ b/extension/observer/ecsobserver/service_test.go
@@ -55,8 +55,8 @@ func TestServiceMatcher(t *testing.T) {
 			},
 		},
 	}
-	genTasks := func() []*Task {
-		return []*Task{
+	genTasks := func() []*taskAnnotated {
+		return []*taskAnnotated{
 			{
 				Service: &ecs.Service{ServiceName: aws.String("nginx-service")},
 				Definition: &ecs.TaskDefinition{
@@ -102,15 +102,15 @@ func TestServiceMatcher(t *testing.T) {
 			},
 		}
 		res := newMatcherAndMatch(t, &cfg, genTasks())
-		assert.Equal(t, &MatchResult{
+		assert.Equal(t, &matchResult{
 			Tasks: []int{0},
-			Containers: []MatchedContainer{
+			Containers: []matchedContainer{
 				{
 					TaskIndex:      0,
 					ContainerIndex: 0,
-					Targets: []MatchedTarget{
+					Targets: []matchedTarget{
 						{
-							MatcherType: MatcherTypeService,
+							MatcherType: matcherTypeService,
 							Port:        2112,
 							Job:         "CONFIG_PROM_JOB",
 						},
@@ -135,15 +135,15 @@ func TestServiceMatcher(t *testing.T) {
 			},
 		}
 		res := newMatcherAndMatch(t, &cfg, genTasks())
-		assert.Equal(t, &MatchResult{
+		assert.Equal(t, &matchResult{
 			Tasks: []int{0},
-			Containers: []MatchedContainer{
+			Containers: []matchedContainer{
 				{
 					TaskIndex:      0,
 					ContainerIndex: 1,
-					Targets: []MatchedTarget{
+					Targets: []matchedTarget{
 						{
-							MatcherType: MatcherTypeService,
+							MatcherType: matcherTypeService,
 							Port:        2114,
 							Job:         "CONFIG_PROM_JOB",
 						},

--- a/extension/observer/ecsobserver/target.go
+++ b/extension/observer/ecsobserver/target.go
@@ -29,13 +29,13 @@ const (
 	labelPrefix = "__meta_ecs_"
 )
 
-// PrometheusECSTarget contains address and labels extracted from a running ECS task
+// prometheusECSTarget contains address and labels extracted from a running ECS task
 // and its underlying EC2 instance (if available).
 //
 // For serialization
 // - TargetToLabels and LabelsToTarget converts the struct between map[string]string.
 // - TargetsToFileSDYAML and ToTargetYAML converts it between prometheus file discovery format in YAML.
-type PrometheusECSTarget struct {
+type prometheusECSTarget struct {
 	Source                 string            `label:"source"`
 	Address                string            `label:"__address__"`
 	MetricsPath            string            `label:"__metrics_path__"`
@@ -87,7 +87,7 @@ const (
 
 // ToLabels converts fields in the target to map.
 // It also sanitize label name because the requirements on AWS tags and Prometheus are different.
-func (t *PrometheusECSTarget) ToLabels() map[string]string {
+func (t *prometheusECSTarget) ToLabels() map[string]string {
 	labels := map[string]string{
 		labelSource:                 t.Source,
 		labelAddress:                t.Address,
@@ -146,7 +146,7 @@ type fileSDTarget struct {
 	Labels  map[string]string `yaml:"labels" json:"labels"`
 }
 
-func targetsToFileSDTargets(targets []PrometheusECSTarget, jobLabelName string) ([]fileSDTarget, error) {
+func targetsToFileSDTargets(targets []prometheusECSTarget, jobLabelName string) ([]fileSDTarget, error) {
 	var converted []fileSDTarget
 	omitEmpty := []string{labelJob, labelServiceName}
 	for _, t := range targets {
@@ -184,7 +184,7 @@ func targetsToFileSDTargets(targets []PrometheusECSTarget, jobLabelName string) 
 	return converted, nil
 }
 
-func targetsToFileSDYAML(targets []PrometheusECSTarget, jobLabelName string) ([]byte, error) {
+func targetsToFileSDYAML(targets []prometheusECSTarget, jobLabelName string) ([]byte, error) {
 	converted, err := targetsToFileSDTargets(targets, jobLabelName)
 	if err != nil {
 		return nil, err

--- a/extension/observer/ecsobserver/target_test.go
+++ b/extension/observer/ecsobserver/target_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestTargetToLabels(t *testing.T) {
 	t.Run("sanitize tags", func(t *testing.T) {
-		pt := PrometheusECSTarget{
+		pt := prometheusECSTarget{
 			TaskTags: map[string]string{
 				"a:b": "sanitized",
 				"ab":  "same",

--- a/extension/observer/ecsobserver/task.go
+++ b/extension/observer/ecsobserver/task.go
@@ -23,19 +23,19 @@ import (
 	"go.uber.org/zap"
 )
 
-// Task contains both raw task info and its definition.
+// taskAnnotated contains both raw task info and its definition.
 // It is generated from taskFetcher.
-type Task struct {
+type taskAnnotated struct {
 	Task       *ecs.Task
 	Definition *ecs.TaskDefinition
 	EC2        *ec2.Instance
 	Service    *ecs.Service
-	Matched    []MatchedContainer
+	Matched    []matchedContainer
 }
 
 // AddMatchedContainer tries to add a new matched container.
 // If the container already exists will merge targets within one container (i.e. different port/metrics path).
-func (t *Task) AddMatchedContainer(newContainer MatchedContainer) {
+func (t *taskAnnotated) AddMatchedContainer(newContainer matchedContainer) {
 	for i, oldContainer := range t.Matched {
 		if oldContainer.ContainerIndex == newContainer.ContainerIndex {
 			t.Matched[i].MergeTargets(newContainer.Targets)
@@ -45,7 +45,7 @@ func (t *Task) AddMatchedContainer(newContainer MatchedContainer) {
 	t.Matched = append(t.Matched, newContainer)
 }
 
-func (t *Task) TaskTags() map[string]string {
+func (t *taskAnnotated) TaskTags() map[string]string {
 	if len(t.Task.Tags) == 0 {
 		return nil
 	}
@@ -59,7 +59,7 @@ func (t *Task) TaskTags() map[string]string {
 // EC2Tags returns ec2 instance tags as it is. Sanitize to prometheus label format is done during export.
 // NOTE: the tag to string conversion is duplicated because the Tag struct is defined in each service's own API package.
 // i.e. services don't import a common package that includes tag definition.
-func (t *Task) EC2Tags() map[string]string {
+func (t *taskAnnotated) EC2Tags() map[string]string {
 	if t.EC2 == nil || len(t.EC2.Tags) == 0 {
 		return nil
 	}
@@ -70,7 +70,7 @@ func (t *Task) EC2Tags() map[string]string {
 	return tags
 }
 
-func (t *Task) ContainerLabels(containerIndex int) map[string]string {
+func (t *taskAnnotated) ContainerLabels(containerIndex int) map[string]string {
 	def := t.Definition.ContainerDefinitions[containerIndex]
 	if len(def.DockerLabels) == 0 {
 		return nil
@@ -82,14 +82,14 @@ func (t *Task) ContainerLabels(containerIndex int) map[string]string {
 	return labels
 }
 
-// ErrPrivateIPNotFound indicates the awsvpc private ip or EC2 instance ip is not found.
-type ErrPrivateIPNotFound struct {
+// errPrivateIPNotFound indicates the awsvpc private ip or EC2 instance ip is not found.
+type errPrivateIPNotFound struct {
 	TaskArn     string
 	NetworkMode string
 	Extra       string // extra message
 }
 
-func (e *ErrPrivateIPNotFound) Error() string {
+func (e *errPrivateIPNotFound) Error() string {
 	m := fmt.Sprintf("private ip not found for network mode %q and task %s", e.NetworkMode, e.TaskArn)
 	if e.Extra != "" {
 		m = m + " " + e.Extra
@@ -97,11 +97,11 @@ func (e *ErrPrivateIPNotFound) Error() string {
 	return m
 }
 
-func (e *ErrPrivateIPNotFound) message() string {
+func (e *errPrivateIPNotFound) message() string {
 	return "private ip not found"
 }
 
-func (e *ErrPrivateIPNotFound) zapFields() []zap.Field {
+func (e *errPrivateIPNotFound) zapFields() []zap.Field {
 	return []zap.Field{
 		zap.String("NetworkMode", e.NetworkMode),
 		zap.String("Extra", e.Extra),
@@ -111,10 +111,10 @@ func (e *ErrPrivateIPNotFound) zapFields() []zap.Field {
 // PrivateIP returns private ip address based on network mode.
 // EC2 launch type can use host/bridge mode and the private ip is the EC2 instance's ip.
 // awsvpc has its own ip regardless of launch type.
-func (t *Task) PrivateIP() (string, error) {
+func (t *taskAnnotated) PrivateIP() (string, error) {
 	arn := aws.StringValue(t.Task.TaskArn)
 	mode := aws.StringValue(t.Definition.NetworkMode)
-	errNotFound := &ErrPrivateIPNotFound{
+	errNotFound := &errPrivateIPNotFound{
 		TaskArn:     arn,
 		NetworkMode: mode,
 	}
@@ -147,27 +147,27 @@ func (t *Task) PrivateIP() (string, error) {
 	}
 }
 
-// ErrMappedPortNotFound indicates the port specified in config does not exists
+// errMappedPortNotFound indicates the port specified in config does not exists
 // or the location for mapped ports has changed on ECS side.
-type ErrMappedPortNotFound struct {
+type errMappedPortNotFound struct {
 	TaskArn       string
 	NetworkMode   string
 	ContainerName string
 	ContainerPort int64
 }
 
-func (e *ErrMappedPortNotFound) Error() string {
+func (e *errMappedPortNotFound) Error() string {
 	// Output the error message in this order to make searching easier as only task arn changes frequently.
 	// %q for network mode because empty string is valid for ECS EC2.
 	return fmt.Sprintf("mapped port not found for container port %d network mode %q on container %s in task %s",
 		e.ContainerPort, e.NetworkMode, e.ContainerName, e.TaskArn)
 }
 
-func (e *ErrMappedPortNotFound) message() string {
+func (e *errMappedPortNotFound) message() string {
 	return "mapped port not found"
 }
 
-func (e *ErrMappedPortNotFound) zapFields() []zap.Field {
+func (e *errMappedPortNotFound) zapFields() []zap.Field {
 	return []zap.Field{
 		zap.String("NetworkMode", e.NetworkMode),
 		zap.Int64("ContainerPort", e.ContainerPort),
@@ -176,11 +176,11 @@ func (e *ErrMappedPortNotFound) zapFields() []zap.Field {
 
 // MappedPort returns 'external' port based on network mode.
 // EC2 bridge uses a random host port while EC2 host/awsvpc uses a port specified by the user.
-func (t *Task) MappedPort(def *ecs.ContainerDefinition, containerPort int64) (int64, error) {
+func (t *taskAnnotated) MappedPort(def *ecs.ContainerDefinition, containerPort int64) (int64, error) {
 	arn := aws.StringValue(t.Task.TaskArn)
 	mode := aws.StringValue(t.Definition.NetworkMode)
 	// the error is same for all network modes (if any)
-	errNotFound := &ErrMappedPortNotFound{
+	errNotFound := &errMappedPortNotFound{
 		TaskArn:       arn,
 		NetworkMode:   mode,
 		ContainerName: aws.StringValue(def.Name),

--- a/extension/observer/ecsobserver/task_definition.go
+++ b/extension/observer/ecsobserver/task_definition.go
@@ -34,11 +34,11 @@ type TaskDefinitionConfig struct {
 }
 
 func (t *TaskDefinitionConfig) validate() error {
-	_, err := t.newMatcher(MatcherOptions{})
+	_, err := t.newMatcher(matcherOptions{})
 	return err
 }
 
-func (t *TaskDefinitionConfig) newMatcher(opts MatcherOptions) (Matcher, error) {
+func (t *TaskDefinitionConfig) newMatcher(opts matcherOptions) (targetMatcher, error) {
 	if t.ArnPattern == "" {
 		return nil, fmt.Errorf("arn_pattern is empty")
 	}
@@ -87,11 +87,11 @@ type taskDefinitionMatcher struct {
 	exportSetting      *commonExportSetting
 }
 
-func (m *taskDefinitionMatcher) Type() MatcherType {
-	return MatcherTypeTaskDefinition
+func (m *taskDefinitionMatcher) matcherType() matcherType {
+	return matcherTypeTaskDefinition
 }
 
-func (m *taskDefinitionMatcher) MatchTargets(t *Task, c *ecs.ContainerDefinition) ([]MatchedTarget, error) {
+func (m *taskDefinitionMatcher) matchTargets(t *taskAnnotated, c *ecs.ContainerDefinition) ([]matchedTarget, error) {
 	// Check arn
 	if !m.arnRegex.MatchString(aws.StringValue(t.Task.TaskDefinitionArn)) {
 		return nil, errNotMatched

--- a/extension/observer/ecsobserver/task_definition_test.go
+++ b/extension/observer/ecsobserver/task_definition_test.go
@@ -45,7 +45,7 @@ func TestTaskDefinitionMatcher(t *testing.T) {
 		require.Error(t, cfg.validate())
 	})
 
-	emptyTask := &Task{
+	emptyTask := &taskAnnotated{
 		Task: &ecs.Task{TaskDefinitionArn: aws.String("arn:that:never:matches")},
 		Definition: &ecs.TaskDefinition{
 			TaskDefinitionArn: aws.String("arn:that:never:matches"),
@@ -56,8 +56,8 @@ func TestTaskDefinitionMatcher(t *testing.T) {
 			},
 		},
 	}
-	genTasks := func() []*Task {
-		return []*Task{
+	genTasks := func() []*taskAnnotated {
+		return []*taskAnnotated{
 			{
 				Task: &ecs.Task{
 					TaskDefinitionArn: aws.String("arn:alike:nginx-latest"),
@@ -99,15 +99,15 @@ func TestTaskDefinitionMatcher(t *testing.T) {
 			},
 		}
 		res := newMatcherAndMatch(t, &cfg, genTasks())
-		assert.Equal(t, &MatchResult{
+		assert.Equal(t, &matchResult{
 			Tasks: []int{0},
-			Containers: []MatchedContainer{
+			Containers: []matchedContainer{
 				{
 					TaskIndex:      0,
 					ContainerIndex: 0,
-					Targets: []MatchedTarget{
+					Targets: []matchedTarget{
 						{
-							MatcherType: MatcherTypeTaskDefinition,
+							MatcherType: matcherTypeTaskDefinition,
 							Port:        2112,
 							Job:         "CONFIG_PROM_JOB",
 						},
@@ -132,15 +132,15 @@ func TestTaskDefinitionMatcher(t *testing.T) {
 			},
 		}
 		res := newMatcherAndMatch(t, &cfg, genTasks())
-		assert.Equal(t, &MatchResult{
+		assert.Equal(t, &matchResult{
 			Tasks: []int{0},
-			Containers: []MatchedContainer{
+			Containers: []matchedContainer{
 				{
 					TaskIndex:      0,
 					ContainerIndex: 1,
-					Targets: []MatchedTarget{
+					Targets: []matchedTarget{
 						{
-							MatcherType: MatcherTypeTaskDefinition,
+							MatcherType: matcherTypeTaskDefinition,
 							Port:        2114,
 							Job:         "CONFIG_PROM_JOB",
 						},


### PR DESCRIPTION
**Description:** 

For  #4055  Only export config struct and factory for component

- `PrometheusECSTarget` is not exported because eventually we should be importing a similar Prometheus target struct from observer package so it can be used in other components. (We had one in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/1920

**Link to tracking Issue:**

-  #4055 

**Testing:**

```
go doc .                                                                                                                                                                                                    9:36:41
package ecsobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver"

func NewFactory() component.ExtensionFactory
type CommonExporterConfig struct{ ... }
type Config struct{ ... }
    func DefaultConfig() Config
type DockerLabelConfig struct{ ... }
type ServiceConfig struct{ ... }
type TaskDefinitionConfig struct{ ... }
```

**Documentation:** 

N/A