### PR TITLE
[awscontainerinsightreceiver] Add ECS info to collect ECS EC2 instance metrics

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
@@ -131,29 +131,3 @@ func TestGetMetrics(t *testing.T) {
 
 	os.Setenv("HOST_NAME", originalHostName)
 }
-
-func TestGetMetricsWithECS(t *testing.T) {
-	// normal case
-	ecsInfo := &testutils.MockECSInfo{}
-	hostInfo := testutils.MockHostInfo{InstanceIP: "0.0.0.0"}
-	mockCreateManager := func(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, houskeepingConfig manager.HouskeepingConfig,
-		includedMetricsSet container.MetricSet, collectorHTTPClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string,
-		perfEventsFile string) (cadvisorManager, error) {
-		return &mockCadvisorManager{t: t}, nil
-	}
-	c, err := NewWithECSInfo("ecs", hostInfo, zap.NewNop(), ecsInfo, cadvisorManagerCreator(mockCreateManager))
-	assert.NotNil(t, c)
-	assert.Nil(t, err)
-	assert.NotNil(t, c.GetMetrics())
-
-	// error when calling manager.Start
-	c, err = NewWithECSInfo("ecs", hostInfo, zap.NewNop(), ecsInfo, cadvisorManagerCreator(mockCreateManager2))
-	assert.Nil(t, c)
-	assert.NotNil(t, err)
-
-	// error when creating cadvisor manager
-	c, err = NewWithECSInfo("ecs", hostInfo, zap.NewNop(), ecsInfo, cadvisorManagerCreator(mockCreateManagerWithError))
-	assert.Nil(t, c)
-	assert.NotNil(t, err)
-
-}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
@@ -54,6 +54,11 @@ func New(containerOrchestrator string, hostInfo hostInfo, logger *zap.Logger, op
 	return &Cadvisor{}, nil
 }
 
+// NewWithECSInfo is a dummy function to construct a dummy Cadvisor struct for windows
+func NewWithECSInfo(containerOrchestrator string, hostInfo hostInfo, logger *zap.Logger, ecs ecsInfo) (*Cadvisor, error) {
+	return &Cadvisor{}, nil
+}
+
 // GetMetrics is a dummy function that always returns empty metrics for windows
 func (c *Cadvisor) GetMetrics() []pdata.Metrics {
 	return []pdata.Metrics{}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
@@ -54,11 +54,6 @@ func New(containerOrchestrator string, hostInfo hostInfo, logger *zap.Logger, op
 	return &Cadvisor{}, nil
 }
 
-// NewWithECSInfo is a dummy function to construct a dummy Cadvisor struct for windows
-func NewWithECSInfo(containerOrchestrator string, hostInfo hostInfo, logger *zap.Logger, ecs ecsInfo) (*Cadvisor, error) {
-	return &Cadvisor{}, nil
-}
-
 // GetMetrics is a dummy function that always returns empty metrics for windows
 func (c *Cadvisor) GetMetrics() []pdata.Metrics {
 	return []pdata.Metrics{}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor.go
@@ -88,7 +88,7 @@ func processContainers(cInfos []*cInfo.ContainerInfo, mInfo extractors.CPUMemInf
 	}
 
 	// This happens when our cgroup path based pod detection logic is not working.
-	if len(metrics) == beforePod {
+	if len(metrics) == beforePod && containerOrchestrator == ci.EKS {
 		logger.Warn("No pod metric collected", zap.Any("metrics count", beforePod))
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor.go
@@ -54,7 +54,7 @@ func (c *CPUMetricExtractor) GetValue(info *cInfo.ContainerInfo, mInfo CPUMemInf
 		metric.fields[ci.MetricName(containerType, ci.CPUUtilization)] = metric.fields[ci.MetricName(containerType, ci.CPUTotal)].(float64) / float64(numCores*decimalToMillicores) * 100
 	}
 
-	if containerType == ci.TypeNode {
+	if containerType == ci.TypeNode || containerType == ci.TypeInstance {
 		metric.fields[ci.MetricName(containerType, ci.CPULimit)] = numCores * decimalToMillicores
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/cpu_extractor_test.go
@@ -62,4 +62,22 @@ func TestCPUStats(t *testing.T) {
 	AssertContainsTaggedFloat(t, cMetrics[0], "node_cpu_usage_system", 10, 0)
 	AssertContainsTaggedFloat(t, cMetrics[0], "node_cpu_utilization", 0.5, 0)
 	AssertContainsTaggedInt(t, cMetrics[0], "node_cpu_limit", 2000)
+
+	//test instance type
+	containerType = TypeInstance
+	extractor = NewCPUMetricExtractor(nil)
+
+	if extractor.HasValue(result[0]) {
+		cMetrics = extractor.GetValue(result[0], MockCPUMemInfo, containerType)
+	}
+
+	if extractor.HasValue(result2[0]) {
+		cMetrics = extractor.GetValue(result2[0], MockCPUMemInfo, containerType)
+	}
+
+	AssertContainsTaggedFloat(t, cMetrics[0], "instance_cpu_usage_total", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "instance_cpu_usage_user", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "instance_cpu_usage_system", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "instance_cpu_utilization", 0.5, 0)
+	AssertContainsTaggedInt(t, cMetrics[0], "instance_cpu_limit", 2000)
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor.go
@@ -66,7 +66,7 @@ func (m *MemMetricExtractor) GetValue(info *cinfo.ContainerInfo, mInfo CPUMemInf
 		metric.fields[ci.MetricName(containerType, ci.MemUtilization)] = float64(metric.fields[ci.MetricName(containerType, ci.MemWorkingset)].(uint64)) / float64(memoryCapacity) * 100
 	}
 
-	if containerType == ci.TypeNode {
+	if containerType == ci.TypeNode || containerType == ci.TypeInstance {
 		metric.fields[ci.MetricName(containerType, ci.MemLimit)] = memoryCapacity
 	}
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/mem_extractor_test.go
@@ -80,4 +80,32 @@ func TestMemStats(t *testing.T) {
 	AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_hierarchical_pgmajfault", 10, 0)
 	AssertContainsTaggedFloat(t, cMetrics[0], "node_memory_utilization", 2.68630981, 1.0e-8)
 
+	// for instance type
+	containerType = TypeInstance
+	extractor = NewMemMetricExtractor(nil)
+
+	if extractor.HasValue(result[0]) {
+		cMetrics = extractor.GetValue(result[0], MockCPUMemInfo, containerType)
+	}
+
+	if extractor.HasValue(result2[0]) {
+		cMetrics = extractor.GetValue(result2[0], MockCPUMemInfo, containerType)
+	}
+
+	AssertContainsTaggedUint(t, cMetrics[0], "instance_memory_cache", 25645056)
+	AssertContainsTaggedUint(t, cMetrics[0], "instance_memory_rss", 221184)
+	AssertContainsTaggedUint(t, cMetrics[0], "instance_memory_max_usage", 90775552)
+	AssertContainsTaggedUint(t, cMetrics[0], "instance_memory_mapped_file", 0)
+	AssertContainsTaggedUint(t, cMetrics[0], "instance_memory_usage", 29728768)
+	AssertContainsTaggedUint(t, cMetrics[0], "instance_memory_swap", 0)
+	AssertContainsTaggedUint(t, cMetrics[0], "instance_memory_failcnt", 0)
+	AssertContainsTaggedUint(t, cMetrics[0], "instance_memory_working_set", 28844032)
+	AssertContainsTaggedInt(t, cMetrics[0], "instance_memory_limit", 1073741824)
+
+	AssertContainsTaggedFloat(t, cMetrics[0], "instance_memory_pgfault", 1000, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "instance_memory_hierarchical_pgfault", 1000, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "instance_memory_pgmajfault", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "instance_memory_hierarchical_pgmajfault", 10, 0)
+	AssertContainsTaggedFloat(t, cMetrics[0], "instance_memory_utilization", 2.68630981, 1.0e-8)
+
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/ecshelpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/ecshelpers.go
@@ -1,0 +1,40 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+type MockECSInfo struct {
+	ClusterName string
+	InstanceIP  string
+}
+
+func (e *MockECSInfo) GetRunningTaskCount() int64 {
+	return 2
+}
+
+func (e *MockECSInfo) GetCPUReserved() int64 {
+	return 32
+}
+
+func (e *MockECSInfo) GetMemReserved() int64 {
+	return 213
+}
+
+func (e *MockECSInfo) GetContainerInstanceID() string {
+	return "eeee12.dsfr"
+}
+
+func (e *MockECSInfo) GetClusterName() string {
+	return "ecs-cluster"
+}

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
@@ -57,6 +57,7 @@ func (m MockCPUMemInfo) GetMemoryCapacity() int64 {
 type MockHostInfo struct {
 	MockCPUMemInfo
 	ClusterName string
+	InstanceIP  string
 }
 
 func (m MockHostInfo) GetClusterName() string {

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup_test.go
@@ -25,31 +25,6 @@ import (
 	"go.uber.org/zap"
 )
 
-type MockTaskInfo struct {
-	tasks            []ECSTask
-	runningTaskCount int64
-}
-
-func (ii *MockTaskInfo) getRunningTaskCount() int64 {
-	return ii.runningTaskCount
-}
-func (ii *MockTaskInfo) getRunningTasksInfo() []ECSTask {
-
-	return ii.tasks
-}
-
-type MockInstanceInfo struct {
-	clusterName string
-	instanceID  string
-}
-
-func (ii *MockInstanceInfo) GetClusterName() string {
-	return ii.clusterName
-}
-func (ii *MockInstanceInfo) GetContainerInstanceID() string {
-	return ii.instanceID
-}
-
 func TestGetCGroupPathForTask(t *testing.T) {
 	cgroupMount := "test"
 	controller := "cpu"

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info.go
@@ -31,11 +31,6 @@ type containerInstanceInfoProvider interface {
 	GetContainerInstanceID() string
 }
 
-type hostIPProvider interface {
-	GetInstanceIP() string
-	GetInstanceIPReadyC() chan bool
-}
-
 type Requester interface {
 	Request(ctx context.Context, path string) ([]byte, error)
 }

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo.go
@@ -65,7 +65,6 @@ func (e *EcsInfo) GetCPUReserved() int64 {
 		return e.cgroup.getCPUReserved()
 	}
 	return 0
-	//return e.cgroup.getCPUReserved()
 }
 
 func (e *EcsInfo) GetMemReserved() int64 {
@@ -73,8 +72,6 @@ func (e *EcsInfo) GetMemReserved() int64 {
 		return e.cgroup.getMemReserved()
 	}
 	return 0
-	//return e.cgroup.getMemReserved()
-
 }
 
 func (e *EcsInfo) GetContainerInstanceID() string {
@@ -152,7 +149,7 @@ func (e *EcsInfo) initTaskInfo(ctx context.Context) {
 
 	<-e.hostIPProvider.GetInstanceIPReadyC()
 
-	e.logger.Info("instance ip is ready and begin initializing ecs container info")
+	e.logger.Info("instance ip is ready and begin initializing ecs task info")
 
 	e.ecsTaskInfo = e.ecsTaskInfoCreator(ctx, e.hostIPProvider, e.refreshInterval, e.logger, e.httpClient, e.isTaskInfoReadyC)
 

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo.go
@@ -1,0 +1,177 @@
+//Copyright  OpenTelemetry Authors
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package ecsinfo
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.uber.org/zap"
+)
+
+const defaultTimeout = 1 * time.Second
+
+type hostIPProvider interface {
+	GetInstanceIP() string
+	GetInstanceIPReadyC() chan bool
+}
+
+type EcsInfo struct {
+	logger                *zap.Logger
+	refreshInterval       time.Duration
+	cancel                context.CancelFunc
+	hostIPProvider        hostIPProvider
+	isTaskInfoReadyC      chan bool
+	isContainerInfoReadyC chan bool
+
+	isCgroupReadyC          chan bool // close of this channel indicates cgroup is initialized. It is used only in test
+	taskInfoTestReadyC      chan bool // close of this channel indicates taskinfo is initialized. It is used only in test
+	containerInfoTestReadyC chan bool // close of this channel indicates container info is initialized. It is used only in test
+
+	httpClient            doer
+	containerInstanceInfo containerInstanceInfoProvider
+	ecsTaskInfo           ecsTaskInfoProvider
+	cgroup                cgroupScannerProvider
+
+	containerInstanceInfoCreator func(context.Context, hostIPProvider, time.Duration, *zap.Logger, doer, chan bool) containerInstanceInfoProvider
+	ecsTaskInfoCreator           func(context.Context, hostIPProvider, time.Duration, *zap.Logger, doer, chan bool) ecsTaskInfoProvider
+	cgroupScannerCreator         func(context.Context, *zap.Logger, ecsTaskInfoProvider, containerInstanceInfoProvider, time.Duration) cgroupScannerProvider
+}
+
+func (e *EcsInfo) GetRunningTaskCount() int64 {
+	if e.ecsTaskInfo != nil {
+		return e.ecsTaskInfo.getRunningTaskCount()
+	}
+	return 0
+}
+
+func (e *EcsInfo) GetCPUReserved() int64 {
+	if e.cgroup != nil {
+		return e.cgroup.getCPUReserved()
+	}
+	return 0
+	//return e.cgroup.getCPUReserved()
+}
+
+func (e *EcsInfo) GetMemReserved() int64 {
+	if e.cgroup != nil {
+		return e.cgroup.getMemReserved()
+	}
+	return 0
+	//return e.cgroup.getMemReserved()
+
+}
+
+func (e *EcsInfo) GetContainerInstanceID() string {
+	if e.containerInstanceInfo != nil {
+		return e.containerInstanceInfo.GetContainerInstanceID()
+	}
+	return ""
+}
+
+func (e *EcsInfo) GetClusterName() string {
+	if e.containerInstanceInfo != nil {
+		return e.containerInstanceInfo.GetClusterName()
+	}
+	return ""
+}
+
+type ecsInfoOption func(*EcsInfo)
+
+// New creates a k8sApiServer which can generate cluster-level metrics
+func NewECSInfo(refreshInterval time.Duration, hostIPProvider hostIPProvider, logger *zap.Logger, options ...ecsInfoOption) (*EcsInfo, error) {
+
+	setting := confighttp.HTTPClientSettings{
+		Timeout: defaultTimeout,
+	}
+
+	client, err := setting.ToClient(map[config.ComponentID]component.Extension{})
+
+	if err != nil {
+		logger.Warn("Failed to create a http client for ECS info!")
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ecsInfo := &EcsInfo{
+		logger:                       logger,
+		hostIPProvider:               hostIPProvider,
+		refreshInterval:              refreshInterval,
+		httpClient:                   client,
+		cancel:                       cancel,
+		containerInstanceInfoCreator: newECSInstanceInfo,
+		ecsTaskInfoCreator:           newECSTaskInfo,
+		cgroupScannerCreator:         newCGroupScannerForContainer,
+		isTaskInfoReadyC:             make(chan bool),
+		isContainerInfoReadyC:        make(chan bool),
+		isCgroupReadyC:               make(chan bool),
+		taskInfoTestReadyC:           make(chan bool),
+		containerInfoTestReadyC:      make(chan bool),
+	}
+
+	for _, opt := range options {
+		opt(ecsInfo)
+	}
+
+	go ecsInfo.initContainerInfo(ctx)
+
+	go ecsInfo.initTaskInfo(ctx)
+
+	go ecsInfo.initCgroupScanner(ctx)
+
+	return ecsInfo, nil
+}
+
+func (e *EcsInfo) initContainerInfo(ctx context.Context) {
+
+	<-e.hostIPProvider.GetInstanceIPReadyC()
+
+	e.logger.Info("instance ip is ready and begin initializing ecs container info")
+
+	e.containerInstanceInfo = e.containerInstanceInfoCreator(ctx, e.hostIPProvider, e.refreshInterval, e.logger, e.httpClient, e.isContainerInfoReadyC)
+	close(e.containerInfoTestReadyC)
+}
+
+func (e *EcsInfo) initTaskInfo(ctx context.Context) {
+
+	<-e.hostIPProvider.GetInstanceIPReadyC()
+
+	e.logger.Info("instance ip is ready and begin initializing ecs container info")
+
+	e.ecsTaskInfo = e.ecsTaskInfoCreator(ctx, e.hostIPProvider, e.refreshInterval, e.logger, e.httpClient, e.isTaskInfoReadyC)
+
+	close(e.taskInfoTestReadyC)
+}
+
+func (e *EcsInfo) initCgroupScanner(ctx context.Context) {
+
+	<-e.isContainerInfoReadyC
+	<-e.isTaskInfoReadyC
+
+	e.logger.Info("info ready and begin getting info")
+
+	e.cgroup = e.cgroupScannerCreator(ctx, e.logger, e.ecsTaskInfo, e.containerInstanceInfo, e.refreshInterval)
+
+	close(e.isCgroupReadyC)
+}
+
+// Shutdown stops the ecs Info
+func (e *EcsInfo) Shutdown() {
+	e.cancel()
+}

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
@@ -1,0 +1,145 @@
+//Copyright  OpenTelemetry Authors
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package ecsinfo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+type FakehostInfo struct{}
+
+func (hi *FakehostInfo) GetInstanceIP() string {
+	return "host-ip-address"
+}
+func (hi *FakehostInfo) GetClusterName() string {
+	return ""
+}
+func (hi *FakehostInfo) GetInstanceIPReadyC() chan bool {
+	readyC := make(chan bool)
+	close(readyC)
+	return readyC
+}
+
+type MockInstanceInfo struct {
+	clusterName string
+	instanceID  string
+}
+
+func (ii *MockInstanceInfo) GetClusterName() string {
+	return ii.clusterName
+}
+func (ii *MockInstanceInfo) GetContainerInstanceID() string {
+	return ii.instanceID
+}
+
+type MockTaskInfo struct {
+	tasks            []ECSTask
+	runningTaskCount int64
+}
+
+func (ii *MockTaskInfo) getRunningTaskCount() int64 {
+	return ii.runningTaskCount
+}
+func (ii *MockTaskInfo) getRunningTasksInfo() []ECSTask {
+
+	return ii.tasks
+}
+
+type MockCgroupScanner struct {
+	cpuReserved int64
+	memReserved int64
+}
+
+func (c *MockCgroupScanner) getCPUReserved() int64 {
+	return c.memReserved
+}
+
+func (c *MockCgroupScanner) getMemReserved() int64 {
+	return c.memReserved
+}
+
+func (c *MockCgroupScanner) getCPUReservedInTask(taskID string, clusterName string) int64 {
+	return int64(10)
+}
+
+func (c *MockCgroupScanner) getMEMReservedInTask(taskID string, clusterName string, containers []ECSContainer) int64 {
+	return int64(512)
+}
+
+func TestNewECSInfo(t *testing.T) {
+	// test the case when containerInstanceInfor fails to initialize
+	containerInstanceInfoCreatorOpt := func(ei *EcsInfo) {
+
+		ei.containerInstanceInfoCreator = func(context.Context, hostIPProvider, time.Duration, *zap.Logger, doer, chan bool) containerInstanceInfoProvider {
+			return &MockInstanceInfo{
+				clusterName: "Cluster-name",
+				instanceID:  "instance-id",
+			}
+		}
+	}
+
+	taskinfoCreatorOpt := func(ei *EcsInfo) {
+		ei.ecsTaskInfoCreator = func(context.Context, hostIPProvider, time.Duration, *zap.Logger, doer,
+			chan bool) ecsTaskInfoProvider {
+			tasks := []ECSTask{}
+			return &MockTaskInfo{
+				tasks:            tasks,
+				runningTaskCount: int64(2),
+			}
+		}
+	}
+
+	cgroupScannerCreatorOpt := func(ei *EcsInfo) {
+		ei.cgroupScannerCreator = func(context.Context, *zap.Logger, ecsTaskInfoProvider, containerInstanceInfoProvider,
+			time.Duration) cgroupScannerProvider {
+			return &MockCgroupScanner{
+				cpuReserved: int64(20),
+				memReserved: int64(1024),
+			}
+		}
+	}
+	hostIPProvider := &FakehostInfo{}
+
+	ecsinfo, _ := NewECSInfo(time.Minute, hostIPProvider, zap.NewNop(), containerInstanceInfoCreatorOpt, taskinfoCreatorOpt, cgroupScannerCreatorOpt)
+	assert.NotNil(t, ecsinfo)
+
+	<-ecsinfo.taskInfoTestReadyC
+	assert.NotNil(t, ecsinfo.ecsTaskInfo)
+	assert.Equal(t, int64(2), ecsinfo.GetRunningTaskCount())
+
+	<-ecsinfo.containerInfoTestReadyC
+	assert.NotNil(t, ecsinfo.containerInstanceInfo)
+	assert.Equal(t, "instance-id", ecsinfo.GetContainerInstanceID())
+	assert.Equal(t, "Cluster-name", ecsinfo.GetClusterName())
+
+	assert.Nil(t, ecsinfo.cgroup)
+	assert.Equal(t, int64(0), ecsinfo.GetCPUReserved())
+	assert.Equal(t, int64(0), ecsinfo.GetMemReserved())
+
+	close(ecsinfo.isTaskInfoReadyC)
+	close(ecsinfo.isContainerInfoReadyC)
+
+	<-ecsinfo.isCgroupReadyC
+	assert.NotNil(t, ecsinfo.cgroup)
+
+	assert.Equal(t, int64(1024), ecsinfo.GetCPUReserved())
+	assert.Equal(t, int64(1024), ecsinfo.GetMemReserved())
+
+}

--- a/receiver/awscontainerinsightreceiver/internal/host/ec2tags_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ec2tags_test.go
@@ -25,17 +25,19 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 )
 
 type mockEC2TagsClient struct {
-	count int
+	count                 int
+	tokenString           string
+	clusterKey            string
+	clusterValue          string
+	asgKey                string
+	asgValue              string
+	containerOrchestrator string
 }
-
-var tokenString = "tokenString"
-var clusterKey = clusterNameTagKeyPrefix + "cluster-name"
-var clusterValue = "owned"
-var asgKey = autoScalingGroupNameTag
-var asgValue = "asg"
 
 func (m *mockEC2TagsClient) DescribeTagsWithContext(ctx context.Context, input *ec2.DescribeTagsInput,
 	opts ...request.Option) (*ec2.DescribeTagsOutput, error) {
@@ -46,11 +48,11 @@ func (m *mockEC2TagsClient) DescribeTagsWithContext(ctx context.Context, input *
 
 	if m.count == 2 {
 		return &ec2.DescribeTagsOutput{
-			NextToken: &tokenString,
+			NextToken: &m.tokenString,
 			Tags: []*ec2.TagDescription{
 				{
-					Key:   &asgKey,
-					Value: &asgValue,
+					Key:   &m.asgKey,
+					Value: &m.asgValue,
 				},
 			},
 		}, nil
@@ -59,18 +61,25 @@ func (m *mockEC2TagsClient) DescribeTagsWithContext(ctx context.Context, input *
 	return &ec2.DescribeTagsOutput{
 		Tags: []*ec2.TagDescription{
 			{
-				Key:   &clusterKey,
-				Value: &clusterValue,
+				Key:   &m.clusterKey,
+				Value: &m.clusterValue,
 			},
 		},
 	}, nil
 }
 
-func TestEC2Tags(t *testing.T) {
+func TestEC2TagsForEKS(t *testing.T) {
 	ctx := context.Background()
 	sess := mock.Session
 	clientOption := func(e *ec2Tags) {
-		e.client = &mockEC2TagsClient{}
+		e.client = &mockEC2TagsClient{
+			tokenString:           "tokenString",
+			clusterKey:            clusterNameTagKeyPrefix + "cluster-name",
+			clusterValue:          "owned",
+			asgKey:                autoScalingGroupNameTag,
+			asgValue:              "asg",
+			containerOrchestrator: ci.EKS,
+		}
 	}
 	maxJitterOption := func(e *ec2Tags) {
 		e.maxJitterTime = 0
@@ -78,12 +87,40 @@ func TestEC2Tags(t *testing.T) {
 	isSucessOption := func(e *ec2Tags) {
 		e.isSucess = make(chan bool)
 	}
-	et := newEC2Tags(ctx, sess, "instanceId", "us-west-2", time.Millisecond, zap.NewNop(), clientOption,
+	et := newEC2Tags(ctx, sess, "instanceId", "us-west-2", ci.EKS, time.Millisecond, zap.NewNop(), clientOption,
 		maxJitterOption, isSucessOption)
 
 	// wait for ec2 tags are fetched
 	e := et.(*ec2Tags)
 	<-e.isSucess
 	assert.Equal(t, "cluster-name", et.getClusterName())
+	assert.Equal(t, "asg", et.getAutoScalingGroupName())
+}
+
+func TestEC2TagsForECS(t *testing.T) {
+	ctx := context.Background()
+	sess := mock.Session
+	clientOption := func(e *ec2Tags) {
+		e.client = &mockEC2TagsClient{
+			tokenString:           "tokenString",
+			clusterKey:            clusterNameTagKeyPrefix + "cluster-name",
+			clusterValue:          "",
+			asgKey:                autoScalingGroupNameTag,
+			asgValue:              "asg",
+			containerOrchestrator: ci.ECS,
+		}
+	}
+	maxJitterOption := func(e *ec2Tags) {
+		e.maxJitterTime = 0
+	}
+	isSucessOption := func(e *ec2Tags) {
+		e.isSucess = make(chan bool)
+	}
+	et := newEC2Tags(ctx, sess, "instanceId", "us-west-2", ci.ECS, time.Millisecond, zap.NewNop(), clientOption,
+		maxJitterOption, isSucessOption)
+
+	// wait for ec2 tags are fetched
+	e := et.(*ec2Tags)
+	<-e.isSucess
 	assert.Equal(t, "asg", et.getAutoScalingGroupName())
 }

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -91,11 +91,15 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 		}
 	}
 	if acir.config.ContainerOrchestrator == ci.ECS {
+
 		ecsInfo, err := ecsinfo.NewECSInfo(acir.config.CollectionInterval, hostinfo, acir.logger)
 		if err != nil {
 			return err
 		}
-		acir.cadvisor, err = cadvisor.NewWithECSInfo(acir.config.ContainerOrchestrator, hostinfo, acir.logger, ecsInfo)
+
+		ecsOption := cadvisor.WithECSInfoCreator(ecsInfo)
+
+		acir.cadvisor, err = cadvisor.New(acir.config.ContainerOrchestrator, hostinfo, acir.logger, ecsOption)
 		if err != nil {
 			return err
 		}

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -24,7 +24,9 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
 
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor"
+	ecsinfo "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/ecsInfo"
 	hostInfo "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/host"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/stores"
@@ -67,25 +69,36 @@ func newAWSContainerInsightReceiver(
 func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host component.Host) error {
 	ctx, acir.cancel = context.WithCancel(context.Background())
 
-	hostinfo, err := hostInfo.NewInfo(acir.config.CollectionInterval, acir.logger)
+	hostinfo, err := hostInfo.NewInfo(acir.config.ContainerOrchestrator, acir.config.CollectionInterval, acir.logger)
 	if err != nil {
 		return err
 	}
 
-	k8sDecorator, err := stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.logger)
-	if err != nil {
-		return err
-	}
+	if acir.config.ContainerOrchestrator == ci.EKS {
+		k8sDecorator, err := stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.logger)
+		if err != nil {
+			return err
+		}
 
-	decoratorOption := cadvisor.WithDecorator(k8sDecorator)
-	acir.cadvisor, err = cadvisor.New(acir.config.ContainerOrchestrator, hostinfo, acir.logger, decoratorOption)
-	if err != nil {
-		return err
+		decoratorOption := cadvisor.WithDecorator(k8sDecorator)
+		acir.cadvisor, err = cadvisor.New(acir.config.ContainerOrchestrator, hostinfo, acir.logger, decoratorOption)
+		if err != nil {
+			return err
+		}
+		acir.k8sapiserver, err = k8sapiserver.New(hostinfo, acir.logger)
+		if err != nil {
+			return err
+		}
 	}
-
-	acir.k8sapiserver, err = k8sapiserver.New(hostinfo, acir.logger)
-	if err != nil {
-		return err
+	if acir.config.ContainerOrchestrator == ci.ECS {
+		ecsInfo, err := ecsinfo.NewECSInfo(acir.config.CollectionInterval, hostinfo, acir.logger)
+		if err != nil {
+			return err
+		}
+		acir.cadvisor, err = cadvisor.NewWithECSInfo(acir.config.ContainerOrchestrator, hostinfo, acir.logger, ecsInfo)
+		if err != nil {
+			return err
+		}
 	}
 
 	go func() {


### PR DESCRIPTION
**Description:** <Describe what has changed.>

The last pr for ecs ec2 instance level metrics:
1, Add  CPU mem reserved metrics which get from cgroup.
2, Decorate the cadvisor metrics which ECS info which get from ecs task info and container info.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Unit test and integration test

**Documentation:** <Describe the documentation added.>