### PR TITLE
Fix link to JMX metric gatherer

### DIFF
--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -2,7 +2,7 @@
 
 ### Overview
 
-The JMX Receiver will work in conjunction with the [OpenTelemetry JMX Metric Gatherer](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/contrib/jmx-metrics/README.md)
+The JMX Receiver will work in conjunction with the [OpenTelemetry JMX Metric Gatherer](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/README.md)
 to report metrics from a target MBean server using a built-in or your custom `otel` helper-utilizing
 Groovy script.
 


### PR DESCRIPTION
The link to the jmx metric gatherer has changed, and this fixes the link.