### PR TITLE
Fix the wrong aws env resource setting in x-ray exporter

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -225,24 +225,24 @@ func determineAwsOrigin(resource pdata.Resource) string {
 	// implemented for robustness
 	if is, present := resource.Attributes().Get(semconventions.AttributeCloudPlatform); present {
 		switch is.StringVal() {
-		case "EKS":
+		case semconventions.AttributeCloudPlatformAWSEKS:
 			return OriginEKS
-		case "ElasticBeanstalk":
+		case semconventions.AttributeCloudPlatformAWSElasticBeanstalk:
 			return OriginEB
-		case "ECS":
+		case semconventions.AttributeCloudPlatformAWSECS:
 			lt, present := resource.Attributes().Get("aws.ecs.launchtype")
 			if !present {
 				return OriginECS
 			}
 			switch lt.StringVal() {
-			case "ec2":
+			case semconventions.AttributeAWSECSLaunchTypeEC2:
 				return OriginECSEC2
-			case "fargate":
+			case semconventions.AttributeAWSECSLaunchTypeFargate:
 				return OriginECSFargate
 			default:
 				return OriginECS
 			}
-		case "EC2":
+		case semconventions.AttributeCloudPlatformAWSEC2:
 			return OriginEC2
 
 		// If infrastructure_service is defined with a non-AWS value, we should not assign it an AWS origin
@@ -251,23 +251,6 @@ func determineAwsOrigin(resource pdata.Resource) string {
 		}
 	}
 
-	// EKS > EB > ECS > EC2
-	_, eks := resource.Attributes().Get(semconventions.AttributeK8sCluster)
-	if eks {
-		return OriginEKS
-	}
-	_, eb := resource.Attributes().Get(semconventions.AttributeServiceInstance)
-	if eb {
-		return OriginEB
-	}
-	_, ecs := resource.Attributes().Get(semconventions.AttributeContainerName)
-	if ecs {
-		return OriginECS
-	}
-	_, ec2 := resource.Attributes().Get(semconventions.AttributeHostID)
-	if ec2 {
-		return OriginEC2
-	}
 	return ""
 }
 

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -523,7 +523,7 @@ func TestOriginEc2(t *testing.T) {
 	resource := pdata.NewResource()
 	attrs := pdata.NewAttributeMap()
 	attrs.InsertString(semconventions.AttributeCloudProvider, semconventions.AttributeCloudProviderAWS)
-	attrs.InsertString("cloud.platform", "EC2")
+	attrs.InsertString(semconventions.AttributeCloudPlatform, semconventions.AttributeCloudPlatformAWSEC2)
 	attrs.InsertString(semconventions.AttributeHostID, "instance-123")
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
@@ -541,7 +541,7 @@ func TestOriginEcs(t *testing.T) {
 	resource := pdata.NewResource()
 	attrs := pdata.NewAttributeMap()
 	attrs.InsertString(semconventions.AttributeCloudProvider, semconventions.AttributeCloudProviderAWS)
-	attrs.InsertString("cloud.platform", "ECS")
+	attrs.InsertString(semconventions.AttributeCloudPlatform, semconventions.AttributeCloudPlatformAWSECS)
 	attrs.InsertString(semconventions.AttributeHostID, "instance-123")
 	attrs.InsertString(semconventions.AttributeContainerName, "container-123")
 	attrs.CopyTo(resource.Attributes())
@@ -560,8 +560,8 @@ func TestOriginEcsEc2(t *testing.T) {
 	resource := pdata.NewResource()
 	attrs := pdata.NewAttributeMap()
 	attrs.InsertString(semconventions.AttributeCloudProvider, semconventions.AttributeCloudProviderAWS)
-	attrs.InsertString("cloud.platform", "ECS")
-	attrs.InsertString("aws.ecs.launchtype", "ec2")
+	attrs.InsertString(semconventions.AttributeCloudPlatform, semconventions.AttributeCloudPlatformAWSECS)
+	attrs.InsertString(semconventions.AttributeAWSECSLaunchType, semconventions.AttributeAWSECSLaunchTypeEC2)
 	attrs.InsertString(semconventions.AttributeHostID, "instance-123")
 	attrs.InsertString(semconventions.AttributeContainerName, "container-123")
 	attrs.CopyTo(resource.Attributes())
@@ -580,8 +580,8 @@ func TestOriginEcsFargate(t *testing.T) {
 	resource := pdata.NewResource()
 	attrs := pdata.NewAttributeMap()
 	attrs.InsertString(semconventions.AttributeCloudProvider, semconventions.AttributeCloudProviderAWS)
-	attrs.InsertString("cloud.platform", "ECS")
-	attrs.InsertString("aws.ecs.launchtype", "fargate")
+	attrs.InsertString(semconventions.AttributeCloudPlatform, semconventions.AttributeCloudPlatformAWSECS)
+	attrs.InsertString(semconventions.AttributeAWSECSLaunchType, semconventions.AttributeAWSECSLaunchTypeFargate)
 	attrs.InsertString(semconventions.AttributeHostID, "instance-123")
 	attrs.InsertString(semconventions.AttributeContainerName, "container-123")
 	attrs.CopyTo(resource.Attributes())
@@ -600,6 +600,7 @@ func TestOriginEb(t *testing.T) {
 	resource := pdata.NewResource()
 	attrs := pdata.NewAttributeMap()
 	attrs.InsertString(semconventions.AttributeCloudProvider, semconventions.AttributeCloudProviderAWS)
+	attrs.InsertString(semconventions.AttributeCloudPlatform, semconventions.AttributeCloudPlatformAWSElasticBeanstalk)
 	attrs.InsertString(semconventions.AttributeHostID, "instance-123")
 	attrs.InsertString(semconventions.AttributeContainerName, "container-123")
 	attrs.InsertString(semconventions.AttributeServiceInstance, "service-123")
@@ -610,6 +611,38 @@ func TestOriginEb(t *testing.T) {
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, OriginEB, *segment.Origin)
+}
+
+func TestOriginEks(t *testing.T) {
+	instanceID := "i-00f7c0bcb26da2a99"
+	containerName := "signup_aggregator-x82ufje83"
+	containerID := "0123456789A"
+	spanName := "/test"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	resource := pdata.NewResource()
+	attrs := pdata.NewAttributeMap()
+	attrs.InsertString(semconventions.AttributeCloudProvider, semconventions.AttributeCloudProviderAWS)
+	attrs.InsertString(semconventions.AttributeCloudPlatform, semconventions.AttributeCloudPlatformAWSEKS)
+	attrs.InsertString(semconventions.AttributeCloudAccount, "123456789")
+	attrs.InsertString(semconventions.AttributeCloudAvailabilityZone, "us-east-1c")
+	attrs.InsertString(semconventions.AttributeContainerImage, "otel/signupaggregator")
+	attrs.InsertString(semconventions.AttributeContainerTag, "v1")
+	attrs.InsertString(semconventions.AttributeK8sCluster, "production")
+	attrs.InsertString(semconventions.AttributeK8sNamespace, "default")
+	attrs.InsertString(semconventions.AttributeK8sDeployment, "signup_aggregator")
+	attrs.InsertString(semconventions.AttributeK8sPod, "my-deployment-65dcf7d447-ddjnl")
+	attrs.InsertString(semconventions.AttributeContainerName, containerName)
+	attrs.InsertString(semconventions.AttributeContainerID, containerID)
+	attrs.InsertString(semconventions.AttributeHostID, instanceID)
+	attrs.InsertString(semconventions.AttributeHostType, "m5.xlarge")
+	attrs.CopyTo(resource.Attributes())
+	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, []string{}, false)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, OriginEKS, *segment.Origin)
 }
 
 func TestOriginBlank(t *testing.T) {
@@ -635,7 +668,7 @@ func TestOriginPrefersInfraService(t *testing.T) {
 	resource := pdata.NewResource()
 	attrs := pdata.NewAttributeMap()
 	attrs.InsertString(semconventions.AttributeCloudProvider, semconventions.AttributeCloudProviderAWS)
-	attrs.InsertString("cloud.platform", "EC2")
+	attrs.InsertString(semconventions.AttributeCloudPlatform, semconventions.AttributeCloudPlatformAWSEC2)
 	attrs.InsertString(semconventions.AttributeK8sCluster, "cluster-123")
 	attrs.InsertString(semconventions.AttributeHostID, "instance-123")
 	attrs.InsertString(semconventions.AttributeContainerName, "container-123")


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fix the wrong aws env resource setting(ECS was recognized as Beanstalk) in x-ray request and adopt the resource naming from core conventions pkg.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/aws-observability/aws-otel-collector/issues/590