### PR TITLE
Add expr language for logs and use it in filter processor

### DIFF
--- a/internal/coreinternal/processor/filterexpr/README.md
+++ b/internal/coreinternal/processor/filterexpr/README.md
@@ -12,14 +12,14 @@ For metrics the following variables as available:
 
 | Name       | [Type][type] | Description         |
 |------------|--------------|---------------------|
-| MetricName | string       | Name of the metric. |
+| MetricName | string       | Name of the Metric. |
 
 In addtion the following functions are available:
 
-| Name     | Signature               | Description                                              |
-|----------|-------------------------|----------------------------------------------------------|
-| HasLabel | func(key string) bool   | Returns true if metric has given label, otherwise false. |
-| Label    | func(key string) string | Returns value of given label name.                       |
+| Name     | Signature               | Description                                                  |
+|----------|-------------------------|--------------------------------------------------------------|
+| HasLabel | func(key string) bool   | Returns true if the Metric has given label, otherwise false. |
+| Label    | func(key string) string | Returns value of given label name if exists, otherwise `""`  |
 
 ## Logs
 

--- a/internal/coreinternal/processor/filterexpr/README.md
+++ b/internal/coreinternal/processor/filterexpr/README.md
@@ -14,7 +14,7 @@ For metrics the following variables as available:
 |------------|--------------|---------------------|
 | MetricName | string       | Name of the Metric. |
 
-In addtion the following functions are available:
+In addition the following functions are available:
 
 | Name     | Signature               | Description                                                  |
 |----------|-------------------------|--------------------------------------------------------------|

--- a/internal/coreinternal/processor/filterexpr/README.md
+++ b/internal/coreinternal/processor/filterexpr/README.md
@@ -1,0 +1,35 @@
+# Expr language
+
+Expressions give the config flexibility by allowing dynamic business logic rules to be included in static configs.
+Most notably, expressions can be used to filter logs and metrics based on content and properties of processed records.
+
+For reference documentation of the expression language,
+see [here](https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md).
+
+## Metrics
+
+For metrics the following variables as available:
+
+| Name       | [Type][type] | Description         |
+|------------|--------------|---------------------|
+| MetricName | string       | Name of the metric. |
+
+In addtion the following functions are available:
+
+| Name     | Signature               | Description                                              |
+|----------|-------------------------|----------------------------------------------------------|
+| HasLabel | func(key string) bool   | Returns true if metric has given label, otherwise false. |
+| Label    | func(key string) string | Returns value of given label name.                       |
+
+## Logs
+
+For logs, the following variables are available:
+
+| Name           | [Type][type] | Description                        |
+|----------------|--------------|------------------------------------|
+| Body           | string       | Stringified Body of the LogRecord. |
+| Name           | string       | Name of the LogRecord.             |
+| SeverityNumber | number       | SeverityNumber of the LogRecord.   |
+| SeverityText   | string       | SeverityText of the LogRecord.     |
+
+[type]: https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md#supported-literals

--- a/internal/coreinternal/processor/filterexpr/README.md
+++ b/internal/coreinternal/processor/filterexpr/README.md
@@ -3,6 +3,11 @@
 Expressions give the config flexibility by allowing dynamic business logic rules to be included in static configs.
 Most notably, expressions can be used to filter logs and metrics based on content and properties of processed records.
 
+To ensure that everything is safe and secure:
+
+- only basic types (like `string` instead of more complex log body) are being exposed
+- expr has only access to a copy of object values
+
 For reference documentation of the expression language,
 see [here](https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md).
 

--- a/internal/coreinternal/processor/filterexpr/log_matcher.go
+++ b/internal/coreinternal/processor/filterexpr/log_matcher.go
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/vm"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+type LogMatcher struct {
+	program *vm.Program
+	v       vm.VM
+}
+
+type logEnv struct {
+	Body           string
+	Name           string
+	SeverityNumber int32
+	SeverityText   string
+}
+
+func NewLogMatcher(expression string) (*LogMatcher, error) {
+	program, err := expr.Compile(expression)
+	if err != nil {
+		return nil, err
+	}
+	return &LogMatcher{program: program, v: vm.VM{}}, nil
+}
+
+func (m *LogMatcher) MatchLog(log pdata.LogRecord) (bool, error) {
+	matched, err := m.match(createLogEnv(log))
+	if err != nil {
+		return false, err
+	}
+
+	if matched {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func createLogEnv(log pdata.LogRecord) logEnv {
+	return logEnv{
+		Name:           log.Name(),
+		Body:           log.Body().AsString(),
+		SeverityNumber: int32(log.SeverityNumber()),
+		SeverityText:   log.SeverityText(),
+	}
+}
+
+func (m *LogMatcher) match(env logEnv) (bool, error) {
+	result, err := m.v.Run(m.program, env)
+	if err != nil {
+		return false, err
+	}
+	return result.(bool), nil
+}

--- a/internal/coreinternal/processor/filterexpr/log_matcher.go
+++ b/internal/coreinternal/processor/filterexpr/log_matcher.go
@@ -25,6 +25,7 @@ type LogMatcher struct {
 	v       vm.VM
 }
 
+// logEnv is a structure of variables and functions for expr language
 type logEnv struct {
 	Body           string
 	Name           string
@@ -32,6 +33,7 @@ type logEnv struct {
 	SeverityText   string
 }
 
+// NewLogMatcher creates new log matcher
 func NewLogMatcher(expression string) (*LogMatcher, error) {
 	program, err := expr.Compile(expression)
 	if err != nil {
@@ -40,6 +42,7 @@ func NewLogMatcher(expression string) (*LogMatcher, error) {
 	return &LogMatcher{program: program, v: vm.VM{}}, nil
 }
 
+// MatchLog returns true if log matches the matcher
 func (m *LogMatcher) MatchLog(log pdata.LogRecord) (bool, error) {
 	matched, err := m.match(createLogEnv(log))
 	if err != nil {
@@ -53,6 +56,7 @@ func (m *LogMatcher) MatchLog(log pdata.LogRecord) (bool, error) {
 	return false, nil
 }
 
+// createLogEnv converts pdata.LogRecord to logEnv
 func createLogEnv(log pdata.LogRecord) logEnv {
 	return logEnv{
 		Name:           log.Name(),

--- a/internal/coreinternal/processor/filterexpr/log_matcher_test.go
+++ b/internal/coreinternal/processor/filterexpr/log_matcher_test.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterexpr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestLogCompileExprError(t *testing.T) {
+	_, err := NewMetricMatcher("")
+	require.Error(t, err)
+}
+
+func TestLogRunExprError(t *testing.T) {
+	matcher, err := NewMetricMatcher("foo")
+	require.NoError(t, err)
+	matched, _ := matcher.match(metricEnv{})
+	require.False(t, matched)
+}
+
+func TestLogStringBodyMatches(t *testing.T) {
+	matcher, err := NewLogMatcher(`Body matches 'my.log'`)
+	require.NoError(t, err)
+	l := pdata.NewLogRecord()
+	l.Body().SetStringVal("my.log")
+	matched, err := matcher.MatchLog(l)
+	assert.NoError(t, err)
+	assert.True(t, matched)
+}
+
+func TestLogStringodyDoesntMatch(t *testing.T) {
+	matcher, err := NewLogMatcher(`Body matches 'my.logs'`)
+	require.NoError(t, err)
+	l := pdata.NewLogRecord()
+	l.Body().SetStringVal("my.log")
+	matched, err := matcher.MatchLog(l)
+	assert.NoError(t, err)
+	assert.False(t, matched)
+}

--- a/internal/coreinternal/processor/filterexpr/metric_matcher_test.go
+++ b/internal/coreinternal/processor/filterexpr/metric_matcher_test.go
@@ -22,20 +22,20 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
-func TestCompileExprError(t *testing.T) {
-	_, err := NewMatcher("")
+func TestMetricCompileExprError(t *testing.T) {
+	_, err := NewMetricMatcher("")
 	require.Error(t, err)
 }
 
-func TestRunExprError(t *testing.T) {
-	matcher, err := NewMatcher("foo")
+func TestMetricRunExprError(t *testing.T) {
+	matcher, err := NewMetricMatcher("foo")
 	require.NoError(t, err)
-	matched, _ := matcher.match(env{})
+	matched, _ := matcher.match(metricEnv{})
 	require.False(t, matched)
 }
 
-func TestUnknownDataType(t *testing.T) {
-	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+func TestMetricUnknownDataType(t *testing.T) {
+	matcher, err := NewMetricMatcher(`MetricName == 'my.metric'`)
 	require.NoError(t, err)
 	m := pdata.NewMetric()
 	m.SetName("my.metric")
@@ -45,20 +45,20 @@ func TestUnknownDataType(t *testing.T) {
 	assert.False(t, matched)
 }
 
-func TestEmptyGauge(t *testing.T) {
-	testEmptyValue(t, pdata.MetricDataTypeGauge)
+func TestMetricEmptyGauge(t *testing.T) {
+	testMetricEmptyValue(t, pdata.MetricDataTypeGauge)
 }
 
-func TestEmptySum(t *testing.T) {
-	testEmptyValue(t, pdata.MetricDataTypeSum)
+func TestMetricEmptySum(t *testing.T) {
+	testMetricEmptyValue(t, pdata.MetricDataTypeSum)
 }
 
-func TestEmptyHistogram(t *testing.T) {
-	testEmptyValue(t, pdata.MetricDataTypeHistogram)
+func TestMetricEmptyHistogram(t *testing.T) {
+	testMetricEmptyValue(t, pdata.MetricDataTypeHistogram)
 }
 
-func testEmptyValue(t *testing.T, dataType pdata.MetricDataType) {
-	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+func testMetricEmptyValue(t *testing.T, dataType pdata.MetricDataType) {
+	matcher, err := NewMetricMatcher(`MetricName == 'my.metric'`)
 	require.NoError(t, err)
 	m := pdata.NewMetric()
 	m.SetName("my.metric")
@@ -68,8 +68,8 @@ func testEmptyValue(t *testing.T, dataType pdata.MetricDataType) {
 	assert.False(t, matched)
 }
 
-func TestGaugeEmptyDataPoint(t *testing.T) {
-	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+func TestMetricGaugeEmptyDataPoint(t *testing.T) {
+	matcher, err := NewMetricMatcher(`MetricName == 'my.metric'`)
 	require.NoError(t, err)
 	m := pdata.NewMetric()
 	m.SetName("my.metric")
@@ -80,8 +80,8 @@ func TestGaugeEmptyDataPoint(t *testing.T) {
 	assert.True(t, matched)
 }
 
-func TestSumEmptyDataPoint(t *testing.T) {
-	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+func TestMetricSumEmptyDataPoint(t *testing.T) {
+	matcher, err := NewMetricMatcher(`MetricName == 'my.metric'`)
 	require.NoError(t, err)
 	m := pdata.NewMetric()
 	m.SetName("my.metric")
@@ -92,8 +92,8 @@ func TestSumEmptyDataPoint(t *testing.T) {
 	assert.True(t, matched)
 }
 
-func TestHistogramEmptyDataPoint(t *testing.T) {
-	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+func TestMetricHistogramEmptyDataPoint(t *testing.T) {
+	matcher, err := NewMetricMatcher(`MetricName == 'my.metric'`)
 	require.NoError(t, err)
 	m := pdata.NewMetric()
 	m.SetName("my.metric")
@@ -104,8 +104,8 @@ func TestHistogramEmptyDataPoint(t *testing.T) {
 	assert.True(t, matched)
 }
 
-func TestMatchIntGaugeDataPointByMetricAndSecondPointLabelValue(t *testing.T) {
-	matcher, err := NewMatcher(
+func TestMetricMatchIntGaugeDataPointByMetricAndSecondPointLabelValue(t *testing.T) {
+	matcher, err := NewMetricMatcher(
 		`MetricName == 'my.metric' && Label("baz") == "glarch"`,
 	)
 	require.NoError(t, err)
@@ -122,38 +122,38 @@ func TestMatchIntGaugeDataPointByMetricAndSecondPointLabelValue(t *testing.T) {
 	assert.True(t, matched)
 }
 
-func TestMatchGaugeByMetricName(t *testing.T) {
+func TestMetricMatchGaugeByMetricName(t *testing.T) {
 	expression := `MetricName == 'my.metric'`
-	assert.True(t, testMatchGauge(t, "my.metric", expression, nil))
+	assert.True(t, testMetricMatchGauge(t, "my.metric", expression, nil))
 }
 
-func TestNonMatchGaugeByMetricName(t *testing.T) {
+func TestMetricNonMatchGaugeByMetricName(t *testing.T) {
 	expression := `MetricName == 'my.metric'`
-	assert.False(t, testMatchGauge(t, "foo.metric", expression, nil))
+	assert.False(t, testMetricMatchGauge(t, "foo.metric", expression, nil))
 }
 
-func TestNonMatchGaugeDataPointByMetricAndHasLabel(t *testing.T) {
+func TestMetricNonMatchGaugeDataPointByMetricAndHasLabel(t *testing.T) {
 	expression := `MetricName == 'my.metric' && HasLabel("foo")`
-	assert.False(t, testMatchGauge(t, "foo.metric", expression, nil))
+	assert.False(t, testMetricMatchGauge(t, "foo.metric", expression, nil))
 }
 
-func TestMatchGaugeDataPointByMetricAndHasLabel(t *testing.T) {
+func TestMetricMatchGaugeDataPointByMetricAndHasLabel(t *testing.T) {
 	expression := `MetricName == 'my.metric' && HasLabel("foo")`
-	assert.True(t, testMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
+	assert.True(t, testMetricMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
 }
 
-func TestMatchGaugeDataPointByMetricAndLabelValue(t *testing.T) {
+func TestMetricMatchGaugeDataPointByMetricAndLabelValue(t *testing.T) {
 	expression := `MetricName == 'my.metric' && Label("foo") == "bar"`
-	assert.False(t, testMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
+	assert.False(t, testMetricMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
 }
 
-func TestNonMatchGaugeDataPointByMetricAndLabelValue(t *testing.T) {
+func TestMetricNonMatchGaugeDataPointByMetricAndLabelValue(t *testing.T) {
 	expression := `MetricName == 'my.metric' && Label("foo") == "bar"`
-	assert.False(t, testMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
+	assert.False(t, testMetricMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
 }
 
-func testMatchGauge(t *testing.T, metricName, expression string, lbls map[string]pdata.AttributeValue) bool {
-	matcher, err := NewMatcher(expression)
+func testMetricMatchGauge(t *testing.T, metricName, expression string, lbls map[string]pdata.AttributeValue) bool {
+	matcher, err := NewMetricMatcher(expression)
 	require.NoError(t, err)
 	m := pdata.NewMetric()
 	m.SetName(metricName)
@@ -168,16 +168,16 @@ func testMatchGauge(t *testing.T, metricName, expression string, lbls map[string
 	return match
 }
 
-func TestMatchSumByMetricName(t *testing.T) {
+func TestMetricMatchSumByMetricName(t *testing.T) {
 	assert.True(t, matchSum(t, "my.metric"))
 }
 
-func TestNonMatchSumByMetricName(t *testing.T) {
+func TestMetricNonMatchSumByMetricName(t *testing.T) {
 	assert.False(t, matchSum(t, "foo.metric"))
 }
 
 func matchSum(t *testing.T, metricName string) bool {
-	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	matcher, err := NewMetricMatcher(`MetricName == 'my.metric'`)
 	require.NoError(t, err)
 	m := pdata.NewMetric()
 	m.SetName(metricName)
@@ -189,16 +189,16 @@ func matchSum(t *testing.T, metricName string) bool {
 	return matched
 }
 
-func TestMatchHistogramByMetricName(t *testing.T) {
+func TestMetricMatchHistogramByMetricName(t *testing.T) {
 	assert.True(t, matchHistogram(t, "my.metric"))
 }
 
-func TestNonMatchHistogramByMetricName(t *testing.T) {
+func TestMetricNonMatchHistogramByMetricName(t *testing.T) {
 	assert.False(t, matchHistogram(t, "foo.metric"))
 }
 
 func matchHistogram(t *testing.T, metricName string) bool {
-	matcher, err := NewMatcher(`MetricName == 'my.metric'`)
+	matcher, err := NewMetricMatcher(`MetricName == 'my.metric'`)
 	require.NoError(t, err)
 	m := pdata.NewMetric()
 	m.SetName(metricName)

--- a/internal/coreinternal/processor/filterlog/config.go
+++ b/internal/coreinternal/processor/filterlog/config.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterlog
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset/regexp"
+)
+
+// MatchType specifies the strategy for matching against `pdata.Log`s. This
+// is distinct from filterset.MatchType which matches against metric (and
+// tracing) names only. To support matching against log names and
+// `pdata.Log`s, filterlog.MatchType is effectively a superset of
+// filterset.MatchType.
+type MatchType string
+
+// These are the MatchTypes that users can specify for filtering
+// `pdata.Metric`s.
+const (
+	Regexp           = MatchType(filterset.Regexp)
+	Strict           = MatchType(filterset.Strict)
+	Expr   MatchType = "expr"
+)
+
+// LogMatchProperties specifies the set of properties in a log to match against and the
+// type of string pattern matching to use.
+type LogMatchProperties struct {
+	// MatchType specifies the type of matching desired
+	MatchType MatchType `mapstructure:"match_type"`
+
+	// RegexpConfig specifies options for the Regexp match type
+	RegexpConfig *regexp.Config `mapstructure:"regexp"`
+
+	// Expressions specifies the list of expr expressions to match metrics against.
+	// A match occurs if any datapoint in a metric matches at least one expression in this list.
+	Expressions []string `mapstructure:"expressions"`
+
+	// ResourceAttributes defines a list of possible resource attributes to match logs against.
+	// A match occurs if any resource attribute matches all expressions in this given list.
+	ResourceAttributes []filterconfig.Attribute `mapstructure:"resource_attributes"`
+
+	// RecordAttributes defines a list of possible record attributes to match logs against.
+	// A match occurs if any record attribute matches at least one expression in this given list.
+	RecordAttributes []filterconfig.Attribute `mapstructure:"record_attributes"`
+}
+
+func (lmp *LogMatchProperties) convertToFilterConfig() *filterconfig.MatchProperties {
+	return &filterconfig.MatchProperties{
+		Config: filterset.Config{
+			MatchType:    filterset.MatchType(lmp.MatchType),
+			RegexpConfig: lmp.RegexpConfig,
+		},
+		Attributes: lmp.RecordAttributes,
+		Resources:  lmp.ResourceAttributes,
+	}
+}

--- a/internal/coreinternal/processor/filterlog/expr_matcher.go
+++ b/internal/coreinternal/processor/filterlog/expr_matcher.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterlog
+
+import (
+	"go.opentelemetry.io/collector/model/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterexpr"
+)
+
+type exprMatcher struct {
+	matchers []*filterexpr.LogMatcher
+}
+
+func newExprMatcher(expressions []string) (*exprMatcher, error) {
+	m := &exprMatcher{}
+	for _, expression := range expressions {
+		matcher, err := filterexpr.NewLogMatcher(expression)
+		if err != nil {
+			return nil, err
+		}
+		m.matchers = append(m.matchers, matcher)
+	}
+	return m, nil
+}
+
+func (m *exprMatcher) MatchLog(lr pdata.LogRecord, resource pdata.Resource, library pdata.InstrumentationLibrary) bool {
+	return m.MatchLogRecord(lr)
+}
+
+func (m *exprMatcher) MatchLogRecord(lr pdata.LogRecord) bool {
+	for _, matcher := range m.matchers {
+		matched, err := matcher.MatchLog(lr)
+		if err != nil {
+			return false
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/coreinternal/processor/filterlog/filterlog.go
+++ b/internal/coreinternal/processor/filterlog/filterlog.go
@@ -29,7 +29,8 @@ import (
 // TODO: Modify Matcher to invoke both the include and exclude properties so
 //  calling processors will always have the same logic.
 type Matcher interface {
-	MatchLogRecord(lr pdata.LogRecord, resource pdata.Resource, library pdata.InstrumentationLibrary) bool
+	MatchLog(lr pdata.LogRecord, resource pdata.Resource, library pdata.InstrumentationLibrary) bool
+	MatchLogRecord(lr pdata.LogRecord) bool
 }
 
 // propertiesMatcher allows matching a log record against various log record properties.
@@ -40,8 +41,8 @@ type propertiesMatcher struct {
 	nameFilters filterset.FilterSet
 }
 
-// NewMatcher creates a LogRecord Matcher that matches based on the given MatchProperties.
-func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
+// NewClassicMatcher creates a LogRecord Matcher that matches based on the given MatchProperties.
+func NewClassicMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 	if mp == nil {
 		return nil, nil
 	}
@@ -69,17 +70,35 @@ func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 	}, nil
 }
 
-// MatchLogRecord matches a log record to a set of properties.
+func NewMatcher(mp *LogMatchProperties) (Matcher, error) {
+	if mp.MatchType == Expr {
+		return newExprMatcher(mp.Expressions)
+	}
+
+	return NewClassicMatcher(mp.convertToFilterConfig())
+}
+
+// MatchLogRecord matches a log to a set of properties.
 // There are 3 sets of properties to match against.
 // The log record names are matched, if specified.
 // The attributes are then checked, if specified.
 // At least one of log record names or attributes must be specified. It is
 // supported to have more than one of these specified, and all specified must
 // evaluate to true for a match to occur.
-func (mp *propertiesMatcher) MatchLogRecord(lr pdata.LogRecord, resource pdata.Resource, library pdata.InstrumentationLibrary) bool {
+func (mp *propertiesMatcher) MatchLog(lr pdata.LogRecord, resource pdata.Resource, library pdata.InstrumentationLibrary) bool {
 	if mp.nameFilters != nil && !mp.nameFilters.Matches(lr.Name()) {
 		return false
 	}
 
 	return mp.PropertiesMatcher.Match(lr.Attributes(), resource, library)
+}
+
+// MatchLogRecord matches a log record to a set of properties.
+// Only the log record name is matched, if specified.
+func (mp *propertiesMatcher) MatchLogRecord(lr pdata.LogRecord) bool {
+	if mp.nameFilters != nil && !mp.nameFilters.Matches(lr.Name()) {
+		return false
+	}
+
+	return true
 }

--- a/internal/coreinternal/processor/filterlog/filterlog_test.go
+++ b/internal/coreinternal/processor/filterlog/filterlog_test.go
@@ -90,7 +90,7 @@ func TestLogRecord_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := NewMatcher(&tc.property)
+			output, err := NewClassicMatcher(&tc.property)
 			assert.Nil(t, output)
 			require.NotNil(t, err)
 			assert.Equal(t, tc.errorString, err.Error())
@@ -130,11 +130,11 @@ func TestLogRecord_Matching_False(t *testing.T) {
 	lr.SetName("logName")
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			matcher, err := NewMatcher(tc.properties)
+			matcher, err := NewClassicMatcher(tc.properties)
 			assert.Nil(t, err)
 			assert.NotNil(t, matcher)
 
-			assert.False(t, matcher.MatchLogRecord(lr, pdata.Resource{}, pdata.InstrumentationLibrary{}))
+			assert.False(t, matcher.MatchLog(lr, pdata.Resource{}, pdata.InstrumentationLibrary{}))
 		})
 	}
 }
@@ -172,12 +172,12 @@ func TestLogRecord_Matching_True(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			mp, err := NewMatcher(tc.properties)
+			mp, err := NewClassicMatcher(tc.properties)
 			assert.Nil(t, err)
 			assert.NotNil(t, mp)
 
 			assert.NotNil(t, lr)
-			assert.True(t, mp.MatchLogRecord(lr, pdata.Resource{}, pdata.InstrumentationLibrary{}))
+			assert.True(t, mp.MatchLog(lr, pdata.Resource{}, pdata.InstrumentationLibrary{}))
 		})
 	}
 }

--- a/internal/coreinternal/processor/filtermetric/expr_matcher.go
+++ b/internal/coreinternal/processor/filtermetric/expr_matcher.go
@@ -21,13 +21,13 @@ import (
 )
 
 type exprMatcher struct {
-	matchers []*filterexpr.Matcher
+	matchers []*filterexpr.MetricMatcher
 }
 
 func newExprMatcher(expressions []string) (*exprMatcher, error) {
 	m := &exprMatcher{}
 	for _, expression := range expressions {
-		matcher, err := filterexpr.NewMatcher(expression)
+		matcher, err := filterexpr.NewMetricMatcher(expression)
 		if err != nil {
 			return nil, err
 		}

--- a/processor/attributesprocessor/attributes_log.go
+++ b/processor/attributesprocessor/attributes_log.go
@@ -72,14 +72,14 @@ func (a *logAttributesProcessor) processLogs(_ context.Context, ld pdata.Logs) (
 func (a *logAttributesProcessor) skipLog(lr pdata.LogRecord, resource pdata.Resource, library pdata.InstrumentationLibrary) bool {
 	if a.include != nil {
 		// A false returned in this case means the log should not be processed.
-		if include := a.include.MatchLogRecord(lr, resource, library); !include {
+		if include := a.include.MatchLog(lr, resource, library); !include {
 			return true
 		}
 	}
 
 	if a.exclude != nil {
 		// A true returned in this case means the log should not be processed.
-		if exclude := a.exclude.MatchLogRecord(lr, resource, library); exclude {
+		if exclude := a.exclude.MatchLog(lr, resource, library); exclude {
 			return true
 		}
 	}

--- a/processor/attributesprocessor/factory.go
+++ b/processor/attributesprocessor/factory.go
@@ -95,11 +95,11 @@ func createLogProcessor(
 	if err != nil {
 		return nil, fmt.Errorf("error creating \"attributes\" processor: %w of processor %v", err, cfg.ID())
 	}
-	include, err := filterlog.NewMatcher(oCfg.Include)
+	include, err := filterlog.NewClassicMatcher(oCfg.Include)
 	if err != nil {
 		return nil, err
 	}
-	exclude, err := filterlog.NewMatcher(oCfg.Exclude)
+	exclude, err := filterlog.NewClassicMatcher(oCfg.Exclude)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/attributesprocessor/go.mod
+++ b/processor/attributesprocessor/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/antonmedv/expr v1.9.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/processor/attributesprocessor/go.sum
+++ b/processor/attributesprocessor/go.sum
@@ -49,6 +49,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/antonmedv/expr v1.9.0 h1:j4HI3NHEdgDnN9p6oI6Ndr0G5QryMY0FNxT4ONrFDGU=
 github.com/antonmedv/expr v1.9.0/go.mod h1:5qsM3oLGDND7sDmQGDXHkYfkjYMUX14qsgqmHhwGEk8=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -19,13 +19,16 @@ For the actions the following parameters are required:
 
 For logs:
 
-- `match_type`: `strict`|`regexp`
+- `match_type`: `strict`|`regexp`|`expr`
 - `resource_attributes`: ResourceAttributes defines a list of possible resource
   attributes to match logs against.
   A match occurs if any resource attribute matches all expressions in this given list.
 - `record_attributes`: RecordAttributes defines a list of possible record
   attributes to match logs against.
   A match occurs if any record attribute matches all expressions in this given list.
+- `expressions`: (only for a `match_type` of `expr`) list of expr expressions
+  (for more details see "Using an 'expr' match_type" below and
+  [expr documentation](../../internal/coreinternal/processor/filterexpr/README.md))
 
 For metrics:
 
@@ -33,7 +36,8 @@ For metrics:
 - `metric_names`: (only for a `match_type` of `strict` or `regexp`) list of strings
   or re2 regex patterns
 - `expressions`: (only for a `match_type` of `expr`) list of expr expressions
-  (see "Using an 'expr' match_type" below)
+  (for more details see "Using an 'expr' match_type" below and
+  [expr documentation](../../internal/coreinternal/processor/filterexpr/README.md))
 - `resource_attributes`: ResourceAttributes defines a list of possible resource
   attributes to match metrics against.
   A match occurs if any resource attribute matches all expressions in this given list.
@@ -87,23 +91,15 @@ examples on using the processor.
 
 ## Using an 'expr' match_type
 
-In addition to matching metric names with the 'strict' or 'regexp' match types, the filter processor
-supports matching entire `Metric`s using the [expr](https://github.com/antonmedv/expr) expression engine.
+In addition to matching with the 'strict' or 'regexp' match types, the filter processor
+supports matching entire `Metric`s and `Log`s using the [expr](https://github.com/antonmedv/expr) expression engine.
 
 The 'expr' filter evaluates the supplied boolean expressions _per datapoint_ on a metric, and returns a result
 for the entire metric. If any datapoint evaluates to true then the entire metric evaluates to true, otherwise
 false.
 
-Made available to the expression environment are the following:
-
-* `MetricName`
-    a variable containing the current Metric's name
-* `Label(name)`
-    a function that takes a label name string as an argument and returns a string: the value of a label with that
-    name if one exists, or ""
-* `HasLabel(name)`
-    a function that takes a label name string as an argument and returns a boolean: true if the datapoint has a label
-    with that name, false otherwise
+See [expr documentation for metrics](../../internal/coreinternal/processor/filterexpr/README.md#metrics)
+for available environment variables and functions.
 
 Example:
 
@@ -119,6 +115,11 @@ processors:
 
 The above config will filter out any Metric that both has the name "my.metric" and has at least one datapoint
 with a label of 'my_label="abc123"'.
+
+For logs 'expr` filter evaluates the supplied boolean expressions per LogRecord.
+
+See [expr documentation for logs](../../internal/coreinternal/processor/filterexpr/README.md#logs)
+for available environment variables and functions.
 
 ### Support for multiple expressions
 

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -116,7 +116,7 @@ processors:
 The above config will filter out any Metric that both has the name "my.metric" and has at least one datapoint
 with a label of 'my_label="abc123"'.
 
-For logs 'expr` filter evaluates the supplied boolean expressions per LogRecord.
+For logs `expr` filter evaluates the supplied boolean expressions per LogRecord.
 
 See [expr documentation for logs](../../internal/coreinternal/processor/filterexpr/README.md#logs)
 for available environment variables and functions.

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -75,11 +75,13 @@ processors:
           - Key: host.name
             Value: just_this_one_hostname
     logs/regexp:
+      exclude:
         match_type: regexp
         resource_attributes:
           - Key: host.name
             Value: prefix.*
     logs/regexp_record:
+      include:
         match_type: regexp
         record_attributes:
           - Key: record_attr
@@ -117,6 +119,18 @@ The above config will filter out any Metric that both has the name "my.metric" a
 with a label of 'my_label="abc123"'.
 
 For logs `expr` filter evaluates the supplied boolean expressions per LogRecord.
+
+Example:
+
+```yaml
+processors:
+  filter:
+    logs:
+      include:
+        match_type: expr
+        expressions:
+          - Body matches '\[INFO\]
+```
 
 See [expr documentation for logs](../../internal/coreinternal/processor/filterexpr/README.md#logs)
 for available environment variables and functions.

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -17,9 +17,8 @@ package filterprocessor
 import (
 	"go.opentelemetry.io/collector/config"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterlog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filtermetric"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 )
 
 // Config defines configuration for Resource processor.
@@ -49,36 +48,11 @@ type LogFilters struct {
 	// Include match properties describe logs that should be included in the Collector Service pipeline,
 	// all other logs should be dropped from further processing.
 	// If both Include and Exclude are specified, Include filtering occurs first.
-	Include *LogMatchProperties `mapstructure:"include"`
+	Include *filterlog.LogMatchProperties `mapstructure:"include"`
 	// Exclude match properties describe logs that should be excluded from the Collector Service pipeline,
 	// all other logs should be included.
 	// If both Include and Exclude are specified, Include filtering occurs first.
-	Exclude *LogMatchProperties `mapstructure:"exclude"`
-}
-
-// LogMatchType specifies the strategy for matching against `pdata.Log`s.
-type LogMatchType string
-
-// These are the MatchTypes that users can specify for filtering
-// `pdata.Log`s.
-const (
-	Strict = LogMatchType(filterset.Strict)
-	Regexp = LogMatchType(filterset.Regexp)
-)
-
-// LogMatchProperties specifies the set of properties in a log to match against and the
-// type of string pattern matching to use.
-type LogMatchProperties struct {
-	// LogMatchType specifies the type of matching desired
-	LogMatchType LogMatchType `mapstructure:"match_type"`
-
-	// ResourceAttributes defines a list of possible resource attributes to match logs against.
-	// A match occurs if any resource attribute matches all expressions in this given list.
-	ResourceAttributes []filterconfig.Attribute `mapstructure:"resource_attributes"`
-
-	// RecordAttributes defines a list of possible record attributes to match logs against.
-	// A match occurs if any record attribute matches at least one expression in this given list.
-	RecordAttributes []filterconfig.Attribute `mapstructure:"record_attributes"`
+	Exclude *filterlog.LogMatchProperties `mapstructure:"exclude"`
 }
 
 var _ config.Processor = (*Config)(nil)

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -25,7 +25,9 @@ import (
 	"go.opentelemetry.io/collector/config/configtest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterlog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filtermetric"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 	fsregexp "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset/regexp"
 )
 
@@ -108,8 +110,8 @@ func TestLoadingConfigStrict(t *testing.T) {
 // TestLoadingConfigStrictLogs tests loading testdata/config_logs_strict.yaml
 func TestLoadingConfigStrictLogs(t *testing.T) {
 
-	testDataLogPropertiesInclude := &LogMatchProperties{
-		LogMatchType: Strict,
+	testDataLogPropertiesInclude := &filterlog.LogMatchProperties{
+		MatchType: filterlog.MatchType(filterset.Strict),
 		ResourceAttributes: []filterconfig.Attribute{
 			{
 				Key:   "should_include",
@@ -118,8 +120,8 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 		},
 	}
 
-	testDataLogPropertiesExclude := &LogMatchProperties{
-		LogMatchType: Strict,
+	testDataLogPropertiesExclude := &filterlog.LogMatchProperties{
+		MatchType: filterlog.MatchType(filterset.Strict),
 		ResourceAttributes: []filterconfig.Attribute{
 			{
 				Key:   "should_exclude",
@@ -147,8 +149,8 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 			expCfg: &Config{
 				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "empty")),
 				Logs: LogFilters{
-					Include: &LogMatchProperties{
-						LogMatchType: Strict,
+					Include: &filterlog.LogMatchProperties{
+						MatchType: filterlog.MatchType(filterset.Strict),
 					},
 				},
 			},

--- a/processor/filterprocessor/filter_processor_logs.go
+++ b/processor/filterprocessor/filter_processor_logs.go
@@ -100,7 +100,7 @@ func createLogsMatcher(lp *filterlog.LogMatchProperties) (logMatcher filterlog.M
 
 	logMatcher, err = filterlog.NewMatcher(lp)
 	if err != nil {
-		return logMatcher, resourceMatcher, recordMatcher, fmt.Errorf("expr matcher: %v", err)
+		return logMatcher, resourceMatcher, recordMatcher, fmt.Errorf("expr matcher: %w", err)
 	}
 
 	return logMatcher, resourceMatcher, recordMatcher, nil

--- a/processor/filterprocessor/filter_processor_logs.go
+++ b/processor/filterprocessor/filter_processor_logs.go
@@ -91,7 +91,7 @@ func createLogsMatcher(lp *filterlog.LogMatchProperties) (logMatcher filterlog.M
 		lp.ResourceAttributes,
 	)
 	if err != nil {
-		return nil, resourceMatcher, recordMatcher, fmt.Errorf("resource attributes: %v", err)
+		return nil, resourceMatcher, recordMatcher, fmt.Errorf("resource attributes: %w", err)
 	}
 
 	if lp.MatchType != filterlog.Expr {

--- a/processor/filterprocessor/filter_processor_logs_test.go
+++ b/processor/filterprocessor/filter_processor_logs_test.go
@@ -26,12 +26,14 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterlog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 )
 
 type logNameTest struct {
 	name   string
-	inc    *LogMatchProperties
-	exc    *LogMatchProperties
+	inc    *filterlog.LogMatchProperties
+	exc    *filterlog.LogMatchProperties
 	inLogs pdata.Logs
 	outLN  [][]string // output Log names per Resource
 }
@@ -154,13 +156,13 @@ var (
 	standardLogTests = []logNameTest{
 		{
 			name:   "emptyFilterInclude",
-			inc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{}},
 			inLogs: testResourceLogs([]logWithResource{{logNames: inLogNames}}),
 			outLN:  [][]string{inLogNames},
 		},
 		{
 			name:   "includeNilWithResourceAttributes",
-			inc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{}},
 			inLogs: testResourceLogs(inLogForResourceTest),
 			outLN: [][]string{
 				{"log1", "log2"},
@@ -168,7 +170,7 @@ var (
 		},
 		{
 			name:   "includeAllWithMissingResourceAttributes",
-			inc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val2"}}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val2"}}},
 			inLogs: testResourceLogs(inLogForTwoResource),
 			outLN: [][]string{
 				{"log3", "log4"},
@@ -176,13 +178,13 @@ var (
 		},
 		{
 			name:   "emptyFilterExclude",
-			exc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{}},
+			exc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{}},
 			inLogs: testResourceLogs([]logWithResource{{logNames: inLogNames}}),
 			outLN:  [][]string{inLogNames},
 		},
 		{
 			name:   "excludeNilWithResourceAttributes",
-			exc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{}},
+			exc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{}},
 			inLogs: testResourceLogs(inLogForResourceTest),
 			outLN: [][]string{
 				{"log1", "log2"},
@@ -190,7 +192,7 @@ var (
 		},
 		{
 			name:   "excludeAllWithMissingResourceAttributes",
-			exc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}}},
+			exc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}}},
 			inLogs: testResourceLogs(inLogForTwoResource),
 			outLN: [][]string{
 				{"log3", "log4"},
@@ -198,22 +200,22 @@ var (
 		},
 		{
 			name:   "emptyFilterIncludeAndExclude",
-			inc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{}},
-			exc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{}},
+			exc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{}},
 			inLogs: testResourceLogs([]logWithResource{{logNames: inLogNames}}),
 			outLN:  [][]string{inLogNames},
 		},
 		{
 			name:   "nilWithResourceAttributesIncludeAndExclude",
-			inc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{}},
-			exc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{}},
+			exc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{}},
 			inLogs: testResourceLogs([]logWithResource{{logNames: inLogNames}}),
 			outLN:  [][]string{inLogNames},
 		},
 		{
 			name:   "allWithMissingResourceAttributesIncludeAndExclude",
-			inc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val2"}}},
-			exc:    &LogMatchProperties{LogMatchType: Strict, ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val2"}}},
+			exc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Strict), ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}}},
 			inLogs: testResourceLogs(inLogForTwoResource),
 			outLN: [][]string{
 				{"log3", "log4"},
@@ -221,7 +223,7 @@ var (
 		},
 		{
 			name:   "matchAttributesWithRegexpInclude",
-			inc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val2"}}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Regexp), ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val2"}}},
 			inLogs: testResourceLogs(inLogForFourResource),
 			outLN: [][]string{
 				{"log2"},
@@ -229,7 +231,7 @@ var (
 		},
 		{
 			name:   "matchAttributesWithRegexpInclude2",
-			inc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val(2|3)"}}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Regexp), ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val(2|3)"}}},
 			inLogs: testResourceLogs(inLogForFourResource),
 			outLN: [][]string{
 				{"log2"},
@@ -238,7 +240,7 @@ var (
 		},
 		{
 			name:   "matchAttributesWithRegexpInclude3",
-			inc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val[234]"}}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Regexp), ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val[234]"}}},
 			inLogs: testResourceLogs(inLogForFourResource),
 			outLN: [][]string{
 				{"log2"},
@@ -248,7 +250,7 @@ var (
 		},
 		{
 			name:   "matchAttributesWithRegexpInclude4",
-			inc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val.*"}}},
+			inc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Regexp), ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val.*"}}},
 			inLogs: testResourceLogs(inLogForFourResource),
 			outLN: [][]string{
 				{"log1"},
@@ -259,7 +261,7 @@ var (
 		},
 		{
 			name:   "matchAttributesWithRegexpExclude",
-			exc:    &LogMatchProperties{LogMatchType: Regexp, ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val[23]"}}},
+			exc:    &filterlog.LogMatchProperties{MatchType: filterlog.MatchType(filterset.Regexp), ResourceAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val[23]"}}},
 			inLogs: testResourceLogs(inLogForFourResource),
 			outLN: [][]string{
 				{"log1"},
@@ -268,8 +270,8 @@ var (
 		},
 		{
 			name: "matchRecordAttributeWithRegexp1",
-			inc: &LogMatchProperties{
-				LogMatchType: Regexp,
+			inc: &filterlog.LogMatchProperties{
+				MatchType: filterlog.MatchType(filterset.Regexp),
 				RecordAttributes: []filterconfig.Attribute{
 					{
 						Key:   "rec",
@@ -284,8 +286,8 @@ var (
 		},
 		{
 			name: "matchRecordAttributeWithRegexp2",
-			inc: &LogMatchProperties{
-				LogMatchType: Regexp,
+			inc: &filterlog.LogMatchProperties{
+				MatchType: filterlog.MatchType(filterset.Regexp),
 				RecordAttributes: []filterconfig.Attribute{
 					{
 						Key:   "rec",
@@ -300,8 +302,8 @@ var (
 		},
 		{
 			name: "matchRecordAttributeWithRegexp2",
-			inc: &LogMatchProperties{
-				LogMatchType: Regexp,
+			inc: &filterlog.LogMatchProperties{
+				MatchType: filterlog.MatchType(filterset.Regexp),
 				RecordAttributes: []filterconfig.Attribute{
 					{
 						Key:   "rec",
@@ -317,8 +319,8 @@ var (
 		},
 		{
 			name: "matchRecordAttributeWithRegexp3",
-			inc: &LogMatchProperties{
-				LogMatchType: Regexp,
+			inc: &filterlog.LogMatchProperties{
+				MatchType: filterlog.MatchType(filterset.Regexp),
 				RecordAttributes: []filterconfig.Attribute{
 					{
 						Key:   "rec",

--- a/processor/filterprocessor/log_expr_test.go
+++ b/processor/filterprocessor/log_expr_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterlog"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"

--- a/processor/filterprocessor/log_expr_test.go
+++ b/processor/filterprocessor/log_expr_test.go
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterlog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+)
+
+type log struct {
+	body               string
+	name               string
+	severity           pdata.SeverityNumber
+	attributes         map[string]string
+	resourceAttributes map[string]string
+}
+
+func logsToPdata(logs []log) pdata.Logs {
+	pl := pdata.NewLogs()
+	pl.ResourceLogs().EnsureCapacity(len(logs))
+
+	for _, log := range logs {
+		rl := pl.ResourceLogs().AppendEmpty()
+
+		attrs := rl.Resource().Attributes()
+		attrs.EnsureCapacity(len(log.resourceAttributes))
+		for k, v := range log.resourceAttributes {
+			attrs.InsertString(k, v)
+		}
+		// sort to ensure that assert.Equal works as expected
+		attrs.Sort()
+
+		rl.InstrumentationLibraryLogs().EnsureCapacity(1)
+		l := rl.InstrumentationLibraryLogs().AppendEmpty().Logs().AppendEmpty()
+		attrs = l.Attributes()
+		for k, v := range log.attributes {
+			attrs.InsertString(k, v)
+		}
+		// sort to ensure that assert.Equal works as expected
+		attrs.Sort()
+
+		l.SetName(log.name)
+		l.SetSeverityNumber(log.severity)
+		l.SetSeverityText(log.severity.String())
+		l.Body().SetStringVal(log.body)
+	}
+	return pl
+}
+
+func TestLogExpr(t *testing.T) {
+
+	type testCase struct {
+		name        string
+		expressions []string
+		logs        []log
+		expected    []log
+	}
+
+	allLogs := []log{
+		// 0
+		{
+			body:     "Example log",
+			name:     "first",
+			severity: pdata.SeverityNumberDEBUG,
+			attributes: map[string]string{
+				"foo":       "bar",
+				"file.name": "first.log",
+			},
+			resourceAttributes: map[string]string{
+				"app.name": "test",
+				"instance": "pluto",
+			},
+		},
+		// 1
+		{
+			body:     "[INFO] Another example log",
+			name:     "second",
+			severity: pdata.SeverityNumberWARN,
+			attributes: map[string]string{
+				"foo":       "bar",
+				"file.name": "second.log",
+			},
+			resourceAttributes: map[string]string{
+				"app.name": "test",
+				"instance": "mars",
+			},
+		},
+		// 2
+		{
+			body:     "Info log",
+			name:     "third",
+			severity: pdata.SeverityNumberINFO,
+			attributes: map[string]string{
+				"foo":       "bar",
+				"file.name": "third.log",
+			},
+			resourceAttributes: map[string]string{
+				"app.name": "test",
+				"instance": "dione",
+			},
+		},
+	}
+
+	testCases := []testCase{
+		{
+			name: "match by body and name",
+			expressions: []string{
+				"Body matches 'log' && Name matches 'first'",
+			},
+			logs: allLogs,
+			expected: []log{
+				allLogs[0],
+			},
+		},
+		{
+			name: "match info logs",
+			expressions: []string{
+				"Body matches '[INFO]' || SeverityNumber == 9",
+			},
+			logs: allLogs,
+			expected: []log{
+				allLogs[1],
+				allLogs[2],
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Logs: LogFilters{
+					Include: &filterlog.LogMatchProperties{
+						MatchType:   filterlog.Expr,
+						Expressions: tc.expressions,
+					},
+				},
+			}
+			flp, err := newFilterLogsProcessor(&zap.Logger{}, cfg)
+
+			expected := logsToPdata(tc.expected)
+			logs := logsToPdata(tc.logs)
+
+			require.NoError(t, err)
+			result, err := flp.ProcessLogs(context.Background(), logs)
+
+			require.NoError(t, err)
+			assert.Equal(t, expected, result)
+		})
+	}
+}

--- a/processor/filterprocessor/log_expr_test.go
+++ b/processor/filterprocessor/log_expr_test.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterlog"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterlog"
 )
 
 type log struct {


### PR DESCRIPTION
**Description:**

- rename existing matcher to metric_matcher
- add matcher for logs with support for Body (as string), Name, SeverityNumber ans SeverityText
- use matcher in filterprocessor

**Link to tracking Issue:**
#5679 

**Testing:**

- unit tests

**Documentation:**

README