### PR TITLE
Allow JMX receiver logging level to be configured

### DIFF
--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -92,11 +92,6 @@ func (oec otlpExporterConfig) headersToString() string {
 }
 
 func (c *Config) parseProperties() []string {
-	// Set defaults if not present
-	if _, present := c.Properties["org.slf4j.simpleLogger.defaultLogLevel"]; !present {
-		c.Properties["org.slf4j.simpleLogger.defaultLogLevel"] = "info"
-	}
-
 	parsed := make([]string, 0, len(c.Properties))
 	for property, value := range c.Properties {
 		parsed = append(parsed, fmt.Sprintf("-D%s=%s", property, value))

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -125,6 +125,7 @@ func (c *Config) validate() error {
 	if c.CollectionInterval < 0 {
 		return fmt.Errorf("%v `interval` must be positive: %vms", c.ID(), c.CollectionInterval.Milliseconds())
 	}
+
 	if c.OTLPExporterConfig.Timeout < 0 {
 		return fmt.Errorf("%v `otlp.timeout` must be positive: %vms", c.ID(), c.OTLPExporterConfig.Timeout.Milliseconds())
 	}

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -92,6 +92,15 @@ func (oec otlpExporterConfig) headersToString() string {
 }
 
 func (c *Config) parseProperties() []string {
+	if c.Properties == nil {
+		c.Properties = make(map[string]string)
+	}
+
+	// Set defaults if not present
+	if _, present := c.Properties["org.slf4j.simpleLogger.defaultLogLevel"]; !present {
+		c.Properties["org.slf4j.simpleLogger.defaultLogLevel"] = "info"
+	}
+
 	parsed := make([]string, 0, len(c.Properties))
 	for property, value := range c.Properties {
 		parsed = append(parsed, fmt.Sprintf("-D%s=%s", property, value))

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -125,7 +125,6 @@ func (c *Config) validate() error {
 	if c.CollectionInterval < 0 {
 		return fmt.Errorf("%v `interval` must be positive: %vms", c.ID(), c.CollectionInterval.Milliseconds())
 	}
-
 	if c.OTLPExporterConfig.Timeout < 0 {
 		return fmt.Errorf("%v `otlp.timeout` must be positive: %vms", c.ID(), c.OTLPExporterConfig.Timeout.Milliseconds())
 	}

--- a/receiver/jmxreceiver/config.go
+++ b/receiver/jmxreceiver/config.go
@@ -92,10 +92,6 @@ func (oec otlpExporterConfig) headersToString() string {
 }
 
 func (c *Config) parseProperties() []string {
-	if c.Properties == nil {
-		c.Properties = make(map[string]string)
-	}
-
 	// Set defaults if not present
 	if _, present := c.Properties["org.slf4j.simpleLogger.defaultLogLevel"]; !present {
 		c.Properties["org.slf4j.simpleLogger.defaultLogLevel"] = "info"

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -84,7 +84,7 @@ func TestLoadConfig(t *testing.T) {
 		}, r1)
 
 	assert.Equal(
-		t, []string{"-Dproperty.one=value.one", "-Dproperty.two=value.two.a=value.two.b,value.two.c=value.two.d"},
+		t, []string{"-Dorg.slf4j.simpleLogger.defaultLogLevel=info", "-Dproperty.one=value.one", "-Dproperty.two=value.two.a=value.two.b,value.two.c=value.two.d"},
 		r1.parseProperties(),
 	)
 

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -78,8 +78,9 @@ func TestLoadConfig(t *testing.T) {
 			RemoteProfile:      "myremoteprofile",
 			Realm:              "myrealm",
 			Properties: map[string]string{
-				"property.one": "value.one",
-				"property.two": "value.two.a=value.two.b,value.two.c=value.two.d",
+				"property.one":                           "value.one",
+				"property.two":                           "value.two.a=value.two.b,value.two.c=value.two.d",
+				"org.slf4j.simpleLogger.defaultLogLevel": "info",
 			},
 		}, r1)
 
@@ -96,7 +97,7 @@ func TestLoadConfig(t *testing.T) {
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
 			GroovyScript:       "mygroovyscriptpath",
 			CollectionInterval: 10 * time.Second,
-			Properties:         make(map[string]string),
+			Properties:         map[string]string{"org.slf4j.simpleLogger.defaultLogLevel": "info"},
 			OTLPExporterConfig: otlpExporterConfig{
 				Endpoint: "0.0.0.0:0",
 				TimeoutSettings: exporterhelper.TimeoutSettings{
@@ -115,7 +116,7 @@ func TestLoadConfig(t *testing.T) {
 			ReceiverSettings:   config.NewReceiverSettings(config.NewIDWithName(typeStr, "missinggroovy")),
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
 			Endpoint:           "service:jmx:rmi:///jndi/rmi://host:12345/jmxrmi",
-			Properties:         make(map[string]string),
+			Properties:         map[string]string{"org.slf4j.simpleLogger.defaultLogLevel": "info"},
 			CollectionInterval: 10 * time.Second,
 			OTLPExporterConfig: otlpExporterConfig{
 				Endpoint: "0.0.0.0:0",
@@ -136,7 +137,7 @@ func TestLoadConfig(t *testing.T) {
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
 			Endpoint:           "myendpoint:23456",
 			GroovyScript:       "mygroovyscriptpath",
-			Properties:         make(map[string]string),
+			Properties:         map[string]string{"org.slf4j.simpleLogger.defaultLogLevel": "info"},
 			CollectionInterval: -100 * time.Millisecond,
 			OTLPExporterConfig: otlpExporterConfig{
 				Endpoint: "0.0.0.0:0",
@@ -157,7 +158,7 @@ func TestLoadConfig(t *testing.T) {
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
 			Endpoint:           "myendpoint:34567",
 			GroovyScript:       "mygroovyscriptpath",
-			Properties:         make(map[string]string),
+			Properties:         map[string]string{"org.slf4j.simpleLogger.defaultLogLevel": "info"},
 			CollectionInterval: 10 * time.Second,
 			OTLPExporterConfig: otlpExporterConfig{
 				Endpoint: "0.0.0.0:0",

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -96,6 +96,7 @@ func TestLoadConfig(t *testing.T) {
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
 			GroovyScript:       "mygroovyscriptpath",
 			CollectionInterval: 10 * time.Second,
+			Properties:         make(map[string]string),
 			OTLPExporterConfig: otlpExporterConfig{
 				Endpoint: "0.0.0.0:0",
 				TimeoutSettings: exporterhelper.TimeoutSettings{
@@ -114,6 +115,7 @@ func TestLoadConfig(t *testing.T) {
 			ReceiverSettings:   config.NewReceiverSettings(config.NewIDWithName(typeStr, "missinggroovy")),
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
 			Endpoint:           "service:jmx:rmi:///jndi/rmi://host:12345/jmxrmi",
+			Properties:         make(map[string]string),
 			CollectionInterval: 10 * time.Second,
 			OTLPExporterConfig: otlpExporterConfig{
 				Endpoint: "0.0.0.0:0",
@@ -134,6 +136,7 @@ func TestLoadConfig(t *testing.T) {
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
 			Endpoint:           "myendpoint:23456",
 			GroovyScript:       "mygroovyscriptpath",
+			Properties:         make(map[string]string),
 			CollectionInterval: -100 * time.Millisecond,
 			OTLPExporterConfig: otlpExporterConfig{
 				Endpoint: "0.0.0.0:0",
@@ -154,6 +157,7 @@ func TestLoadConfig(t *testing.T) {
 			JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
 			Endpoint:           "myendpoint:34567",
 			GroovyScript:       "mygroovyscriptpath",
+			Properties:         make(map[string]string),
 			CollectionInterval: 10 * time.Second,
 			OTLPExporterConfig: otlpExporterConfig{
 				Endpoint: "0.0.0.0:0",

--- a/receiver/jmxreceiver/factory.go
+++ b/receiver/jmxreceiver/factory.go
@@ -41,6 +41,7 @@ func createDefaultConfig() config.Receiver {
 	return &Config{
 		ReceiverSettings:   config.NewReceiverSettings(config.NewID(typeStr)),
 		JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
+		Properties:         make(map[string]string),
 		CollectionInterval: 10 * time.Second,
 		OTLPExporterConfig: otlpExporterConfig{
 			Endpoint: otlpEndpoint,

--- a/receiver/jmxreceiver/factory.go
+++ b/receiver/jmxreceiver/factory.go
@@ -41,7 +41,7 @@ func createDefaultConfig() config.Receiver {
 	return &Config{
 		ReceiverSettings:   config.NewReceiverSettings(config.NewID(typeStr)),
 		JARPath:            "/opt/opentelemetry-java-contrib-jmx-metrics.jar",
-		Properties:         make(map[string]string),
+		Properties:         map[string]string{"org.slf4j.simpleLogger.defaultLogLevel": "info"},
 		CollectionInterval: 10 * time.Second,
 		OTLPExporterConfig: otlpExporterConfig{
 			Endpoint: otlpEndpoint,

--- a/receiver/jmxreceiver/factory_test.go
+++ b/receiver/jmxreceiver/factory_test.go
@@ -58,3 +58,22 @@ func TestWithValidConfig(t *testing.T) {
 	assert.Same(t, receiver.logger, params.Logger)
 	assert.Same(t, receiver.config, cfg)
 }
+
+func TestWithSetProperties(t *testing.T) {
+	f := NewFactory()
+	assert.Equal(t, config.Type("jmx"), f.Type())
+
+	cfg := f.CreateDefaultConfig()
+	cfg.(*Config).Endpoint = "myendpoint:12345"
+	cfg.(*Config).GroovyScript = "mygroovyscriptpath"
+	cfg.(*Config).Properties["org.slf4j.simpleLogger.defaultLogLevel"] = "trace"
+	cfg.(*Config).Properties["org.java.fake.property"] = "true"
+
+	params := componenttest.NewNopReceiverCreateSettings()
+	r, err := f.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	receiver := r.(*jmxMetricReceiver)
+	assert.Same(t, receiver.logger, params.Logger)
+	assert.Same(t, receiver.config, cfg)
+}

--- a/receiver/jmxreceiver/integration_test.go
+++ b/receiver/jmxreceiver/integration_test.go
@@ -240,6 +240,7 @@ func TestJMXReceiverInvalidOTLPEndpointIntegration(t *testing.T) {
 		CollectionInterval: 100 * time.Millisecond,
 		Endpoint:           fmt.Sprintf("service:jmx:rmi:///jndi/rmi://localhost:7199/jmxrmi"),
 		JARPath:            "/notavalidpath",
+		Properties:         make(map[string]string),
 		GroovyScript:       path.Join(".", "testdata", "script.groovy"),
 		OTLPExporterConfig: otlpExporterConfig{
 			Endpoint: "<invalid>:123",

--- a/receiver/jmxreceiver/receiver.go
+++ b/receiver/jmxreceiver/receiver.go
@@ -70,7 +70,7 @@ func (jmx *jmxMetricReceiver) Start(ctx context.Context, host component.Host) (e
 
 	subprocessConfig := subprocess.Config{
 		ExecutablePath: "java",
-		Args:           append(jmx.config.parseProperties(), "-Dorg.slf4j.simpleLogger.defaultLogLevel=info", "-jar", jmx.config.JARPath, "-config", "-"),
+		Args:           append(jmx.config.parseProperties(), "-jar", jmx.config.JARPath, "-config", "-"),
 		StdInContents:  javaConfig,
 	}
 

--- a/receiver/jmxreceiver/receiver_test.go
+++ b/receiver/jmxreceiver/receiver_test.go
@@ -35,6 +35,7 @@ func TestReceiver(t *testing.T) {
 		OTLPExporterConfig: otlpExporterConfig{
 			Endpoint: fmt.Sprintf("localhost:%d", testutil.GetAvailablePort(t)),
 		},
+		Properties: make(map[string]string),
 	}
 
 	receiver := newJMXMetricReceiver(params, config, consumertest.NewNop())


### PR DESCRIPTION
**Description:** JMX Receiver log level was set in the Java command in a way that could not be overridden, this allows it to be still set by default to info but overridden if needed for debugging.