### PR TITLE
Update multimod tool

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/tcnksm/ghr v0.14.0
 	go.opentelemetry.io/build-tools/checkdoc v0.0.0-20210826185254-a20c5b1e2d7c
 	go.opentelemetry.io/build-tools/issuegenerator v0.0.0-20210826185254-a20c5b1e2d7c
-	go.opentelemetry.io/build-tools/multimod v0.0.0-20210826185254-a20c5b1e2d7c
+	go.opentelemetry.io/build-tools/multimod v0.0.0-20210831190859-d115afa5390e
 	go.uber.org/atomic v1.8.0 // indirect
 	golang.org/x/tools v0.1.5
 	google.golang.org/protobuf v1.27.1 // indirect
@@ -154,6 +154,7 @@ require (
 	github.com/ultraware/whitespace v0.0.4 // indirect
 	github.com/uudashr/gocognit v1.0.5 // indirect
 	github.com/yeya24/promlinter v0.1.0 // indirect
+	go.opentelemetry.io/build-tools v0.0.0-20210719163622-92017e64f35b // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 // indirect

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -781,8 +781,8 @@ go.opentelemetry.io/build-tools/checkdoc v0.0.0-20210826185254-a20c5b1e2d7c h1:P
 go.opentelemetry.io/build-tools/checkdoc v0.0.0-20210826185254-a20c5b1e2d7c/go.mod h1:LSxCgynkoVzMPV/OEMaGXWm48o0WVAXocdfpvmJX1pE=
 go.opentelemetry.io/build-tools/issuegenerator v0.0.0-20210826185254-a20c5b1e2d7c h1:JW6d8hV1v8azYP9SAjA3Yh0uqLDBjYHz2VcvI+TPHLw=
 go.opentelemetry.io/build-tools/issuegenerator v0.0.0-20210826185254-a20c5b1e2d7c/go.mod h1:NSrnkWJbEC6r27HIE2fnIpQ/ttCgXEaIyVGzOGE8nqs=
-go.opentelemetry.io/build-tools/multimod v0.0.0-20210826185254-a20c5b1e2d7c h1:E+nIxuc5xD3PuuX9s6jLu+WUBM+YBEpYyqQE2pZ1d5Q=
-go.opentelemetry.io/build-tools/multimod v0.0.0-20210826185254-a20c5b1e2d7c/go.mod h1:dfkKkcGHOm8THLcgxygDBPJsbtppr0yoZuphRDeb06U=
+go.opentelemetry.io/build-tools/multimod v0.0.0-20210831190859-d115afa5390e h1:OS/4bGPu4DGjxcAlQZzgUpyux7T6xqmkdCNBq9llHHg=
+go.opentelemetry.io/build-tools/multimod v0.0.0-20210831190859-d115afa5390e/go.mod h1:dfkKkcGHOm8THLcgxygDBPJsbtppr0yoZuphRDeb06U=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

Updates `multimod` tool dependency to a version that can correctly handle Go 1.17 indirect dependency statements.