### PR TITLE
loadbalancingexporter: Fix race in unit test

### DIFF
--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -330,6 +330,11 @@ func TestRollingUpdatesWhenConsumeLogs(t *testing.T) {
 	res, err := newDNSResolver(zap.NewNop(), "service-1", "")
 	require.NoError(t, err)
 
+	var lastResolved []string
+	res.onChange(func(s []string) {
+		lastResolved = s
+	})
+
 	resolverCh := make(chan struct{}, 1)
 	counter := 0
 	resolve := [][]net.IPAddr{
@@ -441,7 +446,7 @@ func TestRollingUpdatesWhenConsumeLogs(t *testing.T) {
 	<-consumeCh
 
 	// verify
-	require.Equal(t, []string{"127.0.0.2"}, res.endpoints)
+	require.Equal(t, []string{"127.0.0.2"}, lastResolved)
 	require.Greater(t, atomic.LoadInt64(&counter1), int64(0))
 	require.Greater(t, atomic.LoadInt64(&counter2), int64(0))
 }

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -327,6 +327,11 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	res, err := newDNSResolver(zap.NewNop(), "service-1", "")
 	require.NoError(t, err)
 
+	var lastResolved []string
+	res.onChange(func(s []string) {
+		lastResolved = s
+	})
+
 	resolverCh := make(chan struct{}, 1)
 	counter := 0
 	resolve := [][]net.IPAddr{
@@ -437,7 +442,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	<-consumeCh
 
 	// verify
-	require.Equal(t, []string{"127.0.0.2"}, res.endpoints)
+	require.Equal(t, []string{"127.0.0.2"}, lastResolved)
 	require.Greater(t, atomic.LoadInt64(&counter1), int64(0))
 	require.Greater(t, atomic.LoadInt64(&counter2), int64(0))
 }


### PR DESCRIPTION
I wasn't able to reproduce the reported issue, even with commands like:

```console
$ go test -race . -count 100
ok      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter        12.872s
```

Given that the report had pointers to the code, I was able to find a place where one go routine was writing to a value and reading in another: the endpoints property of the DNS resolver. That resolver has a callback delivering notifications when the list of endpoints changes, so, the fix is to have the test to subscribe to that callback.

Fixes #2532

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
