### PR TITLE
receiver/prometheus/internal: track staleness marker per instance instead of globally

### DIFF
--- a/receiver/prometheusreceiver/internal/staleness_bugs_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_bugs_test.go
@@ -1,0 +1,235 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
+	"go.opentelemetry.io/collector/service"
+	"go.opentelemetry.io/collector/service/parserprovider"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+)
+
+// Test that staleness markers are NOT emitted for replicated services whose scrapes might alternate
+// between intervals.
+// Ideally after this test, which runs the entire collector and end-to-end scrapes then checks with the
+// Prometheus remotewrite exporter should count NO staleness markers emitted.
+// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4748
+func TestStalenessMarkersReplicatedServicesDoNotProduceStalenessMarkers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("This test can take a long time")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	createStalenessHandler := func() http.HandlerFunc {
+		// 1. Setup the server's handler.
+		var n uint64
+		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			fmt.Fprintf(rw, `
+# HELP jvm_memory_bytes_used Used bytes of a given JVM memory area.
+# TYPE jvm_memory_bytes_used gauge
+jvm_memory_bytes_used{area="heap"} %.1f`, float64(atomic.AddUint64(&n, 1)))
+		})
+	}
+
+	scrapeServer1 := httptest.NewServer(createStalenessHandler())
+	defer scrapeServer1.Close()
+	scrapeServer2 := httptest.NewServer(createStalenessHandler())
+	defer scrapeServer2.Close()
+
+	serverURL1, err := url.Parse(scrapeServer1.URL)
+	require.Nil(t, err)
+	serverURL2, err := url.Parse(scrapeServer2.URL)
+	require.Nil(t, err)
+
+	// 2. Set up the Prometheus RemoteWrite endpoint.
+	prweUploads := make(chan *prompb.WriteRequest)
+	prweServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Snappy decode the uploads.
+		payload, rerr := ioutil.ReadAll(req.Body)
+		if err != nil {
+			panic(rerr)
+		}
+		recv := make([]byte, len(payload))
+		decoded, derr := snappy.Decode(recv, payload)
+		if err != nil {
+			panic(derr)
+		}
+
+		writeReq := new(prompb.WriteRequest)
+		if uerr := proto.Unmarshal(decoded, writeReq); uerr != nil {
+			panic(uerr)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case prweUploads <- writeReq:
+		}
+	}))
+	defer prweServer.Close()
+
+	// 3. Set the OpenTelemetry Prometheus receiver.
+	config := fmt.Sprintf(`
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'test'
+          scrape_interval: 2ms
+          static_configs:
+            - targets: [%q,%q]
+
+processors:
+  batch:
+exporters:
+  prometheusremotewrite:
+    endpoint: %q
+    insecure: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [prometheusremotewrite]`, serverURL1.Host, serverURL2.Host, prweServer.URL)
+
+	// 4. Run the OpenTelemetry Collector.
+	receivers, err := component.MakeReceiverFactoryMap(prometheusreceiver.NewFactory())
+	require.Nil(t, err)
+	exporters, err := component.MakeExporterFactoryMap(prometheusremotewriteexporter.NewFactory())
+	require.Nil(t, err)
+	processors, err := component.MakeProcessorFactoryMap(batchprocessor.NewFactory())
+	require.Nil(t, err)
+
+	factories := component.Factories{
+		Receivers:  receivers,
+		Exporters:  exporters,
+		Processors: processors,
+	}
+
+	appSettings := service.CollectorSettings{
+		Factories:      factories,
+		ParserProvider: parserprovider.NewInMemory(strings.NewReader(config)),
+		BuildInfo: component.BuildInfo{
+			Command:     "otelcol",
+			Description: "OpenTelemetry Collector",
+			Version:     "tests",
+		},
+		LoggingOptions: []zap.Option{
+			// Turn off the verbose logging from the collector.
+			zap.WrapCore(func(zapcore.Core) zapcore.Core {
+				return zapcore.NewNopCore()
+			}),
+		},
+	}
+	app, err := service.New(appSettings)
+	require.Nil(t, err)
+
+	go func() {
+		if err := app.Run(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Wait until the collector has actually started.
+	stateChannel := app.GetStateChannel()
+	for notYetStarted := true; notYetStarted; {
+		switch state := <-stateChannel; state {
+		case service.Running, service.Closed, service.Closing:
+			notYetStarted = false
+		}
+	}
+
+	defer func() {
+		app.Shutdown()
+		// Wait until we are closed.
+		<-stateChannel
+		for notClosed := true; notClosed; {
+			switch state := <-stateChannel; state {
+			case service.Closed:
+				notClosed = false
+			}
+		}
+	}()
+
+	// 5. Let's wait on 10 fetches.
+	var wReqL []*prompb.WriteRequest
+	for i := 0; i < 10; i++ {
+		wReqL = append(wReqL, <-prweUploads)
+	}
+	defer cancel()
+
+	// 6. Assert that we encounter the stale markers aka special NaNs for the various time series.
+	staleMarkerCount := 0
+	totalSamples := 0
+	for i, wReq := range wReqL {
+		name := fmt.Sprintf("WriteRequest#%d", i)
+		require.True(t, len(wReq.Timeseries) > 0, "Expecting at least 1 timeSeries for:: "+name)
+		for j, ts := range wReq.Timeseries {
+			fullName := fmt.Sprintf("%s/TimeSeries#%d", name, j)
+			assert.True(t, len(ts.Samples) > 0, "Expected at least 1 Sample in:: "+fullName)
+
+			// We are strictly counting series directly included in the scrapes, and no
+			// internal timeseries like "up" nor "scrape_seconds" etc.
+			metricName := ""
+			for _, label := range ts.Labels {
+				if label.Name == "__name__" {
+					metricName = label.Value
+				}
+			}
+			if !strings.HasPrefix(metricName, "jvm") {
+				continue
+			}
+
+			for _, sample := range ts.Samples {
+				totalSamples++
+				if value.IsStaleNaN(sample.Value) {
+					staleMarkerCount++
+				}
+			}
+		}
+	}
+
+	require.True(t, totalSamples > 0, "Expected at least 1 sample")
+	require.False(t, staleMarkerCount > 0, fmt.Sprintf("Expected no stale markers, got: %d", staleMarkerCount))
+}

--- a/receiver/prometheusreceiver/internal/staleness_store.go
+++ b/receiver/prometheusreceiver/internal/staleness_store.go
@@ -31,7 +31,12 @@ var stalenessSpecialValue = math.Float64frombits(value.StaleNaN)
 // issue a staleness marker aka a special NaN value.
 // See https://github.com/open-telemetry/opentelemetry-collector/issues/3413
 type stalenessStore struct {
-	mu             sync.Mutex // mu protects all the fields below.
+	mu sync.Mutex // mu protects all the fields below.
+
+	byInstance map[string]*byInstance
+}
+
+type byInstance struct {
 	currentHashes  map[uint64]int64
 	previousHashes map[uint64]int64
 	previous       []labels.Labels
@@ -40,6 +45,12 @@ type stalenessStore struct {
 
 func newStalenessStore() *stalenessStore {
 	return &stalenessStore{
+		byInstance: make(map[string]*byInstance),
+	}
+}
+
+func newByInstance() *byInstance {
+	return &byInstance{
 		previousHashes: make(map[uint64]int64),
 		currentHashes:  make(map[uint64]int64),
 	}
@@ -51,29 +62,46 @@ func (ss *stalenessStore) refresh() {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
-	// 1. Clear ss.previousHashes firstly. Please don't edit
+	for _, bi := range ss.byInstance {
+		// TODO(@odeke-em): perhaps run this codd concurrently.
+		bi.refresh()
+	}
+}
+
+func (bi *byInstance) refresh() {
+	// 1. Clear bi.previousHashes firstly. Please don't edit
 	// this map clearing idiom as it ensures speed.
 	// See:
 	// * https://github.com/golang/go/issues/20138
 	// * https://github.com/golang/go/commit/aee71dd70b3779c66950ce6a952deca13d48e55e
-	for hash := range ss.previousHashes {
-		delete(ss.previousHashes, hash)
+	for hash := range bi.previousHashes {
+		delete(bi.previousHashes, hash)
 	}
 	// 2. Copy over ss.currentHashes to ss.previousHashes.
-	for hash := range ss.currentHashes {
-		ss.previousHashes[hash] = ss.currentHashes[hash]
+	for hash := range bi.currentHashes {
+		bi.previousHashes[hash] = bi.currentHashes[hash]
 	}
-	// 3. Clear ss.currentHashes, with the map clearing idiom for speed.
+	// 3. Clear bi.currentHashes, with the map clearing idiom for speed.
 	// See:
 	// * https://github.com/golang/go/issues/20138
 	// * https://github.com/golang/go/commit/aee71dd70b3779c66950ce6a952deca13d48e55e
-	for hash := range ss.currentHashes {
-		delete(ss.currentHashes, hash)
+	for hash := range bi.currentHashes {
+		delete(bi.currentHashes, hash)
 	}
 	// 4. Copy all the prior labels from what was previously ss.current.
-	ss.previous = ss.current
+	bi.previous = bi.current
 	// 5. Clear ss.current to make for another cycle.
-	ss.current = nil
+	bi.current = nil
+}
+
+func (bi *byInstance) emitStaleLabels() (stale []*staleEntry) {
+	for _, labels := range bi.previous {
+		hash := labels.Hash()
+		if _, ok := bi.currentHashes[hash]; !ok {
+			stale = append(stale, &staleEntry{seenAtMs: bi.previousHashes[hash], labels: labels})
+		}
+	}
+	return stale
 }
 
 // isStale returns whether lbl was seen only in the previous scrape and not the current.
@@ -81,9 +109,15 @@ func (ss *stalenessStore) isStale(lbl labels.Labels) bool {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
+	instanceID := lbl.Get("instance")
+	bi := ss.byInstance[instanceID]
+	if bi == nil {
+		return false
+	}
+
 	hash := lbl.Hash()
-	_, inPrev := ss.previousHashes[hash]
-	_, inCurrent := ss.currentHashes[hash]
+	_, inPrev := bi.previousHashes[hash]
+	_, inCurrent := bi.currentHashes[hash]
 	return inPrev && !inCurrent
 }
 
@@ -93,8 +127,15 @@ func (ss *stalenessStore) markAsCurrentlySeen(lbl labels.Labels, seenAtMs int64)
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
-	ss.currentHashes[lbl.Hash()] = seenAtMs
-	ss.current = append(ss.current, lbl)
+	instanceID := lbl.Get("instance")
+	bi := ss.byInstance[instanceID]
+	if bi == nil {
+		bi = newByInstance()
+		ss.byInstance[instanceID] = bi
+	}
+
+	bi.currentHashes[lbl.Hash()] = seenAtMs
+	bi.current = append(bi.current, lbl)
 }
 
 type staleEntry struct {
@@ -108,11 +149,10 @@ func (ss *stalenessStore) emitStaleLabels() (stale []*staleEntry) {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
-	for _, labels := range ss.previous {
-		hash := labels.Hash()
-		if _, ok := ss.currentHashes[hash]; !ok {
-			stale = append(stale, &staleEntry{seenAtMs: ss.previousHashes[hash], labels: labels})
-		}
+	for _, bi := range ss.byInstance {
+		// TODO(@odeke-em): perhaps run this codd concurrently.
+		stale = append(stale, bi.emitStaleLabels()...)
 	}
+
 	return stale
 }

--- a/receiver/prometheusreceiver/internal/staleness_store_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_store_test.go
@@ -24,10 +24,8 @@ import (
 
 func TestStalenessStore(t *testing.T) {
 	ss := newStalenessStore()
-	require.NotNil(t, ss.previousHashes)
-	require.Zero(t, len(ss.previousHashes))
-	require.NotNil(t, ss.currentHashes)
-	require.Zero(t, len(ss.currentHashes))
+	require.NotNil(t, ss.byInstance)
+	require.Zero(t, len(ss.byInstance))
 
 	lbl1 := labels.Labels{
 		{Name: "__name__", Value: "lbl1"},
@@ -38,18 +36,22 @@ func TestStalenessStore(t *testing.T) {
 		{Name: "b", Value: "1"},
 	}
 	ss.markAsCurrentlySeen(lbl1, time.Now().Unix())
+	require.Equal(t, 1, len(ss.byInstance))
 	require.Nil(t, ss.emitStaleLabels())
 	require.False(t, ss.isStale(lbl1))
 	require.False(t, ss.isStale(lbl2))
+	require.Equal(t, 1, len(ss.byInstance))
 
 	// Now refresh, the case of a new scrape.
 	// Without having marked lbl1 as being current, it should be reported as stale.
 	ss.refresh()
 	require.True(t, ss.isStale(lbl1))
 	require.False(t, ss.isStale(lbl2))
+	bi := ss.byInstance[lbl1.Get("instance")]
+	require.NotNil(t, bi)
 	// .previous should have been the prior contents of current and current should be nil.
-	require.Equal(t, ss.previous, []labels.Labels{lbl1})
-	require.Nil(t, ss.current)
+	require.Equal(t, bi.previous, []labels.Labels{lbl1})
+	require.Nil(t, bi.current)
 
 	// After the next refresh cycle, we shouldn't have any stale labels.
 	ss.refresh()


### PR DESCRIPTION
With this change, instead of using a global staleness marker store,
we now track staleness markers by instance. This ensures that replicated
targets which can be scraped in alternating intervals won't erroneously
have staleness markers emitted.

Fixes #4748