### PR TITLE
Remove usage of deprecated log-level flag

### DIFF
--- a/exporter/datadogexporter/example/example_k8s_manifest.yaml
+++ b/exporter/datadogexporter/example/example_k8s_manifest.yaml
@@ -169,6 +169,9 @@ data:
         api:
           key: <YOUR_API_KEY>
     service:
+      telemetry:
+        logs:
+          level: "DEBUG"
       extensions: [health_check, zpages]
       pipelines:
         metrics/2:
@@ -223,7 +226,6 @@ spec:
       - command:
           - "/otelcontribcol"
           - "--config=/conf/otel-collectorcollector-config.yaml"
-          - "--log-level=debug"
         image: otel/opentelemetry-collector-contrib:latest
         name: otel-collector
         resources:

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -208,7 +208,6 @@ data:
 
       extensions: [health_check]
 
-
 ---
 # create Daemonset
 apiVersion: apps/v1
@@ -250,7 +249,6 @@ spec:
           imagePullPolicy: Always
           command:
             - "/awscollector"
-              #- "--log-level=DEBUG"
             - "--config=/conf/otel-agent-config.yaml"
           volumeMounts:
             - name: rootfs

--- a/receiver/simpleprometheusreceiver/examples/federation/docker-compose.yml
+++ b/receiver/simpleprometheusreceiver/examples/federation/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   otelcollector:
     image: otel/opentelemetry-collector-contrib-dev:latest
     container_name: otelcollector
-    command: ["--config=/etc/otel-collector-config.yml", "--log-level=DEBUG"]
+    command: ["--config=/etc/otel-collector-config.yml"]
     volumes:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
     depends_on:

--- a/receiver/simpleprometheusreceiver/examples/federation/otel-collector-config.yml
+++ b/receiver/simpleprometheusreceiver/examples/federation/otel-collector-config.yml
@@ -1,35 +1,38 @@
 receivers:
-    prometheus_simple:
-        collection_interval: 10s
-        # the federation endpoint:
-        # Read more about it here: https://prometheus.io/docs/prometheus/latest/federation/
-        # You can query the federation with PromQL, encoded as part of the query string.
-        endpoint: prometheus:9090
-        metrics_path: /federate
-        params:
-            match[]: '{job="counter"}'
-    otlp:
-        protocols:
-            grpc:
+  prometheus_simple:
+    collection_interval: 10s
+    # the federation endpoint:
+    # Read more about it here: https://prometheus.io/docs/prometheus/latest/federation/
+    # You can query the federation with PromQL, encoded as part of the query string.
+    endpoint: prometheus:9090
+    metrics_path: /federate
+    params:
+      match[]: '{job="counter"}'
+  otlp:
+    protocols:
+      grpc:
 
 exporters:
-    logging:
-      loglevel: debug
+  logging:
+    loglevel: debug
 
 processors:
-    batch:
+  batch:
 
 extensions:
-    health_check:
-    pprof:
-      endpoint: :1888
-    zpages:
-      endpoint: :55679
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
 
 service:
-    extensions: [pprof, zpages, health_check]
-    pipelines:
-      metrics:
-        receivers: [prometheus_simple]
-        processors: [batch]
-        exporters: [logging]
+  telemetry:
+    logs:
+      level: "DEBUG"
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    metrics:
+      receivers: [prometheus_simple]
+      processors: [batch]
+      exporters: [logging]

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -141,7 +141,7 @@ func TestMetricsFromFile(t *testing.T) {
 	defer tc.Stop()
 
 	tc.StartBackend()
-	tc.StartAgent("--log-level=debug")
+	tc.StartAgent()
 
 	tc.StartLoad(options)
 

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -173,7 +173,7 @@ func Scenario10kItemsPerSecond(
 	defer tc.Stop()
 
 	tc.StartBackend()
-	tc.StartAgent("--log-level=debug")
+	tc.StartAgent()
 
 	tc.StartLoad(options)
 


### PR DESCRIPTION
For testbed simply disable debug logging, for other places replace with configuration.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
