### PR TITLE
Creating an empty CertPool when the system run environment is windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## 💡 Enhancements 💡
 
 - `filter` processor: Add ability to `include` logs based on resource attributes in addition to excluding logs based on resource attributes for strict matching. (#4895)
+- `kubelet` API: Add ability to create a empty CertPool when the system run environment is windows
 
 ## v0.35.0
 

--- a/internal/kubelet/cert.go
+++ b/internal/kubelet/cert.go
@@ -19,10 +19,17 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"runtime"
 )
 
 func systemCertPoolPlusPath(certPath string) (*x509.CertPool, error) {
-	sysCerts, err := x509.SystemCertPool()
+	var sysCerts *x509.CertPool
+	var err error
+	if runtime.GOOS == "windows" {
+		sysCerts, err = x509.NewCertPool(), nil
+	} else {
+		sysCerts, err = x509.SystemCertPool()
+	}
 	if err != nil {
 		return nil, fmt.Errorf("could not load system x509 cert pool: %w", err)
 	}


### PR DESCRIPTION
**Description:** Fixing a bug - Function x509.SystemCertPool() used [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/kubelet/cert.go#L25) is not available for windows. because of this issue while using `kubeletstats` receiver we are getting following error.<img width="1792" alt="Screenshot 2021-09-16 at 11 00 43 AM" src="https://user-images.githubusercontent.com/88535006/133599760-44d48a70-2af6-41b2-ad5a-0355b97e5df3.png">
To solve the above issue we have created an empty CertPool when the system run environment is windows, just like smart-agent - [reference](https://github.com/signalfx/signalfx-agent/blob/main/pkg/core/common/auth/tls.go#L62)

**Testing:** For testing we have exported matrices collected by `kubeletstats` receiver to `signalfx` export and got matrices to Observability UI

<img width="1792" alt="Screenshot 2021-09-16 at 4 02 20 PM" src="https://user-images.githubusercontent.com/88535006/133600743-ed63c291-dd94-4272-bbb0-32a575c13acc.png">
