### PR TITLE
reuse the gzip reader with a sync.Pool

### DIFF
--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -78,6 +79,7 @@ type splunkReceiver struct {
 	metricsConsumer consumer.Metrics
 	server          *http.Server
 	obsrecv         *obsreport.Receiver
+	gzipReaderPool  sync.Pool
 }
 
 var _ component.MetricsReceiver = (*splunkReceiver)(nil)
@@ -143,6 +145,7 @@ func newLogsReceiver(
 			ReadHeaderTimeout: defaultServerTimeout,
 			WriteTimeout:      defaultServerTimeout,
 		},
+		gzipReaderPool: sync.Pool{New: func() interface{} { return new(gzip.Reader) }},
 	}
 
 	return r, nil
@@ -208,12 +211,13 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 
 	bodyReader := req.Body
 	if encoding == gzipEncoding {
-		var err error
-		bodyReader, err = gzip.NewReader(bodyReader)
+		reader := r.gzipReaderPool.Get().(*gzip.Reader)
+		err := reader.Reset(bodyReader)
 		if err != nil {
 			r.failRequest(ctx, resp, http.StatusBadRequest, errGzipReaderRespBody, err)
 			return
 		}
+		bodyReader = reader
 	}
 
 	if req.ContentLength == 0 {

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -114,7 +114,7 @@ func newMetricsReceiver(
 			ReadHeaderTimeout: defaultServerTimeout,
 			WriteTimeout:      defaultServerTimeout,
 		},
-		obsrecv: obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: config.ID(), Transport: transport}),
+		obsrecv:        obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverID: config.ID(), Transport: transport}),
 		gzipReaderPool: &sync.Pool{New: func() interface{} { return new(gzip.Reader) }},
 	}
 


### PR DESCRIPTION
**Description:** 
Add code to reuse a gzip.Reader instead of recreating one every time.
