### PR TITLE
Add check codeowners on CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,6 +86,16 @@ jobs:
       - name: Split Stability Jobs
         id: splitstabilitytest
         run: ./.github/workflows/scripts/setup_stability_tests.sh
+  check-codeowners:
+    runs-on: ubuntu-latest
+    needs: [setup-environment]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Check Code Owner Existence
+        run: ./.github/workflows/scripts/check-codeowners.sh check_code_owner_existence
+      - name: Check Component Existence
+        run: ./.github/workflows/scripts/check-codeowners.sh check_component_existence
   lint:
     runs-on: ubuntu-latest
     needs: [setup-environment]

--- a/.github/workflows/scripts/check-codeowners.sh
+++ b/.github/workflows/scripts/check-codeowners.sh
@@ -1,0 +1,41 @@
+CODEOWNERS=".github/CODEOWNERS"
+
+check_code_owner_existence() {
+  MODULES=$(find . -type f -name "go.mod" -exec dirname {} \; | sort | grep -E '^./' | cut -c 3-)
+  MISSING_COMPONENTS=0
+  for module in ${MODULES}
+  do
+    if ! grep -q "^$module" "$CODEOWNERS"; then
+      ((MISSING_COMPONENTS=MISSING_COMPONENTS+1))
+      echo "\"$module\" not included in CODEOWNERS"
+    fi
+  done
+  echo "there are $MISSING_COMPONENTS components not included in CODEOWNERS"
+  if [ "$MISSING_COMPONENTS" -gt 0 ]; then
+    exit 1
+  fi
+}
+
+check_component_existence() {
+  NOT_EXIST_COMPONENTS=0
+  while IFS= read -r line
+  do
+    if [[ $line =~ ^[^#\*] ]]; then
+      COMPONENT_PATH=$(echo "$line" | cut -d" " -f1)
+      if [ ! -d "$COMPONENT_PATH" ]; then
+        echo "\"$COMPONENT_PATH\" not existed as specified in CODEOWNERS"
+        ((NOT_EXIST_COMPONENTS=NOT_EXIST_COMPONENTS+1))
+      fi
+    fi
+  done <"$CODEOWNERS"
+  echo "there are $NOT_EXIST_COMPONENTS components not existed as specified in CODEOWNERS"
+  if [ "$NOT_EXIST_COMPONENTS" -gt 0 ]; then
+    exit 1
+  fi
+}
+
+if [[ "$1" == "check_code_owner_existence" ]];  then
+  check_code_owner_existence
+elif [[ "$1" == "check_component_existence" ]]; then
+  check_component_existence
+fi

--- a/.github/workflows/scripts/check-codeowners.sh
+++ b/.github/workflows/scripts/check-codeowners.sh
@@ -23,7 +23,7 @@ check_component_existence() {
     if [[ $line =~ ^[^#\*] ]]; then
       COMPONENT_PATH=$(echo "$line" | cut -d" " -f1)
       if [ ! -d "$COMPONENT_PATH" ]; then
-        echo "\"$COMPONENT_PATH\" not existed as specified in CODEOWNERS"
+        echo "\"$COMPONENT_PATH\" does not exist as specified in CODEOWNERS"
         ((NOT_EXIST_COMPONENTS=NOT_EXIST_COMPONENTS+1))
       fi
     fi

--- a/.github/workflows/scripts/check-codeowners.sh
+++ b/.github/workflows/scripts/check-codeowners.sh
@@ -28,7 +28,7 @@ check_component_existence() {
       fi
     fi
   done <"$CODEOWNERS"
-  echo "there are $NOT_EXIST_COMPONENTS components not existed as specified in CODEOWNERS"
+  echo "there are $NOT_EXIST_COMPONENTS component(s) that do not exist as specified in CODEOWNERS"
   if [ "$NOT_EXIST_COMPONENTS" -gt 0 ]; then
     exit 1
   fi


### PR DESCRIPTION
Signed-off-by: Eundoo Song <eundoo.song@gmail.com>

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
- To check every component has a CODEOWNERS line, `check_code_owner_existence` is added.
  - To get the list of every component, I used `find` to search for `go.mod` as commented in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3871#issuecomment-869700055. 
  But there are more components not included in CODEOWNERS in addition to #3870 as you see below result.  Are these all required to be in CODEOWNERS?
- To check every component listed on CODEOWNERS actually exists (to prevent typos), `check_component_existence` is added.
- To call these two on CI,  a separate job `check-codeowners` is added in build-and-test.yml and called after `setup-environment`

#### The result of `check_code_owner_existence`
```
"exporter/awscloudwatchlogsexporter" not included in CODEOWNERS
"exporter/influxdbexporter" not included in CODEOWNERS
"exporter/observiqexporter" not included in CODEOWNERS
"extension/fluentbitextension" not included in CODEOWNERS
"extension/oauth2clientauthextension" not included in CODEOWNERS
"extension/observer/ecsobserver" not included in CODEOWNERS
"extension/observer/hostobserver" not included in CODEOWNERS
"extension/observer/k8sobserver" not included in CODEOWNERS
"extension/storage" not included in CODEOWNERS
"internal/aws/awsutil" not included in CODEOWNERS
"internal/aws/containerinsight" not included in CODEOWNERS
"internal/aws/k8s" not included in CODEOWNERS
"internal/aws/metrics" not included in CODEOWNERS
"internal/aws/xray" not included in CODEOWNERS
"internal/aws/xray/testdata/sampleapp" not included in CODEOWNERS
"internal/aws/xray/testdata/sampleserver" not included in CODEOWNERS
"internal/common" not included in CODEOWNERS
"internal/kubelet" not included in CODEOWNERS
"internal/tools" not included in CODEOWNERS
"pkg/batchperresourceattr" not included in CODEOWNERS
"pkg/batchpersignal" not included in CODEOWNERS
"pkg/experimentalmetricmetadata" not included in CODEOWNERS
"processor/cumulativetodeltaprocessor" not included in CODEOWNERS
"processor/metricsgenerationprocessor" not included in CODEOWNERS
"receiver/fluentforwardreceiver" not included in CODEOWNERS
"receiver/googlecloudpubsubreceiver" not included in CODEOWNERS
"receiver/influxdbreceiver" not included in CODEOWNERS
"receiver/kafkametricsreceiver" not included in CODEOWNERS
"receiver/memcachedreceiver" not included in CODEOWNERS
"receiver/nginxreceiver" not included in CODEOWNERS
"receiver/simpleprometheusreceiver/examples/federation/prom-counter" not included in CODEOWNERS
"receiver/syslogreceiver" not included in CODEOWNERS
"receiver/tcplogreceiver" not included in CODEOWNERS
"receiver/udplogreceiver" not included in CODEOWNERS
"receiver/zookeeperreceiver" not included in CODEOWNERS
"testbed" not included in CODEOWNERS
"testbed/mockdatareceivers/mockawsxrayreceiver" not included in CODEOWNERS
there are 37 components not included in CODEOWNERS
```

#### The result of `check_component_existence`
```
"receiver/googlecloudpubsubexporter/" does not exist as specified in CODEOWNERS
there are 1 component(s) that do not exist as specified in CODEOWNERS
```



**Link to tracking Issue:** <Issue number if applicable>
#3871 

**Testing:** <Describe what testing was performed and which tests were added.>

