### PR TITLE
Log datapoints option

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -64,6 +64,8 @@ The following configuration options can also be configured:
         state: [interrupt, user, system]
   ```
 - `headers` (no default): Headers to pass in the payload.
+- `log_data_points` (default = `false`): If the log level is set to `debug` 
+  and this is true, all datapoints dispatched to Splunk Observability Cloud will be logged
 - `log_dimension_updates` (default = `false`): Whether or not to log dimension
   updates.
 - `timeout` (default = 5s): Amount of time to wait for a send operation to

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -64,6 +64,9 @@ type Config struct {
 	// here.
 	Headers map[string]string `mapstructure:"headers"`
 
+	// Whether to log datapoints dispatched to Splunk Observability Cloud
+	LogDataPoints bool `mapstructure:"log_data_points"`
+
 	// Whether to log dimension updates being sent to SignalFx.
 	LogDimensionUpdates bool `mapstructure:"log_dimension_updates"`
 
@@ -137,6 +140,7 @@ func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {
 		apiURL:           apiURL,
 		httpTimeout:      cfg.Timeout,
 		token:            cfg.AccessToken,
+		logDataPoints:    cfg.LogDataPoints,
 		logDimUpdate:     cfg.LogDimensionUpdates,
 		metricTranslator: metricTranslator,
 	}, nil

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -68,6 +68,7 @@ type exporterOptions struct {
 	apiURL           *url.URL
 	httpTimeout      time.Duration
 	token            string
+	logDataPoints    bool
 	logDimUpdate     bool
 	metricTranslator *translation.MetricTranslator
 }
@@ -109,6 +110,7 @@ func newSignalFxExporter(
 			},
 			zippers: newGzipPool(),
 		},
+		logDataPoints:          options.logDataPoints,
 		logger:                 logger,
 		accessTokenPassthrough: config.AccessTokenPassthrough,
 		converter:              converter,


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

**Description:** 
This PR introduces a new option `log_data_points` to the `signalfx` exporter; when set to true and the log level is set to debug, we will log datapoints coming to the signalfx exporter and all sfx datapoints that will be dispatched to SignalFX, after they got converted, translated and filtered by the exporter
This greatly helps debugging issues related to dispatched datapoints to confirm what's been sent to the backend/system.

This PR will also log filtered datapoints when log level is set to debug, independently of `log_data_points`. 

**Documentation:** 
`log_data_points` (default = `false`): If the log level is set to `debug` 
  and this is true, all datapoints dispatched to SignalFX will be logged