### PR TITLE
statsdreceiver: update labels -> attributes

### DIFF
--- a/receiver/statsdreceiver/protocol/metric_translator.go
+++ b/receiver/statsdreceiver/protocol/metric_translator.go
@@ -41,7 +41,7 @@ func buildCounterMetric(parsedMetric statsDMetric, isMonotonicCounter bool, time
 	dp.SetIntVal(parsedMetric.intvalue)
 	dp.SetTimestamp(pdata.TimestampFromTime(timeNow))
 	for i, key := range parsedMetric.labelKeys {
-		dp.LabelsMap().Insert(key, parsedMetric.labelValues[i])
+		dp.Attributes().InsertString(key, parsedMetric.labelValues[i])
 	}
 
 	return ilm
@@ -59,7 +59,7 @@ func buildGaugeMetric(parsedMetric statsDMetric, timeNow time.Time) pdata.Instru
 	dp.SetDoubleVal(parsedMetric.floatvalue)
 	dp.SetTimestamp(pdata.TimestampFromTime(timeNow))
 	for i, key := range parsedMetric.labelKeys {
-		dp.LabelsMap().Insert(key, parsedMetric.labelValues[i])
+		dp.Attributes().InsertString(key, parsedMetric.labelValues[i])
 	}
 
 	return ilm
@@ -77,7 +77,7 @@ func buildSummaryMetric(summaryMetric summaryMetric) pdata.InstrumentationLibrar
 	dp.SetSum(sum)
 	dp.SetTimestamp(pdata.TimestampFromTime(summaryMetric.timeNow))
 	for i, key := range summaryMetric.labelKeys {
-		dp.LabelsMap().Insert(key, summaryMetric.labelValues[i])
+		dp.Attributes().InsertString(key, summaryMetric.labelValues[i])
 	}
 
 	quantile := []float64{0, 10, 50, 90, 95, 100}

--- a/receiver/statsdreceiver/protocol/metric_translator_test.go
+++ b/receiver/statsdreceiver/protocol/metric_translator_test.go
@@ -46,7 +46,7 @@ func TestBuildCounterMetric(t *testing.T) {
 	dp := expectedMetric.Sum().DataPoints().AppendEmpty()
 	dp.SetIntVal(32)
 	dp.SetTimestamp(pdata.TimestampFromTime(timeNow))
-	dp.LabelsMap().Insert("mykey", "myvalue")
+	dp.Attributes().InsertString("mykey", "myvalue")
 	assert.Equal(t, metric, expectedMetrics)
 }
 
@@ -71,8 +71,8 @@ func TestBuildGaugeMetric(t *testing.T) {
 	dp := expectedMetric.Gauge().DataPoints().AppendEmpty()
 	dp.SetDoubleVal(32.3)
 	dp.SetTimestamp(pdata.TimestampFromTime(timeNow))
-	dp.LabelsMap().Insert("mykey", "myvalue")
-	dp.LabelsMap().Insert("mykey2", "myvalue2")
+	dp.Attributes().InsertString("mykey", "myvalue")
+	dp.Attributes().InsertString("mykey2", "myvalue2")
 	assert.Equal(t, metric, expectedMetrics)
 }
 
@@ -97,7 +97,7 @@ func TestBuildSummaryMetric(t *testing.T) {
 	dp.SetCount(6)
 	dp.SetTimestamp(pdata.TimestampFromTime(timeNow))
 	for i, key := range oneSummaryMetric.labelKeys {
-		dp.LabelsMap().Insert(key, oneSummaryMetric.labelValues[i])
+		dp.Attributes().InsertString(key, oneSummaryMetric.labelValues[i])
 	}
 	quantile := []float64{0, 10, 50, 90, 95, 100}
 	value := []float64{1, 1, 3, 6, 6, 6}


### PR DESCRIPTION
**Description:**
Following the changes in core to OTLP 0.9.0 to move away from `Labels` and on to `Attributes`

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3535