### PR TITLE
bump max ram to help flaky TestBallastMemory test

### DIFF
--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -67,7 +67,7 @@ func TestLog10kDPS(t *testing.T) {
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 85,
+				ExpectedMaxRAM: 86,
 			},
 			extensions: datasenders.NewLocalFileStorageExtension(),
 		},


### PR DESCRIPTION
**Description:** 
The `TestBallastMemory|TestLog10kDPS` test have been failing intermittently, see example run here: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5262/checks?check_run_id=3635509904

Bumping the memory up to help tests pass more consistently.
