### PR TITLE
Introduce metricsConsumer and gaugeMetricConsumer.

### DIFF
--- a/exporter/tanzuobservabilityexporter/metrics.go
+++ b/exporter/tanzuobservabilityexporter/metrics.go
@@ -19,8 +19,8 @@ import (
 	"errors"
 	"fmt"
 
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/multierr"
 )
 
 // metricsConsumer instances consume OTEL metrics
@@ -63,7 +63,7 @@ func (c *metricsConsumer) Consume(ctx context.Context, md pdata.Metrics) error {
 				m := ms.At(k)
 				select {
 				case <-ctx.Done():
-					return consumererror.Combine(append(errs, errors.New("context canceled")))
+					return multierr.Combine(append(errs, errors.New("context canceled"))...)
 				default:
 					c.pushSingleMetric(m, &errs)
 				}
@@ -75,7 +75,7 @@ func (c *metricsConsumer) Consume(ctx context.Context, md pdata.Metrics) error {
 			errs = append(errs, err)
 		}
 	}
-	return consumererror.Combine(errs)
+	return multierr.Combine(errs...)
 }
 
 // Close closes this metricsConsumer by calling Close on the sender passed

--- a/exporter/tanzuobservabilityexporter/metrics.go
+++ b/exporter/tanzuobservabilityexporter/metrics.go
@@ -1,0 +1,167 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tanzuobservabilityexporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+// metricsConsumer instances consume OTEL metrics
+type metricsConsumer struct {
+	consumerMap map[pdata.MetricDataType]metricConsumer
+	sender      flushCloser
+}
+
+// newMetricsConsumer returns a new metricsConsumer. consumers are the
+// consumers responsible for consuming each type metric. The Consume method
+// of returned consumer calls the Flush method on sender after consuming
+// all the metrics. Calling Close on the returned metricsConsumer calls Close
+// on sender. sender can be nil.
+func newMetricsConsumer(
+	consumers []metricConsumer, sender flushCloser) *metricsConsumer {
+	consumerMap := make(map[pdata.MetricDataType]metricConsumer, len(consumers))
+	for _, consumer := range consumers {
+		consumerMap[consumer.Type()] = consumer
+	}
+	return &metricsConsumer{
+		consumerMap: consumerMap,
+		sender:      sender,
+	}
+}
+
+// Consume consumes OTEL metrics. For each metric in md, it delegates to the
+// metricConsumer that consumes that type of metric. Once Consume consumes
+// all the metrics, it calls Flush() on the sender passed to
+// newMetricsConsumer.
+func (c *metricsConsumer) Consume(ctx context.Context, md pdata.Metrics) error {
+	var errs []error
+	rms := md.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		ilms := rms.At(i).InstrumentationLibraryMetrics()
+		for j := 0; j < ilms.Len(); j++ {
+			ms := ilms.At(j).Metrics()
+			for k := 0; k < ms.Len(); k++ {
+				m := ms.At(k)
+				select {
+				case <-ctx.Done():
+					return consumererror.Combine(append(errs, errors.New("context canceled")))
+				default:
+					c.pushSingleMetric(m, &errs)
+				}
+			}
+		}
+	}
+	if c.sender != nil {
+		if err := c.sender.Flush(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return consumererror.Combine(errs)
+}
+
+// Close closes this metricsConsumer by calling Close on the sender passed
+// to newMetricsConsumer.
+func (c *metricsConsumer) Close() {
+	if c.sender != nil {
+		c.sender.Close()
+	}
+}
+
+func (c *metricsConsumer) pushSingleMetric(m pdata.Metric, errs *[]error) {
+	dataType := m.DataType()
+	consumer := c.consumerMap[dataType]
+	if consumer == nil {
+		*errs = append(
+			*errs, fmt.Errorf("no support for metric type %v", dataType))
+
+	} else {
+		consumer.Consume(m, errs)
+	}
+}
+
+// metricConsumer consumes one specific type of OTEL metric
+type metricConsumer interface {
+
+	// Type returns the type of metric this consumer consumes. For example
+	// Gauge, Sum, or Histogram
+	Type() pdata.MetricDataType
+
+	// Consume consumes the metric and appends any errors encountered to errs
+	Consume(m pdata.Metric, errs *[]error)
+}
+
+// flushCloser is the interface for the Flush and Close method
+type flushCloser interface {
+	Flush() error
+	Close()
+}
+
+// gaugeSender sends gauge metrics to tanzu observability
+type gaugeSender interface {
+	SendMetric(name string, value float64, ts int64, source string, tags map[string]string) error
+}
+
+type gaugeConsumer struct {
+	sender gaugeSender
+}
+
+// newGaugeConsumer returns a metricConsumer that consumes gauge metrics
+// by sending them to tanzu observability
+func newGaugeConsumer(sender gaugeSender) metricConsumer {
+	return &gaugeConsumer{sender: sender}
+}
+
+func (g *gaugeConsumer) Type() pdata.MetricDataType {
+	return pdata.MetricDataTypeGauge
+}
+
+func (g *gaugeConsumer) Consume(metric pdata.Metric, errs *[]error) {
+	gauge := metric.Gauge()
+	numberDataPoints := gauge.DataPoints()
+	for i := 0; i < numberDataPoints.Len(); i++ {
+		g.pushSingleNumberDataPoint(metric, numberDataPoints.At(i), errs)
+	}
+}
+
+func getValue(numberDataPoint pdata.NumberDataPoint) (float64, error) {
+	switch numberDataPoint.Type() {
+	case pdata.MetricValueTypeInt:
+		return float64(numberDataPoint.IntVal()), nil
+	case pdata.MetricValueTypeDouble:
+		return numberDataPoint.DoubleVal(), nil
+	default:
+		return 0.0, errors.New("unsupported metric value type")
+	}
+}
+
+func (g *gaugeConsumer) pushSingleNumberDataPoint(
+	metric pdata.Metric, numberDataPoint pdata.NumberDataPoint, errs *[]error) {
+	tags := attributesToTags(numberDataPoint.Attributes())
+	ts := numberDataPoint.Timestamp().AsTime().Unix()
+	value, err := getValue(numberDataPoint)
+	if err != nil {
+		*errs = append(*errs, err)
+		return
+	}
+	err = g.sender.SendMetric(metric.Name(), value, ts, "", tags)
+	if err != nil {
+		*errs = append(*errs, err)
+	}
+}

--- a/exporter/tanzuobservabilityexporter/metrics_test.go
+++ b/exporter/tanzuobservabilityexporter/metrics_test.go
@@ -1,0 +1,284 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tanzuobservabilityexporter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestMetricsConsumerNormal(t *testing.T) {
+	gauge1 := newMetric("gauge1", pdata.MetricDataTypeGauge)
+	sum1 := newMetric("sum1", pdata.MetricDataTypeSum)
+	gauge2 := newMetric("gauge2", pdata.MetricDataTypeGauge)
+	sum2 := newMetric("sum2", pdata.MetricDataTypeSum)
+	mockGaugeConsumer := &mockMetricConsumer{typ: pdata.MetricDataTypeGauge}
+	mockSumConsumer := &mockMetricConsumer{typ: pdata.MetricDataTypeSum}
+	sender := &mockFlushCloser{}
+	metrics := constructMetrics(gauge1, sum1, gauge2, sum2)
+	consumer := newMetricsConsumer(
+		[]metricConsumer{mockGaugeConsumer, mockSumConsumer}, sender)
+	assert.NoError(t, consumer.Consume(context.Background(), metrics))
+	assert.ElementsMatch(
+		t, []string{"gauge1", "gauge2"}, mockGaugeConsumer.names)
+	assert.ElementsMatch(
+		t, []string{"sum1", "sum2"}, mockSumConsumer.names)
+	assert.Equal(t, 1, sender.numFlushCalls)
+	assert.Equal(t, 0, sender.numCloseCalls)
+	consumer.Close()
+	assert.Equal(t, 1, sender.numCloseCalls)
+}
+
+func TestMetricsConsumerNone(t *testing.T) {
+	consumer := newMetricsConsumer(nil, nil)
+	metrics := constructMetrics()
+	assert.NoError(t, consumer.Consume(context.Background(), metrics))
+	consumer.Close()
+}
+
+func TestMetricsConsumerErrorOnFlush(t *testing.T) {
+	sender := &mockFlushCloser{errorOnFlush: true}
+	metrics := constructMetrics()
+	consumer := newMetricsConsumer(nil, sender)
+	assert.Error(t, consumer.Consume(context.Background(), metrics))
+	assert.Equal(t, 1, sender.numFlushCalls)
+}
+
+func TestMetricsConsumerBadMetricType(t *testing.T) {
+	gauge1 := newMetric("gauge1", pdata.MetricDataTypeGauge)
+	metrics := constructMetrics(gauge1)
+	consumer := newMetricsConsumer(nil, nil)
+	assert.Error(t, consumer.Consume(context.Background(), metrics))
+}
+
+func TestMetricsConsumerErrorConsuming(t *testing.T) {
+	gauge1 := newMetric("gauge1", pdata.MetricDataTypeGauge)
+	mockGaugeConsumer := &mockMetricConsumer{
+		typ: pdata.MetricDataTypeGauge, errorOnConsume: true}
+	metrics := constructMetrics(gauge1)
+	consumer := newMetricsConsumer([]metricConsumer{mockGaugeConsumer}, nil)
+	assert.Error(t, consumer.Consume(context.Background(), metrics))
+	assert.Len(t, mockGaugeConsumer.names, 1)
+}
+
+func TestMetricsConsumerRespectContext(t *testing.T) {
+	sender := &mockFlushCloser{}
+	gauge1 := newMetric("gauge1", pdata.MetricDataTypeGauge)
+	mockGaugeConsumer := &mockMetricConsumer{typ: pdata.MetricDataTypeGauge}
+	consumer := newMetricsConsumer([]metricConsumer{mockGaugeConsumer}, sender)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.Error(t, consumer.Consume(ctx, constructMetrics(gauge1)))
+	assert.Zero(t, sender.numFlushCalls)
+	assert.Empty(t, mockGaugeConsumer.names)
+}
+
+func TestGaugeConsumerNormal(t *testing.T) {
+	verifyGaugeConsumer(t, false)
+}
+
+func TestGaugeConsumerErrorSending(t *testing.T) {
+	verifyGaugeConsumer(t, true)
+}
+
+func verifyGaugeConsumer(t *testing.T, errorOnSend bool) {
+	metric := newMetric("test.metric", pdata.MetricDataTypeGauge)
+	dataPoints := metric.Gauge().DataPoints()
+	dataPoints.EnsureCapacity(2)
+	addDataPoint(
+		7,
+		1631205001,
+		map[string]interface{}{
+			"env":    "prod",
+			"bucket": 73,
+		},
+		dataPoints,
+	)
+	addDataPoint(
+		7.5,
+		1631205002,
+		map[string]interface{}{
+			"env":    "prod",
+			"bucket": 73,
+		},
+		dataPoints,
+	)
+	expected := []singleMetric{
+		{
+			Name:  "test.metric",
+			Value: 7.0,
+			Ts:    1631205001,
+			Tags:  map[string]string{"env": "prod", "bucket": "73"},
+		},
+		{
+			Name:  "test.metric",
+			Value: 7.5,
+			Ts:    1631205002,
+			Tags:  map[string]string{"env": "prod", "bucket": "73"},
+		},
+	}
+	sender := &mockGaugeSender{errorOnSend: errorOnSend}
+	consumer := newGaugeConsumer(sender)
+	assert.Equal(t, pdata.MetricDataTypeGauge, consumer.Type())
+	var errs []error
+	consumer.Consume(metric, &errs)
+	assert.ElementsMatch(t, expected, sender.metrics)
+	if errorOnSend {
+		assert.Len(t, errs, 2)
+	} else {
+		assert.Empty(t, errs)
+	}
+}
+
+func constructMetrics(metricList ...pdata.Metric) pdata.Metrics {
+	result := pdata.NewMetrics()
+	result.ResourceMetrics().EnsureCapacity(1)
+	rm := result.ResourceMetrics().AppendEmpty()
+	rm.InstrumentationLibraryMetrics().EnsureCapacity(1)
+	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ilm.Metrics().EnsureCapacity(len(metricList))
+	for _, metric := range metricList {
+		metric.CopyTo(ilm.Metrics().AppendEmpty())
+	}
+	return result
+}
+
+func newMetric(name string, typ pdata.MetricDataType) pdata.Metric {
+	result := pdata.NewMetric()
+	result.SetName(name)
+	result.SetDataType(typ)
+	return result
+}
+
+func addDataPoint(
+	value interface{},
+	ts int64,
+	tags map[string]interface{},
+	slice pdata.NumberDataPointSlice) {
+	dataPoint := slice.AppendEmpty()
+	setDataPointValue(value, dataPoint)
+	setDataPointTimestamp(ts, dataPoint)
+	setTags(tags, dataPoint)
+}
+
+func setDataPointTimestamp(ts int64, dataPoint pdata.NumberDataPoint) {
+	dataPoint.SetTimestamp(
+		pdata.NewTimestampFromTime(time.Unix(ts, 0)))
+}
+
+func setDataPointValue(value interface{}, dataPoint pdata.NumberDataPoint) {
+	switch v := value.(type) {
+	case int:
+		dataPoint.SetIntVal(int64(v))
+	case int64:
+		dataPoint.SetIntVal(v)
+	case float64:
+		dataPoint.SetDoubleVal(v)
+	default:
+		panic("Unsupported value type")
+	}
+}
+
+func setTags(tags map[string]interface{}, dataPoint pdata.NumberDataPoint) {
+	valueMap := make(map[string]pdata.AttributeValue, len(tags))
+	for key, value := range tags {
+		switch v := value.(type) {
+		case int:
+			valueMap[key] = pdata.NewAttributeValueInt(int64(v))
+		case int64:
+			valueMap[key] = pdata.NewAttributeValueInt(v)
+		case float64:
+			valueMap[key] = pdata.NewAttributeValueDouble(v)
+		case string:
+			valueMap[key] = pdata.NewAttributeValueString(v)
+		default:
+			panic("Invalid value type")
+		}
+	}
+	attributeMap := pdata.NewAttributeMapFromMap(valueMap)
+	attributeMap.CopyTo(dataPoint.Attributes())
+}
+
+type singleMetric struct {
+	Name   string
+	Value  float64
+	Ts     int64
+	Source string
+	Tags   map[string]string
+}
+
+type mockGaugeSender struct {
+	errorOnSend bool
+	metrics     []singleMetric
+}
+
+func (m *mockGaugeSender) SendMetric(
+	name string, value float64, ts int64, source string, tags map[string]string) error {
+	tagsCopy := make(map[string]string, len(tags))
+	for k, v := range tags {
+		tagsCopy[k] = v
+	}
+	m.metrics = append(m.metrics, singleMetric{
+		Name:   name,
+		Value:  value,
+		Ts:     ts,
+		Source: source,
+		Tags:   tagsCopy,
+	})
+	if m.errorOnSend {
+		return errors.New("error sending")
+	}
+	return nil
+}
+
+type mockMetricConsumer struct {
+	typ            pdata.MetricDataType
+	errorOnConsume bool
+	names          []string
+}
+
+func (m *mockMetricConsumer) Type() pdata.MetricDataType {
+	return m.typ
+}
+
+func (m *mockMetricConsumer) Consume(metric pdata.Metric, errs *[]error) {
+	m.names = append(m.names, metric.Name())
+	if m.errorOnConsume {
+		*errs = append(*errs, errors.New("error in consume"))
+	}
+}
+
+type mockFlushCloser struct {
+	errorOnFlush  bool
+	numFlushCalls int
+	numCloseCalls int
+}
+
+func (m *mockFlushCloser) Flush() error {
+	m.numFlushCalls++
+	if m.errorOnFlush {
+		return errors.New("error flushing")
+	}
+	return nil
+}
+
+func (m *mockFlushCloser) Close() {
+	m.numCloseCalls++
+}


### PR DESCRIPTION
**Description:** 

This is the first pull request for adding a tanzu observability metrics exporter.
This PR introduces the metricsConsumer type which consumes pdata.Metrics instances by sending the metrics within to
tanzu observability.
A metricsConsumer instance is made up of multiple metricConsumer instances. Each metricConsumer instance consumes
a specific type of metric such as Gauge, Sum, or Histogram.
This PR also introduces a function that returns a metricConsumer that consumes gauge metrics.
Future PRs will introduce new implementations of metricConsumer. Each new implementation will consume a different type
of metric.

**Testing:**

Unit tests only.  The instances that will send data to tanzu observability are interfaces.  The unit tests create mock
implementations of these interfaces and verify that the right calls were made to them.
