### PR TITLE
Update metricstransformprocessor README with correct example

### DIFF
--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -152,10 +152,11 @@ new_name: system.cpu.usage_time
 ### Rename multiple metrics using Substitution
 ```yaml
 # rename all system.cpu metrics to system.processor.*
-include: ^system\.cpu\.(.*)$
+# instead of regular $ use double dollar $$. Because $ is treated as a special character.
+include: ^system\.cpu\.(.*)$$
 match_type: regexp
 action: update
-new_name: system.processor.$1
+new_name: system.processor.$$1
 ```
 
 ### Add a label
@@ -294,13 +295,15 @@ operations:
 # 
 # ex: Consider pod and container metrics collected from Kubernetes. Both the metrics are recorded under under one ResourceMetric
 # applying this transformation will result in two separate ResourceMetric packets with corresponding resource labels in the resource headers
+#
+# instead of regular $ use double dollar $$. Because $ is treated as a special character.
 
 
-- include: ^k8s\.pod\.(.*)$
+- include: ^k8s\.pod\.(.*)$$
   match_type: regexp
   action: group
   group_resource_labels: {"resouce.type": "k8s.pod", "source": "kubelet"}
-- include: ^container\.(.*)$
+- include: ^container\.(.*)$$
   match_type: regexp
   action: group
   group_resource_labels: {"resouce.type": "container", "source": "kubelet"}


### PR DESCRIPTION
Renaming multiple metrics following the README example of `metricstransformprocessor` doesn't work. In the current example we used `$` which is treated a special character and doesn't work. After replacing it with `$$`, it worked for me. So, updating the README. 

**Describe the bug**
I am using the `metricstransformprocessor` to rename multiple metrics using `substitution`. I tried to follow the given example in the [README](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstransformprocessor#rename-multiple-metrics-using-substitution). But it didn't work for me.
```yaml
# rename all system.cpu metrics to system.processor.*
include: ^system\.cpu\.(.*)$
match_type: regexp
action: update
new_name: system.processor.$1

```

I have a metric nane `new_container_memory_limit` and I want to rename it to `container_memory_limit`. I was using the following config:
```yaml
- include: ^new_container_(.*)$
  match_type: regexp
  action: update
  new_name: container_$1
```
The metric is being renamed as `container_` (whereas I am expecting `container_memory_limit`)

I am not sure what I am missing here. Any guidance is appreciated.

**What version did you use?**
Latest contrib build, version: v0.29.0-60-g168076c3

**Solution:**
`$` is being treated as a special character. We need to use double dollar sign `$$` instead of a single `$`. 

Following cofig worked for me:
```yaml
- include: ^new_container_(.*)$$
  match_type: regexp
  action: update
  new_name: container_$$1
  ```

