### PR TITLE
[exporter/datadogexporter] Scrub sensitive information from errors

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -133,7 +133,7 @@ func createMetricsExporter(
 			return nil
 		}
 	} else {
-		pushMetricsFn = newMetricsExporter(ctx, set, cfg).PushMetricsData
+		pushMetricsFn = newMetricsExporter(ctx, set, cfg).PushMetricsDataScrubbed
 	}
 
 	exporter, err := exporterhelper.NewMetricsExporter(
@@ -186,7 +186,7 @@ func createTracesExporter(
 			return nil
 		}
 	} else {
-		pushTracesFn = newTracesExporter(ctx, set, cfg).pushTraceData
+		pushTracesFn = newTracesExporter(ctx, set, cfg).pushTraceDataScrubbed
 	}
 
 	return exporterhelper.NewTracesExporter(

--- a/exporter/datadogexporter/internal/scrub/scrub.go
+++ b/exporter/datadogexporter/internal/scrub/scrub.go
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scrub
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ErrorScrubber scrubs error from sensitive details
+type Scrubber interface {
+	// Scrub sensitive data from an error.
+	Scrub(error) error
+}
+
+// replacer structure to store regex matching and replacement functions
+type replacer struct {
+	Regex *regexp.Regexp
+	Hints []string // If any of these hints do not exist in the line, then we know the regex wont match either
+	Repl  string
+}
+
+var _ error = (*scrubbedError)(nil)
+
+// scrubbedError wraps an error and scrubs its `Error()` output.
+type scrubbedError struct {
+	err      error
+	scrubbed string
+}
+
+func (s *scrubbedError) Error() string {
+	return s.scrubbed
+}
+
+func (s *scrubbedError) Unwrap() error {
+	return s.err
+}
+
+var _ Scrubber = (*scrubber)(nil)
+
+// scrubber scrubs sensitive information from logs
+type scrubber struct {
+	replacers []replacer
+}
+
+func NewScrubber() Scrubber {
+	return &scrubber{
+		replacers: []replacer{
+			{
+				// If hinted, mask the value regardless if it doesn't match 32-char hexadecimal string
+				Regex: regexp.MustCompile(`(api_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
+				Hints: []string{"api_key", "apikey"},
+				Repl:  `$1***************************$2`,
+			},
+			{
+				// If hinted, mask the value regardless if it doesn't match 40-char hexadecimal string
+				Regex: regexp.MustCompile(`(ap(?:p|plication)_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
+				Hints: []string{"app_key", "appkey", "application_key"},
+				Repl:  `$1***********************************$2`,
+			},
+			{
+				Regex: regexp.MustCompile(`\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
+				Repl:  `***************************$1`,
+			},
+			{
+				Regex: regexp.MustCompile(`\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b`),
+				Repl:  `***********************************$1`,
+			},
+		},
+	}
+}
+
+func (s *scrubber) Scrub(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &scrubbedError{err, s.scrubStr(err.Error())}
+}
+
+// Scrub sensitive details from a string.
+func (s *scrubber) scrubStr(data string) string {
+	for _, repl := range s.replacers {
+		containsHint := false
+		for _, hint := range repl.Hints {
+			if strings.Contains(data, hint) {
+				containsHint = true
+				break
+			}
+		}
+		if len(repl.Hints) == 0 || containsHint {
+			data = repl.Regex.ReplaceAllString(data, repl.Repl)
+		}
+	}
+	return data
+}

--- a/exporter/datadogexporter/internal/scrub/scrub.go
+++ b/exporter/datadogexporter/internal/scrub/scrub.go
@@ -18,13 +18,13 @@ import (
 	"regexp"
 )
 
-// ErrorScrubber scrubs error from sensitive details
+// Scrubber scrubs error from sensitive details.
 type Scrubber interface {
 	// Scrub sensitive data from an error.
 	Scrub(error) error
 }
 
-// replacer structure to store regex matching and replacement functions
+// replacer structure to store regex matching and replacement functions.
 type replacer struct {
 	Regex *regexp.Regexp
 	Repl  string
@@ -56,20 +56,24 @@ type scrubber struct {
 func NewScrubber() Scrubber {
 	return &scrubber{
 		replacers: []replacer{
+			// API key as URL parameter (api_key=<API KEY> or apikey=<API KEY>).
+			// Any alphanumeric string gets censored, even if not 32 characters long.
 			{
-				// If hinted, mask the value regardless if it doesn't match 32-char hexadecimal string
 				Regex: regexp.MustCompile(`(api_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
 				Repl:  `$1***************************$2`,
 			},
+			// Application key as URL parameter (api_key=<API KEY> or apikey=<API KEY>).
+			// Any alphanumeric string gets censored, even if not 40 characters long.
 			{
-				// If hinted, mask the value regardless if it doesn't match 40-char hexadecimal string
 				Regex: regexp.MustCompile(`(ap(?:p|plication)_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
 				Repl:  `$1***********************************$2`,
 			},
+			// API key in any place (32 character long alphanumeric ASCII string).
 			{
 				Regex: regexp.MustCompile(`\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
 				Repl:  `***************************$1`,
 			},
+			// Application key in any place (40 character long alphanumeric ASCII string).
 			{
 				Regex: regexp.MustCompile(`\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b`),
 				Repl:  `***********************************$1`,

--- a/exporter/datadogexporter/internal/scrub/scrub_test.go
+++ b/exporter/datadogexporter/internal/scrub/scrub_test.go
@@ -63,14 +63,15 @@ func TestScrubber(t *testing.T) {
 	scrubber := NewScrubber()
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, scrubber.Scrub(errors.New(test.original)).Error())
+			assert.EqualError(t, scrubber.Scrub(errors.New(test.original)), test.expected)
 		})
 	}
 }
 
 func TestPermanentErrorScrub(t *testing.T) {
-	err := consumererror.NewPermanent(errors.New("this is an error"))
+	err := consumererror.NewPermanent(errors.New("this is an error with an app key AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBB"))
 	scrubber := NewScrubber()
 	err = scrubber.Scrub(err)
 	assert.True(t, consumererror.IsPermanent(err))
+	assert.EqualError(t, err, "Permanent error: this is an error with an app key ***********************************ABBBB")
 }

--- a/exporter/datadogexporter/internal/scrub/scrub_test.go
+++ b/exporter/datadogexporter/internal/scrub/scrub_test.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scrub
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+)
+
+func TestScrubber(t *testing.T) {
+	tests := []struct {
+		name     string
+		original string
+		expected string
+	}{
+		{
+			name:     "no scrub",
+			original: "This is an error",
+			expected: "This is an error",
+		},
+		{
+			name:     "no scrub (container id)",
+			original: "container id: b32bd6f9b73ba7ccb64953a04b82b48e29dfafab65fd57ca01d3b94a0e024885",
+			expected: "container id: b32bd6f9b73ba7ccb64953a04b82b48e29dfafab65fd57ca01d3b94a0e024885",
+		},
+		{
+			name:     "api key (as parameter)",
+			original: "Post \"https://api.datadoghq.com/api/v1/series?api_key=aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb&application_key=\": EOF",
+			expected: "Post \"https://api.datadoghq.com/api/v1/series?api_key=***************************abbbb&application_key=\": EOF",
+		},
+		{
+			name:     "api key",
+			original: "aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb something aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb",
+			expected: "***************************abbbb something ***************************abbbb",
+		},
+		{
+			name:     "app key (as parameter)",
+			original: "Failed to connect to http://something?app_key=reallylong40characterssecretkeygoeshere",
+			expected: "Failed to connect to http://something?app_key=***********************************shere",
+		},
+		{
+			name:     "app key",
+			original: "should scrub: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBB",
+			expected: "should scrub: ***********************************ABBBB",
+		},
+	}
+
+	scrubber := NewScrubber()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, scrubber.Scrub(errors.New(test.original)).Error())
+		})
+	}
+}
+
+func TestPermanentErrorScrub(t *testing.T) {
+	err := consumererror.NewPermanent(errors.New("this is an error"))
+	scrubber := NewScrubber()
+	err = scrubber.Scrub(err)
+	assert.True(t, consumererror.IsPermanent(err))
+}

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -29,17 +29,19 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metrics"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/scrub"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/sketches"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/utils"
 )
 
 type metricsExporter struct {
-	params component.ExporterCreateSettings
-	cfg    *config.Config
-	ctx    context.Context
-	client *datadog.Client
-	tr     *translator.Translator
+	params   component.ExporterCreateSettings
+	cfg      *config.Config
+	ctx      context.Context
+	client   *datadog.Client
+	tr       *translator.Translator
+	scrubber scrub.Scrubber
 }
 
 // assert `hostProvider` implements HostnameProvider interface
@@ -67,7 +69,14 @@ func newMetricsExporter(ctx context.Context, params component.ExporterCreateSett
 	}
 	prevPts := translator.NewTTLCache(sweepInterval, cfg.Metrics.DeltaTTL)
 	tr := translator.New(prevPts, params, cfg.Metrics, &hostProvider{params.Logger, cfg})
-	return &metricsExporter{params, cfg, ctx, client, tr}
+	return &metricsExporter{
+		params:   params,
+		cfg:      cfg,
+		ctx:      ctx,
+		client:   client,
+		tr:       tr,
+		scrubber: scrub.NewScrubber(),
+	}
 }
 
 func (exp *metricsExporter) pushSketches(ctx context.Context, sl sketches.SketchSeriesList) error {
@@ -98,6 +107,10 @@ func (exp *metricsExporter) pushSketches(ctx context.Context, sl sketches.Sketch
 		return fmt.Errorf("error when sending payload to %s: %s", sketches.SketchSeriesEndpoint, resp.Status)
 	}
 	return nil
+}
+
+func (exp *metricsExporter) PushMetricsDataScrubbed(ctx context.Context, md pdata.Metrics) error {
+	return exp.scrubber.Scrub(exp.PushMetricsData(ctx, md))
 }
 
 func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pdata.Metrics) error {

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/scrub"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/utils"
 )
 
@@ -39,6 +40,7 @@ type traceExporter struct {
 	obfuscator     *obfuscate.Obfuscator
 	client         *datadog.Client
 	denylister     *denylister
+	scrubber       scrub.Scrubber
 }
 
 var (
@@ -79,6 +81,7 @@ func newTracesExporter(ctx context.Context, params component.ExporterCreateSetti
 		obfuscator:     obfuscator,
 		client:         client,
 		denylister:     denylister,
+		scrubber:       scrub.NewScrubber(),
 	}
 
 	return exporter
@@ -94,6 +97,10 @@ func newTracesExporter(ctx context.Context, params component.ExporterCreateSetti
 // func (exp *traceExporter) Start(_ context.Context, _ component.Host) error {
 // 	return nil
 // }
+
+func (exp *traceExporter) pushTraceDataScrubbed(ctx context.Context, td pdata.Traces) error {
+	return exp.scrubber.Scrub(exp.pushTraceData(ctx, td))
+}
 
 func (exp *traceExporter) pushTraceData(
 	ctx context.Context,

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/pb"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumerhelper"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
 	"gopkg.in/zorkian/go-datadog-api.v2"
@@ -101,6 +102,9 @@ func newTracesExporter(ctx context.Context, params component.ExporterCreateSetti
 func (exp *traceExporter) pushTraceDataScrubbed(ctx context.Context, td pdata.Traces) error {
 	return exp.scrubber.Scrub(exp.pushTraceData(ctx, td))
 }
+
+// force pushTraceData to be a ConsumeTracesFunc, even if no error is returned.
+var _ consumerhelper.ConsumeTracesFunc = (*traceExporter)(nil).pushTraceData
 
 func (exp *traceExporter) pushTraceData(
 	ctx context.Context,


### PR DESCRIPTION
**Description:** 

Scrub sensitive information from errors returned by the exporter, so that credentials don't get accidentally logged (e.g. in network errors). Inspired by [similar functionality in the Datadog Agent](https://github.com/DataDog/datadog-agent/blob/7.31.1/pkg/util/log/strip.go).

**Link to tracking Issue:** n/a

**Testing:** Added unit tests.
