### PR TITLE
[k8sattributes processor] Remove redundant block

### DIFF
--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -107,11 +107,6 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pda
 		resource.Attributes().InsertString(podIdentifierKey, string(podIdentifierValue))
 	}
 
-	namespace := stringAttributeFromMap(resource.Attributes(), conventions.AttributeK8SNamespaceName)
-	if namespace != "" {
-		resource.Attributes().InsertString(conventions.AttributeK8SNamespaceName, namespace)
-	}
-
 	if kp.passthroughMode {
 		return
 	}
@@ -123,6 +118,7 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pda
 		}
 	}
 
+	namespace := stringAttributeFromMap(resource.Attributes(), conventions.AttributeK8SNamespaceName)
 	if namespace != "" {
 		attrsToAdd := kp.getAttributesForPodsNamespace(namespace)
 		for key, val := range attrsToAdd {


### PR DESCRIPTION
Remove redundant block that adds namespace attribute to the map where it was just taken from, and also move the namespace fetching closer to the usage.
