### PR TITLE
Remove Honeycomb exporter support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,7 @@ exporter/dynatraceexporter/                          @open-telemetry/collector-c
 exporter/elasticexporter/                            @open-telemetry/collector-contrib-approvers @axw @simitt @jalvz
 exporter/elasticsearchexporter/                      @open-telemetry/collector-contrib-approvers @urso @faec @blakerouse
 exporter/f5cloudexporter/                            @open-telemetry/collector-contrib-approvers @gramidt
-exporter/honeycombexporter/                          @open-telemetry/collector-contrib-approvers @paulosman @lizthegrey @MikeGoldsmith
+exporter/honeycombexporter/                          @open-telemetry/collector-contrib-approvers
 exporter/humioexporter/                              @open-telemetry/collector-contrib-approvers @xitric
 exporter/awskinesisexporter/                         @open-telemetry/collector-contrib-approvers @owais @anuraaga
 exporter/loadbalancingexporter/                      @open-telemetry/collector-contrib-approvers @jpkrohling

--- a/exporter/honeycombexporter/README.md
+++ b/exporter/honeycombexporter/README.md
@@ -1,6 +1,6 @@
-# Honeycomb Exporter
+# Honeycomb Exporter (Unsupported)
 
-**NOTE:** Honeycomb now supports OTLP ingest directly. This means you can use an [OTLP](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter) exporter and no longer need this exporter to send data to Honeycomb.
+**NOTE** This is no longer supported by Honeycomb and is considered a community project. Honeycomb supports OTLP ingest directly. This means you can use an [OTLP](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter) exporter to send telemetry data to Honeycomb.
 
 This exporter supports sending trace data to [Honeycomb](https://www.honeycomb.io).
 


### PR DESCRIPTION
**Description:**

Honeycomb no longer supports the custom Honeycomb exporter. Instead, collector users should use the built-in OTLP exporter. This PR updates the note at the top of the repository and removes the list of Honeycomb engineers as codeowners.

The preference would be for the exporter to be removed, but I sympathise that may be disruptive for existing users.