### PR TITLE
Move Jaeger receiver validation to config.Validate

### DIFF
--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -90,6 +90,44 @@ func (cfg *Config) Validate() error {
 		cfg.ThriftCompact == nil {
 		return fmt.Errorf("must specify at least one protocol when using the Jaeger receiver")
 	}
+
+	var grpcPort int
+	if cfg.GRPC != nil {
+		if port, err := extractPortFromEndpoint(cfg.GRPC.NetAddr.Endpoint); err != nil {
+			return fmt.Errorf("unable to extract port for the gRPC endpoint: %w", err)
+		} else {
+			grpcPort = port
+		}
+	}
+
+	if cfg.ThriftHTTP != nil {
+		if _, err := extractPortFromEndpoint(cfg.ThriftHTTP.Endpoint); err != nil {
+			return fmt.Errorf("unable to extract port for the Thrift HTTP endpoint: %w", err)
+		}
+	}
+
+	if cfg.ThriftBinary != nil {
+		if _, err := extractPortFromEndpoint(cfg.ThriftBinary.Endpoint); err != nil {
+			return fmt.Errorf("unable to extract port for the Thrift UDP Binary endpoint: %w", err)
+		}
+	}
+
+	if cfg.ThriftCompact != nil {
+		if _, err := extractPortFromEndpoint(cfg.ThriftCompact.Endpoint); err != nil {
+			return fmt.Errorf("unable to extract port for the Thrift UDP Compact endpoint: %w", err)
+		}
+	}
+
+	if cfg.RemoteSampling != nil {
+		if _, err := extractPortFromEndpoint(cfg.RemoteSampling.HostEndpoint); err != nil {
+			return fmt.Errorf("unable to extract port for the Remote Sampling endpoint: %w", err)
+		}
+
+		if len(cfg.RemoteSampling.StrategyFile) != 0 && grpcPort == 0 {
+			return fmt.Errorf("strategy file requires the gRPC protocol to be enabled")
+		}
+	}
+
 	return nil
 }
 

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -93,10 +93,9 @@ func (cfg *Config) Validate() error {
 
 	var grpcPort int
 	if cfg.GRPC != nil {
-		if port, err := extractPortFromEndpoint(cfg.GRPC.NetAddr.Endpoint); err != nil {
+		var err error
+		if grpcPort, err = extractPortFromEndpoint(cfg.GRPC.NetAddr.Endpoint); err != nil {
 			return fmt.Errorf("unable to extract port for the gRPC endpoint: %w", err)
-		} else {
-			grpcPort = port
 		}
 	}
 

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -92,6 +92,7 @@ func createTracesReceiver(
 
 	// Convert settings in the source config to configuration struct
 	// that Jaeger receiver understands.
+	// Error handling for the conversion is done in the Validate function from the Config object itself.
 
 	rCfg := cfg.(*Config)
 	remoteSamplingConfig := rCfg.RemoteSampling
@@ -100,39 +101,22 @@ func createTracesReceiver(
 	// Set ports
 	if rCfg.Protocols.GRPC != nil {
 		config.CollectorGRPCServerSettings = *rCfg.Protocols.GRPC
-		var err error
-		config.CollectorGRPCPort, err = extractPortFromEndpoint(rCfg.Protocols.GRPC.NetAddr.Endpoint)
-		if err != nil {
-			return nil, fmt.Errorf("unable to extract port for GRPC: %w", err)
-		}
+		config.CollectorGRPCPort, _ = extractPortFromEndpoint(rCfg.Protocols.GRPC.NetAddr.Endpoint)
 	}
 
 	if rCfg.Protocols.ThriftHTTP != nil {
-		var err error
-		config.CollectorHTTPPort, err = extractPortFromEndpoint(rCfg.Protocols.ThriftHTTP.Endpoint)
-		if err != nil {
-			return nil, fmt.Errorf("unable to extract port for ThriftHTTP: %w", err)
-		}
-
+		config.CollectorHTTPPort, _ = extractPortFromEndpoint(rCfg.Protocols.ThriftHTTP.Endpoint)
 		config.CollectorHTTPSettings = *rCfg.ThriftHTTP
 	}
 
 	if rCfg.Protocols.ThriftBinary != nil {
 		config.AgentBinaryThriftConfig = rCfg.ThriftBinary.ServerConfigUDP
-		var err error
-		config.AgentBinaryThriftPort, err = extractPortFromEndpoint(rCfg.Protocols.ThriftBinary.Endpoint)
-		if err != nil {
-			return nil, fmt.Errorf("unable to extract port for ThriftBinary: %w", err)
-		}
+		config.AgentBinaryThriftPort, _ = extractPortFromEndpoint(rCfg.Protocols.ThriftBinary.Endpoint)
 	}
 
 	if rCfg.Protocols.ThriftCompact != nil {
 		config.AgentCompactThriftConfig = rCfg.ThriftCompact.ServerConfigUDP
-		var err error
-		config.AgentCompactThriftPort, err = extractPortFromEndpoint(rCfg.Protocols.ThriftCompact.Endpoint)
-		if err != nil {
-			return nil, fmt.Errorf("unable to extract port for ThriftCompact: %w", err)
-		}
+		config.AgentCompactThriftPort, _ = extractPortFromEndpoint(rCfg.Protocols.ThriftCompact.Endpoint)
 	}
 
 	if remoteSamplingConfig != nil {
@@ -144,33 +128,13 @@ func createTracesReceiver(
 		if len(remoteSamplingConfig.HostEndpoint) == 0 {
 			config.AgentHTTPPort = defaultAgentRemoteSamplingHTTPPort
 		} else {
-			var err error
-			config.AgentHTTPPort, err = extractPortFromEndpoint(remoteSamplingConfig.HostEndpoint)
-			if err != nil {
-				return nil, err
-			}
+			config.AgentHTTPPort, _ = extractPortFromEndpoint(remoteSamplingConfig.HostEndpoint)
 		}
 
 		// strategies are served over grpc so if grpc is not enabled and strategies are present return an error
 		if len(remoteSamplingConfig.StrategyFile) != 0 {
-			if config.CollectorGRPCPort == 0 {
-				return nil, fmt.Errorf("strategy file requires the GRPC protocol to be enabled")
-			}
-
 			config.RemoteSamplingStrategyFile = remoteSamplingConfig.StrategyFile
 		}
-	}
-
-	if (rCfg.Protocols.GRPC == nil && rCfg.Protocols.ThriftHTTP == nil && rCfg.Protocols.ThriftBinary == nil && rCfg.Protocols.ThriftCompact == nil) ||
-		(config.CollectorGRPCPort == 0 && config.CollectorHTTPPort == 0 && config.CollectorThriftPort == 0 && config.AgentBinaryThriftPort == 0 && config.AgentCompactThriftPort == 0) {
-		err := fmt.Errorf("either GRPC(%v), ThriftHTTP(%v), ThriftCompact(%v), or ThriftBinary(%v) protocol endpoint with non-zero port must be enabled for %s receiver",
-			rCfg.Protocols.GRPC,
-			rCfg.Protocols.ThriftHTTP,
-			rCfg.Protocols.ThriftCompact,
-			rCfg.Protocols.ThriftBinary,
-			cfg.ID().String(),
-		)
-		return nil, err
 	}
 
 	// Create the receiver.

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -230,81 +230,6 @@ func TestAgentRemoteSamplingEndpoint(t *testing.T) {
 	assert.Equal(t, defaultAgentRemoteSamplingHTTPPort, r.(*jReceiver).config.AgentHTTPPort, "agent http port should be default")
 }
 
-func TestCreateNoPort(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
-
-	cfg.(*Config).Protocols.ThriftHTTP = &confighttp.HTTPServerSettings{
-		Endpoint: "localhost:",
-	}
-	set := componenttest.NewNopReceiverCreateSettings()
-	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
-	assert.Error(t, err, "receiver creation with no port number must fail")
-}
-
-func TestCreateLargePort(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
-
-	cfg.(*Config).Protocols.ThriftHTTP = &confighttp.HTTPServerSettings{
-		Endpoint: "localhost:65536",
-	}
-	set := componenttest.NewNopReceiverCreateSettings()
-	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
-	assert.Error(t, err, "receiver creation with too large port number must fail")
-}
-
-func TestCreateInvalidHost(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
-
-	cfg.(*Config).Protocols.GRPC = &configgrpc.GRPCServerSettings{
-		NetAddr: confignet.NetAddr{
-			Endpoint:  "1234",
-			Transport: "tcp",
-		},
-	}
-
-	set := componenttest.NewNopReceiverCreateSettings()
-	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
-	assert.Error(t, err, "receiver creation with bad hostname must fail")
-}
-
-func TestCreateNoProtocols(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
-
-	cfg.(*Config).Protocols = Protocols{}
-	set := componenttest.NewNopReceiverCreateSettings()
-	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
-	assert.Error(t, err, "receiver creation with no protocols must fail")
-}
-
-func TestThriftBinaryBadPort(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
-
-	cfg.(*Config).Protocols.ThriftBinary = &ProtocolUDP{
-		Endpoint: "localhost:65536",
-	}
-	set := componenttest.NewNopReceiverCreateSettings()
-	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
-	assert.Error(t, err, "receiver creation with a bad thrift binary port must fail")
-}
-
-func TestThriftCompactBadPort(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
-
-	cfg.(*Config).Protocols.ThriftCompact = &ProtocolUDP{
-		Endpoint: "localhost:65536",
-	}
-
-	set := componenttest.NewNopReceiverCreateSettings()
-	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
-	assert.Error(t, err, "receiver creation with a bad thrift compact port must fail")
-}
-
 func TestRemoteSamplingConfigPropagation(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
@@ -333,23 +258,4 @@ func TestRemoteSamplingConfigPropagation(t *testing.T) {
 	assert.Equal(t, endpoint, r.(*jReceiver).config.RemoteSamplingClientSettings.Endpoint)
 	assert.Equal(t, hostPort, r.(*jReceiver).config.AgentHTTPPort, "agent http port should be configured value")
 	assert.Equal(t, strategyFile, r.(*jReceiver).config.RemoteSamplingStrategyFile)
-}
-
-func TestRemoteSamplingFileRequiresGRPC(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig()
-	rCfg := cfg.(*Config)
-
-	// Remove all default protocols
-	rCfg.Protocols = Protocols{}
-	rCfg.Protocols.ThriftCompact = &ProtocolUDP{
-		Endpoint: defaultThriftCompactBindEndpoint,
-	}
-	rCfg.RemoteSampling = &RemoteSamplingConfig{
-		StrategyFile: "strategies.json",
-	}
-	set := componenttest.NewNopReceiverCreateSettings()
-	_, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
-
-	assert.Error(t, err, "create trace receiver should error")
 }


### PR DESCRIPTION
This PR moves the validation code from the factory to the config.Validate for the Jaeger receiver.

Closes #5002