### PR TITLE
signalfx exporter: prefix temporary metric translations

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -116,9 +116,9 @@ One of `realm` and `api_url` are required.
 
 ## Translation Rules and Metric Transformations
 
-The `translation_rules` configuration field accepts a list of metric-transforming actions to
-help ensure compatibility with custom charts and dashboards when using the OpenTelemetry Collector or provide the ability to produce custom metrics by copying, calculating new, or aggregating other metric values without requiring an additional processor.
-The rule language is expressed in yaml mappings and is [documented here](./internal/translation/translator.go.  Translation rules currently allow the following actions:
+The `translation_rules` metrics configuration field accepts a list of metric-transforming actions to
+help ensure compatibility with custom charts and dashboards when using the OpenTelemetry Collector. It also provides the ability to produce custom metrics by copying, calculating new, or aggregating other metric values without requiring an additional processor.
+The rule language is expressed in yaml mappings and is [documented here](./internal/translation/translator.go).  Translation rules currently allow the following actions:
 
 * `aggregate_metric` - Aggregates a metric through removal of specified dimensions
 * `calculate_new_metric` - Creates a new metric via operating on two consistuent ones

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -134,7 +134,7 @@ The rule language is expressed in yaml mappings and is [documented here](./inter
 * `rename_metrics` - Replaces a given metric name with specified one
 * `split_metric` - Splits a given metric into multiple new ones for a specified dimension
 
-The translation rules defined in [`translation/constants.go]`](./internal/translation/constants.go) are used by default for this value.  The default rules will create the following aggregated metrics from the [`hostmetrics` receiver](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/hostmetricsreceiver/README.md):
+The translation rules defined in [`translation/constants.go`](./internal/translation/constants.go) are used by default for this value.  The default rules will create the following aggregated metrics from the [`hostmetrics` receiver](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/hostmetricsreceiver/README.md):
 
 * cpu.idle
 * cpu.interrupt

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -163,6 +163,8 @@ The translation rules defined in [`translation/constants.go`](./internal/transla
 * vmpage_io.swap.in
 * vmpage_io.swap.out
 
+These metrics are intended to be reported directly to Splunk IM by the SignalFx exporter.  Any desired changes to their attributes or values should be made via additional translation rules or from their constituent host metrics.
+
 ## Example Config
 
 ```yaml

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -114,7 +114,56 @@ One of `realm` and `api_url` are required.
   - `cleanup_interval` (default = 1 minute): How frequently to purge duplicate requests.
   - `sync_attributes` (default = `{"k8s.pod.uid": "k8s.pod.uid", "container.id": "container.id"}`) Map containing key of the attribute to read from spans to sync to dimensions specified as the value.
 
-## Example
+## Translation Rules and Metric Transformations
+
+The `translation_rules` configuration field accepts a list of metric-transforming actions to
+help ensure compatibility with custom charts and dashboards when using the OpenTelemetry Collector or provide the ability to produce custom metrics by copying, calculating new, or aggregating other metric values without requiring an additional processor.
+The rule language is expressed in yaml mappings and is [documented here](./internal/translation/translator.go.  Translation rules currently allow the following actions:
+
+* `aggregate_metric` - Aggregates a metric through removal of specified dimensions
+* `calculate_new_metric` - Creates a new metric via operating on two consistuent ones
+* `convert_values` - Convert float values to int for specified metric names
+* `copy_metrics` - Creates a new metric as a copy of another
+* `delta_metric` - Creates a new delta metric for a specified non-delta one
+* `divide_int` - Scales a metric's integer value by a given factor
+* `drop_dimensions` - Drops dimensions for specified metrics, or globally
+* `drop_metrics` - Drops all metrics with a given name
+* `multiply_float` - Scales a metric's integer value by a given float factor
+* `multiply_int` - Scales a metric's integer value by a given int factor
+* `rename_dimension_keys` - Renames dimensions for specified metrics, or globally
+* `rename_metrics` - Replaces a given metric name with specified one
+* `split_metric` - Splits a given metric into multiple new ones for a specified dimension
+
+The translation rules defined in [`translation/constants.go]`](./internal/translation/constants.go) are used by default for this value.  The default rules will create the following aggregated metrics from the [`hostmetrics` receiver](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/hostmetricsreceiver/README.md):
+
+* cpu.idle
+* cpu.interrupt
+* cpu.nice
+* cpu.num_processors
+* cpu.softirq
+* cpu.steal
+* cpu.system
+* cpu.user
+* cpu.utilization
+* cpu.utilization_per_core
+* cpu.wait
+* disk.summary_utilization
+* disk.utilization
+* disk_ops.pending
+* disk_ops.total
+* memory.total
+* memory.utilization
+* network.total
+* system.disk.io.total
+* system.disk.operations.total
+* system.network.io.total
+* system.network.packets.total
+* vmpage_io.memory.in
+* vmpage_io.memory.out
+* vmpage_io.swap.in
+* vmpage_io.swap.out
+
+## Example Config
 
 ```yaml
 exporters:

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -17,6 +17,7 @@ package signalfxexporter
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -612,6 +613,16 @@ func TestDefaultCPUTranslations(t *testing.T) {
 	require.Equal(t, 1, len(cpuUtil))
 	for _, pt := range cpuUtil {
 		require.Equal(t, 66, int(*pt.Value.DoubleValue))
+	}
+
+	cpuUtilPerCore := m["cpu.utilization_per_core"]
+	require.Equal(t, 8, len(cpuUtilPerCore))
+
+	cpuStateMetrics := []string{"cpu.idle", "cpu.interrupt", "cpu.num_processors", "cpu.system", "cpu.user"}
+	for _, metric := range cpuStateMetrics {
+		dps, ok := m[metric]
+		require.True(t, ok, fmt.Sprintf("%s metrics not found", metric))
+		require.Len(t, dps, 1)
 	}
 }
 

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -83,15 +83,6 @@ translation_rules:
 - action: multiply_float
   scale_factors_float:
     sf_temp.cpu.utilization: 100
-- action: rename_metrics
-  mapping:
-    sf_temp.cpu.utilization: cpu.utilization
-
-- action: drop_metrics
-  metric_names:
-    sf_temp.system.cpu.delta: true
-    sf_temp.system.cpu.total: true
-    sf_temp.system.cpu.usage: true
 
 # convert cpu metrics
 - action: split_metric
@@ -129,10 +120,6 @@ translation_rules:
     sf_temp.cpu.softirq: int
     sf_temp.cpu.nice: int
 
-- action: rename_metrics
-  mapping:
-    sf_temp.container_cpu_utilization: container_cpu_utilization
-
 # compute cpu.num_processors
 - action: copy_metrics
   mapping:
@@ -142,10 +129,6 @@ translation_rules:
   aggregation_method: count
   without_dimensions:
   - cpu
-
-- action: rename_metrics
-  mapping:
-    sf_temp.cpu.num_processors: cpu.num_processors
 
 - action: aggregate_metric
   metric_name: sf_temp.cpu.idle
@@ -187,17 +170,6 @@ translation_rules:
   aggregation_method: sum
   without_dimensions:
   - cpu
-
-- action: rename_metrics
-  mapping:
-    sf_temp.cpu.idle: cpu.idle
-    sf_temp.cpu.interrupt: cpu.interrupt
-    sf_temp.cpu.nice: cpu.nice
-    sf_temp.cpu.softirq: cpu.softirq
-    sf_temp.cpu.steal: cpu.steal
-    sf_temp.cpu.system: cpu.system
-    sf_temp.cpu.user: cpu.user
-    sf_temp.cpu.wait: cpu.wait
 
 # compute memory.total
 - action: copy_metrics
@@ -277,25 +249,10 @@ translation_rules:
   scale_factors_float:
     sf_temp.disk.utilization: 100
 
-- action: rename_metrics
-  mapping:
-    sf_temp.disk.utilization: disk.utilization
-
-- action: drop_metrics
-  metric_names:
-    sf_temp.disk.total: true
-    sf_temp.system.filesystem.usage: true
-    sf_temp.system.memory.usage: true
-
 ## disk.summary_utilization
 - action: copy_metrics
   mapping:
     sf_temp.df_complex.used: sf_temp.df_complex.used_total
-
-# remove redundant metrics
-- action: drop_metrics
-  metric_names:
-    sf_temp.df_complex.used: true
 
 - action: aggregate_metric
   metric_name: sf_temp.df_complex.used_total
@@ -320,15 +277,6 @@ translation_rules:
   scale_factors_float:
     sf_temp.disk.summary_utilization: 100
 
-- action: drop_metrics
-  metric_names:
-    sf_temp.disk.summary_total: true
-    sf_temp.df_complex.used_total: true
-
-- action: rename_metrics
-  mapping:
-    sf_temp.disk.summary_utilization: disk.summary_utilization
-
 
 # Translations to derive disk I/O metrics.
 
@@ -348,11 +296,6 @@ translation_rules:
   without_dimensions:
     - device
 
-- action: rename_metrics
-  mapping:
-    sf_temp.system.disk.operations.total: system.disk.operations.total
-    sf_temp.system.disk.io.total: system.disk.io.total
-
 ## Calculate an extra disk_ops.total metric as number all all read and write operations happened since the last report.
 - action: copy_metrics
   mapping:
@@ -366,10 +309,6 @@ translation_rules:
 - action: delta_metric
   mapping:
     sf_temp.disk.ops: disk_ops.total
-
-- action: drop_metrics
-  metric_names:
-    sf_temp.disk.ops: true
 
 - action: delta_metric
   mapping:
@@ -392,10 +331,6 @@ translation_rules:
   aggregation_method: sum
   without_dimensions:
   - device
-- action: rename_metrics
-  mapping:
-    sf_temp.system.network.io.total: system.network.io.total
-    sf_temp.system.network.packets.total: system.network.packets.total
 
 ## Calculate extra network.total metric.
 - action: copy_metrics
@@ -411,9 +346,6 @@ translation_rules:
   without_dimensions:
   - direction
   - device
-- action: rename_metrics
-  mapping:
-    sf_temp.network.total: network.total
 
 # memory utilization
 - action: calculate_new_metric
@@ -450,13 +382,41 @@ translation_rules:
 
 - action: rename_metrics
   mapping:
+    sf_temp.container_cpu_utilization: container_cpu_utilization
+    sf_temp.cpu.idle: cpu.idle
+    sf_temp.cpu.interrupt: cpu.interrupt
+    sf_temp.cpu.nice: cpu.nice
+    sf_temp.cpu.num_processors: cpu.num_processors
+    sf_temp.cpu.softirq: cpu.softirq
+    sf_temp.cpu.steal: cpu.steal
+    sf_temp.cpu.system: cpu.system
+    sf_temp.cpu.user: cpu.user
+    sf_temp.cpu.utilization: cpu.utilization
+    sf_temp.cpu.wait: cpu.wait
+    sf_temp.disk.summary_utilization: disk.summary_utilization
+    sf_temp.disk.utilization: disk.utilization
     sf_temp.memory.total: memory.total
     sf_temp.memory.utilization: memory.utilization
+    sf_temp.network.total: network.total
+    sf_temp.system.disk.io.total: system.disk.io.total
+    sf_temp.system.disk.operations.total: system.disk.operations.total
+    sf_temp.system.network.io.total: system.network.io.total
+    sf_temp.system.network.packets.total: system.network.packets.total
 
 # remove redundant metrics
 - action: drop_metrics
   metric_names:
+    sf_temp.df_complex.used: true
+    sf_temp.df_complex.used_total: true
+    sf_temp.disk.ops: true
+    sf_temp.disk.summary_total: true
+    sf_temp.disk.total: true
     sf_temp.memory.used: true
+    sf_temp.system.cpu.delta: true
+    sf_temp.system.cpu.total: true
+    sf_temp.system.cpu.usage: true
+    sf_temp.system.filesystem.usage: true
+    sf_temp.system.memory.usage: true
     sf_temp.system.paging.operations.page_in: true
     sf_temp.system.paging.operations.page_out: true
 `

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -312,7 +312,7 @@ translation_rules:
 
 - action: delta_metric
   mapping:
-    system.disk.pending_operations: sf_temp.disk.ops.pending
+    system.disk.pending_operations: disk_ops.pending
 
 # Translations to derive Network I/O metrics.
 

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -335,18 +335,23 @@ translation_rules:
 ## Calculate extra system.disk.operations.total and system.disk.io.total metrics summing up read/write ops/IO across all devices.
 - action: copy_metrics
   mapping:
-    system.disk.operations: system.disk.operations.total
-    system.disk.io: system.disk.io.total
+    system.disk.operations: sf_temp.system.disk.operations.total
+    system.disk.io: sf_temp.system.disk.io.total
 - action: aggregate_metric
-  metric_name: system.disk.operations.total
+  metric_name: sf_temp.system.disk.operations.total
   aggregation_method: sum
   without_dimensions:
     - device
 - action: aggregate_metric
-  metric_name: system.disk.io.total
+  metric_name: sf_temp.system.disk.io.total
   aggregation_method: sum
   without_dimensions:
     - device
+
+- action: rename_metrics
+  mapping:
+    sf_temp.system.disk.operations.total: system.disk.operations.total
+    sf_temp.system.disk.io.total: system.disk.io.total
 
 ## Calculate an extra disk_ops.total metric as number all all read and write operations happened since the last report.
 - action: copy_metrics
@@ -375,33 +380,40 @@ translation_rules:
 ## Calculate extra network I/O metrics system.network.packets.total and system.network.io.total.
 - action: copy_metrics
   mapping:
-    system.network.packets: system.network.packets.total
-    system.network.io: system.network.io.total
+    system.network.packets: sf_temp.system.network.packets.total
+    system.network.io: sf_temp.system.network.io.total
 - action: aggregate_metric
-  metric_name: system.network.packets.total
+  metric_name: sf_temp.system.network.packets.total
   aggregation_method: sum
   without_dimensions:
   - device
 - action: aggregate_metric
-  metric_name: system.network.io.total
+  metric_name: sf_temp.system.network.io.total
   aggregation_method: sum
   without_dimensions:
   - device
+- action: rename_metrics
+  mapping:
+    sf_temp.system.network.io.total: system.network.io.total
+    sf_temp.system.network.packets.total: system.network.packets.total
 
 ## Calculate extra network.total metric.
 - action: copy_metrics
   mapping:
-    system.network.io: network.total
+    system.network.io: sf_temp.network.total
   dimension_key: direction
   dimension_values:
     receive: true
     transmit: true
 - action: aggregate_metric
-  metric_name: network.total
+  metric_name: sf_temp.network.total
   aggregation_method: sum
   without_dimensions:
   - direction
   - device
+- action: rename_metrics
+  mapping:
+    sf_temp.network.total: network.total
 
 # memory utilization
 - action: calculate_new_metric

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -36,15 +36,15 @@ translation_rules:
 - action: rename_metrics
   mapping:
     # kubeletstats container cpu needed for calculation below
-    container.cpu.time: container_cpu_utilization
+    container.cpu.time: sf_temp.container_cpu_utilization
 
 # compute cpu utilization metrics: cpu.utilization_per_core (excluded by default) and cpu.utilization
 - action: delta_metric
   mapping:
-    system.cpu.time: system.cpu.delta
+    system.cpu.time: sf_temp.system.cpu.delta
 - action: copy_metrics
   mapping:
-    system.cpu.delta: system.cpu.usage
+    sf_temp.system.cpu.delta: sf_temp.system.cpu.usage
   dimension_key: state
   dimension_values:
     interrupt: true
@@ -55,123 +55,154 @@ translation_rules:
     user: true
     wait: true
 - action: aggregate_metric
-  metric_name: system.cpu.usage
+  metric_name: sf_temp.system.cpu.usage
   aggregation_method: sum
   without_dimensions:
   - state
 - action: copy_metrics
   mapping:
-    system.cpu.delta: system.cpu.total
+    sf_temp.system.cpu.delta: sf_temp.system.cpu.total
 - action: aggregate_metric
-  metric_name: system.cpu.total
+  metric_name: sf_temp.system.cpu.total
   aggregation_method: sum
   without_dimensions:
   - state
 - action: calculate_new_metric
   metric_name: cpu.utilization_per_core
-  operand1_metric: system.cpu.usage
-  operand2_metric: system.cpu.total
+  operand1_metric: sf_temp.system.cpu.usage
+  operand2_metric: sf_temp.system.cpu.total
   operator: /
 - action: copy_metrics
   mapping:
-    cpu.utilization_per_core: cpu.utilization
+    cpu.utilization_per_core: sf_temp.cpu.utilization
 - action: aggregate_metric
-  metric_name: cpu.utilization
+  metric_name: sf_temp.cpu.utilization
   aggregation_method: avg
   without_dimensions:
   - cpu
+- action: multiply_float
+  scale_factors_float:
+    sf_temp.cpu.utilization: 100
+- action: rename_metrics
+  mapping:
+    sf_temp.cpu.utilization: cpu.utilization
+
+- action: drop_metrics
+  metric_names:
+    sf_temp.system.cpu.delta: true
+    sf_temp.system.cpu.total: true
+    sf_temp.system.cpu.usage: true
 
 # convert cpu metrics
 - action: split_metric
   metric_name: system.cpu.time
   dimension_key: state
   mapping:
-    idle: cpu.idle
-    interrupt: cpu.interrupt
-    system: cpu.system
-    user: cpu.user
-    steal: cpu.steal
-    wait: cpu.wait
-    softirq: cpu.softirq
-    nice: cpu.nice
+    idle: sf_temp.cpu.idle
+    interrupt: sf_temp.cpu.interrupt
+    system: sf_temp.cpu.system
+    user: sf_temp.cpu.user
+    steal: sf_temp.cpu.steal
+    wait: sf_temp.cpu.wait
+    softirq: sf_temp.cpu.softirq
+    nice: sf_temp.cpu.nice
 - action: multiply_float
   scale_factors_float:
-    container_cpu_utilization: 100
-    cpu.idle: 100
-    cpu.interrupt: 100
-    cpu.system: 100
-    cpu.user: 100
-    cpu.steal: 100
-    cpu.wait: 100
-    cpu.softirq: 100
-    cpu.nice: 100
+    sf_temp.container_cpu_utilization: 100
+    sf_temp.cpu.idle: 100
+    sf_temp.cpu.interrupt: 100
+    sf_temp.cpu.system: 100
+    sf_temp.cpu.user: 100
+    sf_temp.cpu.steal: 100
+    sf_temp.cpu.wait: 100
+    sf_temp.cpu.softirq: 100
+    sf_temp.cpu.nice: 100
 - action: convert_values
   types_mapping:
-    container_cpu_utilization: int
-    cpu.idle: int
-    cpu.interrupt: int
-    cpu.system: int
-    cpu.user: int
-    cpu.steal: int
-    cpu.wait: int
-    cpu.softirq: int
-    cpu.nice: int
+    sf_temp.container_cpu_utilization: int
+    sf_temp.cpu.idle: int
+    sf_temp.cpu.interrupt: int
+    sf_temp.cpu.system: int
+    sf_temp.cpu.user: int
+    sf_temp.cpu.steal: int
+    sf_temp.cpu.wait: int
+    sf_temp.cpu.softirq: int
+    sf_temp.cpu.nice: int
+
+- action: rename_metrics
+  mapping:
+    sf_temp.container_cpu_utilization: container_cpu_utilization
 
 # compute cpu.num_processors
 - action: copy_metrics
   mapping:
-    cpu.idle: cpu.num_processors
+    sf_temp.cpu.idle: sf_temp.cpu.num_processors
 - action: aggregate_metric
-  metric_name: cpu.num_processors
+  metric_name: sf_temp.cpu.num_processors
   aggregation_method: count
   without_dimensions:
   - cpu
 
+- action: rename_metrics
+  mapping:
+    sf_temp.cpu.num_processors: cpu.num_processors
+
 - action: aggregate_metric
-  metric_name: cpu.idle
+  metric_name: sf_temp.cpu.idle
   aggregation_method: sum
   without_dimensions:
   - cpu
 - action: aggregate_metric
-  metric_name: cpu.interrupt
+  metric_name: sf_temp.cpu.interrupt
   aggregation_method: sum
   without_dimensions:
   - cpu
 - action: aggregate_metric
-  metric_name: cpu.system
+  metric_name: sf_temp.cpu.system
   aggregation_method: sum
   without_dimensions:
   - cpu
 - action: aggregate_metric
-  metric_name: cpu.user
+  metric_name: sf_temp.cpu.user
   aggregation_method: sum
   without_dimensions:
   - cpu
 - action: aggregate_metric
-  metric_name: cpu.steal
+  metric_name: sf_temp.cpu.steal
   aggregation_method: sum
   without_dimensions:
   - cpu
 - action: aggregate_metric
-  metric_name: cpu.wait
+  metric_name: sf_temp.cpu.wait
   aggregation_method: sum
   without_dimensions:
   - cpu
 - action: aggregate_metric
-  metric_name: cpu.softirq
+  metric_name: sf_temp.cpu.softirq
   aggregation_method: sum
   without_dimensions:
   - cpu
 - action: aggregate_metric
-  metric_name: cpu.nice
+  metric_name: sf_temp.cpu.nice
   aggregation_method: sum
   without_dimensions:
   - cpu
 
+- action: rename_metrics
+  mapping:
+    sf_temp.cpu.idle: cpu.idle
+    sf_temp.cpu.interrupt: cpu.interrupt
+    sf_temp.cpu.nice: cpu.nice
+    sf_temp.cpu.softirq: cpu.softirq
+    sf_temp.cpu.steal: cpu.steal
+    sf_temp.cpu.system: cpu.system
+    sf_temp.cpu.user: cpu.user
+    sf_temp.cpu.wait: cpu.wait
+
 # compute memory.total
 - action: copy_metrics
   mapping:
-    system.memory.usage: memory.total
+    system.memory.usage: sf_temp.memory.total
   dimension_key: state
   dimension_values:
     buffered: true
@@ -179,7 +210,7 @@ translation_rules:
     free: true
     used: true
 - action: aggregate_metric
-  metric_name: memory.total
+  metric_name: sf_temp.memory.total
   aggregation_method: sum
   without_dimensions:
   - state
@@ -187,93 +218,116 @@ translation_rules:
 # convert memory metrics
 - action: copy_metrics
   mapping:
-    system.memory.usage: system.memory.usage.copy
+    system.memory.usage: sf_temp.system.memory.usage
 
-# memory.used needed to calculate memory.utilization
+# sf_temp.memory.used needed to calculate memory.utilization
 - action: split_metric
-  metric_name: system.memory.usage.copy
+  metric_name: sf_temp.system.memory.usage
   dimension_key: state
   mapping:
-    used: memory.used
+    used: sf_temp.memory.used
 
 # Translations to derive filesystem metrics
-## disk.total, required to compute disk.utilization
+## sf_temp.disk.total, required to compute disk.utilization
 - action: copy_metrics
   mapping:
-    system.filesystem.usage: disk.total
+    system.filesystem.usage: sf_temp.disk.total
 - action: aggregate_metric
-  metric_name: disk.total
+  metric_name: sf_temp.disk.total
   aggregation_method: sum
   without_dimensions:
     - state
 
-## disk.summary_total, required to compute disk.summary_utilization
+## sf_temp.disk.summary_total, required to compute disk.summary_utilization
 - action: copy_metrics
   mapping:
-    system.filesystem.usage: disk.summary_total
+    system.filesystem.usage: sf_temp.disk.summary_total
 - action: aggregate_metric
-  metric_name: disk.summary_total
+  metric_name: sf_temp.disk.summary_total
   aggregation_method: avg
   without_dimensions:
     - mode
     - mountpoint
 - action: aggregate_metric
-  metric_name: disk.summary_total
+  metric_name: sf_temp.disk.summary_total
   aggregation_method: sum
   without_dimensions:
     - state
     - device
     - type
 
-## df_complex.used needed to calculate disk.utilization
+## sf_temp.df_complex.used needed to calculate disk.utilization
 - action: copy_metrics
   mapping:
-    system.filesystem.usage: system.filesystem.usage.copy
+    system.filesystem.usage: sf_temp.system.filesystem.usage
 
 - action: split_metric
-  metric_name: system.filesystem.usage.copy
+  metric_name: sf_temp.system.filesystem.usage
   dimension_key: state
   mapping:
-    used: df_complex.used
+    used: sf_temp.df_complex.used
 
 ## disk.utilization
 - action: calculate_new_metric
-  metric_name: disk.utilization
-  operand1_metric: df_complex.used
-  operand2_metric: disk.total
+  metric_name: sf_temp.disk.utilization
+  operand1_metric: sf_temp.df_complex.used
+  operand2_metric: sf_temp.disk.total
   operator: /
 - action: multiply_float
   scale_factors_float:
-    disk.utilization: 100
+    sf_temp.disk.utilization: 100
 
+- action: rename_metrics
+  mapping:
+    sf_temp.disk.utilization: disk.utilization
+
+- action: drop_metrics
+  metric_names:
+    sf_temp.disk.total: true
+    sf_temp.system.filesystem.usage: true
+    sf_temp.system.memory.usage: true
 
 ## disk.summary_utilization
 - action: copy_metrics
   mapping:
-    df_complex.used: df_complex.used_total
+    sf_temp.df_complex.used: sf_temp.df_complex.used_total
+
+# remove redundant metrics
+- action: drop_metrics
+  metric_names:
+    sf_temp.df_complex.used: true
 
 - action: aggregate_metric
-  metric_name: df_complex.used_total
+  metric_name: sf_temp.df_complex.used_total
   aggregation_method: avg
   without_dimensions:
     - mode
     - mountpoint
 
 - action: aggregate_metric
-  metric_name: df_complex.used_total
+  metric_name: sf_temp.df_complex.used_total
   aggregation_method: sum
   without_dimensions:
   - device
   - type
 
 - action: calculate_new_metric
-  metric_name: disk.summary_utilization
-  operand1_metric: df_complex.used_total
-  operand2_metric: disk.summary_total
+  metric_name: sf_temp.disk.summary_utilization
+  operand1_metric: sf_temp.df_complex.used_total
+  operand2_metric: sf_temp.disk.summary_total
   operator: /
 - action: multiply_float
   scale_factors_float:
-    disk.summary_utilization: 100
+    sf_temp.disk.summary_utilization: 100
+
+- action: drop_metrics
+  metric_names:
+    sf_temp.disk.summary_total: true
+    sf_temp.df_complex.used_total: true
+
+- action: rename_metrics
+  mapping:
+    sf_temp.disk.summary_utilization: disk.summary_utilization
 
 
 # Translations to derive disk I/O metrics.
@@ -297,20 +351,24 @@ translation_rules:
 ## Calculate an extra disk_ops.total metric as number all all read and write operations happened since the last report.
 - action: copy_metrics
   mapping:
-    system.disk.operations: disk.ops
+    system.disk.operations: sf_temp.disk.ops
 - action: aggregate_metric
-  metric_name: disk.ops
+  metric_name: sf_temp.disk.ops
   aggregation_method: sum
   without_dimensions:
     - direction
     - device
 - action: delta_metric
   mapping:
-    disk.ops: disk_ops.total
+    sf_temp.disk.ops: disk_ops.total
+
+- action: drop_metrics
+  metric_names:
+    sf_temp.disk.ops: true
 
 - action: delta_metric
   mapping:
-    system.disk.pending_operations: disk_ops.pending
+    system.disk.pending_operations: sf_temp.disk.ops.pending
 
 # Translations to derive Network I/O metrics.
 
@@ -347,53 +405,47 @@ translation_rules:
 
 # memory utilization
 - action: calculate_new_metric
-  metric_name: memory.utilization
-  operand1_metric: memory.used
-  operand2_metric: memory.total
+  metric_name: sf_temp.memory.utilization
+  operand1_metric: sf_temp.memory.used
+  operand2_metric: sf_temp.memory.total
   operator: /
 
 - action: multiply_float
   scale_factors_float:
-    memory.utilization: 100
-    cpu.utilization: 100
+    sf_temp.memory.utilization: 100
 
 # Virtual memory metrics
 - action: split_metric
   metric_name: system.paging.operations
   dimension_key: direction
   mapping:
-    page_in: system.paging.operations.page_in
-    page_out: system.paging.operations.page_out
+    page_in: sf_temp.system.paging.operations.page_in
+    page_out: sf_temp.system.paging.operations.page_out
 
 - action: split_metric
-  metric_name: system.paging.operations.page_in
+  metric_name: sf_temp.system.paging.operations.page_in
   dimension_key: type
   mapping:
     major: vmpage_io.swap.in
     minor: vmpage_io.memory.in
 
 - action: split_metric
-  metric_name: system.paging.operations.page_out
+  metric_name: sf_temp.system.paging.operations.page_out
   dimension_key: type
   mapping:
     major: vmpage_io.swap.out
     minor: vmpage_io.memory.out
 
+- action: rename_metrics
+  mapping:
+    sf_temp.memory.total: memory.total
+    sf_temp.memory.utilization: memory.utilization
+
 # remove redundant metrics
 - action: drop_metrics
   metric_names:
-    system.filesystem.usage.copy: true
-    df_complex.used: true
-    df_complex.used_total: true
-    disk.ops: true
-    disk.summary_total: true
-    disk.total: true
-    system.cpu.usage: true
-    system.cpu.total: true
-    system.cpu.delta: true
-    system.paging.operations.page_in: true
-    system.paging.operations.page_out: true
-    system.memory.usage.copy: true
-    memory.used: true
+    sf_temp.memory.used: true
+    sf_temp.system.paging.operations.page_in: true
+    sf_temp.system.paging.operations.page_out: true
 `
 )


### PR DESCRIPTION
**Description:**
Fixing a bug - by not using a reserved prefix (one disallowed by Splunk IM) for default translation metric names, undesired effects will occur for coincidentally named metrics.

**Testing:**
Added more produced metric cases.

**Documentation:**
Updated exporter readme to list translation actions and generated metrics.