### PR TITLE
containerinsight: update IntSum/IntGauge Sum/Gauge

### DIFF
--- a/internal/aws/containerinsight/go.mod
+++ b/internal/aws/containerinsight/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/collector/model v0.30.2-0.20210719230137-809cae954ed3
+	go.opentelemetry.io/collector/model v0.30.2-0.20210723184018-3b7d6ce4830c
 	go.uber.org/atomic v1.8.0 // indirect
 	go.uber.org/zap v1.18.1
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect

--- a/internal/aws/containerinsight/go.sum
+++ b/internal/aws/containerinsight/go.sum
@@ -74,8 +74,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.opentelemetry.io/collector/model v0.30.2-0.20210719230137-809cae954ed3 h1:UbVyz4rYL0W+Y9nrsGqdDHhn5H1WxIOTbcUH5nVcVQk=
-go.opentelemetry.io/collector/model v0.30.2-0.20210719230137-809cae954ed3/go.mod h1:PcHNnM+RUl0uD8VkSn93PO78N7kQYhfqpI/eki57pl4=
+go.opentelemetry.io/collector/model v0.30.2-0.20210723184018-3b7d6ce4830c h1:QAIPOjFfdyg897AIeJIDX+Kz7G1N91Fk8bIWc6AK8oc=
+go.opentelemetry.io/collector/model v0.30.2-0.20210723184018-3b7d6ce4830c/go.mod h1:PcHNnM+RUl0uD8VkSn93PO78N7kQYhfqpI/eki57pl4=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.8.0 h1:CUhrE4N1rqSE6FM9ecihEjRkLQu8cDfgDyoOs83mEY4=

--- a/internal/aws/containerinsight/utils.go
+++ b/internal/aws/containerinsight/utils.go
@@ -217,12 +217,12 @@ func ConvertToOTLPMetrics(fields map[string]interface{}, tags map[string]string,
 func intGauge(ilm pdata.InstrumentationLibraryMetrics, metricName string, unit string, value int64, ts pdata.Timestamp) {
 	metric := initMetric(ilm, metricName, unit)
 
-	metric.SetDataType(pdata.MetricDataTypeIntGauge)
-	intGauge := metric.IntGauge()
+	metric.SetDataType(pdata.MetricDataTypeGauge)
+	intGauge := metric.Gauge()
 	dataPoints := intGauge.DataPoints()
 	dataPoint := dataPoints.AppendEmpty()
 
-	dataPoint.SetValue(value)
+	dataPoint.SetIntVal(value)
 	dataPoint.SetTimestamp(ts)
 }
 
@@ -234,7 +234,7 @@ func doubleGauge(ilm pdata.InstrumentationLibraryMetrics, metricName string, uni
 	dataPoints := doubleGauge.DataPoints()
 	dataPoint := dataPoints.AppendEmpty()
 
-	dataPoint.SetValue(value)
+	dataPoint.SetDoubleVal(value)
 	dataPoint.SetTimestamp(ts)
 }
 

--- a/internal/aws/containerinsight/utils_test.go
+++ b/internal/aws/containerinsight/utils_test.go
@@ -175,17 +175,16 @@ func checkMetricsAreExpected(t *testing.T, md pdata.Metrics, fields map[string]i
 			assert.Equal(t, expectedUnits[metricName], m.Unit(), "Wrong unit for metric: "+metricName)
 			switch m.DataType() {
 			//we only need to worry about gauge types for container insights metrics
-			case pdata.MetricDataTypeIntGauge:
-				dps := m.IntGauge().DataPoints()
-				assert.Equal(t, 1, dps.Len())
-				dp := dps.At(0)
-				assert.Equal(t, convertToInt64(fields[metricName]), dp.Value())
-				assert.Equal(t, pdata.Timestamp(timeUnixNano), dp.Timestamp())
 			case pdata.MetricDataTypeGauge:
 				dps := m.Gauge().DataPoints()
 				assert.Equal(t, 1, dps.Len())
 				dp := dps.At(0)
-				assert.Equal(t, convertToFloat64(fields[metricName]), dp.Value())
+				switch dp.Type() {
+				case pdata.MetricValueTypeDouble:
+					assert.Equal(t, convertToFloat64(fields[metricName]), dp.DoubleVal())
+				case pdata.MetricValueTypeInt:
+					assert.Equal(t, convertToInt64(fields[metricName]), dp.IntVal())
+				}
 				assert.Equal(t, pdata.Timestamp(timeUnixNano), dp.Timestamp())
 			}
 		}

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -132,8 +132,14 @@ func assertMetricValueEqual(t *testing.T, m pdata.Metrics, metricName string, ex
 		for i := 0; i < metricSlice.Len(); i++ {
 			metric := metricSlice.At(i)
 			if metric.Name() == metricName {
-				if metric.DataType() == pdata.MetricDataTypeIntGauge {
-					assert.Equal(t, expected, metric.IntGauge().DataPoints().At(0).Value())
+				if metric.DataType() == pdata.MetricDataTypeGauge {
+					switch metric.Gauge().DataPoints().At(0).Type() {
+					case pdata.MetricValueTypeDouble:
+						assert.Equal(t, expected, metric.Gauge().DataPoints().At(0).DoubleVal())
+					case pdata.MetricValueTypeInt:
+						assert.Equal(t, expected, metric.Gauge().DataPoints().At(0).IntVal())
+					}
+
 					return
 				}
 


### PR DESCRIPTION
**Description:** Updating containerinsight to use `SetIntVal` / `SetDoubleVal` and remove `IntGauge`/`IntSum` altogether.

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3534

