### PR TITLE
Avoid using cast, use the result of Sub in receivercreator

### DIFF
--- a/receiver/receivercreator/config.go
+++ b/receiver/receivercreator/config.go
@@ -102,8 +102,7 @@ func (cfg *Config) Unmarshal(componentParser *configparser.Parser) error {
 		return fmt.Errorf("unable to extract key %v: %v", receiversConfigKey, err)
 	}
 
-	receiversSettings := cast.ToStringMap(componentParser.Get(receiversConfigKey))
-	for subreceiverKey := range receiversSettings {
+	for subreceiverKey := range receiversCfg.ToStringMap() {
 		subreceiverSection, err := receiversCfg.Sub(subreceiverKey)
 		if err != nil {
 			return fmt.Errorf("unable to extract subreceiver key %v: %v", subreceiverKey, err)


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
