### PR TITLE
Update testutil/metricstestutil paths to point to contrib coreinternal/metricstestutil

### DIFF
--- a/exporter/alibabacloudlogserviceexporter/go.mod
+++ b/exporter/alibabacloudlogserviceexporter/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/aliyun/aliyun-log-go-sdk v0.1.21
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.33.1-0.20210820002854-d3000232f8f6
 	go.opentelemetry.io/collector/model v0.33.1-0.20210820002854-d3000232f8f6

--- a/exporter/alibabacloudlogserviceexporter/metrics_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/metrics_exporter_test.go
@@ -24,7 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/testutil/metricstestutil"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
 
 	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 )

--- a/exporter/carbonexporter/exporter_test.go
+++ b/exporter/carbonexporter/exporter_test.go
@@ -35,8 +35,9 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/testutil"
-	"go.opentelemetry.io/collector/testutil/metricstestutil"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
 
 	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 )

--- a/exporter/carbonexporter/go.mod
+++ b/exporter/carbonexporter/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/mattn/go-colorable v0.1.7 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.33.1-0.20210820002854-d3000232f8f6

--- a/exporter/carbonexporter/metricdata_to_plaintext_test.go
+++ b/exporter/carbonexporter/metricdata_to_plaintext_test.go
@@ -24,8 +24,9 @@ import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/testutil/metricstestutil"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
 )
 
 func Test_sanitizeTagKey(t *testing.T) {

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.0.0-RC2
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/mattn/go-colorable v0.1.7 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.23.0

--- a/exporter/googlecloudexporter/googlecloud_test.go
+++ b/exporter/googlecloudexporter/googlecloud_test.go
@@ -30,7 +30,6 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/model/pdata"
-	"go.opentelemetry.io/collector/testutil/metricstestutil"
 	"google.golang.org/api/option"
 	cloudmetricpb "google.golang.org/genproto/googleapis/api/metric"
 	cloudtracepb "google.golang.org/genproto/googleapis/devtools/cloudtrace/v2"
@@ -39,6 +38,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
 
 	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 )

--- a/exporter/splunkhecexporter/exporter_test.go
+++ b/exporter/splunkhecexporter/exporter_test.go
@@ -37,10 +37,11 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/model/pdata"
-	"go.opentelemetry.io/collector/testutil/metricstestutil"
 	conventions "go.opentelemetry.io/collector/translator/conventions/v1.5.0"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
 
 	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 

--- a/exporter/splunkhecexporter/go.mod
+++ b/exporter/splunkhecexporter/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.0.0-00010101000000-000000000000
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0

--- a/receiver/awsecscontainermetricsreceiver/go.mod
+++ b/receiver/awsecscontainermetricsreceiver/go.mod
@@ -6,9 +6,12 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/hashicorp/go-msgpack v0.5.5 // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.33.1-0.20210820002854-d3000232f8f6
 	go.opentelemetry.io/collector/model v0.33.1-0.20210820002854-d3000232f8f6
 	go.uber.org/zap v1.19.0
 	google.golang.org/protobuf v1.27.1
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/utils.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/utils.go
@@ -19,8 +19,9 @@ import (
 	"time"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	"go.opentelemetry.io/collector/testutil/metricstestutil"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/metricstestutil"
 )
 
 // createGaugeIntMetric creates a int gauge metric


### PR DESCRIPTION
This PR updates the imports and go mod of several components to point to internal/coreinternal/metricstestutil

Related issues include: 
[opentelemetry-collector/#3474](https://github.com/open-telemetry/opentelemetry-collector/issues/3474)