### PR TITLE
replace calls to deprecated AttributeMapToMap

### DIFF
--- a/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice.go
+++ b/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice.go
@@ -135,8 +135,7 @@ func spanToLogServiceData(span pdata.Span, resourceContents, instrumentationLibr
 		Key:   proto.String(durationField),
 		Value: proto.String(strconv.FormatUint(uint64((span.EndTimestamp()-span.StartTimestamp())/1000), 10)),
 	})
-	attributeMap := pdata.AttributeMapToMap(span.Attributes())
-	attributeJSONBytes, _ := json.Marshal(attributeMap)
+	attributeJSONBytes, _ := json.Marshal(span.Attributes().AsRaw())
 	contentsBuffer = append(contentsBuffer, sls.LogContent{
 		Key:   proto.String(attributeField),
 		Value: proto.String(string(attributeJSONBytes)),
@@ -193,7 +192,7 @@ func eventsToString(events pdata.SpanEventSlice) string {
 		event := map[string]interface{}{}
 		event[nameField] = spanEvent.Name()
 		event[timeField] = spanEvent.Timestamp()
-		event[attributeField] = pdata.AttributeMapToMap(spanEvent.Attributes())
+		event[attributeField] = spanEvent.Attributes().AsRaw()
 		eventArray = append(eventArray, event)
 	}
 	eventArrayBytes, _ := json.Marshal(&eventArray)
@@ -208,7 +207,7 @@ func spanLinksToString(spanLinkSlice pdata.SpanLinkSlice) string {
 		link := map[string]interface{}{}
 		link[spanIDField] = spanLink.SpanID().HexString()
 		link[traceIDField] = spanLink.TraceID().HexString()
-		link[attributeField] = pdata.AttributeMapToMap(spanLink.Attributes())
+		link[attributeField] = spanLink.Attributes().AsRaw()
 		linkArray = append(linkArray, link)
 	}
 	linkArrayBytes, _ := json.Marshal(&linkArray)

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -674,7 +674,7 @@ func eventsToString(evts pdata.SpanEventSlice) string {
 		event := map[string]interface{}{}
 		event[eventNameTag] = spanEvent.Name()
 		event[eventTimeTag] = spanEvent.Timestamp()
-		event[eventAttrTag] = pdata.AttributeMapToMap(spanEvent.Attributes())
+		event[eventAttrTag] = spanEvent.Attributes().AsRaw()
 		eventArray = append(eventArray, event)
 	}
 	eventArrayBytes, _ := json.Marshal(&eventArray)

--- a/exporter/newrelicexporter/transformer.go
+++ b/exporter/newrelicexporter/transformer.go
@@ -67,7 +67,7 @@ func newTransformer(logger *zap.Logger, buildInfo *component.BuildInfo, details 
 
 func (t *transformer) CommonAttributes(resource pdata.Resource, lib pdata.InstrumentationLibrary) map[string]interface{} {
 	resourceAttrs := resource.Attributes()
-	commonAttrs := pdata.AttributeMapToMap(resourceAttrs)
+	commonAttrs := resourceAttrs.AsRaw()
 	t.TrackAttributes(attributeLocationResource, resourceAttrs)
 
 	if n := lib.Name(); n != "" {
@@ -131,7 +131,7 @@ func (t *transformer) Log(log pdata.LogRecord) (telemetry.Log, error) {
 	logAttrs := log.Attributes()
 	attrs := make(map[string]interface{}, logAttrs.Len()+5)
 
-	for k, v := range pdata.AttributeMapToMap(logAttrs) {
+	for k, v := range logAttrs.AsRaw() {
 		// Only include attribute if not an override attribute
 		if _, isOverrideKey := t.OverrideAttributes[k]; !isOverrideKey {
 			attrs[k] = v
@@ -211,7 +211,7 @@ func (t *transformer) SpanAttributes(span pdata.Span) map[string]interface{} {
 		attrs[droppedEventsCountKey] = droppedEventsCount
 	}
 
-	for k, v := range pdata.AttributeMapToMap(spanAttrs) {
+	for k, v := range spanAttrs.AsRaw() {
 		// Only include attribute if not an override attribute
 		if _, isOverrideKey := t.OverrideAttributes[k]; !isOverrideKey {
 			attrs[k] = v
@@ -237,7 +237,7 @@ func (t *transformer) SpanEvents(span pdata.Span) []telemetry.Event {
 		events[i] = telemetry.Event{
 			EventType:  event.Name(),
 			Timestamp:  event.Timestamp().AsTime(),
-			Attributes: pdata.AttributeMapToMap(eventAttrs),
+			Attributes: eventAttrs.AsRaw(),
 		}
 
 		if droppedAttributesCount := event.DroppedAttributesCount(); droppedAttributesCount > 0 {

--- a/exporter/sumologicexporter/sender.go
+++ b/exporter/sumologicexporter/sender.go
@@ -176,7 +176,7 @@ func (s *sender) logToJSON(record pdata.LogRecord) (string, error) {
 	data := s.filter.filterOut(record.Attributes())
 	data.orig.Upsert(logKey, record.Body())
 
-	nextLine, err := json.Marshal(pdata.AttributeMapToMap(data.orig))
+	nextLine, err := json.Marshal(data.orig.AsRaw())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -201,7 +201,7 @@ func spanEventsToZipkinAnnotations(events pdata.SpanEventSlice, zs *zipkinmodel.
 					Value:     event.Name(),
 				}
 			} else {
-				jsonStr, err := json.Marshal(pdata.AttributeMapToMap(event.Attributes()))
+				jsonStr, err := json.Marshal(event.Attributes().AsRaw())
 				if err != nil {
 					return err
 				}
@@ -221,7 +221,7 @@ func spanLinksToZipkinTags(links pdata.SpanLinkSlice, zTags map[string]string) e
 	for i := 0; i < links.Len(); i++ {
 		link := links.At(i)
 		key := fmt.Sprintf("otlp.link.%d", i)
-		jsonStr, err := json.Marshal(pdata.AttributeMapToMap(link.Attributes()))
+		jsonStr, err := json.Marshal(link.Attributes().AsRaw())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description:** 
Follow up to change in core https://github.com/open-telemetry/opentelemetry-collector/pull/3939 to deprecate `AttributeMapToMap` in favour or `AsMap`

**Link to tracking Issue:** Part of https://github.com/open-telemetry/opentelemetry-collector/issues/3926

Will need to update core once the PR mentioned above is merged.