### PR TITLE
Use standard errors.As instead of soon deprecated consumererror.As*

### DIFF
--- a/exporter/humioexporter/traces_exporter_test.go
+++ b/exporter/humioexporter/traces_exporter_test.go
@@ -182,7 +182,7 @@ func TestPushTraceData_TransientOnPartialFailure(t *testing.T) {
 	assert.False(t, consumererror.IsPermanent(err))
 
 	tErr := consumererror.Traces{}
-	if ok := consumererror.AsTraces(err, &tErr); !ok {
+	if ok := errors.As(err, &tErr); !ok {
 		assert.Fail(t, "PushTraceData did not return a Traces error")
 	}
 	assert.Equal(t, 1, tErr.GetTraces().ResourceSpans().Len())

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -16,6 +16,7 @@ package lokiexporter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -161,8 +162,8 @@ func TestExporter_pushLogData(t *testing.T) {
 			genLogsFunc:      genericGenLogsFunc,
 			errFunc: func(err error) {
 				var e consumererror.Logs
-				consumererror.AsLogs(err, &e)
-				require.Equal(t, 10, e.GetLogs().LogRecordCount())
+				require.True(t, errors.As(err, &e))
+				assert.Equal(t, 10, e.GetLogs().LogRecordCount())
 			},
 		},
 		{
@@ -174,8 +175,8 @@ func TestExporter_pushLogData(t *testing.T) {
 			genLogsFunc:      genericGenLogsFunc,
 			errFunc: func(err error) {
 				var e consumererror.Logs
-				consumererror.AsLogs(err, &e)
-				require.Equal(t, 10, e.GetLogs().LogRecordCount())
+				require.True(t, errors.As(err, &e))
+				assert.Equal(t, 10, e.GetLogs().LogRecordCount())
 			},
 		},
 		{

--- a/exporter/sumologicexporter/exporter_test.go
+++ b/exporter/sumologicexporter/exporter_test.go
@@ -166,7 +166,7 @@ func TestAllFailed(t *testing.T) {
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 
 	var partial consumererror.Logs
-	require.True(t, consumererror.AsLogs(err, &partial))
+	require.True(t, errors.As(err, &partial))
 	assert.Equal(t, logs, partial.GetLogs())
 }
 
@@ -199,7 +199,7 @@ func TestPartiallyFailed(t *testing.T) {
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 
 	var partial consumererror.Logs
-	require.True(t, consumererror.AsLogs(err, &partial))
+	require.True(t, errors.As(err, &partial))
 	assert.Equal(t, expected, partial.GetLogs())
 }
 
@@ -340,7 +340,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 
 	var partial consumererror.Metrics
-	require.True(t, consumererror.AsMetrics(err, &partial))
+	require.True(t, errors.As(err, &partial))
 	assert.Equal(t, metrics, partial.GetMetrics())
 }
 
@@ -377,7 +377,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 
 	var partial consumererror.Metrics
-	require.True(t, consumererror.AsMetrics(err, &partial))
+	require.True(t, errors.As(err, &partial))
 	assert.Equal(t, expected, partial.GetMetrics())
 }
 
@@ -443,7 +443,7 @@ gauge_metric_name{foo="bar",key2="value2",remote_name="156955",url="http://anoth
 	assert.EqualError(t, err, "error during sending data: 500 Internal Server Error")
 
 	var partial consumererror.Metrics
-	require.True(t, consumererror.AsMetrics(err, &partial))
+	require.True(t, errors.As(err, &partial))
 	assert.Equal(t, expected, partial.GetMetrics())
 }
 


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
