### PR TITLE
Adding configurable dockerAPIVersion option for Docker stats receiver

### DIFF
--- a/receiver/dockerstatsreceiver/README.md
+++ b/receiver/dockerstatsreceiver/README.md
@@ -32,6 +32,7 @@ only unmatched container image names should be monitored.
     `!my*container` will monitor all containers whose image name doesn't match the blob `my*container`.
 - `provide_per_core_cpu_metrics` (default = `false`): Whether to report `cpu.usage.percpu` metrics.
 - `timeout` (default = `5s`): The request timeout for any docker daemon query.
+- `api_version` (default = `1.22`): The Docker client API version (must be 1.22+). [Docker API versions](https://docs.docker.com/engine/api/).
 
 Example:
 
@@ -41,6 +42,7 @@ receivers:
     endpoint: http://example.com/
     collection_interval: 2s
     timeout: 20s
+    api_version: 1.24
     container_labels_to_metric_labels:
       my.container.label: my-metric-label
       my.other.container.label: my-other-metric-label

--- a/receiver/dockerstatsreceiver/config.go
+++ b/receiver/dockerstatsreceiver/config.go
@@ -67,7 +67,7 @@ func (config Config) Validate() error {
 		return errors.New("config.CollectionInterval must be specified")
 	}
 	if config.DockerAPIVersion < minimalRequiredDockerAPIVersion {
-		return errors.New(fmt.Sprintf("Docker API version must be at least %v", minimalRequiredDockerAPIVersion))
+		return fmt.Errorf("Docker API version must be at least %v", minimalRequiredDockerAPIVersion)
 	}
 	return nil
 }

--- a/receiver/dockerstatsreceiver/config.go
+++ b/receiver/dockerstatsreceiver/config.go
@@ -16,6 +16,7 @@ package dockerstatsreceiver
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"go.opentelemetry.io/collector/config"
@@ -53,6 +54,9 @@ type Config struct {
 
 	// Whether to report all CPU metrics.  Default is false
 	ProvidePerCoreCPUMetrics bool `mapstructure:"provide_per_core_cpu_metrics"`
+
+	// Docker client API version. Default is 1.22
+	DockerAPIVersion float64 `mapstructure:"api_version"`
 }
 
 func (config Config) Validate() error {
@@ -61,6 +65,9 @@ func (config Config) Validate() error {
 	}
 	if config.CollectionInterval == 0 {
 		return errors.New("config.CollectionInterval must be specified")
+	}
+	if config.DockerAPIVersion < minimalRequiredDockerAPIVersion {
+		return errors.New(fmt.Sprintf("Docker API version must be at least %v", minimalRequiredDockerAPIVersion))
 	}
 	return nil
 }

--- a/receiver/dockerstatsreceiver/config_test.go
+++ b/receiver/dockerstatsreceiver/config_test.go
@@ -46,6 +46,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "unix:///var/run/docker.sock", dcfg.Endpoint)
 	assert.Equal(t, 10*time.Second, dcfg.CollectionInterval)
 	assert.Equal(t, 5*time.Second, dcfg.Timeout)
+	assert.Equal(t, defaultDockerAPIVersion, dcfg.DockerAPIVersion)
 
 	assert.Nil(t, dcfg.ExcludedImages)
 	assert.Nil(t, dcfg.ContainerLabelsToMetricLabels)
@@ -58,6 +59,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "http://example.com/", ascfg.Endpoint)
 	assert.Equal(t, 2*time.Second, ascfg.CollectionInterval)
 	assert.Equal(t, 20*time.Second, ascfg.Timeout)
+	assert.Equal(t, 1.24, ascfg.DockerAPIVersion)
 
 	assert.Equal(t, []string{
 		"undesired-container",

--- a/receiver/dockerstatsreceiver/docker.go
+++ b/receiver/dockerstatsreceiver/docker.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	dockerAPIVersion = "v1.22"
-	userAgent        = "OpenTelemetry-Collector Docker Stats Receiver/v0.0.1"
+	defaultDockerAPIVersion         = 1.22
+	minimalRequiredDockerAPIVersion = 1.22
+	userAgent                       = "OpenTelemetry-Collector Docker Stats Receiver/v0.0.1"
 )
 
 // dockerClient provides the core metric gathering functionality from the Docker Daemon.
@@ -51,7 +52,7 @@ type dockerClient struct {
 func newDockerClient(config *Config, logger *zap.Logger) (*dockerClient, error) {
 	client, err := docker.NewClientWithOpts(
 		docker.WithHost(config.Endpoint),
-		docker.WithVersion(dockerAPIVersion),
+		docker.WithVersion(fmt.Sprintf("v%v", config.DockerAPIVersion)),
 		docker.WithHTTPHeaders(map[string]string{"User-Agent": userAgent}),
 	)
 	if err != nil {

--- a/receiver/dockerstatsreceiver/factory.go
+++ b/receiver/dockerstatsreceiver/factory.go
@@ -41,6 +41,7 @@ func createDefaultConfig() config.Receiver {
 		Endpoint:           "unix:///var/run/docker.sock",
 		CollectionInterval: 10 * time.Second,
 		Timeout:            5 * time.Second,
+		DockerAPIVersion:   defaultDockerAPIVersion,
 	}
 }
 

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -37,6 +37,7 @@ func TestNewReceiver(t *testing.T) {
 	config := &Config{
 		Endpoint:           "unix:///run/some.sock",
 		CollectionInterval: 1 * time.Second,
+		DockerAPIVersion: defaultDockerAPIVersion,
 	}
 	logger := zap.NewNop()
 	nextConsumer := consumertest.NewNop()
@@ -70,6 +71,7 @@ func TestErrorsInStart(t *testing.T) {
 	config := &Config{
 		Endpoint:           unreachable,
 		CollectionInterval: 1 * time.Second,
+		DockerAPIVersion: defaultDockerAPIVersion,
 	}
 	logger := zap.NewNop()
 	receiver, err := NewReceiver(context.Background(), logger, config, consumertest.NewNop())

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -37,7 +37,7 @@ func TestNewReceiver(t *testing.T) {
 	config := &Config{
 		Endpoint:           "unix:///run/some.sock",
 		CollectionInterval: 1 * time.Second,
-		DockerAPIVersion: defaultDockerAPIVersion,
+		DockerAPIVersion:   defaultDockerAPIVersion,
 	}
 	logger := zap.NewNop()
 	nextConsumer := consumertest.NewNop()
@@ -71,7 +71,7 @@ func TestErrorsInStart(t *testing.T) {
 	config := &Config{
 		Endpoint:           unreachable,
 		CollectionInterval: 1 * time.Second,
-		DockerAPIVersion: defaultDockerAPIVersion,
+		DockerAPIVersion:   defaultDockerAPIVersion,
 	}
 	logger := zap.NewNop()
 	receiver, err := NewReceiver(context.Background(), logger, config, consumertest.NewNop())

--- a/receiver/dockerstatsreceiver/testdata/config.yaml
+++ b/receiver/dockerstatsreceiver/testdata/config.yaml
@@ -4,6 +4,7 @@ receivers:
     endpoint: http://example.com/
     collection_interval: 2s
     timeout: 20s
+    api_version: 1.24
     container_labels_to_metric_labels:
       my.container.label: my-metric-label
       my.other.container.label: my-other-metric-label


### PR DESCRIPTION
Currently the dockerAPIVersion field in the Docker stats receiver is hard coded to a particular version (v1.22).
It's good to be able to modify that value via the config, the default will still be v1.22 and the config validator ensures that users do not use any value <v.1.22, if they use an invalid api version the collector will fail to start with the proper error message.