### PR TITLE
Added implementation of Google Cloud Spanner receiver - 2nd part(metadata parser and metadata config)

### DIFF
--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
@@ -1,0 +1,431 @@
+metadata:
+#
+# -------------------------------------------- Active Queries Summary --------------------------------------------------
+#
+  - name: "active queries summary"
+    query: "SELECT * FROM SPANNER_SYS.ACTIVE_QUERIES_SUMMARY"
+    metric_name_prefix: "database/spanner/active_queries_summary/"
+    metrics:
+      - name: "active_count"
+        column_name: "ACTIVE_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "count_older_than_1s"
+        column_name: "COUNT_OLDER_THAN_1S"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "count_older_than_10s"
+        column_name: "COUNT_OLDER_THAN_10S"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "count_older_than_100s"
+        column_name: "COUNT_OLDER_THAN_100S"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+#
+# -------------------------------------------- Locks Stats -------------------------------------------------------------
+#
+  - name: "top minute lock stats"
+    query: "SELECT * FROM SPANNER_SYS.LOCK_STATS_TOP_MINUTE WHERE INTERVAL_END = @pullTimestamp ORDER BY INTERVAL_END DESC, LOCK_WAIT_SECONDS DESC"
+    metric_name_prefix: "database/spanner/lock_stats/top/"
+    timestamp_column_name: "INTERVAL_END"
+    labels:
+      - name: "row_range_start_key"
+        column_name: "ROW_RANGE_START_KEY"
+        value_type: "byte_slice"
+    metrics:
+      - name: "lock_wait_seconds"
+        column_name: "LOCK_WAIT_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+
+  - name: "total minute lock stats"
+    query: "SELECT * FROM SPANNER_SYS.LOCK_STATS_TOTAL_MINUTE WHERE INTERVAL_END = @pullTimestamp"
+    metric_name_prefix: "database/spanner/lock_stats/total/"
+    timestamp_column_name: "INTERVAL_END"
+    metrics:
+      - name: "total_lock_wait_seconds"
+        column_name: "TOTAL_LOCK_WAIT_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+#
+# -------------------------------------------- Queries Stats -----------------------------------------------------------
+#
+  - name: "top minute query stats"
+    query: "SELECT * FROM SPANNER_SYS.QUERY_STATS_TOP_MINUTE WHERE INTERVAL_END = @pullTimestamp ORDER BY INTERVAL_END DESC, EXECUTION_COUNT * AVG_CPU_SECONDS DESC"
+    metric_name_prefix: "database/spanner/query_stats/top/"
+    timestamp_column_name: "INTERVAL_END"
+    labels:
+      - name: "query_text"
+        column_name: "TEXT"
+        value_type: "string"
+      - name: "query_text_truncated"
+        column_name: "TEXT_TRUNCATED"
+        value_type: "bool"
+      - name: "query_text_fingerprint"
+        column_name: "TEXT_FINGERPRINT"
+        value_type: "int"
+    metrics:
+      - name: "execution_count"
+        column_name: "EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "avg_latency_seconds"
+        column_name: "AVG_LATENCY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_rows"
+        column_name: "AVG_ROWS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "row"
+      - name: "avg_bytes"
+        column_name: "AVG_BYTES"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "byte"
+      - name: "avg_rows_scanned"
+        column_name: "AVG_ROWS_SCANNED"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "row"
+      - name: "avg_cpu_seconds"
+        column_name: "AVG_CPU_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "all_failed_execution_count"
+        column_name: "ALL_FAILED_EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "all_failed_avg_latency_seconds"
+        column_name: "ALL_FAILED_AVG_LATENCY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "cancelled_or_disconnected_execution_count"
+        column_name: "CANCELLED_OR_DISCONNECTED_EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "timed_out_execution_count"
+        column_name: "TIMED_OUT_EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+  - name: "total minute query stats"
+    query: "SELECT * FROM SPANNER_SYS.QUERY_STATS_TOTAL_MINUTE WHERE INTERVAL_END = @pullTimestamp"
+    metric_name_prefix: "database/spanner/query_stats/total/"
+    timestamp_column_name: "INTERVAL_END"
+    metrics:
+      - name: "execution_count"
+        column_name: "EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "avg_latency_seconds"
+        column_name: "AVG_LATENCY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_rows"
+        column_name: "AVG_ROWS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "row"
+      - name: "avg_bytes"
+        column_name: "AVG_BYTES"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "byte"
+      - name: "avg_rows_scanned"
+        column_name: "AVG_ROWS_SCANNED"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "row"
+      - name: "avg_cpu_seconds"
+        column_name: "AVG_CPU_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "all_failed_execution_count"
+        column_name: "ALL_FAILED_EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "all_failed_avg_latency_seconds"
+        column_name: "ALL_FAILED_AVG_LATENCY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "cancelled_or_disconnected_execution_count"
+        column_name: "CANCELLED_OR_DISCONNECTED_EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "timed_out_execution_count"
+        column_name: "TIMED_OUT_EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+#
+# -------------------------------------------- Reads Stats -------------------------------------------------------------
+#
+  - name: "top minute read stats"
+    query: "SELECT * FROM SPANNER_SYS.READ_STATS_TOP_MINUTE WHERE INTERVAL_END = @pullTimestamp ORDER BY INTERVAL_END DESC, EXECUTION_COUNT * AVG_CPU_SECONDS DESC"
+    metric_name_prefix: "database/spanner/read_stats/top/"
+    timestamp_column_name: "INTERVAL_END"
+    labels:
+      - name: "read_columns"
+        column_name: "READ_COLUMNS"
+        value_type: "string_slice"
+      - name: "fingerprint"
+        column_name: "FPRINT"
+        value_type: "int"
+    metrics:
+      - name: "execution_count"
+        column_name: "EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "avg_rows"
+        column_name: "AVG_ROWS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "row"
+      - name: "avg_bytes"
+        column_name: "AVG_BYTES"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "byte"
+      - name: "avg_cpu_seconds"
+        column_name: "AVG_CPU_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_locking_delay_seconds"
+        column_name: "AVG_LOCKING_DELAY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_client_wait_seconds"
+        column_name: "AVG_CLIENT_WAIT_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_leader_refresh_delay_seconds"
+        column_name: "AVG_LEADER_REFRESH_DELAY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+  - name: "total minute read stats"
+    query: "SELECT * FROM SPANNER_SYS.READ_STATS_TOTAL_MINUTE WHERE INTERVAL_END = @pullTimestamp"
+    metric_name_prefix: "database/spanner/read_stats/total/"
+    timestamp_column_name: "INTERVAL_END"
+    metrics:
+      - name: "execution_count"
+        column_name: "EXECUTION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "avg_rows"
+        column_name: "AVG_ROWS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "row"
+      - name: "avg_bytes"
+        column_name: "AVG_BYTES"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "byte"
+      - name: "avg_cpu_seconds"
+        column_name: "AVG_CPU_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_locking_delay_seconds"
+        column_name: "AVG_LOCKING_DELAY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_client_wait_seconds"
+        column_name: "AVG_CLIENT_WAIT_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_leader_refresh_delay_seconds"
+        column_name: "AVG_LEADER_REFRESH_DELAY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+#
+# -------------------------------------------- Transactions Stats ------------------------------------------------------
+#
+  - name: "top minute transaction stats"
+    query: "SELECT * FROM SPANNER_SYS.TXN_STATS_TOP_MINUTE WHERE INTERVAL_END = @pullTimestamp ORDER BY INTERVAL_END DESC, AVG_COMMIT_LATENCY_SECONDS DESC, COMMIT_ATTEMPT_COUNT DESC, AVG_BYTES DESC"
+    metric_name_prefix: "database/spanner/txn_stats/top/"
+    timestamp_column_name: "INTERVAL_END"
+    labels:
+      - name: "fingerprint"
+        column_name: "FPRINT"
+        value_type: "int"
+      - name: "read_columns"
+        column_name: "READ_COLUMNS"
+        value_type: "string_slice"
+      - name: "write_constructive_columns"
+        column_name: "WRITE_CONSTRUCTIVE_COLUMNS"
+        value_type: "string_slice"
+      - name: "write_delete_tables"
+        column_name: "WRITE_DELETE_TABLES"
+        value_type: "string_slice"
+    metrics:
+      - name: "commit_attempt_count"
+        column_name: "COMMIT_ATTEMPT_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "commit_abort_count"
+        column_name: "COMMIT_ABORT_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "commit_retry_count"
+        column_name: "COMMIT_RETRY_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "commit_failed_precondition_count"
+        column_name: "COMMIT_FAILED_PRECONDITION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "avg_participants"
+        column_name: "AVG_PARTICIPANTS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "avg_total_latency_seconds"
+        column_name: "AVG_TOTAL_LATENCY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_commit_latency_seconds"
+        column_name: "AVG_COMMIT_LATENCY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_bytes"
+        column_name: "AVG_BYTES"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "byte"
+  - name: "total minute transaction stats"
+    query: "SELECT * FROM SPANNER_SYS.TXN_STATS_TOTAL_MINUTE WHERE INTERVAL_END = @pullTimestamp"
+    metric_name_prefix: "database/spanner/txn_stats/total/"
+    timestamp_column_name: "INTERVAL_END"
+    metrics:
+      - name: "commit_attempt_count"
+        column_name: "COMMIT_ATTEMPT_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "commit_abort_count"
+        column_name: "COMMIT_ABORT_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "commit_retry_count"
+        column_name: "COMMIT_RETRY_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "commit_failed_precondition_count"
+        column_name: "COMMIT_FAILED_PRECONDITION_COUNT"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "avg_participants"
+        column_name: "AVG_PARTICIPANTS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "one"
+      - name: "avg_total_latency_seconds"
+        column_name: "AVG_TOTAL_LATENCY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_commit_latency_seconds"
+        column_name: "AVG_COMMIT_LATENCY_SECONDS"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "second"
+      - name: "avg_bytes"
+        column_name: "AVG_BYTES"
+        value_type: "float"
+        data:
+          type: "gauge"
+        unit: "byte"

--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata_yaml_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata_yaml_test.go
@@ -1,0 +1,36 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataconfig
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadataparser"
+)
+
+// Kind of sanity check test of metadata.yaml used for production usage
+func TestParsingMetadataYaml(t *testing.T) {
+	content, err := os.ReadFile("metadata.yaml")
+
+	require.NoError(t, err)
+
+	metadataMap, err := metadataparser.ParseMetadataConfig(content)
+
+	require.NoError(t, err)
+	require.NotNil(t, metadataMap)
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/label.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/label.go
@@ -1,0 +1,56 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import (
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+const (
+	labelValueTypeString      = "string"
+	labelValueTypeInt         = "int"
+	labelValueTypeBool        = "bool"
+	labelValueTypeStringSlice = "string_slice"
+	labelValueTypeByteSlice   = "byte_slice"
+)
+
+type Label struct {
+	Name       string `yaml:"name"`
+	ColumnName string `yaml:"column_name"`
+	ValueType  string `yaml:"value_type"`
+}
+
+func (label Label) toLabelValueMetadata() (metadata.LabelValueMetadata, error) {
+	var valueMetadata metadata.LabelValueMetadata
+
+	switch label.ValueType {
+	case labelValueTypeString:
+		valueMetadata = metadata.NewStringLabelValueMetadata(label.Name, label.ColumnName)
+	case labelValueTypeInt:
+		valueMetadata = metadata.NewInt64LabelValueMetadata(label.Name, label.ColumnName)
+	case labelValueTypeBool:
+		valueMetadata = metadata.NewBoolLabelValueMetadata(label.Name, label.ColumnName)
+	case labelValueTypeStringSlice:
+		valueMetadata = metadata.NewStringSliceLabelValueMetadata(label.Name, label.ColumnName)
+	case labelValueTypeByteSlice:
+		valueMetadata = metadata.NewByteSliceLabelValueMetadata(label.Name, label.ColumnName)
+	default:
+		return nil, fmt.Errorf("invalid value type received for label %q", label.Name)
+	}
+
+	return valueMetadata, nil
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/label_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/label_test.go
@@ -1,0 +1,68 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+const (
+	labelName       = "labelName"
+	labelColumnName = "labelColumnName"
+)
+
+func TestLabel_ToLabelValueMetadata(t *testing.T) {
+	testCases := map[string]struct {
+		valueType    string
+		expectedType interface{}
+		expectError  bool
+	}{
+		"Value type is string":       {labelValueTypeString, metadata.StringLabelValueMetadata{}, false},
+		"Value type is int":          {labelValueTypeInt, metadata.Int64LabelValueMetadata{}, false},
+		"Value type is bool":         {labelValueTypeBool, metadata.BoolLabelValueMetadata{}, false},
+		"Value type is string slice": {labelValueTypeStringSlice, metadata.StringSliceLabelValueMetadata{}, false},
+		"Value type is byte slice":   {labelValueTypeByteSlice, metadata.ByteSliceLabelValueMetadata{}, false},
+		"Value type is unknown":      {"unknown", nil, true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			label := Label{
+				Name:       labelName,
+				ColumnName: labelColumnName,
+				ValueType:  testCase.valueType,
+			}
+
+			valueMetadata, err := label.toLabelValueMetadata()
+
+			if testCase.expectError {
+				require.Nil(t, valueMetadata)
+				require.Error(t, err)
+			} else {
+				require.NotNil(t, valueMetadata)
+				require.NoError(t, err)
+
+				assert.IsType(t, testCase.expectedType, valueMetadata)
+				assert.Equal(t, label.Name, valueMetadata.Name())
+				assert.Equal(t, label.ColumnName, valueMetadata.ColumnName())
+			}
+		})
+	}
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata.go
@@ -1,0 +1,76 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+
+type Metadata struct {
+	Name                string   `yaml:"name"`
+	Query               string   `yaml:"query"`
+	MetricNamePrefix    string   `yaml:"metric_name_prefix"`
+	TimestampColumnName string   `yaml:"timestamp_column_name"`
+	Labels              []Label  `yaml:"labels"`
+	Metrics             []Metric `yaml:"metrics"`
+}
+
+func (m Metadata) MetricsMetadata() (*metadata.MetricsMetadata, error) {
+	queryLabelValuesMetadata, err := m.toLabelValuesMetadata()
+	if err != nil {
+		return nil, err
+	}
+
+	queryMetricValuesMetadata, err := m.toMetricValuesMetadata()
+	if err != nil {
+		return nil, err
+	}
+
+	return &metadata.MetricsMetadata{
+		Name:                      m.Name,
+		Query:                     m.Query,
+		MetricNamePrefix:          m.MetricNamePrefix,
+		TimestampColumnName:       m.TimestampColumnName,
+		QueryLabelValuesMetadata:  queryLabelValuesMetadata,
+		QueryMetricValuesMetadata: queryMetricValuesMetadata,
+	}, nil
+}
+
+func (m Metadata) toLabelValuesMetadata() ([]metadata.LabelValueMetadata, error) {
+	valuesMetadata := make([]metadata.LabelValueMetadata, len(m.Labels))
+
+	for i, label := range m.Labels {
+		value, err := label.toLabelValueMetadata()
+		if err != nil {
+			return nil, err
+		}
+
+		valuesMetadata[i] = value
+	}
+
+	return valuesMetadata, nil
+}
+
+func (m Metadata) toMetricValuesMetadata() ([]metadata.MetricValueMetadata, error) {
+	valuesMetadata := make([]metadata.MetricValueMetadata, len(m.Metrics))
+	for i, metric := range m.Metrics {
+		value, err := metric.toMetricValueMetadata()
+		if err != nil {
+			return nil, err
+		}
+
+		valuesMetadata[i] = value
+	}
+
+	return valuesMetadata, nil
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata_test.go
@@ -1,0 +1,152 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadata_ToLabelValuesMetadata(t *testing.T) {
+	testCases := map[string]struct {
+		valueType   string
+		expectError bool
+	}{
+		"Happy path": {labelValueTypeString, false},
+		"With error": {"unknown", true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			label := Label{
+				Name:       labelName,
+				ColumnName: labelColumnName,
+				ValueType:  testCase.valueType,
+			}
+			md := Metadata{
+				Labels: []Label{label},
+			}
+
+			valuesMetadata, err := md.toLabelValuesMetadata()
+
+			if testCase.expectError {
+				require.Nil(t, valuesMetadata)
+				require.Error(t, err)
+			} else {
+				require.NotNil(t, valuesMetadata)
+				require.NoError(t, err)
+
+				assert.Equal(t, 1, len(valuesMetadata))
+			}
+		})
+	}
+}
+
+func TestMetadata_ToMetricValuesMetadata(t *testing.T) {
+	testCases := map[string]struct {
+		valueType   string
+		dataType    MetricType
+		expectError bool
+	}{
+		"Happy path": {metricValueTypeInt, MetricType{DataType: metricDataTypeGauge}, false},
+		"With error": {"unknown", MetricType{DataType: metricDataTypeGauge}, true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			metric := Metric{
+				Label: Label{
+					Name:       metricName,
+					ColumnName: metricColumnName,
+					ValueType:  testCase.valueType,
+				},
+				DataType: testCase.dataType,
+			}
+			md := Metadata{
+				Metrics: []Metric{metric},
+			}
+
+			valuesMetadata, err := md.toMetricValuesMetadata()
+
+			if testCase.expectError {
+				require.Nil(t, valuesMetadata)
+				require.Error(t, err)
+			} else {
+				require.NotNil(t, valuesMetadata)
+				require.NoError(t, err)
+
+				assert.Equal(t, 1, len(valuesMetadata))
+			}
+		})
+	}
+}
+
+func TestMetadata_MetricsMetadata(t *testing.T) {
+	testCases := map[string]struct {
+		labelValueType  string
+		metricValueType string
+		dataType        MetricType
+		expectError     bool
+	}{
+		"Happy path":        {labelValueTypeInt, metricValueTypeInt, MetricType{DataType: metricDataTypeGauge}, false},
+		"With label error":  {"unknown", metricValueTypeInt, MetricType{DataType: metricDataTypeGauge}, true},
+		"With metric error": {labelValueTypeInt, "unknown", MetricType{DataType: metricDataTypeGauge}, true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			label := Label{
+				Name:       labelName,
+				ColumnName: labelColumnName,
+				ValueType:  testCase.labelValueType,
+			}
+			metric := Metric{
+				Label: Label{
+					Name:       metricName,
+					ColumnName: metricColumnName,
+					ValueType:  testCase.metricValueType,
+				},
+				DataType: testCase.dataType,
+			}
+			md := Metadata{
+				Name:                "name",
+				Query:               "query",
+				MetricNamePrefix:    "metricNamePrefix",
+				TimestampColumnName: "timestampColumnName",
+				Labels:              []Label{label},
+				Metrics:             []Metric{metric},
+			}
+
+			metricsMetadata, err := md.MetricsMetadata()
+
+			if testCase.expectError {
+				require.Nil(t, metricsMetadata)
+				require.Error(t, err)
+			} else {
+				require.NotNil(t, metricsMetadata)
+				require.NoError(t, err)
+
+				assert.Equal(t, md.Name, metricsMetadata.Name)
+				assert.Equal(t, md.Query, metricsMetadata.Query)
+				assert.Equal(t, md.MetricNamePrefix, metricsMetadata.MetricNamePrefix)
+				assert.Equal(t, md.TimestampColumnName, metricsMetadata.TimestampColumnName)
+				assert.Equal(t, 1, len(metricsMetadata.QueryLabelValuesMetadata))
+				assert.Equal(t, 1, len(metricsMetadata.QueryMetricValuesMetadata))
+			}
+		})
+	}
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataconfig.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataconfig.go
@@ -1,0 +1,19 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+type MetadataConfig struct {
+	Metadata []Metadata `yaml:"metadata"`
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser.go
@@ -1,0 +1,43 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import (
+	"gopkg.in/yaml.v3"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+func ParseMetadataConfig(metadataContentYaml []byte) ([]*metadata.MetricsMetadata, error) {
+	var config MetadataConfig
+
+	err := yaml.Unmarshal(metadataContentYaml, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*metadata.MetricsMetadata, len(config.Metadata))
+
+	for i, parsedMetadata := range config.Metadata {
+		mData, err := parsedMetadata.MetricsMetadata()
+		if err != nil {
+			return nil, err
+		}
+
+		result[i] = mData
+	}
+
+	return result, nil
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser_test.go
@@ -1,0 +1,83 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+func TestParseMetadataConfig(t *testing.T) {
+	testCases := map[string]struct {
+		filePath    string
+		expectError bool
+	}{
+		"Valid metadata":     {"../../testdata/metadata_valid.yaml", false},
+		"YAML parsing error": {"../../testdata/metadata_not_yaml.yaml", true},
+		"Invalid metadata":   {"../../testdata/metadata_invalid.yaml", true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			content, err := os.ReadFile(testCase.filePath)
+
+			require.NoError(t, err)
+
+			metadataSlice, err := ParseMetadataConfig(content)
+
+			if testCase.expectError {
+				require.Error(t, err)
+				require.Nil(t, metadataSlice)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, 2, len(metadataSlice))
+
+				mData := metadataSlice[0]
+
+				assert.NotNil(t, mData)
+				assertMetricsMetadata(t, "current stats", mData)
+
+				mData = metadataSlice[1]
+
+				assert.NotNil(t, mData)
+				assertMetricsMetadata(t, "interval stats", mData)
+			}
+		})
+	}
+}
+
+func assertMetricsMetadata(t *testing.T, expectedName string, metricsMetadata *metadata.MetricsMetadata) {
+	assert.Equal(t, expectedName, metricsMetadata.Name)
+	assert.Equal(t, "query", metricsMetadata.Query)
+	assert.Equal(t, "metric_name_prefix", metricsMetadata.MetricNamePrefix)
+
+	assert.Equal(t, 1, len(metricsMetadata.QueryLabelValuesMetadata))
+	assert.Equal(t, "label_name", metricsMetadata.QueryLabelValuesMetadata[0].Name())
+	assert.Equal(t, "LABEL_NAME", metricsMetadata.QueryLabelValuesMetadata[0].ColumnName())
+	assert.IsType(t, metadata.StringLabelValueMetadata{}, metricsMetadata.QueryLabelValuesMetadata[0])
+
+	assert.Equal(t, 1, len(metricsMetadata.QueryMetricValuesMetadata))
+	assert.Equal(t, "metric_name", metricsMetadata.QueryMetricValuesMetadata[0].Name())
+	assert.Equal(t, "METRIC_NAME", metricsMetadata.QueryMetricValuesMetadata[0].ColumnName())
+	assert.Equal(t, "metric_unit", metricsMetadata.QueryMetricValuesMetadata[0].Unit())
+	assert.Equal(t, pdata.MetricDataTypeGauge, metricsMetadata.QueryMetricValuesMetadata[0].DataType().MetricDataType())
+	assert.IsType(t, metadata.Int64MetricValueMetadata{}, metricsMetadata.QueryMetricValuesMetadata[0])
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metric.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metric.go
@@ -1,0 +1,52 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import (
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+const (
+	metricValueTypeInt   = "int"
+	metricValueTypeFloat = "float"
+)
+
+type Metric struct {
+	Label    `yaml:",inline"`
+	DataType MetricType `yaml:"data"`
+	Unit     string     `yaml:"unit"`
+}
+
+func (metric Metric) toMetricValueMetadata() (metadata.MetricValueMetadata, error) {
+	var valueMetadata metadata.MetricValueMetadata
+
+	dataType, err := metric.DataType.toMetricDataType()
+	if err != nil {
+		return nil, fmt.Errorf("invalid value data type received for metric %q", metric.Name)
+	}
+
+	switch metric.ValueType {
+	case metricValueTypeInt:
+		valueMetadata = metadata.NewInt64MetricValueMetadata(metric.Name, metric.ColumnName, dataType, metric.Unit)
+	case metricValueTypeFloat:
+		valueMetadata = metadata.NewFloat64MetricValueMetadata(metric.Name, metric.ColumnName, dataType, metric.Unit)
+	default:
+		return nil, fmt.Errorf("invalid value type received for metric %q", metric.Name)
+	}
+
+	return valueMetadata, nil
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metric_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metric_test.go
@@ -1,0 +1,80 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+const (
+	metricName       = "labelName"
+	metricColumnName = "labelColumnName"
+	metricUnit       = "metricUnit"
+)
+
+func TestMetric_ToMetricValueMetadata(t *testing.T) {
+	testCases := map[string]struct {
+		valueType        string
+		dataType         MetricType
+		expectedType     interface{}
+		expectedDataType pdata.MetricDataType
+		expectError      bool
+	}{
+		"Value type is int and data type is gauge":     {metricValueTypeInt, MetricType{DataType: metricDataTypeGauge}, metadata.Int64MetricValueMetadata{}, pdata.MetricDataTypeGauge, false},
+		"Value type is int and data type is sum":       {metricValueTypeInt, MetricType{DataType: metricDataTypeSum, Aggregation: aggregationTemporalityDelta, Monotonic: true}, metadata.Int64MetricValueMetadata{}, pdata.MetricDataTypeSum, false},
+		"Value type is int and data type is unknown":   {metricValueTypeInt, MetricType{DataType: "unknown"}, nil, pdata.MetricDataTypeNone, true},
+		"Value type is float and data type is gauge":   {metricValueTypeFloat, MetricType{DataType: metricDataTypeGauge}, metadata.Float64MetricValueMetadata{}, pdata.MetricDataTypeGauge, false},
+		"Value type is float and data type is sum":     {metricValueTypeFloat, MetricType{DataType: metricDataTypeSum, Aggregation: aggregationTemporalityDelta, Monotonic: true}, metadata.Float64MetricValueMetadata{}, pdata.MetricDataTypeSum, false},
+		"Value type is float and data type is unknown": {metricValueTypeFloat, MetricType{DataType: "unknown"}, nil, pdata.MetricDataTypeNone, true},
+		"Value type is unknown and data type is gauge": {"unknown", MetricType{DataType: metricDataTypeGauge}, nil, pdata.MetricDataTypeNone, true},
+		"Value type is unknown and data type is sum":   {"unknown", MetricType{DataType: metricDataTypeSum, Aggregation: aggregationTemporalityDelta, Monotonic: true}, nil, pdata.MetricDataTypeNone, true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			metric := Metric{
+				Label: Label{
+					Name:       metricName,
+					ColumnName: metricColumnName,
+					ValueType:  testCase.valueType,
+				},
+				DataType: testCase.dataType,
+				Unit:     metricUnit,
+			}
+
+			valueMetadata, err := metric.toMetricValueMetadata()
+
+			if testCase.expectError {
+				require.Nil(t, valueMetadata)
+				require.Error(t, err)
+			} else {
+				require.NotNil(t, valueMetadata)
+				require.NoError(t, err)
+
+				assert.IsType(t, testCase.expectedType, valueMetadata)
+				assert.Equal(t, metric.Name, valueMetadata.Name())
+				assert.Equal(t, metric.ColumnName, valueMetadata.ColumnName())
+				assert.Equal(t, metric.Unit, valueMetadata.Unit())
+				assert.Equal(t, testCase.expectedDataType, valueMetadata.DataType().MetricDataType())
+			}
+		})
+	}
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype.go
@@ -1,0 +1,83 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import (
+	"errors"
+
+	"go.opentelemetry.io/collector/model/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+const (
+	metricDataTypeGauge = "gauge"
+	metricDataTypeSum   = "sum"
+
+	aggregationTemporalityDelta      = "delta"
+	aggregationTemporalityCumulative = "cumulative"
+)
+
+type MetricType struct {
+	DataType    string `yaml:"type"`
+	Aggregation string `yaml:"aggregation"`
+	Monotonic   bool   `yaml:"monotonic"`
+}
+
+func (metricType MetricType) dataType() (pdata.MetricDataType, error) {
+	var dataType pdata.MetricDataType
+
+	switch metricType.DataType {
+	case metricDataTypeGauge:
+		dataType = pdata.MetricDataTypeGauge
+	case metricDataTypeSum:
+		dataType = pdata.MetricDataTypeSum
+	default:
+		return pdata.MetricDataTypeNone, errors.New("invalid data type received")
+	}
+
+	return dataType, nil
+}
+
+func (metricType MetricType) aggregationTemporality() (pdata.MetricAggregationTemporality, error) {
+	var aggregationTemporality pdata.MetricAggregationTemporality
+
+	switch metricType.Aggregation {
+	case aggregationTemporalityDelta:
+		aggregationTemporality = pdata.MetricAggregationTemporalityDelta
+	case aggregationTemporalityCumulative:
+		aggregationTemporality = pdata.MetricAggregationTemporalityCumulative
+	case "":
+		aggregationTemporality = pdata.MetricAggregationTemporalityUnspecified
+	default:
+		return pdata.MetricAggregationTemporalityUnspecified, errors.New("invalid aggregation temporality received")
+	}
+
+	return aggregationTemporality, nil
+}
+
+func (metricType MetricType) toMetricDataType() (metadata.MetricDataType, error) {
+	dataType, err := metricType.dataType()
+	if err != nil {
+		return nil, err
+	}
+
+	aggregationTemporality, err := metricType.aggregationTemporality()
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata.NewMetricDataType(dataType, aggregationTemporality, metricType.Monotonic), nil
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metrictype_test.go
@@ -1,0 +1,122 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadataparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestDataType(t *testing.T) {
+	testCases := map[string]struct {
+		dataType         string
+		expectedDataType pdata.MetricDataType
+		expectError      bool
+	}{
+		"Gauge":   {metricDataTypeGauge, pdata.MetricDataTypeGauge, false},
+		"Sum":     {metricDataTypeSum, pdata.MetricDataTypeSum, false},
+		"Invalid": {"invalid", pdata.MetricDataTypeNone, true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			metricType := MetricType{
+				DataType: testCase.dataType,
+			}
+
+			actualDataType, err := metricType.dataType()
+
+			if testCase.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, testCase.expectedDataType, actualDataType)
+		})
+	}
+}
+
+func TestAggregationTemporality(t *testing.T) {
+	testCases := map[string]struct {
+		aggregationTemporality         string
+		expectedAggregationTemporality pdata.MetricAggregationTemporality
+		expectError                    bool
+	}{
+		"Cumulative": {aggregationTemporalityCumulative, pdata.MetricAggregationTemporalityCumulative, false},
+		"Delta":      {aggregationTemporalityDelta, pdata.MetricAggregationTemporalityDelta, false},
+		"Empty":      {"", pdata.MetricAggregationTemporalityUnspecified, false},
+		"Invalid":    {"invalid", pdata.MetricAggregationTemporalityUnspecified, true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			metricType := MetricType{
+				Aggregation: testCase.aggregationTemporality,
+			}
+
+			actualAggregationTemporality, err := metricType.aggregationTemporality()
+
+			if testCase.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, testCase.expectedAggregationTemporality, actualAggregationTemporality)
+		})
+	}
+}
+
+func TestToMetricDataType(t *testing.T) {
+	testCases := map[string]struct {
+		dataType                       string
+		aggregationTemporality         string
+		expectedDataType               pdata.MetricDataType
+		expectedAggregationTemporality pdata.MetricAggregationTemporality
+		isMonotonic                    bool
+		expectError                    bool
+	}{
+		"Happy path":          {metricDataTypeGauge, aggregationTemporalityCumulative, pdata.MetricDataTypeGauge, pdata.MetricAggregationTemporalityCumulative, true, false},
+		"Invalid data type":   {"invalid", aggregationTemporalityCumulative, pdata.MetricDataTypeNone, pdata.MetricAggregationTemporalityCumulative, true, true},
+		"Invalid aggregation": {metricDataTypeGauge, "invalid", pdata.MetricDataTypeGauge, pdata.MetricAggregationTemporalityUnspecified, true, true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			metricType := MetricType{
+				DataType:    testCase.dataType,
+				Aggregation: testCase.aggregationTemporality,
+				Monotonic:   testCase.isMonotonic,
+			}
+
+			metricDataType, err := metricType.toMetricDataType()
+
+			if testCase.expectError {
+				require.Error(t, err)
+				require.Nil(t, metricDataType)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, metricDataType)
+				assert.Equal(t, testCase.expectedDataType, metricDataType.MetricDataType())
+				assert.Equal(t, testCase.expectedAggregationTemporality, metricDataType.AggregationTemporality())
+				assert.Equal(t, testCase.isMonotonic, metricDataType.IsMonotonic())
+			}
+		})
+	}
+}

--- a/receiver/googlecloudspannerreceiver/testdata/metadata_invalid.yaml
+++ b/receiver/googlecloudspannerreceiver/testdata/metadata_invalid.yaml
@@ -1,0 +1,15 @@
+metadata:
+  - name: "invalid"
+    query: "query"
+    metric_name_prefix: "metric_name_prefix"
+    labels:
+      - name: "label_name"
+        column_name: "LABEL_NAME"
+        value_type: "invalid"
+    metrics:
+      - name: "metric_name"
+        column_name: "METRIC_NAME"
+        value_type: "int"
+        data:
+          type: "invalid"
+        unit: "metricUnit"

--- a/receiver/googlecloudspannerreceiver/testdata/metadata_not_yaml.yaml
+++ b/receiver/googlecloudspannerreceiver/testdata/metadata_not_yaml.yaml
@@ -1,0 +1,1 @@
+notyaml

--- a/receiver/googlecloudspannerreceiver/testdata/metadata_valid.yaml
+++ b/receiver/googlecloudspannerreceiver/testdata/metadata_valid.yaml
@@ -1,0 +1,36 @@
+metadata:
+#
+# -------------------------------------------- Current Stats -----------------------------------------------------------
+#
+  - name: "current stats"
+    query: "query"
+    metric_name_prefix: "metric_name_prefix"
+    labels:
+      - name: "label_name"
+        column_name: "LABEL_NAME"
+        value_type: "string"
+    metrics:
+      - name: "metric_name"
+        column_name: "METRIC_NAME"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "metric_unit"
+#
+# -------------------------------------------- Interval Stats ----------------------------------------------------------
+#
+  - name: "interval stats"
+    query: "query"
+    metric_name_prefix: "metric_name_prefix"
+    timestamp_column_name: "timestamp_column_name"
+    labels:
+      - name: "label_name"
+        column_name: "LABEL_NAME"
+        value_type: "string"
+    metrics:
+      - name: "metric_name"
+        column_name: "METRIC_NAME"
+        value_type: "int"
+        data:
+          type: "gauge"
+        unit: "metric_unit"


### PR DESCRIPTION
This part of implementation contains metadata parser implementation and metadata config file.
This stuff will be used for constructing metrics metadata and metric readers(will be added as separate MRs).