### PR TITLE
[exporter/datadogexporter] add `histograms` config section

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -97,3 +97,5 @@ There are a number of optional settings for configuring how to send your metrics
 | `send_monotonic_counter` | Cumulative monotonic metrics are sent as deltas between successive measurements. Disable this flag to send get the raw, monotonically increasing value. | `true` |
 | `delta_ttl` | Maximum number of seconds values from cumulative monotonic metrics are kept in memory. | 3600 |
 | `report_quantiles` | Whether to report quantile values for summary type metrics. | `true` |
+| `histograms::mode` | Mode for histograms. Valid values are `off` (no bucket metrics) and `counters` (one metric per bucket) | `off` |
+| `histograms::send_count_sum_metrics` | Whether to report sum and count for histograms as separate metrics | `true` |

--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -97,5 +97,5 @@ There are a number of optional settings for configuring how to send your metrics
 | `send_monotonic_counter` | Cumulative monotonic metrics are sent as deltas between successive measurements. Disable this flag to send get the raw, monotonically increasing value. | `true` |
 | `delta_ttl` | Maximum number of seconds values from cumulative monotonic metrics are kept in memory. | 3600 |
 | `report_quantiles` | Whether to report quantile values for summary type metrics. | `true` |
-| `histograms::mode` | Mode for histograms. Valid values are `off` (no bucket metrics) and `counters` (one metric per bucket) | `off` |
-| `histograms::send_count_sum_metrics` | Whether to report sum and count for histograms as separate metrics | `true` |
+| `histograms::mode` | Mode for histograms. Valid values are `off` (no bucket metrics) and `counters` (one metric per bucket). | `off` |
+| `histograms::send_count_sum_metrics` | Whether to report sum and count for histograms as separate metrics. | `true` |

--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -97,5 +97,5 @@ There are a number of optional settings for configuring how to send your metrics
 | `send_monotonic_counter` | Cumulative monotonic metrics are sent as deltas between successive measurements. Disable this flag to send get the raw, monotonically increasing value. | `true` |
 | `delta_ttl` | Maximum number of seconds values from cumulative monotonic metrics are kept in memory. | 3600 |
 | `report_quantiles` | Whether to report quantile values for summary type metrics. | `true` |
-| `histograms::mode` | Mode for histograms. Valid values are `off` (no bucket metrics) and `counters` (one metric per bucket). | `off` |
+| `histograms::mode` | Mode for histograms. Valid values are `nobuckets` (no bucket metrics) and `counters` (one metric per bucket). | `nobuckets` |
 | `histograms::send_count_sum_metrics` | Whether to report sum and count for histograms as separate metrics. | `true` |

--- a/exporter/datadogexporter/config/config_test.go
+++ b/exporter/datadogexporter/config/config_test.go
@@ -225,3 +225,21 @@ func TestDeprecationReportBuckets(t *testing.T) {
 		})
 	}
 }
+
+func TestNoBucketsAndHistogram(t *testing.T) {
+	stringMap := map[string]interface{}{
+		"api": map[string]interface{}{"key": "aaa"},
+		"metrics": map[string]interface{}{
+			"report_buckets": false,
+			"histograms": map[string]interface{}{
+				"mode": "counters",
+			},
+		},
+	}
+
+	config := Config{Metrics: MetricsConfig{Buckets: false, HistConfig: HistogramConfig{Mode: "off"}}}
+	configMap := configparser.NewConfigMapFromStringMap(stringMap)
+	err := config.Unmarshal(configMap)
+
+	assert.Error(t, errBuckets, err)
+}

--- a/exporter/datadogexporter/config/config_test.go
+++ b/exporter/datadogexporter/config/config_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/confignet"
+	"go.opentelemetry.io/collector/config/configparser"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestHostTags(t *testing.T) {
@@ -94,7 +98,7 @@ func TestOverrideMetricsURL(t *testing.T) {
 		},
 	}
 
-	err := cfg.Sanitize()
+	err := cfg.Sanitize(zap.NewNop())
 	require.NoError(t, err)
 	assert.Equal(t, cfg.Metrics.Endpoint, DebugEndpoint)
 }
@@ -106,14 +110,14 @@ func TestDefaultSite(t *testing.T) {
 		API: APIConfig{Key: "notnull"},
 	}
 
-	err := cfg.Sanitize()
+	err := cfg.Sanitize(zap.NewNop())
 	require.NoError(t, err)
 	assert.Equal(t, cfg.API.Site, DefaultSite)
 }
 
 func TestAPIKeyUnset(t *testing.T) {
 	cfg := Config{}
-	err := cfg.Sanitize()
+	err := cfg.Sanitize(zap.NewNop())
 	assert.Equal(t, err, errUnsetAPIKey)
 }
 
@@ -123,14 +127,14 @@ func TestNoMetadata(t *testing.T) {
 		SendMetadata: false,
 	}
 
-	err := cfg.Sanitize()
+	err := cfg.Sanitize(zap.NewNop())
 	assert.Equal(t, err, errNoMetadata)
 }
 
 func TestInvalidHostname(t *testing.T) {
 	cfg := Config{TagsConfig: TagsConfig{Hostname: "invalid_host"}}
 
-	err := cfg.Sanitize()
+	err := cfg.Sanitize(zap.NewNop())
 	require.Error(t, err)
 }
 
@@ -163,4 +167,61 @@ func TestSpanNameRemappingsValidation(t *testing.T) {
 	err := invalidCfg.Validate()
 	require.NoError(t, noErr)
 	require.Error(t, err)
+}
+
+func TestDeprecationReportBuckets(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		stringMap        map[string]interface{}
+		expectedMode     string
+		expectedWarnings int
+	}{
+		{
+			name: "report buckets false",
+			stringMap: map[string]interface{}{
+				"api": map[string]interface{}{"key": "aaa"},
+				"metrics": map[string]interface{}{
+					"report_buckets": false,
+				},
+			},
+			expectedMode:     "off",
+			expectedWarnings: 1,
+		},
+		{
+			name: "report buckets true",
+			stringMap: map[string]interface{}{
+				"api": map[string]interface{}{"key": "aaa"},
+				"metrics": map[string]interface{}{
+					"report_buckets": true,
+				},
+			},
+			expectedMode:     "counters",
+			expectedWarnings: 1,
+		},
+		{
+			name: "no report buckets",
+			stringMap: map[string]interface{}{
+				"api": map[string]interface{}{"key": "aaa"},
+			},
+			expectedMode:     "off",
+			expectedWarnings: 0,
+		},
+	}
+
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			// default config for buckets
+			config := Config{Metrics: MetricsConfig{Buckets: false, HistConfig: HistogramConfig{Mode: "off"}}}
+			configMap := configparser.NewConfigMapFromStringMap(testInstance.stringMap)
+			err := config.Unmarshal(configMap)
+			require.NoError(t, err)
+			assert.Equal(t, config.Metrics.HistConfig.Mode, testInstance.expectedMode)
+
+			core, observed := observer.New(zapcore.WarnLevel)
+			testLogger := zap.New(core)
+			config.Sanitize(testLogger)
+			assert.Equal(t, len(observed.AllUntimed()), testInstance.expectedWarnings)
+		})
+	}
 }

--- a/exporter/datadogexporter/config/config_test.go
+++ b/exporter/datadogexporter/config/config_test.go
@@ -185,7 +185,7 @@ func TestDeprecationReportBuckets(t *testing.T) {
 					"report_buckets": false,
 				},
 			},
-			expectedMode:     "off",
+			expectedMode:     histogramModeNoBuckets,
 			expectedWarnings: 1,
 		},
 		{
@@ -196,7 +196,7 @@ func TestDeprecationReportBuckets(t *testing.T) {
 					"report_buckets": true,
 				},
 			},
-			expectedMode:     "counters",
+			expectedMode:     histogramModeCounters,
 			expectedWarnings: 1,
 		},
 		{
@@ -204,7 +204,7 @@ func TestDeprecationReportBuckets(t *testing.T) {
 			stringMap: map[string]interface{}{
 				"api": map[string]interface{}{"key": "aaa"},
 			},
-			expectedMode:     "off",
+			expectedMode:     histogramModeNoBuckets,
 			expectedWarnings: 0,
 		},
 	}
@@ -212,7 +212,7 @@ func TestDeprecationReportBuckets(t *testing.T) {
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
 			// default config for buckets
-			config := Config{Metrics: MetricsConfig{Buckets: false, HistConfig: HistogramConfig{Mode: "off"}}}
+			config := Config{Metrics: MetricsConfig{Buckets: false, HistConfig: HistogramConfig{Mode: histogramModeNoBuckets}}}
 			configMap := configparser.NewConfigMapFromStringMap(testInstance.stringMap)
 			err := config.Unmarshal(configMap)
 			require.NoError(t, err)
@@ -232,12 +232,12 @@ func TestNoBucketsAndHistogram(t *testing.T) {
 		"metrics": map[string]interface{}{
 			"report_buckets": false,
 			"histograms": map[string]interface{}{
-				"mode": "counters",
+				"mode": histogramModeCounters,
 			},
 		},
 	}
 
-	config := Config{Metrics: MetricsConfig{Buckets: false, HistConfig: HistogramConfig{Mode: "off"}}}
+	config := Config{Metrics: MetricsConfig{Buckets: false, HistConfig: HistogramConfig{Mode: histogramModeNoBuckets}}}
 	configMap := configparser.NewConfigMapFromStringMap(stringMap)
 	err := config.Unmarshal(configMap)
 

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -94,13 +94,13 @@ exporters:
 
       ## @param histograms - custom object - optional
       ## Histograms specific configuration.
-        ## @param mode - string - optional - default: off
+        ## @param mode - string - optional - default: nobuckets
         ## How to report histograms. Valid values are:
         ## 
-        ## - `off` to not report bucket metrics,
+        ## - `nobuckets` to not report bucket metrics,
         ## - `counters` to report one metric per histogram bucket.
         #
-        # mode: off
+        # mode: nobuckets
       
         ## @param send_count_sum_metrics - boolean - optional - default: true
         ## Whether to report sum and count as separate histogram metrics.

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -65,12 +65,6 @@ exporters:
     ## Metric exporter specific configuration.
     #
     # metrics:
-      ## @param report_buckets - boolean - optional - default: false
-      ## Whether to report bucket counts for distribution metric types.
-      ## Enabling this will increase the number of custom metrics.
-      #
-      # report_buckets: false
-
       ## @param send_monotonic_counter - boolean - optional - default: true
       ## Whether to report monotonic metrics as counters or gauges (raw value).
       ## See https://docs.datadoghq.com/integrations/guide/prometheus-metrics/#counter
@@ -97,6 +91,21 @@ exporters:
       ## to metric tags.
       #
       # resource_attributes_as_tags: false
+
+      ## @param histograms - custom object - optional
+      ## Histograms specific configuration.
+        ## @param mode - string - optional - default: off
+        ## How to report histograms. Valid values are:
+        ## 
+        ## - `off` to not report bucket metrics,
+        ## - `counters` to report one metric per histogram bucket.
+        #
+        # mode: off
+      
+        ## @param send_count_sum_metrics - boolean - optional - default: true
+        ## Whether to report sum and count as separate histogram metrics.
+        #
+        # send_count_sum_metrics: true
 
     ## @param traces - custom object - optional
     ## Trace exporter specific configuration.

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -72,7 +72,7 @@ func createDefaultConfig() config.Exporter {
 				ResourceAttributesAsTags: false,
 			},
 			HistConfig: ddconfig.HistogramConfig{
-				Mode:         "off",
+				Mode:         "nobuckets",
 				SendCountSum: true,
 			},
 		},

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -71,6 +71,10 @@ func createDefaultConfig() config.Exporter {
 			ExporterConfig: ddconfig.MetricsExporterConfig{
 				ResourceAttributesAsTags: false,
 			},
+			HistConfig: ddconfig.HistogramConfig{
+				Mode:         "off",
+				SendCountSum: true,
+			},
 		},
 
 		Traces: ddconfig.TracesConfig{
@@ -96,7 +100,7 @@ func createMetricsExporter(
 	cfg := c.(*ddconfig.Config)
 
 	set.Logger.Info("sanitizing Datadog metrics exporter configuration")
-	if err := cfg.Sanitize(); err != nil {
+	if err := cfg.Sanitize(set.Logger); err != nil {
 		return nil, err
 	}
 
@@ -153,7 +157,7 @@ func createTracesExporter(
 	cfg := c.(*ddconfig.Config)
 
 	set.Logger.Info("sanitizing Datadog metrics exporter configuration")
-	if err := cfg.Sanitize(); err != nil {
+	if err := cfg.Sanitize(set.Logger); err != nil {
 		return nil, err
 	}
 

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -105,7 +105,7 @@ func createMetricsExporter(
 	}
 
 	// TODO: Remove after two releases
-	if cfg.Metrics.Buckets {
+	if cfg.Metrics.HistConfig.Mode == "counters" {
 		set.Logger.Warn("Histogram bucket metrics now end with .bucket instead of .count_per_bucket")
 	}
 

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/config/configcheck"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.uber.org/zap"
 
 	ddconfig "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
@@ -56,6 +57,10 @@ func TestCreateDefaultConfig(t *testing.T) {
 			DeltaTTL:      3600,
 			SendMonotonic: true,
 			Quantiles:     true,
+			HistConfig: ddconfig.HistogramConfig{
+				Mode:         "off",
+				SendCountSum: true,
+			},
 		},
 
 		Traces: ddconfig.TracesConfig{
@@ -95,7 +100,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	apiConfig := cfg.Exporters[config.NewIDWithName(typeStr, "api")].(*ddconfig.Config)
-	err = apiConfig.Sanitize()
+	err = apiConfig.Sanitize(zap.NewNop())
 
 	require.NoError(t, err)
 	assert.Equal(t, &ddconfig.Config{
@@ -121,6 +126,10 @@ func TestLoadConfig(t *testing.T) {
 			DeltaTTL:      3600,
 			SendMonotonic: true,
 			Quantiles:     true,
+			HistConfig: ddconfig.HistogramConfig{
+				Mode:         "off",
+				SendCountSum: true,
+			},
 		},
 
 		Traces: ddconfig.TracesConfig{
@@ -136,7 +145,7 @@ func TestLoadConfig(t *testing.T) {
 	}, apiConfig)
 
 	defaultConfig := cfg.Exporters[config.NewIDWithName(typeStr, "default")].(*ddconfig.Config)
-	err = defaultConfig.Sanitize()
+	err = defaultConfig.Sanitize(zap.NewNop())
 
 	require.NoError(t, err)
 	assert.Equal(t, &ddconfig.Config{
@@ -161,6 +170,10 @@ func TestLoadConfig(t *testing.T) {
 			SendMonotonic: true,
 			DeltaTTL:      3600,
 			Quantiles:     true,
+			HistConfig: ddconfig.HistogramConfig{
+				Mode:         "off",
+				SendCountSum: true,
+			},
 		},
 
 		Traces: ddconfig.TracesConfig{
@@ -176,7 +189,7 @@ func TestLoadConfig(t *testing.T) {
 	}, defaultConfig)
 
 	invalidConfig := cfg.Exporters[config.NewIDWithName(typeStr, "invalid")].(*ddconfig.Config)
-	err = invalidConfig.Sanitize()
+	err = invalidConfig.Sanitize(zap.NewNop())
 	require.Error(t, err)
 }
 
@@ -216,7 +229,7 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	apiConfig := cfg.Exporters[config.NewIDWithName(typeStr, "api2")].(*ddconfig.Config)
-	err = apiConfig.Sanitize()
+	err = apiConfig.Sanitize(zap.NewNop())
 
 	// Check that settings with env variables get overridden when explicitly set in config
 	require.NoError(t, err)
@@ -244,6 +257,10 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 			SendMonotonic: true,
 			Quantiles:     false,
 			DeltaTTL:      3600,
+			HistConfig: ddconfig.HistogramConfig{
+				Mode:         "off",
+				SendCountSum: true,
+			},
 		},
 
 		Traces: ddconfig.TracesConfig{
@@ -259,7 +276,7 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 	}, apiConfig)
 
 	defaultConfig := cfg.Exporters[config.NewIDWithName(typeStr, "default2")].(*ddconfig.Config)
-	err = defaultConfig.Sanitize()
+	err = defaultConfig.Sanitize(zap.NewNop())
 
 	require.NoError(t, err)
 
@@ -288,6 +305,10 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 			SendMonotonic: true,
 			DeltaTTL:      3600,
 			Quantiles:     true,
+			HistConfig: ddconfig.HistogramConfig{
+				Mode:         "off",
+				SendCountSum: true,
+			},
 		},
 
 		Traces: ddconfig.TracesConfig{

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -58,7 +58,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 			SendMonotonic: true,
 			Quantiles:     true,
 			HistConfig: ddconfig.HistogramConfig{
-				Mode:         "off",
+				Mode:         "nobuckets",
 				SendCountSum: true,
 			},
 		},
@@ -127,7 +127,7 @@ func TestLoadConfig(t *testing.T) {
 			SendMonotonic: true,
 			Quantiles:     true,
 			HistConfig: ddconfig.HistogramConfig{
-				Mode:         "off",
+				Mode:         "nobuckets",
 				SendCountSum: true,
 			},
 		},
@@ -171,7 +171,7 @@ func TestLoadConfig(t *testing.T) {
 			DeltaTTL:      3600,
 			Quantiles:     true,
 			HistConfig: ddconfig.HistogramConfig{
-				Mode:         "off",
+				Mode:         "nobuckets",
 				SendCountSum: true,
 			},
 		},
@@ -258,7 +258,7 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 			Quantiles:     false,
 			DeltaTTL:      3600,
 			HistConfig: ddconfig.HistogramConfig{
-				Mode:         "off",
+				Mode:         "nobuckets",
 				SendCountSum: true,
 			},
 		},
@@ -306,7 +306,7 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 			DeltaTTL:      3600,
 			Quantiles:     true,
 			HistConfig: ddconfig.HistogramConfig{
-				Mode:         "off",
+				Mode:         "nobuckets",
 				SendCountSum: true,
 			},
 		},

--- a/exporter/datadogexporter/internal/metrics/utils_test.go
+++ b/exporter/datadogexporter/internal/metrics/utils_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
@@ -88,7 +89,7 @@ func TestProcessMetrics(t *testing.T) {
 			Tags: []string{"key:val"},
 		},
 	}
-	cfg.Sanitize()
+	cfg.Sanitize(zap.NewNop())
 
 	ms := []datadog.Metric{
 		NewGauge(

--- a/exporter/datadogexporter/internal/translator/metrics_translator.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator.go
@@ -34,8 +34,8 @@ import (
 const metricName string = "metric name"
 
 const (
-	histogramModeOff      = "off"
-	histogramModeCounters = "counters"
+	histogramModeNoBuckets = "nobuckets"
+	histogramModeCounters  = "counters"
 )
 
 // HostnameProvider gets a hostname

--- a/exporter/datadogexporter/internal/translator/metrics_translator.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator.go
@@ -33,6 +33,11 @@ import (
 
 const metricName string = "metric name"
 
+const (
+	histogramModeOff      = "off"
+	histogramModeCounters = "counters"
+)
+
 // HostnameProvider gets a hostname
 type HostnameProvider interface {
 	// Hostname gets the hostname from the machine.
@@ -197,7 +202,7 @@ func (t *Translator) mapHistogramMetrics(name string, slice pdata.HistogramDataP
 		tags := getTags(p.Attributes())
 		tags = append(tags, attrTags...)
 
-		{
+		if t.cfg.HistConfig.SendCountSum {
 			count := float64(p.Count())
 			countName := fmt.Sprintf("%s.count", name)
 			if delta {
@@ -207,7 +212,7 @@ func (t *Translator) mapHistogramMetrics(name string, slice pdata.HistogramDataP
 			}
 		}
 
-		{
+		if t.cfg.HistConfig.SendCountSum {
 			sum := p.Sum()
 			sumName := fmt.Sprintf("%s.sum", name)
 			if !t.isSkippable(sumName, p.Sum()) {
@@ -219,7 +224,7 @@ func (t *Translator) mapHistogramMetrics(name string, slice pdata.HistogramDataP
 			}
 		}
 
-		if t.cfg.Buckets {
+		if t.cfg.HistConfig.Mode == histogramModeCounters {
 			ms = append(ms, t.getLegacyBuckets(name, p, delta, tags)...)
 		}
 	}

--- a/exporter/datadogexporter/internal/translator/metrics_translator_test.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator_test.go
@@ -35,6 +35,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metrics"
 )
 
+var defaultCfg = config.MetricsConfig{
+	SendMonotonic: true,
+	HistConfig: config.HistogramConfig{
+		Mode:         histogramModeOff,
+		SendCountSum: true,
+	},
+}
+
 func TestMetricValue(t *testing.T) {
 	var (
 		name  = "name"
@@ -212,7 +220,7 @@ func TestMapIntMonotonicMetrics(t *testing.T) {
 		expected[i] = metrics.NewCount(metricName, uint64(seconds(i+1)), float64(val), []string{})
 	}
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 	output := tr.mapNumberMonotonicMetrics(metricName, slice, []string{})
 
 	assert.ElementsMatch(t, output, expected)
@@ -250,7 +258,7 @@ func TestMapIntMonotonicDifferentDimensions(t *testing.T) {
 	point.SetTimestamp(seconds(1))
 	point.Attributes().InsertString("key1", "valB")
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 
 	assert.ElementsMatch(t,
 		tr.mapNumberMonotonicMetrics(metricName, slice, []string{}),
@@ -274,7 +282,7 @@ func TestMapIntMonotonicWithReboot(t *testing.T) {
 		point.SetIntVal(val)
 	}
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 	assert.ElementsMatch(t,
 		tr.mapNumberMonotonicMetrics(metricName, slice, []string{}),
 		[]datadog.Metric{
@@ -298,7 +306,7 @@ func TestMapIntMonotonicOutOfOrder(t *testing.T) {
 		point.SetIntVal(val)
 	}
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 	assert.ElementsMatch(t,
 		tr.mapNumberMonotonicMetrics(metricName, slice, []string{}),
 		[]datadog.Metric{
@@ -332,7 +340,7 @@ func TestMapDoubleMonotonicMetrics(t *testing.T) {
 		expected[i] = metrics.NewCount(metricName, uint64(seconds(i+1)), val, []string{})
 	}
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 	output := tr.mapNumberMonotonicMetrics(metricName, slice, []string{})
 
 	assert.ElementsMatch(t, expected, output)
@@ -370,7 +378,7 @@ func TestMapDoubleMonotonicDifferentDimensions(t *testing.T) {
 	point.SetTimestamp(seconds(1))
 	point.Attributes().InsertString("key1", "valB")
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 
 	assert.ElementsMatch(t,
 		tr.mapNumberMonotonicMetrics(metricName, slice, []string{}),
@@ -394,7 +402,7 @@ func TestMapDoubleMonotonicWithReboot(t *testing.T) {
 		point.SetDoubleVal(val)
 	}
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 	assert.ElementsMatch(t,
 		tr.mapNumberMonotonicMetrics(metricName, slice, []string{}),
 		[]datadog.Metric{
@@ -418,7 +426,7 @@ func TestMapDoubleMonotonicOutOfOrder(t *testing.T) {
 		point.SetDoubleVal(val)
 	}
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 	assert.ElementsMatch(t,
 		tr.mapNumberMonotonicMetrics(metricName, slice, []string{}),
 		[]datadog.Metric{
@@ -448,16 +456,16 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 		metrics.NewCount("doubleHist.test.bucket", uint64(ts), 18, []string{"lower_bound:0", "upper_bound:inf"}),
 	}
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 	delta := true
 
-	tr.cfg.Buckets = false
+	tr.cfg.HistConfig.Mode = histogramModeOff
 	assert.ElementsMatch(t,
 		tr.mapHistogramMetrics("doubleHist.test", slice, delta, []string{}), // No buckets
 		noBuckets,
 	)
 
-	tr.cfg.Buckets = true
+	tr.cfg.HistConfig.Mode = histogramModeCounters
 	assert.ElementsMatch(t,
 		tr.mapHistogramMetrics("doubleHist.test", slice, delta, []string{}), // buckets
 		append(noBuckets, buckets...),
@@ -474,13 +482,13 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 		metrics.NewCount("doubleHist.test.bucket", uint64(ts), 18, []string{"attribute_tag:attribute_value", "lower_bound:0", "upper_bound:inf"}),
 	}
 
-	tr.cfg.Buckets = false
+	tr.cfg.HistConfig.Mode = histogramModeOff
 	assert.ElementsMatch(t,
 		tr.mapHistogramMetrics("doubleHist.test", slice, delta, []string{"attribute_tag:attribute_value"}), // No buckets
 		noBucketsAttributeTags,
 	)
 
-	tr.cfg.Buckets = true
+	tr.cfg.HistConfig.Mode = histogramModeCounters
 	assert.ElementsMatch(t,
 		tr.mapHistogramMetrics("doubleHist.test", slice, delta, []string{"attribute_tag:attribute_value"}), // buckets
 		append(noBucketsAttributeTags, bucketsAttributeTags...),
@@ -510,10 +518,10 @@ func TestMapCumulativeHistogramMetrics(t *testing.T) {
 		metrics.NewCount("doubleHist.test.bucket", uint64(seconds(2)), 2, []string{"lower_bound:0", "upper_bound:inf"}),
 	}
 
-	tr := newTranslator(zap.NewNop(), config.MetricsConfig{SendMonotonic: true})
+	tr := newTranslator(zap.NewNop(), defaultCfg)
 	delta := false
 
-	tr.cfg.Buckets = true
+	tr.cfg.HistConfig.Mode = histogramModeCounters
 	assert.ElementsMatch(t,
 		tr.mapHistogramMetrics("doubleHist.test", slice, delta, []string{}),
 		expected,
@@ -854,11 +862,10 @@ func testCount(name string, val float64, seconds uint64) datadog.Metric {
 
 func TestMapMetrics(t *testing.T) {
 	md := createTestMetrics()
-	cfg := config.MetricsConfig{SendMonotonic: true}
 
 	core, observed := observer.New(zapcore.DebugLevel)
 	testLogger := zap.New(core)
-	tr := newTranslator(testLogger, cfg)
+	tr := newTranslator(testLogger, defaultCfg)
 	series := tr.MapMetrics(md)
 
 	filtered := removeRunningMetrics(series)
@@ -977,11 +984,10 @@ func createNaNMetrics() pdata.Metrics {
 
 func TestNaNMetrics(t *testing.T) {
 	md := createNaNMetrics()
-	cfg := config.MetricsConfig{SendMonotonic: true}
 
 	core, observed := observer.New(zapcore.DebugLevel)
 	testLogger := zap.New(core)
-	tr := newTranslator(testLogger, cfg)
+	tr := newTranslator(testLogger, defaultCfg)
 	series := tr.MapMetrics(md)
 
 	filtered := removeRunningMetrics(series)

--- a/exporter/datadogexporter/internal/translator/metrics_translator_test.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator_test.go
@@ -38,7 +38,7 @@ import (
 var defaultCfg = config.MetricsConfig{
 	SendMonotonic: true,
 	HistConfig: config.HistogramConfig{
-		Mode:         histogramModeOff,
+		Mode:         histogramModeNoBuckets,
 		SendCountSum: true,
 	},
 }
@@ -459,7 +459,7 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 	tr := newTranslator(zap.NewNop(), defaultCfg)
 	delta := true
 
-	tr.cfg.HistConfig.Mode = histogramModeOff
+	tr.cfg.HistConfig.Mode = histogramModeNoBuckets
 	assert.ElementsMatch(t,
 		tr.mapHistogramMetrics("doubleHist.test", slice, delta, []string{}), // No buckets
 		noBuckets,
@@ -482,7 +482,7 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 		metrics.NewCount("doubleHist.test.bucket", uint64(ts), 18, []string{"attribute_tag:attribute_value", "lower_bound:0", "upper_bound:inf"}),
 	}
 
-	tr.cfg.HistConfig.Mode = histogramModeOff
+	tr.cfg.HistConfig.Mode = histogramModeNoBuckets
 	assert.ElementsMatch(t,
 		tr.mapHistogramMetrics("doubleHist.test", slice, delta, []string{"attribute_tag:attribute_value"}), // No buckets
 		noBucketsAttributeTags,


### PR DESCRIPTION
**Description:** 

- Create new `histograms` section in the configuration for customizing histograms output.
- Deprecates `report_buckets` option and nudges toward using `histograms::mode` instead.

**Testing:** Amended unit tests. Added test for deprecation.

**Documentation:** Updated documentation.

---

@KSerrania to review
