### PR TITLE
Avoid potential integer overflow

### DIFF
--- a/pkg/translator/opencensus/resource_to_oc.go
+++ b/pkg/translator/opencensus/resource_to_oc.go
@@ -107,11 +107,10 @@ func internalResourceToOC(resource pdata.Resource) (*occommon.Node, *ocresource.
 		case conventions.AttributeHostName:
 			getProcessIdentifier(ocNode).HostName = val
 		case conventions.AttributeProcessPID:
-			pid, err := strconv.Atoi(val)
-			if err != nil {
-				pid = defaultProcessID
+			pid, err := strconv.ParseUint(val, 10, 32)
+			if err == nil {
+				getProcessIdentifier(ocNode).Pid = uint32(pid)
 			}
-			getProcessIdentifier(ocNode).Pid = uint32(pid)
 		case conventions.AttributeTelemetrySDKVersion:
 			getLibraryInfo(ocNode).CoreLibraryVersion = val
 		case occonventions.AttributeExporterVersion:

--- a/pkg/translator/opencensus/traces_to_oc.go
+++ b/pkg/translator/opencensus/traces_to_oc.go
@@ -30,10 +30,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
 )
 
-var (
-	defaultProcessID = 0
-)
-
 // ResourceSpansToOC may be used only by OpenCensus receiver and exporter implementations.
 // Deprecated: Use pdata.Traces.
 // TODO: move this function to OpenCensus package.


### PR DESCRIPTION
**Description:**
Parse PID as an unsigned int with a specified bit precision, avoiding the situation where the `uint32` conversion could have silently changed an out-of-bounds value. See https://codeql.github.com/codeql-query-help/go/go-incorrect-integer-conversion/ for more details.

**Link to tracking Issue:** None

**Testing:** Unit tests

**Documentation:** None
