### PR TITLE
Replace all mention of conventions.AttributeHTTPStatusText with http.status_text

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/cause.go
+++ b/exporter/awsxrayexporter/internal/translator/cause.go
@@ -94,7 +94,7 @@ func makeCause(span pdata.Span, attributes map[string]pdata.AttributeValue, reso
 		filtered = make(map[string]pdata.AttributeValue)
 		for key, value := range attributes {
 			switch key {
-			case conventions.AttributeHTTPStatusText:
+			case "http.status_text":
 				if message == "" {
 					message = value.StringVal()
 				}

--- a/exporter/awsxrayexporter/internal/translator/cause_test.go
+++ b/exporter/awsxrayexporter/internal/translator/cause_test.go
@@ -105,7 +105,7 @@ func TestCauseWithHttpStatusMessage(t *testing.T) {
 	attributes[conventions.AttributeHTTPMethod] = "POST"
 	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
 	attributes[conventions.AttributeHTTPStatusCode] = 500
-	attributes[conventions.AttributeHTTPStatusText] = errorMsg
+	attributes["http.status_text"] = errorMsg
 	span := constructExceptionServerSpan(attributes, pdata.StatusCodeError)
 	filtered, _ := makeHTTP(span)
 
@@ -132,7 +132,7 @@ func TestCauseWithZeroStatusMessage(t *testing.T) {
 	attributes[conventions.AttributeHTTPMethod] = "POST"
 	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
 	attributes[conventions.AttributeHTTPStatusCode] = 500
-	attributes[conventions.AttributeHTTPStatusText] = errorMsg
+	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, pdata.StatusCodeUnset)
 	filtered, _ := makeHTTP(span)
@@ -156,7 +156,7 @@ func TestCauseWithClientErrorMessage(t *testing.T) {
 	attributes[conventions.AttributeHTTPMethod] = "POST"
 	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
 	attributes[conventions.AttributeHTTPStatusCode] = 499
-	attributes[conventions.AttributeHTTPStatusText] = errorMsg
+	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, pdata.StatusCodeError)
 	filtered, _ := makeHTTP(span)
@@ -177,7 +177,7 @@ func TestCauseWithThrottled(t *testing.T) {
 	attributes[conventions.AttributeHTTPMethod] = "POST"
 	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
 	attributes[conventions.AttributeHTTPStatusCode] = 429
-	attributes[conventions.AttributeHTTPStatusText] = errorMsg
+	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, pdata.StatusCodeError)
 	filtered, _ := makeHTTP(span)

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -103,7 +103,7 @@ func TestServerSpanWithInternalServerError(t *testing.T) {
 	attributes[conventions.AttributeHTTPURL] = "https://api.example.org/api/locations"
 	attributes[conventions.AttributeHTTPTarget] = "/api/locations"
 	attributes[conventions.AttributeHTTPStatusCode] = 500
-	attributes[conventions.AttributeHTTPStatusText] = "java.lang.NullPointerException"
+	attributes["http.status_text"] = "java.lang.NullPointerException"
 	attributes[conventions.AttributeHTTPUserAgent] = userAgent
 	attributes[conventions.AttributeEnduserID] = enduser
 	resource := constructDefaultResource()
@@ -130,7 +130,7 @@ func TestServerSpanWithThrottle(t *testing.T) {
 	attributes[conventions.AttributeHTTPURL] = "https://api.example.org/api/locations"
 	attributes[conventions.AttributeHTTPTarget] = "/api/locations"
 	attributes[conventions.AttributeHTTPStatusCode] = 429
-	attributes[conventions.AttributeHTTPStatusText] = "java.lang.NullPointerException"
+	attributes["http.status_text"] = "java.lang.NullPointerException"
 	attributes[conventions.AttributeHTTPUserAgent] = userAgent
 	attributes[conventions.AttributeEnduserID] = enduser
 	resource := constructDefaultResource()

--- a/exporter/azuremonitorexporter/conventions.go
+++ b/exporter/azuremonitorexporter/conventions.go
@@ -114,7 +114,7 @@ func (attrs *HTTPAttributes) MapAttribute(k string, v pdata.AttributeValue) bool
 		if val, err := getAttributeValueAsInt(v); err == nil {
 			attrs.HTTPStatusCode = val
 		}
-	case conventions.AttributeHTTPStatusText:
+	case "http.status_text":
 		attrs.HTTPStatusText = v.StringVal()
 	case conventions.AttributeHTTPFlavor:
 		attrs.HTTPFlavor = v.StringVal()

--- a/exporter/azuremonitorexporter/conventions_test.go
+++ b/exporter/azuremonitorexporter/conventions_test.go
@@ -32,7 +32,7 @@ func TestHTTPAttributeMapping(t *testing.T) {
 
 		// Exercise the INT or STRING logic
 		conventions.AttributeHTTPStatusCode:                        pdata.NewAttributeValueString("200"),
-		conventions.AttributeHTTPStatusText:                        pdata.NewAttributeValueString(conventions.AttributeHTTPStatusText),
+		"http.status_text":                        					pdata.NewAttributeValueString("http.status_text"),
 		conventions.AttributeHTTPFlavor:                            pdata.NewAttributeValueString(conventions.AttributeHTTPFlavor),
 		conventions.AttributeHTTPUserAgent:                         pdata.NewAttributeValueString(conventions.AttributeHTTPUserAgent),
 		conventions.AttributeHTTPRequestContentLength:              pdata.NewAttributeValueInt(1),
@@ -60,7 +60,7 @@ func TestHTTPAttributeMapping(t *testing.T) {
 	assert.Equal(t, conventions.AttributeHTTPHost, httpAttributes.HTTPHost)
 	assert.Equal(t, conventions.AttributeHTTPScheme, httpAttributes.HTTPScheme)
 	assert.Equal(t, int64(200), httpAttributes.HTTPStatusCode)
-	assert.Equal(t, conventions.AttributeHTTPStatusText, httpAttributes.HTTPStatusText)
+	assert.Equal(t, "http.status_text", httpAttributes.HTTPStatusText)
 	assert.Equal(t, conventions.AttributeHTTPFlavor, httpAttributes.HTTPFlavor)
 	assert.Equal(t, conventions.AttributeHTTPUserAgent, httpAttributes.HTTPUserAgent)
 	assert.Equal(t, int64(1), httpAttributes.HTTPRequestContentLength)

--- a/exporter/azuremonitorexporter/conventions_test.go
+++ b/exporter/azuremonitorexporter/conventions_test.go
@@ -32,7 +32,7 @@ func TestHTTPAttributeMapping(t *testing.T) {
 
 		// Exercise the INT or STRING logic
 		conventions.AttributeHTTPStatusCode:                        pdata.NewAttributeValueString("200"),
-		"http.status_text":                        					pdata.NewAttributeValueString("http.status_text"),
+		"http.status_text":                                         pdata.NewAttributeValueString("http.status_text"),
 		conventions.AttributeHTTPFlavor:                            pdata.NewAttributeValueString(conventions.AttributeHTTPFlavor),
 		conventions.AttributeHTTPUserAgent:                         pdata.NewAttributeValueString(conventions.AttributeHTTPUserAgent),
 		conventions.AttributeHTTPRequestContentLength:              pdata.NewAttributeValueInt(1),

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -592,7 +592,7 @@ func getSpanErrorAndSetTags(s pdata.Span, tags map[string]string) int32 {
 				tags[ext.ErrorMsg] = status.Message()
 				// look for useful http metadata if it exists and add that as a fallback for the error message
 			} else if statusCode, ok := tags[conventions.AttributeHTTPStatusCode]; ok {
-				if statusText, ok := tags[conventions.AttributeHTTPStatusText]; ok {
+				if statusText, ok := tags[conventions."http.status_text"]; ok {
 					tags[ext.ErrorMsg] = fmt.Sprintf("%s %s", statusCode, statusText)
 				} else {
 					tags[ext.ErrorMsg] = statusCode

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -592,7 +592,7 @@ func getSpanErrorAndSetTags(s pdata.Span, tags map[string]string) int32 {
 				tags[ext.ErrorMsg] = status.Message()
 				// look for useful http metadata if it exists and add that as a fallback for the error message
 			} else if statusCode, ok := tags[conventions.AttributeHTTPStatusCode]; ok {
-				if statusText, ok := tags[conventions."http.status_text"]; ok {
+				if statusText, ok := tags["http.status_text"]; ok {
 					tags[ext.ErrorMsg] = fmt.Sprintf("%s %s", statusCode, statusText)
 				} else {
 					tags[ext.ErrorMsg] = statusCode

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -422,7 +422,7 @@ func TestTracesFallbackErrorMessage(t *testing.T) {
 	status.SetCode(pdata.StatusCodeError)
 
 	span.Attributes().InsertString(conventions.AttributeHTTPStatusCode, "404")
-	span.Attributes().InsertString(conventions."http.status_text", "Not Found")
+	span.Attributes().InsertString("http.status_text", "Not Found")
 
 	// translate mocks to datadog traces
 	datadogPayload := resourceSpansToDatadogSpans(rs, hostname, &config.Config{}, denylister, map[string]string{})

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -422,7 +422,7 @@ func TestTracesFallbackErrorMessage(t *testing.T) {
 	status.SetCode(pdata.StatusCodeError)
 
 	span.Attributes().InsertString(conventions.AttributeHTTPStatusCode, "404")
-	span.Attributes().InsertString(conventions.AttributeHTTPStatusText, "Not Found")
+	span.Attributes().InsertString(conventions."http.status_text", "Not Found")
 
 	// translate mocks to datadog traces
 	datadogPayload := resourceSpansToDatadogSpans(rs, hostname, &config.Config{}, denylister, map[string]string{})

--- a/internal/coreinternal/goldendataset/span_generator.go
+++ b/internal/coreinternal/goldendataset/span_generator.go
@@ -279,7 +279,7 @@ func appendHTTPClientAttributes(includeStatus bool, attrMap pdata.AttributeMap) 
 	attrMap.UpsertString(conventions.AttributeHTTPURL, "https://opentelemetry.io/registry/")
 	if includeStatus {
 		attrMap.UpsertInt(conventions.AttributeHTTPStatusCode, 200)
-		attrMap.UpsertString(conventions.AttributeHTTPStatusText, "More Than OK")
+		attrMap.UpsertString("http.status_text", "More Than OK")
 	}
 	attrMap.UpsertString(conventions.AttributeEnduserID, "unittest")
 }
@@ -348,7 +348,7 @@ func appendMaxCountAttributes(includeStatus bool, attrMap pdata.AttributeMap) {
 	attrMap.UpsertString(conventions.AttributeHTTPFlavor, "2")
 	if includeStatus {
 		attrMap.UpsertInt(conventions.AttributeHTTPStatusCode, 201)
-		attrMap.UpsertString(conventions.AttributeHTTPStatusText, "Created")
+		attrMap.UpsertString("http.status_text", "Created")
 	}
 	attrMap.UpsertString(conventions.AttributeHTTPUserAgent,
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36")

--- a/processor/probabilisticsamplerprocessor/probabilisticsampler_test.go
+++ b/processor/probabilisticsamplerprocessor/probabilisticsampler_test.go
@@ -471,7 +471,7 @@ func genRandomTestData(numBatches, numTracesPerBatch int, serviceName string, re
 				span.SetSpanID(idutils.UInt64ToSpanID(r.Uint64()))
 				attributes := make(map[string]pdata.AttributeValue)
 				attributes[conventions.AttributeHTTPStatusCode] = pdata.NewAttributeValueInt(404)
-				attributes[conventions.AttributeHTTPStatusText] = pdata.NewAttributeValueString("Not Found")
+				attributes["http.status_text"] = pdata.NewAttributeValueString("Not Found")
 				span.Attributes().InitFromMap(attributes)
 			}
 		}

--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -329,7 +329,7 @@ func (r *sfxReceiver) failRequest(
 	reqSpan := trace.FromContext(ctx)
 	reqSpan.AddAttributes(
 		trace.Int64Attribute(conventions.AttributeHTTPStatusCode, int64(httpStatusCode)),
-		trace.StringAttribute(conventions.AttributeHTTPStatusText, msg))
+		trace.StringAttribute("http.status_text", msg))
 	traceStatus := trace.Status{
 		Code: trace.StatusCodeInvalidArgument,
 	}

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -327,7 +327,7 @@ func (r *splunkReceiver) failRequest(
 	reqSpan := trace.FromContext(ctx)
 	reqSpan.AddAttributes(
 		trace.Int64Attribute(conventions.AttributeHTTPStatusCode, int64(httpStatusCode)),
-		trace.StringAttribute(conventions.AttributeHTTPStatusText, msg))
+		trace.StringAttribute("http.status_text", msg))
 	traceStatus := trace.Status{
 		Code: trace.StatusCodeInvalidArgument,
 	}


### PR DESCRIPTION
**Description:**
This PR removes all usage of `conventions.AttributeHTTPStatusText` and replaces it with `"http.status_text"`.

**Link to tracking Issue:**
This PR, along with PR [4015](https://github.com/open-telemetry/opentelemetry-collector/pull/4015) in the collector repository, addresses issue [3999](https://github.com/open-telemetry/opentelemetry-collector/issues/3999) in the collector repository. 