### PR TITLE
Fix $attributes.file_path when collecting logs from Kubernetes

### DIFF
--- a/examples/kubernetes/otel-collector-config.yml
+++ b/examples/kubernetes/otel-collector-config.yml
@@ -47,7 +47,7 @@ receivers:
       - type: regex_parser
         id: extract_metadata_from_filepath
         regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$'
-        parse_from: $$attributes.file_path
+        parse_from: $$attributes["file.path"]
       # Move out attributes to Attributes
       - type: metadata
         attributes:

--- a/examples/kubernetes/otel-collector.yaml
+++ b/examples/kubernetes/otel-collector.yaml
@@ -54,7 +54,7 @@ data:
           - type: regex_parser
             id: extract_metadata_from_filepath
             regex: '^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]{36})\/(?P<container_name>[^\._]+)\/(?P<run_id>\d+)\.log$'
-            parse_from: $$attributes.file_path
+            parse_from: $$attributes["file.path"]
           # Move out attributes to Attributes
           - type: metadata
             attributes:


### PR DESCRIPTION
On AWS EKS 1.21, I'd get this error (from your original code):

```console
$ kubectl logs -f --tail=10 ds/otel-collector
 
2021-08-28T17:46:38.930Z	error	Failed to process entry	{"kind": "receiver", "name": "filelog", "operator_id": "$.extract_metadata_from_filepath", "operator_type": "regex_parser", "error": {"description": "Entry is missing the expected parse_from field.", "suggestion": "Ensure that all incoming entries contain the parse_from field.", "details": {"parse_from": "$attributes.file_path"}}, "action": "send", "entry": {"timestamp":"2021-08-28T17:22:14.809709717Z","body":{"log":"2021-08-28T17:22:14+0000 DEBUG This is a debug log that shows a log that can be ignored.\n","stream":"stdout"},"attributes":{"file.path":"/var/log/pods/default_random-logger_4cf99717-08db-425b-88b6-1ee98fdf3660/random-logger/0.log"},"severity":0}}
```

The error message is showing that the actual attribute is `file.path`, not `file_path`. My proposed fix will correct that.

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>