### PR TITLE
Remove lint exception for deprecated method warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,6 +118,3 @@ issues:
     - text: "G402:"
       linters:
         - gosec
-    - text: "SA1019:.*Resize is deprecated.*"
-      linters:
-        - staticcheck


### PR DESCRIPTION
**Description:** Removes temporary CI lint exception now that the deprecated method is no longer used.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4189