### PR TITLE
Add ability to configure mappings from fluent attributes to otel fields

### DIFF
--- a/receiver/fluentforwardreceiver/README.md
+++ b/receiver/fluentforwardreceiver/README.md
@@ -22,6 +22,7 @@ Fluentforward doesn't have a native notion of log body, severity, resources and 
 We could considere evething as structured body or attributes. Attributes has been choosed to ease processors manipulation.
 With `mappings` config you can move a fluent attribute to a body attribute or as severity text.
 In this case, all found attributes will be moved.
+If you set body_encoding to map it will not be serialized.
 
 Here is a basic example config that makes the receiver listen on all interfaces
 on port 8006:
@@ -30,7 +31,7 @@ on port 8006:
 receivers:
   fluentforward:
     endpoint: 0.0.0.0:8006
-    body_as_string: true
+    body_encoding: otel
     mappings:
       body:
         - log

--- a/receiver/fluentforwardreceiver/README.md
+++ b/receiver/fluentforwardreceiver/README.md
@@ -18,6 +18,11 @@ This receiver:
  - If using TCP, it will start a UDP server on the same port to deliver
    heartbeat echos, as per the spec.
 
+Fluentforward doesn't have a native notion of log body, severity, resources and so on.
+We could considere evething as structured body or attributes. Attributes has been choosed to ease processors manipulation.
+With `mappings` config you can move a fluent attribute to a body attribute or as severity text.
+In this case, all found attributes will be moved.
+
 Here is a basic example config that makes the receiver listen on all interfaces
 on port 8006:
 
@@ -25,6 +30,13 @@ on port 8006:
 receivers:
   fluentforward:
     endpoint: 0.0.0.0:8006
+    body_as_string: true
+    mappings:
+      body:
+        - log
+        - message
+      severity:
+        - severity
 ```
 
 

--- a/receiver/fluentforwardreceiver/config.go
+++ b/receiver/fluentforwardreceiver/config.go
@@ -14,7 +14,11 @@
 
 package fluentforwardreceiver
 
-import "go.opentelemetry.io/collector/config"
+import (
+	"errors"
+
+	"go.opentelemetry.io/collector/config"
+)
 
 // Config defines configuration for the SignalFx receiver.
 type Config struct {
@@ -24,4 +28,32 @@ type Config struct {
 	// of the form `<ip addr>:<port>` (TCP) or `unix://<socket_path>` (Unix
 	// domain socket).
 	ListenAddress string `mapstructure:"endpoint"`
+
+	Mappings MappingWhitelist `mapstructure:"mappings"`
+
+	BodyAsString bool `mapstructure:"body_as_string"`
+}
+
+func (c *Config) validate() error {
+	if c.ListenAddress == "" {
+		return errors.New("`endpoint` not specified")
+	}
+
+	/*if c.BodyAsString == nil {
+		c.BodyAsString = true
+	}*/
+
+	if len(c.Mappings.Body) == 0 {
+		c.Mappings.Body = []string{"log", "message"}
+	}
+	return nil
+}
+
+// MappingWhitelist defines the fluent attributes mapping configuration
+type MappingWhitelist struct {
+	// Body is the list of fluent attributes ok to become the OTEL body
+	Body []string `mapstructure:"body"`
+
+	// Severity is the list of fluent attributes ok to become the OTEL SeverityText
+	Severity []string `mapstructure:"severity"`
 }

--- a/receiver/fluentforwardreceiver/config.go
+++ b/receiver/fluentforwardreceiver/config.go
@@ -31,7 +31,7 @@ type Config struct {
 
 	Mappings MappingWhitelist `mapstructure:"mappings"`
 
-	BodyAsString bool `mapstructure:"body_as_string"`
+	BodyAsString string `mapstructure:"body_encoding"`
 }
 
 func (c *Config) validate() error {
@@ -39,9 +39,12 @@ func (c *Config) validate() error {
 		return errors.New("`endpoint` not specified")
 	}
 
-	/*if c.BodyAsString == nil {
-		c.BodyAsString = true
-	}*/
+	if c.BodyAsString == "" {
+		c.BodyAsString = "otel"
+	}
+	if !Contains([]string{"otel", "map"}, c.BodyAsString) {
+		return errors.New("Invalid body_encoding")
+	}
 
 	if len(c.Mappings.Body) == 0 {
 		c.Mappings.Body = []string{"log", "message"}

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -162,20 +162,19 @@ func parseRecordToLogRecord(dc *msgp.Reader, lr pdata.LogRecord, conf *Config) e
 			return msgp.WrapError(err, "Record", key)
 		}
 
-		s, err := ValueToString(val)
-		if err != nil {
-			return err
-		}
-
 		if Contains(conf.Mappings.Body, key) {
 			insertToAttributeMap(key, val, &bodyMap)
 		} else if Contains(conf.Mappings.Severity, key) {
+			s, err := ValueToString(val)
+			if err != nil {
+				return err
+			}
 			lr.SetSeverityText(s)
 		} else {
 			insertToAttributeMap(key, val, &attrs)
 		}
 	}
-	if conf.BodyAsString {
+	if conf.BodyAsString == "otel" {
 		lr.Body().SetStringVal(lr.Body().AsString())
 	}
 

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -27,9 +27,13 @@ import (
 func TestMessageEventConversion(t *testing.T) {
 	eventBytes := parseHexDump("testdata/message-event")
 	reader := msgp.NewReader(bytes.NewReader(eventBytes))
+	config := &Config{
+		ListenAddress: "127.0.0.1:0",
+		Mappings:      MappingWhitelist{Severity: []string{"severity"}},
+	}
 
 	var event MessageEventLogRecord
-	err := event.DecodeMsg(reader)
+	err := event.DecodeMsg(reader, config)
 	require.Nil(t, err)
 
 	le := event.LogRecords().At(0)
@@ -93,9 +97,13 @@ func TestAttributeTypeConversion(t *testing.T) {
 	require.NoError(t, err)
 
 	reader := msgp.NewReader(bytes.NewReader(b))
+	config := &Config{
+		ListenAddress: "127.0.0.1:0",
+		Mappings:      MappingWhitelist{Severity: []string{"severity"}},
+	}
 
 	var event MessageEventLogRecord
-	err = event.DecodeMsg(reader)
+	err = event.DecodeMsg(reader, config)
 	require.Nil(t, err)
 
 	le := event.LogRecords().At(0)
@@ -150,13 +158,17 @@ func TestMessageEventConversionWithErrors(t *testing.T) {
 	b = msgp.AppendMapHeader(b, 1)
 	b = msgp.AppendString(b, "a")
 	b = msgp.AppendFloat64(b, 5.0)
+	config := &Config{
+		ListenAddress: "127.0.0.1:0",
+		Mappings:      MappingWhitelist{Severity: []string{"severity"}},
+	}
 
 	for i := 0; i < len(b)-1; i++ {
 		t.Run(fmt.Sprintf("EOF at byte %d", i), func(t *testing.T) {
 			reader := msgp.NewReader(bytes.NewReader(b[:i]))
 
 			var event MessageEventLogRecord
-			err := event.DecodeMsg(reader)
+			err := event.DecodeMsg(reader, config)
 			require.NotNil(t, err)
 		})
 	}
@@ -168,20 +180,24 @@ func TestMessageEventConversionWithErrors(t *testing.T) {
 		reader := msgp.NewReader(bytes.NewReader(in))
 
 		var event MessageEventLogRecord
-		err := event.DecodeMsg(reader)
+		err := event.DecodeMsg(reader, config)
 		require.NotNil(t, err)
 	})
 }
 
 func TestForwardEventConversionWithErrors(t *testing.T) {
 	b := parseHexDump("testdata/forward-event")
+	config := &Config{
+		ListenAddress: "127.0.0.1:0",
+		Mappings:      MappingWhitelist{Severity: []string{"severity"}},
+	}
 
 	for i := 0; i < len(b)-1; i++ {
 		t.Run(fmt.Sprintf("EOF at byte %d", i), func(t *testing.T) {
 			reader := msgp.NewReader(bytes.NewReader(b[:i]))
 
 			var event ForwardEventLogRecords
-			err := event.DecodeMsg(reader)
+			err := event.DecodeMsg(reader, config)
 			require.NotNil(t, err)
 		})
 	}
@@ -189,13 +205,17 @@ func TestForwardEventConversionWithErrors(t *testing.T) {
 
 func TestPackedForwardEventConversionWithErrors(t *testing.T) {
 	b := parseHexDump("testdata/forward-packed-compressed")
+	config := &Config{
+		ListenAddress: "127.0.0.1:0",
+		Mappings:      MappingWhitelist{Severity: []string{"severity"}},
+	}
 
 	for i := 0; i < len(b)-1; i++ {
 		t.Run(fmt.Sprintf("EOF at byte %d", i), func(t *testing.T) {
 			reader := msgp.NewReader(bytes.NewReader(b[:i]))
 
 			var event PackedForwardEventLogRecords
-			err := event.DecodeMsg(reader)
+			err := event.DecodeMsg(reader, config)
 			require.NotNil(t, err)
 		})
 	}
@@ -207,7 +227,7 @@ func TestPackedForwardEventConversionWithErrors(t *testing.T) {
 		reader := msgp.NewReader(bytes.NewReader(in))
 
 		var event PackedForwardEventLogRecords
-		err := event.DecodeMsg(reader)
+		err := event.DecodeMsg(reader, config)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "gzip")
 		print(err.Error())

--- a/receiver/fluentforwardreceiver/receiver.go
+++ b/receiver/fluentforwardreceiver/receiver.go
@@ -39,10 +39,11 @@ type fluentReceiver struct {
 
 func newFluentReceiver(logger *zap.Logger, conf *Config, next consumer.Logs) (component.LogsReceiver, error) {
 	eventCh := make(chan Event, eventChannelLength)
+	conf.validate()
 
 	collector := newCollector(eventCh, next, logger)
 
-	server := newServer(eventCh, logger)
+	server := newServer(eventCh, logger, conf)
 
 	return &fluentReceiver{
 		collector: collector,

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -37,12 +37,14 @@ const readBufferSize = 10 * 1024
 type server struct {
 	outCh  chan<- Event
 	logger *zap.Logger
+	conf   *Config
 }
 
-func newServer(outCh chan<- Event, logger *zap.Logger) *server {
+func newServer(outCh chan<- Event, logger *zap.Logger, conf *Config) *server {
 	return &server{
 		outCh:  outCh,
 		logger: logger,
+		conf:   conf,
 	}
 }
 
@@ -111,7 +113,7 @@ func (s *server) handleConn(ctx context.Context, conn net.Conn) error {
 			panic("programmer bug in mode handling")
 		}
 
-		err = event.DecodeMsg(reader)
+		err = event.DecodeMsg(reader, s.conf)
 		if err != nil {
 			if err != io.EOF {
 				stats.Record(ctx, observ.FailedToParse.M(1))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Help to solve : https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14718

This change allow to create a very basic mapping as kind of whitelist
You can "move" an attribute data to severyty text if the key is found, or "move" attributes to structured body data (attributemap).

Then, if you prefer a string body you can convert it.

**Testing:** 
Nothing for now

**Documentation:**
Some notes about the new mappings