### PR TITLE
[datadogexporter] Fix cache key generation for cumulative metrics

### DIFF
--- a/exporter/datadogexporter/internal/translator/ttlcache_test.go
+++ b/exporter/datadogexporter/internal/translator/ttlcache_test.go
@@ -52,4 +52,18 @@ func TestMetricDimensionsToMapKey(t *testing.T) {
 	assert.NotEqual(t, noTags, someTags)
 	assert.NotEqual(t, someTags, diffTags)
 	assert.Equal(t, someTags, sameTags)
+
+	// The original metricDimensionsToMapKey had an issue where:
+	// - if the capacity of the tags array passed to it was higher than its length
+	// - and the metric name is earlier (in alphabetical order) than one of the tags
+	// then the original tag array would be modified (without a reallocation, since there is enough capacity),
+	// and would contain a tag labelled as the metric name, while the final tag (in alphabetical order)
+	// would get left out.
+	// This test checks that this doesn't happen anymore.
+	originalTags := make([]string, 2, 3)
+	originalTags[0] = "key1:val1"
+	originalTags[1] = "key2:val2"
+	c.metricDimensionsToMapKey("a.metric.name", originalTags)
+	assert.Equal(t, []string{"key1:val1", "key2:val2"}, originalTags)
+
 }

--- a/exporter/datadogexporter/internal/translator/ttlcache_test.go
+++ b/exporter/datadogexporter/internal/translator/ttlcache_test.go
@@ -57,7 +57,7 @@ func TestMetricDimensionsToMapKey(t *testing.T) {
 	// - if the capacity of the tags array passed to it was higher than its length
 	// - and the metric name is earlier (in alphabetical order) than one of the tags
 	// then the original tag array would be modified (without a reallocation, since there is enough capacity),
-	// and would contain a tag labelled as the metric name, while the final tag (in alphabetical order)
+	// and would contain a tag labeled as the metric name, while the final tag (in alphabetical order)
 	// would get left out.
 	// This test checks that this doesn't happen anymore.
 	originalTags := make([]string, 2, 3)

--- a/exporter/datadogexporter/internal/translator/ttlcache_test.go
+++ b/exporter/datadogexporter/internal/translator/ttlcache_test.go
@@ -52,7 +52,9 @@ func TestMetricDimensionsToMapKey(t *testing.T) {
 	assert.NotEqual(t, noTags, someTags)
 	assert.NotEqual(t, someTags, diffTags)
 	assert.Equal(t, someTags, sameTags)
+}
 
+func TestMetricDimensionsToMapKeyNoTagsChange(t *testing.T) {
 	// The original metricDimensionsToMapKey had an issue where:
 	// - if the capacity of the tags array passed to it was higher than its length
 	// - and the metric name is earlier (in alphabetical order) than one of the tags
@@ -60,10 +62,14 @@ func TestMetricDimensionsToMapKey(t *testing.T) {
 	// and would contain a tag labeled as the metric name, while the final tag (in alphabetical order)
 	// would get left out.
 	// This test checks that this doesn't happen anymore.
+
+	metricName := "a.metric.name"
+	c := newTestCache()
+
 	originalTags := make([]string, 2, 3)
 	originalTags[0] = "key1:val1"
 	originalTags[1] = "key2:val2"
-	c.metricDimensionsToMapKey("a.metric.name", originalTags)
+	c.metricDimensionsToMapKey(metricName, originalTags)
 	assert.Equal(t, []string{"key1:val1", "key2:val2"}, originalTags)
 
 }


### PR DESCRIPTION
**Description:** 

Fixes a bug in `metricDimensionsToMapKey` that is used to derive a cache key from a metric name + its tag. The function would modify the original tag array, possibly resulting in some tags being replaced by the metric's name (in cases where elements could be appended to the original tag array without any reallocation, eg. if its length is lower than its capacity).
Uses `strings.Builder` to build the cache key, instead of manually joining strings.

**Link to tracking Issue:** n/a

**Testing:** Added a unit test against this specific case.

**Documentation:** n/a