### PR TITLE
signalfxexporter: update labels -> attributes

### DIFF
--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -124,9 +124,9 @@ func TestConsumeMetrics(t *testing.T) {
 	m.SetName("test_gauge")
 	m.SetDataType(pdata.MetricDataTypeGauge)
 	dp := m.Gauge().DataPoints().AppendEmpty()
-	dp.LabelsMap().InitFromMap(map[string]string{
-		"k0": "v0",
-		"k1": "v1",
+	dp.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"k0": pdata.NewAttributeValueString("v0"),
+		"k1": pdata.NewAttributeValueString("v1"),
 	})
 	dp.SetDoubleVal(123)
 
@@ -260,9 +260,9 @@ func TestConsumeMetricsWithAccessTokenPassthrough(t *testing.T) {
 		m.SetDataType(pdata.MetricDataTypeGauge)
 
 		dp := m.Gauge().DataPoints().AppendEmpty()
-		dp.LabelsMap().InitFromMap(map[string]string{
-			"k0": "v0",
-			"k1": "v1",
+		dp.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+			"k0": pdata.NewAttributeValueString("v0"),
+			"k1": pdata.NewAttributeValueString("v1"),
 		})
 		dp.SetDoubleVal(123)
 		return out
@@ -325,9 +325,9 @@ func TestConsumeMetricsWithAccessTokenPassthrough(t *testing.T) {
 				m.SetName("test_gauge")
 				m.SetDataType(pdata.MetricDataTypeGauge)
 				dp := m.Gauge().DataPoints().AppendEmpty()
-				dp.LabelsMap().InitFromMap(map[string]string{
-					"k0": "v0",
-					"k1": "v1",
+				dp.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+					"k0": pdata.NewAttributeValueString("v0"),
+					"k1": pdata.NewAttributeValueString("v1"),
 				})
 				dp.SetDoubleVal(123)
 
@@ -708,9 +708,9 @@ func generateLargeDPBatch() pdata.Metrics {
 
 		dp := m.Gauge().DataPoints().AppendEmpty()
 		dp.SetTimestamp(pdata.TimestampFromTime(ts))
-		dp.LabelsMap().InitFromMap(map[string]string{
-			"k0": "v0",
-			"k1": "v1",
+		dp.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+			"k0": pdata.NewAttributeValueString("v0"),
+			"k1": pdata.NewAttributeValueString("v1"),
 		})
 		dp.SetIntVal(int64(i))
 	}

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -310,20 +310,20 @@ func testMetricsData() pdata.ResourceMetrics {
 	m1.SetUnit("bytes")
 	m1.SetDataType(pdata.MetricDataTypeGauge)
 	dp11 := m1.Gauge().DataPoints().AppendEmpty()
-	dp11.LabelsMap().InitFromMap(map[string]string{
-		"state":              "used",
-		"host":               "host0",
-		"kubernetes_node":    "node0",
-		"kubernetes_cluster": "cluster0",
+	dp11.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"state":              pdata.NewAttributeValueString("used"),
+		"host":               pdata.NewAttributeValueString("host0"),
+		"kubernetes_node":    pdata.NewAttributeValueString("node0"),
+		"kubernetes_cluster": pdata.NewAttributeValueString("cluster0"),
 	}).Sort()
 	dp11.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp11.SetIntVal(4e9)
 	dp12 := m1.Gauge().DataPoints().AppendEmpty()
-	dp12.LabelsMap().InitFromMap(map[string]string{
-		"state":              "free",
-		"host":               "host0",
-		"kubernetes_node":    "node0",
-		"kubernetes_cluster": "cluster0",
+	dp12.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"state":              pdata.NewAttributeValueString("free"),
+		"host":               pdata.NewAttributeValueString("host0"),
+		"kubernetes_node":    pdata.NewAttributeValueString("node0"),
+		"kubernetes_cluster": pdata.NewAttributeValueString("cluster0"),
 	}).Sort()
 	dp12.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp12.SetIntVal(6e9)
@@ -335,34 +335,34 @@ func testMetricsData() pdata.ResourceMetrics {
 	m2.Sum().SetIsMonotonic(true)
 	m2.Sum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 	dp21 := m2.Sum().DataPoints().AppendEmpty()
-	dp21.LabelsMap().InitFromMap(map[string]string{
-		"host":      "host0",
-		"direction": "read",
-		"device":    "sda1",
+	dp21.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":      pdata.NewAttributeValueString("host0"),
+		"direction": pdata.NewAttributeValueString("read"),
+		"device":    pdata.NewAttributeValueString("sda1"),
 	}).Sort()
 	dp21.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp21.SetIntVal(1e9)
 	dp22 := m2.Sum().DataPoints().AppendEmpty()
-	dp22.LabelsMap().InitFromMap(map[string]string{
-		"host":      "host0",
-		"direction": "read",
-		"device":    "sda2",
+	dp22.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":      pdata.NewAttributeValueString("host0"),
+		"direction": pdata.NewAttributeValueString("read"),
+		"device":    pdata.NewAttributeValueString("sda2"),
 	}).Sort()
 	dp22.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp22.SetIntVal(2e9)
 	dp23 := m2.Sum().DataPoints().AppendEmpty()
-	dp23.LabelsMap().InitFromMap(map[string]string{
-		"host":      "host0",
-		"direction": "write",
-		"device":    "sda1",
+	dp23.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":      pdata.NewAttributeValueString("host0"),
+		"direction": pdata.NewAttributeValueString("write"),
+		"device":    pdata.NewAttributeValueString("sda1"),
 	}).Sort()
 	dp23.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp23.SetIntVal(3e9)
 	dp24 := m2.Sum().DataPoints().AppendEmpty()
-	dp24.LabelsMap().InitFromMap(map[string]string{
-		"host":      "host0",
-		"direction": "write",
-		"device":    "sda2",
+	dp24.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":      pdata.NewAttributeValueString("host0"),
+		"direction": pdata.NewAttributeValueString("write"),
+		"device":    pdata.NewAttributeValueString("sda2"),
 	}).Sort()
 	dp24.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp24.SetIntVal(8e9)
@@ -375,34 +375,34 @@ func testMetricsData() pdata.ResourceMetrics {
 	m3.Sum().SetIsMonotonic(true)
 	m3.Sum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 	dp31 := m3.Sum().DataPoints().AppendEmpty()
-	dp31.LabelsMap().InitFromMap(map[string]string{
-		"host":      "host0",
-		"direction": "read",
-		"device":    "sda1",
+	dp31.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":      pdata.NewAttributeValueString("host0"),
+		"direction": pdata.NewAttributeValueString("read"),
+		"device":    pdata.NewAttributeValueString("sda1"),
 	}).Sort()
 	dp31.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp31.SetIntVal(4e3)
 	dp32 := m3.Sum().DataPoints().AppendEmpty()
-	dp32.LabelsMap().InitFromMap(map[string]string{
-		"host":      "host0",
-		"direction": "read",
-		"device":    "sda2",
+	dp32.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":      pdata.NewAttributeValueString("host0"),
+		"direction": pdata.NewAttributeValueString("read"),
+		"device":    pdata.NewAttributeValueString("sda2"),
 	}).Sort()
 	dp32.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp32.SetIntVal(6e3)
 	dp33 := m3.Sum().DataPoints().AppendEmpty()
-	dp33.LabelsMap().InitFromMap(map[string]string{
-		"host":      "host0",
-		"direction": "write",
-		"device":    "sda1",
+	dp33.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":      pdata.NewAttributeValueString("host0"),
+		"direction": pdata.NewAttributeValueString("write"),
+		"device":    pdata.NewAttributeValueString("sda1"),
 	}).Sort()
 	dp33.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp33.SetIntVal(1e3)
 	dp34 := m3.Sum().DataPoints().AppendEmpty()
-	dp34.LabelsMap().InitFromMap(map[string]string{
-		"host":      "host0",
-		"direction": "write",
-		"device":    "sda2",
+	dp34.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":      pdata.NewAttributeValueString("host0"),
+		"direction": pdata.NewAttributeValueString("write"),
+		"device":    pdata.NewAttributeValueString("sda2"),
 	}).Sort()
 	dp34.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp34.SetIntVal(5e3)
@@ -415,34 +415,34 @@ func testMetricsData() pdata.ResourceMetrics {
 	m4.Sum().SetIsMonotonic(true)
 	m4.Sum().SetAggregationTemporality(pdata.AggregationTemporalityCumulative)
 	dp41 := m4.Sum().DataPoints().AppendEmpty()
-	dp41.LabelsMap().InitFromMap(map[string]string{
-		"device":    "sda1",
-		"direction": "read",
-		"host":      "host0",
+	dp41.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"device":    pdata.NewAttributeValueString("sda1"),
+		"direction": pdata.NewAttributeValueString("read"),
+		"host":      pdata.NewAttributeValueString("host0"),
 	}).Sort()
 	dp41.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000060, 0)))
 	dp41.SetIntVal(6e3)
 	dp42 := m4.Sum().DataPoints().AppendEmpty()
-	dp42.LabelsMap().InitFromMap(map[string]string{
-		"device":    "sda2",
-		"direction": "read",
-		"host":      "host0",
+	dp42.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"device":    pdata.NewAttributeValueString("sda2"),
+		"direction": pdata.NewAttributeValueString("read"),
+		"host":      pdata.NewAttributeValueString("host0"),
 	}).Sort()
 	dp42.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000060, 0)))
 	dp42.SetIntVal(8e3)
 	dp43 := m4.Sum().DataPoints().AppendEmpty()
-	dp43.LabelsMap().InitFromMap(map[string]string{
-		"device":    "sda1",
-		"direction": "write",
-		"host":      "host0",
+	dp43.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"device":    pdata.NewAttributeValueString("sda1"),
+		"direction": pdata.NewAttributeValueString("write"),
+		"host":      pdata.NewAttributeValueString("host0"),
 	}).Sort()
 	dp43.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000060, 0)))
 	dp43.SetIntVal(3e3)
 	dp44 := m4.Sum().DataPoints().AppendEmpty()
-	dp44.LabelsMap().InitFromMap(map[string]string{
-		"device":    "sda2",
-		"direction": "write",
-		"host":      "host0",
+	dp44.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"device":    pdata.NewAttributeValueString("sda2"),
+		"direction": pdata.NewAttributeValueString("write"),
+		"host":      pdata.NewAttributeValueString("host0"),
 	}).Sort()
 	dp44.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000060, 0)))
 	dp44.SetIntVal(7e3)
@@ -453,22 +453,22 @@ func testMetricsData() pdata.ResourceMetrics {
 	m5.SetUnit("bytes")
 	m5.SetDataType(pdata.MetricDataTypeGauge)
 	dp51 := m5.Gauge().DataPoints().AppendEmpty()
-	dp51.LabelsMap().InitFromMap(map[string]string{
-		"direction":          "receive",
-		"device":             "eth0",
-		"host":               "host0",
-		"kubernetes_node":    "node0",
-		"kubernetes_cluster": "cluster0",
+	dp51.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"direction":          pdata.NewAttributeValueString("receive"),
+		"device":             pdata.NewAttributeValueString("eth0"),
+		"host":               pdata.NewAttributeValueString("host0"),
+		"kubernetes_node":    pdata.NewAttributeValueString("node0"),
+		"kubernetes_cluster": pdata.NewAttributeValueString("cluster0"),
 	}).Sort()
 	dp51.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp51.SetIntVal(4e9)
 	dp52 := m5.Gauge().DataPoints().AppendEmpty()
-	dp52.LabelsMap().InitFromMap(map[string]string{
-		"direction":          "transmit",
-		"device":             "eth0",
-		"host":               "host0",
-		"kubernetes_node":    "node0",
-		"kubernetes_cluster": "cluster0",
+	dp52.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"direction":          pdata.NewAttributeValueString("transmit"),
+		"device":             pdata.NewAttributeValueString("eth0"),
+		"host":               pdata.NewAttributeValueString("host0"),
+		"kubernetes_node":    pdata.NewAttributeValueString("node0"),
+		"kubernetes_cluster": pdata.NewAttributeValueString("cluster0"),
 	}).Sort()
 	dp52.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp52.SetIntVal(6e9)
@@ -478,22 +478,22 @@ func testMetricsData() pdata.ResourceMetrics {
 	m6.SetDescription("The number of packets transferred")
 	m6.SetDataType(pdata.MetricDataTypeGauge)
 	dp61 := m6.Gauge().DataPoints().AppendEmpty()
-	dp61.LabelsMap().InitFromMap(map[string]string{
-		"direction":          "receive",
-		"device":             "eth0",
-		"host":               "host0",
-		"kubernetes_node":    "node0",
-		"kubernetes_cluster": "cluster0",
+	dp61.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"direction":          pdata.NewAttributeValueString("receive"),
+		"device":             pdata.NewAttributeValueString("eth0"),
+		"host":               pdata.NewAttributeValueString("host0"),
+		"kubernetes_node":    pdata.NewAttributeValueString("node0"),
+		"kubernetes_cluster": pdata.NewAttributeValueString("cluster0"),
 	}).Sort()
 	dp61.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp61.SetIntVal(200)
 	dp62 := m6.Gauge().DataPoints().AppendEmpty()
-	dp62.LabelsMap().InitFromMap(map[string]string{
-		"direction":          "receive",
-		"device":             "eth1",
-		"host":               "host0",
-		"kubernetes_node":    "node0",
-		"kubernetes_cluster": "cluster0",
+	dp62.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"direction":          pdata.NewAttributeValueString("receive"),
+		"device":             pdata.NewAttributeValueString("eth1"),
+		"host":               pdata.NewAttributeValueString("host0"),
+		"kubernetes_node":    pdata.NewAttributeValueString("node0"),
+		"kubernetes_cluster": pdata.NewAttributeValueString("cluster0"),
 	}).Sort()
 	dp62.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp62.SetIntVal(150)
@@ -503,10 +503,10 @@ func testMetricsData() pdata.ResourceMetrics {
 	m7.SetUnit("bytes")
 	m7.SetDataType(pdata.MetricDataTypeGauge)
 	dp71 := m7.Gauge().DataPoints().AppendEmpty()
-	dp71.LabelsMap().InitFromMap(map[string]string{
-		"host":               "host0",
-		"kubernetes_node":    "node0",
-		"kubernetes_cluster": "cluster0",
+	dp71.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":               pdata.NewAttributeValueString("host0"),
+		"kubernetes_node":    pdata.NewAttributeValueString("node0"),
+		"kubernetes_cluster": pdata.NewAttributeValueString("cluster0"),
 	}).Sort()
 	dp71.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp71.SetIntVal(1000)
@@ -515,10 +515,10 @@ func testMetricsData() pdata.ResourceMetrics {
 	m8.SetName("container.memory.page_faults")
 	m8.SetDataType(pdata.MetricDataTypeGauge)
 	dp81 := m8.Gauge().DataPoints().AppendEmpty()
-	dp81.LabelsMap().InitFromMap(map[string]string{
-		"host":               "host0",
-		"kubernetes_node":    "node0",
-		"kubernetes_cluster": "cluster0",
+	dp81.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":               pdata.NewAttributeValueString("host0"),
+		"kubernetes_node":    pdata.NewAttributeValueString("node0"),
+		"kubernetes_cluster": pdata.NewAttributeValueString("cluster0"),
 	}).Sort()
 	dp81.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp81.SetIntVal(1000)
@@ -527,10 +527,10 @@ func testMetricsData() pdata.ResourceMetrics {
 	m9.SetName("container.memory.major_page_faults")
 	m9.SetDataType(pdata.MetricDataTypeGauge)
 	dp91 := m9.Gauge().DataPoints().AppendEmpty()
-	dp91.LabelsMap().InitFromMap(map[string]string{
-		"host":               "host0",
-		"kubernetes_node":    "node0",
-		"kubernetes_cluster": "cluster0",
+	dp91.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"host":               pdata.NewAttributeValueString("host0"),
+		"kubernetes_node":    pdata.NewAttributeValueString("node0"),
+		"kubernetes_cluster": pdata.NewAttributeValueString("cluster0"),
 	}).Sort()
 	dp91.SetTimestamp(pdata.TimestampFromTime(time.Unix(1596000000, 0)))
 	dp91.SetIntVal(1000)
@@ -678,13 +678,13 @@ func getResourceMetrics(metrics []map[string]string) pdata.ResourceMetrics {
 		m.SetDataType(pdata.MetricDataTypeSum)
 		dp := m.Sum().DataPoints().AppendEmpty()
 		dp.SetIntVal(0)
-		labelsMap := dp.LabelsMap()
+		attributesMap := dp.Attributes()
 		for k, v := range mp {
 			if v == "" {
 				m.SetName(k)
 				continue
 			}
-			labelsMap.Insert(k, v)
+			attributesMap.InsertString(k, v)
 		}
 	}
 	return rms

--- a/exporter/signalfxexporter/internal/translation/converter.go
+++ b/exporter/signalfxexporter/internal/translation/converter.go
@@ -134,17 +134,17 @@ func (c *MetricsConverter) metricToSfxDataPoints(metric pdata.Metric, extraDimen
 	return dps
 }
 
-func labelsToDimensions(labels pdata.StringMap, extraDims []*sfxpb.Dimension) []*sfxpb.Dimension {
-	dimensions := make([]*sfxpb.Dimension, len(extraDims), labels.Len()+len(extraDims))
+func attributesToDimensions(attributes pdata.AttributeMap, extraDims []*sfxpb.Dimension) []*sfxpb.Dimension {
+	dimensions := make([]*sfxpb.Dimension, len(extraDims), attributes.Len()+len(extraDims))
 	copy(dimensions, extraDims)
-	if labels.Len() == 0 {
+	if attributes.Len() == 0 {
 		return dimensions
 	}
-	dimensionsValue := make([]sfxpb.Dimension, labels.Len())
+	dimensionsValue := make([]sfxpb.Dimension, attributes.Len())
 	pos := 0
-	labels.Range(func(k string, v string) bool {
+	attributes.Range(func(k string, v pdata.AttributeValue) bool {
 		dimensionsValue[pos].Key = k
-		dimensionsValue[pos].Value = v
+		dimensionsValue[pos].Value = v.StringVal()
 		dimensions = append(dimensions, &dimensionsValue[pos])
 		pos++
 		return true
@@ -162,7 +162,7 @@ func convertSummaryDataPoints(
 	for i := 0; i < in.Len(); i++ {
 		inDp := in.At(i)
 
-		dims := labelsToDimensions(inDp.LabelsMap(), extraDims)
+		dims := attributesToDimensions(inDp.Attributes(), extraDims)
 		ts := timestampToSignalFx(inDp.Timestamp())
 
 		countPt := sfxpb.DataPoint{
@@ -214,7 +214,7 @@ func convertNumberDatapoints(in pdata.NumberDataPointSlice, basePoint *sfxpb.Dat
 
 		dp := *basePoint
 		dp.Timestamp = timestampToSignalFx(inDp.Timestamp())
-		dp.Dimensions = labelsToDimensions(inDp.LabelsMap(), extraDims)
+		dp.Dimensions = attributesToDimensions(inDp.Attributes(), extraDims)
 
 		switch inDp.Type() {
 		case pdata.MetricValueTypeInt:
@@ -272,13 +272,13 @@ func convertHistogram(histDPs pdata.HistogramDataPointSlice, basePoint *sfxpb.Da
 		countDP := *basePoint
 		countDP.Metric = basePoint.Metric + "_count"
 		countDP.Timestamp = ts
-		countDP.Dimensions = labelsToDimensions(histDP.LabelsMap(), extraDims)
+		countDP.Dimensions = attributesToDimensions(histDP.Attributes(), extraDims)
 		count := int64(histDP.Count())
 		countDP.Value.IntValue = &count
 
 		sumDP := *basePoint
 		sumDP.Timestamp = ts
-		sumDP.Dimensions = labelsToDimensions(histDP.LabelsMap(), extraDims)
+		sumDP.Dimensions = attributesToDimensions(histDP.Attributes(), extraDims)
 		sum := histDP.Sum()
 		sumDP.Value.DoubleValue = &sum
 
@@ -302,7 +302,7 @@ func convertHistogram(histDPs pdata.HistogramDataPointSlice, basePoint *sfxpb.Da
 			dp := *basePoint
 			dp.Metric = basePoint.Metric + "_bucket"
 			dp.Timestamp = ts
-			dp.Dimensions = labelsToDimensions(histDP.LabelsMap(), extraDims)
+			dp.Dimensions = attributesToDimensions(histDP.Attributes(), extraDims)
 			dp.Dimensions = append(dp.Dimensions, &sfxpb.Dimension{
 				Key:   upperBoundDimensionKey,
 				Value: bound,

--- a/exporter/signalfxexporter/internal/translation/converter_test.go
+++ b/exporter/signalfxexporter/internal/translation/converter_test.go
@@ -62,12 +62,12 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 
 	initDoublePtWithLabels := func(doublePtWithLabels pdata.NumberDataPoint) {
 		initDoublePt(doublePtWithLabels)
-		doublePtWithLabels.LabelsMap().InitFromMap(labelMap)
+		doublePtWithLabels.Attributes().InitFromMap(stringMapToAttributeMap(labelMap))
 	}
 
 	initDoublePtWithLongLabels := func(doublePtWithLabels pdata.NumberDataPoint) {
 		initDoublePt(doublePtWithLabels)
-		doublePtWithLabels.LabelsMap().InitFromMap(longLabelMap)
+		doublePtWithLabels.Attributes().InitFromMap(stringMapToAttributeMap(longLabelMap))
 	}
 
 	differentLabelMap := map[string]string{
@@ -76,7 +76,7 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 	}
 	initDoublePtWithDifferentLabels := func(doublePtWithDifferentLabels pdata.NumberDataPoint) {
 		initDoublePt(doublePtWithDifferentLabels)
-		doublePtWithDifferentLabels.LabelsMap().InitFromMap(differentLabelMap)
+		doublePtWithDifferentLabels.Attributes().InitFromMap(stringMapToAttributeMap(differentLabelMap))
 	}
 
 	const int64Val = int64(123)
@@ -87,7 +87,7 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 
 	initInt64PtWithLabels := func(int64PtWithLabels pdata.NumberDataPoint) {
 		initInt64Pt(int64PtWithLabels)
-		int64PtWithLabels.LabelsMap().InitFromMap(labelMap)
+		int64PtWithLabels.Attributes().InitFromMap(stringMapToAttributeMap(labelMap))
 	}
 
 	histBounds := []float64{1, 2, 4}
@@ -99,7 +99,7 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 		histDP.SetSum(100.0)
 		histDP.SetExplicitBounds(histBounds)
 		histDP.SetBucketCounts(histCounts)
-		histDP.LabelsMap().InitFromMap(labelMap)
+		histDP.Attributes().InitFromMap(stringMapToAttributeMap(labelMap))
 	}
 	histDP := pdata.NewHistogramDataPoint()
 	initHistDP(histDP)
@@ -108,7 +108,7 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 		histDP.SetCount(2)
 		histDP.SetSum(10)
 		histDP.SetTimestamp(ts)
-		histDP.LabelsMap().InitFromMap(labelMap)
+		histDP.Attributes().InitFromMap(stringMapToAttributeMap(labelMap))
 	}
 	histDPNoBuckets := pdata.NewHistogramDataPoint()
 	initHistDPNoBuckets(histDPNoBuckets)
@@ -126,14 +126,14 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 			qv.SetQuantile(0.25 * float64(i+1))
 			qv.SetValue(float64(i))
 		}
-		summaryDP.LabelsMap().InitFromMap(labelMap)
+		summaryDP.Attributes().InitFromMap(stringMapToAttributeMap(labelMap))
 	}
 
 	initEmptySummaryDP := func(summaryDP pdata.SummaryDataPoint) {
 		summaryDP.SetTimestamp(ts)
 		summaryDP.SetSum(summarySumVal)
 		summaryDP.SetCount(summaryCountVal)
-		summaryDP.LabelsMap().InitFromMap(labelMap)
+		summaryDP.Attributes().InitFromMap(stringMapToAttributeMap(labelMap))
 	}
 
 	tests := []struct {
@@ -793,8 +793,8 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 	md.SetName("metric1")
 	dp := md.Gauge().DataPoints().AppendEmpty()
 	dp.SetIntVal(123)
-	dp.LabelsMap().InitFromMap(map[string]string{
-		"old.dim": "val1",
+	dp.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"old.dim": pdata.NewAttributeValueString("val1"),
 	})
 
 	gaugeType := sfxpb.MetricType_GAUGE
@@ -835,8 +835,8 @@ func TestDimensionKeyCharsWithPeriod(t *testing.T) {
 	md.SetName("metric1")
 	dp := md.Gauge().DataPoints().AppendEmpty()
 	dp.SetIntVal(123)
-	dp.LabelsMap().InitFromMap(map[string]string{
-		"old.dim.with.periods": "val1",
+	dp.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"old.dim.with.periods": pdata.NewAttributeValueString("val1"),
 	})
 
 	gaugeType := sfxpb.MetricType_GAUGE
@@ -1150,4 +1150,12 @@ func assertHasExtraDim(t *testing.T, pt *sfxpb.DataPoint) {
 	extraDim := pt.Dimensions[0]
 	assert.Equal(t, "dim1", extraDim.Key)
 	assert.Equal(t, "val1", extraDim.Value)
+}
+
+func stringMapToAttributeMap(m map[string]string) map[string]pdata.AttributeValue {
+	ret := map[string]pdata.AttributeValue{}
+	for k, v := range m {
+		ret[k] = pdata.NewAttributeValueString(v)
+	}
+	return ret
 }

--- a/exporter/signalfxexporter/internal/translation/translator_test.go
+++ b/exporter/signalfxexporter/internal/translation/translator_test.go
@@ -3030,9 +3030,9 @@ func baseMD() pdata.Metric {
 }
 
 func dblTS(lbl0 string, lbl1 string, secondsDelta int64, v float64, valueDelta float64, out pdata.NumberDataPoint) {
-	out.LabelsMap().InitFromMap(map[string]string{
-		"cpu":   lbl0,
-		"state": lbl1,
+	out.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"cpu":   pdata.NewAttributeValueString(lbl0),
+		"state": pdata.NewAttributeValueString(lbl1),
 	})
 	const startTime = 1600000000
 	out.SetTimestamp(pdata.Timestamp(time.Duration(startTime+secondsDelta) * time.Second))
@@ -3040,9 +3040,9 @@ func dblTS(lbl0 string, lbl1 string, secondsDelta int64, v float64, valueDelta f
 }
 
 func intTS(lbl0 string, lbl1 string, secondsDelta int64, v int64, valueDelta int64, out pdata.NumberDataPoint) {
-	out.LabelsMap().InitFromMap(map[string]string{
-		"cpu":   lbl0,
-		"state": lbl1,
+	out.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"cpu":   pdata.NewAttributeValueString(lbl0),
+		"state": pdata.NewAttributeValueString(lbl1),
 	})
 	const startTime = 1600000000
 	out.SetTimestamp(pdata.Timestamp(time.Duration(startTime+secondsDelta) * time.Second))


### PR DESCRIPTION
**Description:**
Following the changes in core to OTLP 0.9.0 to move away from `Labels` and on to `Attributes`

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3535