### PR TITLE
Add a make target for running tests for modules that depend on opente…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ MOD_NAME=github.com/open-telemetry/opentelemetry-collector-contrib
 # ALL_MODULES includes ./* dirs (excludes . dir and example with go code)
 ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./' )
 
+LOG_COLLECTION_MOD_NAME=github.com/open-telemetry/opentelemetry-log-collection
+
+# LOG_COLLECTION_MODULES includes modules depending on github.com/open-telemetry/opentelemetry-log-collection
+LOG_COLLECTION_MODULES := $(shell find . -type f -name "go.mod" -exec grep -l $(LOG_COLLECTION_MOD_NAME) {} \; | xargs -L 1 dirname | sort | egrep  '^./' )
+
 # Modules to run integration tests on.
 # XXX: Find a way to automatically populate this. Too slow to run across all modules when there are just a few.
 INTEGRATION_TEST_MODULES := \
@@ -33,6 +38,9 @@ INTEGRATION_TEST_MODULES := \
 
 all-modules:
 	@echo $(ALL_MODULES) | tr ' ' '\n' | sort
+
+all-modules-using-log-collection:
+	@echo $(LOG_COLLECTION_MODULES) | tr ' ' '\n' | sort
 
 .PHONY: all
 all: common gotest otelcontribcol otelcontribcol-unstable
@@ -58,6 +66,11 @@ integration-tests-with-cover:
 stability-tests: otelcontribcol
 	@echo Stability tests are disabled until we have a stable performance environment.
 	@echo To enable the tests replace this echo by $(MAKE) -C testbed run-stability-tests
+
+.PHONY: log-collection-modules-tests
+log-collection-modules-tests:
+	@echo $(LOG_COLLECTION_MODULES)
+	@$(MAKE) for-all-target TARGET="test" ALL_MODULES="$(LOG_COLLECTION_MODULES)"
 
 .PHONY: gotidy
 gotidy:


### PR DESCRIPTION
…lemetry-log-collection

**Description:** 
`opentelemetry-collector-contrib` repo has some modules that list `opentelemetry-log-collection` as a dependency. When changes are made to `opentelemetry-log-collection` library, we need a way to test the dependent modules in CI. (https://github.com/open-telemetry/opentelemetry-log-collection/issues/199)

Having a make target that will identify these modules and help to run tests for those modules might come in handy. I have a PR that aims to fix the above issue (PR - https://github.com/open-telemetry/opentelemetry-log-collection/pull/232), and I am planning to plug in this make target in there.

\cc @djaglowski 