### PR TITLE
Fix internal/interval module path

### DIFF
--- a/internal/interval/go.mod
+++ b/internal/interval/go.mod
@@ -1,3 +1,3 @@
-module github.com/open-telemetry/opentelemetry-collector-contrib/interval
+module github.com/open-telemetry/opentelemetry-collector-contrib/internal/interval
 
 go 1.16


### PR DESCRIPTION
**Description:**
Fixed Go module path for the interval package.
