### PR TITLE
redisreceiver: update labels -> attributes

### DIFF
--- a/receiver/redisreceiver/metric_functions.go
+++ b/receiver/redisreceiver/metric_functions.go
@@ -90,7 +90,7 @@ func usedCPUSys() *redisMetric {
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeDouble,
 		isMonotonic: true,
-		labels:      map[string]string{"state": "sys"},
+		labels:      map[string]pdata.AttributeValue{"state": pdata.NewAttributeValueString("sys")},
 		desc:        "System CPU consumed by the Redis server in seconds since server start",
 	}
 }
@@ -103,7 +103,7 @@ func usedCPUUser() *redisMetric {
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeDouble,
 		isMonotonic: true,
-		labels:      map[string]string{"state": "user"},
+		labels:      map[string]pdata.AttributeValue{"state": pdata.NewAttributeValueString("user")},
 		desc:        "User CPU consumed by the Redis server in seconds since server start",
 	}
 }
@@ -116,7 +116,7 @@ func usedCPUSysChildren() *redisMetric {
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeDouble,
 		isMonotonic: true,
-		labels:      map[string]string{"state": "children"},
+		labels:      map[string]pdata.AttributeValue{"state": pdata.NewAttributeValueString("children")},
 		desc:        "User CPU consumed by the background processes in seconds since server start",
 	}
 }

--- a/receiver/redisreceiver/pdata.go
+++ b/receiver/redisreceiver/pdata.go
@@ -30,7 +30,7 @@ func buildKeyspaceTriplet(k *keyspace, t *timeBundle) pdata.MetricSlice {
 func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
 		name:   "redis/db/keys",
-		labels: map[string]string{"db": k.db},
+		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
 	}
 	initIntMetric(m, int64(k.keys), t, dest)
@@ -39,7 +39,7 @@ func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 func initKeyspaceExpiresMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
 		name:   "redis/db/expires",
-		labels: map[string]string{"db": k.db},
+		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
 	}
 	initIntMetric(m, int64(k.expires), t, dest)
@@ -49,7 +49,7 @@ func initKeyspaceTTLMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
 		name:   "redis/db/avg_ttl",
 		units:  "ms",
-		labels: map[string]string{"db": k.db},
+		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
 	}
 	initIntMetric(m, int64(k.avgTTL), t, dest)
@@ -70,7 +70,7 @@ func initIntMetric(m *redisMetric, value int64, t *timeBundle, dest pdata.Metric
 	}
 	pt.SetIntVal(value)
 	pt.SetTimestamp(pdata.TimestampFromTime(t.current))
-	pt.LabelsMap().InitFromMap(m.labels)
+	pt.Attributes().InitFromMap(m.labels)
 }
 
 func initDoubleMetric(m *redisMetric, value float64, t *timeBundle, dest pdata.Metric) {
@@ -88,7 +88,7 @@ func initDoubleMetric(m *redisMetric, value float64, t *timeBundle, dest pdata.M
 	}
 	pt.SetDoubleVal(value)
 	pt.SetTimestamp(pdata.TimestampFromTime(t.current))
-	pt.LabelsMap().InitFromMap(m.labels)
+	pt.Attributes().InitFromMap(m.labels)
 }
 
 func redisMetricToPDM(m *redisMetric, dest pdata.Metric) {

--- a/receiver/redisreceiver/pdata_test.go
+++ b/receiver/redisreceiver/pdata_test.go
@@ -104,14 +104,15 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, 6, ms.Len())
 
 	const lblKey = "db"
-	const lblVal = "0"
 	const name1 = "redis/db/keys"
+
+	lblVal := pdata.NewAttributeValueString("0")
 
 	pdm := ms.At(0)
 	assert.Equal(t, name1, pdm.Name())
 	dps := pdm.Gauge().DataPoints()
 	pt := dps.At(0)
-	v, ok := pt.LabelsMap().Get(lblKey)
+	v, ok := pt.Attributes().Get(lblKey)
 	assert.True(t, ok)
 	assert.Equal(t, lblVal, v)
 	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
@@ -123,7 +124,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, name2, pdm.Name())
 	dps = pdm.Gauge().DataPoints()
 	pt = dps.At(0)
-	v, ok = pt.LabelsMap().Get(lblKey)
+	v, ok = pt.Attributes().Get(lblKey)
 	assert.True(t, ok)
 	assert.Equal(t, lblVal, v)
 	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
@@ -135,7 +136,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, name3, pdm.Name())
 	dps = pdm.Gauge().DataPoints()
 	pt = dps.At(0)
-	v, ok = pt.LabelsMap().Get(lblKey)
+	v, ok = pt.Attributes().Get(lblKey)
 	assert.True(t, ok)
 	assert.Equal(t, lblVal, v)
 	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())

--- a/receiver/redisreceiver/redis_metric.go
+++ b/receiver/redisreceiver/redis_metric.go
@@ -27,7 +27,7 @@ type redisMetric struct {
 	name        string
 	units       string
 	desc        string
-	labels      map[string]string
+	labels      map[string]pdata.AttributeValue
 	pdType      pdata.MetricDataType
 	valueType   pdata.MetricValueType
 	isMonotonic bool

--- a/receiver/redisreceiver/redis_metric_test.go
+++ b/receiver/redisreceiver/redis_metric_test.go
@@ -41,12 +41,12 @@ func TestParseMetric_Labels(t *testing.T) {
 	require.NoError(t, err)
 
 	pt := pdm.Sum().DataPoints().At(0)
-	labelsMap := pt.LabelsMap()
-	l := labelsMap.Len()
+	attributesMap := pt.Attributes()
+	l := attributesMap.Len()
 	assert.Equal(t, 1, l)
-	state, ok := labelsMap.Get("state")
+	state, ok := attributesMap.Get("state")
 	assert.True(t, ok)
-	assert.Equal(t, "sys", state)
+	assert.Equal(t, "sys", state.StringVal())
 }
 
 func TestParseMetric_Errors(t *testing.T) {


### PR DESCRIPTION
**Description:**
Following the changes in core to OTLP 0.9.0 to move away from `Labels` and on to `Attributes`

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3535