### PR TITLE
Bump go.elastic.co/apm to v1.11.0, fix low security issue

### DIFF
--- a/exporter/elasticexporter/go.mod
+++ b/exporter/elasticexporter/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/elastic/go-windows v1.0.1 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/stretchr/testify v1.7.0
-	go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6
+	go.elastic.co/apm v1.11.0
 	go.elastic.co/fastjson v1.1.0
 	go.opentelemetry.io/collector v0.30.2-0.20210721214806-6cce4224c6e7
 	go.opentelemetry.io/collector/model v0.30.2-0.20210721214806-6cce4224c6e7

--- a/exporter/elasticexporter/go.sum
+++ b/exporter/elasticexporter/go.sum
@@ -1194,8 +1194,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6 h1:0f5DeTBm0f+uMovH0QvlVH1S3j4RrGV8Gk7RvYfYp0A=
-go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6/go.mod h1:qoOSi09pnzJDh5fKnfY7bPmQgl8yl2tULdOu03xhui0=
+go.elastic.co/apm v1.11.0 h1:uJyt6nCW9880sZhfl1tB//Jy/5TadNoAd8edRUtgb3w=
+go.elastic.co/apm v1.11.0/go.mod h1:qoOSi09pnzJDh5fKnfY7bPmQgl8yl2tULdOu03xhui0=
 go.elastic.co/fastjson v1.1.0 h1:3MrGBWWVIxe/xvsbpghtkFoPciPhOCmjsR/HfwEeQR4=
 go.elastic.co/fastjson v1.1.0/go.mod h1:boNGISWMjQsUPy/t6yqt2/1Wx4YNPSe+mZjlyw9vKKI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/go.sum
+++ b/go.sum
@@ -1900,8 +1900,8 @@ github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPS
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/zorkian/go-datadog-api v2.29.0+incompatible h1:uZZg0POZ6tLmVFtjUSaTZYwR6Q6RrHx6f/blTEDn8dA=
 github.com/zorkian/go-datadog-api v2.29.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
-go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6 h1:0f5DeTBm0f+uMovH0QvlVH1S3j4RrGV8Gk7RvYfYp0A=
-go.elastic.co/apm v1.9.1-0.20201218004853-18a8126106c6/go.mod h1:qoOSi09pnzJDh5fKnfY7bPmQgl8yl2tULdOu03xhui0=
+go.elastic.co/apm v1.11.0 h1:uJyt6nCW9880sZhfl1tB//Jy/5TadNoAd8edRUtgb3w=
+go.elastic.co/apm v1.11.0/go.mod h1:qoOSi09pnzJDh5fKnfY7bPmQgl8yl2tULdOu03xhui0=
 go.elastic.co/fastjson v1.1.0 h1:3MrGBWWVIxe/xvsbpghtkFoPciPhOCmjsR/HfwEeQR4=
 go.elastic.co/fastjson v1.1.0/go.mod h1:boNGISWMjQsUPy/t6yqt2/1Wx4YNPSe+mZjlyw9vKKI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
