### PR TITLE
feat(dynatrace): tags is deprecated in favor of default_dimensions

### DIFF
--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -90,9 +90,10 @@ processors:
 
 exporters:
   dynatrace:
-    # optional - tags specified here will be included as a dimension on every exported metric
-    tags:
-      - example=tag
+    # optional - Dimensions specified here will be included as a dimension on every exported metric
+    #            unless that metric already has a dimension with the same key.
+    default_dimensions:
+      example_dimension: example value
 
     # optional - prefix will be prepended to each metric name in prefix.name format
     prefix: my_prefix
@@ -128,8 +129,8 @@ exporters:
   dynatrace:
     endpoint: https://ab12345.live.dynatrace.com
     api_token: <api token must have metrics.write permission>
-    tags:
-      - example=tag
+    default_dimensions:
+      example_dimension: example value
     prefix: my_prefix
     headers:
       - header1: value1
@@ -154,10 +155,10 @@ service:
       exporters: [dynatrace]
 ```
 
-### tags (Optional)
+### default_dimensions (Optional)
 
-Tags are included as dimensions on all exported metrics.
-Tags must be in the `key=value` dimension format specified by the [metrics ingestion protocol](https://www.dynatrace.com/support/help/how-to-use-dynatrace/metrics/metric-ingestion/metric-ingestion-protocol/).
+`default_dimensions` are included as dimensions on all exported metrics unless that metric already has a dimension with the same key.
+`default_dimensions` is specified as a map of string key-value pairs.
 
 ### prefix (Optional)
 
@@ -240,3 +241,7 @@ User should calculate this as `num_seconds * requests_per_second` where:
 - `requests_per_second` is the average number of requests per seconds.
 
 Default: `5000`
+
+### tags (Deprecated, Optional)
+
+**Deprecated: Please use [default_dimensions](#default_dimensions-optional) instead**

--- a/exporter/dynatraceexporter/config/config.go
+++ b/exporter/dynatraceexporter/config/config.go
@@ -39,11 +39,15 @@ type Config struct {
 	// Dynatrace API token with metrics ingest permission
 	APIToken string `mapstructure:"api_token"`
 
-	// Tags will be added to all exported metrics
-	Tags []string `mapstructure:"tags"`
+	// DefaultDimensions will be added to all exported metrics
+	DefaultDimensions map[string]string `mapstructure:"default_dimensions"`
 
 	// String to prefix all metric names
 	Prefix string `mapstructure:"prefix"`
+
+	// Tags will be added to all exported metrics
+	// Deprecated: Please use DefaultDimensions instead
+	Tags []string `mapstructure:"tags"`
 }
 
 // ValidateAndConfigureHTTPClientSettings validates the configuration and sets default values

--- a/exporter/dynatraceexporter/factory.go
+++ b/exporter/dynatraceexporter/factory.go
@@ -53,7 +53,8 @@ func createDefaultConfig() config.Exporter {
 		APIToken:           "",
 		HTTPClientSettings: confighttp.HTTPClientSettings{Endpoint: ""},
 
-		Tags: []string{},
+		Tags:              []string{},
+		DefaultDimensions: make(map[string]string),
 	}
 }
 

--- a/exporter/dynatraceexporter/factory_test.go
+++ b/exporter/dynatraceexporter/factory_test.go
@@ -45,7 +45,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 			Enabled: false,
 		},
 
-		Tags: []string{},
+		Tags:              []string{},
+		DefaultDimensions: make(map[string]string),
 	}, cfg, "failed to create default config")
 
 	assert.NoError(t, configcheck.ValidateConfig(cfg))
@@ -78,7 +79,8 @@ func TestLoadConfig(t *testing.T) {
 					"Content-Type": "text/plain; charset=UTF-8",
 					"User-Agent":   "opentelemetry-collector"},
 			},
-			Tags: []string{},
+			Tags:              []string{},
+			DefaultDimensions: make(map[string]string),
 		}, defaultConfig)
 	})
 	t.Run("valid config", func(t *testing.T) {
@@ -102,7 +104,35 @@ func TestLoadConfig(t *testing.T) {
 
 			Prefix: "myprefix",
 
-			Tags: []string{"tag_example=tag_value"},
+			Tags: []string{},
+			DefaultDimensions: map[string]string{
+				"dimension_example": "dimension_value",
+			},
+		}, validConfig)
+	})
+	t.Run("valid config with tags", func(t *testing.T) {
+		validConfig := cfg.Exporters[config.NewIDWithName(typeStr, "valid_tags")].(*dtconfig.Config)
+		err = validConfig.ValidateAndConfigureHTTPClientSettings()
+
+		require.NoError(t, err)
+		assert.Equal(t, &dtconfig.Config{
+			ExporterSettings: config.NewExporterSettings(config.NewIDWithName(typeStr, "valid_tags")),
+			RetrySettings:    exporterhelper.DefaultRetrySettings(),
+			QueueSettings:    exporterhelper.DefaultQueueSettings(),
+
+			HTTPClientSettings: confighttp.HTTPClientSettings{
+				Endpoint: "http://example.com/api/v2/metrics/ingest",
+				Headers: map[string]string{
+					"Authorization": "Api-Token token",
+					"Content-Type":  "text/plain; charset=UTF-8",
+					"User-Agent":    "opentelemetry-collector"},
+			},
+			APIToken: "token",
+
+			Prefix: "myprefix",
+
+			Tags:              []string{"tag_example=tag_value"},
+			DefaultDimensions: make(map[string]string),
 		}, validConfig)
 	})
 	t.Run("bad endpoint", func(t *testing.T) {

--- a/exporter/dynatraceexporter/metrics_exporter.go
+++ b/exporter/dynatraceexporter/metrics_exporter.go
@@ -37,7 +37,16 @@ import (
 
 // NewExporter exports to a Dynatrace Metrics v2 API
 func newMetricsExporter(params component.ExporterCreateSettings, cfg *config.Config) *exporter {
-	defaultDimensions := dimensionsFromTags(cfg.Tags)
+	confDefaultDims := []dimensions.Dimension{}
+	for key, value := range cfg.DefaultDimensions {
+		confDefaultDims = append(confDefaultDims, dimensions.NewDimension(key, value))
+	}
+
+	defaultDimensions := dimensions.MergeLists(
+		dimensionsFromTags(cfg.Tags),
+		dimensions.NewNormalizedDimensionList(confDefaultDims...),
+	)
+
 	staticDimensions := dimensions.NewNormalizedDimensionList(dimensions.NewDimension("dt.metrics.source", "opentelemetry"))
 
 	return &exporter{

--- a/exporter/dynatraceexporter/metrics_exporter_test.go
+++ b/exporter/dynatraceexporter/metrics_exporter_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/dimensions"
+	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
@@ -482,4 +484,35 @@ func Test_exporter_start_InvalidHTTPClientSettings(t *testing.T) {
 		t.Errorf("Expected error when creating a metrics exporter with invalid HTTP Client Settings")
 		return
 	}
+}
+
+func Test_exporter_new_with_tags(t *testing.T) {
+	config := &config.Config{
+		Tags: []string{"test_tag=value"},
+	}
+
+	exp := newMetricsExporter(componenttest.NewNopExporterCreateSettings(), config)
+
+	assert.Equal(t, dimensions.NewNormalizedDimensionList(dimensions.NewDimension("test_tag", "value")), exp.defaultDimensions)
+}
+
+func Test_exporter_new_with_default_dimensions(t *testing.T) {
+	config := &config.Config{
+		DefaultDimensions: map[string]string{"test_dimension": "value"},
+	}
+
+	exp := newMetricsExporter(componenttest.NewNopExporterCreateSettings(), config)
+
+	assert.Equal(t, dimensions.NewNormalizedDimensionList(dimensions.NewDimension("test_dimension", "value")), exp.defaultDimensions)
+}
+
+func Test_exporter_new_with_default_dimensions_override_tag(t *testing.T) {
+	config := &config.Config{
+		Tags:              []string{"from=tag"},
+		DefaultDimensions: map[string]string{"from": "default_dimensions"},
+	}
+
+	exp := newMetricsExporter(componenttest.NewNopExporterCreateSettings(), config)
+
+	assert.Equal(t, dimensions.NewNormalizedDimensionList(dimensions.NewDimension("from", "default_dimensions")), exp.defaultDimensions)
 }

--- a/exporter/dynatraceexporter/testdata/config.yml
+++ b/exporter/dynatraceexporter/testdata/config.yml
@@ -10,9 +10,17 @@ exporters:
     endpoint: not a url
   dynatrace/missing_token:
     endpoint: https://example.com
-  dynatrace/valid:
+  dynatrace/valid_tags:
     tags:
       - tag_example=tag_value
+
+    prefix: myprefix
+
+    endpoint: http://example.com/api/v2/metrics/ingest
+    api_token: token
+  dynatrace/valid:
+    default_dimensions:
+      dimension_example: dimension_value
 
     prefix: myprefix
 


### PR DESCRIPTION
Part 2 of splitting #4853 into smaller PRs

Currently it is possible to specify a set of "tags" as a list of strings which are added as dimensions to every exported metric in the dynatrace exporter.

This PR deprecates tags in favor of "default_dimensions" which is specified as a `map[string]string`. This reduces the chance that a malformed tag will be added to the list, uses a more obvious name for the property, and maintains backwards compatibility.