### PR TITLE
awsecscontainermetrics receiver: populate SchemaURL

### DIFF
--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
@@ -16,11 +16,13 @@ package awsecscontainermetrics
 
 import (
 	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
 )
 
 func convertToOTLPMetrics(prefix string, m ECSMetrics, r pdata.Resource, timestamp pdata.Timestamp) pdata.Metrics {
 	md := pdata.NewMetrics()
 	rm := md.ResourceMetrics().AppendEmpty()
+	rm.SetSchemaUrl(conventions.SchemaURL)
 	r.CopyTo(rm.Resource())
 
 	ilms := rm.InstrumentationLibraryMetrics()

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator_test.go
@@ -17,8 +17,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
 )
 
 func TestConvertToOTMetrics(t *testing.T) {
@@ -34,6 +36,7 @@ func TestConvertToOTMetrics(t *testing.T) {
 	resource := pdata.NewResource()
 	md := convertToOTLPMetrics("container.", m, resource, timestamp)
 	require.EqualValues(t, 26, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().Len())
+	assert.EqualValues(t, conventions.SchemaURL, md.ResourceMetrics().At(0).SchemaUrl())
 }
 
 func TestIntGauge(t *testing.T) {


### PR DESCRIPTION
This changes ensures that all metrics produced by awsecscontainermetrics
receiver set the SchemaURL. The assumption is that the code that
produces these metrics uses semantic conventions defined in
package "conventions".
