### PR TITLE
emfexporter: update labels -> attributes 

### DIFF
--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -64,14 +64,14 @@ type Config struct {
 	// TODO: we can support directing output to a file (in the future) while customer specifies a file path here.
 	OutputDestination string `mapstructure:"output_destination"`
 
-	// EKSFargateContainerInsightsEnabled is an option to reformat certin metric labels so that they take the form of a high level object
-	// The end result will make the labels look like those coming out of ECS and be more easily injected into cloudwatch
+	// EKSFargateContainerInsightsEnabled is an option to reformat certain metric attributes so that they take the form of a high level object
+	// The end result will make the attributes look like those coming out of ECS and be more easily injected into cloudwatch
 	// Note that at the moment in order to use this feature the value "kubernetes" must also be added to the ParseJSONEncodedAttributeValues array in order to be used
 	EKSFargateContainerInsightsEnabled bool `mapstructure:"eks_fargate_container_insights_enabled"`
 
 	// ResourceToTelemetrySettings is the option for converting resource attrihutes to telemetry attributes.
 	// "Enabled" - A boolean field to enable/disable this option. Default is `false`.
-	// If enabled, all the resource attributes will be converted to metric labels by default.
+	// If enabled, all the resource attributes will be converted to metric attributes by default.
 	exporterhelper.ResourceToTelemetrySettings `mapstructure:"resource_to_telemetry_conversion"`
 
 	// logger is the Logger used for writing error/warning logs

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -43,7 +43,7 @@ func calculateSummaryDelta(prev *aws.MetricValue, val interface{}, timestampMs t
 // dataPoint represents a processed metric data point
 type dataPoint struct {
 	value       interface{}
-	labels      map[string]string
+	attributes  map[string]string
 	timestampMs int64
 }
 
@@ -110,7 +110,16 @@ type summaryMetricEntry struct {
 // At retrieves the NumberDataPoint at the given index and performs rate/delta calculation if necessary.
 func (dps numberDataPointSlice) At(i int) (dataPoint, bool) {
 	metric := dps.NumberDataPointSlice.At(i)
-	labels := createLabels(metric.Attributes(), dps.instrumentationLibraryName)
+	// To work backward compatible on the old OTel SDKs
+	// will get metric dimensions from Attributes first
+	// then get the dimension from LabelsMap if Attributes is not populated
+	attributes := make(map[string]string)
+	if metric.Attributes().Len() > 0 {
+		attributes = createAttributes(metric.Attributes(), dps.instrumentationLibraryName)
+	} else {
+		attributes = createLabels(metric.LabelsMap(), dps.instrumentationLibraryName)
+	}
+
 	timestampMs := unixNanoToMilliseconds(metric.Timestamp())
 
 	var metricVal float64
@@ -124,7 +133,7 @@ func (dps numberDataPointSlice) At(i int) (dataPoint, bool) {
 	retained := true
 	if dps.adjustToDelta {
 		var deltaVal interface{}
-		deltaVal, retained = deltaMetricCalculator.Calculate(dps.metricName, mergeLabels(dps.deltaMetricMetadata, labels),
+		deltaVal, retained = deltaMetricCalculator.Calculate(dps.metricName, mergeLabels(dps.deltaMetricMetadata, attributes),
 			metricVal, metric.Timestamp().AsTime())
 		if !retained {
 			return dataPoint{}, retained
@@ -138,7 +147,7 @@ func (dps numberDataPointSlice) At(i int) (dataPoint, bool) {
 
 	return dataPoint{
 		value:       metricVal,
-		labels:      labels,
+		attributes:  attributes,
 		timestampMs: timestampMs,
 	}, retained
 }
@@ -146,7 +155,16 @@ func (dps numberDataPointSlice) At(i int) (dataPoint, bool) {
 // At retrieves the HistogramDataPoint at the given index.
 func (dps histogramDataPointSlice) At(i int) (dataPoint, bool) {
 	metric := dps.HistogramDataPointSlice.At(i)
-	labels := createLabels(metric.Attributes(), dps.instrumentationLibraryName)
+	// To work backward compatible on the old OTel SDKs
+	// will get metric dimensions from Attributes first
+	// then get the dimension from LabelsMap if Attributes is not populated
+	attributes := make(map[string]string)
+	if metric.Attributes().Len() > 0 {
+		attributes = createAttributes(metric.Attributes(), dps.instrumentationLibraryName)
+	} else {
+		attributes = createLabels(metric.LabelsMap(), dps.instrumentationLibraryName)
+	}
+
 	timestamp := unixNanoToMilliseconds(metric.Timestamp())
 
 	return dataPoint{
@@ -154,7 +172,7 @@ func (dps histogramDataPointSlice) At(i int) (dataPoint, bool) {
 			Count: metric.Count(),
 			Sum:   metric.Sum(),
 		},
-		labels:      labels,
+		attributes:  attributes,
 		timestampMs: timestamp,
 	}, true
 }
@@ -162,7 +180,16 @@ func (dps histogramDataPointSlice) At(i int) (dataPoint, bool) {
 // At retrieves the SummaryDataPoint at the given index.
 func (dps summaryDataPointSlice) At(i int) (dataPoint, bool) {
 	metric := dps.SummaryDataPointSlice.At(i)
-	labels := createLabels(metric.Attributes(), dps.instrumentationLibraryName)
+	// To work backward compatible on the old OTel SDKs
+	// will get metric dimensions from Attributes first
+	// then get the dimension from LabelsMap if Attributes is not populated
+	attributes := make(map[string]string)
+	if metric.Attributes().Len() > 0 {
+		attributes = createAttributes(metric.Attributes(), dps.instrumentationLibraryName)
+	} else {
+		attributes = createLabels(metric.LabelsMap(), dps.instrumentationLibraryName)
+	}
+
 	timestampMs := unixNanoToMilliseconds(metric.Timestamp())
 
 	sum := metric.Sum()
@@ -170,7 +197,7 @@ func (dps summaryDataPointSlice) At(i int) (dataPoint, bool) {
 	retained := true
 	if dps.adjustToDelta {
 		var delta interface{}
-		delta, retained = summaryMetricCalculator.Calculate(dps.metricName, mergeLabels(dps.deltaMetricMetadata, labels),
+		delta, retained = summaryMetricCalculator.Calculate(dps.metricName, mergeLabels(dps.deltaMetricMetadata, attributes),
 			summaryMetricEntry{metric.Sum(), metric.Count()}, metric.Timestamp().AsTime())
 		if !retained {
 			return dataPoint{}, retained
@@ -191,17 +218,17 @@ func (dps summaryDataPointSlice) At(i int) (dataPoint, bool) {
 
 	return dataPoint{
 		value:       metricVal,
-		labels:      labels,
+		attributes:  attributes,
 		timestampMs: timestampMs,
 	}, retained
 }
 
-// createLabels converts OTel AttributesMap attributes to a map
+// createLabels converts OTel StringMap attributes to a map
 // and optionally adds in the OTel instrumentation library name
-func createLabels(attributes pdata.AttributeMap, instrLibName string) map[string]string {
-	labels := make(map[string]string, attributes.Len()+1)
-	attributes.Range(func(k string, v pdata.AttributeValue) bool {
-		labels[k] = v.StringVal()
+func createLabels(labelsMap pdata.StringMap, instrLibName string) map[string]string {
+	labels := make(map[string]string, labelsMap.Len()+1)
+	labelsMap.Range(func(k, v string) bool {
+		labels[k] = v
 		return true
 	})
 
@@ -211,6 +238,23 @@ func createLabels(attributes pdata.AttributeMap, instrLibName string) map[string
 	}
 
 	return labels
+}
+
+// createAttributes converts OTel metric attributes to a map
+// and optionally adds in the OTel instrumentation library name
+func createAttributes(attributeMap pdata.AttributeMap, instrLibName string) map[string]string {
+	attributes := make(map[string]string, attributeMap.Len()+1)
+	attributeMap.Range(func(k string, v pdata.AttributeValue) bool {
+		attributes[k] = v.StringVal()
+		return true
+	})
+
+	// Add OTel instrumentation lib name as an additional attribute if it is defined
+	if instrLibName != noInstrumentationLibraryName {
+		attributes[oTellibDimensionKey] = instrLibName
+	}
+
+	return attributes
 }
 
 // getDataPoints retrieves data points from OT Metric.

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -263,7 +263,6 @@ func TestIntDataPointSliceAt(t *testing.T) {
 	setupDataPointCache()
 
 	instrLibName := "cloudwatch-otel"
-	labels := map[string]pdata.AttributeValue{"label": pdata.NewAttributeValueString("value")}
 
 	testDeltaCases := []struct {
 		testName        string
@@ -296,7 +295,7 @@ func TestIntDataPointSliceAt(t *testing.T) {
 			testDPS := pdata.NewNumberDataPointSlice()
 			testDP := testDPS.AppendEmpty()
 			testDP.SetIntVal(tc.value.(int64))
-			testDP.Attributes().InitFromMap(labels)
+			testDP.Attributes().InsertString("label", "value")
 
 			dps := numberDataPointSlice{
 				instrLibName,
@@ -313,7 +312,7 @@ func TestIntDataPointSliceAt(t *testing.T) {
 
 			expectedDP := dataPoint{
 				value: tc.calculatedValue,
-				labels: map[string]string{
+				attributes: map[string]string{
 					oTellibDimensionKey: instrLibName,
 					"label":             "value",
 				},
@@ -323,7 +322,7 @@ func TestIntDataPointSliceAt(t *testing.T) {
 			dp, retained := dps.At(0)
 			assert.Equal(t, i > 0, retained)
 			if retained {
-				assert.Equal(t, expectedDP.labels, dp.labels)
+				assert.Equal(t, expectedDP.attributes, dp.attributes)
 				assert.InDelta(t, expectedDP.value.(float64), dp.value.(float64), 0.02)
 			}
 		})
@@ -334,7 +333,6 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 	setupDataPointCache()
 
 	instrLibName := "cloudwatch-otel"
-	labels := map[string]pdata.AttributeValue{"label1": pdata.NewAttributeValueString("value1")}
 
 	testDeltaCases := []struct {
 		testName        string
@@ -367,7 +365,7 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 			testDPS := pdata.NewNumberDataPointSlice()
 			testDP := testDPS.AppendEmpty()
 			testDP.SetDoubleVal(tc.value.(float64))
-			testDP.Attributes().InitFromMap(labels)
+			testDP.Attributes().InsertString("label", "value")
 
 			dps := numberDataPointSlice{
 				instrLibName,
@@ -394,7 +392,6 @@ func TestDoubleDataPointSliceAt(t *testing.T) {
 
 func TestHistogramDataPointSliceAt(t *testing.T) {
 	instrLibName := "cloudwatch-otel"
-	labels := map[string]pdata.AttributeValue{"label1": pdata.NewAttributeValueString("value1")}
 
 	testDPS := pdata.NewHistogramDataPointSlice()
 	testDP := testDPS.AppendEmpty()
@@ -402,7 +399,7 @@ func TestHistogramDataPointSliceAt(t *testing.T) {
 	testDP.SetSum(17.13)
 	testDP.SetBucketCounts([]uint64{1, 2, 3})
 	testDP.SetExplicitBounds([]float64{1, 2, 3})
-	testDP.Attributes().InitFromMap(labels)
+	testDP.Attributes().InsertString("label1", "value1")
 
 	dps := histogramDataPointSlice{
 		instrLibName,
@@ -414,7 +411,7 @@ func TestHistogramDataPointSliceAt(t *testing.T) {
 			Sum:   17.13,
 			Count: 17,
 		},
-		labels: map[string]string{
+		attributes: map[string]string{
 			oTellibDimensionKey: instrLibName,
 			"label1":            "value1",
 		},
@@ -429,7 +426,7 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 	setupDataPointCache()
 
 	instrLibName := "cloudwatch-otel"
-	labels := map[string]pdata.AttributeValue{"label1": pdata.NewAttributeValueString("value1")}
+
 	metadataTimeStamp := time.Now().UnixNano() / int64(time.Millisecond)
 
 	testCases := []struct {
@@ -468,7 +465,7 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 			testQuantileValue = testDP.QuantileValues().AppendEmpty()
 			testQuantileValue.SetQuantile(100)
 			testQuantileValue.SetValue(float64(5))
-			testDP.Attributes().InitFromMap(labels)
+			testDP.Attributes().InsertString("label1", "value1")
 
 			dps := summaryDataPointSlice{
 				instrLibName,
@@ -490,7 +487,7 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 					Sum:   tt.calculatedSumCount[0].(float64),
 					Count: tt.calculatedSumCount[1].(uint64),
 				},
-				labels: map[string]string{
+				attributes: map[string]string{
 					oTellibDimensionKey: instrLibName,
 					"label1":            "value1",
 				},
@@ -502,7 +499,7 @@ func TestSummaryDataPointSliceAt(t *testing.T) {
 			if retained {
 				expectedMetricStats := expectedDP.value.(*cWMetricStats)
 				actualMetricsStats := dp.value.(*cWMetricStats)
-				assert.Equal(t, expectedDP.labels, dp.labels)
+				assert.Equal(t, expectedDP.attributes, dp.attributes)
 				assert.Equal(t, expectedMetricStats.Max, actualMetricsStats.Max)
 				assert.Equal(t, expectedMetricStats.Min, actualMetricsStats.Min)
 				assert.InDelta(t, expectedMetricStats.Count, actualMetricsStats.Count, 0.1)
@@ -518,17 +515,34 @@ func TestCreateLabels(t *testing.T) {
 		"b": "B",
 		"c": "C",
 	}
-	labelsMap := pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{
-		"a": pdata.NewAttributeValueString("A"),
-		"b": pdata.NewAttributeValueString("B"),
-		"c": pdata.NewAttributeValueString("C"),
-	})
+	labelsMap := pdata.NewStringMap().InitFromMap(expectedLabels)
 
 	labels := createLabels(labelsMap, noInstrumentationLibraryName)
 	assert.Equal(t, expectedLabels, labels)
 
 	// With isntrumentation library name
 	labels = createLabels(labelsMap, "cloudwatch-otel")
+	expectedLabels[oTellibDimensionKey] = "cloudwatch-otel"
+	assert.Equal(t, expectedLabels, labels)
+}
+
+func TestCreateAttributes(t *testing.T) {
+	expectedLabels := map[string]string{
+		"a": "A",
+		"b": "B",
+		"c": "C",
+	}
+	attributeMap := make(map[string]pdata.AttributeValue)
+	for k, v := range expectedLabels {
+		attributeMap[k] = pdata.NewAttributeValueString(v)
+	}
+	attributes := pdata.NewAttributeMap().InitFromMap(attributeMap)
+
+	labels := createAttributes(attributes, noInstrumentationLibraryName)
+	assert.Equal(t, expectedLabels, labels)
+
+	// With isntrumentation library name
+	labels = createAttributes(attributes, "cloudwatch-otel")
 	expectedLabels[oTellibDimensionKey] = "cloudwatch-otel"
 	assert.Equal(t, expectedLabels, labels)
 }
@@ -646,7 +660,7 @@ func TestGetDataPoints(t *testing.T) {
 
 		logger := zap.NewNop()
 
-		expectedAttributes := pdata.NewAttributeMap().InitFromMap(map[string]pdata.AttributeValue{"label1": pdata.NewAttributeValueString("value1")})
+		expectedLabels := pdata.NewStringMap().InitFromMap(map[string]string{"label1": "value1"})
 
 		t.Run(tc.testName, func(t *testing.T) {
 			setupDataPointCache()
@@ -672,7 +686,7 @@ func TestGetDataPoints(t *testing.T) {
 				case pdata.MetricValueTypeInt:
 					assert.Equal(t, int64(1), dp.IntVal())
 				}
-				assert.Equal(t, expectedAttributes, dp.Attributes())
+				assert.Equal(t, expectedLabels, dp.LabelsMap())
 			case histogramDataPointSlice:
 				assert.Equal(t, metadata.instrumentationLibraryName, convertedDPS.instrumentationLibraryName)
 				assert.Equal(t, 1, convertedDPS.Len())
@@ -680,7 +694,7 @@ func TestGetDataPoints(t *testing.T) {
 				assert.Equal(t, 35.0, dp.Sum())
 				assert.Equal(t, uint64(18), dp.Count())
 				assert.Equal(t, []float64{0, 10}, dp.ExplicitBounds())
-				assert.Equal(t, expectedAttributes, dp.Attributes())
+				assert.Equal(t, expectedLabels, dp.LabelsMap())
 			case summaryDataPointSlice:
 				expectedDPS := tc.expectedDataPoints.(summaryDataPointSlice)
 				assert.Equal(t, metadata.instrumentationLibraryName, convertedDPS.instrumentationLibraryName)

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -125,7 +125,7 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pdata.Metrics) err
 			})
 		}
 	}
-	emf.logger.Info("Start processing resource metrics", zap.Any("labels", labels))
+	emf.logger.Info("Start processing resource metrics", zap.Any("attributes", labels))
 
 	groupedMetrics := make(map[interface{}]*groupedMetric)
 	expConfig := emf.config.(*Config)
@@ -177,7 +177,7 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pdata.Metrics) err
 		}
 	}
 
-	emf.logger.Info("Finish processing resource metrics", zap.Any("labels", labels))
+	emf.logger.Info("Finish processing resource metrics", zap.Any("attributes", labels))
 
 	return nil
 }

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -55,7 +55,7 @@ func addToGroupedMetric(pmd *pdata.Metric, groupedMetrics map[interface{}]*group
 			continue
 		}
 
-		labels := dp.labels
+		labels := dp.attributes
 
 		if metricType, ok := labels["Type"]; ok {
 			if (metricType == "Pod" || metricType == "Container") && config.EKSFargateContainerInsightsEnabled {
@@ -63,7 +63,7 @@ func addToGroupedMetric(pmd *pdata.Metric, groupedMetrics map[interface{}]*group
 			}
 		}
 
-		// if patterns were found in config file and weren't replaced by resource attributes, replace those patterns with metric labels.
+		// if patterns were found in config file and weren't replaced by resource attributes, replace those patterns with metric attributes.
 		// if patterns are provided for a valid key and that key doesn't exist in the resource attributes, it is replaced with `undefined`.
 		if !patternReplaceSucceeded {
 			if strings.Contains(metadata.logGroup, "undefined") {

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -2261,7 +2261,7 @@ type testMetric struct {
 	metricNames          []string
 	metricValues         [][]float64
 	resourceAttributeMap map[string]pdata.AttributeValue
-	attributeMap         map[string]pdata.AttributeValue
+	labelMap             map[string]string
 }
 
 type logGroupStreamTest struct {
@@ -2321,9 +2321,9 @@ var (
 			inputMetrics: generateTestMetrics(testMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100}, {4}},
-				attributeMap: map[string]pdata.AttributeValue{
-					"ClusterName": pdata.NewAttributeValueString("test-cluster"),
-					"PodName":     pdata.NewAttributeValueString("test-pod"),
+				labelMap: map[string]string{
+					"ClusterName": "test-cluster",
+					"PodName":     "test-pod",
 				},
 			}),
 			inLogGroupName:   "test-log-group-{ClusterName}",
@@ -2336,9 +2336,9 @@ var (
 			inputMetrics: generateTestMetrics(testMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100}, {4}},
-				attributeMap: map[string]pdata.AttributeValue{
-					"ClusterName": pdata.NewAttributeValueString("test-cluster"),
-					"PodName":     pdata.NewAttributeValueString("test-pod"),
+				labelMap: map[string]string{
+					"ClusterName": "test-cluster",
+					"PodName":     "test-pod",
 				},
 			}),
 			inLogGroupName:   "test-log-group",
@@ -2354,8 +2354,8 @@ var (
 				resourceAttributeMap: map[string]pdata.AttributeValue{
 					"ClusterName": pdata.NewAttributeValueString("test-cluster"),
 				},
-				attributeMap: map[string]pdata.AttributeValue{
-					"PodName": pdata.NewAttributeValueString("test-pod"),
+				labelMap: map[string]string{
+					"PodName": "test-pod",
 				},
 			}),
 			inLogGroupName:   "test-log-group-{ClusterName}",
@@ -2379,8 +2379,8 @@ var (
 			inputMetrics: generateTestMetrics(testMetric{
 				metricNames:  []string{"metric_1", "metric_2"},
 				metricValues: [][]float64{{100}, {4}},
-				attributeMap: map[string]pdata.AttributeValue{
-					"PodName": pdata.NewAttributeValueString("test-pod"),
+				labelMap: map[string]string{
+					"PodName": "test-pod",
 				},
 			}),
 			inLogGroupName:   "test-log-group-{ClusterName}",
@@ -2437,7 +2437,7 @@ func generateTestMetrics(tm testMetric) pdata.Metrics {
 			dp := m.Gauge().DataPoints().AppendEmpty()
 			dp.SetTimestamp(pdata.TimestampFromTime(now.Add(10 * time.Second)))
 			dp.SetDoubleVal(value)
-			dp.Attributes().InitFromMap(tm.attributeMap)
+			dp.LabelsMap().InitFromMap(tm.labelMap)
 		}
 	}
 	return md


### PR DESCRIPTION
**Description:** <Describe what has changed.>
To support backward compatibility on the old OTel SDKs, will still check LabelsMap if Attributes is not populated.
