### PR TITLE
remove remaining use of pdata slice Resize()

### DIFF
--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -168,8 +168,7 @@ func GetUnitForMetric(metric string) string {
 func ConvertToOTLPMetrics(fields map[string]interface{}, tags map[string]string, logger *zap.Logger) pdata.Metrics {
 	md := pdata.NewMetrics()
 	rms := md.ResourceMetrics()
-	rms.Resize(1)
-	rm := rms.At(0)
+	rm := rms.AppendEmpty()
 
 	var timestamp pdata.Timestamp
 	resource := rm.Resource()
@@ -221,8 +220,7 @@ func intGauge(ilm pdata.InstrumentationLibraryMetrics, metricName string, unit s
 	metric.SetDataType(pdata.MetricDataTypeIntGauge)
 	intGauge := metric.IntGauge()
 	dataPoints := intGauge.DataPoints()
-	dataPoints.Resize(1)
-	dataPoint := dataPoints.At(0)
+	dataPoint := dataPoints.AppendEmpty()
 
 	dataPoint.SetValue(value)
 	dataPoint.SetTimestamp(ts)
@@ -234,16 +232,14 @@ func doubleGauge(ilm pdata.InstrumentationLibraryMetrics, metricName string, uni
 	metric.SetDataType(pdata.MetricDataTypeGauge)
 	doubleGauge := metric.Gauge()
 	dataPoints := doubleGauge.DataPoints()
-	dataPoints.Resize(1)
-	dataPoint := dataPoints.At(0)
+	dataPoint := dataPoints.AppendEmpty()
 
 	dataPoint.SetValue(value)
 	dataPoint.SetTimestamp(ts)
 }
 
 func initMetric(ilm pdata.InstrumentationLibraryMetrics, name, unit string) pdata.Metric {
-	ilm.Metrics().Resize(1)
-	metric := ilm.Metrics().At(0)
+	metric := ilm.Metrics().AppendEmpty()
 	metric.SetName(name)
 	metric.SetUnit(unit)
 

--- a/internal/stanza/converter.go
+++ b/internal/stanza/converter.go
@@ -276,8 +276,7 @@ func (c *Converter) batchLoop() {
 			} else {
 				pLogs = pdata.NewLogs()
 				logs := pLogs.ResourceLogs()
-				logs.Resize(1)
-				rls := logs.At(0)
+				rls := logs.AppendEmpty()
 
 				resource := rls.Resource()
 				resourceAtts := resource.Attributes()
@@ -287,8 +286,7 @@ func (c *Converter) batchLoop() {
 				}
 
 				ills := rls.InstrumentationLibraryLogs()
-				ills.Resize(1)
-				lr := ills.At(0).Logs().AppendEmpty()
+				lr := ills.AppendEmpty().Logs().AppendEmpty()
 				wi.LogRecord.CopyTo(lr)
 			}
 
@@ -524,9 +522,9 @@ func toAttributeMap(obsMap map[string]interface{}) pdata.AttributeValue {
 func toAttributeArray(obsArr []interface{}) pdata.AttributeValue {
 	arrVal := pdata.NewAttributeValueArray()
 	arr := arrVal.ArrayVal()
-	arr.Resize(len(obsArr))
-	for i, v := range obsArr {
-		insertToAttributeVal(v, arr.At(i))
+	arr.EnsureCapacity(len(obsArr))
+	for _, v := range obsArr {
+		insertToAttributeVal(v, arr.AppendEmpty())
 	}
 	return arrVal
 }

--- a/internal/stanza/converter_test.go
+++ b/internal/stanza/converter_test.go
@@ -401,15 +401,10 @@ func TestConverterCancelledContextCancellsTheFlush(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		pLogs := pdata.NewLogs()
-		logs := pLogs.ResourceLogs()
-		logs.Resize(1)
-		rls := logs.At(0)
-		rls.InstrumentationLibraryLogs().Resize(1)
-		ills := rls.InstrumentationLibraryLogs().At(0)
+		ills := pLogs.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty()
 
 		lr := convert(complexEntry())
-		tgt := ills.Logs().AppendEmpty()
-		lr.CopyTo(tgt)
+		lr.CopyTo(ills.Logs().AppendEmpty())
 
 		assert.Error(t, converter.flush(ctx, pLogs))
 	}()

--- a/pkg/batchperresourceattr/batchperresourceattr_test.go
+++ b/pkg/batchperresourceattr/batchperresourceattr_test.go
@@ -319,9 +319,9 @@ func fillResourceLogs(rs pdata.ResourceLogs, key string, val pdata.AttributeValu
 func BenchmarkBatchPerResourceTraces(b *testing.B) {
 	inBatch := pdata.NewTraces()
 	rss := inBatch.ResourceSpans()
-	rss.Resize(64)
+	rss.EnsureCapacity(64)
 	for i := 0; i < 64; i++ {
-		fillResourceSpans(rss.At(i), "attr_key", pdata.NewAttributeValueString(strconv.Itoa(i%8)))
+		fillResourceSpans(rss.AppendEmpty(), "attr_key", pdata.NewAttributeValueString(strconv.Itoa(i%8)))
 	}
 	bpr := NewBatchPerResourceTraces("attr_key", consumertest.NewNop())
 	b.ReportAllocs()
@@ -335,9 +335,9 @@ func BenchmarkBatchPerResourceTraces(b *testing.B) {
 
 func BenchmarkBatchPerResourceMetrics(b *testing.B) {
 	inBatch := pdata.NewMetrics()
-	inBatch.ResourceMetrics().Resize(64)
+	inBatch.ResourceMetrics().EnsureCapacity(64)
 	for i := 0; i < 64; i++ {
-		fillResourceMetrics(inBatch.ResourceMetrics().At(i), "attr_key", pdata.NewAttributeValueString(strconv.Itoa(i%8)))
+		fillResourceMetrics(inBatch.ResourceMetrics().AppendEmpty(), "attr_key", pdata.NewAttributeValueString(strconv.Itoa(i%8)))
 	}
 	bpr := NewBatchPerResourceMetrics("attr_key", consumertest.NewNop())
 	b.ReportAllocs()
@@ -351,9 +351,9 @@ func BenchmarkBatchPerResourceMetrics(b *testing.B) {
 
 func BenchmarkBatchPerResourceLogs(b *testing.B) {
 	inBatch := pdata.NewLogs()
-	inBatch.ResourceLogs().Resize(64)
+	inBatch.ResourceLogs().EnsureCapacity(64)
 	for i := 0; i < 64; i++ {
-		fillResourceLogs(inBatch.ResourceLogs().At(i), "attr_key", pdata.NewAttributeValueString(strconv.Itoa(i%8)))
+		fillResourceLogs(inBatch.ResourceLogs().AppendEmpty(), "attr_key", pdata.NewAttributeValueString(strconv.Itoa(i%8)))
 	}
 	bpr := NewBatchPerResourceLogs("attr_key", consumertest.NewNop())
 	b.ReportAllocs()

--- a/pkg/batchpersignal/batchpersignal_test.go
+++ b/pkg/batchpersignal/batchpersignal_test.go
@@ -76,22 +76,22 @@ func TestSplitSameTraceIntoDifferentBatches(t *testing.T) {
 	rs := inBatch.ResourceSpans().AppendEmpty()
 
 	// we have 1 ResourceSpans with 2 ILS, resulting in two batches
-	rs.InstrumentationLibrarySpans().Resize(2)
+	rs.InstrumentationLibrarySpans().EnsureCapacity(2)
 
 	// the first ILS has two spans
-	firstILS := rs.InstrumentationLibrarySpans().At(0)
+	firstILS := rs.InstrumentationLibrarySpans().AppendEmpty()
 	firstLibrary := firstILS.InstrumentationLibrary()
 	firstLibrary.SetName("first-library")
-	firstILS.Spans().Resize(2)
-	firstSpan := firstILS.Spans().At(0)
+	firstILS.Spans().EnsureCapacity(2)
+	firstSpan := firstILS.Spans().AppendEmpty()
 	firstSpan.SetName("first-batch-first-span")
 	firstSpan.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4}))
-	secondSpan := firstILS.Spans().At(1)
+	secondSpan := firstILS.Spans().AppendEmpty()
 	secondSpan.SetName("first-batch-second-span")
 	secondSpan.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4}))
 
 	// the second ILS has one span
-	secondILS := rs.InstrumentationLibrarySpans().At(1)
+	secondILS := rs.InstrumentationLibrarySpans().AppendEmpty()
 	secondLibrary := secondILS.InstrumentationLibrary()
 	secondLibrary.SetName("second-library")
 	thirdSpan := secondILS.Spans().AppendEmpty()
@@ -125,14 +125,14 @@ func TestSplitDifferentLogsIntoDifferentBatches(t *testing.T) {
 	ill := rl.InstrumentationLibraryLogs().AppendEmpty()
 	library := ill.InstrumentationLibrary()
 	library.SetName("first-library")
-	ill.Logs().Resize(3)
-	firstLog := ill.Logs().At(0)
+	ill.Logs().EnsureCapacity(3)
+	firstLog := ill.Logs().AppendEmpty()
 	firstLog.SetName("first-batch-first-log")
 	firstLog.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4}))
-	secondLog := ill.Logs().At(1)
+	secondLog := ill.Logs().AppendEmpty()
 	secondLog.SetName("first-batch-second-log")
 	secondLog.SetTraceID(pdata.NewTraceID([16]byte{2, 3, 4, 5}))
-	thirdLog := ill.Logs().At(2)
+	thirdLog := ill.Logs().AppendEmpty()
 	thirdLog.SetName("first-batch-third-log")
 	// do not set traceID for third log
 
@@ -180,22 +180,22 @@ func TestSplitLogsSameTraceIntoDifferentBatches(t *testing.T) {
 	rl := inBatch.ResourceLogs().AppendEmpty()
 
 	// we have 1 ResourceLogs with 2 ILL, resulting in two batches
-	rl.InstrumentationLibraryLogs().Resize(2)
+	rl.InstrumentationLibraryLogs().EnsureCapacity(2)
 
 	// the first ILL has two logs
-	firstILS := rl.InstrumentationLibraryLogs().At(0)
+	firstILS := rl.InstrumentationLibraryLogs().AppendEmpty()
 	firstLibrary := firstILS.InstrumentationLibrary()
 	firstLibrary.SetName("first-library")
-	firstILS.Logs().Resize(2)
-	firstLog := firstILS.Logs().At(0)
+	firstILS.Logs().EnsureCapacity(2)
+	firstLog := firstILS.Logs().AppendEmpty()
 	firstLog.SetName("first-batch-first-log")
 	firstLog.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4}))
-	secondLog := firstILS.Logs().At(1)
+	secondLog := firstILS.Logs().AppendEmpty()
 	secondLog.SetName("first-batch-second-log")
 	secondLog.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4}))
 
 	// the second ILL has one log
-	secondILS := rl.InstrumentationLibraryLogs().At(1)
+	secondILS := rl.InstrumentationLibraryLogs().AppendEmpty()
 	secondLibrary := secondILS.InstrumentationLibrary()
 	secondLibrary.SetName("second-library")
 	thirdLog := secondILS.Logs().AppendEmpty()

--- a/processor/groupbyattrsprocessor/attribute_groups.go
+++ b/processor/groupbyattrsprocessor/attribute_groups.go
@@ -33,8 +33,7 @@ func matchingInstrumentationLibrarySpans(rl pdata.ResourceSpans, library pdata.I
 		}
 	}
 
-	ilss.Resize(ilss.Len() + 1)
-	ils := ilss.At(ilss.Len() - 1)
+	ils := ilss.AppendEmpty()
 	library.CopyTo(ils.InstrumentationLibrary())
 	return ils
 }
@@ -50,8 +49,7 @@ func matchingInstrumentationLibraryLogs(rl pdata.ResourceLogs, library pdata.Ins
 		}
 	}
 
-	ills.Resize(ills.Len() + 1)
-	ill := ills.At(ills.Len() - 1)
+	ill := ills.AppendEmpty()
 	library.CopyTo(ill.InstrumentationLibrary())
 	return ill
 }

--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -296,13 +296,10 @@ func TestEventTracePerWorker(t *testing.T) {
 			defer em.shutdown()
 
 			td := pdata.NewTraces()
-			td.ResourceSpans().Resize(1)
-			td.ResourceSpans().At(0).InstrumentationLibrarySpans().Resize(1)
+			ils := td.ResourceSpans().AppendEmpty().InstrumentationLibrarySpans().AppendEmpty()
 			if tt.traceID != [16]byte{} {
-				td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().Resize(1)
-				span := pdata.NewSpan()
+				span := ils.Spans().AppendEmpty()
 				span.SetTraceID(pdata.NewTraceID(tt.traceID))
-				span.CopyTo(td.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0))
 			}
 
 			// test

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -253,9 +253,9 @@ func TestAttributesToMap(t *testing.T) {
 
 	ava := pdata.NewAttributeValueArray()
 	arrayAttr := ava.ArrayVal()
-	arrayAttr.Resize(2)
-	arrayAttr.At(0).SetStringVal("inner")
-	arrayAttr.At(1).SetIntVal(42)
+	arrayAttr.EnsureCapacity(2)
+	arrayAttr.AppendEmpty().SetStringVal("inner")
+	arrayAttr.AppendEmpty().SetIntVal(42)
 	attr.Insert("array", ava)
 
 	assert.Equal(t, m, AttributesToMap(attr))

--- a/testbed/mockdatareceivers/mockawsxrayreceiver/trace_receiver.go
+++ b/testbed/mockdatareceivers/mockawsxrayreceiver/trace_receiver.go
@@ -149,7 +149,11 @@ func ToTraces(rawSeg []byte) (*pdata.Traces, error) {
 	traceData := pdata.NewTraces()
 	rspan := traceData.ResourceSpans().AppendEmpty()
 	ils := rspan.InstrumentationLibrarySpans().AppendEmpty()
-	ils.Spans().Resize(len(records))
+	ils.Spans().EnsureCapacity(len(records))
+
+	for i := 0; i < len(records); i++ {
+		ils.Spans().AppendEmpty()
+	}
 
 	return &traceData, nil
 }


### PR DESCRIPTION
**Description:** eliminates use of deprecated pdata slice APIs in all other packages

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/2488