### PR TITLE
tailsampling: end go routines during shutdown

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -14,7 +14,7 @@ ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))) 2>/dev/null)
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
-GOTEST_OPT?= -race -timeout 300s --tags=$(GO_BUILD_TAGS)
+GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
 GOTEST_INTEGRATION_OPT?= -race -timeout 60s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic

--- a/processor/tailsamplingprocessor/internal/idbatcher/id_batcher.go
+++ b/processor/tailsamplingprocessor/internal/idbatcher/id_batcher.go
@@ -69,6 +69,7 @@ type batcher struct {
 	newBatchesInitialCapacity uint64
 	stopchan                  chan bool
 	stopped                   bool
+	stopLock                  sync.RWMutex
 }
 
 // New creates a Batcher that will hold numBatches in its pipeline, having a channel with
@@ -119,6 +120,7 @@ func (b *batcher) AddToCurrentBatch(id pdata.TraceID) {
 
 func (b *batcher) CloseCurrentAndTakeFirstBatch() (Batch, bool) {
 	if readBatch, ok := <-b.batches; ok {
+		b.stopLock.RLock()
 		if !b.stopped {
 			nextBatch := make(Batch, 0, b.newBatchesInitialCapacity)
 			b.cbMutex.Lock()
@@ -126,6 +128,7 @@ func (b *batcher) CloseCurrentAndTakeFirstBatch() (Batch, bool) {
 			b.currentBatch = nextBatch
 			b.cbMutex.Unlock()
 		}
+		b.stopLock.RUnlock()
 		return readBatch, true
 	}
 
@@ -136,6 +139,8 @@ func (b *batcher) CloseCurrentAndTakeFirstBatch() (Batch, bool) {
 
 func (b *batcher) Stop() {
 	close(b.pendingIds)
+	b.stopLock.Lock()
 	b.stopped = <-b.stopchan
+	b.stopLock.Unlock()
 	close(b.batches)
 }

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
@@ -48,6 +49,8 @@ func TestSequentialTraceArrival(t *testing.T) {
 	}
 	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
+	tsp.tickerFrequency = 100 * time.Millisecond
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
@@ -76,6 +79,8 @@ func TestConcurrentTraceArrival(t *testing.T) {
 	}
 	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
+	tsp.tickerFrequency = 100 * time.Millisecond
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
@@ -114,6 +119,8 @@ func TestSequentialTraceMapSize(t *testing.T) {
 	}
 	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
+	tsp.tickerFrequency = 100 * time.Millisecond
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
@@ -141,6 +148,8 @@ func TestConcurrentTraceMapSize(t *testing.T) {
 	}
 	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
+	tsp.tickerFrequency = 100 * time.Millisecond
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
@@ -182,7 +191,9 @@ func TestSamplingPolicyTypicalPath(t *testing.T) {
 		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
 	}
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
@@ -241,7 +252,9 @@ func TestSamplingPolicyInvertSampled(t *testing.T) {
 		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
 	}
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
@@ -305,9 +318,11 @@ func TestSamplingMultiplePolicies(t *testing.T) {
 			{
 				name: "policy-2", evaluator: mpe2, ctx: context.TODO(),
 			}},
-		deleteChan:   make(chan pdata.TraceID, maxSize),
-		policyTicker: mtt,
+		deleteChan:      make(chan pdata.TraceID, maxSize),
+		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
 	}
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
@@ -369,7 +384,9 @@ func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
 		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
 	}
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
@@ -431,7 +448,9 @@ func TestSamplingPolicyDecisionInvertNotSampled(t *testing.T) {
 		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
 	}
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
@@ -493,7 +512,9 @@ func TestMultipleBatchesAreCombinedIntoOne(t *testing.T) {
 		policies:        []*policy{{name: "mock-policy", evaluator: mpe, ctx: context.TODO()}},
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
+		tickerFrequency: 100 * time.Millisecond,
 	}
+	tsp.Start(context.Background(), componenttest.NewNopHost())
 	defer func() {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -48,6 +48,10 @@ func TestSequentialTraceArrival(t *testing.T) {
 	}
 	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
 	for _, batch := range batches {
 		tsp.ConsumeTraces(context.Background(), batch)
 	}
@@ -72,6 +76,10 @@ func TestConcurrentTraceArrival(t *testing.T) {
 	}
 	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
 	for _, batch := range batches {
 		// Add the same traceId twice.
 		wg.Add(2)
@@ -106,6 +114,10 @@ func TestSequentialTraceMapSize(t *testing.T) {
 	}
 	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
 	for _, batch := range batches {
 		tsp.ConsumeTraces(context.Background(), batch)
 	}
@@ -129,6 +141,10 @@ func TestConcurrentTraceMapSize(t *testing.T) {
 	}
 	sp, _ := newTracesProcessor(zap.NewNop(), consumertest.NewNop(), cfg)
 	tsp := sp.(*tailSamplingSpanProcessor)
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
 	for _, batch := range batches {
 		wg.Add(1)
 		go func(td pdata.Traces) {
@@ -167,6 +183,9 @@ func TestSamplingPolicyTypicalPath(t *testing.T) {
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
 	}
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
 
 	_, batches := generateIdsAndBatches(210)
 	currItem := 0
@@ -223,6 +242,9 @@ func TestSamplingPolicyInvertSampled(t *testing.T) {
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
 	}
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
 
 	_, batches := generateIdsAndBatches(210)
 	currItem := 0
@@ -286,6 +308,9 @@ func TestSamplingMultiplePolicies(t *testing.T) {
 		deleteChan:   make(chan pdata.TraceID, maxSize),
 		policyTicker: mtt,
 	}
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
 
 	_, batches := generateIdsAndBatches(210)
 	currItem := 0
@@ -345,6 +370,9 @@ func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
 	}
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
 
 	_, batches := generateIdsAndBatches(210)
 	currItem := 0
@@ -404,6 +432,9 @@ func TestSamplingPolicyDecisionInvertNotSampled(t *testing.T) {
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
 	}
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
 
 	_, batches := generateIdsAndBatches(210)
 	currItem := 0
@@ -463,6 +494,9 @@ func TestMultipleBatchesAreCombinedIntoOne(t *testing.T) {
 		deleteChan:      make(chan pdata.TraceID, maxSize),
 		policyTicker:    mtt,
 	}
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
 
 	mpe.NextDecision = sampling.Sampled
 


### PR DESCRIPTION
Running the following command shows that there was a go routine leak, probably caused by not cleaning up the resources after running the test:

```console
$ go test -race -count 100 -timeout 60s -run "^TestConcurrentTraceArrival$"
race: limit on 8128 simultaneously alive goroutines is exceeded, dying
exit status 66
FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor       17.702s
```

This PR changes the processor's `Shutdown` function to close the underlying resources. It also fixes the stop logic for the ticker's loop.

After this PR, the test passes all the time with the same command as above:

```
$ go test -race -count 100 -timeout 60s -run "^TestConcurrentTraceArrival$"
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor       38.512s
```

Fixes #5678

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>