### PR TITLE
dynatraceexporter: update labels to attributes

### DIFF
--- a/exporter/dynatraceexporter/serialization/serialization.go
+++ b/exporter/dynatraceexporter/serialization/serialization.go
@@ -44,7 +44,7 @@ func SerializeNumberDataPoints(name string, data pdata.NumberDataPointSlice, tag
 		case pdata.MetricValueTypeInt:
 			val = strconv.FormatInt(p.IntVal(), 10)
 		}
-		output = append(output, serializeLine(name, serializeTags(p.LabelsMap(), tags), val, p.Timestamp()))
+		output = append(output, serializeLine(name, serializeTags(p.Attributes(), tags), val, p.Timestamp()))
 	}
 
 	return output
@@ -58,7 +58,7 @@ func SerializeHistogramMetrics(name string, data pdata.HistogramDataPointSlice, 
 	output := []string{}
 	for i := 0; i < data.Len(); i++ {
 		p := data.At(i)
-		tagline := serializeTags(p.LabelsMap(), tags)
+		tagline := serializeTags(p.Attributes(), tags)
 		if p.Count() == 0 {
 			return []string{}
 		}
@@ -87,14 +87,14 @@ func serializeLine(name, tagline, valueline string, timestamp pdata.Timestamp) s
 	return output
 }
 
-func serializeTags(labels pdata.StringMap, exporterTags []string) string {
+func serializeTags(labels pdata.AttributeMap, exporterTags []string) string {
 	tags := append([]string{}, exporterTags...)
-	labels.Range(func(k string, v string) bool {
+	labels.Range(func(k string, v pdata.AttributeValue) bool {
 		key, err := NormalizeString(strings.ToLower(k), maxDimKeyLen)
 		if err != nil {
 			return true
 		}
-		value := escapeDimension(v)
+		value := escapeDimension(v.StringVal()) // TODO(codeboten): Fix as part of https://github.com/open-telemetry/opentelemetry-collector/issues/3815
 		tag := key + "=" + value
 		tags = append(tags, tag)
 		return true

--- a/exporter/dynatraceexporter/serialization/serialization_test.go
+++ b/exporter/dynatraceexporter/serialization/serialization_test.go
@@ -39,13 +39,13 @@ func TestSerializeIntDataPoints(t *testing.T) {
 	labelIntPoint := labelIntSlice.AppendEmpty()
 	labelIntPoint.SetIntVal(13)
 	labelIntPoint.SetTimestamp(pdata.Timestamp(100_000_000))
-	labelIntPoint.LabelsMap().Insert("labelKey", "labelValue")
+	labelIntPoint.Attributes().InsertString("labelKey", "labelValue")
 
 	emptyLabelIntSlice := pdata.NewNumberDataPointSlice()
 	emptyLabelIntPoint := emptyLabelIntSlice.AppendEmpty()
 	emptyLabelIntPoint.SetIntVal(13)
 	emptyLabelIntPoint.SetTimestamp(pdata.Timestamp(100_000_000))
-	emptyLabelIntPoint.LabelsMap().Insert("emptyLabelKey", "")
+	emptyLabelIntPoint.Attributes().InsertString("emptyLabelKey", "")
 
 	tests := []struct {
 		name string
@@ -108,7 +108,7 @@ func TestSerializeDoubleDataPoints(t *testing.T) {
 	labelDoublePoint := labelDoubleSlice.AppendEmpty()
 	labelDoublePoint.SetDoubleVal(13.1)
 	labelDoublePoint.SetTimestamp(pdata.Timestamp(100_000_000))
-	labelDoublePoint.LabelsMap().Insert("labelKey", "labelValue")
+	labelDoublePoint.Attributes().InsertString("labelKey", "labelValue")
 
 	type args struct {
 		name string
@@ -169,7 +169,7 @@ func TestSerializeHistogramMetrics(t *testing.T) {
 	labelDoubleHistPoint.SetCount(10)
 	labelDoubleHistPoint.SetSum(101.0)
 	labelDoubleHistPoint.SetTimestamp(pdata.Timestamp(100_000_000))
-	labelDoubleHistPoint.LabelsMap().Insert("labelKey", "labelValue")
+	labelDoubleHistPoint.Attributes().InsertString("labelKey", "labelValue")
 
 	zeroHistogramSlice := pdata.NewHistogramDataPointSlice()
 	zeroHistogramDataPoint := zeroHistogramSlice.AppendEmpty()
@@ -262,7 +262,7 @@ func Test_serializeLine(t *testing.T) {
 
 func Test_serializeTags(t *testing.T) {
 	type args struct {
-		labels       pdata.StringMap
+		attributes   pdata.AttributeMap
 		exporterTags []string
 	}
 	tests := []struct {
@@ -271,39 +271,39 @@ func Test_serializeTags(t *testing.T) {
 		want string
 	}{
 		{
-			name: "No labels or tags",
-			args: args{labels: pdata.NewStringMap()},
+			name: "No attributes or tags",
+			args: args{attributes: pdata.NewAttributeMap()},
 			want: "",
 		},
 		{
-			name: "Labels with no tags",
-			args: args{labels: pdata.NewStringMap().InitFromMap(map[string]string{"test": "value"})},
+			name: "Attributes with no tags",
+			args: args{attributes: pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{"test": pdata.NewAttributeValueString("value")})},
 			want: "test=\"value\"",
 		},
 		{
-			name: "Tags with no labels",
-			args: args{labels: pdata.NewStringMap(), exporterTags: []string{"tag=value"}},
+			name: "Tags with no attributes",
+			args: args{attributes: pdata.NewAttributeMap(), exporterTags: []string{"tag=value"}},
 			want: "tag=value",
 		},
 		{
-			name: "Tags and labels",
-			args: args{labels: pdata.NewStringMap().InitFromMap(map[string]string{"test": "value"}), exporterTags: []string{"tag=value"}},
+			name: "Tags and attributes",
+			args: args{attributes: pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{"test": pdata.NewAttributeValueString("value")}), exporterTags: []string{"tag=value"}},
 			want: "tag=value,test=\"value\"",
 		},
 		{
 			name: "Invalid tags",
-			args: args{labels: pdata.NewStringMap().InitFromMap(map[string]string{"_": "value"}), exporterTags: []string{"tag=value"}},
+			args: args{attributes: pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{"_": pdata.NewAttributeValueString("value")}), exporterTags: []string{"tag=value"}},
 			want: "tag=value",
 		},
 		{
 			name: "Tag with trailing _",
-			args: args{labels: pdata.NewStringMap().InitFromMap(map[string]string{"test__": "value"}), exporterTags: []string{"tag=value"}},
+			args: args{attributes: pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{"test__": pdata.NewAttributeValueString("value")}), exporterTags: []string{"tag=value"}},
 			want: "tag=value,test=\"value\"",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := serializeTags(tt.args.labels, tt.args.exporterTags); got != tt.want {
+			if got := serializeTags(tt.args.attributes, tt.args.exporterTags); got != tt.want {
 				t.Errorf("serializeTags() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
**Description:**
Following the changes in core to OTLP 0.9.0 to move away from `Labels` and on to `Attributes`

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3535