### PR TITLE
Use pdata.AttributeValueToString(v) instead of attrvalue.StringVal()

### DIFF
--- a/processor/cumulativetodeltaprocessor/processor.go
+++ b/processor/cumulativetodeltaprocessor/processor.go
@@ -69,7 +69,7 @@ func (ctdp *cumulativeToDeltaProcessor) processMetrics(_ context.Context, md pda
 							labelMap := make(map[string]string)
 
 							fromDataPoint.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
-								labelMap[k] = v.StringVal()
+								labelMap[k] = pdata.AttributeValueToString(v)
 								return true
 							})
 


### PR DESCRIPTION
Not all attributes are string. Use a safer approach. 

Note: We use these string values to generate a map key and we don't need to retrive the exact types of the attributes. As long as we can get the string values we are good to generate our desired keys. 