### PR TITLE
Collapse go.sum diffs in PR view

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# This file is documented at https://git-scm.com/docs/gitattributes.
+# Linguist-specific attributes are documented at
+# https://github.com/github/linguist.
+
+go.sum linguist-generated=true
+


### PR DESCRIPTION
When reviewing https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5229/files I noticed go.sum changes are pretty distracting