### PR TITLE
[StatsD receiver fix]: Set quantiles for metrics in StatsD receiver 

### DIFF
--- a/receiver/statsdreceiver/protocol/metric_translator.go
+++ b/receiver/statsdreceiver/protocol/metric_translator.go
@@ -83,7 +83,7 @@ func buildSummaryMetric(summaryMetric summaryMetric) pdata.InstrumentationLibrar
 	quantile := []float64{0, 10, 50, 90, 95, 100}
 	for _, v := range quantile {
 		eachQuantile := dp.QuantileValues().AppendEmpty()
-		eachQuantile.SetQuantile(v/100)
+		eachQuantile.SetQuantile(v / 100)
 		eachQuantileValue, _ := stats.PercentileNearestRank(summaryMetric.summaryPoints, v)
 		eachQuantile.SetValue(eachQuantileValue)
 	}

--- a/receiver/statsdreceiver/protocol/metric_translator.go
+++ b/receiver/statsdreceiver/protocol/metric_translator.go
@@ -83,7 +83,7 @@ func buildSummaryMetric(summaryMetric summaryMetric) pdata.InstrumentationLibrar
 	quantile := []float64{0, 10, 50, 90, 95, 100}
 	for _, v := range quantile {
 		eachQuantile := dp.QuantileValues().AppendEmpty()
-		eachQuantile.SetQuantile(v)
+		eachQuantile.SetQuantile(v/100)
 		eachQuantileValue, _ := stats.PercentileNearestRank(summaryMetric.summaryPoints, v)
 		eachQuantile.SetValue(eachQuantileValue)
 	}

--- a/receiver/statsdreceiver/protocol/metric_translator_test.go
+++ b/receiver/statsdreceiver/protocol/metric_translator_test.go
@@ -103,7 +103,7 @@ func TestBuildSummaryMetric(t *testing.T) {
 	value := []float64{1, 1, 3, 6, 6, 6}
 	for int, v := range quantile {
 		eachQuantile := dp.QuantileValues().AppendEmpty()
-		eachQuantile.SetQuantile(v/100)
+		eachQuantile.SetQuantile(v / 100)
 		eachQuantileValue := value[int]
 		eachQuantile.SetValue(eachQuantileValue)
 	}

--- a/receiver/statsdreceiver/protocol/metric_translator_test.go
+++ b/receiver/statsdreceiver/protocol/metric_translator_test.go
@@ -103,7 +103,7 @@ func TestBuildSummaryMetric(t *testing.T) {
 	value := []float64{1, 1, 3, 6, 6, 6}
 	for int, v := range quantile {
 		eachQuantile := dp.QuantileValues().AppendEmpty()
-		eachQuantile.SetQuantile(v)
+		eachQuantile.SetQuantile(v/100)
 		eachQuantileValue := value[int]
 		eachQuantile.SetValue(eachQuantileValue)
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This adjusts the line in the StatsD receiver's [metrics translator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/statsdreceiver/protocol/metric_translator.go#L86) to divide by 100 to store the data point in a range of [0,1] instead of [0,100] to match the [proto spec](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L631).

There are various ways to approach this, but reviewing the [oc_to_metrics translator](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/44660a0ea0399cec1314b3c3e8f485187ca6bd87/pkg/translator/opencensus/oc_to_metrics.go#L336) it seems there is some prior art for something like this. The otlp exporter doesn't modify data, and there is currently no way to adjust this calculation in any existing processor that I can see.

**Link to tracking Issue:** <Issue number if applicable>

Closes #5515 

**Testing:** <Describe what testing was performed and which tests were added.>

Updated test in `metric_translator_test.go` with the same change.

**Documentation:** <Describe the documentation added.>