### PR TITLE
Update configs+readmes to reflect de-squash of tls

### DIFF
--- a/examples/demo/otel-collector-config.yaml
+++ b/examples/demo/otel-collector-config.yaml
@@ -17,7 +17,8 @@ exporters:
 
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:

--- a/exporter/elasticexporter/README.md
+++ b/exporter/elasticexporter/README.md
@@ -54,7 +54,8 @@ exporters:
 exporters:
   otlp/elastic:
       endpoint: "localhost:8200"
-      insecure: true
+      tls:
+        insecure: true
 ```
 
 ## Migration
@@ -121,6 +122,7 @@ Complete documentation is available on [Elastic.co](https://www.elastic.co/guide
 - `apm_server_url` (required): Elastic APM Server URL.
 - `api_key` (optional): credential for API Key authorization, if enabled in Elastic APM Server.
 - `secret_token` (optional): credential for Secret Token authorization, if enabled in Elastic APM Server.
+#### The below options all belong beneath the `tls` header
 - `ca_file` (optional): root Certificate Authority (CA) certificate, for verifying the server's identity, if TLS is enabled.
 - `cert_file` (optional): client TLS certificate.
 - `key_file` (optional): client TLS key.

--- a/exporter/jaegerexporter/README.md
+++ b/exporter/jaegerexporter/README.md
@@ -13,7 +13,7 @@ The following settings are required:
 using the gRPC protocol. The valid syntax is described
 [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 
-By default, TLS is enabled:
+By default, TLS is enabled and must be configured under `tls`:
 
 - `insecure` (default = `false`): whether to enable client transport security for
   the exporter's connection.
@@ -31,11 +31,13 @@ Example:
 exporters:
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    cert_file: file.cert
-    key_file: file.key
+    tls:
+      cert_file: file.cert
+      key_file: file.key
   jaeger/2:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 ```
 
 ## Advanced Configuration

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -96,7 +96,8 @@ exporters:
     protocol:
       otlp:
         timeout: 1s
-        insecure: true
+        tls:
+          insecure: true
     resolver:
       static:
         hostnames:

--- a/exporter/loadbalancingexporter/example/otel-agent-config.yaml
+++ b/exporter/loadbalancingexporter/example/otel-agent-config.yaml
@@ -12,7 +12,8 @@ exporters:
     protocol:
       otlp:
         timeout: 1s
-        insecure: true
+        tls:
+          insecure: true
     resolver:
       static:
         hostnames:

--- a/exporter/opencensusexporter/README.md
+++ b/exporter/opencensusexporter/README.md
@@ -13,7 +13,7 @@ The following settings are required:
 using the gRPC protocol. The valid syntax is described
 [here](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 
-By default, TLS is enabled:
+By default, TLS is enabled and must be configured under `tls`:
 
 - `insecure` (default = `false`): whether to enable client transport security for
   the exporter's connection.
@@ -31,11 +31,13 @@ Example:
 exporters:
   opencensus:
     endpoint: opencensus2:55678
-    cert_file: file.cert
-    key_file: file.key
-  otlp/2:
+    tls:
+      cert_file: file.cert
+      key_file: file.key
+  opencensus/2:
     endpoint: opencensus2:55678
-    insecure: true
+    tls:
+      insecure: true
 ```
 
 ## Advanced Configuration

--- a/exporter/zipkinexporter/README.md
+++ b/exporter/zipkinexporter/README.md
@@ -12,7 +12,7 @@ The following settings are required:
 - `endpoint` (no default): URL to which the exporter is going to send Zipkin trace data.
 - `format` (default = `JSON`): The format to sent events in. Can be set to `JSON` or `proto`.
 
-By default, TLS is enabled:
+By default, TLS is enabled and must be configured under `tls`:
 
 - `insecure` (default = `false`): whether to enable client transport security for
   the exporter's connection.
@@ -35,11 +35,13 @@ Example:
 exporters:
   zipkin:
     endpoint: "http://some.url:9411/api/v2/spans"
-    cert_file: file.cert
-    key_file: file.key
+    tls:
+      cert_file: file.cert
+      key_file: file.key
   zipkin/2:
     endpoint: "http://some.url:9411/api/v2/spans"
-    insecure: true
+    tls:
+      insecure: true
 ```
 
 ## Advanced Configuration

--- a/receiver/jaegerreceiver/README.md
+++ b/receiver/jaegerreceiver/README.md
@@ -78,7 +78,8 @@ receivers:
       grpc:
     remote_sampling:
       endpoint: "jaeger-collector:14250"
-      insecure: true
+      tls:
+        insecure: true
 ```
 
 Remote sampling can also be directly served by the collector by providing a


### PR DESCRIPTION
Changed some example/test configs which did not compile since the `tls` struct (under grpc config) was changed from squashed to not squashed in the main parent repo (not -contrib). All changes are indenting insecure or other tls properties under the `tls` label.

**Link to tracking Issue:** 
In parent repo the issue causing these errors are discussed in this issue: https://github.com/open-telemetry/opentelemetry-collector/issues/4028
And specifically this merge: https://github.com/open-telemetry/opentelemetry-collector/pull/4063

There is an issue in this (-contrib) repo discussing this: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5385

**Testing:** 
No changes. Some example configs and readme demo configs now pass the config validation at startup.

**Documentation:** 
Updated appropriate readmes to match change described above. Let me know if I missed some!