### PR TITLE
fix: replaces conventions.AttributeMessageType to "message.type"

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/http.go
+++ b/exporter/awsxrayexporter/internal/translator/http.go
@@ -141,7 +141,7 @@ func extractResponseSizeFromEvents(span pdata.Span) int64 {
 }
 
 func extractResponseSizeFromAttributes(attributes pdata.AttributeMap) int64 {
-	typeVal, ok := attributes.Get(conventions.AttributeMessageType)
+	typeVal, ok := attributes.Get("message.type")
 	if ok && typeVal.StringVal() == "RECEIVED" {
 		if sizeVal, ok := attributes.Get(conventions.AttributeMessagingMessagePayloadSizeBytes); ok {
 			return sizeVal.IntVal()

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -830,7 +830,7 @@ func constructDefaultResource() pdata.Resource {
 
 func constructTimedEventsWithReceivedMessageEvent(tm pdata.Timestamp) pdata.SpanEventSlice {
 	eventAttr := pdata.NewAttributeMap()
-	eventAttr.InsertString(conventions.AttributeMessageType, "RECEIVED")
+	eventAttr.InsertString("message.type", "RECEIVED")
 	eventAttr.InsertInt(conventions.AttributeMessagingMessageID, 1)
 	eventAttr.InsertInt(conventions.AttributeMessagingMessagePayloadCompressedSizeBytes, 6478)
 	eventAttr.InsertInt(conventions.AttributeMessagingMessagePayloadSizeBytes, 12452)
@@ -847,7 +847,7 @@ func constructTimedEventsWithReceivedMessageEvent(tm pdata.Timestamp) pdata.Span
 
 func constructTimedEventsWithSentMessageEvent(tm pdata.Timestamp) pdata.SpanEventSlice {
 	eventAttr := pdata.NewAttributeMap()
-	eventAttr.InsertString(conventions.AttributeMessageType, "SENT")
+	eventAttr.InsertString("message.type", "SENT")
 	eventAttr.InsertInt(conventions.AttributeMessagingMessageID, 1)
 	eventAttr.InsertInt(conventions.AttributeMessagingMessagePayloadSizeBytes, 7480)
 

--- a/internal/coreinternal/goldendataset/span_generator.go
+++ b/internal/coreinternal/goldendataset/span_generator.go
@@ -421,9 +421,9 @@ func appendSpanEvent(index int, spanEvents pdata.SpanEventSlice) {
 		spanEvent.SetName("message")
 		attrMap := spanEvent.Attributes()
 		if index%2 == 0 {
-			attrMap.UpsertString(conventions.AttributeMessageType, "SENT")
+			attrMap.UpsertString("message.type", "SENT")
 		} else {
-			attrMap.UpsertString(conventions.AttributeMessageType, "RECEIVED")
+			attrMap.UpsertString("message.type", "RECEIVED")
 		}
 		attrMap.UpsertInt(conventions.AttributeMessagingMessageID, int64(index/4))
 		attrMap.UpsertInt(conventions.AttributeMessagingMessagePayloadCompressedSizeBytes, int64(17*index))

--- a/pkg/translator/opencensus/oc_to_traces.go
+++ b/pkg/translator/opencensus/oc_to_traces.go
@@ -352,7 +352,7 @@ func ocMessageEventToInternalAttrs(msgEvent *octrace.Span_TimeEvent_MessageEvent
 		return
 	}
 
-	dest.UpsertString(conventions.AttributeMessageType, msgEvent.Type.String())
+	dest.UpsertString("message.type", msgEvent.Type.String())
 	dest.UpsertInt(conventions.AttributeMessagingMessageID, int64(msgEvent.Id))
 	dest.UpsertInt(conventions.AttributeMessagingMessagePayloadSizeBytes, int64(msgEvent.UncompressedSize))
 	dest.UpsertInt(conventions.AttributeMessagingMessagePayloadCompressedSizeBytes, int64(msgEvent.CompressedSize))

--- a/pkg/translator/opencensus/traces_to_oc.go
+++ b/pkg/translator/opencensus/traces_to_oc.go
@@ -277,7 +277,7 @@ func eventToOC(event pdata.SpanEvent) *octrace.Span_TimeEvent {
 
 	// Consider TimeEvent to be of MessageEvent type if all and only relevant attributes are set
 	ocMessageEventAttrs := []string{
-		conventions.AttributeMessageType,
+		"message.type",
 		conventions.AttributeMessagingMessageID,
 		conventions.AttributeMessagingMessagePayloadSizeBytes,
 		conventions.AttributeMessagingMessagePayloadCompressedSizeBytes,
@@ -294,7 +294,7 @@ func eventToOC(event pdata.SpanEvent) *octrace.Span_TimeEvent {
 			ocMessageEventAttrValues[attr] = akv
 		}
 		if ocMessageEventAttrFound {
-			ocMessageEventType := ocMessageEventAttrValues[conventions.AttributeMessageType]
+			ocMessageEventType := ocMessageEventAttrValues["message.type"]
 			ocMessageEventTypeVal := octrace.Span_TimeEvent_MessageEvent_Type_value[ocMessageEventType.StringVal()]
 			return &octrace.Span_TimeEvent{
 				Time: timestampAsTimestampPb(event.Timestamp()),


### PR DESCRIPTION
**Description:**
Replaces all usage of conventions.AttributeMessageType to "message.type".

**Link to tracking Issue:**
This PR and PR in [collector/4020](https://github.com/open-telemetry/opentelemetry-collector/pull/4020), addresses [#3998 in the collector repository](https://github.com/open-telemetry/opentelemetry-collector/issues/3998).