### PR TITLE
Fix the origin on ECS/EKS/EB on EC2 cases

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -154,8 +154,10 @@ func makeAws(attributes map[string]pdata.AttributeValue, resource pdata.Resource
 		return filtered, nil // not AWS so return nil
 	}
 
-	// EC2 - hostID/ec2_instanceId should be always returned by ec2 detector
-	if service == semconventions.AttributeCloudPlatformAWSEC2 && hostID != "" {
+	// EC2 - add ec2 metadata to xray request if
+	//       1. cloud.platfrom is set to "aws_ec2" or
+	//       2. there is an non-blank host/instance id found
+	if service == semconventions.AttributeCloudPlatformAWSEC2 || hostID != "" {
 		ec2 = &awsxray.EC2Metadata{
 			InstanceID:       awsxray.String(hostID),
 			AvailabilityZone: awsxray.String(zone),

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -96,7 +96,7 @@ func TestAwsFromEcsResource(t *testing.T) {
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
 	assert.NotNil(t, awsData.ECS)
-	assert.Nil(t, awsData.EC2)
+	assert.NotNil(t, awsData.EC2)
 	assert.Nil(t, awsData.Beanstalk)
 	assert.Nil(t, awsData.EKS)
 	assert.Equal(t, &awsxray.ECSMetadata{
@@ -171,7 +171,7 @@ func TestAwsFromEksResource(t *testing.T) {
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
 	assert.NotNil(t, awsData.EKS)
-	assert.Nil(t, awsData.EC2)
+	assert.NotNil(t, awsData.EC2)
 	assert.Nil(t, awsData.ECS)
 	assert.Nil(t, awsData.Beanstalk)
 	assert.Equal(t, &awsxray.EKSMetadata{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
When customer is running OTel Collector on ECS/EKS/EB with EC2 instances. We need to capture both ECS/EKS/EB and EC2 metadata attributes in x-ray request. 