### PR TITLE
[exporter/datadog]: remove v0.28 datadogexporter readme warnings

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -1,7 +1,5 @@
 # Datadog Exporter
 
-> :warning: The Datadog exporter version v0.28.0 (the current latest version at time of writing) has reports of an [unintended issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3786) that may cause Traces exported to Datadog to not be retained past 15 minutes. This may cause unexpected behavior in the Datadog UI. This issued should be resolved in the next release (v0.29.0), but at present the current recommended version of the Datadog Exporter is [v0.27.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.27.0). Please [Reach out to Datadog support](https://docs.datadoghq.com/help/) if it doesn't work as you expect.
-
 This exporter sends metric and trace data to [Datadog](https://datadoghq.com). For environment specific setup instructions visit the [Datadog Documentation](https://docs.datadoghq.com/tracing/setup_overview/open_standards/#opentelemetry-collector-datadog-exporter).
 
 > Please review the Collector's [security


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Removes the doc warnings for the datadog exporter about span retention issues in v0.28. As this is resolved in v0.29 and going forward, updating readme accordingly

**Link to tracking Issue:** <Issue number if applicable> n/a

**Testing:** <Describe what testing was performed and which tests were added.> n/a

**Documentation:** <Describe the documentation added.> updated README.md