### PR TITLE
Better document SignalFx access token passthrough feature

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -35,12 +35,13 @@ The following configuration options are required:
 The following configuration options can also be configured:
 
 - `access_token_passthrough`: (default = `true`) Whether to use
-  `"com.splunk.signalfx.access_token"` metric resource label, if any, as the
-  SignalFx access token.  In either case this label will be dropped during
-  final translation.  Intended to be used in tandem with identical
-  configuration option for [SignalFx
+  `"com.splunk.signalfx.access_token"` metric resource attribute, if any, as the
+  SignalFx access token.  In either case this attribute will be dropped during
+  final translation, in this exporter only.  Intended to be used in tandem with
+  identical configuration option for [SignalFx
   receiver](../../receiver/signalfxreceiver/README.md) to preserve datapoint
-  origin.
+  origin for only this exporter, as others will reveal the organization access token
+  by not filtering the attribute.
 - `exclude_metrics`: List of metric filters that will determine metrics to be
   excluded from sending to Signalfx backend. If `translation_rules` options
   are enabled, the exclusion will be applied on translated metrics.

--- a/receiver/signalfxreceiver/README.md
+++ b/receiver/signalfxreceiver/README.md
@@ -23,10 +23,11 @@ The following settings are optional:
 
 - `access_token_passthrough`: (default = `false`) Whether to preserve incoming
   access token (`X-Sf-Token` header value) as
-  `"com.splunk.signalfx.access_token"` metric resource label.  Can be used in
-  tandem with identical configuration option for [SignalFx
+  `"com.splunk.signalfx.access_token"` metric resource attribute.  Should only be
+  used in tandem with identical configuration option for [SignalFx
   exporter](../../exporter/signalfxexporter/README.md) to preserve datapoint
-  origin.
+  origin.  Usage of any other exporter in a metric pipeline with this configuration
+  option enabled will reveal all organization access tokens contained in this attribute.
 - `tls_settings` (no default): This is an optional object used to specify if
   TLS should be used for incoming connections. Both `key_file` and `cert_file`
   are required to support incoming TLS connections.


### PR DESCRIPTION
**Description:**
SignalFx receiver and exporter documentation improvements to replace "label" usage and clearly denote the consequences of using flag with any other exporters.