### PR TITLE
metricsgenerationprocessor: update IntSum/IntGauge Sum/Gauge

### DIFF
--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -354,7 +354,7 @@ func generateTestMetrics(tm testMetric) pdata.Metrics {
 		for _, value := range tm.metricValues[i] {
 			dp := m.Gauge().DataPoints().AppendEmpty()
 			dp.SetTimestamp(pdata.TimestampFromTime(now.Add(10 * time.Second)))
-			dp.SetValue(value)
+			dp.SetDoubleVal(value)
 		}
 	}
 
@@ -391,7 +391,7 @@ func getOutputForIntGaugeTest() pdata.Metrics {
 	doubleMetric.SetDataType(pdata.MetricDataTypeGauge)
 	doubleMetric.SetName("metric_calculated")
 	neweDoubleDataPoint := doubleMetric.Gauge().DataPoints().AppendEmpty()
-	neweDoubleDataPoint.SetValue(105)
+	neweDoubleDataPoint.SetDoubleVal(105)
 
 	return intGaugeOutputMetrics
 }

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -324,17 +324,13 @@ func TestMetricsGenerationProcessor(t *testing.T) {
 					require.Equal(t, eDataPoints.Len(), aDataPoints.Len())
 
 					for j := 0; j < eDataPoints.Len(); j++ {
-						require.Equal(t, eDataPoints.At(j).Value(), aDataPoints.At(j).Value())
-					}
-				}
+						switch eDataPoints.At(j).Type() {
+						case pdata.MetricValueTypeDouble:
+							require.Equal(t, eDataPoints.At(j).DoubleVal(), aDataPoints.At(j).DoubleVal())
+						case pdata.MetricValueTypeInt:
+							require.Equal(t, eDataPoints.At(j).IntVal(), aDataPoints.At(j).IntVal())
+						}
 
-				if eM.DataType() == pdata.MetricDataTypeIntGauge {
-					eDataPoints := eM.IntGauge().DataPoints()
-					aDataPoints := aM.IntGauge().DataPoints()
-					require.Equal(t, eDataPoints.Len(), aDataPoints.Len())
-
-					for j := 0; j < eDataPoints.Len(); j++ {
-						require.Equal(t, eDataPoints.At(j).Value(), aDataPoints.At(j).Value())
 					}
 				}
 
@@ -374,11 +370,11 @@ func generateTestMetricsWithIntDatapoint(tm testMetricIntGauge) pdata.Metrics {
 	for i, name := range tm.metricNames {
 		m := ms.AppendEmpty()
 		m.SetName(name)
-		m.SetDataType(pdata.MetricDataTypeIntGauge)
+		m.SetDataType(pdata.MetricDataTypeGauge)
 		for _, value := range tm.metricValues[i] {
-			dp := m.IntGauge().DataPoints().AppendEmpty()
+			dp := m.Gauge().DataPoints().AppendEmpty()
 			dp.SetTimestamp(pdata.TimestampFromTime(now.Add(10 * time.Second)))
-			dp.SetValue(value)
+			dp.SetIntVal(value)
 		}
 	}
 

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -85,7 +85,7 @@ func addDoubleGaugeDataPoints(from pdata.Metric, to pdata.Metric, operand2 float
 		neweDoubleDataPoint := to.Gauge().DataPoints().AppendEmpty()
 		fromDataPoint.CopyTo(neweDoubleDataPoint)
 		value := calculateValue(operand1, operand2, operation, logger, to.Name())
-		neweDoubleDataPoint.SetValue(value)
+		neweDoubleDataPoint.SetDoubleVal(value)
 	}
 }
 

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -36,17 +36,15 @@ func getNameToMetricMap(rm pdata.ResourceMetrics) map[string]pdata.Metric {
 
 // getMetricValue returns the value of the first data point from the given metric.
 func getMetricValue(metric pdata.Metric) float64 {
-	if metric.DataType() == pdata.MetricDataTypeIntGauge {
-		dataPoints := metric.IntGauge().DataPoints()
-		if dataPoints.Len() > 0 {
-			return float64(dataPoints.At(0).Value())
-		}
-		return 0
-	}
 	if metric.DataType() == pdata.MetricDataTypeGauge {
 		dataPoints := metric.Gauge().DataPoints()
 		if dataPoints.Len() > 0 {
-			return dataPoints.At(0).Value()
+			switch dataPoints.At(0).Type() {
+			case pdata.MetricValueTypeDouble:
+				return dataPoints.At(0).DoubleVal()
+			case pdata.MetricValueTypeInt:
+				return float64(dataPoints.At(0).IntVal())
+			}
 		}
 		return 0
 	}
@@ -73,28 +71,21 @@ func generateMetrics(rm pdata.ResourceMetrics, operand2 float64, rule internalRu
 }
 
 func addDoubleGaugeDataPoints(from pdata.Metric, to pdata.Metric, operand2 float64, operation string, logger *zap.Logger) {
-	if from.DataType() == pdata.MetricDataTypeIntGauge {
-		dataPoints := from.IntGauge().DataPoints()
-		for i := 0; i < dataPoints.Len(); i++ {
-			fromDataPoint := dataPoints.At(i)
-			operand1 := float64(fromDataPoint.Value())
-			neweDoubleDataPoint := to.Gauge().DataPoints().AppendEmpty()
-			value := calculateValue(operand1, operand2, operation, logger, to.Name())
-			neweDoubleDataPoint.SetValue(value)
-			fromDataPoint.LabelsMap().CopyTo(neweDoubleDataPoint.LabelsMap())
-			neweDoubleDataPoint.SetStartTimestamp(fromDataPoint.StartTimestamp())
-			neweDoubleDataPoint.SetTimestamp(fromDataPoint.Timestamp())
+	dataPoints := from.Gauge().DataPoints()
+	for i := 0; i < dataPoints.Len(); i++ {
+		fromDataPoint := dataPoints.At(i)
+		var operand1 float64
+		switch fromDataPoint.Type() {
+		case pdata.MetricValueTypeDouble:
+			operand1 = fromDataPoint.DoubleVal()
+		case pdata.MetricValueTypeInt:
+			operand1 = float64(fromDataPoint.IntVal())
 		}
-	} else if from.DataType() == pdata.MetricDataTypeGauge {
-		dataPoints := from.Gauge().DataPoints()
-		for i := 0; i < dataPoints.Len(); i++ {
-			fromDataPoint := dataPoints.At(i)
-			operand1 := fromDataPoint.Value()
-			neweDoubleDataPoint := to.Gauge().DataPoints().AppendEmpty()
-			fromDataPoint.CopyTo(neweDoubleDataPoint)
-			value := calculateValue(operand1, operand2, operation, logger, to.Name())
-			neweDoubleDataPoint.SetValue(value)
-		}
+
+		neweDoubleDataPoint := to.Gauge().DataPoints().AppendEmpty()
+		fromDataPoint.CopyTo(neweDoubleDataPoint)
+		value := calculateValue(operand1, operand2, operation, logger, to.Name())
+		neweDoubleDataPoint.SetValue(value)
 	}
 }
 


### PR DESCRIPTION
**Description:** Updating metricsgenerationprocessor to use `SetIntVal` / `SetDoubleVal` and remove `IntGauge`/`IntSum` altogether.

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3534

