### PR TITLE
[exporter/signalfx] document list of default excluded metrics

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -45,7 +45,7 @@ The following configuration options can also be configured:
   excluded from sending to Signalfx backend. If `translation_rules` options
   are enabled, the exclusion will be applied on translated metrics.
   See [here](./testdata/config.yaml) for examples. Apart from the values explicitly
-  provided via this option, by default, [these](./translation/default_metrics.go) are
+  provided via this option, by default, [these](./internal/translation/default_metrics.go) are
   also appended to this list. Setting this option to `[]` will override all the default
   excludes.
 - `include_metrics`: List of filters to override exclusion of any metrics.
@@ -113,6 +113,21 @@ One of `realm` and `api_url` are required.
   - `retry_delay` (default = 30 seconds): How long to wait between retries.
   - `cleanup_interval` (default = 1 minute): How frequently to purge duplicate requests.
   - `sync_attributes` (default = `{"k8s.pod.uid": "k8s.pod.uid", "container.id": "container.id"}`) Map containing key of the attribute to read from spans to sync to dimensions specified as the value.
+
+## Default Metric Filters
+[List of metrics excluded by default](./internal/translation/default_metrics.go)
+
+Some OpenTelemetry receivers may send metrics that SignalFx considers to be categorized as custom metrics. In order to prevent unwanted overage usage due to custom metrics from these receivers, the SignalFx exporter has a [set of metrics excluded by default](./internal/translation/default_metrics.go). Some exclusion rules use regex to exclude multiple metric names. Some metrics are only excluded if specific resource labels (dimensions) are present. If `translation_rules` are configured and new metrics match a default exclusion, the new metric will still be excluded. Users may configure the SignalFx exporter's `include_metrics` config option to override the any of the default exclusions, as `include_metrics` will always take precedence over any exclusions. An example of `include_metrics` is shown below.
+
+```
+exporters:
+  signalfx:
+    include_metrics:
+      - metric_names: [cpu.interrupt, cpu.user, cpu.system]
+      - metric_name: system.cpu.time
+        dimensions:
+          state: [interrupt, user, system]
+```
 
 ## Translation Rules and Metric Transformations
 


### PR DESCRIPTION
We exclude several metrics by default with our exporter - it is good practice to list them out in the readme.