### PR TITLE
[exporter/tanzuobservability] Support queued retries

### DIFF
--- a/exporter/tanzuobservabilityexporter/config.go
+++ b/exporter/tanzuobservabilityexporter/config.go
@@ -20,6 +20,7 @@ import (
 
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 type TracesConfig struct {
@@ -28,7 +29,9 @@ type TracesConfig struct {
 
 // Config defines configuration options for the exporter.
 type Config struct {
-	config.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	config.ExporterSettings      `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	exporterhelper.QueueSettings `mapstructure:"sending_queue"`
+	exporterhelper.RetrySettings `mapstructure:"retry_on_failure"`
 
 	// Traces defines the Traces exporter specific configuration
 	Traces TracesConfig `mapstructure:"traces"`

--- a/exporter/tanzuobservabilityexporter/exporter.go
+++ b/exporter/tanzuobservabilityexporter/exporter.go
@@ -122,6 +122,9 @@ func (e *tracesExporter) pushTraceData(ctx context.Context, td pdata.Traces) err
 		}
 	}
 
+	if err := e.sender.Flush(); err != nil {
+		errs = append(errs, err)
+	}
 	return consumererror.Combine(errs)
 }
 
@@ -131,7 +134,7 @@ func (e *tracesExporter) recordSpan(span span) error {
 		parents = []string{span.ParentSpanID.String()}
 	}
 
-	err := e.sender.SendSpan(
+	return e.sender.SendSpan(
 		span.Name,
 		span.StartMillis,
 		span.DurationMillis,
@@ -143,11 +146,6 @@ func (e *tracesExporter) recordSpan(span span) error {
 		mapToSpanTags(span.Tags),
 		span.SpanLogs,
 	)
-
-	if err != nil {
-		return err
-	}
-	return e.sender.Flush()
 }
 
 func (e *tracesExporter) shutdown(_ context.Context) error {

--- a/exporter/tanzuobservabilityexporter/factory.go
+++ b/exporter/tanzuobservabilityexporter/factory.go
@@ -40,6 +40,8 @@ func createDefaultConfig() config.Exporter {
 	}
 	return &Config{
 		ExporterSettings: config.NewExporterSettings(config.NewID(exporterType)),
+		QueueSettings:    exporterhelper.DefaultQueueSettings(),
+		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		Traces:           tracesCfg,
 	}
 }
@@ -56,10 +58,14 @@ func createTracesExporter(
 		return nil, err
 	}
 
+	tobsCfg := cfg.(*Config)
+
 	return exporterhelper.NewTracesExporter(
 		cfg,
 		set,
 		exp.pushTraceData,
+		exporterhelper.WithQueue(tobsCfg.QueueSettings),
+		exporterhelper.WithRetry(tobsCfg.RetrySettings),
 		exporterhelper.WithShutdown(exp.shutdown),
 	)
 }

--- a/exporter/tanzuobservabilityexporter/factory_test.go
+++ b/exporter/tanzuobservabilityexporter/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -55,6 +57,17 @@ func TestLoadConfig(t *testing.T) {
 		ExporterSettings: config.NewExporterSettings(config.NewID("tanzuobservability")),
 		Traces: TracesConfig{
 			HTTPClientSettings: confighttp.HTTPClientSettings{Endpoint: "http://localhost:40001"},
+		},
+		QueueSettings: exporterhelper.QueueSettings{
+			Enabled:      true,
+			NumConsumers: 2,
+			QueueSize:    10,
+		},
+		RetrySettings: exporterhelper.RetrySettings{
+			Enabled:         true,
+			InitialInterval: 10 * time.Second,
+			MaxInterval:     60 * time.Second,
+			MaxElapsedTime:  10 * time.Minute,
 		},
 	}
 	assert.Equal(t, expected, actual)

--- a/exporter/tanzuobservabilityexporter/testdata/config.yaml
+++ b/exporter/tanzuobservabilityexporter/testdata/config.yaml
@@ -8,6 +8,15 @@ exporters:
   tanzuobservability:
     traces:
       endpoint: "http://localhost:40001"
+    retry_on_failure:
+      enabled: true
+      initial_interval: 10s
+      max_interval: 60s
+      max_elapsed_time: 10m
+    sending_queue:
+      enabled: true
+      num_consumers: 2
+      queue_size: 10
 
 service:
   pipelines:


### PR DESCRIPTION
**Description:** 
Added support for the `retry_on_failure` and `sending_queue` exporter helpers.

**Testing:**
Unit tests passed, and manually tested new config options for our exporter in failure scenarios.

**Documentation:**
Updated our README with the new config options