### PR TITLE
Fix broken link to prometheus receiver

### DIFF
--- a/receiver/simpleprometheusreceiver/README.md
+++ b/receiver/simpleprometheusreceiver/README.md
@@ -1,7 +1,7 @@
 # Simple Prometheus Receiver
 
 The `prometheus_simple` receiver is a wrapper around the [prometheus
-receiver](https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/prometheusreceiver).
+receiver](../prometheusreceiver).
 This receiver provides a simple configuration interface to configure the
 prometheus receiver to scrape metrics from a single target.
 


### PR DESCRIPTION
**Description:** 
Fix broken link to prometheus receiver. The link was hardcoding the full URL to the `opentelemtry-collector` repo.

**Testing:** Tested link in my fork.
