### PR TITLE
Ensure AWS CloudWatch logs exporter exposes `sending_queue`

### DIFF
--- a/exporter/awscloudwatchlogsexporter/README.md
+++ b/exporter/awscloudwatchlogsexporter/README.md
@@ -38,6 +38,8 @@ exporters:
     log_stream_name: "testing-integrations-stream"
     region: "us-east-1"
     endpoint: "logs.us-east-1.amazonaws.com"
+    sending_queue:
+      queue_size: 50
     retry_on_failure:
       enabled: true
       initial_interval: 10ms

--- a/exporter/awscloudwatchlogsexporter/config.go
+++ b/exporter/awscloudwatchlogsexporter/config.go
@@ -15,6 +15,8 @@
 package awscloudwatchlogsexporter
 
 import (
+	"errors"
+
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
@@ -42,6 +44,40 @@ type Config struct {
 	// e.g. logs.us-east-1.amazonaws.com
 	// Optional.
 	Endpoint string `mapstructure:"endpoint"`
+
+	// QueueSettings is a subset of exporterhelper.QueueSettings,
+	// because only QueueSize is user-settable due to how AWS CloudWatch API works
+	QueueSettings QueueSettings `mapstructure:"sending_queue"`
+}
+
+type QueueSettings struct {
+	// QueueSize set the length of the sending queue
+	QueueSize int `mapstructure:"queue_size"`
+}
+
+var _ config.Exporter = (*Config)(nil)
+
+// Validate config
+func (config *Config) Validate() error {
+	if config.LogGroupName == "" {
+		return errors.New("'log_group_name' must be set")
+	}
+	if config.LogStreamName == "" {
+		return errors.New("'log_stream_name' must be set")
+	}
+	if config.QueueSettings.QueueSize < 1 {
+		return errors.New("'sending_queue.queue_size' must be 1 or greater")
+	}
+	return nil
+}
+
+func (config *Config) enforcedQueueSettings() exporterhelper.QueueSettings {
+	return exporterhelper.QueueSettings{
+		Enabled: true,
+		// due to the sequence token, there can be only one request in flight
+		NumConsumers: 1,
+		QueueSize:    config.QueueSettings.QueueSize,
+	}
 }
 
 // TODO(jbd): Add ARN role to config.

--- a/exporter/awscloudwatchlogsexporter/config_test.go
+++ b/exporter/awscloudwatchlogsexporter/config_test.go
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awscloudwatchlogsexporter
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+func TestLoadConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Exporters[typeStr] = factory
+	cfg, err := configtest.LoadConfigAndValidate(path.Join(".", "testdata", "config.yaml"), factories)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, len(cfg.Exporters), 2)
+
+	defaultRetrySettings := exporterhelper.DefaultRetrySettings()
+
+	e1 := cfg.Exporters[config.NewIDWithName(typeStr, "e1-defaults")].(*Config)
+
+	assert.Equal(t,
+		&Config{
+			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "e1-defaults")),
+			RetrySettings:    defaultRetrySettings,
+			LogGroupName:     "test-1",
+			LogStreamName:    "testing",
+			Region:           "",
+			Endpoint:         "",
+			QueueSettings: QueueSettings{
+				QueueSize: exporterhelper.DefaultQueueSettings().QueueSize,
+			},
+		},
+		e1,
+	)
+
+	e2 := cfg.Exporters[config.NewIDWithName(typeStr, "e2-no-retries-short-queue")].(*Config)
+
+	assert.Equal(t,
+		&Config{
+			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "e2-no-retries-short-queue")),
+			RetrySettings: exporterhelper.RetrySettings{
+				Enabled:         false,
+				InitialInterval: defaultRetrySettings.InitialInterval,
+				MaxInterval:     defaultRetrySettings.MaxInterval,
+				MaxElapsedTime:  defaultRetrySettings.MaxElapsedTime,
+			},
+			LogGroupName:  "test-2",
+			LogStreamName: "testing",
+			QueueSettings: QueueSettings{
+				QueueSize: 2,
+			},
+		},
+		e2,
+	)
+}
+
+func TestFailedLoadConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Exporters[typeStr] = factory
+
+	_, err = configtest.LoadConfigAndValidate(path.Join(".", "testdata", "missing_required_field_1_config.yaml"), factories)
+	assert.EqualError(t, err, "exporter \"awscloudwatchlogs\" has invalid configuration: 'log_stream_name' must be set")
+
+	_, err = configtest.LoadConfigAndValidate(path.Join(".", "testdata", "missing_required_field_2_config.yaml"), factories)
+	assert.EqualError(t, err, "exporter \"awscloudwatchlogs\" has invalid configuration: 'log_group_name' must be set")
+
+	_, err = configtest.LoadConfigAndValidate(path.Join(".", "testdata", "invalid_queue_size.yaml"), factories)
+	assert.EqualError(t, err, "exporter \"awscloudwatchlogs\" has invalid configuration: 'sending_queue.queue_size' must be 1 or greater")
+
+	_, err = configtest.LoadConfigAndValidate(path.Join(".", "testdata", "invalid_queue_setting.yaml"), factories)
+	assert.EqualError(t, err, "error reading exporters configuration for awscloudwatchlogs: 1 error(s) decoding:\n\n* 'sending_queue' has invalid keys: enabled, num_consumers")
+}

--- a/exporter/awscloudwatchlogsexporter/factory.go
+++ b/exporter/awscloudwatchlogsexporter/factory.go
@@ -37,6 +37,10 @@ func NewFactory() component.ExporterFactory {
 func createDefaultConfig() config.Exporter {
 	return &Config{
 		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		RetrySettings:    exporterhelper.DefaultRetrySettings(),
+		QueueSettings: QueueSettings{
+			QueueSize: exporterhelper.DefaultQueueSettings().QueueSize,
+		},
 	}
 }
 
@@ -53,10 +57,7 @@ func createLogsExporter(_ context.Context, set component.ExporterCreateSettings,
 		exporter.PushLogs,
 		exporterhelper.WithStart(exporter.Start),
 		exporterhelper.WithShutdown(exporter.Shutdown),
-		exporterhelper.WithQueue(exporterhelper.QueueSettings{
-			Enabled:      true,
-			NumConsumers: 1, // due to the sequence token, there can be only one request in flight
-		}),
+		exporterhelper.WithQueue(oCfg.enforcedQueueSettings()),
 		exporterhelper.WithRetry(oCfg.RetrySettings),
 	)
 }

--- a/exporter/awscloudwatchlogsexporter/factory_test.go
+++ b/exporter/awscloudwatchlogsexporter/factory_test.go
@@ -19,11 +19,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestDefaultConfig_exporterSettings(t *testing.T) {
 	want := &Config{
 		ExporterSettings: config.NewExporterSettings(config.NewID(typeStr)),
+		RetrySettings:    exporterhelper.DefaultRetrySettings(),
+		QueueSettings: QueueSettings{
+			QueueSize: exporterhelper.DefaultQueueSettings().QueueSize,
+		},
 	}
 	assert.Equal(t, want, createDefaultConfig())
 }

--- a/exporter/awscloudwatchlogsexporter/testdata/config.yaml
+++ b/exporter/awscloudwatchlogsexporter/testdata/config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  nop: {}
+
+exporters:
+  awscloudwatchlogs/e1-defaults:
+    log_group_name: "test-1"
+    log_stream_name: "testing"
+  awscloudwatchlogs/e2-no-retries-short-queue:
+    log_group_name: "test-2"
+    log_stream_name: "testing"
+    sending_queue:
+      queue_size: 2
+    retry_on_failure:
+      enabled: false
+
+service:
+  pipelines:
+    logs:
+      receivers: [nop]
+      exporters:
+      - awscloudwatchlogs/e1-defaults
+      - awscloudwatchlogs/e2-no-retries-short-queue

--- a/exporter/awscloudwatchlogsexporter/testdata/invalid_queue_setting.yaml
+++ b/exporter/awscloudwatchlogsexporter/testdata/invalid_queue_setting.yaml
@@ -1,0 +1,16 @@
+receivers:
+  nop: {}
+
+exporters:
+  awscloudwatchlogs:
+    log_group_name: "test-4"
+    log_stream_name: "testing"
+    sending_queue:
+      enabled: false
+      num_consumers: 2
+
+service:
+  pipelines:
+    logs:
+      receivers: [nop]
+      exporters: [awscloudwatchlogs]

--- a/exporter/awscloudwatchlogsexporter/testdata/invalid_queue_size.yaml
+++ b/exporter/awscloudwatchlogsexporter/testdata/invalid_queue_size.yaml
@@ -1,0 +1,15 @@
+receivers:
+  nop: {}
+
+exporters:
+  awscloudwatchlogs:
+    log_group_name: "test-3"
+    log_stream_name: "testing"
+    sending_queue:
+      queue_size: 0
+
+service:
+  pipelines:
+    logs:
+      receivers: [nop]
+      exporters: [awscloudwatchlogs]

--- a/exporter/awscloudwatchlogsexporter/testdata/missing_required_field_1_config.yaml
+++ b/exporter/awscloudwatchlogsexporter/testdata/missing_required_field_1_config.yaml
@@ -1,0 +1,12 @@
+receivers:
+  nop: {}
+
+exporters:
+  awscloudwatchlogs:
+    log_group_name: "test-1"
+
+service:
+  pipelines:
+    logs:
+      receivers: [nop]
+      exporters: [awscloudwatchlogs]

--- a/exporter/awscloudwatchlogsexporter/testdata/missing_required_field_2_config.yaml
+++ b/exporter/awscloudwatchlogsexporter/testdata/missing_required_field_2_config.yaml
@@ -1,0 +1,12 @@
+receivers:
+  nop: {}
+
+exporters:
+  awscloudwatchlogs:
+    log_stream_name: "testing"
+
+service:
+  pipelines:
+    logs:
+      receivers: [nop]
+      exporters: [awscloudwatchlogs]


### PR DESCRIPTION
**Description:** Ensure AWS CloudWatch logs exporter exposes `sending_queue`

**Link to tracking Issue:**  #4683