### PR TITLE
Remove unnecessary public apis for container insight receiver

### DIFF
--- a/receiver/awscontainerinsightreceiver/factory.go
+++ b/receiver/awscontainerinsightreceiver/factory.go
@@ -71,5 +71,5 @@ func createMetricsReceiver(
 
 	rCfg := baseCfg.(*Config)
 	logger := params.Logger
-	return New(logger, rCfg, consumer)
+	return newAWSContainerInsightReceiver(logger, rCfg, consumer)
 }

--- a/receiver/awscontainerinsightreceiver/go.sum
+++ b/receiver/awscontainerinsightreceiver/go.sum
@@ -258,6 +258,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/crossdock/crossdock-go v0.0.0-20160816171116-049aabb0122b/go.mod h1:v9FBN7gdVTpiD/+LZ7Po0UKvROyT87uLVxTHVky/dlQ=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
@@ -628,7 +629,9 @@ github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -1381,6 +1384,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -32,7 +32,7 @@ import (
 
 var _ component.MetricsReceiver = (*awsContainerInsightReceiver)(nil)
 
-type MetricsProvider interface {
+type metricsProvider interface {
 	GetMetrics() []pdata.Metrics
 }
 
@@ -42,12 +42,12 @@ type awsContainerInsightReceiver struct {
 	nextConsumer consumer.Metrics
 	config       *Config
 	cancel       context.CancelFunc
-	cadvisor     MetricsProvider
-	k8sapiserver MetricsProvider
+	cadvisor     metricsProvider
+	k8sapiserver metricsProvider
 }
 
-// New creates the aws container insight receiver with the given parameters.
-func New(
+// newAWSContainerInsightReceiver creates the aws container insight receiver with the given parameters.
+func newAWSContainerInsightReceiver(
 	logger *zap.Logger,
 	config *Config,
 	nextConsumer consumer.Metrics) (component.MetricsReceiver, error) {

--- a/receiver/awscontainerinsightreceiver/receiver_test.go
+++ b/receiver/awscontainerinsightreceiver/receiver_test.go
@@ -45,7 +45,7 @@ func (m *MockK8sAPIServer) GetMetrics() []pdata.Metrics {
 
 func TestReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	metricsReceiver, err := New(
+	metricsReceiver, err := newAWSContainerInsightReceiver(
 		zap.NewNop(),
 		cfg,
 		consumertest.NewNop(),
@@ -66,7 +66,7 @@ func TestReceiver(t *testing.T) {
 
 func TestReceiverForNilConsumer(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	metricsReceiver, err := New(
+	metricsReceiver, err := newAWSContainerInsightReceiver(
 		zap.NewNop(),
 		cfg,
 		nil,
@@ -78,7 +78,7 @@ func TestReceiverForNilConsumer(t *testing.T) {
 
 func TestCollectData(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	metricsReceiver, err := New(
+	metricsReceiver, err := newAWSContainerInsightReceiver(
 		zap.NewNop(),
 		cfg,
 		new(consumertest.MetricsSink),
@@ -104,7 +104,7 @@ func TestCollectData(t *testing.T) {
 
 func TestCollectDataWithErrConsumer(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	metricsReceiver, err := New(
+	metricsReceiver, err := newAWSContainerInsightReceiver(
 		zap.NewNop(),
 		cfg,
 		consumertest.NewErr(errors.New("an error")),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Remove some public apis

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4078

