### PR TITLE
add container endpoint type

### DIFF
--- a/extension/observer/endpoints.go
+++ b/extension/observer/endpoints.go
@@ -35,12 +35,15 @@ const (
 	PodType EndpointType = "pod"
 	// HostPortType is a hostport endpoint.
 	HostPortType EndpointType = "hostport"
+	// Container is a container endpoint.
+	ContainerType EndpointType = "container"
 )
 
 var (
 	_ EndpointDetails = (*Pod)(nil)
 	_ EndpointDetails = (*Port)(nil)
 	_ EndpointDetails = (*HostPort)(nil)
+	_ EndpointDetails = (*Container)(nil)
 )
 
 // EndpointDetails provides additional context about an endpoint such as a Pod or Port.
@@ -157,4 +160,45 @@ func (h *HostPort) Env() EndpointEnv {
 
 func (h *HostPort) Type() EndpointType {
 	return HostPortType
+}
+
+// Container is a discovered container
+type Container struct {
+	// Name is the primary name of the container
+	Name string
+	// Image is the name of the container image
+	Image string
+	// Port is the exposed port of container
+	Port uint16
+	// AlternatePort is the exposed port accessed through some kind of redirection,
+	// such as Docker port redirection
+	AlternatePort uint16
+	// Command used to invoke the process using the Endpoint.
+	Command string
+	// ContainerID is the id of the container exposing the Endpoint.
+	ContainerID string
+	// Host is the hostname/ip address of the Endpoint.
+	Host string
+	// Transport is the transport protocol used by the Endpoint. (TCP or UDP).
+	Transport Transport
+	// Labels is a map of user-specified metadata on the container.
+	Labels map[string]string
+}
+
+func (c *Container) Env() EndpointEnv {
+	return map[string]interface{}{
+		"name":           c.Name,
+		"image":          c.Image,
+		"port":           c.Port,
+		"alternate_port": c.AlternatePort,
+		"command":        c.Command,
+		"container_id":   c.ContainerID,
+		"host":           c.Host,
+		"transport":      c.Transport,
+		"labels":         c.Labels,
+	}
+}
+
+func (c *Container) Type() EndpointType {
+	return ContainerType
 }

--- a/extension/observer/endpoints_test.go
+++ b/extension/observer/endpoints_test.go
@@ -124,6 +124,42 @@ func TestEndpointEnv(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Container",
+			endpoint: Endpoint{
+				ID:     EndpointID("container_endpoint_id"),
+				Target: "127.0.0.1",
+				Details: &Container{
+					Name:          "otel-collector",
+					Image:         "otel-collector-image",
+					Port:          2379,
+					AlternatePort: 2380,
+					Command:       "./cmd --config config.yaml",
+					ContainerID:   "abcdefg123456",
+					Host:          "127.0.0.1",
+					Transport:     ProtocolTCP,
+					Labels: map[string]string{
+						"label_key": "label_val",
+					},
+				},
+			},
+			want: EndpointEnv{
+				"type":           "container",
+				"name":           "otel-collector",
+				"image":          "otel-collector-image",
+				"port":           uint16(2379),
+				"alternate_port": uint16(2380),
+				"command":        "./cmd --config config.yaml",
+				"container_id":   "abcdefg123456",
+				"host":           "127.0.0.1",
+				"transport":      ProtocolTCP,
+				"labels": map[string]string{
+					"label_key": "label_val",
+				},
+				"endpoint": "127.0.0.1",
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:** This PR adds a new `container` endpoint type to be consumed (currently only by) the receiver creator. This will be used in the future by the docker observer, but is generic enough to be used by a future different container observer.

**Link to tracking Issue:** #4446 

**Testing:** Added a container endpoint test to the existing test

**Documentation:** Currently not in use, but documentation will be added to the `receiver_creator` in a separate PR when it gets enabled in that receiver. 