### PR TITLE
Extend kafkareceiver configuration capabilities

### DIFF
--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -55,6 +55,13 @@ The following settings can be optionally configured:
   - `retry`
     - `max` (default = 3): The number of retries to get metadata
     - `backoff` (default = 250ms): How long to wait between metadata retries
+- `autocommit`
+  - `enable`: (default = true) Whether or not to auto-commit updated offsets back to the broker
+  - `interval`: (default = 1s) How frequently to commit updated offsets. Ineffective unless auto-commit is enabled
+- `message_marking`:
+  - `after`: (default =  false)  If true, the messages are marked after the pipeline execution
+  - `on_error`: (default = false) If false, only the successfully processed messages are marked
+     **Note: this can block the entire partition in case a message precessing returns a permanent error**
 
 Example:
 

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -61,7 +61,7 @@ The following settings can be optionally configured:
 - `message_marking`:
   - `after`: (default =  false)  If true, the messages are marked after the pipeline execution
   - `on_error`: (default = false) If false, only the successfully processed messages are marked
-     **Note: this can block the entire partition in case a message precessing returns a permanent error**
+     **Note: this can block the entire partition in case a message processing returns a permanent error**
 
 Example:
 

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -64,7 +64,7 @@ type Config struct {
 
 	Authentication kafkaexporter.Authentication `mapstructure:"auth"`
 
-	// Controls the auto-commit funcionality
+	// Controls the auto-commit functionality
 	AutoCommit AutoCommit `mapstructure:"autocommit"`
 
 	// Controls the way the messages are marked as consumed

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -15,10 +15,21 @@
 package kafkareceiver
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/config"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 )
+
+type AutoCommit struct {
+	// Whether or not to auto-commit updated offsets back to the broker.
+	// (default enabled).
+	Enable bool `mapstructure:"enable"`
+	// How frequently to commit updated offsets. Ineffective unless
+	// auto-commit is enabled (default 1s)
+	Interval time.Duration `mapstructure:"interval"`
+}
 
 // Config defines configuration for Kafka receiver.
 type Config struct {
@@ -41,6 +52,9 @@ type Config struct {
 	Metadata kafkaexporter.Metadata `mapstructure:"metadata"`
 
 	Authentication kafkaexporter.Authentication `mapstructure:"auth"`
+
+	// Controls the auto-commit funcionality
+	AutoCommit AutoCommit `mapstructure:"autocommit"`
 }
 
 var _ config.Receiver = (*Config)(nil)

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -31,6 +31,17 @@ type AutoCommit struct {
 	Interval time.Duration `mapstructure:"interval"`
 }
 
+type MessageMarking struct {
+	// If true, the messages are marked after the pipeline execution
+	After bool `mapstructure:"after"`
+
+	// If false, only the successfully processed messages are marked, it has no impact if
+	// After is set to false.
+	// Note: this can block the entire partition in case a message precessing returns
+	// a permanent error.
+	OnError bool `mapstructure:"on_error"`
+}
+
 // Config defines configuration for Kafka receiver.
 type Config struct {
 	config.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
@@ -55,6 +66,9 @@ type Config struct {
 
 	// Controls the auto-commit funcionality
 	AutoCommit AutoCommit `mapstructure:"autocommit"`
+
+	// Controls the way the messages are marked as consumed
+	MessageMarking MessageMarking `mapstructure:"message_marking"`
 }
 
 var _ config.Receiver = (*Config)(nil)

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -37,7 +37,7 @@ type MessageMarking struct {
 
 	// If false, only the successfully processed messages are marked, it has no impact if
 	// After is set to false.
-	// Note: this can block the entire partition in case a message precessing returns
+	// Note: this can block the entire partition in case a message processing returns
 	// a permanent error.
 	OnError bool `mapstructure:"on_error"`
 }

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -63,5 +63,9 @@ func TestLoadConfig(t *testing.T) {
 				Backoff: time.Second * 5,
 			},
 		},
+		AutoCommit: AutoCommit{
+			Enable:   true,
+			Interval: 1 * time.Second,
+		},
 	}, r)
 }

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -116,6 +116,10 @@ func createDefaultConfig() config.Receiver {
 			Enable:   defaultAutoCommitEnable,
 			Interval: defaultAutoCommitInterval,
 		},
+		MessageMarking: MessageMarking{
+			After:   false,
+			OnError: false,
+		},
 	}
 }
 

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -41,6 +41,11 @@ const (
 	defaultMetadataRetryBackoff = time.Millisecond * 250
 	// default from sarama.NewConfig()
 	defaultMetadataFull = true
+
+	// default from sarama.NewConfig()
+	defaultAutoCommitEnable = true
+	// default from sarama.NewConfig()
+	defaultAutoCommitInterval = 1 * time.Second
 )
 
 // FactoryOption applies changes to kafkaExporterFactory.
@@ -106,6 +111,10 @@ func createDefaultConfig() config.Receiver {
 				Max:     defaultMetadataRetryMax,
 				Backoff: defaultMetadataRetryBackoff,
 			},
+		},
+		AutoCommit: AutoCommit{
+			Enable:   defaultAutoCommitEnable,
+			Interval: defaultAutoCommitInterval,
 		},
 	}
 }

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -635,7 +635,6 @@ type testConsumerGroupSession struct {
 }
 
 func (t testConsumerGroupSession) Commit() {
-	panic("implement me")
 }
 
 var _ sarama.ConsumerGroupSession = (*testConsumerGroupSession)(nil)
@@ -653,7 +652,6 @@ func (t testConsumerGroupSession) GenerationID() int32 {
 }
 
 func (t testConsumerGroupSession) MarkOffset(string, int32, int64, string) {
-	panic("implement me")
 }
 
 func (t testConsumerGroupSession) ResetOffset(string, int32, int64, string) {


### PR DESCRIPTION
**Description:** Extend the kafkareceiver's configuration capabilities to be able to control the offsets autocommit and message marking strategy.

**Link to tracking Issue:**  n/a

**Testing:** No regressions in local testing. 

**Documentation:** kafkareceiver documentation was updated to reflect the changes