### PR TITLE
[honeycombexporter] remove opencensus pdata in tests

### DIFF
--- a/exporter/honeycombexporter/go.mod
+++ b/exporter/honeycombexporter/go.mod
@@ -3,7 +3,6 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeyc
 go 1.16
 
 require (
-	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/google/go-cmp v0.5.6
 	github.com/honeycombio/libhoney-go v1.15.4
 	github.com/klauspost/compress v1.13.4

--- a/exporter/honeycombexporter/honeycomb_test.go
+++ b/exporter/honeycombexporter/honeycomb_test.go
@@ -24,9 +24,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"github.com/google/go-cmp/cmp"
 	"github.com/honeycombio/libhoney-go/transmission"
 	"github.com/klauspost/compress/zstd"
@@ -35,21 +32,10 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/model/pdata"
-	"go.opentelemetry.io/collector/translator/internaldata"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
-	"google.golang.org/protobuf/types/known/timestamppb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
-
-// traceData helper struct for conversion.
-// TODO: Remove this when exporter translates directly to pdata.
-type traceData struct {
-	Node     *commonpb.Node
-	Resource *resourcepb.Resource
-	Spans    []*tracepb.Span
-}
 
 type honeycombData struct {
 	Data map[string]interface{} `json:"data"`
@@ -112,104 +98,56 @@ func baseConfig() *Config {
 }
 
 func TestExporter(t *testing.T) {
-	td := traceData{
-		Node: &commonpb.Node{
-			ServiceInfo: &commonpb.ServiceInfo{Name: "test_service"},
-			Attributes: map[string]string{
-				"A": "B",
-			},
-		},
-		Resource: &resourcepb.Resource{
-			Type: "foobar",
-			Labels: map[string]string{
-				"B": "C",
-			},
-		},
-		Spans: []*tracepb.Span{
-			{
-				TraceId:                 []byte{0x01},
-				SpanId:                  []byte{0x02},
-				Name:                    &tracepb.TruncatableString{Value: "root"},
-				Kind:                    tracepb.Span_SERVER,
-				SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: true},
-				Attributes: &tracepb.Span_Attributes{
-					AttributeMap: map[string]*tracepb.AttributeValue{
-						"span_attr_name": {
-							Value: &tracepb.AttributeValue_StringValue{
-								StringValue: &tracepb.TruncatableString{Value: "Span Attribute"},
-							},
-						},
-					},
-				},
-				Resource: &resourcepb.Resource{
-					Type: "override",
-					Labels: map[string]string{
-						"B": "D",
-					},
-				},
-				TimeEvents: &tracepb.Span_TimeEvents{
-					TimeEvent: []*tracepb.Span_TimeEvent{
-						{
-							Time: &timestamppb.Timestamp{
-								Seconds: 0,
-								Nanos:   0,
-							},
-							Value: &tracepb.Span_TimeEvent_Annotation_{
-								Annotation: &tracepb.Span_TimeEvent_Annotation{
-									Description: &tracepb.TruncatableString{Value: "Some Description"},
-									Attributes: &tracepb.Span_Attributes{
-										AttributeMap: map[string]*tracepb.AttributeValue{
-											"attribute_name": {
-												Value: &tracepb.AttributeValue_StringValue{
-													StringValue: &tracepb.TruncatableString{Value: "Hello MessageEvent"},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			{
-				TraceId:                 []byte{0x01},
-				SpanId:                  []byte{0x03},
-				ParentSpanId:            []byte{0x02},
-				Name:                    &tracepb.TruncatableString{Value: "client"},
-				Kind:                    tracepb.Span_CLIENT,
-				SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: true},
-				Links: &tracepb.Span_Links{
-					Link: []*tracepb.Span_Link{
-						{
-							TraceId: []byte{0x04},
-							SpanId:  []byte{0x05},
-							Type:    tracepb.Span_Link_PARENT_LINKED_SPAN,
-							Attributes: &tracepb.Span_Attributes{
-								AttributeMap: map[string]*tracepb.AttributeValue{
-									"span_link_attr": {
-										Value: &tracepb.AttributeValue_IntValue{
-											IntValue: 12345,
-										},
-									},
-								},
-							},
-						},
-					},
-					DroppedLinksCount: 0,
-				},
-			},
-			{
-				TraceId:                 []byte{0x01},
-				SpanId:                  []byte{0x04},
-				ParentSpanId:            []byte{0x03},
-				Name:                    &tracepb.TruncatableString{Value: "server"},
-				Kind:                    tracepb.Span_SERVER,
-				SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: false},
-			},
-		},
-	}
-	got := testTracesExporter(internaldata.OCToTraces(td.Node, td.Resource, td.Spans), t, baseConfig())
+	td := pdata.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"service.name": pdata.NewAttributeValueString("test_service"),
+		"A":            pdata.NewAttributeValueString("B"),
+		"B":            pdata.NewAttributeValueString("C"),
+	})
+	instrLibrarySpans := rs.InstrumentationLibrarySpans().AppendEmpty()
+	lib := instrLibrarySpans.InstrumentationLibrary()
+	lib.SetName("my.custom.library")
+	lib.SetVersion("1.0.0")
+
+	clientSpan := instrLibrarySpans.Spans().AppendEmpty()
+	clientSpan.SetTraceID(pdata.NewTraceID([16]byte{0x01}))
+	clientSpan.SetSpanID(pdata.NewSpanID([8]byte{0x03}))
+	clientSpan.SetParentSpanID(pdata.NewSpanID([8]byte{0x02}))
+	clientSpan.SetName("client")
+	clientSpan.SetKind(pdata.SpanKindClient)
+	clientSpanLink := clientSpan.Links().AppendEmpty()
+	clientSpanLink.SetTraceID(pdata.NewTraceID([16]byte{0x04}))
+	clientSpanLink.SetSpanID(pdata.NewSpanID([8]byte{0x05}))
+	clientSpanLink.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"span_link_attr": pdata.NewAttributeValueInt(12345),
+	})
+
+	serverSpan := instrLibrarySpans.Spans().AppendEmpty()
+	serverSpan.SetTraceID(pdata.NewTraceID([16]byte{0x01}))
+	serverSpan.SetSpanID(pdata.NewSpanID([8]byte{0x04}))
+	serverSpan.SetParentSpanID(pdata.NewSpanID([8]byte{0x03}))
+	serverSpan.SetName("server")
+	serverSpan.SetKind(pdata.SpanKindServer)
+
+	rootSpan := instrLibrarySpans.Spans().AppendEmpty()
+	rootSpan.SetTraceID(pdata.NewTraceID([16]byte{0x01}))
+	rootSpan.SetSpanID(pdata.NewSpanID([8]byte{0x02}))
+	rootSpan.SetName("root")
+	rootSpan.SetKind(pdata.SpanKindServer)
+	rootSpan.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"span_attr_name": pdata.NewAttributeValueString("Span Attribute"),
+		"B":              pdata.NewAttributeValueString("D"),
+	})
+	rootSpanEvent := rootSpan.Events().AppendEmpty()
+	rootSpanEvent.SetTimestamp(0)
+	rootSpanEvent.SetName("Some Description")
+	rootSpanEvent.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"attribute_name": pdata.NewAttributeValueString("Hello MessageEvent"),
+		"B":              pdata.NewAttributeValueString("D"),
+	})
+
+	got := testTracesExporter(td, t, baseConfig())
 	want := []honeycombData{
 		{
 			Data: map[string]interface{}{
@@ -223,67 +161,66 @@ func TestExporter(t *testing.T) {
 		},
 		{
 			Data: map[string]interface{}{
-				"duration_ms":                            float64(0),
-				"name":                                   "client",
-				"service.name":                           "test_service",
-				"span_kind":                              "client",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.parent_id":                        "0200000000000000",
-				"trace.span_id":                          "0300000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"opencensus.resourcetype":                "foobar",
-				"opencensus.same_process_as_parent_span": true,
-				"A":                                      "B",
-				"B":                                      "C",
+				"duration_ms":     float64(0),
+				"name":            "client",
+				"service.name":    "test_service",
+				"span_kind":       "client",
+				"status.code":     float64(0), // Default status code
+				"status.message":  "STATUS_CODE_UNSET",
+				"trace.parent_id": "0200000000000000",
+				"trace.span_id":   "0300000000000000",
+				"trace.trace_id":  "01000000000000000000000000000000",
+				"library.name":    "my.custom.library",
+				"library.version": "1.0.0",
+				"A":               "B",
+				"B":               "C",
 			},
 		},
 		{
 			Data: map[string]interface{}{
-				"duration_ms":                            float64(0),
-				"name":                                   "server",
-				"service.name":                           "test_service",
-				"span_kind":                              "server",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.parent_id":                        "0300000000000000",
-				"trace.span_id":                          "0400000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"A":                                      "B",
-				"B":                                      "C",
-				"opencensus.resourcetype":                "foobar",
-				"opencensus.same_process_as_parent_span": false,
+				"duration_ms":     float64(0),
+				"name":            "server",
+				"service.name":    "test_service",
+				"span_kind":       "server",
+				"status.code":     float64(0), // Default status code
+				"status.message":  "STATUS_CODE_UNSET",
+				"trace.parent_id": "0300000000000000",
+				"trace.span_id":   "0400000000000000",
+				"trace.trace_id":  "01000000000000000000000000000000",
+				"library.name":    "my.custom.library",
+				"library.version": "1.0.0",
+				"A":               "B",
+				"B":               "C",
 			},
 		},
 		{
 			Data: map[string]interface{}{
-				"A":                       "B",
-				"B":                       "D",
-				"attribute_name":          "Hello MessageEvent",
-				"meta.annotation_type":    "span_event",
-				"name":                    "Some Description",
-				"opencensus.resourcetype": "override",
-				"service.name":            "test_service",
-				"trace.parent_id":         "0200000000000000",
-				"trace.parent_name":       "root",
-				"trace.trace_id":          "01000000000000000000000000000000",
+				"A":                    "B",
+				"B":                    "D",
+				"attribute_name":       "Hello MessageEvent",
+				"meta.annotation_type": "span_event",
+				"name":                 "Some Description",
+				"service.name":         "test_service",
+				"trace.parent_id":      "0200000000000000",
+				"trace.parent_name":    "root",
+				"trace.trace_id":       "01000000000000000000000000000000",
 			},
 		},
 		{
 			Data: map[string]interface{}{
-				"duration_ms":                            float64(0),
-				"name":                                   "root",
-				"service.name":                           "test_service",
-				"span_attr_name":                         "Span Attribute",
-				"span_kind":                              "server",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.span_id":                          "0200000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"A":                                      "B",
-				"B":                                      "D",
-				"opencensus.resourcetype":                "override",
-				"opencensus.same_process_as_parent_span": true,
+				"duration_ms":     float64(0),
+				"name":            "root",
+				"service.name":    "test_service",
+				"span_attr_name":  "Span Attribute",
+				"span_kind":       "server",
+				"status.code":     float64(0), // Default status code
+				"status.message":  "STATUS_CODE_UNSET",
+				"trace.span_id":   "0200000000000000",
+				"trace.trace_id":  "01000000000000000000000000000000",
+				"A":               "B",
+				"B":               "D",
+				"library.name":    "my.custom.library",
+				"library.version": "1.0.0",
 			},
 		},
 	}
@@ -371,109 +308,80 @@ func initSpan(span pdata.Span) {
 }
 
 func TestSampleRateAttribute(t *testing.T) {
-	td := traceData{
-		Node: nil,
-		Spans: []*tracepb.Span{
-			{
-				TraceId:                 []byte{0x01},
-				SpanId:                  []byte{0x02},
-				Name:                    &tracepb.TruncatableString{Value: "root"},
-				Kind:                    tracepb.Span_SERVER,
-				SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: true},
-				Attributes: &tracepb.Span_Attributes{
-					AttributeMap: map[string]*tracepb.AttributeValue{
-						"some_attribute": {
-							Value: &tracepb.AttributeValue_StringValue{
-								StringValue: &tracepb.TruncatableString{Value: "A value"},
-							},
-						},
-						"hc.sample.rate": {
-							Value: &tracepb.AttributeValue_IntValue{
-								IntValue: 13,
-							},
-						},
-					},
-				},
-			},
-			{
-				TraceId:                 []byte{0x01},
-				SpanId:                  []byte{0x02},
-				Name:                    &tracepb.TruncatableString{Value: "root"},
-				Kind:                    tracepb.Span_SERVER,
-				SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: true},
-				Attributes: &tracepb.Span_Attributes{
-					AttributeMap: map[string]*tracepb.AttributeValue{
-						"no_sample_rate": {
-							Value: &tracepb.AttributeValue_StringValue{
-								StringValue: &tracepb.TruncatableString{Value: "gets_default"},
-							},
-						},
-					},
-				},
-			},
-			{
-				TraceId:                 []byte{0x01},
-				SpanId:                  []byte{0x02},
-				Name:                    &tracepb.TruncatableString{Value: "root"},
-				Kind:                    tracepb.Span_SERVER,
-				SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: true},
-				Attributes: &tracepb.Span_Attributes{
-					AttributeMap: map[string]*tracepb.AttributeValue{
-						"hc.sample.rate": {
-							Value: &tracepb.AttributeValue_StringValue{
-								StringValue: &tracepb.TruncatableString{Value: "wrong_type"},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	td := pdata.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().InitFromMap(map[string]pdata.AttributeValue{})
+	instrLibrarySpans := rs.InstrumentationLibrarySpans().AppendEmpty()
+
+	intSampleRateSpan := instrLibrarySpans.Spans().AppendEmpty()
+	intSampleRateSpan.SetTraceID(pdata.NewTraceID([16]byte{0x01}))
+	intSampleRateSpan.SetSpanID(pdata.NewSpanID([8]byte{0x02}))
+	intSampleRateSpan.SetName("root")
+	intSampleRateSpan.SetKind(pdata.SpanKindServer)
+	intSampleRateSpan.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"some_attribute": pdata.NewAttributeValueString("A value"),
+		"hc.sample.rate": pdata.NewAttributeValueInt(13),
+	})
+
+	noSampleRateSpan := instrLibrarySpans.Spans().AppendEmpty()
+	noSampleRateSpan.SetTraceID(pdata.NewTraceID([16]byte{0x01}))
+	noSampleRateSpan.SetSpanID(pdata.NewSpanID([8]byte{0x02}))
+	noSampleRateSpan.SetName("root")
+	noSampleRateSpan.SetKind(pdata.SpanKindServer)
+	noSampleRateSpan.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"no_sample_rate": pdata.NewAttributeValueString("gets_default"),
+	})
+
+	invalidSampleRateSpan := instrLibrarySpans.Spans().AppendEmpty()
+	invalidSampleRateSpan.SetTraceID(pdata.NewTraceID([16]byte{0x01}))
+	invalidSampleRateSpan.SetSpanID(pdata.NewSpanID([8]byte{0x02}))
+	invalidSampleRateSpan.SetName("root")
+	invalidSampleRateSpan.SetKind(pdata.SpanKindServer)
+	invalidSampleRateSpan.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"hc.sample.rate": pdata.NewAttributeValueString("wrong_type"),
+	})
 
 	cfg := baseConfig()
 	cfg.SampleRateAttribute = "hc.sample.rate"
 
-	got := testTracesExporter(internaldata.OCToTraces(td.Node, td.Resource, td.Spans), t, cfg)
+	got := testTracesExporter(td, t, cfg)
 
 	want := []honeycombData{
 		{
 			Data: map[string]interface{}{
-				"duration_ms":                            float64(0),
-				"hc.sample.rate":                         float64(13),
-				"name":                                   "root",
-				"span_kind":                              "server",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.span_id":                          "0200000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"opencensus.same_process_as_parent_span": true,
-				"some_attribute":                         "A value",
+				"duration_ms":    float64(0),
+				"hc.sample.rate": float64(13),
+				"name":           "root",
+				"span_kind":      "server",
+				"status.code":    float64(0), // Default status code
+				"status.message": "STATUS_CODE_UNSET",
+				"trace.span_id":  "0200000000000000",
+				"trace.trace_id": "01000000000000000000000000000000",
+				"some_attribute": "A value",
 			},
 		},
 		{
 			Data: map[string]interface{}{
-				"duration_ms":                            float64(0),
-				"name":                                   "root",
-				"span_kind":                              "server",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.span_id":                          "0200000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"opencensus.same_process_as_parent_span": true,
-				"no_sample_rate":                         "gets_default",
+				"duration_ms":    float64(0),
+				"name":           "root",
+				"span_kind":      "server",
+				"status.code":    float64(0), // Default status code
+				"status.message": "STATUS_CODE_UNSET",
+				"trace.span_id":  "0200000000000000",
+				"trace.trace_id": "01000000000000000000000000000000",
+				"no_sample_rate": "gets_default",
 			},
 		},
 		{
 			Data: map[string]interface{}{
-				"duration_ms":                            float64(0),
-				"hc.sample.rate":                         "wrong_type",
-				"name":                                   "root",
-				"span_kind":                              "server",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.span_id":                          "0200000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"opencensus.same_process_as_parent_span": true,
+				"duration_ms":    float64(0),
+				"hc.sample.rate": "wrong_type",
+				"name":           "root",
+				"span_kind":      "server",
+				"status.code":    float64(0), // Default status code
+				"status.message": "STATUS_CODE_UNSET",
+				"trace.span_id":  "0200000000000000",
+				"trace.trace_id": "01000000000000000000000000000000",
 			},
 		},
 	}
@@ -481,157 +389,6 @@ func TestSampleRateAttribute(t *testing.T) {
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("otel span: (-want +got):\n%s", diff)
 	}
-}
-
-func TestEmptyNode(t *testing.T) {
-	td := traceData{
-		Node: nil,
-		Spans: []*tracepb.Span{
-			{
-				TraceId:                 []byte{0x01},
-				SpanId:                  []byte{0x02},
-				Name:                    &tracepb.TruncatableString{Value: "root"},
-				Kind:                    tracepb.Span_SERVER,
-				SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: true},
-			},
-		},
-	}
-
-	got := testTracesExporter(internaldata.OCToTraces(td.Node, td.Resource, td.Spans), t, baseConfig())
-
-	want := []honeycombData{
-		{
-			Data: map[string]interface{}{
-				"duration_ms":                            float64(0),
-				"name":                                   "root",
-				"span_kind":                              "server",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.span_id":                          "0200000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"opencensus.same_process_as_parent_span": true,
-			},
-		},
-	}
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("otel span: (-want +got):\n%s", diff)
-	}
-}
-
-type testNodeCase struct {
-	name       string
-	identifier *commonpb.ProcessIdentifier
-	expected   map[string]interface{}
-}
-
-func TestNode(t *testing.T) {
-
-	testcases := []testNodeCase{
-		{
-			name: "all_information",
-			identifier: &commonpb.ProcessIdentifier{
-				HostName: "my-host",
-				Pid:      123,
-				StartTimestamp: &timestamppb.Timestamp{
-					Seconds: 1599596112,
-					Nanos:   0,
-				},
-			},
-			expected: map[string]interface{}{
-				"B":                                      "C",
-				"duration_ms":                            float64(0),
-				"name":                                   "root",
-				"span_kind":                              "server",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.span_id":                          "0200000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"opencensus.resourcetype":                "container",
-				"opencensus.same_process_as_parent_span": true,
-				"opencensus.starttime":                   "2020-09-08T20:15:12Z",
-				"host.name":                              "my-host",
-				"process.pid":                            float64(123),
-				"service.name":                           "test_service",
-			},
-		},
-		{
-			name: "missing_pid_and_time",
-			identifier: &commonpb.ProcessIdentifier{
-				HostName: "my-host",
-			},
-			expected: map[string]interface{}{
-				"B":                                      "C",
-				"duration_ms":                            float64(0),
-				"name":                                   "root",
-				"span_kind":                              "server",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.span_id":                          "0200000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"opencensus.resourcetype":                "container",
-				"opencensus.same_process_as_parent_span": true,
-				"host.name":                              "my-host",
-				"service.name":                           "test_service",
-			},
-		},
-		{
-			name:       "nil_identifier",
-			identifier: nil,
-			expected: map[string]interface{}{
-				"B":                                      "C",
-				"duration_ms":                            float64(0),
-				"name":                                   "root",
-				"span_kind":                              "server",
-				"status.code":                            float64(0), // Default status code
-				"status.message":                         "STATUS_CODE_UNSET",
-				"trace.span_id":                          "0200000000000000",
-				"trace.trace_id":                         "01000000000000000000000000000000",
-				"opencensus.resourcetype":                "container",
-				"opencensus.same_process_as_parent_span": true,
-				"service.name":                           "test_service",
-			},
-		},
-	}
-
-	for _, test := range testcases {
-		t.Run(test.name, func(t *testing.T) {
-			td := traceData{
-				Node: &commonpb.Node{
-					ServiceInfo: &commonpb.ServiceInfo{Name: "test_service"},
-					Identifier:  test.identifier,
-				},
-				Resource: &resourcepb.Resource{
-					Type: "container",
-					Labels: map[string]string{
-						"B": "C",
-					},
-				},
-				Spans: []*tracepb.Span{
-					{
-						TraceId:                 []byte{0x01},
-						SpanId:                  []byte{0x02},
-						Name:                    &tracepb.TruncatableString{Value: "root"},
-						Kind:                    tracepb.Span_SERVER,
-						SameProcessAsParentSpan: &wrapperspb.BoolValue{Value: true},
-					},
-				},
-			}
-
-			got := testTracesExporter(internaldata.OCToTraces(td.Node, td.Resource, td.Spans), t, baseConfig())
-
-			want := []honeycombData{
-				{
-					Data: test.expected,
-				},
-			}
-
-			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("otel span: (-want +got):\n%s", diff)
-			}
-		})
-	}
-
 }
 
 func TestRunErrorLogger_OnError(t *testing.T) {


### PR DESCRIPTION
**Description:**
Removes OpenCensus pdata usage and replace with OTel pdata.

**Link to tracking Issue:**
N/A

**Testing:**
Manually executed tests

**Documentation:**
N/A