### PR TITLE
docs(metricstransformprocessor): use braces when substituting regex match groups

### DIFF
--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -151,12 +151,13 @@ new_name: system.cpu.usage_time
 
 ### Rename multiple metrics using Substitution
 ```yaml
-# rename all system.cpu metrics to system.processor.*
+# rename all system.cpu metrics to system.processor.*.stat
 # instead of regular $ use double dollar $$. Because $ is treated as a special character.
+# wrap the group name/number with braces
 include: ^system\.cpu\.(.*)$$
 match_type: regexp
 action: update
-new_name: system.processor.$$1
+new_name: system.processor.$${1}.stat
 ```
 
 ### Add a label


### PR DESCRIPTION
**Description:** use braces when substituting regex match groups

The linked issue documents what scenarios are we looking for to cover, specifically:

Given this config:

```yaml
    - include: ^net_(.*)_recv$
      match_type: regexp
      action: update
```

and the metric called `net_bytes_recv`, we have the following set of results:

```
      new_name: net_${1}recv -> returns net_recv
      new_name: net_$${1}recv -> returns net_bytesrecv
      new_name: net_$1recv -> returns net_recv
      new_name: net_$$1recv -> returns net_
      new_name: net_$1.recv -> returns net_.recv
      new_name: net_$$1.recv -> returns net_bytes.recv
      new_name: net_${1}.recv -> returns net_.recv
      new_name: net_$${1}.recv -> returns net_bytes.recv
```

Hence add braces around regex match group name/number in readme to make sure the user gets what's the desired result.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3849

