### PR TITLE
New Relic exporter updates.

### DIFF
--- a/exporter/newrelicexporter/errors.go
+++ b/exporter/newrelicexporter/errors.go
@@ -19,28 +19,45 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/golang/protobuf/ptypes/duration"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
 )
 
 type urlError struct {
-	Err error
+	err error
 }
 
-func (e *urlError) Error() string { return e.Err.Error() }
-func (e *urlError) Unwrap() error { return e.Err }
+func (e *urlError) Error() string { return e.err.Error() }
+func (e *urlError) Unwrap() error { return e.err }
 
 func (e *urlError) GRPCStatus() *grpcStatus.Status {
-	urlError := e.Err.(*url.Error)
+	urlError := e.err.(*url.Error)
 	// If error is temporary, return retryable DataLoss code
 	if urlError.Temporary() {
 		return grpcStatus.New(codes.DataLoss, urlError.Error())
 	}
 	// Else, return non-retryable Internal code
 	return grpcStatus.New(codes.Internal, urlError.Error())
+}
+
+func (e *urlError) IsPermanent() bool {
+	urlError := e.err.(*url.Error)
+	return !urlError.Temporary()
+}
+
+func (e *urlError) Wrap() error {
+	var out error
+	out = e
+	if e.IsPermanent() {
+		out = consumererror.Permanent(out)
+	}
+	return out
 }
 
 // Explicit mapping for the error status codes describe by the trace API:
@@ -58,36 +75,83 @@ var httpGrpcMapping = map[int]codes.Code{
 	http.StatusTooManyRequests:             codes.Unavailable,
 	http.StatusRequestHeaderFieldsTooLarge: codes.InvalidArgument,
 	http.StatusInternalServerError:         codes.DataLoss,
+	http.StatusBadGateway:                  codes.DataLoss,
+	http.StatusServiceUnavailable:          codes.DataLoss,
+}
+
+var retryableHTTPCodes = map[int]struct{}{
+	http.StatusRequestTimeout:      {},
+	http.StatusTooManyRequests:     {},
+	http.StatusInternalServerError: {},
+	http.StatusBadGateway:          {},
+	http.StatusServiceUnavailable:  {},
 }
 
 type httpError struct {
-	Response *http.Response
+	err      error
+	response *http.Response
 }
 
-func (e *httpError) Error() string {
-	return fmt.Sprintf("New Relic HTTP call failed. Status Code: %d", e.Response.StatusCode)
-}
+func (e *httpError) Unwrap() error { return e.err }
+func (e *httpError) Error() string { return e.err.Error() }
 
 func (e *httpError) GRPCStatus() *grpcStatus.Status {
-	mapEntry, ok := httpGrpcMapping[e.Response.StatusCode]
+	mapEntry, ok := httpGrpcMapping[e.response.StatusCode]
 	// If no explicit mapping exists, return retryable DataLoss code
 	if !ok {
-		return grpcStatus.New(codes.DataLoss, e.Response.Status)
+		return grpcStatus.New(codes.DataLoss, e.response.Status)
 	}
 	// The OTLP spec uses the Unavailable code to signal backpressure to the client
 	// If the http status maps to Unavailable, attempt to extract and communicate retry info to the client
-	if mapEntry == codes.Unavailable {
-		retryAfter := e.Response.Header.Get("Retry-After")
-		retrySeconds, err := strconv.ParseInt(retryAfter, 10, 64)
-		if err == nil {
-			message := &errdetails.RetryInfo{RetryDelay: &duration.Duration{Seconds: retrySeconds}}
-			status, statusErr := grpcStatus.New(codes.Unavailable, e.Response.Status).WithDetails(message)
-			if statusErr == nil {
-				return status
-			}
+	retrySeconds := int64(e.ThrottleDelay().Seconds())
+	if retrySeconds > 0 {
+		message := &errdetails.RetryInfo{RetryDelay: &duration.Duration{Seconds: retrySeconds}}
+		status, statusErr := grpcStatus.New(codes.Unavailable, e.response.Status).WithDetails(message)
+		if statusErr == nil {
+			return status
 		}
 	}
 
 	// Generate an error with the mapped code, and a message containing the server's response status string
-	return grpcStatus.New(mapEntry, e.Response.Status)
+	return grpcStatus.New(mapEntry, e.response.Status)
+}
+
+func newHTTPError(response *http.Response) *httpError {
+	return &httpError{
+		err:      fmt.Errorf("new relic HTTP call failed. Status Code: %d", response.StatusCode),
+		response: response,
+	}
+}
+
+func (e *httpError) IsPermanent() bool {
+	if _, ok := retryableHTTPCodes[e.response.StatusCode]; ok {
+		return false
+	}
+	return true
+}
+
+func (e *httpError) ThrottleDelay() time.Duration {
+	if e.response.StatusCode == http.StatusTooManyRequests {
+		retryAfter := e.response.Header.Get("Retry-After")
+		if retrySeconds, err := strconv.ParseInt(retryAfter, 10, 64); err == nil {
+			return time.Duration(retrySeconds) * time.Second
+		}
+	}
+	return 0
+}
+
+func (e *httpError) Wrap() error {
+	if e.IsPermanent() {
+		out := consumererror.Permanent(e.err)
+		return &httpError{err: out, response: e.response}
+	} else if delay := e.ThrottleDelay(); delay > 0 {
+		// NOTE: a retry-after header means that the error is not
+		// permanent (by definition). Here, we use an else if to
+		// optimize the branch conditions. If an error is permanent,
+		// there's no reason to check for a throttle delay.
+		out := exporterhelper.NewThrottleRetry(e.err, delay)
+		return &httpError{err: out, response: e.response}
+	} else {
+		return e
+	}
 }

--- a/exporter/newrelicexporter/factory_test.go
+++ b/exporter/newrelicexporter/factory_test.go
@@ -32,13 +32,15 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	nrCfg, ok := cfg.(*Config)
 	require.True(t, ok, "invalid Config: %#v", cfg)
-	assert.Equal(t, nrCfg.CommonConfig.Timeout, time.Second*15)
+	assert.Equal(t, nrCfg.CommonConfig.TimeoutSettings.Timeout, time.Second*5)
 }
 
 func TestCreateExporterWithAPIKey(t *testing.T) {
 	cfg := createDefaultConfig()
 	nrConfig := cfg.(*Config)
-	nrConfig.CommonConfig.APIKey = "a1b2c3d4"
+	nrConfig.MetricsConfig.APIKey = "a1b2c3d4"
+	nrConfig.TracesConfig.APIKey = "a1b2c3d4"
+	nrConfig.LogsConfig.APIKey = "a1b2c3d4"
 	params := componenttest.NewNopExporterCreateSettings()
 
 	te, err := createTracesExporter(context.Background(), params, nrConfig)
@@ -57,7 +59,9 @@ func TestCreateExporterWithAPIKey(t *testing.T) {
 func TestCreateExporterWithAPIKeyHeader(t *testing.T) {
 	cfg := createDefaultConfig()
 	nrConfig := cfg.(*Config)
-	nrConfig.CommonConfig.APIKeyHeader = "api-key"
+	nrConfig.MetricsConfig.APIKeyHeader = "api-key"
+	nrConfig.TracesConfig.APIKeyHeader = "api-key"
+	nrConfig.LogsConfig.APIKeyHeader = "api-key"
 	params := componenttest.NewNopExporterCreateSettings()
 
 	te, err := createTracesExporter(context.Background(), params, nrConfig)
@@ -76,8 +80,12 @@ func TestCreateExporterWithAPIKeyHeader(t *testing.T) {
 func TestCreateExporterWithAPIKeyAndAPIKeyHeader(t *testing.T) {
 	cfg := createDefaultConfig()
 	nrConfig := cfg.(*Config)
-	nrConfig.CommonConfig.APIKey = "a1b2c3d4"
-	nrConfig.CommonConfig.APIKeyHeader = "api-key"
+	nrConfig.MetricsConfig.APIKey = "a1b2c3d4"
+	nrConfig.TracesConfig.APIKey = "a1b2c3d4"
+	nrConfig.LogsConfig.APIKey = "a1b2c3d4"
+	nrConfig.MetricsConfig.APIKeyHeader = "api-key"
+	nrConfig.TracesConfig.APIKeyHeader = "api-key"
+	nrConfig.LogsConfig.APIKeyHeader = "api-key"
 	params := componenttest.NewNopExporterCreateSettings()
 
 	te, err := createTracesExporter(context.Background(), params, nrConfig)

--- a/exporter/newrelicexporter/go.mod
+++ b/exporter/newrelicexporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/golang/protobuf v1.5.2
 	github.com/mattn/go-colorable v0.1.7 // indirect
-	github.com/newrelic/newrelic-telemetry-sdk-go v0.7.1
+	github.com/newrelic/newrelic-telemetry-sdk-go v0.8.0
 	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/collector v0.30.2-0.20210723184018-3b7d6ce4830c

--- a/exporter/newrelicexporter/go.sum
+++ b/exporter/newrelicexporter/go.sum
@@ -892,8 +892,8 @@ github.com/nats-io/nkeys v0.2.0/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1t
 github.com/nats-io/nkeys v0.3.0/go.mod h1:gvUNGjVcM2IPr5rCsRsC6Wb3Hr2CQAm08dsxtV6A5y4=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/newrelic/newrelic-telemetry-sdk-go v0.7.1 h1:QXmERkem5rwMxrHPVHogvuflpRaw72Lnfl/knHuyQ0E=
-github.com/newrelic/newrelic-telemetry-sdk-go v0.7.1/go.mod h1:2kY6OeOxrJ+RIQlVjWDc/pZlT3MIf30prs6drzMfJ6E=
+github.com/newrelic/newrelic-telemetry-sdk-go v0.8.0 h1:vkJrmKsI5mbW1gXhuIWolTZTuz+yhUAzgIwTRXIpoF4=
+github.com/newrelic/newrelic-telemetry-sdk-go v0.8.0/go.mod h1:2kY6OeOxrJ+RIQlVjWDc/pZlT3MIf30prs6drzMfJ6E=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/exporter/newrelicexporter/metrics_test.go
+++ b/exporter/newrelicexporter/metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"go.opentelemetry.io/collector/model/pdata"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -42,6 +43,8 @@ func TestMetricViews(t *testing.T) {
 			assert.Equal(t, spanMetadataTagKeys, curView.TagKeys)
 		} else if curView.Name == "newrelicexporter_attribute_metadata_count" {
 			assert.Equal(t, attributeMetadataTagKeys, curView.TagKeys)
+		} else if strings.HasSuffix(curView.Name, "_notag") {
+			assert.Equal(t, []tag.Key{}, curView.TagKeys)
 		} else {
 			assert.Equal(t, tagKeys, curView.TagKeys)
 		}

--- a/exporter/newrelicexporter/mock_test.go
+++ b/exporter/newrelicexporter/mock_test.go
@@ -61,9 +61,10 @@ type Log struct {
 
 // Mock caches decompressed request bodies
 type Mock struct {
-	Header     http.Header
-	Batches    []Batch
-	StatusCode int
+	Header          http.Header
+	Batches         []Batch
+	StatusCode      int
+	ResponseHeaders map[string]string
 }
 
 func (c *Mock) Spans() []Span {
@@ -109,6 +110,10 @@ func (c *Mock) Server() *httptest.Server {
 		}
 
 		c.Header = r.Header
+
+		for k, v := range c.ResponseHeaders {
+			w.Header().Set(k, v)
+		}
 
 		w.WriteHeader(c.StatusCode)
 	}))

--- a/exporter/newrelicexporter/newrelic_test.go
+++ b/exporter/newrelicexporter/newrelic_test.go
@@ -74,9 +74,9 @@ func runTraceMock(initialContext context.Context, ptrace pdata.Traces, cfg mockC
 	u, _ := url.Parse(urlString)
 
 	if cfg.useAPIKeyHeader {
-		c.CommonConfig.APIKeyHeader = "api-key"
+		c.TracesConfig.APIKeyHeader = "api-key"
 	} else {
-		c.CommonConfig.APIKey = "NRII-1"
+		c.TracesConfig.APIKey = "NRII-1"
 	}
 	c.TracesConfig.insecure, c.TracesConfig.HostOverride = true, u.Host
 	exp, err := f.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), c)
@@ -117,9 +117,9 @@ func runMetricMock(initialContext context.Context, pmetrics pdata.Metrics, cfg m
 	u, _ := url.Parse(urlString)
 
 	if cfg.useAPIKeyHeader {
-		c.CommonConfig.APIKeyHeader = "api-key"
+		c.MetricsConfig.APIKeyHeader = "api-key"
 	} else {
-		c.CommonConfig.APIKey = "NRII-1"
+		c.MetricsConfig.APIKey = "NRII-1"
 	}
 	c.MetricsConfig.insecure, c.MetricsConfig.HostOverride = true, u.Host
 	exp, err := f.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), c)
@@ -160,9 +160,9 @@ func runLogMock(initialContext context.Context, plogs pdata.Logs, cfg mockConfig
 	u, _ := url.Parse(urlString)
 
 	if cfg.useAPIKeyHeader {
-		c.CommonConfig.APIKeyHeader = "api-key"
+		c.LogsConfig.APIKeyHeader = "api-key"
 	} else {
-		c.CommonConfig.APIKey = "NRII-1"
+		c.LogsConfig.APIKey = "NRII-1"
 	}
 	c.LogsConfig.insecure, c.LogsConfig.HostOverride = true, u.Host
 	exp, err := f.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), c)
@@ -745,9 +745,9 @@ func TestCreatesClientOptionWithVersionInUserAgent(t *testing.T) {
 	u, _ := url.Parse(urlString)
 
 	if cfg.useAPIKeyHeader {
-		c.CommonConfig.APIKeyHeader = "api-key"
+		c.TracesConfig.APIKeyHeader = "api-key"
 	} else {
-		c.CommonConfig.APIKey = "NRII-1"
+		c.TracesConfig.APIKey = "NRII-1"
 	}
 	c.TracesConfig.insecure, c.TracesConfig.HostOverride = true, u.Host
 	exp, err := f.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), c)
@@ -790,9 +790,9 @@ func TestBadSpanResourceGeneratesError(t *testing.T) {
 	u, _ := url.Parse(urlString)
 
 	if cfg.useAPIKeyHeader {
-		c.CommonConfig.APIKeyHeader = "api-key"
+		c.TracesConfig.APIKeyHeader = "api-key"
 	} else {
-		c.CommonConfig.APIKey = "NRII-1"
+		c.TracesConfig.APIKey = "NRII-1"
 	}
 	c.TracesConfig.insecure, c.TracesConfig.HostOverride = true, u.Host
 	exp, err := f.CreateTracesExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), c)
@@ -837,9 +837,9 @@ func TestBadMetricResourceGeneratesError(t *testing.T) {
 	u, _ := url.Parse(urlString)
 
 	if cfg.useAPIKeyHeader {
-		c.CommonConfig.APIKeyHeader = "api-key"
+		c.MetricsConfig.APIKeyHeader = "api-key"
 	} else {
-		c.CommonConfig.APIKey = "NRII-1"
+		c.MetricsConfig.APIKey = "NRII-1"
 	}
 	c.TracesConfig.insecure, c.TracesConfig.HostOverride = true, u.Host
 	exp, err := f.CreateMetricsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), c)
@@ -882,9 +882,9 @@ func TestBadLogResourceGeneratesError(t *testing.T) {
 	u, _ := url.Parse(urlString)
 
 	if cfg.useAPIKeyHeader {
-		c.CommonConfig.APIKeyHeader = "api-key"
+		c.LogsConfig.APIKeyHeader = "api-key"
 	} else {
-		c.CommonConfig.APIKey = "NRII-1"
+		c.LogsConfig.APIKey = "NRII-1"
 	}
 	c.TracesConfig.insecure, c.TracesConfig.HostOverride = true, u.Host
 	exp, err := f.CreateLogsExporter(context.Background(), componenttest.NewNopExporterCreateSettings(), c)
@@ -930,9 +930,9 @@ func TestFailureToRecordMetricsDoesNotAffectExportingData(t *testing.T) {
 	u, _ := url.Parse(urlString)
 
 	if cfg.useAPIKeyHeader {
-		c.CommonConfig.APIKeyHeader = "api-key"
+		c.TracesConfig.APIKeyHeader = "api-key"
 	} else {
-		c.CommonConfig.APIKey = "NRII-1"
+		c.TracesConfig.APIKey = "NRII-1"
 	}
 	c.TracesConfig.insecure, c.TracesConfig.HostOverride = true, u.Host
 

--- a/exporter/newrelicexporter/testdata/config.yaml
+++ b/exporter/newrelicexporter/testdata/config.yaml
@@ -9,6 +9,11 @@ exporters:
   newrelic/alt:
     apikey: a1b2c3d4
     timeout: 30s
+    retry:
+      enabled: false
+      initial_interval: 0
+      max_interval: 0
+      max_elapsed_time: 0
     metrics:
       host_override: alt.metrics.newrelic.com
     traces:
@@ -19,9 +24,9 @@ exporters:
 service:
   pipelines:
     traces:
-        receivers: [nop]
-        processors: [nop]
-        exporters: [newrelic]
+      receivers: [nop]
+      processors: [nop]
+      exporters: [newrelic]
     metrics:
       receivers: [nop]
       processors: [nop]

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -428,7 +428,7 @@ func (t *transformer) MetricAttributes(baseAttributes map[string]interface{}, at
 }
 
 func (t *transformer) TrackAttributes(location attributeLocation, attributeMap pdata.AttributeMap) {
-	attributeMap.Range(func(k string, v pdata.AttributeValue) bool {
+	attributeMap.Range(func(_ string, v pdata.AttributeValue) bool {
 		statsKey := attributeStatsKey{location: location, attributeType: v.Type()}
 		t.details.attributeMetadataCount[statsKey]++
 		return true

--- a/go.sum
+++ b/go.sum
@@ -1391,8 +1391,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/newrelic/newrelic-telemetry-sdk-go v0.7.1 h1:QXmERkem5rwMxrHPVHogvuflpRaw72Lnfl/knHuyQ0E=
-github.com/newrelic/newrelic-telemetry-sdk-go v0.7.1/go.mod h1:2kY6OeOxrJ+RIQlVjWDc/pZlT3MIf30prs6drzMfJ6E=
+github.com/newrelic/newrelic-telemetry-sdk-go v0.8.0 h1:vkJrmKsI5mbW1gXhuIWolTZTuz+yhUAzgIwTRXIpoF4=
+github.com/newrelic/newrelic-telemetry-sdk-go v0.8.0/go.mod h1:2kY6OeOxrJ+RIQlVjWDc/pZlT3MIf30prs6drzMfJ6E=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/predeclared v0.2.1/go.mod h1:HvkGJcA3naj4lOwnFXFDkFxVtSqQMB9sbB1usJ+xjQE=


### PR DESCRIPTION
**Description:** 

This PR includes the following updates to the New Relic collector:

## Improvements
* Requests are now retry-able via configuration option (defaults to retries enabled). Permanent errors are not retried
* The exporter monitoring metrics now include an untagged summary metric for ease of use
* Improved error logging to include URLs that fail to post messages to New Relic

## Bugfix
* Configuration unmarshalling did not allow timeout value to be set to 0 in the endpoint specific section
* Request cancellation was not propagated via context into the http request
* The queued retry logger is set to a zap.Nop logger as intended

CC @alanwest 