### PR TITLE
filterprocessor: regexp log filters

### DIFF
--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -1,22 +1,43 @@
 # Filter Processor
 
-Supported pipeline types: metrics
+Supported pipeline types: logs, metrics
 
-The filter processor can be configured to include or exclude metrics based on
-metric name in the case of the 'strict' or 'regexp' match types, or based on other
-metric attributes in the case of the 'expr' match type. Please refer to
-[config.go](./config.go) for the config spec.
+The filter processor can be configured to include or exclude:
 
-It takes a pipeline type, of which only `metrics` is supported, followed by an
-action:
+- logs, based on resource attributes using the `strict` or `regexp` match types
+- metrics based on metric name in the case of the `strict` or `regexp` match types,
+  or based on other metric attributes in the case of the `expr` match type.
+  Please refer to [config.go](./config.go) for the config spec.
+
+It takes a pipeline type, of which `logs` and `metrics` are supported, followed
+by an action:
+
 - `include`: Any names NOT matching filters are excluded from remainder of pipeline
 - `exclude`: Any names matching filters are excluded from remainder of pipeline
 
 For the actions the following parameters are required:
- - `match_type`: strict|regexp|expr
- - `metric_names`: (only for a `match_type` of 'strict' or 'regexp') list of strings or re2 regex patterns
- - `expressions`: (only for a `match_type` of 'expr') list of expr expressions (see "Using an 'expr' match_type" below)
- - `resource_attributes`: ResourceAttributes defines a list of possible resource attributes to match metrics against. A match occurs if any resource attribute matches all expressions in this given list. 
+
+For logs:
+
+- `match_type`: `strict`|`regexp`
+- `resource_attributes`: ResourceAttributes defines a list of possible resource
+  attributes to match logs against.
+  A match occurs if any resource attribute matches all expressions in this given list.
+
+For metrics:
+
+- `match_type`: `strict`|`regexp`|`expr`
+- `metric_names`: (only for a `match_type` of `strict` or `regexp`) list of strings
+  or re2 regex patterns
+- `expressions`: (only for a `match_type` of `expr`) list of expr expressions
+  (see "Using an 'expr' match_type" below)
+- `resource_attributes`: ResourceAttributes defines a list of possible resource
+  attributes to match metrics against.
+  A match occurs if any resource attribute matches all expressions in this given list.
+
+This processor uses [re2 regex][re2_regex] for regex syntax.
+
+[re2_regex]: https://github.com/google/re2/wiki/Syntax
 
 More details can found at [include/exclude metrics](../README.md#includeexclude-metrics).
 
@@ -39,6 +60,17 @@ processors:
         metric_names:
           - hello_world
           - hello/world
+  filter/2:
+    logs:
+      include:
+        match_type: strict
+        resource_attributes:
+          - Key: host.name
+            Value: just_this_one_hostname
+        match_type: regexp
+        resource_attributes:
+          - Key: host.name
+            Value: prefix.*
 ```
 
 Refer to the config files in [testdata](./testdata) for detailed

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -63,6 +63,7 @@ type LogMatchType string
 // `pdata.Log`s.
 const (
 	Strict = LogMatchType(filterset.Strict)
+	Regexp = LogMatchType(filterset.Regexp)
 )
 
 // LogMatchProperties specifies the set of properties in a log to match against and the

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -60,6 +60,9 @@ func TestCreateProcessors(t *testing.T) {
 		}, {
 			configName: "config_logs_strict.yaml",
 			succeed:    true,
+		}, {
+			configName: "config_logs_regexp.yaml",
+			succeed:    true,
 		},
 	}
 

--- a/processor/filterprocessor/filter_processor_logs.go
+++ b/processor/filterprocessor/filter_processor_logs.go
@@ -68,7 +68,7 @@ func createLogsMatcher(lp *LogMatchProperties) (filtermatcher.AttributesMatcher,
 	var attributeMatcher filtermatcher.AttributesMatcher
 	attributeMatcher, err := filtermatcher.NewAttributesMatcher(
 		filterset.Config{
-			MatchType: filterset.MatchType("strict"),
+			MatchType: filterset.MatchType(lp.LogMatchType),
 		},
 		lp.ResourceAttributes,
 	)

--- a/processor/filterprocessor/filter_processor_logs_test.go
+++ b/processor/filterprocessor/filter_processor_logs_test.go
@@ -73,6 +73,33 @@ var (
 		},
 	}
 
+	inLogForFourResource = []logWithResource{
+		{
+			logNames: []string{"log1"},
+			resourceAttributes: map[string]pdata.AttributeValue{
+				"attr": pdata.NewAttributeValueString("attr/val1"),
+			},
+		},
+		{
+			logNames: []string{"log2"},
+			resourceAttributes: map[string]pdata.AttributeValue{
+				"attr": pdata.NewAttributeValueString("attr/val2"),
+			},
+		},
+		{
+			logNames: []string{"log3"},
+			resourceAttributes: map[string]pdata.AttributeValue{
+				"attr": pdata.NewAttributeValueString("attr/val3"),
+			},
+		},
+		{
+			logNames: []string{"log4"},
+			resourceAttributes: map[string]pdata.AttributeValue{
+				"attr": pdata.NewAttributeValueString("attr/val4"),
+			},
+		},
+	}
+
 	standardLogTests = []logNameTest{
 		{
 			name:   "emptyFilterInclude",
@@ -139,6 +166,53 @@ var (
 			inLogs: testResourceLogs(inLogForTwoResource),
 			outLN: [][]string{
 				{"log3", "log4"},
+			},
+		},
+		{
+			name:   "matchAttributesWithRegexpInclude",
+			inc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val2"}}},
+			inLogs: testResourceLogs(inLogForFourResource),
+			outLN: [][]string{
+				{"log2"},
+			},
+		},
+		{
+			name:   "matchAttributesWithRegexpInclude2",
+			inc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val(2|3)"}}},
+			inLogs: testResourceLogs(inLogForFourResource),
+			outLN: [][]string{
+				{"log2"},
+				{"log3"},
+			},
+		},
+		{
+			name:   "matchAttributesWithRegexpInclude3",
+			inc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val[234]"}}},
+			inLogs: testResourceLogs(inLogForFourResource),
+			outLN: [][]string{
+				{"log2"},
+				{"log3"},
+				{"log4"},
+			},
+		},
+		{
+			name:   "matchAttributesWithRegexpInclude4",
+			inc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val.*"}}},
+			inLogs: testResourceLogs(inLogForFourResource),
+			outLN: [][]string{
+				{"log1"},
+				{"log2"},
+				{"log3"},
+				{"log4"},
+			},
+		},
+		{
+			name:   "matchAttributesWithRegexpExclude",
+			exc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val[23]"}}},
+			inLogs: testResourceLogs(inLogForFourResource),
+			outLN: [][]string{
+				{"log1"},
+				{"log4"},
 			},
 		},
 	}

--- a/processor/filterprocessor/testdata/config_logs_regexp.yaml
+++ b/processor/filterprocessor/testdata/config_logs_regexp.yaml
@@ -5,48 +5,44 @@ processors:
     filter/empty:
         logs:
             include:
-                match_type: strict
+                match_type: regexp
     filter/include:
         logs:
             # any logs NOT matching filters are excluded from remainder of pipeline
             include:
-                match_type: strict
+                match_type: regexp
                 resource_attributes:
-                    - key: should_include
-                      value: "true"
+                    - key: host.name
+                      value: "(host1|mycustomhost2)"
     filter/exclude:
         logs:
             # any logs matching filters are excluded from remainder of pipeline
             exclude:
-                match_type: strict
+                match_type: regexp
                 resource_attributes:
-                    - key: should_exclude
-                      value: "true"
+                    - key: host.name
+                      value: banned_host_.*
     filter/includeexclude:
         logs:
             # if both include and exclude are specified, include filters are applied first
             # the following configuration would only allow logs with resource attributes
             # "should_include" to pass through
             include:
-                match_type: strict
+                match_type: regexp
                 resource_attributes:
                     - key: should_include
-                      value: "true"
+                      value: "(true|probably_true)"
             exclude:
-                match_type: strict
+                match_type: regexp
                 resource_attributes:
                     - key: should_exclude
-                      value: "true"
+                      value: "(probably_false|false)"
 
 exporters:
     nop:
 
 service:
     pipelines:
-        traces:
-            receivers: [nop]
-            processors: [filter/empty]
-            exporters: [nop]
         logs:
             receivers: [nop]
             processors: [filter/empty, filter/include, filter/exclude, filter/includeexclude]


### PR DESCRIPTION
**Description:** add log filtering by `regexp` type filters in filterprocessor

**Link to tracking Issue:** - / related issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5234 (a separate one needs to be created strictly for this feature)

**Testing:** Added UTs

**Documentation:** updated filterprocessor doc