### PR TITLE
[exporter/datadogexporter] Avoid using `internal/common`

### DIFF
--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/aws/aws-sdk-go v1.40.19
 	github.com/gogo/protobuf v1.3.2
 	github.com/mattn/go-colorable v0.1.7 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.0.0-00010101000000-000000000000
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/stretchr/testify v1.7.0
 	github.com/tinylib/msgp v1.1.5 // indirect
@@ -18,5 +17,3 @@ require (
 	gopkg.in/DataDog/dd-trace-go.v1 v1.31.1
 	gopkg.in/zorkian/go-datadog-api.v2 v2.30.0
 )
-
-replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -26,7 +26,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/utils"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/ttlmap"
 )
 
 type metricsExporter struct {
@@ -34,7 +33,7 @@ type metricsExporter struct {
 	cfg     *config.Config
 	ctx     context.Context
 	client  *datadog.Client
-	prevPts *ttlmap.TTLMap
+	prevPts *ttlCache
 }
 
 func newMetricsExporter(ctx context.Context, params component.ExporterCreateSettings, cfg *config.Config) *metricsExporter {
@@ -48,7 +47,7 @@ func newMetricsExporter(ctx context.Context, params component.ExporterCreateSett
 	if cfg.Metrics.DeltaTTL > 1 {
 		sweepInterval = cfg.Metrics.DeltaTTL / 2
 	}
-	prevPts := ttlmap.New(sweepInterval, cfg.Metrics.DeltaTTL)
+	prevPts := newTTLCache(sweepInterval, cfg.Metrics.DeltaTTL)
 	prevPts.Start()
 
 	return &metricsExporter{params, cfg, ctx, client, prevPts}

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -48,8 +48,6 @@ func newMetricsExporter(ctx context.Context, params component.ExporterCreateSett
 		sweepInterval = cfg.Metrics.DeltaTTL / 2
 	}
 	prevPts := newTTLCache(sweepInterval, cfg.Metrics.DeltaTTL)
-	prevPts.Start()
-
 	return &metricsExporter{params, cfg, ctx, client, prevPts}
 }
 

--- a/exporter/datadogexporter/metrics_translator.go
+++ b/exporter/datadogexporter/metrics_translator.go
@@ -33,6 +33,45 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/ttlmap"
 )
 
+type ttlCache struct {
+	ttlMap *ttlmap.TTLMap
+}
+
+// numberCounter keeps the value of a number
+// monotonic counter at a given point in time
+type numberCounter struct {
+	ts    uint64
+	value float64
+}
+
+func newTTLCache(sweepInterval int64, deltaTTL int64) *ttlCache {
+	return &ttlCache{ttlmap.New(sweepInterval, deltaTTL)}
+}
+
+func (t *ttlCache) Start() {
+	t.ttlMap.Start()
+}
+
+// putAndGetDiff submits a new value for a given key and returns the difference with the
+// last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
+func (t *ttlCache) putAndGetDiff(key string, ts uint64, val float64) (dx float64, ok bool) {
+	if c := t.ttlMap.Get(key); c != nil {
+		cnt := c.(numberCounter)
+		if cnt.ts > ts {
+			// We were given a point older than the one in memory so we drop it
+			// We keep the existing point in memory since it is the most recent
+			return 0, false
+		}
+		// if dx < 0, we assume there was a reset, thus we save the point
+		// but don't export it (it's the first one so we can't do a delta)
+		dx = val - cnt.value
+		ok = dx >= 0
+	}
+
+	t.ttlMap.Put(key, numberCounter{ts, val})
+	return
+}
+
 // getTags maps an attributeMap into a slice of Datadog tags
 func getTags(labels pdata.AttributeMap) []string {
 	tags := make([]string, 0, labels.Len())
@@ -88,35 +127,8 @@ func mapNumberMetrics(name string, dt metrics.MetricDataType, slice pdata.Number
 	return ms
 }
 
-// numberCounter keeps the value of a number
-// monotonic counter at a given point in time
-type numberCounter struct {
-	ts    uint64
-	value float64
-}
-
-// putAndGetDiff submits a new value for a given key and returns the difference with the
-// last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
-func putAndGetDiff(prevPts *ttlmap.TTLMap, key string, ts uint64, val float64) (dx float64, ok bool) {
-	if c := prevPts.Get(key); c != nil {
-		cnt := c.(numberCounter)
-		if cnt.ts > ts {
-			// We were given a point older than the one in memory so we drop it
-			// We keep the existing point in memory since it is the most recent
-			return 0, false
-		}
-		// if dx < 0, we assume there was a reset, thus we save the point
-		// but don't export it (it's the first one so we can't do a delta)
-		dx = val - cnt.value
-		ok = dx >= 0
-	}
-
-	prevPts.Put(key, numberCounter{ts, val})
-	return
-}
-
 // mapNumberMonotonicMetrics maps monotonic datapoints into Datadog metrics
-func mapNumberMonotonicMetrics(name string, prevPts *ttlmap.TTLMap, slice pdata.NumberDataPointSlice, attrTags []string) []datadog.Metric {
+func mapNumberMonotonicMetrics(name string, prevPts *ttlCache, slice pdata.NumberDataPointSlice, attrTags []string) []datadog.Metric {
 	ms := make([]datadog.Metric, 0, slice.Len())
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
@@ -133,7 +145,7 @@ func mapNumberMonotonicMetrics(name string, prevPts *ttlmap.TTLMap, slice pdata.
 			val = float64(p.IntVal())
 		}
 
-		if dx, ok := putAndGetDiff(prevPts, key, ts, val); ok {
+		if dx, ok := prevPts.putAndGetDiff(key, ts, val); ok {
 			ms = append(ms, metrics.NewCount(name, ts, dx, tags))
 		}
 	}
@@ -199,7 +211,7 @@ func getQuantileTag(quantile float64) string {
 }
 
 // mapSummaryMetrics maps summary datapoints into Datadog metrics
-func mapSummaryMetrics(name string, prevPts *ttlmap.TTLMap, slice pdata.SummaryDataPointSlice, quantiles bool, attrTags []string) []datadog.Metric {
+func mapSummaryMetrics(name string, prevPts *ttlCache, slice pdata.SummaryDataPointSlice, quantiles bool, attrTags []string) []datadog.Metric {
 	// Allocate assuming none are nil and no quantiles
 	ms := make([]datadog.Metric, 0, 2*slice.Len())
 	for i := 0; i < slice.Len(); i++ {
@@ -212,7 +224,7 @@ func mapSummaryMetrics(name string, prevPts *ttlmap.TTLMap, slice pdata.SummaryD
 		{
 			countName := fmt.Sprintf("%s.count", name)
 			countKey := metricDimensionsToMapKey(countName, tags)
-			if dx, ok := putAndGetDiff(prevPts, countKey, ts, float64(p.Count())); ok {
+			if dx, ok := prevPts.putAndGetDiff(countKey, ts, float64(p.Count())); ok {
 				ms = append(ms, metrics.NewCount(countName, ts, dx, tags))
 			}
 		}
@@ -220,7 +232,7 @@ func mapSummaryMetrics(name string, prevPts *ttlmap.TTLMap, slice pdata.SummaryD
 		{
 			sumName := fmt.Sprintf("%s.sum", name)
 			sumKey := metricDimensionsToMapKey(sumName, tags)
-			if dx, ok := putAndGetDiff(prevPts, sumKey, ts, p.Sum()); ok {
+			if dx, ok := prevPts.putAndGetDiff(sumKey, ts, p.Sum()); ok {
 				ms = append(ms, metrics.NewCount(sumName, ts, dx, tags))
 			}
 		}
@@ -241,7 +253,7 @@ func mapSummaryMetrics(name string, prevPts *ttlmap.TTLMap, slice pdata.SummaryD
 }
 
 // mapMetrics maps OTLP metrics into the DataDog format
-func mapMetrics(logger *zap.Logger, cfg config.MetricsConfig, prevPts *ttlmap.TTLMap, fallbackHost string, md pdata.Metrics, buildInfo component.BuildInfo) (series []datadog.Metric, droppedTimeSeries int) {
+func mapMetrics(logger *zap.Logger, cfg config.MetricsConfig, prevPts *ttlCache, fallbackHost string, md pdata.Metrics, buildInfo component.BuildInfo) (series []datadog.Metric, droppedTimeSeries int) {
 	pushTime := uint64(time.Now().UTC().UnixNano())
 	rms := md.ResourceMetrics()
 	seenHosts := make(map[string]struct{})

--- a/exporter/datadogexporter/metrics_translator_test.go
+++ b/exporter/datadogexporter/metrics_translator_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	gocache "github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
@@ -173,9 +174,8 @@ func TestMapDoubleMetrics(t *testing.T) {
 }
 
 func newTestCache() *ttlCache {
-	// don't start the sweeping goroutine
-	// since it is not needed
-	return newTTLCache(1800, 3600)
+	cache := newTTLCache(1800, 3600)
+	return cache
 }
 
 func seconds(i int) pdata.Timestamp {
@@ -543,8 +543,8 @@ func TestMapSummaryMetrics(t *testing.T) {
 
 	newPrevPts := func(tags []string) *ttlCache {
 		prevPts := newTestCache()
-		prevPts.ttlMap.Put(metricDimensionsToMapKey("summary.example.count", tags), numberCounter{0, 1})
-		prevPts.ttlMap.Put(metricDimensionsToMapKey("summary.example.sum", tags), numberCounter{0, 1})
+		prevPts.cache.Set(metricDimensionsToMapKey("summary.example.count", tags), numberCounter{0, 1}, gocache.NoExpiration)
+		prevPts.cache.Set(metricDimensionsToMapKey("summary.example.sum", tags), numberCounter{0, 1}, gocache.NoExpiration)
 		return prevPts
 	}
 


### PR DESCRIPTION
**Description:** 

Avoid using `internal/common` and replace `ttlmap` by existing `go-cache` dependency.
Once the metrics breaking changes are completed we want to move part of the exporter to the datadog-agent repository,
so we want to avoid depending on internal components of this repository. Commits can be reviewed separately.

**Link to tracking Issue:** n/a

**Testing:** Amended unit tests. Ran end to end tests
