### PR TITLE
observIQ exporter -  Conversion to observIQ format implementation

### DIFF
--- a/exporter/observiqexporter/client.go
+++ b/exporter/observiqexporter/client.go
@@ -43,7 +43,7 @@ type client struct {
 	throttleTimer  *time.Timer
 	throttleLock   sync.RWMutex
 	timesThrottled int
-	buildInfo      component.BuildInfo
+	buildVersion   string
 }
 
 func (c *client) sendLogs(
@@ -58,7 +58,7 @@ func (c *client) sendLogs(
 	}
 
 	// Conversion errors should be returned after sending what could be converted.
-	data, conversionErrs := logdataToObservIQFormat(ld, c.config.AgentID, c.config.AgentName, c.buildInfo)
+	data, conversionErrs := logdataToObservIQFormat(ld, c.config.AgentID, c.config.AgentName, c.buildVersion)
 
 	jsonData, err := json.Marshal(data)
 
@@ -198,8 +198,8 @@ func buildClient(config *Config, logger *zap.Logger, buildInfo component.BuildIn
 				TLSClientConfig: tlsCfg,
 			},
 		},
-		logger:    logger,
-		config:    config,
-		buildInfo: buildInfo,
+		logger:       logger,
+		config:       config,
+		buildVersion: buildInfo.Version,
 	}, nil
 }

--- a/exporter/observiqexporter/client.go
+++ b/exporter/observiqexporter/client.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
@@ -42,6 +43,7 @@ type client struct {
 	throttleTimer  *time.Timer
 	throttleLock   sync.RWMutex
 	timesThrottled int
+	buildInfo      component.BuildInfo
 }
 
 func (c *client) sendLogs(
@@ -56,7 +58,7 @@ func (c *client) sendLogs(
 	}
 
 	// Conversion errors should be returned after sending what could be converted.
-	data, conversionErrs := logdataToObservIQFormat(ld, c.config.AgentID, c.config.AgentName)
+	data, conversionErrs := logdataToObservIQFormat(ld, c.config.AgentID, c.config.AgentName, c.buildInfo)
 
 	jsonData, err := json.Marshal(data)
 
@@ -182,7 +184,7 @@ func (c *client) stop(context.Context) error {
 	return nil
 }
 
-func buildClient(config *Config, logger *zap.Logger) (*client, error) {
+func buildClient(config *Config, logger *zap.Logger, buildInfo component.BuildInfo) (*client, error) {
 	tlsCfg, err := config.TLSSetting.LoadTLSConfig()
 	if err != nil {
 		return nil, err
@@ -196,7 +198,8 @@ func buildClient(config *Config, logger *zap.Logger) (*client, error) {
 				TLSClientConfig: tlsCfg,
 			},
 		},
-		logger: logger,
-		config: config,
+		logger:    logger,
+		config:    config,
+		buildInfo: buildInfo,
 	}, nil
 }

--- a/exporter/observiqexporter/client_test.go
+++ b/exporter/observiqexporter/client_test.go
@@ -77,10 +77,10 @@ func newTestHTTPClient(t *testing.T, respCode *int, respBody *string, testFunc *
 
 func newTestClient(config *Config, httpClient *http.Client) *client {
 	return &client{
-		client:    httpClient,
-		logger:    zap.NewNop(),
-		config:    config,
-		buildInfo: component.DefaultBuildInfo(),
+		client:       httpClient,
+		logger:       zap.NewNop(),
+		config:       config,
+		buildVersion: component.DefaultBuildInfo().Version,
 	}
 }
 

--- a/exporter/observiqexporter/client_test.go
+++ b/exporter/observiqexporter/client_test.go
@@ -16,7 +16,9 @@ package observiqexporter
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -47,8 +49,14 @@ func (t testFailRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 
 }
 
-func newTestHTTPClient(respCode *int, respBody *string, err error) *http.Client {
+type requestVerificationFunc func(t *testing.T, req *http.Request)
+
+func newTestHTTPClient(t *testing.T, respCode *int, respBody *string, testFunc *requestVerificationFunc, err error) *http.Client {
 	var rt http.RoundTripper = testRoundTripper(func(req *http.Request) *http.Response {
+		if testFunc != nil && *testFunc != nil {
+			(*testFunc)(t, req)
+		}
+
 		return &http.Response{
 			StatusCode: *respCode,
 			Body:       ioutil.NopCloser(bytes.NewBufferString(*respBody)),
@@ -96,6 +104,31 @@ func createLogData() pdata.Logs {
 	return logs
 }
 
+type observIQLogAddRequest struct {
+	Logs []observIQLogAddRequestLog `json:"logs"`
+}
+
+type observIQLogAddRequestLog struct {
+	ID    string           `json:"id"`
+	Size  int              `json:"size"`
+	Entry observIQLogEntry `json:"entry"`
+}
+
+func verifyFirstElementIsEntryFunc(e observIQLogEntry) requestVerificationFunc {
+	return func(t *testing.T, req *http.Request) {
+		gunzip, err := gzip.NewReader(req.Body)
+
+		require.NoError(t, err)
+
+		parsedReq := observIQLogAddRequest{}
+		err = json.NewDecoder(gunzip).Decode(&parsedReq)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, parsedReq.Logs)
+		require.Equal(t, e, parsedReq.Logs[0].Entry)
+	}
+}
+
 func TestClientSendLogs(t *testing.T) {
 	type testCaseRequest struct {
 		// Inputs
@@ -104,8 +137,26 @@ func TestClientSendLogs(t *testing.T) {
 		respBody       string
 		timeoutTimer   bool // Timeout the last set timer created through timeAfterFunc()
 		//Outputs
+		verifyRequest    requestVerificationFunc // Function is used to verify the request submitted to the client is valid.
 		shouldError      bool
 		errorIsPermanant bool
+	}
+
+	timeNow = func() time.Time {
+		return time.Unix(0, 0)
+	}
+
+	defaultLogEntry := observIQLogEntry{
+		Timestamp: "1970-01-01T00:00:00.000Z",
+		Data: map[string]interface{}{
+			conventions.AttributeNetHostIP:   "1.1.1.1",
+			conventions.AttributeNetHostPort: float64(4000),
+			"recordNum":                      float64(0),
+		},
+		Message:  "message",
+		Severity: "default",
+		Resource: map[string]interface{}{},
+		Agent:    &observIQAgentInfo{Name: "agent"},
 	}
 
 	testCases := []struct {
@@ -125,6 +176,7 @@ func TestClientSendLogs(t *testing.T) {
 					logs:           createLogData(),
 					responseStatus: 200,
 					respBody:       "",
+					verifyRequest:  verifyFirstElementIsEntryFunc(defaultLogEntry),
 				},
 			},
 		},
@@ -218,13 +270,15 @@ func TestClientSendLogs(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			var respCode int
 			var respBody string
+			var verifyFunc requestVerificationFunc
 
-			httpClient := newTestHTTPClient(&respCode, &respBody, testCase.clientError)
+			httpClient := newTestHTTPClient(t, &respCode, &respBody, &verifyFunc, testCase.clientError)
 			c := newTestClient(&testCase.config, httpClient)
 
 			for _, req := range testCase.reqs {
 				respCode = req.responseStatus
 				respBody = req.respBody
+				verifyFunc = req.verifyRequest
 
 				if req.timeoutTimer {
 					require.NotNil(t, timerFunc)

--- a/exporter/observiqexporter/converter.go
+++ b/exporter/observiqexporter/converter.go
@@ -25,7 +25,7 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
-// Type aliases []byte, represents JSON that has already been encoded
+// Type preEncodedJSON aliases []byte, represents JSON that has already been encoded
 // Does not support unmarshalling
 type preEncodedJSON []byte
 
@@ -96,7 +96,7 @@ func logdataToObservIQFormat(ld pdata.Logs, agentID string, agentName string, bu
 	return &observIQLogBatch{Logs: sliceOut}, errorsOut
 }
 
-// Output timestamp format, and ISO8601 compliant timesetamp with millisecond precision
+// Output timestamp format, an ISO8601 compliant timesetamp with millisecond precision
 const timestampFieldOutputLayout = "2006-01-02T15:04:05.000Z07:00"
 
 func resourceAndInstrmentationLogToEntry(resMap interface{}, log pdata.LogRecord, agentID string, agentName string, buildInfo component.BuildInfo) *observIQLogEntry {
@@ -128,7 +128,7 @@ func messageFromRecord(log pdata.LogRecord) string {
 	return ""
 }
 
-// If Body is a map, it is suitable to be used on the observiq log entry as "body"
+// If Body is a map, it is suitable to be used on the observIQ log entry as "body"
 func bodyFromRecord(log pdata.LogRecord) map[string]interface{} {
 	if log.Body().Type() == pdata.AttributeValueTypeMap {
 		return attributeMapToBaseType(log.Body().MapVal())
@@ -174,13 +174,13 @@ var severityNumberToObservIQName = map[int32]string{
 func severityFromRecord(log pdata.LogRecord) string {
 	var sevAsInt32 = int32(log.SeverityNumber())
 	if sevAsInt32 < int32(len(severityNumberToObservIQName)) && sevAsInt32 >= 0 {
-		return severityNumberToObservIQName[int32(log.SeverityNumber())]
+		return severityNumberToObservIQName[sevAsInt32]
 	}
 	return "default"
 }
 
 /*
-	Transform AttributeMap to native Go map, skipping nils, and replacing dots in keys with _
+	Transform AttributeMap to native Go map, skipping keys with nil values, and replacing dots in keys with _
 */
 func attributeMapToBaseType(m pdata.AttributeMap) map[string]interface{} {
 	mapOut := make(map[string]interface{}, m.Len())

--- a/exporter/observiqexporter/converter.go
+++ b/exporter/observiqexporter/converter.go
@@ -14,23 +14,33 @@
 
 package observiqexporter
 
-import "go.opentelemetry.io/collector/model/pdata"
+import (
+	"crypto/md5" //nolint:gosec // Not used for crypto, just for generating ID based on contents of log
+	"encoding/hex"
+	"encoding/json"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+// Type aliases []byte, represents JSON that has already been encoded
+// Does not support unmarshalling
+type preEncodedJSON []byte
 
 type observIQLogBatch struct {
 	Logs []*observIQLog `json:"logs"`
 }
 
 type observIQLog struct {
-	ID    string           `json:"id"`
-	Size  int              `json:"size"`
-	Entry observIQLogEntry `json:"entry"`
+	ID    string         `json:"id"`
+	Size  int            `json:"size"`
+	Entry preEncodedJSON `json:"entry"`
 }
 
 type observIQAgentInfo struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
-
 type observIQLogEntry struct {
 	Timestamp string                 `json:"@timestamp"`
 	Severity  string                 `json:"severity,omitempty"`
@@ -44,5 +54,177 @@ type observIQLogEntry struct {
 
 // Convert pdata.Logs to observIQLogBatch
 func logdataToObservIQFormat(ld pdata.Logs, agentID string, agentName string) (*observIQLogBatch, []error) {
-	return &observIQLogBatch{}, []error{}
+	var rls = ld.ResourceLogs()
+	var sliceOut = make([]*observIQLog, 0, ld.LogRecordCount())
+	var errorsOut = make([]error, 0)
+
+	for i := 0; i < rls.Len(); i++ {
+		rl := rls.At(i)
+		res := rl.Resource()
+		resMap := attributeMapToBaseType(res.Attributes())
+		ills := rl.InstrumentationLibraryLogs()
+		for j := 0; j < ills.Len(); j++ {
+			ill := ills.At(j)
+			logs := ill.Logs()
+			for k := 0; k < logs.Len(); k++ {
+				oiqLogEntry := resourceAndInstrmentationLogToEntry(resMap, logs.At(k), agentID, agentName)
+
+				jsonOiqLogEntry, err := json.Marshal(oiqLogEntry)
+
+				if err != nil {
+					//Skip this log, keep record of error
+					errorsOut = append(errorsOut, consumererror.Permanent(err))
+					continue
+				}
+
+				//md5 sum of the message is ID
+				md5Sum := md5.Sum(jsonOiqLogEntry) //nolint:gosec // Not used for crypto, just for generating ID based on contents of log
+				md5SumAsHex := hex.EncodeToString(md5Sum[:])
+
+				sliceOut = append(sliceOut, &observIQLog{
+					ID:    md5SumAsHex,
+					Size:  len(jsonOiqLogEntry),
+					Entry: preEncodedJSON(jsonOiqLogEntry),
+				})
+			}
+		}
+	}
+
+	return &observIQLogBatch{Logs: sliceOut}, errorsOut
+}
+
+// Output timestamp format, and ISO8601 compliant timesetamp with millisecond precision
+const timestampFieldOutputLayout = "2006-01-02T15:04:05.000Z07:00"
+
+func resourceAndInstrmentationLogToEntry(resMap interface{}, log pdata.LogRecord, agentID string, agentName string) *observIQLogEntry {
+	msg := messageFromRecord(log)
+
+	return &observIQLogEntry{
+		Timestamp: timestampFromRecord(log),
+		Severity:  severityFromRecord(log),
+		Resource:  resMap,
+		Message:   msg,
+		Data:      attributeMapToBaseType(log.Attributes()),
+		Body:      bodyFromRecord(log),
+		Agent:     &observIQAgentInfo{Name: agentName, ID: agentID},
+	}
+}
+
+func timestampFromRecord(log pdata.LogRecord) string {
+	if log.Timestamp() == 0 {
+		return timeNow().UTC().Format(timestampFieldOutputLayout)
+	}
+	return log.Timestamp().AsTime().UTC().Format(timestampFieldOutputLayout)
+}
+
+func messageFromRecord(log pdata.LogRecord) string {
+	if log.Body().Type() == pdata.AttributeValueTypeString {
+		return log.Body().StringVal()
+	}
+
+	return ""
+}
+
+// If Body is a map, it is suitable to be used on the observiq log entry
+func bodyFromRecord(log pdata.LogRecord) map[string]interface{} {
+	if log.Body().Type() == pdata.AttributeValueTypeMap {
+		return attributeMapToBaseType(log.Body().MapVal())
+	}
+	return nil
+}
+
+//Mappings from opentelemetry severity number to observIQ severity string
+var severityNumberToObservIQName = map[int32]string{
+	0:  "default",
+	1:  "trace",
+	2:  "trace",
+	3:  "trace",
+	4:  "trace",
+	5:  "debug",
+	6:  "debug",
+	7:  "debug",
+	8:  "debug",
+	9:  "info",
+	10: "info",
+	11: "info",
+	12: "info",
+	13: "warn",
+	14: "warn",
+	15: "warn",
+	16: "warn",
+	17: "error",
+	18: "error",
+	19: "error",
+	20: "error",
+	21: "fatal",
+	22: "fatal",
+	23: "fatal",
+	24: "fatal",
+}
+
+/*
+	Get severity from the a log record.
+	We prefer the severity number, and map it to a string
+	representing the opentelemetry defined severity.
+	TODO: Should we potentially use the string severity?
+	If there is no severity number, we use "default"
+*/
+func severityFromRecord(log pdata.LogRecord) string {
+	var sevAsInt32 = int32(log.SeverityNumber())
+	if sevAsInt32 < int32(len(severityNumberToObservIQName)) && sevAsInt32 >= 0 {
+		return severityNumberToObservIQName[int32(log.SeverityNumber())]
+	}
+	return "default"
+}
+
+/*
+	Transform AttributeMap to native Go map, skipping nils
+*/
+func attributeMapToBaseType(m pdata.AttributeMap) map[string]interface{} {
+	mapOut := make(map[string]interface{}, m.Len())
+	m.Range(func(k string, v pdata.AttributeValue) bool {
+		val := attributeValueToBaseType(v)
+		if val != nil {
+			mapOut[k] = val
+		}
+		return true
+	})
+	return mapOut
+}
+
+/*
+	attrib is the attribute value to convert to it's native Go type
+*/
+func attributeValueToBaseType(attrib pdata.AttributeValue) interface{} {
+	switch attrib.Type() {
+	case pdata.AttributeValueTypeString:
+		return attrib.StringVal()
+	case pdata.AttributeValueTypeBool:
+		return attrib.BoolVal()
+	case pdata.AttributeValueTypeInt:
+		return attrib.IntVal()
+	case pdata.AttributeValueTypeDouble:
+		return attrib.DoubleVal()
+	case pdata.AttributeValueTypeMap:
+		attribMap := attrib.MapVal()
+		return attributeMapToBaseType(attribMap)
+	case pdata.AttributeValueTypeArray:
+		arrayVal := attrib.ArrayVal()
+		slice := make([]interface{}, 0, arrayVal.Len())
+		for i := 0; i < arrayVal.Len(); i++ {
+			val := attributeValueToBaseType(arrayVal.At(i))
+			if val != nil {
+				slice = append(slice, val)
+			}
+		}
+		return slice
+	case pdata.AttributeValueTypeNull:
+		return nil
+	}
+	return nil
+}
+
+// The marshaled JSON is just the []byte that this type aliases.
+func (p preEncodedJSON) MarshalJSON() ([]byte, error) {
+	return p, nil
 }

--- a/exporter/observiqexporter/converter.go
+++ b/exporter/observiqexporter/converter.go
@@ -51,7 +51,7 @@ type observIQLogEntry struct {
 	Resource  interface{}            `json:"resource,omitempty"`
 	Agent     *observIQAgentInfo     `json:"agent,omitempty"`
 	Data      map[string]interface{} `json:"data,omitempty"`
-	Body      map[string]interface{} `json:"body,omitempty"`
+	Body      interface{}            `json:"body,omitempty"`
 }
 
 // Convert pdata.Logs to observIQLogBatch
@@ -125,10 +125,10 @@ func messageFromRecord(log pdata.LogRecord) string {
 	return ""
 }
 
-// If Body is a map, it is suitable to be used on the observIQ log entry as "body"
-func bodyFromRecord(log pdata.LogRecord) map[string]interface{} {
-	if log.Body().Type() == pdata.AttributeValueTypeMap {
-		return attributeMapToBaseType(log.Body().MapVal())
+// If Body is not a string, it is suitable to be used on the observIQ log entry as "body"
+func bodyFromRecord(log pdata.LogRecord) interface{} {
+	if log.Body().Type() != pdata.AttributeValueTypeString {
+		return attributeValueToBaseType(log.Body())
 	}
 	return nil
 }

--- a/exporter/observiqexporter/converter.go
+++ b/exporter/observiqexporter/converter.go
@@ -15,9 +15,9 @@
 package observiqexporter
 
 import (
-	"crypto/md5" //nolint:gosec // Not used for crypto, just for generating ID based on contents of log
 	"encoding/hex"
 	"encoding/json"
+	"hash/fnv"
 	"strings"
 
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -79,12 +79,12 @@ func logdataToObservIQFormat(ld pdata.Logs, agentID string, agentName string, bu
 					continue
 				}
 
-				//md5 sum of the message is ID
-				md5Sum := md5.Sum(jsonOIQLogEntry) //nolint:gosec // Not used for crypto, just for generating ID based on contents of log
-				md5SumAsHex := hex.EncodeToString(md5Sum[:])
+				//fnv sum of the message is ID
+				fnvHash := fnv.New128a().Sum(jsonOIQLogEntry)
+				fnvHashAsHex := hex.EncodeToString(fnvHash[:])
 
 				sliceOut = append(sliceOut, &observIQLog{
-					ID:    md5SumAsHex,
+					ID:    fnvHashAsHex,
 					Size:  len(jsonOIQLogEntry),
 					Entry: preEncodedJSON(jsonOIQLogEntry),
 				})

--- a/exporter/observiqexporter/converter.go
+++ b/exporter/observiqexporter/converter.go
@@ -70,7 +70,7 @@ func logdataToObservIQFormat(ld pdata.Logs, agentID string, agentName string, bu
 			ill := ills.At(j)
 			logs := ill.Logs()
 			for k := 0; k < logs.Len(); k++ {
-				oiqLogEntry := resourceAndInstrmentationLogToEntry(resMap, logs.At(k), agentID, agentName, buildInfo)
+				oiqLogEntry := resourceAndInstrumentationLogToEntry(resMap, logs.At(k), agentID, agentName, buildInfo)
 
 				jsonOIQLogEntry, err := json.Marshal(oiqLogEntry)
 
@@ -96,17 +96,15 @@ func logdataToObservIQFormat(ld pdata.Logs, agentID string, agentName string, bu
 	return &observIQLogBatch{Logs: sliceOut}, errorsOut
 }
 
-// Output timestamp format, an ISO8601 compliant timesetamp with millisecond precision
+// Output timestamp format, an ISO8601 compliant timestamp with millisecond precision
 const timestampFieldOutputLayout = "2006-01-02T15:04:05.000Z07:00"
 
-func resourceAndInstrmentationLogToEntry(resMap interface{}, log pdata.LogRecord, agentID string, agentName string, buildInfo component.BuildInfo) *observIQLogEntry {
-	msg := messageFromRecord(log)
-
+func resourceAndInstrumentationLogToEntry(resMap interface{}, log pdata.LogRecord, agentID string, agentName string, buildInfo component.BuildInfo) *observIQLogEntry {
 	return &observIQLogEntry{
 		Timestamp: timestampFromRecord(log),
 		Severity:  severityFromRecord(log),
 		Resource:  resMap,
-		Message:   msg,
+		Message:   messageFromRecord(log),
 		Data:      attributeMapToBaseType(log.Attributes()),
 		Body:      bodyFromRecord(log),
 		Agent:     &observIQAgentInfo{Name: agentName, ID: agentID, Version: buildInfo.Version},

--- a/exporter/observiqexporter/converter_test.go
+++ b/exporter/observiqexporter/converter_test.go
@@ -218,7 +218,7 @@ func TestLogdataToObservIQFormat(t *testing.T) {
 				logs,
 				testCase.agentID,
 				testCase.agentName,
-				component.DefaultBuildInfo())
+				component.DefaultBuildInfo().Version)
 
 			if testCase.expectErr {
 				require.NotEmpty(t, errs)

--- a/exporter/observiqexporter/converter_test.go
+++ b/exporter/observiqexporter/converter_test.go
@@ -341,7 +341,10 @@ func TestLogdataToObservIQFormat(t *testing.T) {
 				require.Empty(t, errs)
 			}
 
-			require.Equal(t, 1, len(res.Logs))
+			require.Len(t, res.Logs, 1)
+
+			// ID must be of length 32
+			require.Len(t, res.Logs[0].ID, 32)
 
 			oiqLogEntry := observIQLogEntry{}
 			err := json.Unmarshal(res.Logs[0].Entry, &oiqLogEntry)

--- a/exporter/observiqexporter/converter_test.go
+++ b/exporter/observiqexporter/converter_test.go
@@ -15,14 +15,223 @@
 package observiqexporter
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
 )
 
+func resourceAndLogRecordsToLogs(r pdata.Resource, lrs []pdata.LogRecord) pdata.Logs {
+	logs := pdata.NewLogs()
+	resLogs := logs.ResourceLogs()
+	resLogs.AppendEmpty()
+
+	resLog := resLogs.At(0)
+	resLogRes := resLog.Resource()
+
+	r.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
+		resLogRes.Attributes().Insert(k, v)
+		return true
+	})
+
+	resLog.InstrumentationLibraryLogs().Resize(len(lrs))
+	for i, l := range lrs {
+		ills := pdata.NewInstrumentationLibraryLogs()
+		ills.Logs().Resize(1)
+		l.CopyTo(ills.Logs().At(0))
+
+		ills.CopyTo(resLog.InstrumentationLibraryLogs().At(i))
+	}
+
+	return logs
+}
+
 func TestLogdataToObservIQFormat(t *testing.T) {
-	data, errs := logdataToObservIQFormat(pdata.NewLogs(), "", "")
-	require.NotNil(t, errs)
-	require.NotNil(t, data)
+	ts := time.Date(2021, 12, 11, 10, 9, 8, 1, time.UTC)
+	stringTs := "2021-12-11T10:09:08.000Z"
+	nanoTs := pdata.Timestamp(ts.UnixNano())
+	timeNow = func() time.Time {
+		return ts
+	}
+
+	testCases := []struct {
+		name          string
+		logRecordFn   func() pdata.LogRecord
+		logResourceFn func() pdata.Resource
+		agentName     string
+		agentID       string
+		output        observIQLogEntry
+		expectErr     bool
+	}{
+		{
+			"Happy path with string attributes",
+			func() pdata.LogRecord {
+				logRecord := pdata.NewLogRecord()
+				logRecord.Body().SetStringVal("Message")
+				logRecord.Attributes().InsertString(conventions.AttributeServiceName, "myapp")
+				logRecord.Attributes().InsertString(conventions.AttributeHostName, "myhost")
+				logRecord.Attributes().InsertString("custom", "custom")
+				logRecord.SetTimestamp(nanoTs)
+				return logRecord
+			},
+			pdata.NewResource,
+			"agent",
+			"agentID",
+			observIQLogEntry{
+				Timestamp: stringTs,
+				Message:   "Message",
+				Severity:  "default",
+				Resource:  map[string]interface{}{},
+				Data: map[string]interface{}{
+					conventions.AttributeServiceName: "myapp",
+					conventions.AttributeHostName:    "myhost",
+					"custom":                         "custom",
+				},
+				Agent: &observIQAgentInfo{Name: "agent", ID: "agentID"},
+			},
+			false,
+		},
+		{
+			"works with attributes of all types",
+			func() pdata.LogRecord {
+				logRecord := pdata.NewLogRecord()
+				logRecord.Body().SetStringVal("Message")
+				logRecord.Attributes().InsertString(conventions.AttributeServiceName, "myapp")
+				logRecord.Attributes().InsertBool("bool", true)
+				logRecord.Attributes().InsertDouble("double", 1.0)
+				logRecord.Attributes().InsertInt("int", 3)
+				logRecord.Attributes().InsertNull("null")
+
+				mapVal := pdata.NewAttributeValueMap()
+				mapVal.MapVal().Insert("mapKey", pdata.NewAttributeValueString("value"))
+				logRecord.Attributes().Insert("map", mapVal)
+
+				arrVal := pdata.NewAttributeValueArray()
+				arrVal.ArrayVal().Resize(2)
+				arrVal.ArrayVal().At(0).SetIntVal(1)
+				arrVal.ArrayVal().At(1).SetIntVal(2)
+				logRecord.Attributes().Insert("array", arrVal)
+
+				logRecord.SetTimestamp(nanoTs)
+				return logRecord
+			},
+			pdata.NewResource,
+			"agent",
+			"agentID",
+			observIQLogEntry{
+				Timestamp: stringTs,
+				Message:   "Message",
+				Severity:  "default",
+				Resource:  map[string]interface{}{},
+				Data: map[string]interface{}{
+					conventions.AttributeServiceName: "myapp",
+					"bool":                           true,
+					"double":                         float64(1.0),
+					"int":                            float64(3),
+					"map": map[string]interface{}{
+						"mapKey": "value",
+					},
+					"array": []interface{}{float64(1), float64(2)},
+				},
+				Agent: &observIQAgentInfo{Name: "agent", ID: "agentID"},
+			},
+			false,
+		},
+		{
+			"Body is nil",
+			func() pdata.LogRecord {
+				logRecord := pdata.NewLogRecord()
+				logRecord.SetTimestamp(nanoTs)
+				return logRecord
+			},
+			pdata.NewResource,
+			"agent",
+			"agentID",
+			observIQLogEntry{
+				Timestamp: stringTs,
+				Message:   "",
+				Severity:  "default",
+				Resource:  map[string]interface{}{},
+				Data:      nil,
+				Agent:     &observIQAgentInfo{Name: "agent", ID: "agentID"},
+			},
+			false,
+		},
+		{
+			"Body is map",
+			func() pdata.LogRecord {
+				logRecord := pdata.NewLogRecord()
+
+				mapVal := pdata.NewAttributeValueMap()
+				mapVal.MapVal().Insert("mapKey", pdata.NewAttributeValueString("value"))
+				mapVal.CopyTo(logRecord.Body())
+
+				logRecord.SetTimestamp(nanoTs)
+				return logRecord
+			},
+			pdata.NewResource,
+			"agent",
+			"agentID",
+			observIQLogEntry{
+				Timestamp: stringTs,
+				Severity:  "default",
+				Resource:  map[string]interface{}{},
+				Data:      nil,
+				Agent:     &observIQAgentInfo{Name: "agent", ID: "agentID"},
+				Body: map[string]interface{}{
+					"mapKey": "value",
+				},
+			},
+			false,
+		},
+		{
+			"No timestamp on record",
+			func() pdata.LogRecord {
+				logRecord := pdata.NewLogRecord()
+				logRecord.Body().SetStringVal("Message")
+				return logRecord
+			},
+			pdata.NewResource,
+			"agent",
+			"agentID",
+			observIQLogEntry{
+				Timestamp: stringTs,
+				Message:   "Message",
+				Severity:  "default",
+				Resource:  map[string]interface{}{},
+				Data:      nil,
+				Agent:     &observIQAgentInfo{Name: "agent", ID: "agentID"},
+			},
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			logs := resourceAndLogRecordsToLogs(testCase.logResourceFn(), []pdata.LogRecord{testCase.logRecordFn()})
+			res, errs := logdataToObservIQFormat(logs, testCase.agentID, testCase.agentName)
+
+			if testCase.expectErr {
+				require.NotEmpty(t, errs)
+			} else {
+				require.Empty(t, errs)
+			}
+
+			require.Equal(t, 1, len(res.Logs))
+
+			oiqLogEntry := observIQLogEntry{}
+			err := json.Unmarshal(res.Logs[0].Entry, &oiqLogEntry)
+
+			if testCase.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, testCase.output, oiqLogEntry)
+		})
+	}
 }

--- a/exporter/observiqexporter/converter_test.go
+++ b/exporter/observiqexporter/converter_test.go
@@ -222,6 +222,58 @@ func TestLogdataToObservIQFormat(t *testing.T) {
 			false,
 		},
 		{
+			"Body is array",
+			func() pdata.LogRecord {
+				logRecord := pdata.NewLogRecord()
+
+				pdata.NewAttributeValueArray().CopyTo(logRecord.Body())
+				logRecord.Body().ArrayVal().Resize(2)
+				logRecord.Body().ArrayVal().At(0).SetStringVal("string")
+				logRecord.Body().ArrayVal().At(1).SetDoubleVal(1.0)
+
+				logRecord.SetTimestamp(nanoTs)
+				return logRecord
+			},
+			pdata.NewResource,
+			"agent",
+			"agentID",
+			observIQLogEntry{
+				Timestamp: stringTs,
+				Severity:  "default",
+				Resource:  map[string]interface{}{},
+				Data:      nil,
+				Agent:     &observIQAgentInfo{Name: "agent", ID: "agentID", Version: "latest"},
+				Body: []interface{}{
+					"string",
+					float64(1.0),
+				},
+			},
+			false,
+		},
+		{
+			"Body is an int",
+			func() pdata.LogRecord {
+				logRecord := pdata.NewLogRecord()
+
+				logRecord.Body().SetIntVal(1)
+
+				logRecord.SetTimestamp(nanoTs)
+				return logRecord
+			},
+			pdata.NewResource,
+			"agent",
+			"agentID",
+			observIQLogEntry{
+				Timestamp: stringTs,
+				Severity:  "default",
+				Resource:  map[string]interface{}{},
+				Data:      nil,
+				Agent:     &observIQAgentInfo{Name: "agent", ID: "agentID", Version: "latest"},
+				Body:      float64(1.0),
+			},
+			false,
+		},
+		{
 			"Body and attributes are maps",
 			func() pdata.LogRecord {
 				logRecord := pdata.NewLogRecord()

--- a/exporter/observiqexporter/exporter.go
+++ b/exporter/observiqexporter/exporter.go
@@ -30,7 +30,7 @@ func newObservIQLogExporter(config *Config, set component.ExporterCreateSettings
 		return nil, err
 	}
 
-	client, err := buildClient(config, set.Logger)
+	client, err := buildClient(config, set.Logger, set.BuildInfo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description:**
Implementation of pdata.Logs to observIQ format.

**Link to tracking Issue:**
N/A

**Testing:**
Unit tests added for logdataToObservIQFormat
Tweaked unit tests for client to ensure request has the logs on the request in a parseable format

**Documentation:**
No (externally visible) changes to document