### PR TITLE
[exporter/signalfx] add process metric to translation rules

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -154,6 +154,7 @@ The translation rules defined in [`translation/constants.go`](./internal/transla
 * memory.total
 * memory.utilization
 * network.total
+* process.cpu_time_seconds
 * system.disk.io.total
 * system.disk.operations.total
 * system.network.io.total

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -380,6 +380,21 @@ translation_rules:
     major: vmpage_io.swap.out
     minor: vmpage_io.memory.out
 
+# process metric
+- action: copy_metrics
+  mapping:
+    process.cpu.time: sf_temp.process.cpu.time
+  dimension_key: state
+  dimension_values:
+    user: true
+    system: true
+
+- action: aggregate_metric
+  metric_name: sf_temp.process.cpu.time
+  aggregation_method: sum
+  without_dimensions:
+  - state
+
 - action: rename_metrics
   mapping:
     sf_temp.container_cpu_utilization: container_cpu_utilization
@@ -402,6 +417,7 @@ translation_rules:
     sf_temp.system.disk.operations.total: system.disk.operations.total
     sf_temp.system.network.io.total: system.network.io.total
     sf_temp.system.network.packets.total: system.network.packets.total
+    sf_temp.process.cpu.time: process.cpu_time_seconds
 
 # remove redundant metrics
 - action: drop_metrics


### PR DESCRIPTION
**Description:** Adding an additional translation rule to to create the `cpu.process_time_seconds` metric for parity with signalfx-agent. This metric is calculated from the `cpu.time.seconds` metric by aggregating on the `state: [user, system]` dimension.

**Documentation:** Appended the metric to the note in the README that this metric is calculated.