### PR TITLE
[exporter/datadogexporter] Export histograms as in OpenMetrics Datadog check

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -100,6 +100,11 @@ func createMetricsExporter(
 		return nil, err
 	}
 
+	// TODO: Remove after two releases
+	if cfg.Metrics.Buckets {
+		set.Logger.Warn("Histogram bucket metrics now end with .bucket instead of .count_per_bucket")
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	var pushMetricsFn consumerhelper.ConsumeMetricsFunc
 

--- a/exporter/datadogexporter/internal/translator/metrics_translator.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator.go
@@ -153,7 +153,7 @@ func getBounds(p pdata.HistogramDataPoint, idx int) (lowerBound float64, upperBo
 }
 
 func (t *Translator) getLegacyBuckets(name string, p pdata.HistogramDataPoint, delta bool, tags []string) []datadog.Metric {
-	// We have a single metric, 'bucket', which is tagged with the bucket id. See:
+	// We have a single metric, 'bucket', which is tagged with the bucket bounds. See:
 	// https://github.com/DataDog/integrations-core/blob/7.30.1/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/histogram.py
 	ms := make([]datadog.Metric, 0, len(p.BucketCounts()))
 	fullName := fmt.Sprintf("%s.bucket", name)

--- a/exporter/datadogexporter/internal/translator/metrics_translator_test.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator_test.go
@@ -483,23 +483,27 @@ func TestMapHistogramMetrics(t *testing.T) {
 	)
 }
 
-func TestQuantileTag(t *testing.T) {
+func TestFormatFloat(t *testing.T) {
 	tests := []struct {
-		quantile float64
-		tag      string
+		f float64
+		s string
 	}{
-		{quantile: 0, tag: "quantile:0"},
-		{quantile: 0.001, tag: "quantile:0.001"},
-		{quantile: 0.9, tag: "quantile:0.9"},
-		{quantile: 0.95, tag: "quantile:0.95"},
-		{quantile: 0.99, tag: "quantile:0.99"},
-		{quantile: 0.999, tag: "quantile:0.999"},
-		{quantile: 1, tag: "quantile:1.0"},
-		{quantile: 1e-10, tag: "quantile:1e-10"},
+		{f: 0, s: "0"},
+		{f: 0.001, s: "0.001"},
+		{f: 0.9, s: "0.9"},
+		{f: 0.95, s: "0.95"},
+		{f: 0.99, s: "0.99"},
+		{f: 0.999, s: "0.999"},
+		{f: 1, s: "1.0"},
+		{f: 2, s: "2.0"},
+		{f: math.Inf(1), s: "inf"},
+		{f: math.Inf(-1), s: "-inf"},
+		{f: math.NaN(), s: "nan"},
+		{f: 1e-10, s: "1e-10"},
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.tag, getQuantileTag(test.quantile))
+		assert.Equal(t, test.s, formatFloat(test.f))
 	}
 }
 


### PR DESCRIPTION
**Description:** 

1. Rewrites histogram export to follow what we do in the OpenMetrics when we don't use distributions (the default now).
   This means the following changes:
    - `.sum` and `.count` metrics are now reported as Datadog counts,
    - bucket metrics are not reported ending with `.bucket` instead of `.count_per_bucket`, and tagged by `lower_bound` instead of `bucket_idx`.

2. Adds support for cumulative histograms client-side: when a histogram is reported as cumulative we calculate the difference in the client and report the delta.

3. Ignores histograms with an undefined aggregation temporality.

**Is this a breaking change?**: Yes.

**Migration guide**: If you are using the `report_buckets` flag bucket metrics now end in `.bucket` instead of `.count_per_bucket` and are tagged by lower bound instead of bucket index.

**Testing:** Amended unit tests.
