### PR TITLE
Set Schema URL in dockerstatsreceiver

### DIFF
--- a/receiver/dockerstatsreceiver/metrics.go
+++ b/receiver/dockerstatsreceiver/metrics.go
@@ -44,6 +44,7 @@ func ContainerStatsToMetrics(
 ) (pdata.Metrics, error) {
 	md := pdata.NewMetrics()
 	rs := md.ResourceMetrics().AppendEmpty()
+	rs.SetSchemaUrl(conventions.SchemaURL)
 	resourceAttr := rs.Resource().Attributes()
 	resourceAttr.UpsertString(conventions.AttributeContainerID, container.ID)
 	resourceAttr.UpsertString(conventions.AttributeContainerImageName, container.Config.Image)

--- a/receiver/dockerstatsreceiver/metrics_test.go
+++ b/receiver/dockerstatsreceiver/metrics_test.go
@@ -24,6 +24,7 @@ import (
 	dtypes "github.com/docker/docker/api/types"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 )
 
 type MetricType int32
@@ -56,6 +57,7 @@ func metricsData(
 	rLabels := mergeMaps(defaultLabels(), resourceLabels)
 	md := pdata.NewMetrics()
 	rs := md.ResourceMetrics().AppendEmpty()
+	rs.SetSchemaUrl(conventions.SchemaURL)
 	rsAttr := rs.Resource().Attributes()
 	for k, v := range rLabels {
 		rsAttr.UpsertString(k, v)


### PR DESCRIPTION
The Schema URL is set to match the semantic conventions used.

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5238
