### PR TITLE
emfexporter: update labels -> attributes

### DIFF
--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -64,14 +64,14 @@ type Config struct {
 	// TODO: we can support directing output to a file (in the future) while customer specifies a file path here.
 	OutputDestination string `mapstructure:"output_destination"`
 
-	// EKSFargateContainerInsightsEnabled is an option to reformat certin metric labels so that they take the form of a high level object
-	// The end result will make the labels look like those coming out of ECS and be more easily injected into cloudwatch
+	// EKSFargateContainerInsightsEnabled is an option to reformat certain metric attributes so that they take the form of a high level object
+	// The end result will make the attributes look like those coming out of ECS and be more easily injected into cloudwatch
 	// Note that at the moment in order to use this feature the value "kubernetes" must also be added to the ParseJSONEncodedAttributeValues array in order to be used
 	EKSFargateContainerInsightsEnabled bool `mapstructure:"eks_fargate_container_insights_enabled"`
 
 	// ResourceToTelemetrySettings is the option for converting resource attrihutes to telemetry attributes.
 	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.
-	// If enabled, all the resource attributes will be converted to metric labels by default.
+	// If enabled, all the resource attributes will be converted to metric attributes by default.
 	exporterhelper.ResourceToTelemetrySettings `mapstructure:"resource_to_telemetry_conversion"`
 
 	// logger is the Logger used for writing error/warning logs

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -125,7 +125,7 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pdata.Metrics) err
 			})
 		}
 	}
-	emf.logger.Info("Start processing resource metrics", zap.Any("labels", labels))
+	emf.logger.Info("Start processing resource metrics", zap.Any("attributes", labels))
 
 	groupedMetrics := make(map[interface{}]*groupedMetric)
 	expConfig := emf.config.(*Config)
@@ -177,7 +177,7 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pdata.Metrics) err
 		}
 	}
 
-	emf.logger.Info("Finish processing resource metrics", zap.Any("labels", labels))
+	emf.logger.Info("Finish processing resource metrics", zap.Any("attributes", labels))
 
 	return nil
 }

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -55,7 +55,7 @@ func addToGroupedMetric(pmd *pdata.Metric, groupedMetrics map[interface{}]*group
 			continue
 		}
 
-		labels := dp.labels
+		labels := dp.attributes
 
 		if metricType, ok := labels["Type"]; ok {
 			if (metricType == "Pod" || metricType == "Container") && config.EKSFargateContainerInsightsEnabled {
@@ -63,7 +63,7 @@ func addToGroupedMetric(pmd *pdata.Metric, groupedMetrics map[interface{}]*group
 			}
 		}
 
-		// if patterns were found in config file and weren't replaced by resource attributes, replace those patterns with metric labels.
+		// if patterns were found in config file and weren't replaced by resource attributes, replace those patterns with metric attributes.
 		// if patterns are provided for a valid key and that key doesn't exist in the resource attributes, it is replaced with `undefined`.
 		if !patternReplaceSucceeded {
 			if strings.Contains(metadata.logGroup, "undefined") {

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -2438,6 +2438,9 @@ func generateTestMetrics(tm testMetric) pdata.Metrics {
 			dp.SetTimestamp(pdata.TimestampFromTime(now.Add(10 * time.Second)))
 			dp.SetDoubleVal(value)
 			dp.LabelsMap().InitFromMap(tm.labelMap)
+			for k, v := range tm.labelMap {
+				dp.Attributes().InsertString(k, v)
+			}
 		}
 	}
 	return md


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add support on metrics dimensions from Attributes. 
To work backward compatible on the old OTel SDKs, it will get metric dimensions from Attributes first and then check the dimensions from LabelsMap if Attributes is not populated.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector/issues/3535

