### PR TITLE
receiver/prometheus: support reading Prometheus configurations from a referenced file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 🚀 New components 🚀
+
+- [`prometheus` receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) now supports reading Prometheus configurations from a target file per ([#4980](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4980)) This allows Prometheus configurations to be supplied verbatim directly from other sources.
+
+
 ## v0.34.0
 
 ## 🚀 New components 🚀

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -78,4 +78,33 @@ receivers:
               action: keep
 ```
 
+you can alternatively pass in the Prometheus configuration from a file, by setting `"config_file"` in the Prometheus Receiver configuration
+
+```yaml
+receivers:
+    prometheus:
+      config_file: "./prom.yaml"
+```
+
+where the contents of "prom.yaml" are:
+
+```yaml
+scrape_configs:
+  - job_name: 'otel-collector'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['0.0.0.0:8888']
+  - job_name: k8s
+    kubernetes_sd_configs:
+    - role: pod
+    relabel_configs:
+    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      regex: "true"
+      action: keep
+    metric_relabel_configs:
+    - source_labels: [__name__]
+      regex: "(request_duration_seconds.*|response_duration_seconds.*)"
+      action: keep
+```
+
 [sc]: https://github.com/prometheus/prometheus/blob/v2.28.1/docs/configuration/configuration.md#scrape_config

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -161,3 +161,40 @@ func TestRejectUnsupportedPrometheusFeatures(t *testing.T) {
 	require.Equal(t, wantErrMsg, gotErrMsg)
 
 }
+
+func TestConfigFromFile(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+	cfg, err := configtest.LoadConfig(path.Join(".", "testdata", "config_from_file.yaml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	err = cfg.Validate()
+	require.Nil(t, err, "Expected no error")
+}
+
+func TestConfigFromFileNonExistentFile(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+	cfg, err := configtest.LoadConfig(path.Join(".", "testdata", "config_from_file_nonexistent_file.yaml"), factories)
+	require.Nil(t, cfg, "The config should be nil")
+	require.NotNil(t, err, "Expected an error")
+	require.Contains(t, err.Error(), `failed to read config_file for prometheus config`)
+}
+
+func TestRejectFileAndConfig(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+	cfg, err := configtest.LoadConfig(path.Join(".", "testdata", "config_from_file_filled.yaml"), factories)
+	require.Nil(t, cfg, "The config should be nil")
+	require.NotNil(t, err, "Expected an error")
+	require.Contains(t, err.Error(), `either "config_file" or the Prometheus configuration can be set but not both`)
+}

--- a/receiver/prometheusreceiver/testdata/config_from_file.yaml
+++ b/receiver/prometheusreceiver/testdata/config_from_file.yaml
@@ -1,0 +1,20 @@
+receivers:
+  prometheus:
+    config_file: "./testdata/prom.yaml"
+    buffer_period: 234
+    buffer_count: 45
+    use_start_time_metric: true
+    start_time_metric_regex: '^(.+_)*process_start_time_seconds$'
+
+processors:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [nop]
+      exporters: [nop]

--- a/receiver/prometheusreceiver/testdata/config_from_file_filled.yaml
+++ b/receiver/prometheusreceiver/testdata/config_from_file_filled.yaml
@@ -1,0 +1,24 @@
+receivers:
+  prometheus:
+    config_file: "./testdata/prom.yaml"
+    buffer_period: 234
+    buffer_count: 45
+    use_start_time_metric: true
+    start_time_metric_regex: '^(.+_)*process_start_time_seconds$'
+    config:
+      scrape_configs:
+        - job_name: 'demo'
+          scrape_interval: 5s
+
+processors:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [nop]
+      exporters: [nop]

--- a/receiver/prometheusreceiver/testdata/prom.yaml
+++ b/receiver/prometheusreceiver/testdata/prom.yaml
@@ -1,0 +1,3 @@
+scrape_configs:
+   - job_name: 'demo'
+     scrape_interval: 5s


### PR DESCRIPTION
Allows reading Prometheus configurations verbatim from referenced files.
This ensures that users can share their Prometheus configuration files
as is with Kubernetes, Prometheus etc, without having to sweat with
indentation or formatting.

While here also fixed fmt.Errorf("...%s", err) calls to instead wrap err
so fmt.Errorf("...%w", err) which is the way errors should be propagated.

With this change, we can now do

```yaml
receivers:
    prometheus:
      config_file: "./prom.yaml"
```

where the contents of "prom.yaml" are:

```yaml
scrape_configs:
  - job_name: 'otel-collector'
    scrape_interval: 5s
    static_configs:
      - targets: ['0.0.0.0:8888']
  - job_name: k8s
    kubernetes_sd_configs:
    - role: pod
    relabel_configs:
    - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
      regex: "true"
      action: keep
    metric_relabel_configs:
    - source_labels: [__name__]
      regex: "(request_duration_seconds.*|response_duration_seconds.*)"
      action: keep
```

Fixes #4980