### PR TITLE
Fix: fails to start if at least one resourcedetection detector returns an error

### DIFF
--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -128,12 +128,11 @@ func (p *ResourceProvider) detectResource(ctx context.Context) {
 	for _, detector := range p.detectors {
 		r, schemaURL, err := detector.Detect(ctx)
 		if err != nil {
-			p.detectedResource.err = err
-			return
+			p.logger.Debug("failed to detect resource", zap.Error(err))
+		} else {
+			mergedSchemaURL = MergeSchemaURL(mergedSchemaURL, schemaURL)
+			MergeResource(res, r, false)
 		}
-
-		mergedSchemaURL = MergeSchemaURL(mergedSchemaURL, schemaURL)
-		MergeResource(res, r, false)
 	}
 
 	p.logger.Info("detected resource information", zap.Any("resource", AttributesToMap(res.Attributes())))

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -128,11 +128,12 @@ func (p *ResourceProvider) detectResource(ctx context.Context) {
 	for _, detector := range p.detectors {
 		r, schemaURL, err := detector.Detect(ctx)
 		if err != nil {
-			p.logger.Debug("failed to detect resource", zap.Error(err))
+			p.logger.Warn("failed to detect resource", zap.Error(err))
 		} else {
 			mergedSchemaURL = MergeSchemaURL(mergedSchemaURL, schemaURL)
 			MergeResource(res, r, false)
 		}
+
 	}
 
 	p.logger.Info("detected resource information", zap.Any("resource", AttributesToMap(res.Attributes())))

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -198,18 +198,23 @@ func TestDetectResource_Parallel(t *testing.T) {
 	md2 := NewMockParallelDetector()
 	md2.On("Detect").Return(NewResource(map[string]interface{}{"a": "11", "c": "3"}), nil)
 
+	md3 := NewMockParallelDetector()
+	md3.On("Detect").Return(pdata.NewResource(), errors.New("an error"))
+
 	expectedResource := NewResource(map[string]interface{}{"a": "1", "b": "2", "c": "3"})
 	expectedResource.Attributes().Sort()
 
-	p := NewResourceProvider(zap.NewNop(), time.Second, md1, md2)
+	p := NewResourceProvider(zap.NewNop(), time.Second, md1, md2, md3)
 
+	var detected pdata.Resource
 	// call p.Get multiple times
 	wg := &sync.WaitGroup{}
 	wg.Add(iterations)
 	for i := 0; i < iterations; i++ {
 		go func() {
 			defer wg.Done()
-			_, _, err := p.Get(context.Background())
+			var err error
+			detected, _, err = p.Get(context.Background())
 			require.NoError(t, err)
 		}()
 	}
@@ -220,11 +225,16 @@ func TestDetectResource_Parallel(t *testing.T) {
 	// detector.Detect should only be called once, so we only need to notify each channel once
 	md1.ch <- struct{}{}
 	md2.ch <- struct{}{}
+	md3.ch <- struct{}{}
 
 	// then wait until all goroutines are finished, and ensure p.Detect was only called once
 	wg.Wait()
 	md1.AssertNumberOfCalls(t, "Detect", 1)
 	md2.AssertNumberOfCalls(t, "Detect", 1)
+	md3.AssertNumberOfCalls(t, "Detect", 1)
+
+	detected.Attributes().Sort()
+	assert.Equal(t, expectedResource, detected)
 }
 
 func TestAttributesToMap(t *testing.T) {

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -136,7 +136,7 @@ func TestDetectResource_Error(t *testing.T) {
 
 	p := NewResourceProvider(zap.NewNop(), time.Second, md1, md2)
 	_, _, err := p.Get(context.Background())
-	require.EqualError(t, err, "err1")
+	require.NoError(t, err)
 }
 
 func TestMergeResource(t *testing.T) {

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -206,16 +206,16 @@ func TestDetectResource_Parallel(t *testing.T) {
 
 	p := NewResourceProvider(zap.NewNop(), time.Second, md1, md2, md3)
 
-	var detected pdata.Resource
 	// call p.Get multiple times
 	wg := &sync.WaitGroup{}
 	wg.Add(iterations)
 	for i := 0; i < iterations; i++ {
 		go func() {
 			defer wg.Done()
-			var err error
-			detected, _, err = p.Get(context.Background())
+			detected, _, err := p.Get(context.Background())
 			require.NoError(t, err)
+			detected.Attributes().Sort()
+			assert.Equal(t, expectedResource, detected)
 		}()
 	}
 
@@ -232,9 +232,6 @@ func TestDetectResource_Parallel(t *testing.T) {
 	md1.AssertNumberOfCalls(t, "Detect", 1)
 	md2.AssertNumberOfCalls(t, "Detect", 1)
 	md3.AssertNumberOfCalls(t, "Detect", 1)
-
-	detected.Attributes().Sort()
-	assert.Equal(t, expectedResource, detected)
 }
 
 func TestAttributesToMap(t *testing.T) {

--- a/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
+++ b/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
@@ -55,7 +55,6 @@ func TestResourceProcessor(t *testing.T) {
 		detectedError      error
 		expectedResource   pdata.Resource
 		expectedNewError   string
-		expectedStartError string
 	}{
 		{
 			name:     "Resource is not overridden",
@@ -145,7 +144,6 @@ func TestResourceProcessor(t *testing.T) {
 				"cloud.availability_zone": "original-zone",
 			}),
 			detectedError:      errors.New("err1"),
-			expectedStartError: "err1",
 		},
 		{
 			name:             "Invalid detector key",
@@ -190,8 +188,8 @@ func TestResourceProcessor(t *testing.T) {
 
 			err = rtp.Start(context.Background(), componenttest.NewNopHost())
 
-			if tt.expectedStartError != "" {
-				assert.EqualError(t, err, tt.expectedStartError)
+			if tt.detectedError != nil {
+				require.NoError(t, err)
 				return
 			}
 
@@ -223,8 +221,8 @@ func TestResourceProcessor(t *testing.T) {
 
 			err = rmp.Start(context.Background(), componenttest.NewNopHost())
 
-			if tt.expectedStartError != "" {
-				assert.EqualError(t, err, tt.expectedStartError)
+			if tt.detectedError != nil {
+				require.NoError(t, err)
 				return
 			}
 
@@ -254,8 +252,8 @@ func TestResourceProcessor(t *testing.T) {
 
 			err = rlp.Start(context.Background(), componenttest.NewNopHost())
 
-			if tt.expectedStartError != "" {
-				assert.EqualError(t, err, tt.expectedStartError)
+			if tt.detectedError != nil {
+				require.NoError(t, err)
 				return
 			}
 

--- a/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
+++ b/processor/resourcedetectionprocessor/resourcedetection_processor_test.go
@@ -47,14 +47,14 @@ func (p *MockDetector) Detect(ctx context.Context) (resource pdata.Resource, sch
 
 func TestResourceProcessor(t *testing.T) {
 	tests := []struct {
-		name               string
-		detectorKeys       []string
-		override           bool
-		sourceResource     pdata.Resource
-		detectedResource   pdata.Resource
-		detectedError      error
-		expectedResource   pdata.Resource
-		expectedNewError   string
+		name             string
+		detectorKeys     []string
+		override         bool
+		sourceResource   pdata.Resource
+		detectedResource pdata.Resource
+		detectedError    error
+		expectedResource pdata.Resource
+		expectedNewError string
 	}{
 		{
 			name:     "Resource is not overridden",
@@ -143,7 +143,7 @@ func TestResourceProcessor(t *testing.T) {
 				"original-label":          "original-value",
 				"cloud.availability_zone": "original-zone",
 			}),
-			detectedError:      errors.New("err1"),
+			detectedError: errors.New("err1"),
 		},
 		{
 			name:             "Invalid detector key",


### PR DESCRIPTION
**Description:** <Describe what has changed.>

- As per the given issue [4616](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4616) the opentelemetry collector was failed to start due to an error from resourcedetectionprocessor.
- In the case of if any detector(ec2, was, eks, etc) having some issues it was throwing an error and stop moving ahead and collector was getting failed to start.
- To resolve this issue we have changed the behavior to log an error and continue with the further process instead stop processing further

**Link to tracking Issue:** [4616](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4616)

**Testing:** All the test cases are passing

