### PR TITLE
increase test timeout to 300s to pass opencensus

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -14,7 +14,7 @@ ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))) 2>/dev/null)
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
-GOTEST_OPT?= -race -timeout 60s --tags=$(GO_BUILD_TAGS)
+GOTEST_OPT?= -race -timeout 300s --tags=$(GO_BUILD_TAGS)
 GOTEST_INTEGRATION_OPT?= -race -timeout 60s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic


### PR DESCRIPTION
**Description:** Following up https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5243 the `make` commands fails on `opencensus` receiver caused by timeout.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5243#issuecomment-920136717

**Testing:** Run `make` command

**Documentation:** no change

**Additional information:** here is an example of duration on my laptop:

```
time make -C ./receiver/opencensusreceiver test
make: Entering directory '/home/qmanfroi/git/signalfx/opentelemetry-collector-contrib/receiver/opencensusreceiver'
go test -race -timeout 300s --tags=containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper ./...
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver   140.310s
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver/internal/ocmetrics        0.329s
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver/internal/octrace  0.614s
make: Leaving directory '/home/qmanfroi/git/signalfx/opentelemetry-collector-contrib/receiver/opencensusreceiver'

real    2m21.503s
user    0m4.198s
sys     0m1.047s
```

here is the specification of my laptop:
* CPU: Intel(R) Core(TM) i7-8550U CPU
* Memory: 16GB
* Disk: PM981 NVMe Samsung 512GB
* OS: Arch Linux