### PR TITLE
[awsemf exporter] Collect EKS Fargate Service/Namespace metrics from k8s API Server

### DIFF
--- a/exporter/awsemfexporter/go.mod
+++ b/exporter/awsemfexporter/go.mod
@@ -6,8 +6,12 @@ require (
 	github.com/aws/aws-sdk-go v1.40.19
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/golang/protobuf v1.5.2
+	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0
+	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.31.1-0.20210810171211-8038673eba9e
@@ -15,8 +19,17 @@ require (
 	go.uber.org/zap v1.19.0
 	golang.org/x/tools v0.1.4 // indirect
 	google.golang.org/protobuf v1.27.1
+	k8s.io/client-go v0.22.0
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics => ./../../internal/aws/metrics
 
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight => ./../../internal/aws/containerinsight
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig => ../../internal/k8sconfig
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet => ../../internal/kubelet
+
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil => ./../../internal/aws/awsutil
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s => ./../../internal/aws/k8s

--- a/exporter/awsemfexporter/internal/k8sapiserver/k8sapiserver.go
+++ b/exporter/awsemfexporter/internal/k8sapiserver/k8sapiserver.go
@@ -1,0 +1,98 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sapiserver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+
+	ci "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s/k8sclient"
+)
+
+// const (
+// 	lockName = "otel-container-insight-clusterleader"
+// )
+
+type K8sClient interface {
+	GetClientSet() kubernetes.Interface
+	GetEpClient() k8sclient.EpClient
+}
+
+// K8sAPIServer is a struct that produces metrics from kubernetes api server
+type K8sAPIServer struct {
+	logger      *zap.Logger
+	clusterName string
+
+	k8sClient K8sClient //*k8sclient.K8sClient
+	epClient  k8sclient.EpClient
+}
+
+type k8sAPIServerOption func(*K8sAPIServer)
+
+// New creates a k8sApiServer which can generate cluster-level metrics
+func New(clusterName string, logger *zap.Logger, options ...k8sAPIServerOption) (*K8sAPIServer, error) {
+	k := &K8sAPIServer{
+		logger:      logger,
+		clusterName: clusterName,
+		k8sClient:   k8sclient.Get(logger),
+	}
+
+	for _, opt := range options {
+		opt(k)
+	}
+
+	if k.k8sClient == nil {
+		return nil, errors.New("failed to start k8sapiserver because k8sclient is nil")
+	}
+	k.epClient = k.k8sClient.GetEpClient()
+
+	return k, nil
+}
+
+// GetMetrics returns an array of metrics
+func (k *K8sAPIServer) GetMetrics() []pdata.Metrics {
+	var result []pdata.Metrics
+
+	k.logger.Info("collect data from K8s API Server...")
+	timestampNs := strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	for service, podNum := range k.epClient.ServiceToPodNum() {
+		fields := map[string]interface{}{
+			"service_number_of_running_pods": podNum,
+		}
+		attributes := map[string]string{
+			ci.ClusterNameKey: k.clusterName,
+			ci.MetricType:     ci.TypeClusterService,
+			ci.Timestamp:      timestampNs,
+			ci.TypeService:    service.ServiceName,
+			ci.K8sNamespace:   service.Namespace,
+			ci.Version:        "0",
+		}
+
+		attributes[ci.Kubernetes] = fmt.Sprintf("{\"namespace_name\":\"%s\",\"service_name\":\"%s\"}",
+			service.Namespace, service.ServiceName)
+		md := ci.ConvertToOTLPMetrics(fields, attributes, k.logger)
+		result = append(result, md)
+	}
+
+	return result
+}

--- a/exporter/awsemfexporter/internal/k8sapiserver/k8sapiserver.go
+++ b/exporter/awsemfexporter/internal/k8sapiserver/k8sapiserver.go
@@ -116,3 +116,8 @@ func (k *K8sAPIServer) GetMetrics() []pdata.Metrics {
 
 	return result
 }
+
+// GetPodKeyToServiceNames returns the mapping between pod key and the corresponding service names
+func (k *K8sAPIServer) GetPodKeyToServiceNames() map[string][]string {
+	return k.epClient.PodKeyToServiceNames()
+}

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -97,7 +97,7 @@ func newMetricTranslator(config Config) metricTranslator {
 }
 
 // translateOTelToGroupedMetric converts OT metrics to Grouped Metric format.
-func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetrics, groupedMetrics map[interface{}]*groupedMetric, config *Config) error {
+func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetrics, groupedMetrics map[interface{}]*groupedMetric, config *Config, podKeyToServiceNamesMap map[string][]string) error {
 	timestamp := time.Now().UnixNano() / int64(time.Millisecond)
 	var instrumentationLibName string
 	cWNamespace := getNamespace(rm, config.Namespace)
@@ -130,7 +130,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm *pdata.ResourceMetric
 				receiver:                   metricReceiver,
 				metricDataType:             metric.DataType(),
 			}
-			err := addToGroupedMetric(&metric, groupedMetrics, metadata, patternReplaceSucceeded, config.logger, mt.metricDescriptor, config)
+			err := addToGroupedMetric(&metric, groupedMetrics, metadata, patternReplaceSucceeded, config.logger, mt.metricDescriptor, config, podKeyToServiceNamesMap)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Description:** 
Created for early feedback. Adding more logic and unit tests.

For EKS Fargate Container Insights customers, we need to emit some kubernetes namespace and service metrics which we can collect from k8s API Server. Based on `EKSFargateContainerInsightsEnabled` config, the exporter will collect those metrics and send to CloudWatch. This change will do the followings-

- Add new metric: `service_number_of_running_pods`
- Add new metric: `namespace_number_of_running_pods`
- Pull ServiceName for Pods and add it as a metric label

**Testing:** Unit tests are being added. Published for early feedback.

**Documentation:** will update README.