### PR TITLE
Modify health check extension to add new metrics health check functions

### DIFF
--- a/extension/healthcheckextension/README.md
+++ b/extension/healthcheckextension/README.md
@@ -4,16 +4,33 @@ Health Check extension enables an HTTP url that can be probed to check the
 status of the OpenTelemetry Collector. This extension can be used as a
 liveness and/or readiness probe on Kubernetes.
 
+There is an optional configuration `check_collector_pipeline` which allows
+users to enable health check for the collector pipeline. This feature can
+monitor the number of times that components failed send data to the destinations.
+It only supports monitoring exporter failures and will support receivers and
+processors in the future.
+
 The following settings are required:
 
 - `endpoint` (default = 0.0.0.0:13133): Address to publish the health check status to
 - `port` (default = 13133): [deprecated] What port to expose HTTP health information.
+- `check_collector_pipeline:` (optional): Settings of collector pipeline health check
+    - `enabled` (default = false): Whether enable collector pipeline check or not
+    - `interval` (default = "5m"): Time interval to check the number of failures
+    - `exporter_failure_threshold` (default = 5): The failure number threshold to mark
+      containers as healthy.
 
 Example:
 
 ```yaml
 extensions:
   health_check:
+  health_check/1:
+    endpoint: "localhost:13"
+    check_collector_pipeline:
+      enabled: true
+      interval: "5m"
+      exporter_failure_threshold: 5
 ```
 
 The full list of settings exposed for this exporter is documented [here](./config.go)

--- a/extension/healthcheckextension/config.go
+++ b/extension/healthcheckextension/config.go
@@ -15,6 +15,9 @@
 package healthcheckextension
 
 import (
+	"errors"
+	"time"
+
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confignet"
 )
@@ -33,11 +36,37 @@ type Config struct {
 	// check status.
 	// The default endpoint is "0.0.0.0:13133".
 	TCPAddr confignet.TCPAddr `mapstructure:",squash"`
+
+	// CheckCollectorPipeline contains the list of settings of collector pipeline health check
+	CheckCollectorPipeline checkCollectorPipelineSettings `mapstructure:"check_collector_pipeline"`
 }
 
 var _ config.Extension = (*Config)(nil)
+var (
+	errNoEndpointProvided                      = errors.New("bad config: endpoint must be specified")
+	errInvalidExporterFailureThresholdProvided = errors.New("bad config: exporter_failure_threshold expects a positive number")
+)
 
 // Validate checks if the extension configuration is valid
 func (cfg *Config) Validate() error {
+	_, err := time.ParseDuration(cfg.CheckCollectorPipeline.Interval)
+	if err != nil {
+		return err
+	}
+	if cfg.TCPAddr.Endpoint == "" {
+		return errNoEndpointProvided
+	}
+	if cfg.CheckCollectorPipeline.ExporterFailureThreshold <= 0 {
+		return errInvalidExporterFailureThresholdProvided
+	}
 	return nil
+}
+
+type checkCollectorPipelineSettings struct {
+	// Enabled indicates whether to not enable collector pipeline check.
+	Enabled bool `mapstructure:"enabled"`
+	// Interval the time range to check healthy status of collector pipeline
+	Interval string `mapstructure:"interval"`
+	// ExporterFailureThreshold is the threshold of exporter failure numbers during the Interval
+	ExporterFailureThreshold int `mapstructure:"exporter_failure_threshold"`
 }

--- a/extension/healthcheckextension/exporter.go
+++ b/extension/healthcheckextension/exporter.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheckextension
+
+import (
+	"sync"
+	"time"
+
+	"go.opencensus.io/stats/view"
+)
+
+const (
+	exporterFailureView = "exporter/send_failed_requests"
+)
+
+// healthCheckExporter is a struct implement the exporter interface in open census that could export metrics
+type healthCheckExporter struct {
+	mu                   sync.Mutex
+	exporterFailureQueue []*view.Data
+}
+
+func newHealthCheckExporter() *healthCheckExporter {
+	return &healthCheckExporter{}
+}
+
+// ExportView function could export the failure view to the queue
+func (e *healthCheckExporter) ExportView(vd *view.Data) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if vd.View.Name == exporterFailureView {
+		e.exporterFailureQueue = append(e.exporterFailureQueue, vd)
+	}
+}
+
+func (e *healthCheckExporter) checkHealthStatus(exporterFailureThreshold int) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return exporterFailureThreshold >= len(e.exporterFailureQueue)
+}
+
+// rotate function could rotate the error logs that expired the time interval
+func (e *healthCheckExporter) rotate(interval time.Duration) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	viewNum := len(e.exporterFailureQueue)
+	currentTime := time.Now()
+	for i := 0; i < viewNum; i++ {
+		vd := e.exporterFailureQueue[0]
+		if vd.Start.Add(interval).After(currentTime) {
+			e.exporterFailureQueue = append(e.exporterFailureQueue, vd)
+		}
+		e.exporterFailureQueue = e.exporterFailureQueue[1:]
+	}
+}

--- a/extension/healthcheckextension/exporter_test.go
+++ b/extension/healthcheckextension/exporter_test.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheckextension
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/stats/view"
+)
+
+func TestHealthCheckExporter_ExportView(t *testing.T) {
+	exporter := &healthCheckExporter{}
+	newView := view.View{Name: exporterFailureView}
+	vd := &view.Data{
+		View:  &newView,
+		Start: time.Time{},
+		End:   time.Time{},
+		Rows:  nil,
+	}
+	exporter.ExportView(vd)
+	assert.Equal(t, 1, len(exporter.exporterFailureQueue))
+}
+
+func TestHealthCheckExporter_rotate(t *testing.T) {
+	exporter := &healthCheckExporter{}
+	currentTime := time.Now()
+	time1 := currentTime.Add(-10 * time.Minute)
+	time2 := currentTime.Add(-3 * time.Minute)
+	newView := view.View{Name: exporterFailureView}
+	vd1 := &view.Data{
+		View:  &newView,
+		Start: time1,
+		End:   currentTime,
+		Rows:  nil,
+	}
+	vd2 := &view.Data{
+		View:  &newView,
+		Start: time2,
+		End:   currentTime,
+		Rows:  nil,
+	}
+	exporter.ExportView(vd1)
+	exporter.ExportView(vd2)
+	assert.Equal(t, 2, len(exporter.exporterFailureQueue))
+	exporter.rotate(5 * time.Minute)
+	assert.Equal(t, 1, len(exporter.exporterFailureQueue))
+}

--- a/extension/healthcheckextension/factory.go
+++ b/extension/healthcheckextension/factory.go
@@ -46,6 +46,7 @@ func createDefaultConfig() config.Extension {
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: defaultEndpoint,
 		},
+		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 	}
 }
 
@@ -53,4 +54,13 @@ func createExtension(_ context.Context, set component.ExtensionCreateSettings, c
 	config := cfg.(*Config)
 
 	return newServer(*config, set.Logger), nil
+}
+
+// defaultCheckCollectorPipelineSettings returns the default settings for CheckCollectorPipeline.
+func defaultCheckCollectorPipelineSettings() checkCollectorPipelineSettings {
+	return checkCollectorPipelineSettings{
+		Enabled:                  false,
+		Interval:                 "5m",
+		ExporterFailureThreshold: 5,
+	}
 }

--- a/extension/healthcheckextension/factory_test.go
+++ b/extension/healthcheckextension/factory_test.go
@@ -35,6 +35,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: defaultEndpoint,
 		},
+		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 	}, cfg)
 
 	assert.NoError(t, configtest.CheckConfigStruct(cfg))

--- a/extension/healthcheckextension/go.mod
+++ b/extension/healthcheckextension/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/jaegertracing/jaeger v1.27.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.38.0
 	github.com/stretchr/testify v1.7.0
+	go.opencensus.io v0.23.0
 	go.opentelemetry.io/collector v0.38.0
 	go.uber.org/zap v1.19.1
 

--- a/extension/healthcheckextension/go.sum
+++ b/extension/healthcheckextension/go.sum
@@ -318,6 +318,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -1092,6 +1093,7 @@ golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/extension/healthcheckextension/healthcheckextension_test.go
+++ b/extension/healthcheckextension/healthcheckextension_test.go
@@ -20,9 +20,11 @@ import (
 	"net/http"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
@@ -31,11 +33,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testutil"
 )
 
-func TestHealthCheckExtensionUsage(t *testing.T) {
+func TestHealthCheckExtensionUsageWithoutCheckCollectorPipeline(t *testing.T) {
 	config := Config{
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
+		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 	}
 
 	hcExt := newServer(config, zap.NewNop())
@@ -68,6 +71,70 @@ func TestHealthCheckExtensionUsage(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, resp2.StatusCode)
 }
 
+func TestHealthCheckExtensionUsageWithCheckCollectorPipeline(t *testing.T) {
+	config := Config{
+		TCPAddr: confignet.TCPAddr{
+			Endpoint: testutil.GetAvailableLocalAddress(t),
+		},
+		CheckCollectorPipeline: checkCollectorPipelineSettings{
+			Enabled:                  true,
+			Interval:                 "5m",
+			ExporterFailureThreshold: 1,
+		},
+	}
+
+	hcExt := newServer(config, zap.NewNop())
+	require.NotNil(t, hcExt)
+
+	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
+	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
+
+	// Give a chance for the server goroutine to run.
+	runtime.Gosched()
+
+	newView := view.View{Name: exporterFailureView}
+
+	currentTime := time.Now()
+	vd1 := &view.Data{
+		View:  &newView,
+		Start: currentTime.Add(-2 * time.Minute),
+		End:   currentTime,
+		Rows:  nil,
+	}
+	vd2 := &view.Data{
+		View:  &newView,
+		Start: currentTime.Add(-1 * time.Minute),
+		End:   currentTime,
+		Rows:  nil,
+	}
+
+	client := &http.Client{}
+	url := "http://" + config.TCPAddr.Endpoint
+	resp0, err := client.Get(url)
+	require.NoError(t, err)
+	defer resp0.Body.Close()
+
+	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd1)
+	require.NoError(t, hcExt.Ready())
+	resp1, err := client.Get(url)
+	require.NoError(t, err)
+	defer resp1.Body.Close()
+	require.Equal(t, http.StatusOK, resp1.StatusCode)
+
+	require.NoError(t, hcExt.NotReady())
+	resp2, err := client.Get(url)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp2.StatusCode)
+
+	hcExt.exporter.exporterFailureQueue = append(hcExt.exporter.exporterFailureQueue, vd2)
+	require.NoError(t, hcExt.Ready())
+	resp3, err := client.Get(url)
+	require.NoError(t, err)
+	defer resp3.Body.Close()
+	require.Equal(t, http.StatusInternalServerError, resp3.StatusCode)
+}
+
 func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
 	endpoint := testutil.GetAvailableLocalAddress(t)
 
@@ -82,6 +149,7 @@ func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: endpoint,
 		},
+		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 	}
 	hcExt := newServer(config, zap.NewNop())
 	require.NotNil(t, hcExt)
@@ -95,6 +163,7 @@ func TestHealthCheckMultipleStarts(t *testing.T) {
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
+		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 	}
 
 	hcExt := newServer(config, zap.NewNop())
@@ -112,6 +181,7 @@ func TestHealthCheckMultipleShutdowns(t *testing.T) {
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
+		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 	}
 
 	hcExt := newServer(config, zap.NewNop())
@@ -127,6 +197,7 @@ func TestHealthCheckShutdownWithoutStart(t *testing.T) {
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
+		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 	}
 
 	hcExt := newServer(config, zap.NewNop())

--- a/extension/healthcheckextension/testdata/config_bad.yaml
+++ b/extension/healthcheckextension/testdata/config_bad.yaml
@@ -1,11 +1,17 @@
 extensions:
   health_check:
-  health_check/1:
-    endpoint: "localhost:13"
+  health_check/missingendpoint:
+    endpoint: ""
     check_collector_pipeline:
       enabled: false
       interval: "5m"
       exporter_failure_threshold: 5
+  health_check/invalidthreshold:
+    endpoint: "localhost:13"
+    check_collector_pipeline:
+      enabled: false
+      interval: "5m"
+      exporter_failure_threshold: -1
 
 service:
   extensions: [health_check/1]


### PR DESCRIPTION
**Description:** 
This is a new health check method which allow customers to monitor the health status of containers based on the exporter functionally failures. It will return a 200/500 status when call the endpoint based on if the components can send data to the destination properly. Currently it only supports monitoring the exporter health status, will also support receivers and processors in the future.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2573

**Testing:** 
`make otelcontribcol` and run executable file

**Documentation:** 
https://docs.google.com/document/d/1SpUMsWA2DeaoVazeQ8uEc1Wvu5LphmQU_TjzLmuJ4QM/edit#heading=h.rs1luwizct2w

original pr was creating a new health check extension, but some community members think we should add the new feature in the existing one. Had discussion with @bogdandrutu and @Aneurysm9 and create this new pr.
previous pr:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5144