### PR TITLE
Un-expose the unnecessary public APIs and structs in awsemfexporter

### DIFF
--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -23,9 +23,9 @@ import (
 )
 
 var (
-	// EMFSupportedUnits contains the unit collection supported by CloudWatch backend service.
+	// eMFSupportedUnits contains the unit collection supported by CloudWatch backend service.
 	// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html
-	EMFSupportedUnits = newEMFSupportedUnits()
+	eMFSupportedUnits = newEMFSupportedUnits()
 )
 
 // Config defines configuration for AWS EMF exporter.
@@ -87,7 +87,7 @@ type MetricDescriptor struct {
 func (config *Config) Validate() error {
 	validDeclarations := []*MetricDeclaration{}
 	for _, declaration := range config.MetricDeclarations {
-		err := declaration.Init(config.logger)
+		err := declaration.init(config.logger)
 		if err != nil {
 			config.logger.Warn("Dropped metric declaration.", zap.Error(err))
 		} else {
@@ -101,7 +101,7 @@ func (config *Config) Validate() error {
 		if descriptor.metricName == "" {
 			continue
 		}
-		if _, ok := EMFSupportedUnits[descriptor.unit]; ok {
+		if _, ok := eMFSupportedUnits[descriptor.unit]; ok {
 			validDescriptors = append(validDescriptors, descriptor)
 		} else {
 			config.logger.Warn("Dropped unsupported metric desctriptor.", zap.String("unit", descriptor.unit))

--- a/exporter/awsemfexporter/cwlog_client.go
+++ b/exporter/awsemfexporter/cwlog_client.go
@@ -37,12 +37,6 @@ const (
 	errCodeThrottlingException = "ThrottlingException"
 )
 
-// LogClient will perform the necessary operations for publishing log events use case.
-type LogClient interface {
-	PutLogEvents(input *cloudwatchlogs.PutLogEventsInput, retryCnt int) (*string, error)
-	CreateStream(logGroup, streamName *string) (token string, e error)
-}
-
 // Possible exceptions are combination of common errors (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/CommonErrors.html)
 // and API specific erros (e.g. https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html#API_PutLogEvents_Errors)
 type cloudWatchLogClient struct {
@@ -57,8 +51,8 @@ func newCloudWatchLogClient(svc cloudwatchlogsiface.CloudWatchLogsAPI, logger *z
 	return logClient
 }
 
-// NewCloudWatchLogsClient create cloudWatchLogClient
-func NewCloudWatchLogsClient(logger *zap.Logger, awsConfig *aws.Config, buildInfo component.BuildInfo, sess *session.Session) LogClient {
+// newCloudWatchLogsClient create cloudWatchLogClient
+func newCloudWatchLogsClient(logger *zap.Logger, awsConfig *aws.Config, buildInfo component.BuildInfo, sess *session.Session) *cloudWatchLogClient {
 	client := cloudwatchlogs.New(sess, awsConfig)
 	client.Handlers.Build.PushBackNamed(handler.RequestStructuredLogHandler)
 	client.Handlers.Build.PushFrontNamed(newCollectorUserAgentHandler(buildInfo))

--- a/exporter/awsemfexporter/cwlog_client_test.go
+++ b/exporter/awsemfexporter/cwlog_client_test.go
@@ -32,7 +32,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func NewAlwaysPassMockLogClient(putLogEventsFunc func(args mock.Arguments)) LogClient {
+func newAlwaysPassMockLogClient(putLogEventsFunc func(args mock.Arguments)) *cloudWatchLogClient {
 	logger := zap.NewNop()
 	svc := new(mockCloudWatchLogsClient)
 
@@ -447,8 +447,8 @@ func TestUserAgent(t *testing.T) {
 	}
 
 	session, _ := session.NewSession()
-	cwlog := NewCloudWatchLogsClient(logger, &aws.Config{}, buildInfo, session)
-	logClient := cwlog.(*cloudWatchLogClient).svc.(*cloudwatchlogs.CloudWatchLogs)
+	cwlog := newCloudWatchLogsClient(logger, &aws.Config{}, buildInfo, session)
+	logClient := cwlog.svc.(*cloudwatchlogs.CloudWatchLogs)
 
 	req := request.New(aws.Config{}, metadata.ClientInfo{}, logClient.Handlers, nil, &request.Operation{
 		HTTPMethod: "GET",

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -298,7 +298,7 @@ func TestIntDataPointSliceAt(t *testing.T) {
 			testDP.SetValue(tc.value.(int64))
 			testDP.LabelsMap().InitFromMap(labels)
 
-			dps := IntDataPointSlice{
+			dps := intDataPointSlice{
 				instrLibName,
 				deltaMetricMetadata{
 					tc.adjustToDelta,
@@ -311,9 +311,9 @@ func TestIntDataPointSliceAt(t *testing.T) {
 				testDPS,
 			}
 
-			expectedDP := DataPoint{
-				Value: tc.calculatedValue,
-				Labels: map[string]string{
+			expectedDP := dataPoint{
+				value: tc.calculatedValue,
+				labels: map[string]string{
 					oTellibDimensionKey: instrLibName,
 					"label":             "value",
 				},
@@ -323,8 +323,8 @@ func TestIntDataPointSliceAt(t *testing.T) {
 			dp, retained := dps.At(0)
 			assert.Equal(t, i > 0, retained)
 			if retained {
-				assert.Equal(t, expectedDP.Labels, dp.Labels)
-				assert.InDelta(t, expectedDP.Value.(float64), dp.Value.(float64), 0.02)
+				assert.Equal(t, expectedDP.labels, dp.labels)
+				assert.InDelta(t, expectedDP.value.(float64), dp.value.(float64), 0.02)
 			}
 		})
 	}
@@ -369,7 +369,7 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 			testDP.SetValue(tc.value.(float64))
 			testDP.LabelsMap().InitFromMap(labels)
 
-			dps := DoubleDataPointSlice{
+			dps := doubleDataPointSlice{
 				instrLibName,
 				deltaMetricMetadata{
 					tc.adjustToDelta,
@@ -386,7 +386,7 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 			dp, retained := dps.At(0)
 			assert.Equal(t, i > 0, retained)
 			if retained {
-				assert.InDelta(t, tc.calculatedValue.(float64), dp.Value.(float64), 0.002)
+				assert.InDelta(t, tc.calculatedValue.(float64), dp.value.(float64), 0.002)
 			}
 		})
 	}
@@ -404,17 +404,17 @@ func TestHistogramDataPointSliceAt(t *testing.T) {
 	testDP.SetExplicitBounds([]float64{1, 2, 3})
 	testDP.LabelsMap().InitFromMap(labels)
 
-	dps := HistogramDataPointSlice{
+	dps := histogramDataPointSlice{
 		instrLibName,
 		testDPS,
 	}
 
-	expectedDP := DataPoint{
-		Value: &CWMetricStats{
+	expectedDP := dataPoint{
+		value: &cWMetricStats{
 			Sum:   17.13,
 			Count: 17,
 		},
-		Labels: map[string]string{
+		labels: map[string]string{
 			oTellibDimensionKey: instrLibName,
 			"label1":            "value1",
 		},
@@ -470,7 +470,7 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 			testQuantileValue.SetValue(float64(5))
 			testDP.LabelsMap().InitFromMap(labels)
 
-			dps := SummaryDataPointSlice{
+			dps := summaryDataPointSlice{
 				instrLibName,
 				deltaMetricMetadata{
 					true,
@@ -483,14 +483,14 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 				testDPS,
 			}
 
-			expectedDP := DataPoint{
-				Value: &CWMetricStats{
+			expectedDP := dataPoint{
+				value: &cWMetricStats{
 					Max:   5,
 					Min:   1,
 					Sum:   tt.calculatedSumCount[0].(float64),
 					Count: tt.calculatedSumCount[1].(uint64),
 				},
-				Labels: map[string]string{
+				labels: map[string]string{
 					oTellibDimensionKey: instrLibName,
 					"label1":            "value1",
 				},
@@ -500,9 +500,9 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 			dp, retained := dps.At(0)
 			assert.Equal(t, i > 0, retained)
 			if retained {
-				expectedMetricStats := expectedDP.Value.(*CWMetricStats)
-				actualMetricsStats := dp.Value.(*CWMetricStats)
-				assert.Equal(t, expectedDP.Labels, dp.Labels)
+				expectedMetricStats := expectedDP.value.(*cWMetricStats)
+				actualMetricsStats := dp.value.(*cWMetricStats)
+				assert.Equal(t, expectedDP.labels, dp.labels)
 				assert.Equal(t, expectedMetricStats.Max, actualMetricsStats.Max)
 				assert.Equal(t, expectedMetricStats.Min, actualMetricsStats.Min)
 				assert.InDelta(t, expectedMetricStats.Count, actualMetricsStats.Count, 0.1)
@@ -530,20 +530,20 @@ func TestCreateLabels(t *testing.T) {
 }
 
 func TestGetDataPoints(t *testing.T) {
-	metadata := CWMetricMetadata{
-		GroupedMetricMetadata: GroupedMetricMetadata{
-			Namespace:   "namespace",
-			TimestampMs: time.Now().UnixNano() / int64(time.Millisecond),
-			LogGroup:    "log-group",
-			LogStream:   "log-stream",
+	metadata := cWMetricMetadata{
+		groupedMetricMetadata: groupedMetricMetadata{
+			namespace:   "namespace",
+			timestampMs: time.Now().UnixNano() / int64(time.Millisecond),
+			logGroup:    "log-group",
+			logStream:   "log-stream",
 		},
-		InstrumentationLibraryName: "cloudwatch-otel",
+		instrumentationLibraryName: "cloudwatch-otel",
 	}
 
 	dmm := deltaMetricMetadata{
 		false,
 		"foo",
-		metadata.TimestampMs,
+		metadata.timestampMs,
 		"namespace",
 		"log-group",
 		"log-stream",
@@ -551,7 +551,7 @@ func TestGetDataPoints(t *testing.T) {
 	cumulativeDmm := deltaMetricMetadata{
 		true,
 		"foo",
-		metadata.TimestampMs,
+		metadata.timestampMs,
 		"namespace",
 		"log-group",
 		"log-stream",
@@ -560,14 +560,14 @@ func TestGetDataPoints(t *testing.T) {
 		testName            string
 		isPrometheusMetrics bool
 		metric              *metricspb.Metric
-		expectedDataPoints  DataPoints
+		expectedDataPoints  dataPoints
 	}{
 		{
 			"Int gauge",
 			false,
 			generateTestIntGauge("foo"),
-			IntDataPointSlice{
-				metadata.InstrumentationLibraryName,
+			intDataPointSlice{
+				metadata.instrumentationLibraryName,
 				dmm,
 				pdata.IntDataPointSlice{},
 			},
@@ -576,8 +576,8 @@ func TestGetDataPoints(t *testing.T) {
 			"Double gauge",
 			false,
 			generateTestDoubleGauge("foo"),
-			DoubleDataPointSlice{
-				metadata.InstrumentationLibraryName,
+			doubleDataPointSlice{
+				metadata.instrumentationLibraryName,
 				dmm,
 				pdata.DoubleDataPointSlice{},
 			},
@@ -586,8 +586,8 @@ func TestGetDataPoints(t *testing.T) {
 			"Int sum",
 			false,
 			generateTestIntSum("foo")[1],
-			IntDataPointSlice{
-				metadata.InstrumentationLibraryName,
+			intDataPointSlice{
+				metadata.instrumentationLibraryName,
 				cumulativeDmm,
 				pdata.IntDataPointSlice{},
 			},
@@ -596,8 +596,8 @@ func TestGetDataPoints(t *testing.T) {
 			"Double sum",
 			false,
 			generateTestDoubleSum("foo")[1],
-			DoubleDataPointSlice{
-				metadata.InstrumentationLibraryName,
+			doubleDataPointSlice{
+				metadata.instrumentationLibraryName,
 				cumulativeDmm,
 				pdata.DoubleDataPointSlice{},
 			},
@@ -606,8 +606,8 @@ func TestGetDataPoints(t *testing.T) {
 			"Double histogram",
 			false,
 			generateTestHistogram("foo"),
-			HistogramDataPointSlice{
-				metadata.InstrumentationLibraryName,
+			histogramDataPointSlice{
+				metadata.instrumentationLibraryName,
 				pdata.HistogramDataPointSlice{},
 			},
 		},
@@ -615,8 +615,8 @@ func TestGetDataPoints(t *testing.T) {
 			"Summary from SDK",
 			false,
 			generateTestSummary("foo")[1],
-			SummaryDataPointSlice{
-				metadata.InstrumentationLibraryName,
+			summaryDataPointSlice{
+				metadata.instrumentationLibraryName,
 				dmm,
 				pdata.SummaryDataPointSlice{},
 			},
@@ -625,8 +625,8 @@ func TestGetDataPoints(t *testing.T) {
 			"Summary from Prometheus",
 			true,
 			generateTestSummary("foo")[1],
-			SummaryDataPointSlice{
-				metadata.InstrumentationLibraryName,
+			summaryDataPointSlice{
+				metadata.instrumentationLibraryName,
 				cumulativeDmm,
 				pdata.SummaryDataPointSlice{},
 			},
@@ -656,33 +656,33 @@ func TestGetDataPoints(t *testing.T) {
 			assert.NotNil(t, dps)
 			assert.Equal(t, reflect.TypeOf(tc.expectedDataPoints), reflect.TypeOf(dps))
 			switch convertedDPS := dps.(type) {
-			case IntDataPointSlice:
-				expectedDPS := tc.expectedDataPoints.(IntDataPointSlice)
-				assert.Equal(t, metadata.InstrumentationLibraryName, convertedDPS.instrumentationLibraryName)
+			case intDataPointSlice:
+				expectedDPS := tc.expectedDataPoints.(intDataPointSlice)
+				assert.Equal(t, metadata.instrumentationLibraryName, convertedDPS.instrumentationLibraryName)
 				assert.Equal(t, expectedDPS.deltaMetricMetadata, convertedDPS.deltaMetricMetadata)
 				assert.Equal(t, 1, convertedDPS.Len())
 				dp := convertedDPS.IntDataPointSlice.At(0)
 				assert.Equal(t, int64(1), dp.Value())
 				assert.Equal(t, expectedLabels, dp.LabelsMap())
-			case DoubleDataPointSlice:
-				expectedDPS := tc.expectedDataPoints.(DoubleDataPointSlice)
-				assert.Equal(t, metadata.InstrumentationLibraryName, convertedDPS.instrumentationLibraryName)
+			case doubleDataPointSlice:
+				expectedDPS := tc.expectedDataPoints.(doubleDataPointSlice)
+				assert.Equal(t, metadata.instrumentationLibraryName, convertedDPS.instrumentationLibraryName)
 				assert.Equal(t, expectedDPS.deltaMetricMetadata, convertedDPS.deltaMetricMetadata)
 				assert.Equal(t, 1, convertedDPS.Len())
 				dp := convertedDPS.DoubleDataPointSlice.At(0)
 				assert.Equal(t, 0.1, dp.Value())
 				assert.Equal(t, expectedLabels, dp.LabelsMap())
-			case HistogramDataPointSlice:
-				assert.Equal(t, metadata.InstrumentationLibraryName, convertedDPS.instrumentationLibraryName)
+			case histogramDataPointSlice:
+				assert.Equal(t, metadata.instrumentationLibraryName, convertedDPS.instrumentationLibraryName)
 				assert.Equal(t, 1, convertedDPS.Len())
 				dp := convertedDPS.HistogramDataPointSlice.At(0)
 				assert.Equal(t, 35.0, dp.Sum())
 				assert.Equal(t, uint64(18), dp.Count())
 				assert.Equal(t, []float64{0, 10}, dp.ExplicitBounds())
 				assert.Equal(t, expectedLabels, dp.LabelsMap())
-			case SummaryDataPointSlice:
-				expectedDPS := tc.expectedDataPoints.(SummaryDataPointSlice)
-				assert.Equal(t, metadata.InstrumentationLibraryName, convertedDPS.instrumentationLibraryName)
+			case summaryDataPointSlice:
+				expectedDPS := tc.expectedDataPoints.(summaryDataPointSlice)
+				assert.Equal(t, metadata.instrumentationLibraryName, convertedDPS.instrumentationLibraryName)
 				assert.Equal(t, expectedDPS.deltaMetricMetadata, convertedDPS.deltaMetricMetadata)
 				assert.Equal(t, 1, convertedDPS.Len())
 				dp := convertedDPS.SummaryDataPointSlice.At(0)
@@ -741,14 +741,14 @@ func BenchmarkGetDataPoints(b *testing.B) {
 	metrics := rms.At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	numMetrics := metrics.Len()
 
-	metadata := CWMetricMetadata{
-		GroupedMetricMetadata: GroupedMetricMetadata{
-			Namespace:   "Namespace",
-			TimestampMs: int64(1596151098037),
-			LogGroup:    "log-group",
-			LogStream:   "log-stream",
+	metadata := cWMetricMetadata{
+		groupedMetricMetadata: groupedMetricMetadata{
+			namespace:   "Namespace",
+			timestampMs: int64(1596151098037),
+			logGroup:    "log-group",
+			logStream:   "log-stream",
 		},
-		InstrumentationLibraryName: "cloudwatch-otel",
+		instrumentationLibraryName: "cloudwatch-otel",
 	}
 
 	logger := zap.NewNop()
@@ -775,13 +775,13 @@ func TestIntDataPointSlice_At(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   DataPoint
+		want   dataPoint
 	}{
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dps := IntDataPointSlice{
+			dps := intDataPointSlice{
 				instrumentationLibraryName: tt.fields.instrumentationLibraryName,
 				deltaMetricMetadata:        tt.fields.deltaMetricMetadata,
 				IntDataPointSlice:          tt.fields.IntDataPointSlice,

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -42,9 +42,9 @@ const (
 )
 
 type emfExporter struct {
-	//Each (log group, log stream) keeps a separate Pusher because of each (log group, log stream) requires separate stream token.
-	groupStreamToPusherMap map[string]map[string]Pusher
-	svcStructuredLog       LogClient
+	//Each (log group, log stream) keeps a separate pusher because of each (log group, log stream) requires separate stream token.
+	groupStreamToPusherMap map[string]map[string]pusher
+	svcStructuredLog       *cloudWatchLogClient
 	config                 config.Exporter
 	logger                 *zap.Logger
 
@@ -55,8 +55,8 @@ type emfExporter struct {
 	collectorID   string
 }
 
-// New func creates an EMF Exporter instance with data push callback func
-func New(
+// newEmfPusher func creates an EMF Exporter instance with data push callback func
+func newEmfPusher(
 	config config.Exporter,
 	params component.ExporterCreateSettings,
 ) (component.MetricsExporter, error) {
@@ -75,7 +75,7 @@ func New(
 	}
 
 	// create CWLogs client with aws session config
-	svcStructuredLog := NewCloudWatchLogsClient(logger, awsConfig, params.BuildInfo, session)
+	svcStructuredLog := newCloudWatchLogsClient(logger, awsConfig, params.BuildInfo, session)
 	collectorIdentifier, _ := uuid.NewRandom()
 
 	expConfig.Validate()
@@ -88,17 +88,17 @@ func New(
 		logger:           logger,
 		collectorID:      collectorIdentifier.String(),
 	}
-	emfExporter.groupStreamToPusherMap = map[string]map[string]Pusher{}
+	emfExporter.groupStreamToPusherMap = map[string]map[string]pusher{}
 
 	return emfExporter, nil
 }
 
-// NewEmfExporter creates a new exporter using exporterhelper
-func NewEmfExporter(
+// newEmfExporter creates a new exporter using exporterhelper
+func newEmfExporter(
 	config config.Exporter,
 	params component.ExporterCreateSettings,
 ) (component.MetricsExporter, error) {
-	exp, err := New(config, params)
+	exp, err := newEmfPusher(config, params)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pdata.Metrics) err
 	}
 	emf.logger.Info("Start processing resource metrics", zap.Any("labels", labels))
 
-	groupedMetrics := make(map[interface{}]*GroupedMetric)
+	groupedMetrics := make(map[interface{}]*groupedMetric)
 	expConfig := emf.config.(*Config)
 	defaultLogStream := fmt.Sprintf("otel-stream-%s", emf.collectorID)
 	outputDestination := expConfig.OutputDestination
@@ -142,17 +142,17 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pdata.Metrics) err
 		putLogEvent := translateCWMetricToEMF(cWMetric, expConfig)
 		// Currently we only support two options for "OutputDestination".
 		if strings.EqualFold(outputDestination, outputDestinationStdout) {
-			fmt.Println(*putLogEvent.InputLogEvent.Message)
+			fmt.Println(*putLogEvent.inputLogEvent.Message)
 		} else if strings.EqualFold(outputDestination, outputDestinationCloudWatch) {
-			logGroup := groupedMetric.Metadata.LogGroup
-			logStream := groupedMetric.Metadata.LogStream
+			logGroup := groupedMetric.metadata.logGroup
+			logStream := groupedMetric.metadata.logStream
 			if logStream == "" {
 				logStream = defaultLogStream
 			}
 
-			pusher := emf.getPusher(logGroup, logStream)
-			if pusher != nil {
-				returnError := pusher.AddLogEntry(putLogEvent)
+			emfPusher := emf.getPusher(logGroup, logStream)
+			if emfPusher != nil {
+				returnError := emfPusher.addLogEntry(putLogEvent)
 				if returnError != nil {
 					return wrapErrorIfBadRequest(&returnError)
 				}
@@ -161,13 +161,13 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pdata.Metrics) err
 	}
 
 	if strings.EqualFold(outputDestination, outputDestinationCloudWatch) {
-		for _, pusher := range emf.listPushers() {
-			returnError := pusher.ForceFlush()
+		for _, emfPusher := range emf.listPushers() {
+			returnError := emfPusher.forceFlush()
 			if returnError != nil {
-				//TODO now we only have one pusher, so it's ok to return after first error occurred
+				//TODO now we only have one logPusher, so it's ok to return after first error occurred
 				err := wrapErrorIfBadRequest(&returnError)
 				if err != nil {
-					emf.logger.Error("Error force flushing logs. Skipping to next pusher.", zap.Error(err))
+					emf.logger.Error("Error force flushing logs. Skipping to next logPusher.", zap.Error(err))
 				}
 				return err
 			}
@@ -179,30 +179,30 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pdata.Metrics) err
 	return nil
 }
 
-func (emf *emfExporter) getPusher(logGroup, logStream string) Pusher {
+func (emf *emfExporter) getPusher(logGroup, logStream string) pusher {
 	emf.pusherMapLock.Lock()
 	defer emf.pusherMapLock.Unlock()
 
 	var ok bool
-	var streamToPusherMap map[string]Pusher
+	var streamToPusherMap map[string]pusher
 	if streamToPusherMap, ok = emf.groupStreamToPusherMap[logGroup]; !ok {
-		streamToPusherMap = map[string]Pusher{}
+		streamToPusherMap = map[string]pusher{}
 		emf.groupStreamToPusherMap[logGroup] = streamToPusherMap
 	}
 
-	var pusher Pusher
-	if pusher, ok = streamToPusherMap[logStream]; !ok {
-		pusher = NewPusher(aws.String(logGroup), aws.String(logStream), emf.retryCnt, emf.svcStructuredLog, emf.logger)
-		streamToPusherMap[logStream] = pusher
+	var emfPusher pusher
+	if emfPusher, ok = streamToPusherMap[logStream]; !ok {
+		emfPusher = newPusher(aws.String(logGroup), aws.String(logStream), emf.retryCnt, *emf.svcStructuredLog, emf.logger)
+		streamToPusherMap[logStream] = emfPusher
 	}
-	return pusher
+	return emfPusher
 }
 
-func (emf *emfExporter) listPushers() []Pusher {
+func (emf *emfExporter) listPushers() []pusher {
 	emf.pusherMapLock.Lock()
 	defer emf.pusherMapLock.Unlock()
 
-	pushers := []Pusher{}
+	pushers := []pusher{}
 	for _, pusherMap := range emf.groupStreamToPusherMap {
 		for _, pusher := range pusherMap {
 			pushers = append(pushers, pusher)
@@ -217,12 +217,12 @@ func (emf *emfExporter) ConsumeMetrics(ctx context.Context, md pdata.Metrics) er
 
 // Shutdown stops the exporter and is invoked during shutdown.
 func (emf *emfExporter) Shutdown(ctx context.Context) error {
-	for _, pusher := range emf.listPushers() {
-		returnError := pusher.ForceFlush()
+	for _, emfPusher := range emf.listPushers() {
+		returnError := emfPusher.forceFlush()
 		if returnError != nil {
 			err := wrapErrorIfBadRequest(&returnError)
 			if err != nil {
-				emf.logger.Error("Error when gracefully shutting down emf_exporter. Skipping to next pusher.", zap.Error(err))
+				emf.logger.Error("Error when gracefully shutting down emf_exporter. Skipping to next logPusher.", zap.Error(err))
 			}
 		}
 	}

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -47,7 +47,7 @@ type mockPusher struct {
 	mock.Mock
 }
 
-func (p *mockPusher) AddLogEntry(logEvent *LogEvent) error {
+func (p *mockPusher) addLogEntry(logEvent *logEvent) error {
 	args := p.Called(nil)
 	errorStr := args.String(0)
 	if errorStr != "" {
@@ -56,7 +56,7 @@ func (p *mockPusher) AddLogEntry(logEvent *LogEvent) error {
 	return nil
 }
 
-func (p *mockPusher) ForceFlush() error {
+func (p *mockPusher) forceFlush() error {
 	args := p.Called(nil)
 	errorStr := args.String(0)
 	if errorStr != "" {
@@ -72,7 +72,7 @@ func TestConsumeMetrics(t *testing.T) {
 	expCfg := factory.CreateDefaultConfig().(*Config)
 	expCfg.Region = "us-west-2"
 	expCfg.MaxRetries = 0
-	exp, err := New(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfPusher(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.Nil(t, err)
 	assert.NotNil(t, exp)
 
@@ -134,7 +134,7 @@ func TestConsumeMetricsWithOutputDestination(t *testing.T) {
 	expCfg.Region = "us-west-2"
 	expCfg.MaxRetries = 0
 	expCfg.OutputDestination = "stdout"
-	exp, err := New(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfPusher(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.Nil(t, err)
 	assert.NotNil(t, exp)
 
@@ -195,7 +195,7 @@ func TestConsumeMetricsWithLogGroupStreamConfig(t *testing.T) {
 	expCfg.MaxRetries = defaultRetryCount
 	expCfg.LogGroupName = "test-logGroupName"
 	expCfg.LogStreamName = "test-logStreamName"
-	exp, err := New(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfPusher(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.Nil(t, err)
 	assert.NotNil(t, exp)
 
@@ -251,9 +251,9 @@ func TestConsumeMetricsWithLogGroupStreamConfig(t *testing.T) {
 	require.NoError(t, exp.Shutdown(ctx))
 	streamToPusherMap, ok := exp.(*emfExporter).groupStreamToPusherMap["test-logGroupName"]
 	assert.True(t, ok)
-	pusher, ok := streamToPusherMap["test-logStreamName"]
+	emfPusher, ok := streamToPusherMap["test-logStreamName"]
 	assert.True(t, ok)
-	assert.NotNil(t, pusher)
+	assert.NotNil(t, emfPusher)
 }
 
 func TestConsumeMetricsWithLogGroupStreamValidPlaceholder(t *testing.T) {
@@ -265,7 +265,7 @@ func TestConsumeMetricsWithLogGroupStreamValidPlaceholder(t *testing.T) {
 	expCfg.MaxRetries = defaultRetryCount
 	expCfg.LogGroupName = "/aws/ecs/containerinsights/{ClusterName}/performance"
 	expCfg.LogStreamName = "{TaskId}"
-	exp, err := New(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfPusher(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.Nil(t, err)
 	assert.NotNil(t, exp)
 
@@ -321,9 +321,9 @@ func TestConsumeMetricsWithLogGroupStreamValidPlaceholder(t *testing.T) {
 	require.NoError(t, exp.Shutdown(ctx))
 	streamToPusherMap, ok := exp.(*emfExporter).groupStreamToPusherMap["/aws/ecs/containerinsights/test-cluster-name/performance"]
 	assert.True(t, ok)
-	pusher, ok := streamToPusherMap["test-task-id"]
+	emfPusher, ok := streamToPusherMap["test-task-id"]
 	assert.True(t, ok)
-	assert.NotNil(t, pusher)
+	assert.NotNil(t, emfPusher)
 }
 
 func TestConsumeMetricsWithOnlyLogStreamPlaceholder(t *testing.T) {
@@ -335,7 +335,7 @@ func TestConsumeMetricsWithOnlyLogStreamPlaceholder(t *testing.T) {
 	expCfg.MaxRetries = defaultRetryCount
 	expCfg.LogGroupName = "test-logGroupName"
 	expCfg.LogStreamName = "{TaskId}"
-	exp, err := New(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfPusher(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.Nil(t, err)
 	assert.NotNil(t, exp)
 
@@ -391,9 +391,9 @@ func TestConsumeMetricsWithOnlyLogStreamPlaceholder(t *testing.T) {
 	require.NoError(t, exp.Shutdown(ctx))
 	streamToPusherMap, ok := exp.(*emfExporter).groupStreamToPusherMap["test-logGroupName"]
 	assert.True(t, ok)
-	pusher, ok := streamToPusherMap["test-task-id"]
+	emfPusher, ok := streamToPusherMap["test-task-id"]
 	assert.True(t, ok)
-	assert.NotNil(t, pusher)
+	assert.NotNil(t, emfPusher)
 }
 
 func TestConsumeMetricsWithWrongPlaceholder(t *testing.T) {
@@ -405,7 +405,7 @@ func TestConsumeMetricsWithWrongPlaceholder(t *testing.T) {
 	expCfg.MaxRetries = defaultRetryCount
 	expCfg.LogGroupName = "test-logGroupName"
 	expCfg.LogStreamName = "{WrongKey}"
-	exp, err := New(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfPusher(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.Nil(t, err)
 	assert.NotNil(t, exp)
 
@@ -461,9 +461,9 @@ func TestConsumeMetricsWithWrongPlaceholder(t *testing.T) {
 	require.NoError(t, exp.Shutdown(ctx))
 	streamToPusherMap, ok := exp.(*emfExporter).groupStreamToPusherMap["test-logGroupName"]
 	assert.True(t, ok)
-	pusher, ok := streamToPusherMap["{WrongKey}"]
+	emfPusher, ok := streamToPusherMap["{WrongKey}"]
 	assert.True(t, ok)
-	assert.NotNil(t, pusher)
+	assert.NotNil(t, emfPusher)
 }
 
 func TestPushMetricsDataWithErr(t *testing.T) {
@@ -475,18 +475,18 @@ func TestPushMetricsDataWithErr(t *testing.T) {
 	expCfg.MaxRetries = 0
 	expCfg.LogGroupName = "test-logGroupName"
 	expCfg.LogStreamName = "test-logStreamName"
-	exp, err := New(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfPusher(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.Nil(t, err)
 	assert.NotNil(t, exp)
 
-	pusher := new(mockPusher)
-	pusher.On("AddLogEntry", nil).Return("some error").Once()
-	pusher.On("AddLogEntry", nil).Return("").Twice()
-	pusher.On("ForceFlush", nil).Return("some error").Once()
-	pusher.On("ForceFlush", nil).Return("").Once()
-	pusher.On("ForceFlush", nil).Return("some error").Once()
-	streamToPusherMap := map[string]Pusher{"test-logStreamName": pusher}
-	exp.(*emfExporter).groupStreamToPusherMap = map[string]map[string]Pusher{}
+	logPusher := new(mockPusher)
+	logPusher.On("addLogEntry", nil).Return("some error").Once()
+	logPusher.On("addLogEntry", nil).Return("").Twice()
+	logPusher.On("forceFlush", nil).Return("some error").Once()
+	logPusher.On("forceFlush", nil).Return("").Once()
+	logPusher.On("forceFlush", nil).Return("some error").Once()
+	streamToPusherMap := map[string]pusher{"test-logStreamName": logPusher}
+	exp.(*emfExporter).groupStreamToPusherMap = map[string]map[string]pusher{}
 	exp.(*emfExporter).groupStreamToPusherMap["test-logGroupName"] = streamToPusherMap
 
 	mdata := agentmetricspb.ExportMetricsServiceRequest{
@@ -547,7 +547,7 @@ func TestNewExporterWithoutConfig(t *testing.T) {
 	os.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 
 	assert.Nil(t, expCfg.logger)
-	exp, err := New(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfPusher(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.NotNil(t, err)
 	assert.Nil(t, exp)
 	assert.NotNil(t, expCfg.logger)
@@ -582,7 +582,7 @@ func TestNewExporterWithMetricDeclarations(t *testing.T) {
 
 	obs, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(obs)
-	exp, err := New(expCfg, component.ExporterCreateSettings{Logger: logger})
+	exp, err := newEmfPusher(expCfg, component.ExporterCreateSettings{Logger: logger})
 	assert.Nil(t, err)
 	assert.NotNil(t, exp)
 
@@ -609,7 +609,7 @@ func TestNewExporterWithMetricDeclarations(t *testing.T) {
 }
 
 func TestNewExporterWithoutSession(t *testing.T) {
-	exp, err := New(nil, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfPusher(nil, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.NotNil(t, err)
 	assert.Nil(t, exp)
 }
@@ -623,7 +623,7 @@ func TestWrapErrorIfBadRequest(t *testing.T) {
 	assert.False(t, consumererror.IsPermanent(err))
 }
 
-// This test verifies that if func New() returns an error then NewEmfExporter()
+// This test verifies that if func newEmfPusher() returns an error then newEmfExporter()
 // will do so.
 func TestNewEmfExporterWithoutConfig(t *testing.T) {
 	factory := NewFactory()
@@ -633,7 +633,7 @@ func TestNewEmfExporterWithoutConfig(t *testing.T) {
 	os.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 
 	assert.Nil(t, expCfg.logger)
-	exp, err := NewEmfExporter(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
+	exp, err := newEmfExporter(expCfg, component.ExporterCreateSettings{Logger: zap.NewNop()})
 	assert.NotNil(t, err)
 	assert.Nil(t, exp)
 	assert.NotNil(t, expCfg.logger)

--- a/exporter/awsemfexporter/factory.go
+++ b/exporter/awsemfexporter/factory.go
@@ -61,5 +61,5 @@ func createMetricsExporter(_ context.Context,
 
 	expCfg := config.(*Config)
 
-	return NewEmfExporter(expCfg, params)
+	return newEmfExporter(expCfg, params)
 }

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -38,87 +38,87 @@ func TestAddToGroupedMetric(t *testing.T) {
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 	logger := zap.NewNop()
 
-	metadata := CWMetricMetadata{
+	metadata := cWMetricMetadata{
 		receiver: prometheusReceiver,
-		GroupedMetricMetadata: GroupedMetricMetadata{
-			Namespace:   namespace,
-			TimestampMs: timestamp,
-			LogGroup:    logGroup,
-			LogStream:   logStreamName,
+		groupedMetricMetadata: groupedMetricMetadata{
+			namespace:   namespace,
+			timestampMs: timestamp,
+			logGroup:    logGroup,
+			logStream:   logStreamName,
 		},
-		InstrumentationLibraryName: instrumentationLibName,
+		instrumentationLibraryName: instrumentationLibName,
 	}
 
 	testCases := []struct {
 		testName string
 		metric   []*metricspb.Metric
-		expected map[string]*MetricInfo
+		expected map[string]*metricInfo
 	}{
 		{
 			"Int gauge",
 			[]*metricspb.Metric{generateTestIntGauge("foo")},
-			map[string]*MetricInfo{
+			map[string]*metricInfo{
 				"foo": {
-					Value: float64(1),
-					Unit:  "Count",
+					value: float64(1),
+					unit:  "Count",
 				},
 			},
 		},
 		{
 			"Double gauge",
 			[]*metricspb.Metric{generateTestDoubleGauge("foo")},
-			map[string]*MetricInfo{
+			map[string]*metricInfo{
 				"foo": {
-					Value: 0.1,
-					Unit:  "Count",
+					value: 0.1,
+					unit:  "Count",
 				},
 			},
 		},
 		{
 			"Int sum",
 			generateTestIntSum("foo"),
-			map[string]*MetricInfo{
+			map[string]*metricInfo{
 				"foo": {
-					Value: float64(1),
-					Unit:  "Count",
+					value: float64(1),
+					unit:  "Count",
 				},
 			},
 		},
 		{
 			"Double sum",
 			generateTestDoubleSum("foo"),
-			map[string]*MetricInfo{
+			map[string]*metricInfo{
 				"foo": {
-					Value: 0.1,
-					Unit:  "Count",
+					value: 0.1,
+					unit:  "Count",
 				},
 			},
 		},
 		{
 			"Double histogram",
 			[]*metricspb.Metric{generateTestHistogram("foo")},
-			map[string]*MetricInfo{
+			map[string]*metricInfo{
 				"foo": {
-					Value: &CWMetricStats{
+					value: &cWMetricStats{
 						Count: 18,
 						Sum:   35.0,
 					},
-					Unit: "Seconds",
+					unit: "Seconds",
 				},
 			},
 		},
 		{
 			"Summary",
 			generateTestSummary("foo"),
-			map[string]*MetricInfo{
+			map[string]*metricInfo{
 				"foo": {
-					Value: &CWMetricStats{
+					value: &cWMetricStats{
 						Min:   1,
 						Max:   5,
 						Count: 5,
 						Sum:   15,
 					},
-					Unit: "Seconds",
+					unit: "Seconds",
 				},
 			},
 		},
@@ -128,7 +128,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			setupDataPointCache()
 
-			groupedMetrics := make(map[interface{}]*GroupedMetric)
+			groupedMetrics := make(map[interface{}]*groupedMetric)
 			oc := agentmetricspb.ExportMetricsServiceRequest{
 				Node: &commonpb.Node{},
 				Resource: &resourcepb.Resource{
@@ -160,11 +160,11 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 			assert.Equal(t, 1, len(groupedMetrics))
 			for _, v := range groupedMetrics {
-				assert.Equal(t, len(tc.expected), len(v.Metrics))
-				assert.Equal(t, tc.expected, v.Metrics)
-				assert.Equal(t, 2, len(v.Labels))
-				assert.Equal(t, metadata, v.Metadata)
-				assert.Equal(t, expectedLabels, v.Labels)
+				assert.Equal(t, len(tc.expected), len(v.metrics))
+				assert.Equal(t, tc.expected, v.metrics)
+				assert.Equal(t, 2, len(v.labels))
+				assert.Equal(t, metadata, v.metadata)
+				assert.Equal(t, expectedLabels, v.labels)
 			}
 		})
 	}
@@ -172,7 +172,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 	t.Run("Add multiple different metrics", func(t *testing.T) {
 		setupDataPointCache()
 
-		groupedMetrics := make(map[interface{}]*GroupedMetric)
+		groupedMetrics := make(map[interface{}]*groupedMetric)
 		oc := agentmetricspb.ExportMetricsServiceRequest{
 			Node: &commonpb.Node{},
 			Resource: &resourcepb.Resource{
@@ -203,25 +203,25 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 		assert.Equal(t, 1, len(groupedMetrics))
 		for _, group := range groupedMetrics {
-			assert.Equal(t, 6, len(group.Metrics))
-			for metricName, metricInfo := range group.Metrics {
+			assert.Equal(t, 6, len(group.metrics))
+			for metricName, metricInfo := range group.metrics {
 				if metricName == "double-histogram" || metricName == "summary" {
-					assert.Equal(t, "Seconds", metricInfo.Unit)
+					assert.Equal(t, "Seconds", metricInfo.unit)
 				} else {
-					assert.Equal(t, "Count", metricInfo.Unit)
+					assert.Equal(t, "Count", metricInfo.unit)
 				}
 			}
 			expectedLabels := map[string]string{
 				oTellibDimensionKey: "cloudwatch-otel",
 				"label1":            "value1",
 			}
-			assert.Equal(t, expectedLabels, group.Labels)
-			assert.Equal(t, metadata, group.Metadata)
+			assert.Equal(t, expectedLabels, group.labels)
+			assert.Equal(t, metadata, group.metadata)
 		}
 	})
 
 	t.Run("Add multiple metrics w/ different timestamps", func(t *testing.T) {
-		groupedMetrics := make(map[interface{}]*GroupedMetric)
+		groupedMetrics := make(map[interface{}]*groupedMetric)
 		oc := agentmetricspb.ExportMetricsServiceRequest{
 			Node: &commonpb.Node{},
 			Resource: &resourcepb.Resource{
@@ -266,30 +266,30 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 		assert.Equal(t, 3, len(groupedMetrics))
 		for _, group := range groupedMetrics {
-			for metricName := range group.Metrics {
+			for metricName := range group.metrics {
 				if metricName == "int-gauge" || metricName == "int-sum" {
-					assert.Equal(t, 2, len(group.Metrics))
-					assert.Equal(t, int64(1608068109347), group.Metadata.TimestampMs)
+					assert.Equal(t, 2, len(group.metrics))
+					assert.Equal(t, int64(1608068109347), group.metadata.timestampMs)
 				} else if metricName == "summary" {
-					assert.Equal(t, 1, len(group.Metrics))
-					assert.Equal(t, int64(1608068110347), group.Metadata.TimestampMs)
+					assert.Equal(t, 1, len(group.metrics))
+					assert.Equal(t, int64(1608068110347), group.metadata.timestampMs)
 				} else {
 					// double-gauge should use the default timestamp
-					assert.Equal(t, 1, len(group.Metrics))
+					assert.Equal(t, 1, len(group.metrics))
 					assert.Equal(t, "double-gauge", metricName)
-					assert.Equal(t, timestamp, group.Metadata.TimestampMs)
+					assert.Equal(t, timestamp, group.metadata.timestampMs)
 				}
 			}
 			expectedLabels := map[string]string{
 				oTellibDimensionKey: "cloudwatch-otel",
 				"label1":            "value1",
 			}
-			assert.Equal(t, expectedLabels, group.Labels)
+			assert.Equal(t, expectedLabels, group.labels)
 		}
 	})
 
 	t.Run("Add same metric but different log group", func(t *testing.T) {
-		groupedMetrics := make(map[interface{}]*GroupedMetric)
+		groupedMetrics := make(map[interface{}]*groupedMetric)
 		oc := agentmetricspb.ExportMetricsServiceRequest{
 			Metrics: []*metricspb.Metric{
 				generateTestIntGauge("int-gauge"),
@@ -299,25 +299,25 @@ func TestAddToGroupedMetric(t *testing.T) {
 		ilms := rm.ResourceMetrics().At(0).InstrumentationLibraryMetrics()
 		metric := ilms.At(0).Metrics().At(0)
 
-		metricMetadata1 := CWMetricMetadata{
-			GroupedMetricMetadata: GroupedMetricMetadata{
-				Namespace:   namespace,
-				TimestampMs: timestamp,
-				LogGroup:    "log-group-1",
-				LogStream:   logStreamName,
+		metricMetadata1 := cWMetricMetadata{
+			groupedMetricMetadata: groupedMetricMetadata{
+				namespace:   namespace,
+				timestampMs: timestamp,
+				logGroup:    "log-group-1",
+				logStream:   logStreamName,
 			},
-			InstrumentationLibraryName: instrumentationLibName,
+			instrumentationLibraryName: instrumentationLibName,
 		}
 		addToGroupedMetric(&metric, groupedMetrics, metricMetadata1, logger, nil)
 
-		metricMetadata2 := CWMetricMetadata{
-			GroupedMetricMetadata: GroupedMetricMetadata{
-				Namespace:   namespace,
-				TimestampMs: timestamp,
-				LogGroup:    "log-group-2",
-				LogStream:   logStreamName,
+		metricMetadata2 := cWMetricMetadata{
+			groupedMetricMetadata: groupedMetricMetadata{
+				namespace:   namespace,
+				timestampMs: timestamp,
+				logGroup:    "log-group-2",
+				logStream:   logStreamName,
 			},
-			InstrumentationLibraryName: instrumentationLibName,
+			instrumentationLibraryName: instrumentationLibName,
 		}
 		addToGroupedMetric(&metric, groupedMetrics, metricMetadata2, logger, nil)
 
@@ -325,23 +325,23 @@ func TestAddToGroupedMetric(t *testing.T) {
 		seenLogGroup1 := false
 		seenLogGroup2 := false
 		for _, group := range groupedMetrics {
-			assert.Equal(t, 1, len(group.Metrics))
-			expectedMetrics := map[string]*MetricInfo{
+			assert.Equal(t, 1, len(group.metrics))
+			expectedMetrics := map[string]*metricInfo{
 				"int-gauge": {
-					Value: float64(1),
-					Unit:  "Count",
+					value: float64(1),
+					unit:  "Count",
 				},
 			}
-			assert.Equal(t, expectedMetrics, group.Metrics)
+			assert.Equal(t, expectedMetrics, group.metrics)
 			expectedLabels := map[string]string{
 				oTellibDimensionKey: "cloudwatch-otel",
 				"label1":            "value1",
 			}
-			assert.Equal(t, expectedLabels, group.Labels)
+			assert.Equal(t, expectedLabels, group.labels)
 
-			if group.Metadata.LogGroup == "log-group-2" {
+			if group.metadata.logGroup == "log-group-2" {
 				seenLogGroup2 = true
-			} else if group.Metadata.LogGroup == "log-group-1" {
+			} else if group.metadata.logGroup == "log-group-1" {
 				seenLogGroup1 = true
 			}
 		}
@@ -350,7 +350,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 	})
 
 	t.Run("Duplicate metric names", func(t *testing.T) {
-		groupedMetrics := make(map[interface{}]*GroupedMetric)
+		groupedMetrics := make(map[interface{}]*groupedMetric)
 		oc := agentmetricspb.ExportMetricsServiceRequest{
 			Resource: &resourcepb.Resource{
 				Labels: map[string]string{
@@ -397,7 +397,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 	})
 
 	t.Run("Unhandled metric type", func(t *testing.T) {
-		groupedMetrics := make(map[interface{}]*GroupedMetric)
+		groupedMetrics := make(map[interface{}]*groupedMetric)
 		md := pdata.NewMetrics()
 		rms := md.ResourceMetrics()
 		metric := rms.AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics().AppendEmpty()
@@ -426,7 +426,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 	})
 
 	t.Run("Nil metric", func(t *testing.T) {
-		groupedMetrics := make(map[interface{}]*GroupedMetric)
+		groupedMetrics := make(map[interface{}]*groupedMetric)
 		addToGroupedMetric(nil, groupedMetrics, metadata, logger, nil)
 		assert.Equal(t, 0, len(groupedMetrics))
 	})
@@ -447,21 +447,21 @@ func BenchmarkAddToGroupedMetric(b *testing.B) {
 	metrics := rms.At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	numMetrics := metrics.Len()
 
-	metadata := CWMetricMetadata{
-		GroupedMetricMetadata: GroupedMetricMetadata{
-			Namespace:   "Namespace",
-			TimestampMs: int64(1596151098037),
-			LogGroup:    "log-group",
-			LogStream:   "log-stream",
+	metadata := cWMetricMetadata{
+		groupedMetricMetadata: groupedMetricMetadata{
+			namespace:   "Namespace",
+			timestampMs: int64(1596151098037),
+			logGroup:    "log-group",
+			logStream:   "log-stream",
 		},
-		InstrumentationLibraryName: "cloudwatch-otel",
+		instrumentationLibraryName: "cloudwatch-otel",
 	}
 
 	logger := zap.NewNop()
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		groupedMetrics := make(map[interface{}]*GroupedMetric)
+		groupedMetrics := make(map[interface{}]*groupedMetric)
 		for i := 0; i < numMetrics; i++ {
 			metric := metrics.At(i)
 			addToGroupedMetric(&metric, groupedMetrics, metadata, logger, nil)

--- a/exporter/awsemfexporter/metric_declaration.go
+++ b/exporter/awsemfexporter/metric_declaration.go
@@ -76,9 +76,9 @@ func dedupDimensionSet(dimensions []string) (deduped []string, hasDuplicate bool
 	return
 }
 
-// Init initializes the MetricDeclaration struct. Performs validation and compiles
+// init initializes the MetricDeclaration struct. Performs validation and compiles
 // regex strings. Dimensions are deduped and sorted.
-func (m *MetricDeclaration) Init(logger *zap.Logger) (err error) {
+func (m *MetricDeclaration) init(logger *zap.Logger) (err error) {
 	// Return error if no metric name selectors are defined
 	if len(m.MetricNameSelectors) == 0 {
 		return errors.New("invalid metric declaration: no metric name selectors defined")
@@ -121,7 +121,7 @@ func (m *MetricDeclaration) Init(logger *zap.Logger) (err error) {
 
 	// Initialize label matchers
 	for _, lm := range m.LabelMatchers {
-		if err := lm.Init(); err != nil {
+		if err := lm.init(); err != nil {
 			return err
 		}
 	}
@@ -177,8 +177,8 @@ func (m *MetricDeclaration) ExtractDimensions(labels map[string]string) (dimensi
 	return
 }
 
-// Init LabelMatcher with default values and compile regex string.
-func (lm *LabelMatcher) Init() (err error) {
+// init LabelMatcher with default values and compile regex string.
+func (lm *LabelMatcher) init() (err error) {
 	// Throw error if no label names are specified
 	if len(lm.LabelNames) == 0 {
 		return errors.New("label matcher must have at least one label name specified")

--- a/exporter/awsemfexporter/metric_declaration_test.go
+++ b/exporter/awsemfexporter/metric_declaration_test.go
@@ -29,37 +29,37 @@ func TestLabelMatcherInit(t *testing.T) {
 		LabelNames: []string{"label1", "label2"},
 		Regex:      ".+",
 	}
-	err := lm.Init()
+	err := lm.init()
 	assert.Nil(t, err)
 	assert.Equal(t, ";", lm.Separator)
 	assert.Equal(t, ".+", lm.Regex)
 	assert.NotNil(t, lm.compiledRegex)
 
 	lm.Separator = ""
-	err = lm.Init()
+	err = lm.init()
 	assert.Nil(t, err)
 	assert.Equal(t, ";", lm.Separator)
 
 	lm.Separator = ","
-	err = lm.Init()
+	err = lm.init()
 	assert.Nil(t, err)
 	assert.Equal(t, ",", lm.Separator)
 
 	lm.Regex = "a*"
-	err = lm.Init()
+	err = lm.init()
 	assert.Nil(t, err)
 	assert.Equal(t, "a*", lm.Regex)
 	assert.NotNil(t, lm.compiledRegex)
 
 	// Test error
 	lm.Regex = ""
-	err = lm.Init()
+	err = lm.init()
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "regex not specified for label matcher")
 
 	lm.LabelNames = []string{}
 	lm.Regex = ".+"
-	err = lm.Init()
+	err = lm.init()
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "label matcher must have at least one label name specified")
 }
@@ -114,7 +114,7 @@ func TestGetConcatenatedLabels(t *testing.T) {
 			Separator:  tc.separator,
 			Regex:      ".+",
 		}
-		lm.Init()
+		lm.init()
 		t.Run(tc.testName, func(t *testing.T) {
 			concatenatedLabels := lm.getConcatenatedLabels(labels)
 			assert.Equal(t, tc.expected, concatenatedLabels)
@@ -219,7 +219,7 @@ func TestLabelMatcherMatches(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc.labelMatcher.Init()
+		tc.labelMatcher.init()
 		t.Run(tc.testName, func(t *testing.T) {
 			matches := tc.labelMatcher.Matches(tc.labels)
 			assert.Equal(t, tc.expected, matches)
@@ -233,7 +233,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 		m := &MetricDeclaration{
 			MetricNameSelectors: []string{"a", "b", "aa"},
 		}
-		err := m.Init(logger)
+		err := m.init(logger)
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(m.metricRegexList))
 	})
@@ -246,7 +246,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 			},
 			MetricNameSelectors: []string{"a.*", "b$", "aa+"},
 		}
-		err := m.Init(logger)
+		err := m.init(logger)
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(m.metricRegexList))
 		assert.Equal(t, 2, len(m.Dimensions))
@@ -263,7 +263,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 		}
 		obs, logs := observer.New(zap.WarnLevel)
 		obsLogger := zap.New(obs)
-		err := m.Init(obsLogger)
+		err := m.init(obsLogger)
 		assert.Nil(t, err)
 		assert.Equal(t, 3, len(m.metricRegexList))
 		assert.Equal(t, 1, len(m.Dimensions))
@@ -288,7 +288,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 		}
 		obs, logs := observer.New(zap.DebugLevel)
 		obsLogger := zap.New(obs)
-		err := m.Init(obsLogger)
+		err := m.init(obsLogger)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(m.Dimensions))
 		assert.Equal(t, []string{"a", "b", "c"}, m.Dimensions[0])
@@ -310,7 +310,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 	// Test invalid metric declaration
 	t.Run("invalid metric declaration", func(t *testing.T) {
 		m := &MetricDeclaration{}
-		err := m.Init(logger)
+		err := m.init(logger)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "invalid metric declaration: no metric name selectors defined")
 	})
@@ -331,7 +331,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 				},
 			},
 		}
-		err := m.Init(logger)
+		err := m.init(logger)
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(m.LabelMatchers))
 		assert.Equal(t, ";", m.LabelMatchers[0].Separator)
@@ -357,7 +357,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 				},
 			},
 		}
-		err := m.Init(logger)
+		err := m.init(logger)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "label matcher must have at least one label name specified")
 
@@ -369,7 +369,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 				},
 			},
 		}
-		err = m.Init(logger)
+		err = m.init(logger)
 		assert.NotNil(t, err)
 		assert.EqualError(t, err, "regex not specified for label matcher")
 	})
@@ -380,7 +380,7 @@ func TestMetricDeclarationMatchesName(t *testing.T) {
 		MetricNameSelectors: []string{"^a+$", "^b.*$", "^ac+a$"},
 	}
 	logger := zap.NewNop()
-	err := m.Init(logger)
+	err := m.init(logger)
 	assert.Nil(t, err)
 
 	assert.True(t, m.MatchesName("a"))
@@ -505,7 +505,7 @@ func TestMetricDeclarationMatchesLabels(t *testing.T) {
 			LabelMatchers:       tc.labelMatchers,
 		}
 		t.Run(tc.testName, func(t *testing.T) {
-			err := m.Init(logger)
+			err := m.init(logger)
 			assert.Nil(t, err)
 			matches := m.MatchesLabels(labels)
 			assert.Equal(t, tc.expected, matches)
@@ -588,7 +588,7 @@ func TestExtractDimensions(t *testing.T) {
 			MetricNameSelectors: []string{"foo"},
 		}
 		t.Run(tc.testName, func(t *testing.T) {
-			err := m.Init(logger)
+			err := m.init(logger)
 			assert.Nil(t, err)
 			dimensions := m.ExtractDimensions(tc.labels)
 			assert.Equal(t, tc.extractedDimensions, dimensions)

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -50,36 +50,36 @@ var fieldPrometheusTypes = map[pdata.MetricDataType]string{
 	pdata.MetricDataTypeSummary:      "summary",
 }
 
-type CWMetrics struct {
-	Measurements []CWMeasurement
-	TimestampMs  int64
-	Fields       map[string]interface{}
+type cWMetrics struct {
+	measurements []cWMeasurement
+	timestampMs  int64
+	fields       map[string]interface{}
 }
 
-type CWMeasurement struct {
+type cWMeasurement struct {
 	Namespace  string
 	Dimensions [][]string
 	Metrics    []map[string]string
 }
 
-type CWMetricStats struct {
+type cWMetricStats struct {
 	Max   float64
 	Min   float64
 	Count uint64
 	Sum   float64
 }
 
-type GroupedMetricMetadata struct {
-	Namespace   string
-	TimestampMs int64
-	LogGroup    string
-	LogStream   string
+type groupedMetricMetadata struct {
+	namespace   string
+	timestampMs int64
+	logGroup    string
+	logStream   string
 }
 
-// CWMetricMetadata represents the metadata associated with a given CloudWatch metric
-type CWMetricMetadata struct {
-	GroupedMetricMetadata
-	InstrumentationLibraryName string
+// cWMetricMetadata represents the metadata associated with a given CloudWatch metric
+type cWMetricMetadata struct {
+	groupedMetricMetadata
+	instrumentationLibraryName string
 
 	receiver       string
 	metricDataType pdata.MetricDataType
@@ -100,7 +100,7 @@ func newMetricTranslator(config Config) metricTranslator {
 }
 
 // translateOTelToGroupedMetric converts OT metrics to Grouped Metric format.
-func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetrics, groupedMetrics map[interface{}]*GroupedMetric, config *Config) {
+func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetrics, groupedMetrics map[interface{}]*groupedMetric, config *Config) {
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 	var instrumentationLibName string
 	cWNamespace := getNamespace(rm, config.Namespace)
@@ -122,14 +122,14 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetric
 		metrics := ilm.Metrics()
 		for k := 0; k < metrics.Len(); k++ {
 			metric := metrics.At(k)
-			metadata := CWMetricMetadata{
-				GroupedMetricMetadata: GroupedMetricMetadata{
-					Namespace:   cWNamespace,
-					TimestampMs: timestamp,
-					LogGroup:    logGroup,
-					LogStream:   logStream,
+			metadata := cWMetricMetadata{
+				groupedMetricMetadata: groupedMetricMetadata{
+					namespace:   cWNamespace,
+					timestampMs: timestamp,
+					logGroup:    logGroup,
+					logStream:   logStream,
 				},
-				InstrumentationLibraryName: instrumentationLibName,
+				instrumentationLibraryName: instrumentationLibName,
 				receiver:                   metricReceiver,
 				metricDataType:             metric.DataType(),
 			}
@@ -139,11 +139,11 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetric
 }
 
 // translateGroupedMetricToCWMetric converts Grouped Metric format to CloudWatch Metric format.
-func translateGroupedMetricToCWMetric(groupedMetric *GroupedMetric, config *Config) *CWMetrics {
-	labels := groupedMetric.Labels
-	fieldsLength := len(labels) + len(groupedMetric.Metrics)
+func translateGroupedMetricToCWMetric(groupedMetric *groupedMetric, config *Config) *cWMetrics {
+	labels := groupedMetric.labels
+	fieldsLength := len(labels) + len(groupedMetric.metrics)
 
-	isPrometheusMetric := groupedMetric.Metadata.receiver == prometheusReceiver
+	isPrometheusMetric := groupedMetric.metadata.receiver == prometheusReceiver
 	if isPrometheusMetric {
 		fieldsLength++
 	}
@@ -154,35 +154,35 @@ func translateGroupedMetricToCWMetric(groupedMetric *GroupedMetric, config *Conf
 		fields[k] = v
 	}
 	// Add metrics to fields
-	for metricName, metricInfo := range groupedMetric.Metrics {
-		fields[metricName] = metricInfo.Value
+	for metricName, metricInfo := range groupedMetric.metrics {
+		fields[metricName] = metricInfo.value
 	}
 	if isPrometheusMetric {
-		fields[fieldPrometheusMetricType] = fieldPrometheusTypes[groupedMetric.Metadata.metricDataType]
+		fields[fieldPrometheusMetricType] = fieldPrometheusTypes[groupedMetric.metadata.metricDataType]
 	}
 
-	var cWMeasurements []CWMeasurement
+	var cWMeasurements []cWMeasurement
 	if len(config.MetricDeclarations) == 0 {
 		// If there are no metric declarations defined, translate grouped metric
 		// into the corresponding CW Measurement
 		cwm := groupedMetricToCWMeasurement(groupedMetric, config)
-		cWMeasurements = []CWMeasurement{cwm}
+		cWMeasurements = []cWMeasurement{cwm}
 	} else {
 		// If metric declarations are defined, filter grouped metric's metrics using
 		// metric declarations and translate into the corresponding list of CW Measurements
 		cWMeasurements = groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
 	}
 
-	return &CWMetrics{
-		Measurements: cWMeasurements,
-		TimestampMs:  groupedMetric.Metadata.TimestampMs,
-		Fields:       fields,
+	return &cWMetrics{
+		measurements: cWMeasurements,
+		timestampMs:  groupedMetric.metadata.timestampMs,
+		fields:       fields,
 	}
 }
 
 // groupedMetricToCWMeasurement creates a single CW Measurement from a grouped metric.
-func groupedMetricToCWMeasurement(groupedMetric *GroupedMetric, config *Config) CWMeasurement {
-	labels := groupedMetric.Labels
+func groupedMetricToCWMeasurement(groupedMetric *groupedMetric, config *Config) cWMeasurement {
+	labels := groupedMetric.labels
 	dimensionRollupOption := config.DimensionRollupOption
 
 	// Create a dimension set containing list of label names
@@ -212,20 +212,20 @@ func groupedMetricToCWMeasurement(groupedMetric *GroupedMetric, config *Config) 
 	// Add on rolled-up dimensions
 	dimensions = append(dimensions, rollupDimensionArray...)
 
-	metrics := make([]map[string]string, len(groupedMetric.Metrics))
+	metrics := make([]map[string]string, len(groupedMetric.metrics))
 	idx = 0
-	for metricName, metricInfo := range groupedMetric.Metrics {
+	for metricName, metricInfo := range groupedMetric.metrics {
 		metrics[idx] = map[string]string{
 			"Name": metricName,
 		}
-		if metricInfo.Unit != "" {
-			metrics[idx]["Unit"] = metricInfo.Unit
+		if metricInfo.unit != "" {
+			metrics[idx]["Unit"] = metricInfo.unit
 		}
 		idx++
 	}
 
-	return CWMeasurement{
-		Namespace:  groupedMetric.Metadata.Namespace,
+	return cWMeasurement{
+		Namespace:  groupedMetric.metadata.namespace,
 		Dimensions: dimensions,
 		Metrics:    metrics,
 	}
@@ -233,8 +233,8 @@ func groupedMetricToCWMeasurement(groupedMetric *GroupedMetric, config *Config) 
 
 // groupedMetricToCWMeasurementsWithFilters filters the grouped metric using the given list of metric
 // declarations and returns the corresponding list of CW Measurements.
-func groupedMetricToCWMeasurementsWithFilters(groupedMetric *GroupedMetric, config *Config) (cWMeasurements []CWMeasurement) {
-	labels := groupedMetric.Labels
+func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, config *Config) (cWMeasurements []cWMeasurement) {
+	labels := groupedMetric.labels
 
 	// Filter metric declarations by labels
 	metricDeclarations := make([]*MetricDeclaration, 0, len(config.MetricDeclarations))
@@ -248,7 +248,7 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *GroupedMetric, conf
 	if len(metricDeclarations) == 0 {
 		labelsStr, _ := json.Marshal(labels)
 		metricNames := make([]string, 0)
-		for metricName := range groupedMetric.Metrics {
+		for metricName := range groupedMetric.metrics {
 			metricNames = append(metricNames, metricName)
 		}
 		config.logger.Debug(
@@ -266,7 +266,7 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *GroupedMetric, conf
 	}
 
 	metricDeclGroups := make(map[string]*metricDeclarationGroup)
-	for metricName, metricInfo := range groupedMetric.Metrics {
+	for metricName, metricInfo := range groupedMetric.metrics {
 		// Filter metric declarations by metric name
 		var metricDeclIdx []int
 		for i, metricDeclaration := range metricDeclarations {
@@ -286,8 +286,8 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *GroupedMetric, conf
 		metric := map[string]string{
 			"Name": metricName,
 		}
-		if metricInfo.Unit != "" {
-			metric["Unit"] = metricInfo.Unit
+		if metricInfo.unit != "" {
+			metric["Unit"] = metricInfo.unit
 		}
 		metricDeclKey := fmt.Sprint(metricDeclIdx)
 		if group, ok := metricDeclGroups[metricDeclKey]; ok {
@@ -308,7 +308,7 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *GroupedMetric, conf
 	rollupDimensionArray := dimensionRollup(config.DimensionRollupOption, labels)
 
 	// Translate each group into a CW Measurement
-	cWMeasurements = make([]CWMeasurement, 0, len(metricDeclGroups))
+	cWMeasurements = make([]cWMeasurement, 0, len(metricDeclGroups))
 	for _, group := range metricDeclGroups {
 		var dimensions [][]string
 		// Extract dimensions from matched metric declarations
@@ -323,8 +323,8 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *GroupedMetric, conf
 
 		// Export metrics only with non-empty dimensions list
 		if len(dimensions) > 0 {
-			cwm := CWMeasurement{
-				Namespace:  groupedMetric.Metadata.Namespace,
+			cwm := cWMeasurement{
+				Namespace:  groupedMetric.metadata.namespace,
 				Dimensions: dimensions,
 				Metrics:    group.metrics,
 			}
@@ -336,10 +336,10 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *GroupedMetric, conf
 }
 
 // translateCWMetricToEMF converts CloudWatch Metric format to EMF.
-func translateCWMetricToEMF(cWMetric *CWMetrics, config *Config) *LogEvent {
+func translateCWMetricToEMF(cWMetric *cWMetrics, config *Config) *logEvent {
 	// convert CWMetric into map format for compatible with PLE input
 	cWMetricMap := make(map[string]interface{})
-	fieldMap := cWMetric.Fields
+	fieldMap := cWMetric.fields
 
 	//restore the json objects that are stored as string in attributes
 	for _, key := range config.ParseJSONEncodedAttributeValues {
@@ -370,10 +370,10 @@ func translateCWMetricToEMF(cWMetric *CWMetrics, config *Config) *LogEvent {
 	}
 
 	// Create `_aws` section only if there are measurements
-	if len(cWMetric.Measurements) > 0 {
+	if len(cWMetric.measurements) > 0 {
 		// Create `_aws` section only if there are measurements
-		cWMetricMap["CloudWatchMetrics"] = cWMetric.Measurements
-		cWMetricMap["Timestamp"] = cWMetric.TimestampMs
+		cWMetricMap["CloudWatchMetrics"] = cWMetric.measurements
+		cWMetricMap["Timestamp"] = cWMetric.timestampMs
 		fieldMap["_aws"] = cWMetricMap
 	}
 
@@ -382,12 +382,12 @@ func translateCWMetricToEMF(cWMetric *CWMetrics, config *Config) *LogEvent {
 		return nil
 	}
 
-	metricCreationTime := cWMetric.TimestampMs
+	metricCreationTime := cWMetric.timestampMs
 	logEvent := newLogEvent(
 		metricCreationTime,
 		string(pleMsg),
 	)
-	logEvent.LogGeneratedTime = time.Unix(0, metricCreationTime*int64(time.Millisecond))
+	logEvent.logGeneratedTime = time.Unix(0, metricCreationTime*int64(time.Millisecond))
 
 	return logEvent
 }

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -326,7 +326,7 @@ func assertDimsEqual(t *testing.T, expected, actual [][]string) {
 }
 
 // cWMeasurementEqual returns true if CW Measurements are equal.
-func cWMeasurementEqual(expected, actual CWMeasurement) bool {
+func cWMeasurementEqual(expected, actual cWMeasurement) bool {
 	// Check namespace
 	if expected.Namespace != actual.Namespace {
 		return false
@@ -352,7 +352,7 @@ func cWMeasurementEqual(expected, actual CWMeasurement) bool {
 }
 
 // assertCWMeasurementEqual asserts whether CW Measurements are equal.
-func assertCWMeasurementEqual(t *testing.T, expected, actual CWMeasurement) {
+func assertCWMeasurementEqual(t *testing.T, expected, actual cWMeasurement) {
 	// Check namespace
 	assert.Equal(t, expected.Namespace, actual.Namespace)
 
@@ -367,7 +367,7 @@ func assertCWMeasurementEqual(t *testing.T, expected, actual CWMeasurement) {
 }
 
 // assertCWMeasurementSliceEqual asserts whether CW Measurements are equal, regardless of order.
-func assertCWMeasurementSliceEqual(t *testing.T, expected, actual []CWMeasurement) {
+func assertCWMeasurementSliceEqual(t *testing.T, expected, actual []cWMeasurement) {
 	assert.Equal(t, len(expected), len(actual))
 	seen := make([]bool, len(expected))
 	for _, actualMeasurement := range actual {
@@ -385,11 +385,11 @@ func assertCWMeasurementSliceEqual(t *testing.T, expected, actual []CWMeasuremen
 }
 
 // assertCWMetricsEqual asserts whether CW Metrics are equal.
-func assertCWMetricsEqual(t *testing.T, expected, actual *CWMetrics) {
-	assert.Equal(t, expected.TimestampMs, actual.TimestampMs)
-	assert.Equal(t, expected.Fields, actual.Fields)
-	assert.Equal(t, len(expected.Measurements), len(actual.Measurements))
-	assertCWMeasurementSliceEqual(t, expected.Measurements, actual.Measurements)
+func assertCWMetricsEqual(t *testing.T, expected, actual *cWMetrics) {
+	assert.Equal(t, expected.timestampMs, actual.timestampMs)
+	assert.Equal(t, expected.fields, actual.fields)
+	assert.Equal(t, len(expected.measurements), len(actual.measurements))
+	assertCWMeasurementSliceEqual(t, expected.measurements, actual.measurements)
 }
 
 func TestTranslateOtToGroupedMetric(t *testing.T) {
@@ -411,31 +411,31 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 	noNamespaceMetric.Resource().Attributes().Delete(conventions.AttributeServiceNamespace)
 	noNamespaceMetric.Resource().Attributes().Delete(conventions.AttributeServiceName)
 
-	counterMetrics := map[string]*MetricInfo{
+	counterMetrics := map[string]*metricInfo{
 		"spanCounter": {
-			Value: float64(1),
-			Unit:  "Count",
+			value: float64(1),
+			unit:  "Count",
 		},
 		"spanDoubleCounter": {
-			Value: 0.1,
-			Unit:  "Count",
+			value: 0.1,
+			unit:  "Count",
 		},
 		"spanGaugeCounter": {
-			Value: float64(1),
-			Unit:  "Count",
+			value: float64(1),
+			unit:  "Count",
 		},
 		"spanGaugeDoubleCounter": {
-			Value: 0.1,
-			Unit:  "Count",
+			value: 0.1,
+			unit:  "Count",
 		},
 	}
-	timerMetrics := map[string]*MetricInfo{
+	timerMetrics := map[string]*metricInfo{
 		"spanTimer": {
-			Value: &CWMetricStats{
+			value: &cWMetricStats{
 				Count: 5,
 				Sum:   15,
 			},
-			Unit: "Seconds",
+			unit: "Seconds",
 		},
 	}
 
@@ -490,20 +490,20 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			setupDataPointCache()
 
-			groupedMetrics := make(map[interface{}]*GroupedMetric)
+			groupedMetrics := make(map[interface{}]*groupedMetric)
 			translator.translateOTelToGroupedMetric(tc.metric, groupedMetrics, config)
 			assert.NotNil(t, groupedMetrics)
 			assert.Equal(t, 2, len(groupedMetrics))
 
 			for _, v := range groupedMetrics {
-				assert.Equal(t, tc.expectedNamespace, v.Metadata.Namespace)
-				if len(v.Metrics) == 4 {
-					assert.Equal(t, tc.counterLabels, v.Labels)
-					assert.Equal(t, counterMetrics, v.Metrics)
+				assert.Equal(t, tc.expectedNamespace, v.metadata.namespace)
+				if len(v.metrics) == 4 {
+					assert.Equal(t, tc.counterLabels, v.labels)
+					assert.Equal(t, counterMetrics, v.metrics)
 				} else {
-					assert.Equal(t, 1, len(v.Metrics))
-					assert.Equal(t, tc.timerLabels, v.Labels)
-					assert.Equal(t, timerMetrics, v.Metrics)
+					assert.Equal(t, 1, len(v.metrics))
+					assert.Equal(t, tc.timerLabels, v.labels)
+					assert.Equal(t, timerMetrics, v.metrics)
 				}
 			}
 		})
@@ -522,14 +522,14 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 			Metrics: []*metricspb.Metric{},
 		}
 		rm := internaldata.OCToMetrics(oc.Node, oc.Resource, oc.Metrics).ResourceMetrics().At(0)
-		groupedMetrics := make(map[interface{}]*GroupedMetric)
+		groupedMetrics := make(map[interface{}]*groupedMetric)
 		translator.translateOTelToGroupedMetric(&rm, groupedMetrics, config)
 		assert.Equal(t, 0, len(groupedMetrics))
 	})
 }
 
 func TestTranslateCWMetricToEMF(t *testing.T) {
-	cwMeasurement := CWMeasurement{
+	cwMeasurement := cWMeasurement{
 		Namespace:  "test-emf",
 		Dimensions: [][]string{{oTellibDimensionKey}, {oTellibDimensionKey, "spanName"}},
 		Metrics: []map[string]string{{
@@ -552,14 +552,14 @@ func TestTranslateCWMetricToEMF(t *testing.T) {
 		logger:                          zap.NewNop(),
 	}
 
-	met := &CWMetrics{
-		TimestampMs:  timestamp,
-		Fields:       fields,
-		Measurements: []CWMeasurement{cwMeasurement},
+	met := &cWMetrics{
+		timestampMs:  timestamp,
+		fields:       fields,
+		measurements: []cWMeasurement{cwMeasurement},
 	}
 	inputLogEvent := translateCWMetricToEMF(met, config)
 
-	assert.Equal(t, readFromFile("testdata/testTranslateCWMetricToEMF.json"), *inputLogEvent.InputLogEvent.Message, "Expect to be equal")
+	assert.Equal(t, readFromFile("testdata/testTranslateCWMetricToEMF.json"), *inputLogEvent.inputLogEvent.Message, "Expect to be equal")
 }
 
 func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
@@ -567,32 +567,32 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 	namespace := "Namespace"
 	testCases := []struct {
 		testName           string
-		groupedMetric      *GroupedMetric
+		groupedMetric      *groupedMetric
 		metricDeclarations []*MetricDeclaration
-		expectedCWMetric   *CWMetrics
+		expectedCWMetric   *cWMetrics
 	}{
 		{
 			"single metric w/o metric declarations",
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label1": "value1",
 				},
-				Metrics: map[string]*MetricInfo{
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
 			nil,
-			&CWMetrics{
-				Measurements: []CWMeasurement{
+			&cWMetrics{
+				measurements: []cWMeasurement{
 					{
 						Namespace:  namespace,
 						Dimensions: [][]string{{"label1"}},
@@ -604,8 +604,8 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 						},
 					},
 				},
-				TimestampMs: timestamp,
-				Fields: map[string]interface{}{
+				timestampMs: timestamp,
+				fields: map[string]interface{}{
 					"label1":  "value1",
 					"metric1": 1,
 				},
@@ -613,20 +613,20 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 		},
 		{
 			"single metric w/ metric declarations",
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label1": "value1",
 				},
-				Metrics: map[string]*MetricInfo{
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
@@ -636,8 +636,8 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 					MetricNameSelectors: []string{"metric.*"},
 				},
 			},
-			&CWMetrics{
-				Measurements: []CWMeasurement{
+			&cWMetrics{
+				measurements: []cWMeasurement{
 					{
 						Namespace:  namespace,
 						Dimensions: [][]string{{"label1"}},
@@ -649,8 +649,8 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 						},
 					},
 				},
-				TimestampMs: timestamp,
-				Fields: map[string]interface{}{
+				timestampMs: timestamp,
+				fields: map[string]interface{}{
 					"label1":  "value1",
 					"metric1": 1,
 				},
@@ -658,35 +658,35 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 		},
 		{
 			"multiple metrics w/o metric declarations",
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label2": "value2",
 					"label1": "value1",
 				},
-				Metrics: map[string]*MetricInfo{
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 					"metric2": {
-						Value: 200,
-						Unit:  "Count",
+						value: 200,
+						unit:  "Count",
 					},
 					"metric3": {
-						Value: 3.14,
-						Unit:  "Seconds",
+						value: 3.14,
+						unit:  "Seconds",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
 			nil,
-			&CWMetrics{
-				Measurements: []CWMeasurement{
+			&cWMetrics{
+				measurements: []cWMeasurement{
 					{
 						Namespace:  namespace,
 						Dimensions: [][]string{{"label1", "label2"}},
@@ -706,8 +706,8 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 						},
 					},
 				},
-				TimestampMs: timestamp,
-				Fields: map[string]interface{}{
+				timestampMs: timestamp,
+				fields: map[string]interface{}{
 					"label1":  "value1",
 					"label2":  "value2",
 					"metric1": 1,
@@ -718,29 +718,29 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 		},
 		{
 			"multiple metrics w/ metric declarations",
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label2": "value2",
 					"label1": "value1",
 				},
-				Metrics: map[string]*MetricInfo{
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 					"metric2": {
-						Value: 200,
-						Unit:  "Count",
+						value: 200,
+						unit:  "Count",
 					},
 					"metric3": {
-						Value: 3.14,
-						Unit:  "Seconds",
+						value: 3.14,
+						unit:  "Seconds",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
@@ -760,8 +760,8 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 					MetricNameSelectors: []string{"metric2"},
 				},
 			},
-			&CWMetrics{
-				Measurements: []CWMeasurement{
+			&cWMetrics{
+				measurements: []cWMeasurement{
 					{
 						Namespace:  namespace,
 						Dimensions: [][]string{{"label1"}},
@@ -783,8 +783,8 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 						},
 					},
 				},
-				TimestampMs: timestamp,
-				Fields: map[string]interface{}{
+				timestampMs: timestamp,
+				fields: map[string]interface{}{
 					"label1":  "value1",
 					"label2":  "value2",
 					"metric1": 1,
@@ -795,57 +795,57 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 		},
 		{
 			"no metrics",
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label1": "value1",
 				},
-				Metrics: nil,
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metrics: nil,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
 			nil,
-			&CWMetrics{
-				Measurements: []CWMeasurement{
+			&cWMetrics{
+				measurements: []cWMeasurement{
 					{
 						Namespace:  namespace,
 						Dimensions: [][]string{{"label1"}},
 						Metrics:    nil,
 					},
 				},
-				TimestampMs: timestamp,
-				Fields: map[string]interface{}{
+				timestampMs: timestamp,
+				fields: map[string]interface{}{
 					"label1": "value1",
 				},
 			},
 		},
 		{
 			"prometheus metrics",
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label1": "value1",
 				},
-				Metrics: map[string]*MetricInfo{
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 					receiver:       prometheusReceiver,
 					metricDataType: pdata.MetricDataTypeDoubleGauge,
 				},
 			},
 			nil,
-			&CWMetrics{
-				Measurements: []CWMeasurement{
+			&cWMetrics{
+				measurements: []cWMeasurement{
 					{
 						Namespace:  namespace,
 						Dimensions: [][]string{{"label1"}},
@@ -857,8 +857,8 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 						},
 					},
 				},
-				TimestampMs: timestamp,
-				Fields: map[string]interface{}{
+				timestampMs: timestamp,
+				fields: map[string]interface{}{
 					"label1":                  "value1",
 					"metric1":                 1,
 					fieldPrometheusMetricType: "gauge",
@@ -877,7 +877,7 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 				logger:                logger,
 			}
 			for _, decl := range tc.metricDeclarations {
-				decl.Init(logger)
+				decl.init(logger)
 			}
 			cWMetric := translateGroupedMetricToCWMetric(tc.groupedMetric, config)
 			assert.NotNil(t, cWMetric)
@@ -892,30 +892,30 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 	testCases := []struct {
 		testName              string
 		dimensionRollupOption string
-		groupedMetric         *GroupedMetric
-		expectedMeasurement   CWMeasurement
+		groupedMetric         *groupedMetric
+		expectedMeasurement   cWMeasurement
 	}{
 		{
 			"single metric, no dim rollup",
 			"",
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label1": "value1",
 				},
-				Metrics: map[string]*MetricInfo{
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
-			CWMeasurement{
+			cWMeasurement{
 				Namespace:  namespace,
 				Dimensions: [][]string{{"label1"}},
 				Metrics: []map[string]string{
@@ -929,33 +929,33 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 		{
 			"multiple metrics, no dim rollup",
 			"",
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label2": "value2",
 					"label1": "value1",
 				},
-				Metrics: map[string]*MetricInfo{
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 					"metric2": {
-						Value: 200,
-						Unit:  "Count",
+						value: 200,
+						unit:  "Count",
 					},
 					"metric3": {
-						Value: 3.14,
-						Unit:  "Seconds",
+						value: 3.14,
+						unit:  "Seconds",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
-			CWMeasurement{
+			cWMeasurement{
 				Namespace:  namespace,
 				Dimensions: [][]string{{"label1", "label2"}},
 				Metrics: []map[string]string{
@@ -977,24 +977,24 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 		{
 			"single metric, single dim rollup",
 			singleDimensionRollupOnly,
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label1": "value1",
 				},
-				Metrics: map[string]*MetricInfo{
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
-			CWMeasurement{
+			cWMeasurement{
 				Namespace:  namespace,
 				Dimensions: [][]string{{"label1"}},
 				Metrics: []map[string]string{
@@ -1008,33 +1008,33 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 		{
 			"multiple metrics, zero & single dim rollup",
 			zeroAndSingleDimensionRollup,
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label2": "value2",
 					"label1": "value1",
 				},
-				Metrics: map[string]*MetricInfo{
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 					"metric2": {
-						Value: 200,
-						Unit:  "Count",
+						value: 200,
+						unit:  "Count",
 					},
 					"metric3": {
-						Value: 3.14,
-						Unit:  "Seconds",
+						value: 3.14,
+						unit:  "Seconds",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
-			CWMeasurement{
+			cWMeasurement{
 				Namespace: namespace,
 				Dimensions: [][]string{
 					{"label1", "label2"},
@@ -1061,19 +1061,19 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 		{
 			"no metrics",
 			"",
-			&GroupedMetric{
-				Labels: map[string]string{
+			&groupedMetric{
+				labels: map[string]string{
 					"label1": "value1",
 				},
-				Metrics: nil,
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metrics: nil,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			},
-			CWMeasurement{
+			cWMeasurement{
 				Namespace:  namespace,
 				Dimensions: [][]string{{"label1"}},
 				Metrics:    nil,
@@ -1087,8 +1087,8 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 				MetricDeclarations:    nil,
 				DimensionRollupOption: tc.dimensionRollupOption,
 			}
-			cWMeasurement := groupedMetricToCWMeasurement(tc.groupedMetric, config)
-			assertCWMeasurementEqual(t, tc.expectedMeasurement, cWMeasurement)
+			cWMeasurementGrp := groupedMetricToCWMeasurement(tc.groupedMetric, config)
+			assertCWMeasurementEqual(t, tc.expectedMeasurement, cWMeasurementGrp)
 		})
 	}
 
@@ -1221,26 +1221,26 @@ func TestGroupedMetricToCWMeasurement(t *testing.T) {
 
 	for _, tc := range rollUpTestCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			groupedMetric := &GroupedMetric{
-				Labels: tc.labels,
-				Metrics: map[string]*MetricInfo{
+			groupedMetric := &groupedMetric{
+				labels: tc.labels,
+				metrics: map[string]*metricInfo{
 					"metric1": {
-						Value: 1,
-						Unit:  "Count",
+						value: 1,
+						unit:  "Count",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			}
 			config := &Config{
 				DimensionRollupOption: tc.dimensionRollupOption,
 			}
-			cWMeasurement := groupedMetricToCWMeasurement(groupedMetric, config)
-			assertDimsEqual(t, tc.expectedDims, cWMeasurement.Dimensions)
+			cWMeasurementGrp := groupedMetricToCWMeasurement(groupedMetric, config)
+			assertDimsEqual(t, tc.expectedDims, cWMeasurementGrp.Dimensions)
 		})
 	}
 }
@@ -1254,24 +1254,24 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 		"b": "B",
 		"c": "C",
 	}
-	metrics := map[string]*MetricInfo{
+	metrics := map[string]*metricInfo{
 		"metric1": {
-			Value: 1,
-			Unit:  "Count",
+			value: 1,
+			unit:  "Count",
 		},
 		"metric2": {
-			Value: 200,
-			Unit:  "Count",
+			value: 200,
+			unit:  "Count",
 		},
 		"metric3": {
-			Value: 3.14,
-			Unit:  "Seconds",
+			value: 3.14,
+			unit:  "Seconds",
 		},
 	}
 	testCases := []struct {
 		testName             string
 		metricDeclarations   []*MetricDeclaration
-		expectedMeasurements []CWMeasurement
+		expectedMeasurements []cWMeasurement
 	}{
 		{
 			"single metric declaration",
@@ -1281,7 +1281,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 					MetricNameSelectors: []string{"metric.*"},
 				},
 			},
-			[]CWMeasurement{
+			[]cWMeasurement{
 				{
 					Namespace:  namespace,
 					Dimensions: [][]string{{"a"}, {"a", "c"}},
@@ -1318,7 +1318,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 					MetricNameSelectors: []string{"metric(1|2)"},
 				},
 			},
-			[]CWMeasurement{
+			[]cWMeasurement{
 				{
 					Namespace:  namespace,
 					Dimensions: [][]string{{"a"}, {"b"}, {"a", "c"}},
@@ -1363,7 +1363,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 					MetricNameSelectors: []string{"metric(1|2)"},
 				},
 			},
-			[]CWMeasurement{
+			[]cWMeasurement{
 				{
 					Namespace:  namespace,
 					Dimensions: [][]string{{"a"}, {"b"}},
@@ -1402,7 +1402,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 					MetricNameSelectors: []string{"metric(1|2)"},
 				},
 			},
-			[]CWMeasurement{
+			[]cWMeasurement{
 				{
 					Namespace:  namespace,
 					Dimensions: [][]string{{"a"}, {"b"}},
@@ -1453,7 +1453,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 					},
 				},
 			},
-			[]CWMeasurement{
+			[]cWMeasurement{
 				{
 					Namespace:  namespace,
 					Dimensions: [][]string{{"b"}},
@@ -1480,13 +1480,13 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			groupedMetric := &GroupedMetric{
-				Labels:  labels,
-				Metrics: metrics,
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+			groupedMetric := &groupedMetric{
+				labels:  labels,
+				metrics: metrics,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			}
@@ -1496,7 +1496,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				logger:                logger,
 			}
 			for _, decl := range tc.metricDeclarations {
-				err := decl.Init(logger)
+				err := decl.init(logger)
 				assert.Nil(t, err)
 			}
 
@@ -1508,13 +1508,13 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 	}
 
 	t.Run("No label match", func(t *testing.T) {
-		groupedMetric := &GroupedMetric{
-			Labels:  labels,
-			Metrics: metrics,
-			Metadata: CWMetricMetadata{
-				GroupedMetricMetadata: GroupedMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+		groupedMetric := &groupedMetric{
+			labels:  labels,
+			metrics: metrics,
+			metadata: cWMetricMetadata{
+				groupedMetricMetadata: groupedMetricMetadata{
+					namespace:   namespace,
+					timestampMs: timestamp,
 				},
 			},
 		}
@@ -1541,7 +1541,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 			},
 		}
 		for _, decl := range metricDeclarations {
-			err := decl.Init(zap.NewNop())
+			err := decl.init(zap.NewNop())
 			assert.Nil(t, err)
 		}
 		obs, logs := observer.New(zap.DebugLevel)
@@ -1589,13 +1589,13 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 	})
 
 	t.Run("No metric name match", func(t *testing.T) {
-		groupedMetric := &GroupedMetric{
-			Labels:  labels,
-			Metrics: metrics,
-			Metadata: CWMetricMetadata{
-				GroupedMetricMetadata: GroupedMetricMetadata{
-					Namespace:   namespace,
-					TimestampMs: timestamp,
+		groupedMetric := &groupedMetric{
+			labels:  labels,
+			metrics: metrics,
+			metadata: cWMetricMetadata{
+				groupedMetricMetadata: groupedMetricMetadata{
+					namespace:   namespace,
+					timestampMs: timestamp,
 				},
 			},
 		}
@@ -1606,7 +1606,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 			},
 		}
 		for _, decl := range metricDeclarations {
-			err := decl.Init(zap.NewNop())
+			err := decl.init(zap.NewNop())
 			assert.Nil(t, err)
 		}
 		obs, logs := observer.New(zap.DebugLevel)
@@ -1993,23 +1993,23 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 
 	for _, tc := range rollupTestCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			groupedMetric := &GroupedMetric{
-				Labels: tc.labels,
-				Metrics: map[string]*MetricInfo{
+			groupedMetric := &groupedMetric{
+				labels: tc.labels,
+				metrics: map[string]*metricInfo{
 					(metricName): {
-						Value: int64(5),
-						Unit:  "Count",
+						value: int64(5),
+						unit:  "Count",
 					},
 				},
-				Metadata: CWMetricMetadata{
-					GroupedMetricMetadata: GroupedMetricMetadata{
-						Namespace:   namespace,
-						TimestampMs: timestamp,
+				metadata: cWMetricMetadata{
+					groupedMetricMetadata: groupedMetricMetadata{
+						namespace:   namespace,
+						timestampMs: timestamp,
 					},
 				},
 			}
 			for _, decl := range tc.metricDeclarations {
-				err := decl.Init(zap.NewNop())
+				err := decl.init(zap.NewNop())
 				assert.Nil(t, err)
 			}
 			config := &Config{
@@ -2037,15 +2037,15 @@ func TestTranslateCWMetricToEMFNoMeasurements(t *testing.T) {
 	fields["spanName"] = "test"
 	fields["spanCounter"] = 0
 
-	met := &CWMetrics{
-		TimestampMs:  timestamp,
-		Fields:       fields,
-		Measurements: nil,
+	met := &cWMetrics{
+		timestampMs:  timestamp,
+		fields:       fields,
+		measurements: nil,
 	}
 	inputLogEvent := translateCWMetricToEMF(met, &Config{})
 	expected := "{\"OTelLib\":\"cloudwatch-otel\",\"spanCounter\":0,\"spanName\":\"test\"}"
 
-	assert.Equal(t, expected, *inputLogEvent.InputLogEvent.Message)
+	assert.Equal(t, expected, *inputLogEvent.inputLogEvent.Message)
 }
 
 func BenchmarkTranslateOtToGroupedMetricWithInstrLibrary(b *testing.B) {
@@ -2063,7 +2063,7 @@ func BenchmarkTranslateOtToGroupedMetricWithInstrLibrary(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		groupedMetric := make(map[interface{}]*GroupedMetric)
+		groupedMetric := make(map[interface{}]*groupedMetric)
 		translator.translateOTelToGroupedMetric(&rm, groupedMetric, config)
 	}
 }
@@ -2080,32 +2080,32 @@ func BenchmarkTranslateOtToGroupedMetricWithoutInstrLibrary(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		groupedMetrics := make(map[interface{}]*GroupedMetric)
+		groupedMetrics := make(map[interface{}]*groupedMetric)
 		translator.translateOTelToGroupedMetric(&rm, groupedMetrics, config)
 	}
 }
 
 func BenchmarkTranslateGroupedMetricToCWMetric(b *testing.B) {
-	groupedMetric := &GroupedMetric{
-		Labels: map[string]string{
+	groupedMetric := &groupedMetric{
+		labels: map[string]string{
 			"label1": "value1",
 			"label2": "value2",
 			"label3": "value3",
 		},
-		Metrics: map[string]*MetricInfo{
+		metrics: map[string]*metricInfo{
 			"metric1": {
-				Value: 1,
-				Unit:  "Count",
+				value: 1,
+				unit:  "Count",
 			},
 			"metric2": {
-				Value: 200,
-				Unit:  "Seconds",
+				value: 200,
+				unit:  "Seconds",
 			},
 		},
-		Metadata: CWMetricMetadata{
-			GroupedMetricMetadata: GroupedMetricMetadata{
-				Namespace:   "Namespace",
-				TimestampMs: int64(1596151098037),
+		metadata: cWMetricMetadata{
+			groupedMetricMetadata: groupedMetricMetadata{
+				namespace:   "Namespace",
+				timestampMs: int64(1596151098037),
 			},
 		},
 	}
@@ -2121,26 +2121,26 @@ func BenchmarkTranslateGroupedMetricToCWMetric(b *testing.B) {
 }
 
 func BenchmarkTranslateGroupedMetricToCWMetricWithFiltering(b *testing.B) {
-	groupedMetric := &GroupedMetric{
-		Labels: map[string]string{
+	groupedMetric := &groupedMetric{
+		labels: map[string]string{
 			"label1": "value1",
 			"label2": "value2",
 			"label3": "value3",
 		},
-		Metrics: map[string]*MetricInfo{
+		metrics: map[string]*metricInfo{
 			"metric1": {
-				Value: 1,
-				Unit:  "Count",
+				value: 1,
+				unit:  "Count",
 			},
 			"metric2": {
-				Value: 200,
-				Unit:  "Seconds",
+				value: 200,
+				unit:  "Seconds",
 			},
 		},
-		Metadata: CWMetricMetadata{
-			GroupedMetricMetadata: GroupedMetricMetadata{
-				Namespace:   "Namespace",
-				TimestampMs: int64(1596151098037),
+		metadata: cWMetricMetadata{
+			groupedMetricMetadata: groupedMetricMetadata{
+				namespace:   "Namespace",
+				timestampMs: int64(1596151098037),
 			},
 		},
 	}
@@ -2149,7 +2149,7 @@ func BenchmarkTranslateGroupedMetricToCWMetricWithFiltering(b *testing.B) {
 		MetricNameSelectors: []string{"metric1", "metric2"},
 	}
 	logger := zap.NewNop()
-	m.Init(logger)
+	m.init(logger)
 	config := &Config{
 		MetricDeclarations:    []*MetricDeclaration{m},
 		DimensionRollupOption: zeroAndSingleDimensionRollup,
@@ -2162,7 +2162,7 @@ func BenchmarkTranslateGroupedMetricToCWMetricWithFiltering(b *testing.B) {
 }
 
 func BenchmarkTranslateCWMetricToEMF(b *testing.B) {
-	cwMeasurement := CWMeasurement{
+	cwMeasurement := cWMeasurement{
 		Namespace:  "test-emf",
 		Dimensions: [][]string{{oTellibDimensionKey}, {oTellibDimensionKey, "spanName"}},
 		Metrics: []map[string]string{{
@@ -2176,10 +2176,10 @@ func BenchmarkTranslateCWMetricToEMF(b *testing.B) {
 	fields["spanName"] = "test"
 	fields["spanCounter"] = 0
 
-	met := &CWMetrics{
-		TimestampMs:  timestamp,
-		Fields:       fields,
-		Measurements: []CWMeasurement{cwMeasurement},
+	met := &cWMetrics{
+		timestampMs:  timestamp,
+		fields:       fields,
+		measurements: []cWMeasurement{cwMeasurement},
 	}
 
 	b.ResetTimer()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Make the unnecessary public APIs and structs to private.

**Link to tracking Issue:** <Issue number if applicable>
#4079 
#4055 

