### PR TITLE
awsemf exporter: replace logGroup and logStream pattern with metric labels

### DIFF
--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -151,7 +151,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 			for i := 0; i < metrics.Len(); i++ {
 				metric := metrics.At(i)
-				addToGroupedMetric(&metric, groupedMetrics, metadata, zap.NewNop(), nil, nil)
+				addToGroupedMetric(&metric, groupedMetrics, metadata, true, zap.NewNop(), nil, nil)
 			}
 
 			expectedLabels := map[string]string{
@@ -199,7 +199,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 		for i := 0; i < metrics.Len(); i++ {
 			metric := metrics.At(i)
-			addToGroupedMetric(&metric, groupedMetrics, metadata, logger, nil, nil)
+			addToGroupedMetric(&metric, groupedMetrics, metadata, true, logger, nil, nil)
 		}
 
 		assert.Equal(t, 1, len(groupedMetrics))
@@ -262,7 +262,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 		for i := 0; i < metrics.Len(); i++ {
 			metric := metrics.At(i)
-			addToGroupedMetric(&metric, groupedMetrics, metadata, logger, nil, nil)
+			addToGroupedMetric(&metric, groupedMetrics, metadata, true, logger, nil, nil)
 		}
 
 		assert.Equal(t, 3, len(groupedMetrics))
@@ -309,7 +309,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			},
 			instrumentationLibraryName: instrumentationLibName,
 		}
-		addToGroupedMetric(&metric, groupedMetrics, metricMetadata1, logger, nil, nil)
+		addToGroupedMetric(&metric, groupedMetrics, metricMetadata1, true, logger, nil, nil)
 
 		metricMetadata2 := cWMetricMetadata{
 			groupedMetricMetadata: groupedMetricMetadata{
@@ -320,7 +320,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			},
 			instrumentationLibraryName: instrumentationLibName,
 		}
-		addToGroupedMetric(&metric, groupedMetrics, metricMetadata2, logger, nil, nil)
+		addToGroupedMetric(&metric, groupedMetrics, metricMetadata2, true, logger, nil, nil)
 
 		assert.Equal(t, 2, len(groupedMetrics))
 		seenLogGroup1 := false
@@ -375,7 +375,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 		for i := 0; i < metrics.Len(); i++ {
 			metric := metrics.At(i)
-			addToGroupedMetric(&metric, groupedMetrics, metadata, obsLogger, nil, nil)
+			addToGroupedMetric(&metric, groupedMetrics, metadata, true, obsLogger, nil, nil)
 		}
 		assert.Equal(t, 1, len(groupedMetrics))
 
@@ -408,7 +408,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 		obs, logs := observer.New(zap.WarnLevel)
 		obsLogger := zap.New(obs)
-		addToGroupedMetric(&metric, groupedMetrics, metadata, obsLogger, nil, nil)
+		addToGroupedMetric(&metric, groupedMetrics, metadata, true, obsLogger, nil, nil)
 		assert.Equal(t, 0, len(groupedMetrics))
 
 		// Test output warning logs
@@ -428,7 +428,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 	t.Run("Nil metric", func(t *testing.T) {
 		groupedMetrics := make(map[interface{}]*groupedMetric)
-		addToGroupedMetric(nil, groupedMetrics, metadata, logger, nil, nil)
+		addToGroupedMetric(nil, groupedMetrics, metadata, true, logger, nil, nil)
 		assert.Equal(t, 0, len(groupedMetrics))
 	})
 
@@ -497,7 +497,7 @@ func BenchmarkAddToGroupedMetric(b *testing.B) {
 		groupedMetrics := make(map[interface{}]*groupedMetric)
 		for i := 0; i < numMetrics; i++ {
 			metric := metrics.At(i)
-			addToGroupedMetric(&metric, groupedMetrics, metadata, logger, nil, nil)
+			addToGroupedMetric(&metric, groupedMetrics, metadata, true, logger, nil, nil)
 		}
 	}
 }

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -101,7 +101,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetric
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 	var instrumentationLibName string
 	cWNamespace := getNamespace(rm, config.Namespace)
-	logGroup, logStream := getLogInfo(rm, cWNamespace, config)
+	logGroup, logStream, patternReplaceSucceeded := getLogInfo(rm, cWNamespace, config)
 
 	ilms := rm.InstrumentationLibraryMetrics()
 	var metricReceiver string
@@ -130,7 +130,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetric
 				receiver:                   metricReceiver,
 				metricDataType:             metric.DataType(),
 			}
-			err := addToGroupedMetric(&metric, groupedMetrics, metadata, config.logger, mt.metricDescriptor, config)
+			err := addToGroupedMetric(&metric, groupedMetrics, metadata, patternReplaceSucceeded, config.logger, mt.metricDescriptor, config)
 			if err != nil {
 				return err
 			}

--- a/exporter/awsemfexporter/util.go
+++ b/exporter/awsemfexporter/util.go
@@ -22,6 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/model/pdata"
 	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
+	tracetranslator "go.opentelemetry.io/collector/translator/trace"
 	"go.uber.org/zap"
 )
 
@@ -29,38 +30,42 @@ var patternKeyToAttributeMap = map[string]string{
 	"ClusterName":          "aws.ecs.cluster.name",
 	"TaskId":               "aws.ecs.task.id",
 	"NodeName":             "k8s.node.name",
+	"PodName":              "pod",
 	"ContainerInstanceId":  "aws.ecs.container.instance.id",
 	"TaskDefinitionFamily": "aws.ecs.task.family",
 }
 
-func replacePatterns(s string, attrMap pdata.AttributeMap, logger *zap.Logger) string {
+func replacePatterns(s string, attrMap map[string]string, logger *zap.Logger) (string, bool) {
+	success := true
+	foundAndReplaced := true
 	for key := range patternKeyToAttributeMap {
-		s = replacePatternWithResource(s, key, attrMap, logger)
+		s, foundAndReplaced = replacePatternWithAttrValue(s, key, attrMap, logger)
+		success = success && foundAndReplaced
 	}
-	return s
+	return s, success
 }
 
-func replacePatternWithResource(s, patternKey string, attrMap pdata.AttributeMap, logger *zap.Logger) string {
+func replacePatternWithAttrValue(s, patternKey string, attrMap map[string]string, logger *zap.Logger) (string, bool) {
 	pattern := "{" + patternKey + "}"
 	if strings.Contains(s, pattern) {
-		if value, ok := attrMap.Get(patternKey); ok {
+		if value, ok := attrMap[patternKey]; ok {
 			return replace(s, pattern, value, logger)
-		} else if value, ok := attrMap.Get(patternKeyToAttributeMap[patternKey]); ok {
+		} else if value, ok := attrMap[patternKeyToAttributeMap[patternKey]]; ok {
 			return replace(s, pattern, value, logger)
 		} else {
 			logger.Debug("No resource attribute found for pattern " + pattern)
-			return strings.Replace(s, pattern, "undefined", -1)
+			return strings.Replace(s, pattern, "undefined", -1), false
 		}
 	}
-	return s
+	return s, true
 }
 
-func replace(s, pattern string, value pdata.AttributeValue, logger *zap.Logger) string {
-	if value.StringVal() == "" {
+func replace(s, pattern string, value string, logger *zap.Logger) (string, bool) {
+	if value == "" {
 		logger.Debug("Empty resource attribute value found for pattern " + pattern)
-		return strings.Replace(s, pattern, "undefined", -1)
+		return strings.Replace(s, pattern, "undefined", -1), false
 	}
-	return strings.Replace(s, pattern, value.StringVal(), -1)
+	return strings.Replace(s, pattern, value, -1), true
 }
 
 // getNamespace retrieves namespace for given set of metrics from user config.
@@ -84,20 +89,24 @@ func getNamespace(rm *pdata.ResourceMetrics, namespace string) string {
 }
 
 // getLogInfo retrieves the log group and log stream names from a given set of metrics.
-func getLogInfo(rm *pdata.ResourceMetrics, cWNamespace string, config *Config) (logGroup, logStream string) {
+func getLogInfo(rm *pdata.ResourceMetrics, cWNamespace string, config *Config) (string, string, bool) {
+	var logGroup, logStream string
+	groupReplaced := true
+	streamReplaced := true
+
 	if cWNamespace != "" {
 		logGroup = fmt.Sprintf("/metrics/%s", cWNamespace)
 	}
 
 	// Override log group/stream if specified in config. However, in this case, customer won't have correlation experience
 	if len(config.LogGroupName) > 0 {
-		logGroup = replacePatterns(config.LogGroupName, rm.Resource().Attributes(), config.logger)
+		logGroup, groupReplaced = replacePatterns(config.LogGroupName, attrMaptoStringMap(rm.Resource().Attributes()), config.logger)
 	}
 	if len(config.LogStreamName) > 0 {
-		logStream = replacePatterns(config.LogStreamName, rm.Resource().Attributes(), config.logger)
+		logStream, streamReplaced = replacePatterns(config.LogStreamName, attrMaptoStringMap(rm.Resource().Attributes()), config.logger)
 	}
 
-	return
+	return logGroup, logStream, (groupReplaced && streamReplaced)
 }
 
 // dedupDimensions removes duplicated dimension sets from the given dimensions.
@@ -155,4 +164,15 @@ func dimensionRollup(dimensionRollupOption string, labels map[string]string) [][
 // unixNanoToMilliseconds converts a timestamp in nanoseconds to milliseconds.
 func unixNanoToMilliseconds(timestamp pdata.Timestamp) int64 {
 	return int64(uint64(timestamp) / uint64(time.Millisecond))
+}
+
+// attrMaptoStringMap converts a pdata.AttributeMap to a map[string]string
+func attrMaptoStringMap(attrMap pdata.AttributeMap) map[string]string {
+	strMap := make(map[string]string, attrMap.Len())
+
+	attrMap.Range(func(k string, v pdata.AttributeValue) bool {
+		strMap[k] = tracetranslator.AttributeValueToString(v)
+		return true
+	})
+	return strMap
 }

--- a/exporter/awsemfexporter/util.go
+++ b/exporter/awsemfexporter/util.go
@@ -37,7 +37,7 @@ var patternKeyToAttributeMap = map[string]string{
 
 func replacePatterns(s string, attrMap map[string]string, logger *zap.Logger) (string, bool) {
 	success := true
-	foundAndReplaced := true
+	var foundAndReplaced bool
 	for key := range patternKeyToAttributeMap {
 		s, foundAndReplaced = replacePatternWithAttrValue(s, key, attrMap, logger)
 		success = success && foundAndReplaced

--- a/exporter/awsemfexporter/util.go
+++ b/exporter/awsemfexporter/util.go
@@ -98,12 +98,14 @@ func getLogInfo(rm *pdata.ResourceMetrics, cWNamespace string, config *Config) (
 		logGroup = fmt.Sprintf("/metrics/%s", cWNamespace)
 	}
 
+	strAttributeMap := attrMaptoStringMap(rm.Resource().Attributes())
+
 	// Override log group/stream if specified in config. However, in this case, customer won't have correlation experience
 	if len(config.LogGroupName) > 0 {
-		logGroup, groupReplaced = replacePatterns(config.LogGroupName, attrMaptoStringMap(rm.Resource().Attributes()), config.logger)
+		logGroup, groupReplaced = replacePatterns(config.LogGroupName, strAttributeMap, config.logger)
 	}
 	if len(config.LogStreamName) > 0 {
-		logStream, streamReplaced = replacePatterns(config.LogStreamName, attrMaptoStringMap(rm.Resource().Attributes()), config.logger)
+		logStream, streamReplaced = replacePatterns(config.LogStreamName, strAttributeMap, config.logger)
 	}
 
 	return logGroup, logStream, (groupReplaced && streamReplaced)


### PR DESCRIPTION
Signed-off-by: Rayhan Hossain <hossain.rayhan@outlook.com>

**Description:** 
This is a requirement for EKS Fargate Container Insights.

In the AWS EMF exporter config, customers can use some patterns in the logGroup and logStream name. Those pattern supports a specific set of keys like `{ClusterName}`, `{NodeName}`, `{TaskId}` etc. The exporter automatically looks into resource attributes and replaces those patterns with real values. However, for EKS Fargate Container Insights customers, we need to support the pattern key `PodName` which comes from metric labels not from resource attributes. This PR will add support for adding a new key `PodName` and looking for keys in the metric labels. 

**Issue:** #4465 

**Will it break any existing behavior?**
No.

**What would be the new behavior?**
It will still look for the keys from resource attributes. However, if some keys cannot be found in the resource attributes, it will look into metric labels for them.


**Testing:** Unit tests added.

**Documentation:** Added proper comments.