### PR TITLE
signalfxreceiver: update labels -> attributes

### DIFF
--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -571,12 +571,12 @@ func Test_sfxReceiver_TLS(t *testing.T) {
 	dp.SetTimestamp(pdata.Timestamp(msec * 1e6))
 	dp.SetIntVal(13)
 
-	dp.LabelsMap().InitFromMap(map[string]string{
-		"k0": "v0",
-		"k1": "v1",
-		"k2": "v2",
+	dp.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"k0": pdata.NewAttributeValueString("v0"),
+		"k1": pdata.NewAttributeValueString("v1"),
+		"k2": pdata.NewAttributeValueString("v2"),
 	})
-	dp.LabelsMap().Sort()
+	dp.Attributes().Sort()
 
 	t.Log("Sending SignalFx metric data Request")
 

--- a/receiver/signalfxreceiver/signalfxv2_to_metricdata.go
+++ b/receiver/signalfxreceiver/signalfxv2_to_metricdata.go
@@ -117,7 +117,7 @@ func fillNumberDataPoint(sfxDataPoint *sfxpb.DataPoint, dps pdata.NumberDataPoin
 	case sfxDataPoint.Value.DoubleValue != nil:
 		dp.SetDoubleVal(*sfxDataPoint.Value.DoubleValue)
 	}
-	fillInLabels(sfxDataPoint.Dimensions, dp.LabelsMap())
+	fillInAttributes(sfxDataPoint.Dimensions, dp.Attributes())
 }
 
 func dpTimestamp(dp *sfxpb.DataPoint) pdata.Timestamp {
@@ -125,18 +125,18 @@ func dpTimestamp(dp *sfxpb.DataPoint) pdata.Timestamp {
 	return pdata.Timestamp(dp.GetTimestamp() * 1e6)
 }
 
-func fillInLabels(
+func fillInAttributes(
 	dimensions []*sfxpb.Dimension,
-	labels pdata.StringMap,
+	attributes pdata.AttributeMap,
 ) {
-	labels.Clear()
-	labels.EnsureCapacity(len(dimensions))
+	attributes.Clear()
+	attributes.EnsureCapacity(len(dimensions))
 
 	for _, dim := range dimensions {
 		if dim == nil {
 			// TODO: Log or metric for this odd ball?
 			continue
 		}
-		labels.Insert(dim.Key, dim.Value)
+		attributes.InsertString(dim.Key, dim.Value)
 	}
 }

--- a/receiver/signalfxreceiver/signalfxv2_to_metricdata_test.go
+++ b/receiver/signalfxreceiver/signalfxv2_to_metricdata_test.go
@@ -60,13 +60,12 @@ func Test_signalFxV2ToMetricsData(t *testing.T) {
 		}
 
 		dp := dps.AppendEmpty()
-		labels := dp.LabelsMap()
-		labels.InitFromMap(map[string]string{
-			"k0": "v0",
-			"k1": "v1",
-			"k2": "v2",
+		dp.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+			"k0": pdata.NewAttributeValueString("v0"),
+			"k1": pdata.NewAttributeValueString("v1"),
+			"k2": pdata.NewAttributeValueString("v2"),
 		})
-		labels.Sort()
+		dp.Attributes().Sort()
 
 		dp.SetTimestamp(pdata.TimestampFromTime(now.Truncate(time.Millisecond)))
 
@@ -158,7 +157,7 @@ func Test_signalFxV2ToMetricsData(t *testing.T) {
 			}(),
 			wantMetricsData: func() pdata.Metrics {
 				md := buildDefaultMetricsData(pdata.MetricDataTypeGauge, 13)
-				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).LabelsMap().Update("k0", "")
+				md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Attributes().UpdateString("k0", "")
 				return md
 			}(),
 		},


### PR DESCRIPTION
**Description:**
Following the changes in core to OTLP 0.9.0 to move away from `Labels` and on to `Attributes`

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3535