### PR TITLE
awskinesisexporter: extending to allow for dynamic export types

### DIFF
--- a/exporter/awskinesisexporter/README.md
+++ b/exporter/awskinesisexporter/README.md
@@ -16,7 +16,7 @@ The following settings can be optionally configured:
     - `region` (default = us-west-2): the region that the kinesis stream is deployed in
     - `role` (no default): The role to be used in order to send data to the kinesis stream
 - `encoding`
-    - `name` (default = jaeger): defines the export type to be used to send to kinesis (available is `otlp-proto`, `otlp-json`, `zipkin-proto`, `zipkin-json`, `jaeger`)
+    - `name` (default = otlp): defines the export type to be used to send to kinesis (available is `otlp-proto`, `otlp-json`, `zipkin-proto`, `zipkin-json`, `jaeger`)
     - `compression` (default = none): allows to set the compression type (defaults BestSpeed for all) before forwarding to kinesis (available is `flate`, `gzip`, `zlib` or `none`)
 - `max_records_per_batch` (default = 500, PutRecords limit): The number of records that can be batched together then sent to kinesis.
 - `max_record_size` (default = 1Mb, PutRecord(s) limit on record size): The max allowed size that can be exported to kinesis

--- a/exporter/awskinesisexporter/README.md
+++ b/exporter/awskinesisexporter/README.md
@@ -1,7 +1,7 @@
 # Kinesis Exporter
 
 
-The kinesis exporter currently exports Jaeger traces (dynamic encodings coming) to the configured kinesis stream.
+The kinesis exporter currently exports dynamic encodings to the configured kinesis stream.
 The exporter relies heavily on the kinesis.PutRecords api to reduce network I/O and and reduces records into smallest atomic representation
 to avoid hitting the hard limits placed on Records (No greater than 1Mb).
 This producer will block until the operation is done to allow for retryable and queued data to help during high loads.
@@ -15,6 +15,9 @@ The following settings can be optionally configured:
     - `kinesis_endpoint` (no default)
     - `region` (default = us-west-2): the region that the kinesis stream is deployed in
     - `role` (no default): The role to be used in order to send data to the kinesis stream
+- `encoding`
+    - `name` (default = jaeger): defines the export type to be used to send to kinesis (available is `otlp-proto`, `otlp-json`, `zipkin-proto`, `zipkin-json`, `jaeger`)
+    - `compression` (default = none): allows to set the compression type (defaults BestSpeed for all) before forwarding to kinesis (available is `flate`, `gzip`, `zlib` or `none`)
 - `max_records_per_batch` (default = 500, PutRecords limit): The number of records that can be batched together then sent to kinesis.
 - `max_record_size` (default = 1Mb, PutRecord(s) limit on record size): The max allowed size that can be exported to kinesis
 - `timeout` (default = 5s): Is the timeout for every attempt to send data to the backend.

--- a/exporter/awskinesisexporter/config.go
+++ b/exporter/awskinesisexporter/config.go
@@ -27,6 +27,11 @@ type AWSConfig struct {
 	Role            string `mapstructure:"role"`
 }
 
+type Encoding struct {
+	Name        string `mapstructure:"name"`
+	Compression string `mapstructure:"compression"`
+}
+
 // Config contains the main configuration options for the awskinesis exporter
 type Config struct {
 	config.ExporterSettings        `mapstructure:",squash"`
@@ -34,6 +39,7 @@ type Config struct {
 	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
 
+	Encoding           `mapstructure:"encoding"`
 	AWS                AWSConfig `mapstructure:"aws"`
 	MaxRecordsPerBatch int       `mapstructure:"max_records_per_batch"`
 	MaxRecordSize      int       `mapstructure:"max_record_size"`

--- a/exporter/awskinesisexporter/config_test.go
+++ b/exporter/awskinesisexporter/config_test.go
@@ -47,6 +47,10 @@ func TestDefaultConfig(t *testing.T) {
 			QueueSettings:    exporterhelper.DefaultQueueSettings(),
 			RetrySettings:    exporterhelper.DefaultRetrySettings(),
 			TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
+			Encoding: Encoding{
+				Name:        "otlp",
+				Compression: "none",
+			},
 			AWS: AWSConfig{
 				Region: "us-west-2",
 			},
@@ -80,6 +84,10 @@ func TestConfig(t *testing.T) {
 			},
 			TimeoutSettings: exporterhelper.DefaultTimeoutSettings(),
 			QueueSettings:   exporterhelper.DefaultQueueSettings(),
+			Encoding: Encoding{
+				Name:        "otlp-proto",
+				Compression: "none",
+			},
 			AWS: AWSConfig{
 				StreamName:      "test-stream",
 				KinesisEndpoint: "awskinesis.mars-1.aws.galactic",

--- a/exporter/awskinesisexporter/factory.go
+++ b/exporter/awskinesisexporter/factory.go
@@ -27,6 +27,9 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "awskinesis"
+
+	defaultEncoding    = "otlp"
+	defaultCompression = "none"
 )
 
 // NewFactory creates a factory for Kinesis exporter.
@@ -46,6 +49,10 @@ func createDefaultConfig() config.Exporter {
 		TimeoutSettings:  exporterhelper.DefaultTimeoutSettings(),
 		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		QueueSettings:    exporterhelper.DefaultQueueSettings(),
+		Encoding: Encoding{
+			Name:        defaultEncoding,
+			Compression: defaultCompression,
+		},
 		AWS: AWSConfig{
 			Region: "us-west-2",
 		},

--- a/exporter/awskinesisexporter/go.mod
+++ b/exporter/awskinesisexporter/go.mod
@@ -6,16 +6,16 @@ require (
 	github.com/aws/aws-sdk-go v1.40.56
 	github.com/golang/protobuf v1.5.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.36.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.36.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.36.1-0.20211004155959-190f8fbb2b9a
 	go.opentelemetry.io/collector/model v0.36.1-0.20211004155959-190f8fbb2b9a
 	go.uber.org/zap v1.19.1
-	google.golang.org/protobuf v1.27.1
 )
 
 require (
 	go.uber.org/multierr v1.7.0
-	google.golang.org/genproto v0.0.0-20210909211513-a8c4777a87af // indirect
+	google.golang.org/genproto v0.0.0-20210927142257-433400c27d05 // indirect
 )
 
 require (
@@ -23,8 +23,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/jaegertracing/jaeger v1.26.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/knadh/koanf v1.2.4 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
@@ -33,6 +32,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.36.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/openzipkin/zipkin-go v0.2.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
@@ -40,14 +40,17 @@ require (
 	go.opentelemetry.io/otel/metric v0.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.0.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
-	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/net v0.0.0-20210927181540-4e4d966f7476 // indirect
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/grpc v1.41.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger => ../../pkg/translator/jaeger
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin => ../../pkg/translator/zipkin
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal

--- a/exporter/awskinesisexporter/go.mod
+++ b/exporter/awskinesisexporter/go.mod
@@ -14,6 +14,9 @@ require (
 )
 
 require (
+	github.com/gogo/protobuf v1.3.2
+	github.com/google/uuid v1.3.0
+	github.com/jaegertracing/jaeger v1.26.0
 	go.uber.org/multierr v1.7.0
 	google.golang.org/genproto v0.0.0-20210927142257-433400c27d05 // indirect
 )

--- a/exporter/awskinesisexporter/go.mod
+++ b/exporter/awskinesisexporter/go.mod
@@ -4,7 +4,6 @@ go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.40.56
-	github.com/golang/protobuf v1.5.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.36.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.36.0
 	github.com/stretchr/testify v1.7.0

--- a/exporter/awskinesisexporter/go.sum
+++ b/exporter/awskinesisexporter/go.sum
@@ -467,6 +467,7 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
@@ -736,6 +737,7 @@ github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.36.0/go.mod h1:LDrMMszWIDctEMmytTYodJMRl3BSQDnnQCBf95U35tw=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing-contrib/go-grpc v0.0.0-20191001143057-db30781987df/go.mod h1:DYR5Eij8rJl8h7gblRrOZ8g0kW1umSpKqYIBTgeDtLo=
@@ -752,6 +754,7 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/openzipkin/zipkin-go v0.2.5 h1:UwtQQx2pyPIgWYHRg+epgdx1/HnBQTgN3/oIYEJTQzU=
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1158,8 +1161,9 @@ golang.org/x/net v0.0.0-20210427231257-85d9c07bbe3a/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210927181540-4e4d966f7476 h1:s5hu7bTnLKswvidgtqc4GwsW83m9LZu8UAqzmWOZtI4=
+golang.org/x/net v0.0.0-20210927181540-4e4d966f7476/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1274,8 +1278,9 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210611083646-a4fc73990273/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1287,8 +1292,9 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -1460,8 +1466,8 @@ google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/genproto v0.0.0-20210604141403-392c879c8b08/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
-google.golang.org/genproto v0.0.0-20210909211513-a8c4777a87af h1:aLMMXFYqw01RA6XJim5uaN+afqNNjc9P8HPAbnpnc5s=
-google.golang.org/genproto v0.0.0-20210909211513-a8c4777a87af/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
+google.golang.org/genproto v0.0.0-20210927142257-433400c27d05 h1:6/1QShroBaS9sY9NbPquolxRETG6PZhfv8ohdbLieBg=
+google.golang.org/genproto v0.0.0-20210927142257-433400c27d05/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=

--- a/exporter/awskinesisexporter/internal/batch/batch.go
+++ b/exporter/awskinesisexporter/internal/batch/batch.go
@@ -18,10 +18,10 @@ import (
 	"errors"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/kinesis"
-	protov1 "github.com/golang/protobuf/proto" //nolint:staticcheck // Some encoding types uses legacy prototype version
+	"github.com/aws/aws-sdk-go/service/kinesis" //nolint:staticcheck // Some encoding types uses legacy prototype version
 	"go.opentelemetry.io/collector/consumer/consumererror"
-	protov2 "google.golang.org/protobuf/proto"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/compress"
 )
 
 const (
@@ -39,6 +39,8 @@ var (
 type Batch struct {
 	maxBatchSize  int
 	maxRecordSize int
+
+	compression compress.Compressor
 
 	records []*kinesis.PutRecordsRequestEntry
 }
@@ -63,10 +65,19 @@ func WithMaxRecordSize(size int) Option {
 	}
 }
 
+func WithCompression(compressor compress.Compressor) Option {
+	return func(bt *Batch) {
+		if compressor != nil {
+			bt.compression = compressor
+		}
+	}
+}
+
 func New(opts ...Option) *Batch {
 	bt := &Batch{
 		maxBatchSize:  MaxBatchedRecords,
 		maxRecordSize: MaxRecordSize,
+		compression:   compress.NewNoopCompressor(),
 		records:       make([]*kinesis.PutRecordsRequestEntry, 0, MaxRecordSize),
 	}
 
@@ -77,39 +88,22 @@ func New(opts ...Option) *Batch {
 	return bt
 }
 
-func (b *Batch) addRaw(raw []byte, key string) error {
+func (b *Batch) AddRecord(raw []byte, key string) error {
+	record, err := b.compression.Do(raw)
+	if err != nil {
+		return err
+	}
+
 	if l := len(key); l == 0 || l > 256 {
 		return ErrPartitionKeyLength
 	}
 
-	if len(raw) > b.maxRecordSize {
+	if l := len(record); l == 0 || l > b.maxRecordSize {
 		return ErrRecordLength
 	}
 
-	b.records = append(b.records, &kinesis.PutRecordsRequestEntry{Data: raw, PartitionKey: aws.String(key)})
+	b.records = append(b.records, &kinesis.PutRecordsRequestEntry{Data: record, PartitionKey: aws.String(key)})
 	return nil
-}
-
-// AddProtobufV1 allows for deprecated protobuf generated types to be exported
-// and marshaled into records to be exported to kinesis.
-// The protobuf v1 message is considered deprecated so where possible to use
-// batch.AddProtobufV2.
-func (b *Batch) AddProtobufV1(message protov1.Message, key string) error {
-	data, err := protov1.Marshal(message)
-	if err != nil {
-		return err
-	}
-	return b.addRaw(data, key)
-}
-
-// AddProtobufV2 accepts the protobuf message and marshal it into a record
-// ready to submit to kinesis.
-func (b *Batch) AddProtobufV2(message protov2.Message, key string) error {
-	data, err := protov2.Marshal(message)
-	if err != nil {
-		return err
-	}
-	return b.addRaw(data, key)
 }
 
 // Chunk breaks up the iternal queue into blocks that can be used

--- a/exporter/awskinesisexporter/internal/batch/batch_test.go
+++ b/exporter/awskinesisexporter/internal/batch/batch_test.go
@@ -17,7 +17,6 @@ package batch_test
 import (
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/batch"
@@ -28,14 +27,22 @@ func TestBatchingMessages(t *testing.T) {
 
 	b := batch.New()
 	for i := 0; i < 948; i++ {
-		assert.NoError(t, b.AddProtobufV1(new(empty.Empty), "fixed-string"), "Must not error when adding elements into the batch")
+		assert.NoError(t, b.AddRecord([]byte("foobar"), "fixed-string"), "Must not error when adding elements into the batch")
 	}
 
-	assert.Len(t, b.Chunk(), 2, "Must have split the batch into two chunks")
-	assert.Len(t, b.Chunk(), 2, "Must not modify the stored data within the batch")
+	chunk := b.Chunk()
+	for _, records := range chunk {
+		for _, record := range records {
+			assert.Equal(t, []byte("foobar"), record.Data, "Must have the expected record value")
+			assert.Equal(t, "fixed-string", *record.PartitionKey, "Must have the expected partition key")
+		}
+	}
 
-	assert.Error(t, b.AddProtobufV1(nil, "fixed-string"), "Must error when invalid record provided")
-	assert.Error(t, b.AddProtobufV1(new(empty.Empty), ""), "Must error when invalid partition key provided")
+	assert.Len(t, chunk, 2, "Must have split the batch into two chunks")
+	assert.Len(t, chunk, 2, "Must not modify the stored data within the batch")
+
+	assert.Error(t, b.AddRecord(nil, "fixed-string"), "Must error when invalid record provided")
+	assert.Error(t, b.AddRecord([]byte("some data that is very important"), ""), "Must error when invalid partition key provided")
 }
 
 func TestCustomBatchSizeConstraints(t *testing.T) {
@@ -46,7 +53,7 @@ func TestCustomBatchSizeConstraints(t *testing.T) {
 	)
 	const records = 203
 	for i := 0; i < records; i++ {
-		assert.NoError(t, b.AddProtobufV1(new(empty.Empty), "fixed-string"), "Must not error when adding elements into the batch")
+		assert.NoError(t, b.AddRecord([]byte("foobar"), "fixed-string"), "Must not error when adding elements into the batch")
 	}
 	assert.Len(t, b.Chunk(), records, "Must have one batch per record added")
 }
@@ -54,7 +61,7 @@ func TestCustomBatchSizeConstraints(t *testing.T) {
 func BenchmarkChunkingRecords(b *testing.B) {
 	bt := batch.New()
 	for i := 0; i < 948; i++ {
-		assert.NoError(b, bt.AddProtobufV1(new(empty.Empty), "fixed-string"), "Must not error when adding elements into the batch")
+		assert.NoError(b, bt.AddRecord([]byte("foobar"), "fixed-string"), "Must not error when adding elements into the batch")
 	}
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/exporter/awskinesisexporter/internal/batch/encode.go
+++ b/exporter/awskinesisexporter/internal/batch/encode.go
@@ -20,8 +20,12 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
-// ErrUnsupportedEncodedType is used when the encoder type does not support the type of encoding
-var ErrUnsupportedEncodedType = errors.New("unsupported type to encode")
+var (
+	// ErrUnsupportedEncoding is used when the encoder type does not support the type of encoding
+	ErrUnsupportedEncoding = errors.New("unsupported type to encode")
+	// ErrUnknownExportEncoder is used when a named encoding doesn't not exist
+	ErrUnknownExportEncoder = errors.New("unknown encoding export format")
+)
 
 // Encoder transforms the internal pipeline format into a configurable
 // format that is then used to export to kinesis.

--- a/exporter/awskinesisexporter/internal/batch/encode.go
+++ b/exporter/awskinesisexporter/internal/batch/encode.go
@@ -17,6 +17,9 @@ package batch
 import (
 	"errors"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/key"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv2"
+	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -35,4 +38,39 @@ type Encoder interface {
 	Traces(td pdata.Traces) (*Batch, error)
 
 	Logs(ld pdata.Logs) (*Batch, error)
+}
+
+func NewEncoder(named string, batchOptions ...Option) (Encoder, error) {
+	bm := &batchMarshaller{
+		batchOptions:      batchOptions,
+		partitioner:       key.Randomized,
+		logsMarshaller:    unsupported{},
+		tracesMarshaller:  unsupported{},
+		metricsMarshaller: unsupported{},
+	}
+	switch named {
+	case "zipkin_proto":
+		bm.tracesMarshaller = zipkinv2.NewProtobufTracesMarshaler()
+	case "zipkin_json":
+		bm.tracesMarshaller = zipkinv2.NewJSONTracesMarshaler()
+	case "otlp", "otlp_proto":
+		bm.logsMarshaller = otlp.NewProtobufLogsMarshaler()
+		bm.metricsMarshaller = otlp.NewProtobufMetricsMarshaler()
+		bm.tracesMarshaller = otlp.NewProtobufTracesMarshaler()
+	case "otlp_json":
+		bm.logsMarshaller = otlp.NewJSONLogsMarshaler()
+		bm.metricsMarshaller = otlp.NewJSONMetricsMarshaler()
+		bm.tracesMarshaller = otlp.NewJSONTracesMarshaler()
+	case "jaeger_proto":
+		// Jaeger encoding is a special case
+		// since the internal libraries offer no means of pdata.TraceMarshaller.
+		// In order to preserve historical behavior, a custom type
+		// is used until it can be replaced.
+		return &jaegerEncoder{
+			batchOptions: batchOptions,
+		}, nil
+	default:
+		return nil, ErrUnknownExportEncoder
+	}
+	return bm, nil
 }

--- a/exporter/awskinesisexporter/internal/batch/encode.go
+++ b/exporter/awskinesisexporter/internal/batch/encode.go
@@ -17,10 +17,11 @@ package batch
 import (
 	"errors"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/key"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv2"
 	"go.opentelemetry.io/collector/model/otlp"
 	"go.opentelemetry.io/collector/model/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/key"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv2"
 )
 
 var (

--- a/exporter/awskinesisexporter/internal/batch/encode_jaeger.go
+++ b/exporter/awskinesisexporter/internal/batch/encode_jaeger.go
@@ -15,53 +15,54 @@
 package batch
 
 import (
+	"github.com/gogo/protobuf/proto"
+	"github.com/jaegertracing/jaeger/model"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/multierr"
 
-	jaegertranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/key"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 )
 
-type jaeger struct {
-	batchSize  int
-	recordSize int
-}
-
-var _ Encoder = (*jaeger)(nil)
-
-func NewJaeger(batchSize, recordSize int) Encoder {
-	return jaeger{
-		batchSize:  batchSize,
-		recordSize: recordSize,
+func partitionByTraceID(v interface{}) string {
+	if s, ok := v.(*model.Span); ok && s != nil {
+		return s.TraceID.String()
 	}
+	return key.Randomized(v)
 }
 
-func (j jaeger) Traces(td pdata.Traces) (*Batch, error) {
-	traces, err := jaegertranslator.InternalTracesToJaegerProto(td)
+type jaegerEncoder struct {
+	batchOptions []Option
+}
+
+var _ Encoder = (*jaegerEncoder)(nil)
+
+func (je jaegerEncoder) Traces(td pdata.Traces) (*Batch, error) {
+	traces, err := jaeger.InternalTracesToJaegerProto(td)
 	if err != nil {
-		return nil, err
+		return nil, consumererror.Permanent(consumererror.NewTraces(err, td))
 	}
 
-	bt := New(
-		WithMaxRecordSize(j.recordSize),
-		WithMaxRecordsPerBatch(j.batchSize),
-	)
+	bt := New(je.batchOptions...)
+
 	var errs error
 	for _, trace := range traces {
 		for _, span := range trace.GetSpans() {
 			if span.Process == nil {
-				span.Process = trace.Process
+				span.Process = trace.GetProcess()
 			}
-			errs = multierr.Append(errs, bt.AddProtobufV1(span, span.TraceID.String()))
+			data, err := proto.Marshal(span)
+			if err != nil {
+				errs = multierr.Append(errs, err)
+				continue
+			}
+			errs = multierr.Append(errs, bt.AddRecord(data, partitionByTraceID(span)))
 		}
 	}
 
 	return bt, errs
 }
 
-func (jaeger) Metrics(_ pdata.Metrics) (*Batch, error) {
-	return nil, ErrUnsupportedEncodedType
-}
-
-func (jaeger) Logs(_ pdata.Logs) (*Batch, error) {
-	return nil, ErrUnsupportedEncodedType
-}
+func (jaegerEncoder) Logs(pdata.Logs) (*Batch, error)       { return nil, ErrUnsupportedEncoding }
+func (jaegerEncoder) Metrics(pdata.Metrics) (*Batch, error) { return nil, ErrUnsupportedEncoding }

--- a/exporter/awskinesisexporter/internal/batch/encode_jaeger.go
+++ b/exporter/awskinesisexporter/internal/batch/encode_jaeger.go
@@ -41,7 +41,7 @@ var _ Encoder = (*jaegerEncoder)(nil)
 func (je jaegerEncoder) Traces(td pdata.Traces) (*Batch, error) {
 	traces, err := jaeger.InternalTracesToJaegerProto(td)
 	if err != nil {
-		return nil, consumererror.Permanent(consumererror.NewTraces(err, td))
+		return nil, consumererror.NewTraces(err, td)
 	}
 
 	bt := New(je.batchOptions...)

--- a/exporter/awskinesisexporter/internal/batch/encode_marshaler.go
+++ b/exporter/awskinesisexporter/internal/batch/encode_marshaler.go
@@ -1,0 +1,157 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batch
+
+import (
+	"errors"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/model/otlp"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/multierr"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/key"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv2"
+)
+
+type batchMarshaller struct {
+	batchOptions []Option
+	partitioner  key.Partition
+
+	logsMarshaller    pdata.LogsMarshaler
+	tracesMarshaller  pdata.TracesMarshaler
+	metricsMarshaller pdata.MetricsMarshaler
+}
+
+var _ Encoder = (*batchMarshaller)(nil)
+
+func NewEncoder(named string, batchOptions ...Option) (Encoder, error) {
+	bm := &batchMarshaller{
+		batchOptions:      batchOptions,
+		partitioner:       key.Randomized,
+		logsMarshaller:    unsupported{},
+		tracesMarshaller:  unsupported{},
+		metricsMarshaller: unsupported{},
+	}
+	switch named {
+	case "zipkin-proto", "zipkin_proto", "zipkin/proto":
+		bm.tracesMarshaller = zipkinv2.NewProtobufTracesMarshaler()
+	case "zipkin-json", "zipkin_json", "zipkin/json":
+		bm.tracesMarshaller = zipkinv2.NewJSONTracesMarshaler()
+	case "otlp", "otlp-proto", "otlp_proto", "otlp/proto":
+		bm.logsMarshaller = otlp.NewProtobufLogsMarshaler()
+		bm.metricsMarshaller = otlp.NewProtobufMetricsMarshaler()
+		bm.tracesMarshaller = otlp.NewProtobufTracesMarshaler()
+	case "otlp-json", "otlp_json", "otlp/json":
+		bm.logsMarshaller = otlp.NewJSONLogsMarshaler()
+		bm.metricsMarshaller = otlp.NewJSONMetricsMarshaler()
+		bm.tracesMarshaller = otlp.NewJSONTracesMarshaler()
+	case "jaeger", "jaeger-proto", "jaeger/proto":
+		// Jaeger encoding is a special case
+		// since the internal libraries offer no means of pdata.TraceMarshaller.
+		// In order to preserve historical behavior, a custom type
+		// is used until it can be replaced.
+		return &jaegerEncoder{
+			batchOptions: batchOptions,
+		}, nil
+	default:
+		return nil, ErrUnknownExportEncoder
+	}
+	return bm, nil
+}
+
+func (bm *batchMarshaller) Logs(ld pdata.Logs) (*Batch, error) {
+	bt := New(bm.batchOptions...)
+
+	log := pdata.NewLogs()
+	log.ResourceLogs().AppendEmpty()
+
+	var errs error
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		line := ld.ResourceLogs().At(i)
+		line.CopyTo(log.ResourceLogs().At(0))
+
+		data, err := bm.logsMarshaller.MarshalLogs(log)
+		if err != nil {
+			if errors.Is(err, ErrUnsupportedEncoding) {
+				return nil, err
+			}
+			errs = multierr.Append(errs, consumererror.NewLogs(err, log.Clone()))
+			continue
+		}
+
+		if err := bt.AddRecord(data, bm.partitioner(log)); err != nil {
+			errs = multierr.Append(errs, consumererror.NewLogs(err, log.Clone()))
+		}
+	}
+
+	return bt, errs
+}
+
+func (bm *batchMarshaller) Traces(td pdata.Traces) (*Batch, error) {
+	bt := New(bm.batchOptions...)
+
+	trace := pdata.NewTraces()
+	trace.ResourceSpans().AppendEmpty()
+
+	var errs error
+	for i := 0; i < td.ResourceSpans().Len(); i++ {
+		span := td.ResourceSpans().At(i)
+		span.CopyTo(trace.ResourceSpans().At(0))
+
+		data, err := bm.tracesMarshaller.MarshalTraces(trace)
+		if err != nil {
+			if errors.Is(err, ErrUnsupportedEncoding) {
+				return nil, err
+			}
+			errs = multierr.Append(errs, consumererror.NewTraces(err, trace.Clone()))
+			continue
+		}
+
+		if err := bt.AddRecord(data, bm.partitioner(span)); err != nil {
+			errs = multierr.Append(errs, consumererror.NewTraces(err, trace.Clone()))
+		}
+	}
+
+	return bt, errs
+}
+
+func (bm *batchMarshaller) Metrics(md pdata.Metrics) (*Batch, error) {
+	bt := New(bm.batchOptions...)
+
+	metric := pdata.NewMetrics()
+	metric.ResourceMetrics().AppendEmpty()
+
+	var errs error
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		datapoint := md.ResourceMetrics().At(i)
+		datapoint.CopyTo(metric.ResourceMetrics().At(0))
+
+		data, err := bm.metricsMarshaller.MarshalMetrics(metric)
+		if err != nil {
+			if errors.Is(err, ErrUnsupportedEncoding) {
+				return nil, err
+			}
+			errs = multierr.Append(errs, consumererror.NewMetrics(err, metric.Clone()))
+			continue
+		}
+
+		if err := bt.AddRecord(data, bm.partitioner(metric)); err != nil {
+			errs = multierr.Append(errs, consumererror.NewMetrics(err, metric.Clone()))
+		}
+	}
+
+	return bt, errs
+}

--- a/exporter/awskinesisexporter/internal/batch/encode_marshaler.go
+++ b/exporter/awskinesisexporter/internal/batch/encode_marshaler.go
@@ -38,6 +38,10 @@ var _ Encoder = (*batchMarshaller)(nil)
 func (bm *batchMarshaller) Logs(ld pdata.Logs) (*Batch, error) {
 	bt := New(bm.batchOptions...)
 
+	// Due to kinesis limitations of only allowing 1Mb of data per record,
+	// the resource data is copied to the export variable then marshaled
+	// due to no current means of marshaling per resource.
+
 	export := pdata.NewLogs()
 	export.ResourceLogs().AppendEmpty()
 
@@ -66,6 +70,10 @@ func (bm *batchMarshaller) Logs(ld pdata.Logs) (*Batch, error) {
 func (bm *batchMarshaller) Traces(td pdata.Traces) (*Batch, error) {
 	bt := New(bm.batchOptions...)
 
+	// Due to kinesis limitations of only allowing 1Mb of data per record,
+	// the resource data is copied to the export variable then marshaled
+	// due to no current means of marshaling per resource.
+
 	export := pdata.NewTraces()
 	export.ResourceSpans().AppendEmpty()
 
@@ -93,6 +101,10 @@ func (bm *batchMarshaller) Traces(td pdata.Traces) (*Batch, error) {
 
 func (bm *batchMarshaller) Metrics(md pdata.Metrics) (*Batch, error) {
 	bt := New(bm.batchOptions...)
+
+	// Due to kinesis limitations of only allowing 1Mb of data per record,
+	// the resource data is copied to the export variable then marshaled
+	// due to no current means of marshaling per resource.
 
 	export := pdata.NewMetrics()
 	export.ResourceMetrics().AppendEmpty()

--- a/exporter/awskinesisexporter/internal/batch/encode_marshaler.go
+++ b/exporter/awskinesisexporter/internal/batch/encode_marshaler.go
@@ -75,25 +75,25 @@ func NewEncoder(named string, batchOptions ...Option) (Encoder, error) {
 func (bm *batchMarshaller) Logs(ld pdata.Logs) (*Batch, error) {
 	bt := New(bm.batchOptions...)
 
-	log := pdata.NewLogs()
-	log.ResourceLogs().AppendEmpty()
+	export := pdata.NewLogs()
+	export.ResourceLogs().AppendEmpty()
 
 	var errs error
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		line := ld.ResourceLogs().At(i)
-		line.CopyTo(log.ResourceLogs().At(0))
+		line.CopyTo(export.ResourceLogs().At(0))
 
-		data, err := bm.logsMarshaller.MarshalLogs(log)
+		data, err := bm.logsMarshaller.MarshalLogs(export)
 		if err != nil {
 			if errors.Is(err, ErrUnsupportedEncoding) {
 				return nil, err
 			}
-			errs = multierr.Append(errs, consumererror.NewLogs(err, log.Clone()))
+			errs = multierr.Append(errs, consumererror.NewLogs(err, export.Clone()))
 			continue
 		}
 
-		if err := bt.AddRecord(data, bm.partitioner(log)); err != nil {
-			errs = multierr.Append(errs, consumererror.NewLogs(err, log.Clone()))
+		if err := bt.AddRecord(data, bm.partitioner(export)); err != nil {
+			errs = multierr.Append(errs, consumererror.NewLogs(err, export.Clone()))
 		}
 	}
 
@@ -103,25 +103,25 @@ func (bm *batchMarshaller) Logs(ld pdata.Logs) (*Batch, error) {
 func (bm *batchMarshaller) Traces(td pdata.Traces) (*Batch, error) {
 	bt := New(bm.batchOptions...)
 
-	trace := pdata.NewTraces()
-	trace.ResourceSpans().AppendEmpty()
+	export := pdata.NewTraces()
+	export.ResourceSpans().AppendEmpty()
 
 	var errs error
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		span := td.ResourceSpans().At(i)
-		span.CopyTo(trace.ResourceSpans().At(0))
+		span.CopyTo(export.ResourceSpans().At(0))
 
-		data, err := bm.tracesMarshaller.MarshalTraces(trace)
+		data, err := bm.tracesMarshaller.MarshalTraces(export)
 		if err != nil {
 			if errors.Is(err, ErrUnsupportedEncoding) {
 				return nil, err
 			}
-			errs = multierr.Append(errs, consumererror.NewTraces(err, trace.Clone()))
+			errs = multierr.Append(errs, consumererror.NewTraces(err, export.Clone()))
 			continue
 		}
 
 		if err := bt.AddRecord(data, bm.partitioner(span)); err != nil {
-			errs = multierr.Append(errs, consumererror.NewTraces(err, trace.Clone()))
+			errs = multierr.Append(errs, consumererror.NewTraces(err, export.Clone()))
 		}
 	}
 
@@ -131,25 +131,25 @@ func (bm *batchMarshaller) Traces(td pdata.Traces) (*Batch, error) {
 func (bm *batchMarshaller) Metrics(md pdata.Metrics) (*Batch, error) {
 	bt := New(bm.batchOptions...)
 
-	metric := pdata.NewMetrics()
-	metric.ResourceMetrics().AppendEmpty()
+	export := pdata.NewMetrics()
+	export.ResourceMetrics().AppendEmpty()
 
 	var errs error
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		datapoint := md.ResourceMetrics().At(i)
-		datapoint.CopyTo(metric.ResourceMetrics().At(0))
+		datapoint.CopyTo(export.ResourceMetrics().At(0))
 
-		data, err := bm.metricsMarshaller.MarshalMetrics(metric)
+		data, err := bm.metricsMarshaller.MarshalMetrics(export)
 		if err != nil {
 			if errors.Is(err, ErrUnsupportedEncoding) {
 				return nil, err
 			}
-			errs = multierr.Append(errs, consumererror.NewMetrics(err, metric.Clone()))
+			errs = multierr.Append(errs, consumererror.NewMetrics(err, export.Clone()))
 			continue
 		}
 
-		if err := bt.AddRecord(data, bm.partitioner(metric)); err != nil {
-			errs = multierr.Append(errs, consumererror.NewMetrics(err, metric.Clone()))
+		if err := bt.AddRecord(data, bm.partitioner(export)); err != nil {
+			errs = multierr.Append(errs, consumererror.NewMetrics(err, export.Clone()))
 		}
 	}
 

--- a/exporter/awskinesisexporter/internal/batch/encode_marshaler_test.go
+++ b/exporter/awskinesisexporter/internal/batch/encode_marshaler_test.go
@@ -1,0 +1,305 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batch_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/batch"
+)
+
+func TestMarshalEncoder_Metrics(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		scenario   string
+		encoding   string
+		batchSize  int
+		recordSize int
+
+		validEncoder   bool
+		count          int
+		expectedError  bool
+		expectedChunks int
+	}{
+		{
+			scenario:     "Invalid encoding type provided",
+			encoding:     "invalid-encoding",
+			batchSize:    10,
+			recordSize:   1000,
+			validEncoder: false,
+		},
+		{
+			scenario:      "valid jaeger encoder, does not implement metrics",
+			encoding:      "jaeger",
+			batchSize:     10,
+			recordSize:    1000,
+			count:         10,
+			validEncoder:  true,
+			expectedError: true,
+		},
+		{
+			scenario:      "valid zipkin proto encoder, does not implement metrics",
+			encoding:      "zipkin-proto",
+			batchSize:     10,
+			recordSize:    1000,
+			count:         10,
+			validEncoder:  true,
+			expectedError: true,
+		},
+		{
+			scenario:      "valid zipkin json encoder, does not implement metrics",
+			encoding:      "zipkin-json",
+			batchSize:     10,
+			recordSize:    1000,
+			count:         10,
+			validEncoder:  true,
+			expectedError: true,
+		},
+		{
+			scenario:       "valid otlp proto encoder that implements metrics",
+			encoding:       "otlp-proto",
+			batchSize:      10,
+			recordSize:     100000,
+			validEncoder:   true,
+			count:          20,
+			expectedError:  false,
+			expectedChunks: 2,
+		},
+		{
+			scenario:       "valid otlp json encoder that implements metrics",
+			encoding:       "otlp-json",
+			batchSize:      10,
+			recordSize:     100000,
+			validEncoder:   true,
+			count:          20,
+			expectedError:  false,
+			expectedChunks: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			encoder, err := batch.NewEncoder(
+				tc.encoding,
+				batch.WithMaxRecordSize(tc.recordSize),
+				batch.WithMaxRecordsPerBatch(tc.batchSize),
+			)
+			if !tc.validEncoder {
+				require.ErrorIs(t, err, batch.ErrUnknownExportEncoder, "Must return the expected error when an invalid encoding is provided")
+				return
+			}
+			require.NotNil(t, encoder, "Must have a valid encoder in order to proceed")
+
+			bt, err := encoder.Metrics(NewTestMetrics(tc.count))
+			if tc.expectedError {
+				assert.ErrorIs(t, err, batch.ErrUnsupportedEncoding, "Must match the expected error value")
+				return
+			}
+			assert.NoError(t, err, "Must not have return an error processing data")
+			require.NotNil(t, bt, "Must have a valid batch")
+
+			assert.Len(t, bt.Chunk(), tc.expectedChunks, "Must have provided the expected chunk amount")
+		})
+	}
+}
+
+func TestMarshalEncoder_Traces(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		scenario   string
+		encoding   string
+		batchSize  int
+		recordSize int
+
+		validEncoder   bool
+		count          int
+		expectedChunks int
+	}{
+		{
+			scenario:     "Invalid encoding type provided",
+			encoding:     "invalid-encoding",
+			batchSize:    10,
+			recordSize:   1000,
+			validEncoder: false,
+		},
+		{
+			scenario:       "valid jaeger encoder",
+			encoding:       "jaeger",
+			batchSize:      10,
+			recordSize:     1000,
+			count:          10,
+			validEncoder:   true,
+			expectedChunks: 1,
+		},
+		{
+			scenario:       "valid zipkin proto encoder",
+			encoding:       "zipkin-proto",
+			batchSize:      10,
+			recordSize:     1000,
+			count:          10,
+			validEncoder:   true,
+			expectedChunks: 1,
+		},
+		{
+			scenario:       "valid zipkin json encoder",
+			encoding:       "zipkin-json",
+			batchSize:      10,
+			recordSize:     1000,
+			count:          10,
+			validEncoder:   true,
+			expectedChunks: 1,
+		},
+		{
+			scenario:       "valid otlp proto encoder",
+			encoding:       "otlp-proto",
+			batchSize:      10,
+			recordSize:     100000,
+			validEncoder:   true,
+			count:          20,
+			expectedChunks: 2,
+		},
+		{
+			scenario:       "valid otlp json encoder",
+			encoding:       "otlp-json",
+			batchSize:      10,
+			recordSize:     100000,
+			validEncoder:   true,
+			count:          20,
+			expectedChunks: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			encoder, err := batch.NewEncoder(
+				tc.encoding,
+				batch.WithMaxRecordSize(tc.recordSize),
+				batch.WithMaxRecordsPerBatch(tc.batchSize),
+			)
+			if !tc.validEncoder {
+				require.ErrorIs(t, err, batch.ErrUnknownExportEncoder, "Must return the expected error when an invalid encoding is provided")
+				return
+			}
+			require.NotNil(t, encoder, "Must have a valid encoder in order to proceed")
+
+			bt, err := encoder.Traces(NewTestTraces(tc.count))
+			assert.NoError(t, err, "Must not have return an error processing data")
+			require.NotNil(t, bt, "Must have a valid batch")
+
+			assert.Len(t, bt.Chunk(), tc.expectedChunks, "Must have provided the expected chunk amount")
+		})
+	}
+}
+
+func TestMarshalEncoder_Logs(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		scenario   string
+		encoding   string
+		batchSize  int
+		recordSize int
+
+		validEncoder   bool
+		count          int
+		expectedError  bool
+		expectedChunks int
+	}{
+		{
+			scenario:     "Invalid encoding type provided",
+			encoding:     "invalid-encoding",
+			batchSize:    10,
+			recordSize:   1000,
+			validEncoder: false,
+		},
+		{
+			scenario:      "valid jaeger encoder, does not implement logs",
+			encoding:      "jaeger",
+			batchSize:     10,
+			recordSize:    1000,
+			count:         10,
+			validEncoder:  true,
+			expectedError: true,
+		},
+		{
+			scenario:      "valid zipkin proto encoder, does not implement logs",
+			encoding:      "zipkin-proto",
+			batchSize:     10,
+			recordSize:    1000,
+			count:         10,
+			validEncoder:  true,
+			expectedError: true,
+		},
+		{
+			scenario:      "valid zipkin json encoder, does not implement logs",
+			encoding:      "zipkin-json",
+			batchSize:     10,
+			recordSize:    1000,
+			count:         10,
+			validEncoder:  true,
+			expectedError: true,
+		},
+		{
+			scenario:       "valid otlp proto encoder that implements logs",
+			encoding:       "otlp-proto",
+			batchSize:      10,
+			recordSize:     100000,
+			validEncoder:   true,
+			count:          20,
+			expectedError:  false,
+			expectedChunks: 2,
+		},
+		{
+			scenario:       "valid otlp json encoder that implements logs",
+			encoding:       "otlp-json",
+			batchSize:      10,
+			recordSize:     100000,
+			validEncoder:   true,
+			count:          20,
+			expectedError:  false,
+			expectedChunks: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.scenario, func(t *testing.T) {
+			encoder, err := batch.NewEncoder(
+				tc.encoding,
+				batch.WithMaxRecordSize(tc.recordSize),
+				batch.WithMaxRecordsPerBatch(tc.batchSize),
+			)
+			if !tc.validEncoder {
+				require.ErrorIs(t, err, batch.ErrUnknownExportEncoder, "Must return the expected error when an invalid encoding is provided")
+				return
+			}
+			require.NotNil(t, encoder, "Must have a valid encoder in order to proceed")
+
+			bt, err := encoder.Logs(NewTestLogs(tc.count))
+			if tc.expectedError {
+				assert.ErrorIs(t, err, batch.ErrUnsupportedEncoding, "Must match the expected error value")
+				return
+			}
+			assert.NoError(t, err, "Must not have return an error processing data")
+			require.NotNil(t, bt, "Must have a valid batch")
+
+			assert.Len(t, bt.Chunk(), tc.expectedChunks, "Must have provided the expected chunk amount")
+		})
+	}
+}

--- a/exporter/awskinesisexporter/internal/batch/encode_marshaler_test.go
+++ b/exporter/awskinesisexporter/internal/batch/encode_marshaler_test.go
@@ -46,7 +46,7 @@ func TestMarshalEncoder_Metrics(t *testing.T) {
 		},
 		{
 			scenario:      "valid jaeger encoder, does not implement metrics",
-			encoding:      "jaeger",
+			encoding:      "jaeger_proto",
 			batchSize:     10,
 			recordSize:    1000,
 			count:         10,
@@ -55,7 +55,7 @@ func TestMarshalEncoder_Metrics(t *testing.T) {
 		},
 		{
 			scenario:      "valid zipkin proto encoder, does not implement metrics",
-			encoding:      "zipkin-proto",
+			encoding:      "zipkin_proto",
 			batchSize:     10,
 			recordSize:    1000,
 			count:         10,
@@ -64,7 +64,7 @@ func TestMarshalEncoder_Metrics(t *testing.T) {
 		},
 		{
 			scenario:      "valid zipkin json encoder, does not implement metrics",
-			encoding:      "zipkin-json",
+			encoding:      "zipkin_json",
 			batchSize:     10,
 			recordSize:    1000,
 			count:         10,
@@ -73,7 +73,7 @@ func TestMarshalEncoder_Metrics(t *testing.T) {
 		},
 		{
 			scenario:       "valid otlp proto encoder that implements metrics",
-			encoding:       "otlp-proto",
+			encoding:       "otlp_proto",
 			batchSize:      10,
 			recordSize:     100000,
 			validEncoder:   true,
@@ -83,7 +83,7 @@ func TestMarshalEncoder_Metrics(t *testing.T) {
 		},
 		{
 			scenario:       "valid otlp json encoder that implements metrics",
-			encoding:       "otlp-json",
+			encoding:       "otlp_json",
 			batchSize:      10,
 			recordSize:     100000,
 			validEncoder:   true,
@@ -141,7 +141,7 @@ func TestMarshalEncoder_Traces(t *testing.T) {
 		},
 		{
 			scenario:       "valid jaeger encoder",
-			encoding:       "jaeger",
+			encoding:       "jaeger_proto",
 			batchSize:      10,
 			recordSize:     1000,
 			count:          10,
@@ -150,7 +150,7 @@ func TestMarshalEncoder_Traces(t *testing.T) {
 		},
 		{
 			scenario:       "valid zipkin proto encoder",
-			encoding:       "zipkin-proto",
+			encoding:       "zipkin_proto",
 			batchSize:      10,
 			recordSize:     1000,
 			count:          10,
@@ -159,7 +159,7 @@ func TestMarshalEncoder_Traces(t *testing.T) {
 		},
 		{
 			scenario:       "valid zipkin json encoder",
-			encoding:       "zipkin-json",
+			encoding:       "zipkin_json",
 			batchSize:      10,
 			recordSize:     1000,
 			count:          10,
@@ -168,7 +168,7 @@ func TestMarshalEncoder_Traces(t *testing.T) {
 		},
 		{
 			scenario:       "valid otlp proto encoder",
-			encoding:       "otlp-proto",
+			encoding:       "otlp_proto",
 			batchSize:      10,
 			recordSize:     100000,
 			validEncoder:   true,
@@ -177,7 +177,7 @@ func TestMarshalEncoder_Traces(t *testing.T) {
 		},
 		{
 			scenario:       "valid otlp json encoder",
-			encoding:       "otlp-json",
+			encoding:       "otlp_json",
 			batchSize:      10,
 			recordSize:     100000,
 			validEncoder:   true,
@@ -231,7 +231,7 @@ func TestMarshalEncoder_Logs(t *testing.T) {
 		},
 		{
 			scenario:      "valid jaeger encoder, does not implement logs",
-			encoding:      "jaeger",
+			encoding:      "jaeger_proto",
 			batchSize:     10,
 			recordSize:    1000,
 			count:         10,
@@ -240,7 +240,7 @@ func TestMarshalEncoder_Logs(t *testing.T) {
 		},
 		{
 			scenario:      "valid zipkin proto encoder, does not implement logs",
-			encoding:      "zipkin-proto",
+			encoding:      "zipkin_proto",
 			batchSize:     10,
 			recordSize:    1000,
 			count:         10,
@@ -249,7 +249,7 @@ func TestMarshalEncoder_Logs(t *testing.T) {
 		},
 		{
 			scenario:      "valid zipkin json encoder, does not implement logs",
-			encoding:      "zipkin-json",
+			encoding:      "zipkin_json",
 			batchSize:     10,
 			recordSize:    1000,
 			count:         10,
@@ -258,7 +258,7 @@ func TestMarshalEncoder_Logs(t *testing.T) {
 		},
 		{
 			scenario:       "valid otlp proto encoder that implements logs",
-			encoding:       "otlp-proto",
+			encoding:       "otlp_proto",
 			batchSize:      10,
 			recordSize:     100000,
 			validEncoder:   true,
@@ -268,7 +268,7 @@ func TestMarshalEncoder_Logs(t *testing.T) {
 		},
 		{
 			scenario:       "valid otlp json encoder that implements logs",
-			encoding:       "otlp-json",
+			encoding:       "otlp_json",
 			batchSize:      10,
 			recordSize:     100000,
 			validEncoder:   true,

--- a/exporter/awskinesisexporter/internal/batch/encode_unsupported.go
+++ b/exporter/awskinesisexporter/internal/batch/encode_unsupported.go
@@ -12,6 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package batch_test
+package batch
 
-// Tests for jeager encoder are part of the encode_marshaler_test.go
+import "go.opentelemetry.io/collector/model/pdata"
+
+type unsupported struct{}
+
+var (
+	_ pdata.TracesMarshaler  = (*unsupported)(nil)
+	_ pdata.MetricsMarshaler = (*unsupported)(nil)
+	_ pdata.LogsMarshaler    = (*unsupported)(nil)
+)
+
+func (unsupported) MarshalTraces(_ pdata.Traces) ([]byte, error) {
+	return nil, ErrUnsupportedEncoding
+}
+
+func (unsupported) MarshalMetrics(_ pdata.Metrics) ([]byte, error) {
+	return nil, ErrUnsupportedEncoding
+}
+
+func (unsupported) MarshalLogs(_ pdata.Logs) ([]byte, error) {
+	return nil, ErrUnsupportedEncoding
+}

--- a/exporter/awskinesisexporter/internal/batch/encoder_test.go
+++ b/exporter/awskinesisexporter/internal/batch/encoder_test.go
@@ -1,0 +1,60 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batch_test
+
+import (
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func NewTestTraces(spanCount int) pdata.Traces {
+	traces := pdata.NewTraces()
+
+	for i := 0; i < spanCount; i++ {
+		span := traces.ResourceSpans().AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans().AppendEmpty()
+		span.SetName("foo")
+		span.SetStartTimestamp(pdata.Timestamp(10))
+		span.SetEndTimestamp(pdata.Timestamp(20))
+		span.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}))
+		span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+	}
+
+	return traces
+}
+
+func NewTestMetrics(metricCount int) pdata.Metrics {
+	metrics := pdata.NewMetrics()
+
+	for i := 0; i < metricCount; i++ {
+		metric := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetName("foo")
+		metric.SetUnit("bar")
+		metric.SetDataType(pdata.MetricDataTypeGauge)
+		metric.Gauge().DataPoints().AppendEmpty().SetIntVal(int64(i))
+	}
+
+	return metrics
+}
+
+func NewTestLogs(logCount int) pdata.Logs {
+	logs := pdata.NewLogs()
+
+	for i := 0; i < logCount; i++ {
+		log := logs.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty().Logs().AppendEmpty()
+		log.SetName("foo")
+		log.SetSeverityText("bar")
+	}
+
+	return logs
+}

--- a/exporter/awskinesisexporter/internal/compress/compresser.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser.go
@@ -66,7 +66,7 @@ func NewCompressor(format string) (Compressor, error) {
 	case "noop", "none":
 		// Already the default case
 	default:
-		return nil, fmt.Errorf("uknown compression format: %s", format)
+		return nil, fmt.Errorf("unknown compression format: %s", format)
 	}
 
 	return c, nil

--- a/exporter/awskinesisexporter/internal/compress/compresser.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser.go
@@ -1,0 +1,89 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compress
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
+	"fmt"
+	"io"
+)
+
+type bufferedResetWriter interface {
+	Write(p []byte) (int, error)
+	Flush() error
+	Reset(new io.Writer)
+}
+
+type Compressor interface {
+	Do(in []byte) (out []byte, err error)
+}
+
+var _ Compressor = (*compressor)(nil)
+
+type compressor struct {
+	compression bufferedResetWriter
+}
+
+func NewCompressor(format string) (Compressor, error) {
+	c := &compressor{
+		compression: &noop{},
+	}
+	switch format {
+	case "flate":
+		w, err := flate.NewWriter(nil, flate.BestSpeed)
+		if err != nil {
+			return nil, err
+		}
+		c.compression = w
+	case "gzip":
+		w, err := gzip.NewWriterLevel(nil, gzip.BestSpeed)
+		if err != nil {
+			return nil, err
+		}
+		c.compression = w
+
+	case "zlib":
+		w, err := zlib.NewWriterLevel(nil, zlib.BestSpeed)
+		if err != nil {
+			return nil, err
+		}
+		c.compression = w
+	case "noop", "none":
+		// Already the default case
+	default:
+		return nil, fmt.Errorf("uknown compression format: %s", format)
+	}
+
+	return c, nil
+}
+
+func (c *compressor) Do(in []byte) ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	c.compression.Reset(buf)
+
+	if _, err := c.compression.Write(in); err != nil {
+		return nil, err
+	}
+
+	if err := c.compression.Flush(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/exporter/awskinesisexporter/internal/compress/compresser_test.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser_test.go
@@ -1,0 +1,111 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compress_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/compress"
+)
+
+func TestCompressorFormats(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		format string
+	}{
+		{format: "none"},
+		{format: "noop"},
+		{format: "gzip"},
+		{format: "zlib"},
+		{format: "flate"},
+	}
+
+	const data = "You know nothing Jon Snow"
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("format_%s", tc.format), func(t *testing.T) {
+			c, err := compress.NewCompressor(tc.format)
+			require.NoError(t, err, "Must have a valid compression format")
+			require.NotNil(t, c, "Must have a valid compressor")
+
+			out, err := c.Do([]byte(data))
+			assert.NoError(t, err, "Must not error when processing data")
+			assert.NotNil(t, out, "Must have a valid record")
+		})
+	}
+	_, err := compress.NewCompressor("invalid-format")
+	assert.Error(t, err, "Must error when an invalid compression format is given")
+}
+
+func BenchmarkNoopCompressor_1000Bytes(b *testing.B) {
+	benchmarkCompressor(b, "none", 1000)
+}
+
+func BenchmarkNoopCompressor_1Mb(b *testing.B) {
+	benchmarkCompressor(b, "noop", 131072)
+}
+
+func BenchmarkZlibCompressor_1000Bytes(b *testing.B) {
+	benchmarkCompressor(b, "zlib", 1000)
+}
+
+func BenchmarkZlibCompressor_1Mb(b *testing.B) {
+	benchmarkCompressor(b, "zlib", 131072)
+}
+
+func BenchmarkFlateCompressor_1000Bytes(b *testing.B) {
+	benchmarkCompressor(b, "flate", 1000)
+}
+
+func BenchmarkFlateCompressor_1Mb(b *testing.B) {
+	benchmarkCompressor(b, "flate", 131072)
+}
+
+func BenchmarkGzipCompressor_1000Bytes(b *testing.B) {
+	benchmarkCompressor(b, "gzip", 1000)
+}
+
+func BenchmarkGzipCompressor_1Mb(b *testing.B) {
+	benchmarkCompressor(b, "gzip", 131072)
+}
+
+func benchmarkCompressor(b *testing.B, format string, len int) {
+	b.Helper()
+
+	rand.Seed(time.Now().UnixMilli())
+
+	compressor, err := compress.NewCompressor(format)
+	require.NoError(b, err, "Must not error when given a valid format")
+	require.NotNil(b, compressor, "Must have a valid compressor")
+
+	data := make([]byte, len)
+	for i := 0; i < len; i++ {
+		data[i] = byte(rand.Int31())
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		out, err := compressor.Do(data)
+		assert.NoError(b, err, "Must not error when processing data")
+		assert.NotNil(b, out, "Must have a valid byte array after")
+	}
+}

--- a/exporter/awskinesisexporter/internal/compress/noop_compression.go
+++ b/exporter/awskinesisexporter/internal/compress/noop_compression.go
@@ -12,6 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package batch_test
+package compress
 
-// Tests for jeager encoder are part of the encode_marshaler_test.go
+import "io"
+
+type noop struct {
+	data io.Writer
+}
+
+func NewNoopCompressor() Compressor {
+	return &compressor{
+		compression: &noop{},
+	}
+}
+
+func (n *noop) Reset(w io.Writer) {
+	n.data = w
+}
+
+func (n noop) Write(p []byte) (int, error) {
+	return n.data.Write(p)
+}
+
+func (n noop) Flush() error {
+	return nil
+}

--- a/exporter/awskinesisexporter/internal/key/key.go
+++ b/exporter/awskinesisexporter/internal/key/key.go
@@ -12,6 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package batch_test
+package key
 
-// Tests for jeager encoder are part of the encode_marshaler_test.go
+import (
+	"github.com/google/uuid"
+)
+
+// Partition allows for switching our partitioning behavior
+// when sending data to kinesis.
+type Partition func(v interface{}) string
+
+func Randomized(_ interface{}) string {
+	return uuid.NewString()
+}

--- a/exporter/awskinesisexporter/internal/key/key_test.go
+++ b/exporter/awskinesisexporter/internal/key/key_test.go
@@ -12,6 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package batch_test
+package key_test
 
-// Tests for jeager encoder are part of the encode_marshaler_test.go
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/key"
+)
+
+func TestEnsureDifferentKeys(t *testing.T) {
+	t.Parallel()
+
+	k := key.Randomized(nil)
+	assert.NotEmpty(t, k, "Must have a string that has a value")
+	assert.NotEqual(t, k, key.Randomized(nil), "Must have different string values")
+}

--- a/exporter/awskinesisexporter/internal/producer/batcher_bench_test.go
+++ b/exporter/awskinesisexporter/internal/producer/batcher_bench_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -36,7 +35,7 @@ func benchXEmptyMessages(b *testing.B, msgCount int) {
 
 	bt := batch.New()
 	for i := 0; i < msgCount; i++ {
-		assert.NoError(b, bt.AddProtobufV1(new(empty.Empty), "fixed-key"))
+		assert.NoError(b, bt.AddRecord([]byte("foobar"), "fixed-key"))
 	}
 
 	b.ReportAllocs()

--- a/exporter/awskinesisexporter/internal/producer/batcher_test.go
+++ b/exporter/awskinesisexporter/internal/producer/batcher_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -98,7 +97,7 @@ func TestBatchedExporter(t *testing.T) {
 
 	bt := batch.New()
 	for i := 0; i < 500; i++ {
-		assert.NoError(t, bt.AddProtobufV1(new(empty.Empty), "fixed-key"))
+		assert.NoError(t, bt.AddRecord([]byte("foobar"), "fixed-key"))
 	}
 
 	for _, tc := range cases {

--- a/exporter/awskinesisexporter/testdata/config.yaml
+++ b/exporter/awskinesisexporter/testdata/config.yaml
@@ -12,6 +12,8 @@ exporters:
         kinesis_endpoint: awskinesis.mars-1.aws.galactic
     retry_on_failure:
       enabled: false
+    encoding:
+      name: otlp-proto
 
 
 processors:

--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20210621150501-ff58416a0b02
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.36.1-0.20211004155959-190f8fbb2b9a
-	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6
 )
 
 require github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver v0.0.0-00010101000000-000000000000

--- a/go.mod
+++ b/go.mod
@@ -351,7 +351,7 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20210920023735-84f357641f63 // indirect
-	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf // indirect
+	golang.org/x/net v0.0.0-20210927181540-4e4d966f7476 // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect

--- a/go.mod
+++ b/go.mod
@@ -360,7 +360,7 @@ require (
 	gonum.org/v1/gonum v0.9.3 // indirect
 	google.golang.org/api v0.58.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0 // indirect
+	google.golang.org/genproto v0.0.0-20210927142257-433400c27d05 // indirect
 	google.golang.org/grpc v1.41.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/DataDog/dd-trace-go.v1 v1.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2340,8 +2340,9 @@ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210716203947-853a461950ff/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210917221730-978cfadd31cf h1:R150MpwJIv1MpS0N/pc+NhTM8ajzvlmxlY5OYsrevXQ=
 golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210927181540-4e4d966f7476 h1:s5hu7bTnLKswvidgtqc4GwsW83m9LZu8UAqzmWOZtI4=
+golang.org/x/net v0.0.0-20210927181540-4e4d966f7476/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -2507,8 +2508,9 @@ golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210902050250-f475640dd07b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 h1:J27LZFQBFoihqXoegpscI10HpjZ7B5WQLLKL2FZXQKw=
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
@@ -2797,8 +2799,9 @@ google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2/go.mod h1:eFjDcFEc
 google.golang.org/genproto v0.0.0-20210903162649-d08c68adba83/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210909211513-a8c4777a87af/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210917145530-b395a37504d4/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
-google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0 h1:5Tbluzus3QxoAJx4IefGt1W0HQZW4nuMrVk684jI74Q=
 google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20210927142257-433400c27d05 h1:6/1QShroBaS9sY9NbPquolxRETG6PZhfv8ohdbLieBg=
+google.golang.org/genproto v0.0.0-20210927142257-433400c27d05/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=


### PR DESCRIPTION
**Description:**
This updates the current kinesis exporter to include configurable export formats used to send data to kinesis.



**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1305

**Testing:**
All changes have accompanying unit tests and mock tests where possible. 

**Documentation:**
The kinesis exporter Readme has been updated to include the respective changes.