### PR TITLE
redisreceiver: update IntSum/IntGauge Sum/Gauge

### DIFF
--- a/receiver/redisreceiver/metric_functions.go
+++ b/receiver/redisreceiver/metric_functions.go
@@ -75,7 +75,8 @@ func uptimeInSeconds() *redisMetric {
 		key:         "uptime_in_seconds",
 		name:        "redis/uptime",
 		units:       "s",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		desc:        "Number of seconds since Redis server start",
 	}
@@ -87,6 +88,7 @@ func usedCPUSys() *redisMetric {
 		name:        "redis/cpu/time",
 		units:       "s",
 		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeDouble,
 		isMonotonic: true,
 		labels:      map[string]string{"state": "sys"},
 		desc:        "System CPU consumed by the Redis server in seconds since server start",
@@ -99,6 +101,7 @@ func usedCPUUser() *redisMetric {
 		name:        "redis/cpu/time",
 		units:       "s",
 		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeDouble,
 		isMonotonic: true,
 		labels:      map[string]string{"state": "user"},
 		desc:        "User CPU consumed by the Redis server in seconds since server start",
@@ -111,6 +114,7 @@ func usedCPUSysChildren() *redisMetric {
 		name:        "redis/cpu/time",
 		units:       "s",
 		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeDouble,
 		isMonotonic: true,
 		labels:      map[string]string{"state": "children"},
 		desc:        "User CPU consumed by the background processes in seconds since server start",
@@ -121,7 +125,8 @@ func connectedClients() *redisMetric {
 	return &redisMetric{
 		key:         "connected_clients",
 		name:        "redis/clients/connected",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: false,
 		desc:        "Number of client connections (excluding connections from replicas)",
 	}
@@ -129,19 +134,21 @@ func connectedClients() *redisMetric {
 
 func clientRecentMaxInputBuffer() *redisMetric {
 	return &redisMetric{
-		key:    "client_recent_max_input_buffer",
-		name:   "redis/clients/max_input_buffer",
-		pdType: pdata.MetricDataTypeIntGauge,
-		desc:   "Biggest input buffer among current client connections",
+		key:       "client_recent_max_input_buffer",
+		name:      "redis/clients/max_input_buffer",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		desc:      "Biggest input buffer among current client connections",
 	}
 }
 
 func clientRecentMaxOutputBuffer() *redisMetric {
 	return &redisMetric{
-		key:    "client_recent_max_output_buffer",
-		name:   "redis/clients/max_output_buffer",
-		pdType: pdata.MetricDataTypeIntGauge,
-		desc:   "Longest output list among current client connections",
+		key:       "client_recent_max_output_buffer",
+		name:      "redis/clients/max_output_buffer",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		desc:      "Longest output list among current client connections",
 	}
 }
 
@@ -149,7 +156,8 @@ func blockedClients() *redisMetric {
 	return &redisMetric{
 		key:         "blocked_clients",
 		name:        "redis/clients/blocked",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: false,
 		desc:        "Number of clients pending on a blocking call",
 	}
@@ -159,7 +167,8 @@ func expiredKeys() *redisMetric {
 	return &redisMetric{
 		key:         "expired_keys",
 		name:        "redis/keys/expired",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		desc:        "Total number of key expiration events",
 	}
@@ -169,7 +178,8 @@ func evictedKeys() *redisMetric {
 	return &redisMetric{
 		key:         "evicted_keys",
 		name:        "redis/keys/evicted",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		desc:        "Number of evicted keys due to maxmemory limit",
 	}
@@ -179,7 +189,8 @@ func totalConnectionsReceived() *redisMetric {
 	return &redisMetric{
 		key:         "total_connections_received",
 		name:        "redis/connections/received",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		desc:        "Total number of connections accepted by the server",
 	}
@@ -189,7 +200,8 @@ func rejectedConnections() *redisMetric {
 	return &redisMetric{
 		key:         "rejected_connections",
 		name:        "redis/connections/rejected",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		desc:        "Number of connections rejected because of maxclients limit",
 	}
@@ -197,50 +209,55 @@ func rejectedConnections() *redisMetric {
 
 func usedMemory() *redisMetric {
 	return &redisMetric{
-		key:    "used_memory",
-		name:   "redis/memory/used",
-		units:  "By",
-		pdType: pdata.MetricDataTypeIntGauge,
-		desc:   "Total number of bytes allocated by Redis using its allocator",
+		key:       "used_memory",
+		name:      "redis/memory/used",
+		units:     "By",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		desc:      "Total number of bytes allocated by Redis using its allocator",
 	}
 }
 
 func usedMemoryPeak() *redisMetric {
 	return &redisMetric{
-		key:    "used_memory_peak",
-		name:   "redis/memory/peak",
-		pdType: pdata.MetricDataTypeIntGauge,
-		units:  "By",
-		desc:   "Peak memory consumed by Redis (in bytes)",
+		key:       "used_memory_peak",
+		name:      "redis/memory/peak",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		units:     "By",
+		desc:      "Peak memory consumed by Redis (in bytes)",
 	}
 }
 
 func usedMemoryRss() *redisMetric {
 	return &redisMetric{
-		key:    "used_memory_rss",
-		name:   "redis/memory/rss",
-		pdType: pdata.MetricDataTypeIntGauge,
-		units:  "By",
-		desc:   "Number of bytes that Redis allocated as seen by the operating system",
+		key:       "used_memory_rss",
+		name:      "redis/memory/rss",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		units:     "By",
+		desc:      "Number of bytes that Redis allocated as seen by the operating system",
 	}
 }
 
 func usedMemoryLua() *redisMetric {
 	return &redisMetric{
-		key:    "used_memory_lua",
-		name:   "redis/memory/lua",
-		pdType: pdata.MetricDataTypeIntGauge,
-		units:  "By",
-		desc:   "Number of bytes used by the Lua engine",
+		key:       "used_memory_lua",
+		name:      "redis/memory/lua",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		units:     "By",
+		desc:      "Number of bytes used by the Lua engine",
 	}
 }
 
 func memFragmentationRatio() *redisMetric {
 	return &redisMetric{
-		key:    "mem_fragmentation_ratio",
-		name:   "redis/memory/fragmentation_ratio",
-		pdType: pdata.MetricDataTypeGauge,
-		desc:   "Ratio between used_memory_rss and used_memory",
+		key:       "mem_fragmentation_ratio",
+		name:      "redis/memory/fragmentation_ratio",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeDouble,
+		desc:      "Ratio between used_memory_rss and used_memory",
 	}
 }
 
@@ -248,7 +265,8 @@ func rdbChangesSinceLastSave() *redisMetric {
 	return &redisMetric{
 		key:         "rdb_changes_since_last_save",
 		name:        "redis/rdb/changes_since_last_save",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: false,
 		desc:        "Number of changes since the last dump",
 	}
@@ -256,11 +274,12 @@ func rdbChangesSinceLastSave() *redisMetric {
 
 func instantaneousOpsPerSec() *redisMetric {
 	return &redisMetric{
-		key:    "instantaneous_ops_per_sec",
-		name:   "redis/commands",
-		pdType: pdata.MetricDataTypeIntGauge,
-		units:  "{ops}/s",
-		desc:   "Number of commands processed per second",
+		key:       "instantaneous_ops_per_sec",
+		name:      "redis/commands",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		units:     "{ops}/s",
+		desc:      "Number of commands processed per second",
 	}
 }
 
@@ -268,7 +287,8 @@ func totalCommandsProcessed() *redisMetric {
 	return &redisMetric{
 		key:         "total_commands_processed",
 		name:        "redis/commands/processed",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		desc:        "Total number of commands processed by the server",
 	}
@@ -278,7 +298,8 @@ func totalNetInputBytes() *redisMetric {
 	return &redisMetric{
 		key:         "total_net_input_bytes",
 		name:        "redis/net/input",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		units:       "By",
 		desc:        "The total number of bytes read from the network",
@@ -289,7 +310,8 @@ func totalNetOutputBytes() *redisMetric {
 	return &redisMetric{
 		key:         "total_net_output_bytes",
 		name:        "redis/net/output",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		units:       "By",
 		desc:        "The total number of bytes written to the network",
@@ -300,7 +322,8 @@ func keyspaceHits() *redisMetric {
 	return &redisMetric{
 		key:         "keyspace_hits",
 		name:        "redis/keyspace/hits",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		desc:        "Number of successful lookup of keys in the main dictionary",
 	}
@@ -310,7 +333,8 @@ func keyspaceMisses() *redisMetric {
 	return &redisMetric{
 		key:         "keyspace_misses",
 		name:        "redis/keyspace/misses",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
 		desc:        "Number of failed lookup of keys in the main dictionary",
 	}
@@ -318,11 +342,12 @@ func keyspaceMisses() *redisMetric {
 
 func latestForkUsec() *redisMetric {
 	return &redisMetric{
-		key:    "latest_fork_usec",
-		name:   "redis/latest_fork",
-		pdType: pdata.MetricDataTypeIntGauge,
-		units:  "us",
-		desc:   "Duration of the latest fork operation in microseconds",
+		key:       "latest_fork_usec",
+		name:      "redis/latest_fork",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		units:     "us",
+		desc:      "Duration of the latest fork operation in microseconds",
 	}
 }
 
@@ -330,7 +355,8 @@ func connectedSlaves() *redisMetric {
 	return &redisMetric{
 		key:         "connected_slaves",
 		name:        "redis/slaves/connected",
-		pdType:      pdata.MetricDataTypeIntSum,
+		pdType:      pdata.MetricDataTypeSum,
+		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: false,
 		desc:        "Number of connected replicas",
 	}
@@ -338,18 +364,20 @@ func connectedSlaves() *redisMetric {
 
 func replBacklogFirstByteOffset() *redisMetric {
 	return &redisMetric{
-		key:    "repl_backlog_first_byte_offset",
-		name:   "redis/replication/backlog_first_byte_offset",
-		pdType: pdata.MetricDataTypeIntGauge,
-		desc:   "The master offset of the replication backlog buffer",
+		key:       "repl_backlog_first_byte_offset",
+		name:      "redis/replication/backlog_first_byte_offset",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		desc:      "The master offset of the replication backlog buffer",
 	}
 }
 
 func masterReplOffset() *redisMetric {
 	return &redisMetric{
-		key:    "master_repl_offset",
-		name:   "redis/replication/offset",
-		pdType: pdata.MetricDataTypeIntGauge,
-		desc:   "The server's current replication offset",
+		key:       "master_repl_offset",
+		name:      "redis/replication/offset",
+		pdType:    pdata.MetricDataTypeGauge,
+		valueType: pdata.MetricValueTypeInt,
+		desc:      "The server's current replication offset",
 	}
 }

--- a/receiver/redisreceiver/metric_functions_test.go
+++ b/receiver/redisreceiver/metric_functions_test.go
@@ -29,9 +29,7 @@ func TestDefaultMetrics(t *testing.T) {
 		require.True(t, strings.HasPrefix(metric.name, "redis/"))
 		require.True(
 			t,
-			metric.pdType == pdata.MetricDataTypeIntSum ||
-				metric.pdType == pdata.MetricDataTypeIntGauge ||
-				metric.pdType == pdata.MetricDataTypeSum ||
+			metric.pdType == pdata.MetricDataTypeSum ||
 				metric.pdType == pdata.MetricDataTypeGauge,
 		)
 	}

--- a/receiver/redisreceiver/pdata.go
+++ b/receiver/redisreceiver/pdata.go
@@ -31,7 +31,7 @@ func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
 		name:   "redis/db/keys",
 		labels: map[string]string{"db": k.db},
-		pdType: pdata.MetricDataTypeIntGauge,
+		pdType: pdata.MetricDataTypeGauge,
 	}
 	initIntMetric(m, int64(k.keys), t, dest)
 }
@@ -40,7 +40,7 @@ func initKeyspaceExpiresMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
 		name:   "redis/db/expires",
 		labels: map[string]string{"db": k.db},
-		pdType: pdata.MetricDataTypeIntGauge,
+		pdType: pdata.MetricDataTypeGauge,
 	}
 	initIntMetric(m, int64(k.expires), t, dest)
 }
@@ -50,7 +50,7 @@ func initKeyspaceTTLMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 		name:   "redis/db/avg_ttl",
 		units:  "ms",
 		labels: map[string]string{"db": k.db},
-		pdType: pdata.MetricDataTypeIntGauge,
+		pdType: pdata.MetricDataTypeGauge,
 	}
 	initIntMetric(m, int64(k.avgTTL), t, dest)
 }
@@ -58,17 +58,17 @@ func initKeyspaceTTLMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 func initIntMetric(m *redisMetric, value int64, t *timeBundle, dest pdata.Metric) {
 	redisMetricToPDM(m, dest)
 
-	var pt pdata.IntDataPoint
-	if m.pdType == pdata.MetricDataTypeIntGauge {
-		pt = dest.IntGauge().DataPoints().AppendEmpty()
-	} else if m.pdType == pdata.MetricDataTypeIntSum {
-		sum := dest.IntSum()
+	var pt pdata.NumberDataPoint
+	if m.pdType == pdata.MetricDataTypeGauge {
+		pt = dest.Gauge().DataPoints().AppendEmpty()
+	} else if m.pdType == pdata.MetricDataTypeSum {
+		sum := dest.Sum()
 		sum.SetIsMonotonic(m.isMonotonic)
 		sum.SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 		pt = sum.DataPoints().AppendEmpty()
 		pt.SetStartTimestamp(pdata.TimestampFromTime(t.serverStart))
 	}
-	pt.SetValue(value)
+	pt.SetIntVal(value)
 	pt.SetTimestamp(pdata.TimestampFromTime(t.current))
 	pt.LabelsMap().InitFromMap(m.labels)
 }
@@ -86,7 +86,7 @@ func initDoubleMetric(m *redisMetric, value float64, t *timeBundle, dest pdata.M
 		pt = sum.DataPoints().AppendEmpty()
 		pt.SetStartTimestamp(pdata.TimestampFromTime(t.serverStart))
 	}
-	pt.SetValue(value)
+	pt.SetDoubleVal(value)
 	pt.SetTimestamp(pdata.TimestampFromTime(t.current))
 	pt.LabelsMap().InitFromMap(m.labels)
 }

--- a/receiver/redisreceiver/pdata_test.go
+++ b/receiver/redisreceiver/pdata_test.go
@@ -41,8 +41,8 @@ func TestMemoryMetric(t *testing.T) {
 	assert.Equal(t, metricName, m.Name())
 	assert.Equal(t, desc, m.Description())
 	assert.Equal(t, units, m.Unit())
-	assert.Equal(t, pdata.MetricDataTypeIntGauge, m.DataType())
-	assert.Equal(t, int64(ptVal), m.IntGauge().DataPoints().At(0).Value())
+	assert.Equal(t, pdata.MetricDataTypeGauge, m.DataType())
+	assert.Equal(t, int64(ptVal), m.Gauge().DataPoints().At(0).IntVal())
 }
 
 func TestUptimeInSeconds(t *testing.T) {
@@ -51,7 +51,7 @@ func TestUptimeInSeconds(t *testing.T) {
 	v := 104946
 
 	assert.Equal(t, units, pdm.Unit())
-	assert.Equal(t, int64(v), pdm.IntSum().DataPoints().At(0).Value())
+	assert.Equal(t, int64(v), pdm.Sum().DataPoints().At(0).IntVal())
 }
 
 func TestUsedCpuSys(t *testing.T) {
@@ -109,37 +109,37 @@ func TestKeyspaceMetrics(t *testing.T) {
 
 	pdm := ms.At(0)
 	assert.Equal(t, name1, pdm.Name())
-	dps := pdm.IntGauge().DataPoints()
+	dps := pdm.Gauge().DataPoints()
 	pt := dps.At(0)
 	v, ok := pt.LabelsMap().Get(lblKey)
 	assert.True(t, ok)
 	assert.Equal(t, lblVal, v)
-	assert.Equal(t, pdata.MetricDataTypeIntGauge, pdm.DataType())
-	assert.Equal(t, int64(1), pt.Value())
+	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
+	assert.Equal(t, int64(1), pt.IntVal())
 
 	const name2 = "redis/db/expires"
 
 	pdm = ms.At(1)
 	assert.Equal(t, name2, pdm.Name())
-	dps = pdm.IntGauge().DataPoints()
+	dps = pdm.Gauge().DataPoints()
 	pt = dps.At(0)
 	v, ok = pt.LabelsMap().Get(lblKey)
 	assert.True(t, ok)
 	assert.Equal(t, lblVal, v)
-	assert.Equal(t, pdata.MetricDataTypeIntGauge, pdm.DataType())
-	assert.Equal(t, int64(2), pt.Value())
+	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
+	assert.Equal(t, int64(2), pt.IntVal())
 
 	const name3 = "redis/db/avg_ttl"
 
 	pdm = ms.At(2)
 	assert.Equal(t, name3, pdm.Name())
-	dps = pdm.IntGauge().DataPoints()
+	dps = pdm.Gauge().DataPoints()
 	pt = dps.At(0)
 	v, ok = pt.LabelsMap().Get(lblKey)
 	assert.True(t, ok)
 	assert.Equal(t, lblVal, v)
-	assert.Equal(t, pdata.MetricDataTypeIntGauge, pdm.DataType())
-	assert.Equal(t, int64(3), pt.Value())
+	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
+	assert.Equal(t, int64(3), pt.IntVal())
 }
 
 func TestNewPDM(t *testing.T) {
@@ -147,12 +147,12 @@ func TestNewPDM(t *testing.T) {
 	tb := testTimeBundle()
 
 	pdm := pdata.NewMetric()
-	initIntMetric(&redisMetric{pdType: pdata.MetricDataTypeIntGauge}, 0, tb, pdm)
-	assert.Equal(t, pdata.Timestamp(0), pdm.IntGauge().DataPoints().At(0).StartTimestamp())
+	initIntMetric(&redisMetric{pdType: pdata.MetricDataTypeGauge}, 0, tb, pdm)
+	assert.Equal(t, pdata.Timestamp(0), pdm.Gauge().DataPoints().At(0).StartTimestamp())
 
 	pdm = pdata.NewMetric()
-	initIntMetric(&redisMetric{pdType: pdata.MetricDataTypeIntSum}, 0, tb, pdm)
-	assert.Equal(t, serverStartTime, pdm.IntSum().DataPoints().At(0).StartTimestamp())
+	initIntMetric(&redisMetric{pdType: pdata.MetricDataTypeSum}, 0, tb, pdm)
+	assert.Equal(t, serverStartTime, pdm.Sum().DataPoints().At(0).StartTimestamp())
 
 	pdm = pdata.NewMetric()
 	initDoubleMetric(&redisMetric{pdType: pdata.MetricDataTypeGauge}, 0, tb, pdm)

--- a/receiver/redisreceiver/redis_metric.go
+++ b/receiver/redisreceiver/redis_metric.go
@@ -29,43 +29,45 @@ type redisMetric struct {
 	desc        string
 	labels      map[string]string
 	pdType      pdata.MetricDataType
+	valueType   pdata.MetricValueType
 	isMonotonic bool
 }
 
 // Parse a numeric string to build a metric based on this redisMetric. The
 // passed-in time is applied to the Point.
 func (m *redisMetric) parseMetric(strVal string, t *timeBundle) (pdata.Metric, error) {
-	var err error
 	pdm := pdata.NewMetric()
 	switch m.pdType {
-	case pdata.MetricDataTypeIntSum:
-		var val int64
-		val, err = strToInt64Point(strVal)
-		if err != nil {
-			return pdm, err
-		}
-		initIntMetric(m, val, t, pdm)
-	case pdata.MetricDataTypeIntGauge:
-		var val int64
-		val, err = strToInt64Point(strVal)
-		if err != nil {
-			return pdm, err
-		}
-		initIntMetric(m, val, t, pdm)
 	case pdata.MetricDataTypeSum:
-		var val float64
-		val, err = strToDoublePoint(strVal)
-		if err != nil {
-			return pdm, err
+		switch m.valueType {
+		case pdata.MetricValueTypeDouble:
+			val, err := strToDoublePoint(strVal)
+			if err != nil {
+				return pdm, err
+			}
+			initDoubleMetric(m, val, t, pdm)
+		case pdata.MetricValueTypeInt:
+			val, err := strToInt64Point(strVal)
+			if err != nil {
+				return pdm, err
+			}
+			initIntMetric(m, val, t, pdm)
 		}
-		initDoubleMetric(m, val, t, pdm)
 	case pdata.MetricDataTypeGauge:
-		var val float64
-		val, err = strToDoublePoint(strVal)
-		if err != nil {
-			return pdm, err
+		switch m.valueType {
+		case pdata.MetricValueTypeDouble:
+			val, err := strToDoublePoint(strVal)
+			if err != nil {
+				return pdm, err
+			}
+			initDoubleMetric(m, val, t, pdm)
+		case pdata.MetricValueTypeInt:
+			val, err := strToInt64Point(strVal)
+			if err != nil {
+				return pdm, err
+			}
+			initIntMetric(m, val, t, pdm)
 		}
-		initDoubleMetric(m, val, t, pdm)
 	}
 	return pdm, nil
 }

--- a/receiver/redisreceiver/redis_metric_test.go
+++ b/receiver/redisreceiver/redis_metric_test.go
@@ -29,7 +29,7 @@ func TestParseMetric_PointTimestamp(t *testing.T) {
 	pdm, err := uptimeMetric.parseMetric("42", newTimeBundle(now, 100))
 	require.NoError(t, err)
 
-	pt := pdm.IntSum().DataPoints().At(0)
+	pt := pdm.Sum().DataPoints().At(0)
 	ptTime := pt.Timestamp()
 
 	assert.EqualValues(t, now.UnixNano(), int64(ptTime))
@@ -51,13 +51,16 @@ func TestParseMetric_Labels(t *testing.T) {
 
 func TestParseMetric_Errors(t *testing.T) {
 	for _, dataType := range []pdata.MetricDataType{
-		pdata.MetricDataTypeIntSum,
-		pdata.MetricDataTypeIntGauge,
 		pdata.MetricDataTypeSum,
 		pdata.MetricDataTypeGauge,
 	} {
-		m := redisMetric{pdType: dataType}
-		_, err := m.parseMetric("foo", &timeBundle{})
-		assert.Error(t, err)
+		for _, valueType := range []pdata.MetricValueType{
+			pdata.MetricValueTypeDouble,
+			pdata.MetricValueTypeInt,
+		} {
+			m := redisMetric{pdType: dataType, valueType: valueType}
+			_, err := m.parseMetric("foo", &timeBundle{})
+			assert.Error(t, err)
+		}
 	}
 }


### PR DESCRIPTION
**Description:** Updating redisreceiver to use `SetIntVal` / `SetDoubleVal` and remove `IntGauge`/`IntSum` altogether.

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3534

