### PR TITLE
add per_cpu option to load scraper for hostmetricsreceiver

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -64,6 +64,15 @@ filesystem:
     match_type: <strict|regexp>
 ```
 
+### Load
+
+`per_cpu` divides the average load per CPU (default: `false`).
+
+```yaml
+disk:
+  per_cpu: <false|true>
+```
+
 ### Network
 
 ```yaml
@@ -77,10 +86,9 @@ network:
 
 ```yaml
 process:
-  disk:
-    <include|exclude>:
-      names: [ <process name>, ... ]
-      match_type: <strict|regexp>
+  <include|exclude>:
+    names: [ <process name>, ... ]
+    match_type: <strict|regexp>
 ```
 
 ## Advanced Configuration

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -86,9 +86,10 @@ network:
 
 ```yaml
 process:
-  <include|exclude>:
-    names: [ <process name>, ... ]
-    match_type: <strict|regexp>
+  disk:
+    <include|exclude>:
+      names: [ <process name>, ... ]
+      match_type: <strict|regexp>
 ```
 
 ## Advanced Configuration

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -69,7 +69,7 @@ filesystem:
 `per_cpu` divides the average load per CPU (default: `false`).
 
 ```yaml
-disk:
+load:
   per_cpu: <false|true>
 ```
 

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/config.go
@@ -19,4 +19,7 @@ import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostm
 // Config relating to Load Metric Scraper.
 type Config struct {
 	internal.ConfigSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	// If true, metrics will be average load per cpu
+	PerCPU bool `mapstructure:"per_cpu"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
@@ -66,9 +66,9 @@ func (s *scraper) scrape(_ context.Context) (pdata.MetricSlice, error) {
 
 	if s.config.PerCPU {
 		divisor := float64(runtime.NumCPU())
-		avgLoadValues.Load1 = avgLoadValues.Load1 * divisor
-		avgLoadValues.Load5 = avgLoadValues.Load1 * divisor
-		avgLoadValues.Load15 = avgLoadValues.Load1 * divisor
+		avgLoadValues.Load1 = avgLoadValues.Load1 / divisor
+		avgLoadValues.Load5 = avgLoadValues.Load1 / divisor
+		avgLoadValues.Load15 = avgLoadValues.Load1 / divisor
 	}
 
 	metrics.EnsureCapacity(metricsLen)

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
@@ -67,8 +67,8 @@ func (s *scraper) scrape(_ context.Context) (pdata.MetricSlice, error) {
 	if s.config.PerCPU {
 		divisor := float64(runtime.NumCPU())
 		avgLoadValues.Load1 = avgLoadValues.Load1 / divisor
-		avgLoadValues.Load5 = avgLoadValues.Load1 / divisor
-		avgLoadValues.Load15 = avgLoadValues.Load1 / divisor
+		avgLoadValues.Load5 = avgLoadValues.Load5 / divisor
+		avgLoadValues.Load15 = avgLoadValues.Load15 / divisor
 	}
 
 	metrics.EnsureCapacity(metricsLen)

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
@@ -16,6 +16,7 @@ package loadscraper
 
 import (
 	"context"
+	"runtime"
 	"time"
 
 	"github.com/shirou/gopsutil/load"
@@ -61,6 +62,13 @@ func (s *scraper) scrape(_ context.Context) (pdata.MetricSlice, error) {
 	avgLoadValues, err := s.load()
 	if err != nil {
 		return metrics, scrapererror.NewPartialScrapeError(err, metricsLen)
+	}
+
+	if s.config.PerCPU {
+		divisor := float64(runtime.NumCPU())
+		avgLoadValues.Load1 = avgLoadValues.Load1 * divisor
+		avgLoadValues.Load5 = avgLoadValues.Load1 * divisor
+		avgLoadValues.Load15 = avgLoadValues.Load1 * divisor
 	}
 
 	metrics.EnsureCapacity(metricsLen)

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
@@ -36,11 +36,16 @@ func TestScrape(t *testing.T) {
 		name        string
 		loadFunc    func() (*load.AvgStat, error)
 		expectedErr string
+		perCPU      bool
 	}
 
 	testCases := []testCase{
 		{
 			name: "Standard",
+		},
+		{
+			name:   "PerCPUEnabled",
+			perCPU: true,
 		},
 		{
 			name:        "Load Error",
@@ -51,7 +56,7 @@ func TestScrape(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			scraper := newLoadScraper(context.Background(), zap.NewNop(), &Config{})
+			scraper := newLoadScraper(context.Background(), zap.NewNop(), &Config{PerCPU: test.perCPU})
 			if test.loadFunc != nil {
 				scraper.load = test.loadFunc
 			}


### PR DESCRIPTION
**Description:** Add `per_cpu` optional option to load scraper of hostmetricsreceiver to produce average load per cpu which should ease the creation of alert for users without to divide themselves the metric (when another one is available for cpu count).

**Testing:** no test added. I read the https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md but I confess it not clear for me, help is welcome:

- hostmetricsreceiver is not in the list https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/Makefile#L18

- the `make` command currently fails in my env from main branch:

	  acegen/worker_test.go ./tracegen/main.go ./tracegen/README.md ./versions.yaml
	  make for-all-target TARGET="test"
	  make[1]: Entering directory '/home/qmanfroi/git/signalfx/opentelemetry-collector-contrib'
	  make -C ./cmd/configschema test
	  make[2]: Entering directory '/home/qmanfroi/git/signalfx/opentelemetry-collector-contrib/cmd/configschema'
	  go test -race -timeout 60s --tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper ./...
	  # github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema
	  ../../receiver/jaegerreceiver/trace_receiver.go:34:2: //go:build comment without // +build comment
	  FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema [setup failed]
	  ?       github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema/docsgen      [no test files]
	  ok      github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema/docsgen/docsgen      (cached)
	  FAIL
	  make[2]: *** [../../Makefile.Common:51: test] Error 1
	  make[2]: Leaving directory '/home/qmanfroi/git/signalfx/opentelemetry-collector-contrib/cmd/configschema'
	  make[1]: *** [Makefile:148: for-all-target-./cmd/configschema] Error 2
	  make[1]: Leaving directory '/home/qmanfroi/git/signalfx/opentelemetry-collector-contrib'
	  make: *** [Makefile:68: gotest] Error 2

- the `test` target seems not support to run test only for one receiver (to bypass the existing error) and allows me to test: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/Makefile.Common#L49

**Documentation:** added a config bloc for load including the new option