### PR TITLE
Upgrade to Google Cloud Trace exporter v1.0.0-RC1

### DIFF
--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.8
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.20.1-0.20210712185927-c0aa9a97e391
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.0.0-RC1
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/exporter/googlecloudexporter/go.sum
+++ b/exporter/googlecloudexporter/go.sum
@@ -101,8 +101,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.20.1-0.20210712185927-c0aa9a97e391 h1:EsHyHNlCzdlRzab46PPAPSKhw3rDVCZNGpbMz1G/vhA=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.20.1-0.20210712185927-c0aa9a97e391/go.mod h1:NnHpFdFUt94yacrhX5J/NGbQtf7ZtQrqF+dmxHdQ+xM=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.0.0-RC1 h1:GZtdQHYaNrMQCdkl1QlbiDkHsYzvv/9xKd00vm3BIos=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.0.0-RC1/go.mod h1:NnHpFdFUt94yacrhX5J/NGbQtf7ZtQrqF+dmxHdQ+xM=
 github.com/HdrHistogram/hdrhistogram-go v0.9.0/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qEclQKK70g0KxO61gFFZD4=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=

--- a/exporter/googlecloudexporter/googlecloud.go
+++ b/exporter/googlecloudexporter/googlecloud.go
@@ -31,6 +31,7 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/translator/conventions"
 	"go.opentelemetry.io/collector/translator/internaldata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 )
@@ -236,13 +237,13 @@ func exportAdditionalLabels(mds []*agentmetricspb.ExportMetricsServiceRequest) [
 func (te *traceExporter) pushTraces(ctx context.Context, td pdata.Traces) error {
 	var errs []error
 	resourceSpans := td.ResourceSpans()
-	spans := make([]cloudtrace.ReadOnlySpan, 0, td.SpanCount())
+	spans := make([]sdktrace.ReadOnlySpan, 0, td.SpanCount())
 	for i := 0; i < resourceSpans.Len(); i++ {
 		sd := pdataResourceSpansToOTSpanData(resourceSpans.At(i))
 		spans = append(spans, sd...)
 	}
 
-	err := te.texporter.ExportCustomSpans(ctx, spans)
+	err := te.texporter.ExportSpans(ctx, spans)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/exporter/googlecloudexporter/spandata.go
+++ b/exporter/googlecloudexporter/spandata.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"time"
 
-	cloudtrace "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -29,9 +28,9 @@ import (
 	apitrace "go.opentelemetry.io/otel/trace"
 )
 
-func pdataResourceSpansToOTSpanData(rs pdata.ResourceSpans) []cloudtrace.ReadOnlySpan {
+func pdataResourceSpansToOTSpanData(rs pdata.ResourceSpans) []sdktrace.ReadOnlySpan {
 	resource := rs.Resource()
-	var sds []cloudtrace.ReadOnlySpan
+	var sds []sdktrace.ReadOnlySpan
 	ilss := rs.InstrumentationLibrarySpans()
 	for i := 0; i < ilss.Len(); i++ {
 		ils := ilss.At(i)

--- a/exporter/googlecloudexporter/spansnapshot.go
+++ b/exporter/googlecloudexporter/spansnapshot.go
@@ -17,7 +17,6 @@ package googlecloudexporter
 import (
 	"time"
 
-	cloudtrace "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
@@ -27,6 +26,7 @@ import (
 )
 
 type spanSnapshot struct {
+	sdktrace.ReadOnlySpan                                                 // so we can inherit the "private" func
 	spanContext, parent                                                   apitrace.SpanContext
 	spanKind                                                              apitrace.SpanKind
 	startTime, endTime                                                    time.Time
@@ -39,8 +39,6 @@ type spanSnapshot struct {
 	instrumentationLibrary                                                instrumentation.Library
 	status                                                                sdktrace.Status
 }
-
-var _ cloudtrace.ReadOnlySpan = spanSnapshot{}
 
 func (s spanSnapshot) Name() string                     { return s.name }
 func (s spanSnapshot) SpanContext() trace.SpanContext   { return s.spanContext }

--- a/exporter/stackdriverexporter/go.sum
+++ b/exporter/stackdriverexporter/go.sum
@@ -101,8 +101,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.20.1-0.20210712185927-c0aa9a97e391 h1:EsHyHNlCzdlRzab46PPAPSKhw3rDVCZNGpbMz1G/vhA=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.20.1-0.20210712185927-c0aa9a97e391/go.mod h1:NnHpFdFUt94yacrhX5J/NGbQtf7ZtQrqF+dmxHdQ+xM=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.0.0-RC1 h1:GZtdQHYaNrMQCdkl1QlbiDkHsYzvv/9xKd00vm3BIos=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.0.0-RC1/go.mod h1:NnHpFdFUt94yacrhX5J/NGbQtf7ZtQrqF+dmxHdQ+xM=
 github.com/HdrHistogram/hdrhistogram-go v0.9.0/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qEclQKK70g0KxO61gFFZD4=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/DataDog/zstd v1.4.4/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t
 github.com/DataDog/zstd v1.4.8 h1:Rpmta4xZ/MgZnriKNd24iZMhGpP5dvUcs/uqfBapKZY=
 github.com/DataDog/zstd v1.4.8/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.20.1-0.20210712185927-c0aa9a97e391 h1:EsHyHNlCzdlRzab46PPAPSKhw3rDVCZNGpbMz1G/vhA=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.20.1-0.20210712185927-c0aa9a97e391/go.mod h1:NnHpFdFUt94yacrhX5J/NGbQtf7ZtQrqF+dmxHdQ+xM=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.0.0-RC1 h1:GZtdQHYaNrMQCdkl1QlbiDkHsYzvv/9xKd00vm3BIos=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.0.0-RC1/go.mod h1:NnHpFdFUt94yacrhX5J/NGbQtf7ZtQrqF+dmxHdQ+xM=
 github.com/HdrHistogram/hdrhistogram-go v0.9.0/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qEclQKK70g0KxO61gFFZD4=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=


### PR DESCRIPTION
Fixes #4147.

Also remove the dependency on Cloud Trace's custom `ReadOnlySpan` interface using a suggestion from @bogdandrutu (that interface is set to be removed in the next RC of the exporter).