### PR TITLE
replace a few missed SetValue with SetDoubleVal

### DIFF
--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -101,12 +101,12 @@ func TestSerializeIntDataPoints(t *testing.T) {
 func TestSerializeDoubleDataPoints(t *testing.T) {
 	doubleSlice := pdata.NewNumberDataPointSlice()
 	doublePoint := doubleSlice.AppendEmpty()
-	doublePoint.SetValue(13.1)
+	doublePoint.SetDoubleVal(13.1)
 	doublePoint.SetTimestamp(pdata.Timestamp(100_000_000))
 
 	labelDoubleSlice := pdata.NewNumberDataPointSlice()
 	labelDoublePoint := labelDoubleSlice.AppendEmpty()
-	labelDoublePoint.SetValue(13.1)
+	labelDoublePoint.SetDoubleVal(13.1)
 	labelDoublePoint.SetTimestamp(pdata.Timestamp(100_000_000))
 	labelDoublePoint.LabelsMap().Insert("labelKey", "labelValue")
 

--- a/exporter/elasticexporter/exporter_test.go
+++ b/exporter/elasticexporter/exporter_test.go
@@ -112,7 +112,7 @@ func sampleMetrics() pdata.Metrics {
 		metric := resourceMetrics.AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics().AppendEmpty()
 		metric.SetName("foobar")
 		metric.SetDataType(pdata.MetricDataTypeGauge)
-		metric.Gauge().DataPoints().AppendEmpty().SetValue(123)
+		metric.Gauge().DataPoints().AppendEmpty().SetDoubleVal(123)
 	}
 	return metrics
 }

--- a/exporter/newrelicexporter/transformer_test.go
+++ b/exporter/newrelicexporter/transformer_test.go
@@ -597,7 +597,7 @@ func TestTransformGauge(t *testing.T) {
 		gd := m.Gauge()
 		dp := gd.DataPoints().AppendEmpty()
 		dp.SetTimestamp(ts)
-		dp.SetValue(42.0)
+		dp.SetDoubleVal(42.0)
 		t.Run("Double", func(t *testing.T) { testTransformMetric(t, m, expected) })
 	}
 	{
@@ -653,7 +653,7 @@ func TestTransformSum(t *testing.T) {
 		dp := d.DataPoints().AppendEmpty()
 		dp.SetStartTimestamp(start)
 		dp.SetTimestamp(end)
-		dp.SetValue(42.0)
+		dp.SetDoubleVal(42.0)
 		t.Run("Sum-Delta", func(t *testing.T) { testTransformMetric(t, m, expected) })
 	}
 	{
@@ -667,7 +667,7 @@ func TestTransformSum(t *testing.T) {
 		dp := d.DataPoints().AppendEmpty()
 		dp.SetStartTimestamp(start)
 		dp.SetTimestamp(end)
-		dp.SetValue(42.0)
+		dp.SetDoubleVal(42.0)
 		t.Run("Sum-Cumulative", func(t *testing.T) { testTransformMetric(t, m, expectedGauge) })
 	}
 	{

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -73,7 +73,7 @@ func createMetricsData(numberOfDataPoints int) pdata.Metrics {
 		metric.SetDataType(pdata.MetricDataTypeGauge)
 		doublePt := metric.Gauge().DataPoints().AppendEmpty()
 		doublePt.SetTimestamp(pdata.TimestampFromTime(tsUnix))
-		doublePt.SetValue(doubleVal)
+		doublePt.SetDoubleVal(doubleVal)
 		doublePt.LabelsMap().Insert("k/n0", "vn0")
 		doublePt.LabelsMap().Insert("k/n1", "vn1")
 		doublePt.LabelsMap().Insert("k/r0", "vr0")

--- a/receiver/dotnetdiagnosticsreceiver/metrics/converter.go
+++ b/receiver/dotnetdiagnosticsreceiver/metrics/converter.go
@@ -49,7 +49,7 @@ func rawMetricToPdata(dm dotnet.Metric, pdm pdata.Metric, startTime, now time.Ti
 		dps := pdm.Gauge().DataPoints()
 		dp := dps.AppendEmpty()
 		dp.SetTimestamp(nowPD)
-		dp.SetValue(dm.Mean())
+		dp.SetDoubleVal(dm.Mean())
 	case "Sum":
 		pdm.SetDataType(pdata.MetricDataTypeSum)
 		sum := pdm.Sum()
@@ -58,7 +58,7 @@ func rawMetricToPdata(dm dotnet.Metric, pdm pdata.Metric, startTime, now time.Ti
 		dp := dps.AppendEmpty()
 		dp.SetStartTimestamp(pdata.TimestampFromTime(startTime))
 		dp.SetTimestamp(nowPD)
-		dp.SetValue(dm.Increment())
+		dp.SetDoubleVal(dm.Increment())
 	}
 	return pdm
 }

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
@@ -143,5 +143,5 @@ func initializeNumberDataPointAsDouble(dataPoint pdata.NumberDataPoint, now pdat
 	}
 
 	dataPoint.SetTimestamp(now)
-	dataPoint.SetValue(value)
+	dataPoint.SetDoubleVal(value)
 }


### PR DESCRIPTION
**Description:** Cleaning up the last of `SetValue` calls, this will allow us to remove that func from the core altogether.

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3534
