### PR TITLE
Added implementation of Google Cloud Spanner receiver - 3rd part(stats readers).

### DIFF
--- a/receiver/googlecloudspannerreceiver/internal/statsreader/currentstatsreader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/currentstatsreader.go
@@ -1,0 +1,98 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+	"google.golang.org/api/iterator"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+type currentStatsReader struct {
+	logger                 *zap.Logger
+	database               *datasource.Database
+	metricsMetadata        *metadata.MetricsMetadata
+	topMetricsQueryMaxRows int
+	statement              func(args statementArgs) spanner.Statement
+}
+
+func newCurrentStatsReader(
+	logger *zap.Logger,
+	database *datasource.Database,
+	metricsMetadata *metadata.MetricsMetadata,
+	config ReaderConfig) *currentStatsReader {
+
+	return &currentStatsReader{
+		logger:                 logger,
+		database:               database,
+		metricsMetadata:        metricsMetadata,
+		statement:              currentStatsStatement,
+		topMetricsQueryMaxRows: config.TopMetricsQueryMaxRows,
+	}
+}
+
+func (reader *currentStatsReader) Name() string {
+	return fmt.Sprintf("%v %v::%v::%v", reader.metricsMetadata.Name, reader.database.DatabaseID().ProjectID(),
+		reader.database.DatabaseID().InstanceID(), reader.database.DatabaseID().DatabaseName())
+}
+
+func (reader *currentStatsReader) Read(ctx context.Context) ([]pdata.Metrics, error) {
+	reader.logger.Debug("Executing read method", zap.String("reader", reader.Name()))
+
+	stmt := reader.newPullStatement()
+
+	return reader.pull(ctx, stmt)
+}
+
+func (reader *currentStatsReader) newPullStatement() spanner.Statement {
+	args := statementArgs{
+		query:                  reader.metricsMetadata.Query,
+		topMetricsQueryMaxRows: reader.topMetricsQueryMaxRows,
+	}
+
+	return reader.statement(args)
+}
+
+func (reader *currentStatsReader) pull(ctx context.Context, stmt spanner.Statement) ([]pdata.Metrics, error) {
+	rowsIterator := reader.database.Client().Single().WithTimestampBound(spanner.ExactStaleness(15*time.Second)).Query(ctx, stmt)
+	defer rowsIterator.Stop()
+
+	var collectedMetrics []pdata.Metrics
+
+	for {
+		row, err := rowsIterator.Next()
+		if err != nil {
+			if err == iterator.Done {
+				return collectedMetrics, nil
+			}
+			return nil, fmt.Errorf("query %q failed with error: %w", stmt.SQL, err)
+		}
+
+		rowMetrics, err := reader.metricsMetadata.RowToMetrics(reader.database.DatabaseID(), row)
+		if err != nil {
+			return nil, fmt.Errorf("query %q failed with error: %w", stmt.SQL, err)
+		}
+
+		collectedMetrics = append(collectedMetrics, rowMetrics...)
+	}
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/currentstatsreader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/currentstatsreader_test.go
@@ -1,0 +1,88 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+const (
+	projectID    = "ProjectID"
+	instanceID   = "InstanceID"
+	databaseName = "DatabaseName"
+
+	name = "name"
+)
+
+func TestCurrentStatsReader_Name(t *testing.T) {
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	ctx := context.Background()
+	client, _ := spanner.NewClient(ctx, "")
+	database := datasource.NewDatabaseFromClient(client, databaseID)
+	metricsMetadata := &metadata.MetricsMetadata{
+		Name: name,
+	}
+
+	reader := currentStatsReader{
+		database:        database,
+		metricsMetadata: metricsMetadata,
+	}
+
+	assert.Equal(t, reader.metricsMetadata.Name+" "+databaseID.ProjectID()+"::"+
+		databaseID.InstanceID()+"::"+databaseID.DatabaseName(), reader.Name())
+}
+
+func TestNewCurrentStatsReader(t *testing.T) {
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	ctx := context.Background()
+	client, _ := spanner.NewClient(ctx, "")
+	database := datasource.NewDatabaseFromClient(client, databaseID)
+	metricsMetadata := &metadata.MetricsMetadata{
+		Name: name,
+	}
+	logger := zap.NewNop()
+	config := ReaderConfig{
+		TopMetricsQueryMaxRows: topMetricsQueryMaxRows,
+	}
+
+	reader := newCurrentStatsReader(logger, database, metricsMetadata, config)
+
+	assert.Equal(t, database, reader.database)
+	assert.Equal(t, logger, reader.logger)
+	assert.Equal(t, metricsMetadata, reader.metricsMetadata)
+	assert.Equal(t, topMetricsQueryMaxRows, reader.topMetricsQueryMaxRows)
+}
+
+func TestCurrentStatsReader_NewPullStatement(t *testing.T) {
+	metricsMetadata := &metadata.MetricsMetadata{
+		Query: query,
+	}
+
+	reader := currentStatsReader{
+		metricsMetadata:        metricsMetadata,
+		topMetricsQueryMaxRows: topMetricsQueryMaxRows,
+		statement:              currentStatsStatement,
+	}
+
+	assert.NotZero(t, reader.newPullStatement())
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader.go
@@ -1,0 +1,97 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+type DatabaseReader struct {
+	database *datasource.Database
+	logger   *zap.Logger
+	readers  []Reader
+}
+
+func NewDatabaseReader(ctx context.Context,
+	parsedMetadata []*metadata.MetricsMetadata,
+	databaseID *datasource.DatabaseID,
+	serviceAccountPath string,
+	readerConfig ReaderConfig,
+	logger *zap.Logger) (*DatabaseReader, error) {
+
+	database, err := datasource.NewDatabase(ctx, databaseID, serviceAccountPath)
+	if err != nil {
+		return nil, fmt.Errorf("error occurred during client instantiation for database %q: %w", databaseID.ID(), err)
+	}
+
+	readers := initializeReaders(logger, parsedMetadata, database, readerConfig)
+
+	return &DatabaseReader{
+		database: database,
+		logger:   logger,
+		readers:  readers,
+	}, nil
+}
+
+func initializeReaders(logger *zap.Logger, parsedMetadata []*metadata.MetricsMetadata,
+	database *datasource.Database, readerConfig ReaderConfig) []Reader {
+	readers := make([]Reader, len(parsedMetadata))
+
+	for i, mData := range parsedMetadata {
+		switch mData.MetadataType() {
+		case metadata.MetricsMetadataTypeCurrentStats:
+			readers[i] = newCurrentStatsReader(logger, database, mData, readerConfig)
+		case metadata.MetricsMetadataTypeIntervalStats:
+			readers[i] = newIntervalStatsReader(logger, database, mData, readerConfig)
+		}
+	}
+
+	return readers
+}
+
+func (databaseReader *DatabaseReader) Name() string {
+	return databaseReader.database.DatabaseID().ID()
+}
+
+func (databaseReader *DatabaseReader) Shutdown() {
+	databaseReader.logger.Debug("Closing connection to database",
+		zap.String("database", databaseReader.database.DatabaseID().ID()))
+	databaseReader.database.Client().Close()
+}
+
+func (databaseReader *DatabaseReader) Read(ctx context.Context) []pdata.Metrics {
+	databaseReader.logger.Debug("Executing read method for database",
+		zap.String("database", databaseReader.database.DatabaseID().ID()))
+
+	var result []pdata.Metrics
+
+	for _, reader := range databaseReader.readers {
+		if metrics, err := reader.Read(ctx); err != nil {
+			databaseReader.logger.Error("Cannot read data for metrics databaseReader because of error",
+				zap.String("reader", reader.Name()), zap.Error(err))
+		} else {
+			result = append(result, metrics...)
+		}
+	}
+
+	return result
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
@@ -1,0 +1,193 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+type testReader struct {
+	throwError bool
+}
+
+func (tr testReader) Name() string {
+	return "testReader"
+}
+
+func (tr testReader) Read(_ context.Context) ([]pdata.Metrics, error) {
+	if tr.throwError {
+		return nil, errors.New("error")
+	}
+
+	return []pdata.Metrics{{}}, nil
+}
+
+func TestNewDatabaseReader(t *testing.T) {
+	ctx := context.Background()
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	serviceAccountPath := "../../testdata/serviceAccount.json"
+	readerConfig := ReaderConfig{
+		TopMetricsQueryMaxRows: topMetricsQueryMaxRows,
+		BackfillEnabled:        false,
+	}
+	logger := zap.NewNop()
+	var parsedMetadata []*metadata.MetricsMetadata
+
+	reader, err := NewDatabaseReader(ctx, parsedMetadata, databaseID, serviceAccountPath, readerConfig, logger)
+
+	assert.Nil(t, err)
+
+	defer executeShutdown(reader)
+
+	assert.Equal(t, databaseID, reader.database.DatabaseID())
+	assert.Equal(t, logger, reader.logger)
+	assert.Equal(t, 0, len(reader.readers))
+}
+
+func TestNewDatabaseReaderWithError(t *testing.T) {
+	ctx := context.Background()
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	serviceAccountPath := "does not exist"
+	readerConfig := ReaderConfig{
+		TopMetricsQueryMaxRows: topMetricsQueryMaxRows,
+		BackfillEnabled:        false,
+	}
+	logger := zap.NewNop()
+	var parsedMetadata []*metadata.MetricsMetadata
+
+	reader, err := NewDatabaseReader(ctx, parsedMetadata, databaseID, serviceAccountPath, readerConfig, logger)
+
+	assert.NotNil(t, err)
+	// Do not call executeShutdown() here because reader hasn't been created
+	assert.Nil(t, reader)
+}
+
+func TestInitializeReaders(t *testing.T) {
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	logger := zap.NewNop()
+	var client *spanner.Client
+	database := datasource.NewDatabaseFromClient(client, databaseID)
+	currentStatsMetadata := createMetricsMetadata(query)
+	intervalStatsMetadata := createMetricsMetadata(query)
+
+	currentStatsMetadata.Name = "Current"
+	currentStatsMetadata.TimestampColumnName = ""
+	intervalStatsMetadata.Name = "Interval"
+
+	parsedMetadata := []*metadata.MetricsMetadata{
+		currentStatsMetadata,
+		intervalStatsMetadata,
+	}
+	readerConfig := ReaderConfig{
+		TopMetricsQueryMaxRows: topMetricsQueryMaxRows,
+		BackfillEnabled:        false,
+	}
+
+	readers := initializeReaders(logger, parsedMetadata, database, readerConfig)
+
+	assert.Equal(t, 2, len(readers))
+	assert.IsType(t, &currentStatsReader{}, readers[0])
+	assert.IsType(t, &intervalStatsReader{}, readers[1])
+}
+
+func TestDatabaseReader_Name(t *testing.T) {
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	ctx := context.Background()
+	client, _ := spanner.NewClient(ctx, databaseName)
+	database := datasource.NewDatabaseFromClient(client, databaseID)
+	logger := zap.NewNop()
+
+	reader := &DatabaseReader{
+		logger:   logger,
+		database: database,
+	}
+	defer executeShutdown(reader)
+
+	assert.Equal(t, database.DatabaseID().ID(), reader.Name())
+}
+
+func TestDatabaseReader_Shutdown(t *testing.T) {
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	ctx := context.Background()
+	client, _ := spanner.NewClient(ctx, databaseName)
+	database := datasource.NewDatabaseFromClient(client, databaseID)
+	logger := zap.NewNop()
+
+	reader := &DatabaseReader{
+		logger:   logger,
+		database: database,
+	}
+
+	executeShutdown(reader)
+}
+
+func TestDatabaseReader_Read(t *testing.T) {
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	ctx := context.Background()
+	client, _ := spanner.NewClient(ctx, databaseName)
+	database := datasource.NewDatabaseFromClient(client, databaseID)
+	logger := zap.NewNop()
+
+	testReaderThrowNoError := testReader{
+		throwError: false,
+	}
+
+	testReaderThrowError := testReader{
+		throwError: true,
+	}
+
+	testCases := map[string]struct {
+		readers              []Reader
+		expectedMetricsCount int
+	}{
+		"Read with no error": {[]Reader{testReaderThrowNoError}, 1},
+		"Read with error":    {[]Reader{testReaderThrowError}, 0},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			reader := &DatabaseReader{
+				logger:   logger,
+				database: database,
+				readers:  testCase.readers,
+			}
+			defer executeShutdown(reader)
+
+			metrics := reader.Read(ctx)
+
+			assert.Equal(t, testCase.expectedMetricsCount, len(metrics))
+		})
+	}
+}
+
+func executeShutdown(reader *DatabaseReader) {
+	// Doing this because can't control instantiation of Spanner DB client.
+	// In Shutdown() invocation client with wrong DB parameters produces panic when calling its Close() method.
+	defer func() {
+		_ = recover()
+	}()
+
+	reader.Shutdown()
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader.go
@@ -1,0 +1,99 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+const (
+	// Max duration of data backfilling(if enabled).
+	// Different backends can support or not support such option.
+	// Since, the initial intent was to work mainly with Prometheus backend,
+	// this constant was set to 1 hour - max allowed interval by Prometheus.
+	backfillIntervalDuration = time.Hour
+)
+
+type intervalStatsReader struct {
+	currentStatsReader
+	timestampsGenerator *timestampsGenerator
+	lastPullTimestamp   time.Time
+}
+
+func newIntervalStatsReader(
+	logger *zap.Logger,
+	database *datasource.Database,
+	metricsMetadata *metadata.MetricsMetadata,
+	config ReaderConfig) *intervalStatsReader {
+
+	reader := currentStatsReader{
+		logger:                 logger,
+		database:               database,
+		metricsMetadata:        metricsMetadata,
+		statement:              intervalStatsStatement,
+		topMetricsQueryMaxRows: config.TopMetricsQueryMaxRows,
+	}
+	tsGenerator := &timestampsGenerator{
+		backfillEnabled: config.BackfillEnabled,
+		difference:      time.Minute,
+	}
+
+	return &intervalStatsReader{
+		currentStatsReader:  reader,
+		timestampsGenerator: tsGenerator,
+	}
+}
+
+func (reader *intervalStatsReader) Read(ctx context.Context) ([]pdata.Metrics, error) {
+	reader.logger.Debug("Executing read method", zap.String("reader", reader.Name()))
+
+	// Generating pull timestamps
+	pullTimestamps := reader.timestampsGenerator.pullTimestamps(reader.lastPullTimestamp, time.Now().UTC())
+
+	var collectedMetrics []pdata.Metrics
+
+	// Pulling metrics for each generated pull timestamp
+	for _, pullTimestamp := range pullTimestamps {
+		stmt := reader.newPullStatement(pullTimestamp)
+		metrics, err := reader.pull(ctx, stmt)
+		if err != nil {
+			return nil, err
+		}
+
+		collectedMetrics = append(collectedMetrics, metrics...)
+	}
+
+	reader.lastPullTimestamp = pullTimestamps[len(pullTimestamps)-1]
+
+	return collectedMetrics, nil
+}
+
+func (reader *intervalStatsReader) newPullStatement(pullTimestamp time.Time) spanner.Statement {
+	args := statementArgs{
+		query:                  reader.metricsMetadata.Query,
+		topMetricsQueryMaxRows: reader.topMetricsQueryMaxRows,
+		pullTimestamp:          pullTimestamp,
+	}
+
+	return reader.statement(args)
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader_test.go
@@ -1,0 +1,88 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+func TestIntervalStatsReader_Name(t *testing.T) {
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	ctx := context.Background()
+	client, _ := spanner.NewClient(ctx, "")
+	database := datasource.NewDatabaseFromClient(client, databaseID)
+	metricsMetadata := &metadata.MetricsMetadata{
+		Name: name,
+	}
+
+	reader := intervalStatsReader{
+		currentStatsReader: currentStatsReader{
+			database:        database,
+			metricsMetadata: metricsMetadata,
+		},
+	}
+
+	assert.Equal(t, reader.metricsMetadata.Name+" "+databaseID.ProjectID()+"::"+
+		databaseID.InstanceID()+"::"+databaseID.DatabaseName(), reader.Name())
+}
+
+func TestNewIntervalStatsReader(t *testing.T) {
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	ctx := context.Background()
+	client, _ := spanner.NewClient(ctx, "")
+	database := datasource.NewDatabaseFromClient(client, databaseID)
+	metricsMetadata := &metadata.MetricsMetadata{
+		Name: name,
+	}
+	logger := zap.NewNop()
+	config := ReaderConfig{
+		TopMetricsQueryMaxRows: topMetricsQueryMaxRows,
+		BackfillEnabled:        true,
+	}
+
+	reader := newIntervalStatsReader(logger, database, metricsMetadata, config)
+
+	assert.Equal(t, database, reader.database)
+	assert.Equal(t, logger, reader.logger)
+	assert.Equal(t, metricsMetadata, reader.metricsMetadata)
+	assert.Equal(t, topMetricsQueryMaxRows, reader.topMetricsQueryMaxRows)
+	assert.NotNil(t, reader.timestampsGenerator)
+	assert.True(t, reader.timestampsGenerator.backfillEnabled)
+}
+
+func TestIntervalStatsReader_NewPullStatement(t *testing.T) {
+	timestamp := time.Now().UTC()
+	metricsMetadata := &metadata.MetricsMetadata{
+		Query: query,
+	}
+	reader := intervalStatsReader{
+		currentStatsReader: currentStatsReader{
+			metricsMetadata:        metricsMetadata,
+			topMetricsQueryMaxRows: topMetricsQueryMaxRows,
+			statement:              intervalStatsStatement,
+		},
+	}
+
+	assert.NotZero(t, reader.newPullStatement(timestamp))
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader.go
@@ -1,0 +1,63 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+	"strings"
+
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+)
+
+type ProjectReader struct {
+	databaseReaders []CompositeReader
+	logger          *zap.Logger
+}
+
+func NewProjectReader(databaseReaders []CompositeReader, logger *zap.Logger) *ProjectReader {
+	return &ProjectReader{
+		databaseReaders: databaseReaders,
+		logger:          logger,
+	}
+}
+
+func (projectReader *ProjectReader) Shutdown() {
+	for _, databaseReader := range projectReader.databaseReaders {
+		projectReader.logger.Info("Shutting down projectReader for database",
+			zap.String("database", databaseReader.Name()))
+		databaseReader.Shutdown()
+	}
+}
+
+func (projectReader *ProjectReader) Read(ctx context.Context) []pdata.Metrics {
+	var projectMetrics []pdata.Metrics
+
+	for _, databaseReader := range projectReader.databaseReaders {
+		projectMetrics = append(projectMetrics, databaseReader.Read(ctx)...)
+	}
+
+	return projectMetrics
+}
+
+func (projectReader *ProjectReader) Name() string {
+	databaseReaderNames := make([]string, len(projectReader.databaseReaders))
+
+	for i, databaseReader := range projectReader.databaseReaders {
+		databaseReaderNames[i] = databaseReader.Name()
+	}
+
+	return "Project reader for: " + strings.Join(databaseReaderNames, ",")
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader_test.go
@@ -1,0 +1,98 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+)
+
+type mockCompositeReader struct {
+}
+
+func (tcr mockCompositeReader) Name() string {
+	return "mockCompositeReader"
+}
+
+func (tcr mockCompositeReader) Read(_ context.Context) []pdata.Metrics {
+	return []pdata.Metrics{pdata.NewMetrics()}
+}
+
+func (tcr mockCompositeReader) Shutdown() {
+	// Do nothing
+}
+
+func TestNewProjectReader(t *testing.T) {
+	logger := zap.NewNop()
+	var databaseReaders []CompositeReader
+
+	reader := NewProjectReader(databaseReaders, logger)
+	defer reader.Shutdown()
+
+	assert.NotNil(t, reader)
+	assert.Equal(t, logger, reader.logger)
+	assert.Equal(t, databaseReaders, reader.databaseReaders)
+}
+
+func TestProjectReader_Shutdown(t *testing.T) {
+	logger := zap.NewNop()
+
+	databaseReaders := []CompositeReader{mockCompositeReader{}}
+
+	reader := ProjectReader{
+		databaseReaders: databaseReaders,
+		logger:          logger,
+	}
+
+	reader.Shutdown()
+}
+
+func TestProjectReader_Read(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	databaseReaders := []CompositeReader{mockCompositeReader{}}
+
+	reader := ProjectReader{
+		databaseReaders: databaseReaders,
+		logger:          logger,
+	}
+	defer reader.Shutdown()
+
+	metrics := reader.Read(ctx)
+
+	assert.Equal(t, 1, len(metrics))
+}
+
+func TestProjectReader_Name(t *testing.T) {
+	logger := zap.NewNop()
+
+	databaseReader := mockCompositeReader{}
+	databaseReaders := []CompositeReader{databaseReader}
+
+	reader := ProjectReader{
+		databaseReaders: databaseReaders,
+		logger:          logger,
+	}
+	defer reader.Shutdown()
+
+	name := reader.Name()
+
+	assert.Equal(t, "Project reader for: "+databaseReader.Name(), name)
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
@@ -1,0 +1,42 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+type ReaderConfig struct {
+	TopMetricsQueryMaxRows int
+	BackfillEnabled        bool
+}
+
+type Reader interface {
+	Name() string
+	Read(ctx context.Context) ([]pdata.Metrics, error)
+}
+
+// CompositeReader - this interface is used for the composition of multiple Reader(s).
+// Main differences between it and Reader are:
+// - Read method doesn't return error;
+// - this interface also has Shutdown method for performing some additional cleanup necessary for each Reader instance.
+type CompositeReader interface {
+	Name() string
+	Read(ctx context.Context) []pdata.Metrics
+	// Shutdown Use this method to perform any additional cleanup of underlying components.
+	Shutdown()
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/statements.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/statements.go
@@ -1,0 +1,61 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const (
+	topMetricsQueryLimitParameterName = "topMetricsQueryMaxRows"
+	topMetricsQueryLimitCondition     = " LIMIT @" + topMetricsQueryLimitParameterName
+
+	pullTimestampParameterName = "pullTimestamp"
+)
+
+type statementArgs struct {
+	query                  string
+	topMetricsQueryMaxRows int
+	pullTimestamp          time.Time
+}
+
+func currentStatsStatement(args statementArgs) spanner.Statement {
+	stmt := spanner.Statement{SQL: args.query, Params: map[string]interface{}{}}
+
+	if args.topMetricsQueryMaxRows > 0 {
+		stmt = spanner.Statement{
+			SQL: args.query + topMetricsQueryLimitCondition,
+			Params: map[string]interface{}{
+				topMetricsQueryLimitParameterName: args.topMetricsQueryMaxRows,
+			},
+		}
+	}
+
+	return stmt
+}
+
+func intervalStatsStatement(args statementArgs) spanner.Statement {
+	stmt := currentStatsStatement(args)
+
+	if len(stmt.Params) <= 0 {
+		stmt.Params = map[string]interface{}{}
+	}
+
+	stmt.Params[pullTimestampParameterName] = args.pullTimestamp
+
+	return stmt
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/statements_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/statements_test.go
@@ -1,0 +1,84 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	query = "query"
+
+	topMetricsQueryMaxRows = 10
+)
+
+func TestCurrentStatsStatement(t *testing.T) {
+	testCases := map[string]struct {
+		topMetricsQueryMaxRows int
+		expectedSQL            string
+		expectedParams         map[string]interface{}
+	}{
+		"Statement with top metrics query max rows":    {topMetricsQueryMaxRows, query + topMetricsQueryLimitCondition, map[string]interface{}{topMetricsQueryLimitParameterName: topMetricsQueryMaxRows}},
+		"Statement without top metrics query max rows": {0, query, map[string]interface{}{}},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			args := statementArgs{
+				query:                  query,
+				topMetricsQueryMaxRows: testCase.topMetricsQueryMaxRows,
+			}
+
+			statement := currentStatsStatement(args)
+
+			assert.Equal(t, testCase.expectedSQL, statement.SQL)
+			assert.Equal(t, testCase.expectedParams, statement.Params)
+		})
+	}
+}
+
+func TestIntervalStatsStatement(t *testing.T) {
+	pullTimestamp := time.Now().UTC()
+
+	testCases := map[string]struct {
+		topMetricsQueryMaxRows int
+		expectedSQL            string
+		expectedParams         map[string]interface{}
+	}{
+		"Statement with top metrics query max rows": {topMetricsQueryMaxRows, query + topMetricsQueryLimitCondition, map[string]interface{}{
+			topMetricsQueryLimitParameterName: topMetricsQueryMaxRows,
+			pullTimestampParameterName:        pullTimestamp,
+		}},
+		"Statement without top metrics query max rows": {0, query, map[string]interface{}{pullTimestampParameterName: pullTimestamp}},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			args := statementArgs{
+				query:                  query,
+				topMetricsQueryMaxRows: testCase.topMetricsQueryMaxRows,
+				pullTimestamp:          pullTimestamp,
+			}
+
+			statement := intervalStatsStatement(args)
+
+			assert.Equal(t, testCase.expectedSQL, statement.SQL)
+			assert.Equal(t, testCase.expectedParams, statement.Params)
+		})
+	}
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/statsreaders_mockedspanner_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/statsreaders_mockedspanner_test.go
@@ -1,0 +1,208 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	"cloud.google.com/go/spanner/spannertest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+	"google.golang.org/api/option"
+	databasepb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
+	"google.golang.org/grpc"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
+)
+
+const (
+	spannerDatabaseName = "projects/" + projectID + "/instances/" + instanceID + "/databases/" + databaseName
+	maxRowsLimit        = 1
+)
+
+func createMetricsMetadata(query string) *metadata.MetricsMetadata {
+	return createMetricsMetadataFromTimestampColumn(query, "INTERVAL_END")
+}
+
+func createMetricsMetadataFromTimestampColumn(query string, timestampColumn string) *metadata.MetricsMetadata {
+	// Labels
+	queryLabelValuesMetadata := []metadata.LabelValueMetadata{
+		metadata.NewStringLabelValueMetadata("metric_label", "METRIC_LABEL"),
+	}
+
+	metricDataType := metadata.NewMetricDataType(pdata.MetricDataTypeGauge, pdata.MetricAggregationTemporalityUnspecified, false)
+
+	// Metrics
+	queryMetricValuesMetadata := []metadata.MetricValueMetadata{
+		metadata.NewInt64MetricValueMetadata("metric_value", "METRIC_VALUE", metricDataType, "unit"),
+	}
+
+	return &metadata.MetricsMetadata{
+		Name:                      "test stats",
+		Query:                     query,
+		MetricNamePrefix:          "test_stats/",
+		TimestampColumnName:       timestampColumn,
+		QueryLabelValuesMetadata:  queryLabelValuesMetadata,
+		QueryMetricValuesMetadata: queryMetricValuesMetadata,
+	}
+}
+
+func createCurrentStatsReaderWithCorruptedMetadata(client *spanner.Client) Reader {
+	query := "SELECT * FROM STATS"
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	databaseFromClient := datasource.NewDatabaseFromClient(client, databaseID)
+
+	return newCurrentStatsReader(zap.NewNop(), databaseFromClient,
+		createMetricsMetadataFromTimestampColumn(query, "NOT_EXISTING"), ReaderConfig{})
+}
+
+func createCurrentStatsReader(client *spanner.Client) Reader {
+	query := "SELECT * FROM STATS"
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	databaseFromClient := datasource.NewDatabaseFromClient(client, databaseID)
+
+	return newCurrentStatsReader(zap.NewNop(), databaseFromClient, createMetricsMetadata(query), ReaderConfig{})
+}
+
+func createCurrentStatsReaderWithMaxRowsLimit(client *spanner.Client) Reader {
+	query := "SELECT * FROM STATS"
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	databaseFromClient := datasource.NewDatabaseFromClient(client, databaseID)
+	config := ReaderConfig{
+		TopMetricsQueryMaxRows: maxRowsLimit,
+	}
+
+	return newCurrentStatsReader(zap.NewNop(), databaseFromClient, createMetricsMetadata(query), config)
+}
+
+func createIntervalStatsReaderWithCorruptedMetadata(client *spanner.Client, backfillEnabled bool) Reader {
+	query := "SELECT * FROM STATS WHERE INTERVAL_END = @pullTimestamp"
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	databaseFromClient := datasource.NewDatabaseFromClient(client, databaseID)
+	config := ReaderConfig{
+		BackfillEnabled: backfillEnabled,
+	}
+
+	return newIntervalStatsReader(zap.NewNop(), databaseFromClient,
+		createMetricsMetadataFromTimestampColumn(query, "NOT_EXISTING"), config)
+}
+
+func createIntervalStatsReader(client *spanner.Client, backfillEnabled bool) Reader {
+	query := "SELECT * FROM STATS WHERE INTERVAL_END = @pullTimestamp"
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	databaseFromClient := datasource.NewDatabaseFromClient(client, databaseID)
+	config := ReaderConfig{
+		BackfillEnabled: backfillEnabled,
+	}
+
+	return newIntervalStatsReader(zap.NewNop(), databaseFromClient, createMetricsMetadata(query), config)
+}
+
+func createIntervalStatsReaderWithMaxRowsLimit(client *spanner.Client, backfillEnabled bool) Reader {
+	query := "SELECT * FROM STATS WHERE INTERVAL_END = @pullTimestamp"
+	databaseID := datasource.NewDatabaseID(projectID, instanceID, databaseName)
+	databaseFromClient := datasource.NewDatabaseFromClient(client, databaseID)
+	config := ReaderConfig{
+		TopMetricsQueryMaxRows: maxRowsLimit,
+		BackfillEnabled:        backfillEnabled,
+	}
+
+	return newIntervalStatsReader(zap.NewNop(), databaseFromClient, createMetricsMetadata(query), config)
+}
+
+func TestStatsReaders_Read(t *testing.T) {
+	timestamp := shiftToStartOfMinute(time.Now().UTC())
+	ctx := context.Background()
+	server, err := spannertest.NewServer(":0")
+	require.NoError(t, err)
+	defer server.Close()
+
+	conn, err := grpc.Dial(server.Addr, grpc.WithInsecure())
+	require.NoError(t, err)
+
+	databaseAdminClient, err := database.NewDatabaseAdminClient(ctx, option.WithGRPCConn(conn))
+	require.NoError(t, err)
+	defer func(databaseAdminClient *database.DatabaseAdminClient) {
+		_ = databaseAdminClient.Close()
+	}(databaseAdminClient)
+
+	op, err := databaseAdminClient.UpdateDatabaseDdl(ctx, &databasepb.UpdateDatabaseDdlRequest{
+		Database: databaseName,
+		Statements: []string{`CREATE TABLE STATS (
+			INTERVAL_END TIMESTAMP,
+			METRIC_LABEL STRING(MAX),
+			METRIC_VALUE INT64
+		) PRIMARY KEY (METRIC_LABEL)
+		`},
+	})
+	require.NoError(t, err)
+
+	err = op.Wait(ctx)
+	require.NoError(t, err)
+
+	databaseClient, err := spanner.NewClient(ctx, spannerDatabaseName, option.WithGRPCConn(conn))
+	require.NoError(t, err)
+	defer databaseClient.Close()
+
+	_, err = databaseClient.Apply(ctx, []*spanner.Mutation{
+		spanner.Insert("STATS",
+			[]string{"INTERVAL_END", "METRIC_LABEL", "METRIC_VALUE"},
+			[]interface{}{timestamp, "Qwerty", 10}),
+		spanner.Insert("STATS",
+			[]string{"INTERVAL_END", "METRIC_LABEL", "METRIC_VALUE"},
+			[]interface{}{timestamp.Add(-1 * time.Minute), "Test", 20}),
+		spanner.Insert("STATS",
+			[]string{"INTERVAL_END", "METRIC_LABEL", "METRIC_VALUE"},
+			[]interface{}{timestamp.Add(-1 * time.Minute), "Spanner", 30}),
+	})
+
+	require.NoError(t, err)
+
+	testCases := map[string]struct {
+		reader                Reader
+		expectedMetricsAmount int
+		expectError           bool
+	}{
+		"Current stats reader without max rows limit":                    {createCurrentStatsReader(databaseClient), 3, false},
+		"Current stats reader with max rows limit":                       {createCurrentStatsReaderWithMaxRowsLimit(databaseClient), 1, false},
+		"Current stats reader with corrupted metadata":                   {createCurrentStatsReaderWithCorruptedMetadata(databaseClient), 0, true},
+		"Interval stats reader without backfill without max rows limit":  {createIntervalStatsReader(databaseClient, false), 1, false},
+		"Interval stats reader without backfill with max rows limit":     {createIntervalStatsReaderWithMaxRowsLimit(databaseClient, false), 1, false},
+		"Interval stats reader with backfill without max rows limit":     {createIntervalStatsReader(databaseClient, true), 3, false},
+		"Interval stats reader with backfill with max rows limit":        {createIntervalStatsReaderWithMaxRowsLimit(databaseClient, true), 2, false},
+		"Interval stats reader without backfill with corrupted metadata": {createIntervalStatsReaderWithCorruptedMetadata(databaseClient, false), 0, true},
+		"Interval stats reader with backfill with corrupted metadata":    {createIntervalStatsReaderWithCorruptedMetadata(databaseClient, true), 0, true},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			metrics, err := testCase.reader.Read(ctx)
+
+			if testCase.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, testCase.expectedMetricsAmount, len(metrics))
+			}
+		})
+	}
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator.go
@@ -1,0 +1,64 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import "time"
+
+type timestampsGenerator struct {
+	backfillEnabled bool
+	difference      time.Duration
+}
+
+// This slice will always contain at least one value - now shifted to the start of minute(upper bound).
+// In case lastPullTimestamp is greater than now argument slice will contain only one value - now shifted to the start of minute(upper bound).
+func (g *timestampsGenerator) pullTimestamps(lastPullTimestamp time.Time, now time.Time) []time.Time {
+	var timestamps []time.Time
+	upperBound := shiftToStartOfMinute(now)
+
+	if lastPullTimestamp.IsZero() {
+		if g.backfillEnabled {
+			timestamps = pullTimestampsWithDifference(upperBound.Add(-1*backfillIntervalDuration), upperBound,
+				g.difference)
+		} else {
+			timestamps = []time.Time{upperBound}
+		}
+	} else {
+		// lastPullTimestamp is already set to start of minute
+		timestamps = pullTimestampsWithDifference(lastPullTimestamp, upperBound, g.difference)
+	}
+
+	return timestamps
+}
+
+// This slice will always contain at least one value(upper bound).
+// Difference between each two points is 1 minute.
+func pullTimestampsWithDifference(lowerBound time.Time, upperBound time.Time, difference time.Duration) []time.Time {
+	var timestamps []time.Time
+
+	for value := lowerBound.Add(difference); !value.After(upperBound); value = value.Add(difference) {
+		timestamps = append(timestamps, value)
+	}
+
+	// To ensure that we did not miss upper bound and timestamps slice will contain at least one value
+	if len(timestamps) <= 0 || timestamps[len(timestamps)-1] != upperBound {
+		timestamps = append(timestamps, upperBound)
+	}
+
+	return timestamps
+}
+
+func shiftToStartOfMinute(now time.Time) time.Time {
+	return time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), 0, 0, now.Location())
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator_test.go
@@ -1,0 +1,97 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsreader
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimestampsGenerator_PullTimestamps(t *testing.T) {
+	now := time.Now().UTC()
+	nowAtStartOfMinute := shiftToStartOfMinute(now)
+	backfillIntervalAgo := nowAtStartOfMinute.Add(-1 * backfillIntervalDuration)
+	backfillIntervalAgoWthSomeSeconds := backfillIntervalAgo.Add(-15 * time.Second)
+	lastPullTimestampInFuture := nowAtStartOfMinute.Add(backfillIntervalDuration)
+
+	testCases := map[string]struct {
+		lastPullTimestamp  time.Time
+		backfillEnabled    bool
+		amountOfTimestamps int
+	}{
+		"Zero last pull timestamp without backfill":                                                       {time.Time{}, false, 1},
+		"Zero last pull timestamp with backfill":                                                          {time.Time{}, true, int(backfillIntervalDuration.Minutes())},
+		"Last pull timestamp now at start of minute backfill does not matter":                             {nowAtStartOfMinute, false, 1},
+		"Last pull timestamp back fill interval ago of minute backfill does not matter":                   {backfillIntervalAgo, false, int(backfillIntervalDuration.Minutes())},
+		"Last pull timestamp back fill interval ago with some seconds of minute backfill does not matter": {backfillIntervalAgoWthSomeSeconds, false, int(backfillIntervalDuration.Minutes()) + 1},
+		"Last pull timestamp greater than now without backfill":                                           {lastPullTimestampInFuture, false, 1},
+		"Last pull timestamp greater than now with backfill":                                              {lastPullTimestampInFuture, true, 1},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			generator := &timestampsGenerator{
+				backfillEnabled: testCase.backfillEnabled,
+				difference:      time.Minute,
+			}
+			timestamps := generator.pullTimestamps(testCase.lastPullTimestamp, now)
+
+			assert.Equal(t, testCase.amountOfTimestamps, len(timestamps))
+		})
+	}
+}
+
+func TestPullTimestampsWithDifference(t *testing.T) {
+	expectedAmountOfTimestamps := 5
+	lowerBound := time.Date(2021, 9, 17, 16, 25, 0, 0, time.UTC)
+	upperBound := lowerBound.Add(time.Duration(expectedAmountOfTimestamps) * time.Minute)
+
+	timestamps := pullTimestampsWithDifference(lowerBound, upperBound, time.Minute)
+
+	assert.Equal(t, expectedAmountOfTimestamps, len(timestamps))
+
+	expectedTimestamp := lowerBound.Add(time.Minute)
+
+	for _, timestamp := range timestamps {
+		assert.Equal(t, expectedTimestamp, timestamp)
+		expectedTimestamp = expectedTimestamp.Add(time.Minute)
+	}
+
+	// Check edge case: ensure that we didn't miss upperBound
+	upperBound = lowerBound.Add(5 * time.Minute).Add(15 * time.Second)
+	timestamps = pullTimestampsWithDifference(lowerBound, upperBound, time.Minute)
+
+	assert.Equal(t, 6, len(timestamps))
+
+	expectedTimestamp = lowerBound.Add(time.Minute)
+
+	for i := 0; i < expectedAmountOfTimestamps; i++ {
+		assert.Equal(t, expectedTimestamp, timestamps[i])
+		expectedTimestamp = expectedTimestamp.Add(time.Minute)
+	}
+
+	assert.Equal(t, upperBound, timestamps[expectedAmountOfTimestamps])
+
+}
+
+func TestShiftToStartOfMinute(t *testing.T) {
+	now := time.Now().UTC()
+	actual := shiftToStartOfMinute(now)
+
+	assert.Equal(t, 0, actual.Second())
+	assert.Equal(t, 0, actual.Nanosecond())
+}


### PR DESCRIPTION
This part of implementation contains stats readers implementations.
This stuff will be used for reading data from Google Cloud spanner tables and transforming it to metrics using parsed metrics metadata.
Final integration of all components into receiver will be introduced as separate MR.