### PR TITLE
dynatraceexporter: update IntSum/IntGauge Sum/Gauge

### DIFF
--- a/exporter/dynatraceexporter/metrics_exporter.go
+++ b/exporter/dynatraceexporter/metrics_exporter.go
@@ -105,14 +105,10 @@ func (e *exporter) serializeMetrics(md pdata.Metrics) ([]string, int) {
 				switch metric.DataType() {
 				case pdata.MetricDataTypeNone:
 					continue
-				case pdata.MetricDataTypeIntGauge:
-					l = serialization.SerializeIntDataPoints(name, metric.IntGauge().DataPoints(), e.cfg.Tags)
 				case pdata.MetricDataTypeGauge:
-					l = serialization.SerializeDoubleDataPoints(name, metric.Gauge().DataPoints(), e.cfg.Tags)
-				case pdata.MetricDataTypeIntSum:
-					l = serialization.SerializeIntDataPoints(name, metric.IntSum().DataPoints(), e.cfg.Tags)
+					l = serialization.SerializeNumberDataPoints(name, metric.Gauge().DataPoints(), e.cfg.Tags)
 				case pdata.MetricDataTypeSum:
-					l = serialization.SerializeDoubleDataPoints(name, metric.Sum().DataPoints(), e.cfg.Tags)
+					l = serialization.SerializeNumberDataPoints(name, metric.Sum().DataPoints(), e.cfg.Tags)
 				case pdata.MetricDataTypeHistogram:
 					l = serialization.SerializeHistogramMetrics(name, metric.Histogram().DataPoints(), e.cfg.Tags)
 				}

--- a/exporter/dynatraceexporter/metrics_exporter_test.go
+++ b/exporter/dynatraceexporter/metrics_exporter_test.go
@@ -65,21 +65,21 @@ func Test_exporter_PushMetricsData(t *testing.T) {
 	noneMetric.SetName("none")
 
 	intGaugeMetric := metrics.AppendEmpty()
-	intGaugeMetric.SetDataType(pdata.MetricDataTypeIntGauge)
+	intGaugeMetric.SetDataType(pdata.MetricDataTypeGauge)
 	intGaugeMetric.SetName("int_gauge")
-	intGauge := intGaugeMetric.IntGauge()
+	intGauge := intGaugeMetric.Gauge()
 	intGaugeDataPoints := intGauge.DataPoints()
 	intGaugeDataPoint := intGaugeDataPoints.AppendEmpty()
-	intGaugeDataPoint.SetValue(10)
+	intGaugeDataPoint.SetIntVal(10)
 	intGaugeDataPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 
 	intSumMetric := metrics.AppendEmpty()
-	intSumMetric.SetDataType(pdata.MetricDataTypeIntSum)
+	intSumMetric.SetDataType(pdata.MetricDataTypeSum)
 	intSumMetric.SetName("int_sum")
-	intSum := intSumMetric.IntSum()
+	intSum := intSumMetric.Sum()
 	intSumDataPoints := intSum.DataPoints()
 	intSumDataPoint := intSumDataPoints.AppendEmpty()
-	intSumDataPoint.SetValue(10)
+	intSumDataPoint.SetIntVal(10)
 	intSumDataPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 
 	doubleGaugeMetric := metrics.AppendEmpty()
@@ -88,7 +88,7 @@ func Test_exporter_PushMetricsData(t *testing.T) {
 	doubleGauge := doubleGaugeMetric.Gauge()
 	doubleGaugeDataPoints := doubleGauge.DataPoints()
 	doubleGaugeDataPoint := doubleGaugeDataPoints.AppendEmpty()
-	doubleGaugeDataPoint.SetValue(10.1)
+	doubleGaugeDataPoint.SetDoubleVal(10.1)
 	doubleGaugeDataPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 
 	doubleSumMetric := metrics.AppendEmpty()
@@ -97,7 +97,7 @@ func Test_exporter_PushMetricsData(t *testing.T) {
 	doubleSum := doubleSumMetric.Sum()
 	doubleSumDataPoints := doubleSum.DataPoints()
 	doubleSumDataPoint := doubleSumDataPoints.AppendEmpty()
-	doubleSumDataPoint.SetValue(10.1)
+	doubleSumDataPoint.SetDoubleVal(10.1)
 	doubleSumDataPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 
 	doubleHistogramMetric := metrics.AppendEmpty()
@@ -209,12 +209,12 @@ func Test_exporter_PushMetricsData_isDisabled(t *testing.T) {
 
 	metrics := ilm.Metrics()
 	metric := metrics.AppendEmpty()
-	metric.SetDataType(pdata.MetricDataTypeIntGauge)
+	metric.SetDataType(pdata.MetricDataTypeGauge)
 	metric.SetName("int_gauge")
-	intGauge := metric.IntGauge()
+	intGauge := metric.Gauge()
 	intGaugeDataPoints := intGauge.DataPoints()
 	intGaugeDataPoint := intGaugeDataPoints.AppendEmpty()
-	intGaugeDataPoint.SetValue(10)
+	intGaugeDataPoint.SetIntVal(10)
 	intGaugeDataPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 
 	e := &exporter{
@@ -405,12 +405,12 @@ func Test_exporter_PushMetricsData_Error(t *testing.T) {
 
 	metrics := ilm.Metrics()
 	intGaugeMetric := metrics.AppendEmpty()
-	intGaugeMetric.SetDataType(pdata.MetricDataTypeIntGauge)
+	intGaugeMetric.SetDataType(pdata.MetricDataTypeGauge)
 	intGaugeMetric.SetName("int_gauge")
-	intGauge := intGaugeMetric.IntGauge()
+	intGauge := intGaugeMetric.Gauge()
 	intGaugeDataPoints := intGauge.DataPoints()
 	intGaugeDataPoint := intGaugeDataPoints.AppendEmpty()
-	intGaugeDataPoint.SetValue(10)
+	intGaugeDataPoint.SetIntVal(10)
 	intGaugeDataPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 
 	type fields struct {

--- a/exporter/dynatraceexporter/serialization/serialization.go
+++ b/exporter/dynatraceexporter/serialization/serialization.go
@@ -31,29 +31,20 @@ const (
 	maxDimKeyLen = 100
 )
 
-// SerializeIntDataPoints serializes a slice of integer datapoints to a Dynatrace gauge.
-func SerializeIntDataPoints(name string, data pdata.IntDataPointSlice, tags []string) []string {
-	// {name} {value} {timestamp}
-	output := []string{}
-
-	for i := 0; i < data.Len(); i++ {
-		p := data.At(i)
-		tagline := serializeTags(p.LabelsMap(), tags)
-		valueLine := strconv.FormatInt(p.Value(), 10)
-
-		output = append(output, serializeLine(name, tagline, valueLine, p.Timestamp()))
-	}
-
-	return output
-}
-
-// SerializeDoubleDataPoints serializes a slice of double datapoints to a Dynatrace gauge.
-func SerializeDoubleDataPoints(name string, data pdata.NumberDataPointSlice, tags []string) []string {
+// SerializeNumberDataPoints serializes a slice of number datapoints to a Dynatrace gauge.
+func SerializeNumberDataPoints(name string, data pdata.NumberDataPointSlice, tags []string) []string {
 	// {name} {value} {timestamp}
 	output := []string{}
 	for i := 0; i < data.Len(); i++ {
 		p := data.At(i)
-		output = append(output, serializeLine(name, serializeTags(p.LabelsMap(), tags), serializeFloat64(p.Value()), p.Timestamp()))
+		var val string
+		switch p.Type() {
+		case pdata.MetricValueTypeDouble:
+			val = serializeFloat64(p.DoubleVal())
+		case pdata.MetricValueTypeInt:
+			val = strconv.FormatInt(p.IntVal(), 10)
+		}
+		output = append(output, serializeLine(name, serializeTags(p.LabelsMap(), tags), val, p.Timestamp()))
 	}
 
 	return output

--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -23,27 +23,27 @@ import (
 func TestSerializeIntDataPoints(t *testing.T) {
 	type args struct {
 		name string
-		data pdata.IntDataPointSlice
+		data pdata.NumberDataPointSlice
 		tags []string
 	}
 
-	intSlice := pdata.NewIntDataPointSlice()
+	intSlice := pdata.NewNumberDataPointSlice()
 	intPoint := intSlice.AppendEmpty()
-	intPoint.SetValue(13)
+	intPoint.SetIntVal(13)
 	intPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 	intPoint1 := intSlice.AppendEmpty()
-	intPoint1.SetValue(14)
+	intPoint1.SetIntVal(14)
 	intPoint1.SetTimestamp(pdata.Timestamp(101_000_000))
 
-	labelIntSlice := pdata.NewIntDataPointSlice()
+	labelIntSlice := pdata.NewNumberDataPointSlice()
 	labelIntPoint := labelIntSlice.AppendEmpty()
-	labelIntPoint.SetValue(13)
+	labelIntPoint.SetIntVal(13)
 	labelIntPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 	labelIntPoint.LabelsMap().Insert("labelKey", "labelValue")
 
-	emptyLabelIntSlice := pdata.NewIntDataPointSlice()
+	emptyLabelIntSlice := pdata.NewNumberDataPointSlice()
 	emptyLabelIntPoint := emptyLabelIntSlice.AppendEmpty()
-	emptyLabelIntPoint.SetValue(13)
+	emptyLabelIntPoint.SetIntVal(13)
 	emptyLabelIntPoint.SetTimestamp(pdata.Timestamp(100_000_000))
 	emptyLabelIntPoint.LabelsMap().Insert("emptyLabelKey", "")
 
@@ -91,8 +91,8 @@ func TestSerializeIntDataPoints(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SerializeIntDataPoints(tt.args.name, tt.args.data, tt.args.tags); !equal(got, tt.want) {
-				t.Errorf("SerializeIntDataPoints() = %#v, want %#v", got, tt.want)
+			if got := SerializeNumberDataPoints(tt.args.name, tt.args.data, tt.args.tags); !equal(got, tt.want) {
+				t.Errorf("SerializeNumberDataPoints() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}
@@ -150,8 +150,8 @@ func TestSerializeDoubleDataPoints(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SerializeDoubleDataPoints(tt.args.name, tt.args.data, tt.args.tags); !equal(got, tt.want) {
-				t.Errorf("SerializeDoubleDataPoints() = %v, want %v", got, tt.want)
+			if got := SerializeNumberDataPoints(tt.args.name, tt.args.data, tt.args.tags); !equal(got, tt.want) {
+				t.Errorf("SerializeNumberDataPoints() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
**Description:** Updating dynatraceexporter to use `SetIntVal` / `SetDoubleVal` and remove `IntGauge`/`IntSum` altogether.

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3534

