### PR TITLE
Add documentation for filelog's new force_flush_period parameter

### DIFF
--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -17,6 +17,7 @@ Supported pipeline types: logs
 | `start_at`             | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
 | `write_to`             | $body            | The body [field](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/field.md) written to when creating a new log entry                                  |
 | `multiline`            |                  | A `multiline` configuration block. See below for more details                                                      |
+| `force_flush_period`   | `0s`             | Time since last read of data from file, after which currently buffered log should be send to pipeline. Takes [duration](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/duration.md) as value. Zero means waiting for new data forever |
 | `encoding`             | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `include_file_name`    | `true`           | Whether to add the file name as the label `file_name`                                                              |
 | `include_file_path`    | `false`          | Whether to add the file path as the label `file_path`                                                              |


### PR DESCRIPTION
This PR just documents a new setting on the filelog receiver.

[Related PR](https://github.com/open-telemetry/opentelemetry-log-collection/pull/216)

