### PR TITLE
Signalfx exporter: discourage setting of endpoint path

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -22,15 +22,16 @@ The following configuration options are required:
   - `api_url` (no default): Destination to which SignalFx [properties and
     tags](https://docs.signalfx.com/en/latest/metrics-metadata/metrics-metadata.html#metrics-metadata)
     are sent. If `realm` is set, this option is derived and will be
-    `https://api.{realm}.signalfx.com/`. If a value is explicitly set, the
+    `https://api.{realm}.signalfx.com`. If a value is explicitly set, the
     value of `realm` will not be used in determining `api_url`. The explicit
     value will be used instead.
   - `ingest_url` (no default): Destination where SignalFx metrics are sent. If
     `realm` is set, this option is derived and will be
-    `https://ingest.{realm}.signalfx.com/v2/datapoint`.  If a value is
+    `https://ingest.{realm}.signalfx.com`. If a value is
     explicitly set, the value of `realm` will not be used in determining
-    `ingest_url`. The explicit value will be used instead. If path is not
-    specified, `/v2/datapoint` is used.
+    `ingest_url`. The explicit value will be used instead. The exporter will 
+    automatically append the appropriate path: "/v2/datapoint" for metrics, 
+    and "/v2/event" for events.
 
 The following configuration options can also be configured:
 

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -50,9 +50,8 @@ type Config struct {
 
 	// IngestURL is the destination to where SignalFx metrics will be sent to, it is
 	// intended for tests and debugging. The value of Realm is ignored if the
-	// URL is specified. If a path is not included the exporter will
-	// automatically append the appropriate path, eg.: "v2/datapoint".
-	// If a path is specified it will act as a prefix.
+	// URL is specified. The exporter will automatically append the appropriate
+	// path: "/v2/datapoint" for metrics, and "/v2/event" for events.
 	IngestURL string `mapstructure:"ingest_url"`
 
 	// APIURL is the destination to where SignalFx metadata will be sent. This

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -158,7 +158,7 @@ func Test_signalfxeceiver_EndToEnd(t *testing.T) {
 
 	expCfg := &signalfxexporter.Config{
 		ExporterSettings: config.NewExporterSettings(config.NewComponentID("signalfx")),
-		IngestURL:        "http://" + addr + "/v2/datapoint",
+		IngestURL:        "http://" + addr,
 		APIURL:           "http://localhost",
 		AccessToken:      "access_token",
 	}

--- a/testbed/datareceivers/signalfx.go
+++ b/testbed/datareceivers/signalfx.go
@@ -69,7 +69,7 @@ func (sr *SFxMetricsDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
     signalfx:
-      ingest_url: "http://localhost:%d/v2/datapoint"
+      ingest_url: "http://localhost:%d"
       api_url: "http://localhost/"
       access_token: "access_token"`, sr.Port)
 }

--- a/testbed/datasenders/signalfx.go
+++ b/testbed/datasenders/signalfx.go
@@ -52,7 +52,7 @@ func (sf *SFxMetricsDataSender) Start() error {
 	factory := signalfxexporter.NewFactory()
 	cfg := &signalfxexporter.Config{
 		ExporterSettings: config.NewExporterSettings(config.NewComponentID(factory.Type())),
-		IngestURL:        fmt.Sprintf("http://%s/v2/datapoint", sf.GetEndpoint()),
+		IngestURL:        fmt.Sprintf("http://%s", sf.GetEndpoint()),
 		APIURL:           "http://localhost",
 		AccessToken:      "access_token",
 	}


### PR DESCRIPTION
If a user adds `/v2/datapoint` path to `ingest_url` and has logs/signalfx-events pipeline enabled, then events will be sent to `/v2/datapoint/v2/event` and exporter will be getting 404s. For now, we want to avoid this situation just by discouraging setting the endpoint path. 

This change also has a doc fix for the default value of `ingest_url` when only `realm` is provided.
