### PR TITLE
Add severity mapping from unified model to HEC event

### DIFF
--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -344,10 +344,10 @@ func TestReceiveLogs(t *testing.T) {
 			}(),
 			want: wantType{
 				batches: []string{
-					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_0"}}` + "\n" +
-						`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_1"}}` + "\n" +
-						`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_2"}}` + "\n" +
-						`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_3"}}` + "\n",
+					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_0"}}` + "\n" +
+						`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_1"}}` + "\n" +
+						`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_2"}}` + "\n" +
+						`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_3"}}` + "\n",
 				},
 				numBatches: 1,
 			},
@@ -362,10 +362,10 @@ func TestReceiveLogs(t *testing.T) {
 			}(),
 			want: wantType{
 				batches: []string{
-					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_0"}}` + "\n",
-					`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_1"}}` + "\n",
-					`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_2"}}` + "\n",
-					`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_3"}}` + "\n",
+					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_0"}}` + "\n",
+					`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_1"}}` + "\n",
+					`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_2"}}` + "\n",
+					`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_3"}}` + "\n",
 				},
 				numBatches: 4,
 			},
@@ -380,10 +380,10 @@ func TestReceiveLogs(t *testing.T) {
 			}(),
 			want: wantType{
 				batches: []string{
-					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_0"}}` + "\n" +
-						`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_1"}}` + "\n",
-					`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_2"}}` + "\n" +
-						`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_3"}}` + "\n",
+					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_0"}}` + "\n" +
+						`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_1"}}` + "\n",
+					`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_2"}}` + "\n" +
+						`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_3"}}` + "\n",
 				},
 				numBatches: 2,
 			},
@@ -396,16 +396,16 @@ func TestReceiveLogs(t *testing.T) {
 			}(),
 			want: wantType{
 				batches: []string{
-					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_0"}}` + "\n" +
-						`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_1"}}` + "\n" +
-						`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_2"}}` + "\n" +
-						`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_3"}}` + "\n" +
-						`{"time":0.004,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_4"}}` + "\n" +
-						`{"time":0.005,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_5"}}` + "\n" +
-						`{"time":0.006,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_6"}}` + "\n" +
-						`{"time":0.007,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_7"}}` + "\n" +
-						`{"time":0.008,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_8"}}` + "\n" +
-						`{"time":0.009,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_9"}}` + "\n",
+					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_0"}}` + "\n" +
+						`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_1"}}` + "\n" +
+						`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_2"}}` + "\n" +
+						`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_3"}}` + "\n" +
+						`{"time":0.004,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_4"}}` + "\n" +
+						`{"time":0.005,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_5"}}` + "\n" +
+						`{"time":0.006,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_6"}}` + "\n" +
+						`{"time":0.007,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_7"}}` + "\n" +
+						`{"time":0.008,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_8"}}` + "\n" +
+						`{"time":0.009,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_9"}}` + "\n",
 				},
 				numBatches: 1,
 				compressed: true,
@@ -421,24 +421,24 @@ func TestReceiveLogs(t *testing.T) {
 			}(),
 			want: wantType{
 				batches: []string{
-					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_0"}}` + "\n" +
-						`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_1"}}` + "\n" +
-						`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_2"}}` + "\n" +
-						`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_3"}}` + "\n" +
-						`{"time":0.004,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_4"}}` + "\n" +
-						`{"time":0.005,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_5"}}` + "\n" +
-						`{"time":0.006,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_6"}}` + "\n" +
-						`{"time":0.007,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_7"}}` + "\n" +
-						`{"time":0.008,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_8"}}` + "\n",
-					`{"time":0.009,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_9"}}` + "\n" +
-						`{"time":0.01,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_10"}}` + "\n" +
-						`{"time":0.011,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_11"}}` + "\n" +
-						`{"time":0.012,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_12"}}` + "\n" +
-						`{"time":0.013,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_13"}}` + "\n" +
-						`{"time":0.014,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_14"}}` + "\n" +
-						`{"time":0.015,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_15"}}` + "\n" +
-						`{"time":0.016,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_16"}}` + "\n" +
-						`{"time":0.017,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otlp.log.name":"0_0_17"}}` + "\n",
+					`{"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_0"}}` + "\n" +
+						`{"time":0.001,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_1"}}` + "\n" +
+						`{"time":0.002,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_2"}}` + "\n" +
+						`{"time":0.003,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_3"}}` + "\n" +
+						`{"time":0.004,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_4"}}` + "\n" +
+						`{"time":0.005,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_5"}}` + "\n" +
+						`{"time":0.006,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_6"}}` + "\n" +
+						`{"time":0.007,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_7"}}` + "\n" +
+						`{"time":0.008,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_8"}}` + "\n",
+					`{"time":0.009,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_9"}}` + "\n" +
+						`{"time":0.01,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_10"}}` + "\n" +
+						`{"time":0.011,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_11"}}` + "\n" +
+						`{"time":0.012,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_12"}}` + "\n" +
+						`{"time":0.013,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_13"}}` + "\n" +
+						`{"time":0.014,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_14"}}` + "\n" +
+						`{"time":0.015,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_15"}}` + "\n" +
+						`{"time":0.016,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_16"}}` + "\n" +
+						`{"time":0.017,"host":"myhost","source":"myapp","sourcetype":"myapp-type","index":"myindex","event":"mylog","fields":{"com.splunk.source":"myapp","custom":"custom","host.name":"myhost","otel.log.name":"0_0_17"}}` + "\n",
 				},
 				numBatches: 2,
 				compressed: true,

--- a/exporter/splunkhecexporter/logdata_to_splunk.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk.go
@@ -57,6 +57,9 @@ func mapLogRecordToSplunkEvent(res pdata.Resource, lr pdata.LogRecord, config *C
 	if traceID := lr.TraceID().HexString(); traceID != "" {
 		fields[traceIDFieldKey] = traceID
 	}
+	if lr.SeverityText() != "" {
+		fields[splunk.SeverityLabel] = lr.SeverityText()
+	}
 	res.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
 		switch k {
 		case conventions.AttributeHostName:

--- a/exporter/splunkhecexporter/logdata_to_splunk.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk.go
@@ -58,8 +58,12 @@ func mapLogRecordToSplunkEvent(res pdata.Resource, lr pdata.LogRecord, config *C
 		fields[traceIDFieldKey] = traceID
 	}
 	if lr.SeverityText() != "" {
-		fields[splunk.SeverityLabel] = lr.SeverityText()
+		fields[splunk.SeverityTextLabel] = lr.SeverityText()
 	}
+	if lr.SeverityNumber() != pdata.SeverityNumberUNDEFINED {
+		fields[splunk.SeverityNumberLabel] = lr.SeverityNumber()
+	}
+
 	res.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
 		switch k {
 		case conventions.AttributeHostName:

--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -358,6 +358,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				logRecord.Attributes().InsertString(conventions.AttributeHostName, "myhost")
 				logRecord.Attributes().InsertString("custom", "custom")
 				logRecord.SetSeverityText("DEBUG")
+				logRecord.SetSeverityNumber(pdata.SeverityNumberDEBUG)
 				logRecord.SetTimestamp(ts)
 				return logRecord
 			},
@@ -369,7 +370,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				}
 			},
 			wantSplunkEvents: []*splunk.Event{
-				commonLogSplunkEvent("mylog", ts, map[string]interface{}{"custom": "custom", "com.splunk.source": "myapp", "host.name": "myhost", "otel.log.severity": "DEBUG"},
+				commonLogSplunkEvent("mylog", ts, map[string]interface{}{"custom": "custom", "com.splunk.source": "myapp", "host.name": "myhost", "otel.log.severity.number": pdata.SeverityNumberDEBUG, "otel.log.severity.text": "DEBUG"},
 					"myhost", "myapp", "myapp-type"),
 			},
 		},

--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -81,7 +81,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				}
 			},
 			wantSplunkEvents: []*splunk.Event{
-				commonLogSplunkEvent("mylog", ts, map[string]interface{}{"custom": "custom", "com.splunk.source": "myapp", "host.name": "myhost", "otlp.log.name": "my very own name"},
+				commonLogSplunkEvent("mylog", ts, map[string]interface{}{"custom": "custom", "com.splunk.source": "myapp", "host.name": "myhost", "otel.log.name": "my very own name"},
 					"myhost", "myapp", "myapp-type"),
 			},
 		},
@@ -369,7 +369,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				}
 			},
 			wantSplunkEvents: []*splunk.Event{
-				commonLogSplunkEvent("mylog", ts, map[string]interface{}{"custom": "custom", "com.splunk.source": "myapp", "host.name": "myhost", "otlp.log.severity": "DEBUG"},
+				commonLogSplunkEvent("mylog", ts, map[string]interface{}{"custom": "custom", "com.splunk.source": "myapp", "host.name": "myhost", "otel.log.severity": "DEBUG"},
 					"myhost", "myapp", "myapp-type"),
 			},
 		},

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -30,6 +30,7 @@ const (
 	SourceLabel           = "com.splunk.source"
 	IndexLabel            = "com.splunk.index"
 	NameLabel             = "otlp.log.name"
+	SeverityLabel         = "otlp.log.severity"
 	HECTokenHeader        = "Splunk"
 	HecTokenLabel         = "com.splunk.hec.access_token" // #nosec
 	// HecEventMetricType is the type of HEC event. Set to metric, as per https://docs.splunk.com/Documentation/Splunk/8.0.3/Metrics/GetMetricsInOther.

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -30,7 +30,8 @@ const (
 	SourceLabel           = "com.splunk.source"
 	IndexLabel            = "com.splunk.index"
 	NameLabel             = "otel.log.name"
-	SeverityLabel         = "otel.log.severity"
+	SeverityTextLabel     = "otel.log.severity.text"
+	SeverityNumberLabel   = "otel.log.severity.number"
 	HECTokenHeader        = "Splunk"
 	HecTokenLabel         = "com.splunk.hec.access_token" // #nosec
 	// HecEventMetricType is the type of HEC event. Set to metric, as per https://docs.splunk.com/Documentation/Splunk/8.0.3/Metrics/GetMetricsInOther.

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -29,8 +29,8 @@ const (
 	SourcetypeLabel       = "com.splunk.sourcetype"
 	SourceLabel           = "com.splunk.source"
 	IndexLabel            = "com.splunk.index"
-	NameLabel             = "otlp.log.name"
-	SeverityLabel         = "otlp.log.severity"
+	NameLabel             = "otel.log.name"
+	SeverityLabel         = "otel.log.severity"
 	HECTokenHeader        = "Splunk"
 	HecTokenLabel         = "com.splunk.hec.access_token" // #nosec
 	// HecEventMetricType is the type of HEC event. Set to metric, as per https://docs.splunk.com/Documentation/Splunk/8.0.3/Metrics/GetMetricsInOther.


### PR DESCRIPTION
**Description:** 
Add severitytext and severitynumber field mappings from unified model to HEC event.

**Testing:**
Unit tests.

**Documentation:**
Ongoing mapping changes in specification: https://github.com/open-telemetry/opentelemetry-specification/pull/1866