### PR TITLE
Try to build an ARM64 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,10 @@ run:
 docker-component: check-component
 	GOOS=linux GOARCH=amd64 $(MAKE) $(COMPONENT)
 	cp ./bin/$(COMPONENT)_linux_amd64 ./cmd/$(COMPONENT)/$(COMPONENT)
-	docker build -t $(COMPONENT) ./cmd/$(COMPONENT)/
+	docker buildx build --platform linux/amd64 -t $(COMPONENT) ./cmd/$(COMPONENT)/
+	GOOS=linux GOARCH=arm64 $(MAKE) $(COMPONENT)
+	cp ./bin/$(COMPONENT)_linux_arm64 ./cmd/$(COMPONENT)/$(COMPONENT)
+	docker buildx build --platform linux/arm64 -t $(COMPONENT) ./cmd/$(COMPONENT)/
 	rm ./cmd/$(COMPONENT)/$(COMPONENT)
 
 .PHONY: check-component

--- a/Makefile
+++ b/Makefile
@@ -170,12 +170,10 @@ run:
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component
 	GOOS=linux GOARCH=amd64 $(MAKE) $(COMPONENT)
-	cp ./bin/$(COMPONENT)_linux_amd64 ./cmd/$(COMPONENT)/$(COMPONENT)
-	docker buildx build --platform linux/amd64 -t $(COMPONENT) ./cmd/$(COMPONENT)/
 	GOOS=linux GOARCH=arm64 $(MAKE) $(COMPONENT)
-	cp ./bin/$(COMPONENT)_linux_arm64 ./cmd/$(COMPONENT)/$(COMPONENT)
-	docker buildx build --platform linux/arm64 -t $(COMPONENT) ./cmd/$(COMPONENT)/
-	rm ./cmd/$(COMPONENT)/$(COMPONENT)
+	cp ./bin/$(COMPONENT)_* ./cmd/$(COMPONENT)/
+	docker buildx build --platform linux/amd64,linux/arm64 -t $(COMPONENT) ./cmd/$(COMPONENT)/
+	rm ./cmd/$(COMPONENT)/$(COMPONENT)_*
 
 .PHONY: check-component
 check-component:

--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -8,9 +8,11 @@ RUN mkdir -p /tmp
 FROM scratch
 
 USER ${USER_UID}
+# Args automaticaly filled by buildkit
+ARG TARGETOS TARGETARCH
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY otelcontribcol /
+COPY otelcontribcol_${TARGETOS}_${TARGETARCH} /otelcontribcol
 EXPOSE 4317 55680 55679
 ENTRYPOINT ["/otelcontribcol"]
 CMD ["--config", "/etc/otel/config.yaml"]


### PR DESCRIPTION
**Description:** 
To be able installing otel-collector-contrib on ARM64 oriented nodes (like Amazon Graviton backed CPU) build an image for x64 and another for arm64.

**Notes for mainteners:**

I'm not sure if buildx is enabled on your pipeline platform...
Once done both images have to be pushed on remote repositories.