### PR TITLE
spanmetricsprocessor: update IntSum/IntGauge Sum/Gauge

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -262,15 +262,15 @@ func (p *processorImp) collectLatencyMetrics(ilm pdata.InstrumentationLibraryMet
 func (p *processorImp) collectCallMetrics(ilm pdata.InstrumentationLibraryMetrics) {
 	for key := range p.callSum {
 		mCalls := ilm.Metrics().AppendEmpty()
-		mCalls.SetDataType(pdata.MetricDataTypeIntSum)
+		mCalls.SetDataType(pdata.MetricDataTypeSum)
 		mCalls.SetName("calls_total")
-		mCalls.IntSum().SetIsMonotonic(true)
-		mCalls.IntSum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
+		mCalls.Sum().SetIsMonotonic(true)
+		mCalls.Sum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 
-		dpCalls := mCalls.IntSum().DataPoints().AppendEmpty()
+		dpCalls := mCalls.Sum().DataPoints().AppendEmpty()
 		dpCalls.SetStartTimestamp(pdata.TimestampFromTime(p.startTime))
 		dpCalls.SetTimestamp(pdata.TimestampFromTime(time.Now()))
-		dpCalls.SetValue(p.callSum[key])
+		dpCalls.SetIntVal(p.callSum[key])
 
 		dpCalls.LabelsMap().InitFromMap(p.metricKeyToDimensions[key])
 	}

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -341,7 +341,7 @@ func verifyConsumeMetricsInput(input pdata.Metrics, t *testing.T) bool {
 	for ; mi < 3; mi++ {
 		assert.Equal(t, "calls_total", m.At(mi).Name())
 
-		data := m.At(mi).IntSum()
+		data := m.At(mi).Sum()
 		assert.Equal(t, pdata.AggregationTemporalityCumulative, data.AggregationTemporality())
 		assert.True(t, data.IsMonotonic())
 
@@ -349,7 +349,7 @@ func verifyConsumeMetricsInput(input pdata.Metrics, t *testing.T) bool {
 		require.Equal(t, 1, dps.Len())
 
 		dp := dps.At(0)
-		assert.Equal(t, int64(1), dp.Value(), "There should only be one metric per Service/operation/kind combination")
+		assert.Equal(t, int64(1), dp.IntVal(), "There should only be one metric per Service/operation/kind combination")
 		assert.NotZero(t, dp.StartTimestamp(), "StartTimestamp should be set")
 		assert.NotZero(t, dp.Timestamp(), "Timestamp should be set")
 


### PR DESCRIPTION
**Description:** Updating spanmetricsprocessor to use `SetIntVal` / `SetDoubleVal` and remove `IntGauge`/`IntSum` altogether.

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3534

