### PR TITLE
Span event filter 

### DIFF
--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -1,6 +1,6 @@
 # Filter Processor
 
-Supported pipeline types: logs, metrics
+Supported pipeline types: logs, metrics, traces(span events)
 
 The filter processor can be configured to include or exclude:
 
@@ -37,6 +37,15 @@ For metrics:
 - `resource_attributes`: ResourceAttributes defines a list of possible resource
   attributes to match metrics against.
   A match occurs if any resource attribute matches all expressions in this given list.
+
+For span events:
+
+- `match_type`: `strict`|`regexp`
+- `event_attributes`: EventAttributes defines a list of possible event
+  attributes to match span events against.
+  A match occurs if any span event attribute matches all expressions in this given list.
+- `event_names`: EventNames defines a list of possible event names to match span events against.
+  A match occurs if any span name is matched in the given list.
 
 This processor uses [re2 regex][re2_regex] for regex syntax.
 
@@ -78,6 +87,24 @@ processors:
     logs/regexp_record:
         match_type: regexp
         record_attributes:
+          - Key: record_attr
+            Value: prefix_.*
+  filter/3:
+    span_events:
+      include:
+        match_type: strict
+        event_attributes:
+          - Key: host.name
+            Value: just_this_one_hostname
+    span_events/regexp:
+        match_type: regexp
+        event_attributes:
+          - Key: host.name
+            Value: prefix.*
+        event_names: ["name1", "name2"]
+    span_events/regexp_record:
+        match_type: regexp
+        event_attributes:
           - Key: record_attr
             Value: prefix_.*
 ```

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -71,21 +71,21 @@ type SpanEventFilters struct {
 	Exclude *SpanEventMatchProperties `mapstructure:"exclude"`
 }
 
-// LogMatchType specifies the strategy for matching against `pdata.Log`s.
-type LogMatchType string
+// MatchType specifies the strategy for matching against `pdata.Log`s.
+type MatchType string
 
 // These are the MatchTypes that users can specify for filtering
 // `pdata.Log`s.
 const (
-	Strict = LogMatchType(filterset.Strict)
-	Regexp = LogMatchType(filterset.Regexp)
+	Strict = MatchType(filterset.Strict)
+	Regexp = MatchType(filterset.Regexp)
 )
 
 // LogMatchProperties specifies the set of properties in a log to match against and the
 // type of string pattern matching to use.
 type LogMatchProperties struct {
 	// LogMatchType specifies the type of matching desired
-	LogMatchType LogMatchType `mapstructure:"match_type"`
+	LogMatchType MatchType `mapstructure:"match_type"`
 
 	// ResourceAttributes defines a list of possible resource attributes to match logs against.
 	// A match occurs if any resource attribute matches all expressions in this given list.
@@ -99,9 +99,8 @@ type LogMatchProperties struct {
 // SpanEventMatchProperties specifies the set of properties in a span event to match against and the
 // type of string pattern matching to use.
 type SpanEventMatchProperties struct {
-	// TODO: Rename LogMatchType to MatchType
 	// SpanEventMatchType specifies the type of matching desired
-	SpanEventMatchType LogMatchType `mapstructure:"match_type"`
+	SpanEventMatchType MatchType `mapstructure:"match_type"`
 
 	// RegexpConfig specifies options for the Regexp match type
 	RegexpConfig *regexp.Config `mapstructure:"regexp"`

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filtermetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset/regexp"
 )
 
 // Config defines configuration for Resource processor.
@@ -29,6 +30,8 @@ type Config struct {
 	Metrics MetricFilters `mapstructure:"metrics"`
 
 	Logs LogFilters `mapstructure:"logs"`
+
+	SpanEvents SpanEventFilters `mapstructure:"span_events"`
 }
 
 // MetricFilters filters by Metric properties.
@@ -56,6 +59,18 @@ type LogFilters struct {
 	Exclude *LogMatchProperties `mapstructure:"exclude"`
 }
 
+// SpanEventFilters filters by Span Event properties.
+type SpanEventFilters struct {
+	// Include match properties describe span events that should be included in the Collector Service pipeline,
+	// all other span events should be dropped from further processing.
+	// If both Include and Exclude are specified, Include filtering occurs first.
+	Include *SpanEventMatchProperties `mapstructure:"include"`
+	// Exclude match properties describe span events that should be excluded from the Collector Service pipeline,
+	// all other span events should be included.
+	// If both Include and Exclude are specified, Include filtering occurs first.
+	Exclude *SpanEventMatchProperties `mapstructure:"exclude"`
+}
+
 // LogMatchType specifies the strategy for matching against `pdata.Log`s.
 type LogMatchType string
 
@@ -79,6 +94,25 @@ type LogMatchProperties struct {
 	// RecordAttributes defines a list of possible record attributes to match logs against.
 	// A match occurs if any record attribute matches at least one expression in this given list.
 	RecordAttributes []filterconfig.Attribute `mapstructure:"record_attributes"`
+}
+
+// SpanEventMatchProperties specifies the set of properties in a span event to match against and the
+// type of string pattern matching to use.
+type SpanEventMatchProperties struct {
+	// TODO: Rename LogMatchType to MatchType
+	// SpanEventMatchType specifies the type of matching desired
+	SpanEventMatchType LogMatchType `mapstructure:"match_type"`
+
+	// RegexpConfig specifies options for the Regexp match type
+	RegexpConfig *regexp.Config `mapstructure:"regexp"`
+
+	// EventNames specifies the list of string patterns to match event names against.
+	// A match occurs if the event name matches at least one string pattern in this list.
+	EventNames []string `mapstructure:"event_names"`
+
+	// Attributes defines a list of possible span event attributes to match span events against.
+	// A match occurs if any span event attribute matches at least one expression in this given list.
+	EventAttributes []filterconfig.Attribute `mapstructure:"event_attributes"`
 }
 
 var _ config.Processor = (*Config)(nil)

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -188,6 +188,234 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 	}
 }
 
+// TestLoadingConfigStrictSpanEvents tests loading testdata/config_span_events_strict.yaml
+func TestLoadingConfigStrictSpanEvents(t *testing.T) {
+
+	testDataSpanEventAttributesInclude := &SpanEventMatchProperties{
+		SpanEventMatchType: Strict,
+		EventAttributes: []filterconfig.Attribute{
+			{
+				Key:   "should_include",
+				Value: "true",
+			},
+		},
+	}
+
+	testDataSpanEventAttributesExclude := &SpanEventMatchProperties{
+		SpanEventMatchType: Strict,
+		EventAttributes: []filterconfig.Attribute{
+			{
+				Key:   "should_exclude",
+				Value: "true",
+			},
+		},
+	}
+
+	testDataSpanEventAttributesIncludeWithNames := &SpanEventMatchProperties{
+		SpanEventMatchType: Strict,
+		EventNames:         []string{"name1", "name2"},
+		EventAttributes: []filterconfig.Attribute{
+			{
+				Key:   "should_include",
+				Value: "true",
+			},
+		},
+	}
+
+	testDataSpanEventAttributesExcludeWithNames := &SpanEventMatchProperties{
+		SpanEventMatchType: Strict,
+		EventNames:         []string{"name3", "name4"},
+		EventAttributes: []filterconfig.Attribute{
+			{
+				Key:   "should_exclude",
+				Value: "true",
+			},
+		},
+	}
+
+	factories, err := componenttest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Processors[typeStr] = factory
+	cfg, err := configtest.LoadConfigAndValidate(path.Join(".", "testdata", "config_span_events_strict.yaml"), factories)
+
+	assert.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	tests := []struct {
+		filterID config.ComponentID
+		expCfg   *Config
+	}{
+		{
+			filterID: config.NewComponentIDWithName("filter", "empty"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "empty")),
+				SpanEvents: SpanEventFilters{
+					Include: &SpanEventMatchProperties{
+						SpanEventMatchType: Strict,
+					},
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "include"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "include")),
+				SpanEvents: SpanEventFilters{
+					Include: testDataSpanEventAttributesInclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "exclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "exclude")),
+				SpanEvents: SpanEventFilters{
+					Exclude: testDataSpanEventAttributesExclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "includeexclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "includeexclude")),
+				SpanEvents: SpanEventFilters{
+					Include: testDataSpanEventAttributesInclude,
+					Exclude: testDataSpanEventAttributesExclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "includeexcludewithnames"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "includeexcludewithnames")),
+				SpanEvents: SpanEventFilters{
+					Include: testDataSpanEventAttributesIncludeWithNames,
+					Exclude: testDataSpanEventAttributesExcludeWithNames,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filterID.String(), func(t *testing.T) {
+			cfg := cfg.Processors[test.filterID]
+			assert.Equal(t, test.expCfg, cfg)
+		})
+	}
+}
+
+// TestLoadingConfigRegexpSpanEvents tests loading testdata/config_span_events_regexp.yaml
+func TestLoadingConfigRegexpSpanEvents(t *testing.T) {
+
+	testDataSpanEventAttributesInclude := &SpanEventMatchProperties{
+		SpanEventMatchType: Regexp,
+		EventAttributes: []filterconfig.Attribute{
+			{
+				Key:   "should_include",
+				Value: "(true|probably_true)",
+			},
+		},
+	}
+
+	testDataSpanEventAttributesExclude := &SpanEventMatchProperties{
+		SpanEventMatchType: Regexp,
+		EventAttributes: []filterconfig.Attribute{
+			{
+				Key:   "should_exclude",
+				Value: "(probably_false|false)",
+			},
+		},
+	}
+
+	testDataSpanEventAttributesIncludeWithNames := &SpanEventMatchProperties{
+		SpanEventMatchType: Regexp,
+		EventNames:         []string{"(true|probably_true)"},
+		EventAttributes: []filterconfig.Attribute{
+			{
+				Key:   "should_include",
+				Value: "(true|probably_true)",
+			},
+		},
+	}
+
+	testDataSpanEventAttributesExcludeWithNames := &SpanEventMatchProperties{
+		SpanEventMatchType: Regexp,
+		EventNames:         []string{"(probably_false|false)"},
+		EventAttributes: []filterconfig.Attribute{
+			{
+				Key:   "should_exclude",
+				Value: "(probably_false|false)",
+			},
+		},
+	}
+
+	factories, err := componenttest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Processors[typeStr] = factory
+	cfg, err := configtest.LoadConfigAndValidate(path.Join(".", "testdata", "config_span_events_regexp.yaml"), factories)
+
+	assert.Nil(t, err)
+	require.NotNil(t, cfg)
+
+	tests := []struct {
+		filterID config.ComponentID
+		expCfg   *Config
+	}{
+		{
+			filterID: config.NewComponentIDWithName("filter", "empty"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "empty")),
+				SpanEvents: SpanEventFilters{
+					Include: &SpanEventMatchProperties{
+						SpanEventMatchType: Regexp,
+					},
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "include"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "include")),
+				SpanEvents: SpanEventFilters{
+					Include: testDataSpanEventAttributesInclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "exclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "exclude")),
+				SpanEvents: SpanEventFilters{
+					Exclude: testDataSpanEventAttributesExclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "includeexclude"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "includeexclude")),
+				SpanEvents: SpanEventFilters{
+					Include: testDataSpanEventAttributesInclude,
+					Exclude: testDataSpanEventAttributesExclude,
+				},
+			},
+		}, {
+			filterID: config.NewComponentIDWithName("filter", "includeexcludewithnames"),
+			expCfg: &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "includeexcludewithnames")),
+				SpanEvents: SpanEventFilters{
+					Include: testDataSpanEventAttributesIncludeWithNames,
+					Exclude: testDataSpanEventAttributesExcludeWithNames,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filterID.String(), func(t *testing.T) {
+			cfg := cfg.Processors[test.filterID]
+			assert.Equal(t, test.expCfg, cfg)
+		})
+	}
+}
+
 // TestLoadingConfigRegexp tests loading testdata/config_regexp.yaml
 func TestLoadingConfigRegexp(t *testing.T) {
 	// list of filters used repeatedly on testdata/config.yaml

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -37,6 +37,7 @@ func NewFactory() component.ProcessorFactory {
 		createDefaultConfig,
 		processorhelper.WithMetrics(createMetricsProcessor),
 		processorhelper.WithLogs(createLogsProcessor),
+		processorhelper.WithTraces(createSpanEventsProcessor),
 	)
 }
 
@@ -77,5 +78,22 @@ func createLogsProcessor(
 		cfg,
 		nextConsumer,
 		fp.ProcessLogs,
+		processorhelper.WithCapabilities(processorCapabilities))
+}
+
+func createSpanEventsProcessor(
+	_ context.Context,
+	set component.ProcessorCreateSettings,
+	cfg config.Processor,
+	nextConsumer consumer.Traces,
+) (component.TracesProcessor, error) {
+	fp, err := newFilterSpanEventsProcessor(set.Logger, cfg.(*Config))
+	if err != nil {
+		return nil, err
+	}
+	return processorhelper.NewTracesProcessor(
+		cfg,
+		nextConsumer,
+		fp.ProcessSpanEvents,
 		processorhelper.WithCapabilities(processorCapabilities))
 }

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -85,11 +85,6 @@ func TestCreateProcessors(t *testing.T) {
 			t.Run(fmt.Sprintf("%s/%s", test.configName, name), func(t *testing.T) {
 				factory := NewFactory()
 
-				tp, tErr := factory.CreateTracesProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
-				// Not implemented error
-				assert.NotNil(t, tErr)
-				assert.Nil(t, tp)
-
 				mp, mErr := factory.CreateMetricsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
 				assert.Equal(t, test.succeed, mp != nil)
 				assert.Equal(t, test.succeed, mErr == nil)

--- a/processor/filterprocessor/filter_processor_span_events.go
+++ b/processor/filterprocessor/filter_processor_span_events.go
@@ -1,0 +1,220 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filtermatcher"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
+)
+
+type SpanEventsMatchType int
+
+const (
+	NameMatch      SpanEventsMatchType = iota
+	AttributeMatch SpanEventsMatchType = iota
+)
+
+type filterSpanEventProcessor struct {
+	cfg                *Config
+	nameMatcherInclude *spanEventNameMatcher
+	nameMatcherExclude *spanEventNameMatcher
+	excludeAttributes  filtermatcher.AttributesMatcher
+	includeAttributes  filtermatcher.AttributesMatcher
+	logger             *zap.Logger
+}
+
+func newFilterSpanEventsProcessor(logger *zap.Logger, cfg *Config) (*filterSpanEventProcessor, error) {
+
+	includeAttributes, err := createSpanEventsMatcher(cfg.SpanEvents.Include, AttributeMatch)
+	if err != nil {
+		logger.Error(
+			"filterSpanEvent: Error creating include span events attributes matcher", zap.Error(err),
+		)
+		return nil, err
+	}
+
+	excludeAttributes, err := createSpanEventsMatcher(cfg.SpanEvents.Exclude, AttributeMatch)
+	if err != nil {
+		logger.Error(
+			"filterSpanEvent: Error creating exclude span events attributes matcher", zap.Error(err),
+		)
+		return nil, err
+	}
+
+	nameMatcherInclude, err := newSpanEventNameMatcher(cfg.SpanEvents.Include)
+	if err != nil {
+		logger.Error(
+			"filterSpanEvent: Error creating include span events name matcher", zap.Error(err),
+		)
+		return nil, err
+	}
+
+	nameMatcherExclude, err := newSpanEventNameMatcher(cfg.SpanEvents.Exclude)
+	if err != nil {
+		logger.Error(
+			"filterSpanEvent: Error creating exclude span events name matcher", zap.Error(err),
+		)
+		return nil, err
+	}
+
+	return &filterSpanEventProcessor{
+		cfg:                cfg,
+		nameMatcherInclude: nameMatcherInclude,
+		nameMatcherExclude: nameMatcherExclude,
+		includeAttributes:  includeAttributes,
+		excludeAttributes:  excludeAttributes,
+		logger:             logger,
+	}, nil
+}
+
+func createSpanEventsMatcher(sp *SpanEventMatchProperties, matchLevel SpanEventsMatchType) (filtermatcher.AttributesMatcher, error) {
+	// Nothing specified in configuration
+	if sp == nil {
+		return nil, nil
+	}
+	var attributeMatcher filtermatcher.AttributesMatcher
+	attributeMatcher, err := filtermatcher.NewAttributesMatcher(
+		filterset.Config{
+			MatchType: filterset.MatchType(sp.SpanEventMatchType),
+		},
+		getFilterConfigForSpanEventMatchLevel(sp, matchLevel),
+	)
+	if err != nil {
+		return attributeMatcher, err
+	}
+	return attributeMatcher, nil
+}
+
+func getFilterConfigForSpanEventMatchLevel(sp *SpanEventMatchProperties, m SpanEventsMatchType) []filterconfig.Attribute {
+	switch m {
+	case AttributeMatch:
+		return sp.EventAttributes
+	default:
+		return nil
+	}
+}
+
+func (fsep *filterSpanEventProcessor) ProcessSpanEvents(ctx context.Context, traces pdata.Traces) (pdata.Traces, error) {
+	rSpansSlice := traces.ResourceSpans()
+
+	for i := 0; i < rSpansSlice.Len(); i++ {
+		ilSpans := rSpansSlice.At(i).InstrumentationLibrarySpans()
+
+		for j := 0; j < ilSpans.Len(); j++ {
+			spanSlice := ilSpans.At(j).Spans()
+
+			for k := 0; k < spanSlice.Len(); k++ {
+				eventsSlice := spanSlice.At(k).Events()
+				fsep.filterByEventAttributes(eventsSlice)
+			}
+		}
+	}
+
+	return traces, nil
+}
+
+func (fsep *filterSpanEventProcessor) filterByEventAttributes(events pdata.SpanEventSlice) {
+	for i := 0; i < events.Len(); i++ {
+		event := events.At(i)
+
+		events.RemoveIf(func(se pdata.SpanEvent) bool {
+			return fsep.shouldSkipEvent(event)
+		})
+	}
+}
+
+// shouldSkipEvent determines if a span event should be processed.
+// True is returned when a span event should be skipped.
+// False is returned when a span event should not be skipped.
+// The logic determining if a span event should be skipped is set in the
+// record attribute configuration.
+func (fsep *filterSpanEventProcessor) shouldSkipEvent(se pdata.SpanEvent) bool {
+	if fsep.includeAttributes != nil {
+		matches := fsep.includeAttributes.Match(se.Attributes())
+		if !matches {
+			return true
+		}
+	}
+
+	if fsep.nameMatcherInclude != nil {
+		matches, err := fsep.nameMatcherInclude.MatchSpanEventName(se)
+		if err != nil {
+			fsep.logger.Error(
+				"filterSpanEvent: Error matching include names", zap.Error(err),
+			)
+		}
+		if !matches {
+			return true
+		}
+	}
+
+	if fsep.excludeAttributes != nil {
+		matches := fsep.excludeAttributes.Match(se.Attributes())
+		if matches {
+			return true
+		}
+	}
+
+	if fsep.nameMatcherInclude != nil {
+		matches, err := fsep.nameMatcherInclude.MatchSpanEventName(se)
+		if err != nil {
+			fsep.logger.Error(
+				"filterSpanEvent: Error matching exclude names", zap.Error(err),
+			)
+		}
+		if matches {
+			return true
+		}
+	}
+
+	return false
+}
+
+// spanEventNameMatcher matches metrics by metric properties against prespecified values for each property.
+type spanEventNameMatcher struct {
+	nameFilters filterset.FilterSet
+}
+
+func newSpanEventNameMatcher(config *SpanEventMatchProperties) (*spanEventNameMatcher, error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	nameFS, err := filterset.CreateFilterSet(
+		config.EventNames,
+		&filterset.Config{
+			MatchType:    filterset.MatchType(config.SpanEventMatchType),
+			RegexpConfig: config.RegexpConfig,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &spanEventNameMatcher{
+		nameFilters: nameFS,
+	}, nil
+}
+
+// MatchSpanEventName matches a span event using the span event properties configured on the spanEventNameMatcher.
+// A span event only matches if every span event property configured on the spanEventNameMatcher is a match.
+func (m *spanEventNameMatcher) MatchSpanEventName(spanEvent pdata.SpanEvent) (bool, error) {
+	return m.nameFilters.Matches(spanEvent.Name()), nil
+}

--- a/processor/filterprocessor/filter_processor_span_events.go
+++ b/processor/filterprocessor/filter_processor_span_events.go
@@ -16,6 +16,7 @@ package filterprocessor
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
@@ -150,6 +151,7 @@ func (fsep *filterSpanEventProcessor) shouldSkipEvent(se pdata.SpanEvent) bool {
 	if fsep.includeAttributes != nil {
 		matches := fsep.includeAttributes.Match(se.Attributes())
 		if !matches {
+			fmt.Println("hmm1")
 			return true
 		}
 	}
@@ -162,6 +164,8 @@ func (fsep *filterSpanEventProcessor) shouldSkipEvent(se pdata.SpanEvent) bool {
 			)
 		}
 		if !matches {
+			fmt.Println("hmm2")
+
 			return true
 		}
 	}
@@ -169,6 +173,8 @@ func (fsep *filterSpanEventProcessor) shouldSkipEvent(se pdata.SpanEvent) bool {
 	if fsep.excludeAttributes != nil {
 		matches := fsep.excludeAttributes.Match(se.Attributes())
 		if matches {
+			fmt.Println("hmm3")
+
 			return true
 		}
 	}
@@ -181,6 +187,8 @@ func (fsep *filterSpanEventProcessor) shouldSkipEvent(se pdata.SpanEvent) bool {
 			)
 		}
 		if matches {
+			fmt.Println("hmm4")
+
 			return true
 		}
 	}
@@ -194,7 +202,7 @@ type spanEventNameMatcher struct {
 }
 
 func newSpanEventNameMatcher(config *SpanEventMatchProperties) (*spanEventNameMatcher, error) {
-	if config == nil {
+	if config == nil || len(config.EventNames) == 0 {
 		return nil, nil
 	}
 

--- a/processor/filterprocessor/filter_processor_span_events_test.go
+++ b/processor/filterprocessor/filter_processor_span_events_test.go
@@ -16,7 +16,6 @@ package filterprocessor
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -46,93 +45,79 @@ type spanEventWithAttributes struct {
 var (
 	inSpanEventNames = "random"
 
-	// inSpanEventForResourceTest = []spanEventWithAttributes{
-	// 	{
-	// 		spanEventNames: []string{"log1", "log2"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr1": pdata.NewAttributeValueString("attr1/val1"),
-	// 			"attr2": pdata.NewAttributeValueString("attr2/val2"),
-	// 			"attr3": pdata.NewAttributeValueString("attr3/val3"),
-	// 		},
-	// 	},
-	// }
+	inSpanEventForResourceTest = []spanEventWithAttributes{
+		{
+			spanEventName: "event",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr1": pdata.NewAttributeValueString("attr1/val1"),
+				"attr2": pdata.NewAttributeValueString("attr2/val2"),
+				"attr3": pdata.NewAttributeValueString("attr3/val3"),
+			},
+		},
+	}
 
-	// inSpanEventForTwoResource = []spanEventWithAttributes{
-	// 	{
-	// 		spanEventNames: []string{"log1", "log2"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr1": pdata.NewAttributeValueString("attr1/val1"),
-	// 		},
-	// 	},
-	// 	{
-	// 		spanEventNames: []string{"log3", "log4"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr1": pdata.NewAttributeValueString("attr1/val2"),
-	// 		},
-	// 	},
-	// }
+	inSpanEventForTwoAttributes = []spanEventWithAttributes{
+		{
+			spanEventName: "event1",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr1": pdata.NewAttributeValueString("attr1/val1"),
+			},
+		},
+		{
+			spanEventName: "event2",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr1": pdata.NewAttributeValueString("attr1/val2"),
+			},
+		},
+	}
 
-	// inSpanEventForTwoResourceWithRecordAttributes = []spanEventWithAttributes{
-	// 	{
-	// 		spanEventNames: []string{"log1", "log2"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr1": pdata.NewAttributeValueString("attr1/val1"),
-	// 		},
-	// 	},
-	// 	{
-	// 		spanEventNames: []string{"log3", "log4"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr1": pdata.NewAttributeValueString("attr1/val2"),
-	// 		},
-	// 	},
-	// }
-	// inSpanEventForThreeResourceWithRecordAttributes = []spanEventWithAttributes{
-	// 	{
-	// 		spanEventNames: []string{"log1", "log2"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr1": pdata.NewAttributeValueString("attr1/val1"),
-	// 		},
-	// 	},
-	// 	{
-	// 		spanEventNames: []string{"log3", "log4"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr1": pdata.NewAttributeValueString("attr1/val2"),
-	// 		},
-	// 	},
-	// 	{
-	// 		spanEventNames: []string{"log5"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr1": pdata.NewAttributeValueString("attr1/val5"),
-	// 		},
-	// 	},
-	// }
+	inSpanEventForThreeAttributes = []spanEventWithAttributes{
+		{
+			spanEventName: "event1",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr1": pdata.NewAttributeValueString("attr1/val1"),
+			},
+		},
+		{
+			spanEventName: "event2",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr1": pdata.NewAttributeValueString("attr1/val2"),
+			},
+		},
+		{
+			spanEventName: "event3",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr1": pdata.NewAttributeValueString("attr1/val5"),
+			},
+		},
+	}
 
-	// inSpanEventForFourResource = []spanEventWithAttributes{
-	// 	{
-	// 		spanEventNames: []string{"log1"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr": pdata.NewAttributeValueString("attr/val1"),
-	// 		},
-	// 	},
-	// 	{
-	// 		spanEventNames: []string{"log2"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr": pdata.NewAttributeValueString("attr/val2"),
-	// 		},
-	// 	},
-	// 	{
-	// 		spanEventNames: []string{"log3"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr": pdata.NewAttributeValueString("attr/val3"),
-	// 		},
-	// 	},
-	// 	{
-	// 		spanEventNames: []string{"log4"},
-	// 		eventAttributes: map[string]pdata.AttributeValue{
-	// 			"attr": pdata.NewAttributeValueString("attr/val4"),
-	// 		},
-	// 	},
-	// }
+	inSpanEventForFourAttributes = []spanEventWithAttributes{
+		{
+			spanEventName: "event1",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr": pdata.NewAttributeValueString("attr/val1"),
+			},
+		},
+		{
+			spanEventName: "event2",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr": pdata.NewAttributeValueString("attr/val2"),
+			},
+		},
+		{
+			spanEventName: "event3",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr": pdata.NewAttributeValueString("attr/val3"),
+			},
+		},
+		{
+			spanEventName: "event4",
+			eventAttributes: map[string]pdata.AttributeValue{
+				"attr": pdata.NewAttributeValueString("attr/val4"),
+			},
+		},
+	}
 
 	standardSpanEventTests = []spanEventNameTest{
 		{
@@ -141,22 +126,28 @@ var (
 			inTraces: testSpanEvents([]spanEventWithAttributes{{spanEventName: inSpanEventNames}}),
 			outSES:   []string{inSpanEventNames},
 		},
-		// {
-		// 	name:     "includeNilWithResourceAttributes",
-		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
-		// 	inTraces: testSpanEvents(inSpanEventForResourceTest),
-		// 	outSES: [][]string{
-		// 		{"log1", "log2"},
-		// 	},
-		// },
-		// {
-		// 	name:     "includeAllWithMissingResourceAttributes",
-		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val2"}}},
-		// 	inTraces: testSpanEvents(inSpanEventForTwoResource),
-		// 	outSES: [][]string{
-		// 		{"log3", "log4"},
-		// 	},
-		// },
+		{
+			name:     "emptyFilterExclude",
+			exc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+			inTraces: testSpanEvents([]spanEventWithAttributes{{spanEventName: inSpanEventNames}}),
+			outSES:   []string{inSpanEventNames},
+		},
+		{
+			name:     "emptyFilterIncludeAndExclude",
+			inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+			exc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+			inTraces: testSpanEvents([]spanEventWithAttributes{{spanEventName: inSpanEventNames}}),
+			outSES:   []string{inSpanEventNames},
+		},
+		{
+			name:     "includeAllWithMissingAttributes",
+			inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val2"}}},
+			inTraces: testSpanEvents(inSpanEventForTwoAttributes),
+			outSES: []string{
+				"event1",
+				"event2",
+			},
+		},
 		// {
 		// 	name:     "emptyFilterExclude",
 		// 	exc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
@@ -321,7 +312,7 @@ var (
 func TestFilterSpanEventProcessor(t *testing.T) {
 	for _, test := range standardSpanEventTests {
 		t.Run(test.name, func(t *testing.T) {
-			// next stores the results of the filter log processor
+			// next stores the results of the filter span event processor
 			next := new(consumertest.TracesSink)
 			cfg := &Config{
 				ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
@@ -354,22 +345,11 @@ func TestFilterSpanEventProcessor(t *testing.T) {
 			assert.Equal(t, 1, rTraces.Len())
 
 			ilSpans := rTraces.At(0).InstrumentationLibrarySpans().At(0).Spans()
-			fmt.Println("TRACES LENGTH: ")
-			fmt.Println(rTraces.Len())
-			fmt.Println("SPANS LENGHT: ")
-			fmt.Println(ilSpans.Len())
-			fmt.Println("EVENTS LENGHT: ")
-			fmt.Println(ilSpans.At(0).Events().Len())
 			gotEvents := ilSpans.At(0).Events()
 			assert.Equal(t, len(test.outSES), gotEvents.Len())
-			// for i, wantOut := range test.outSES {
-			// 	fmt.Println("EVENTS LENGHT: ")
-			// 	fmt.Println(gotEvents.Len())
-
-			// 	for idx := range wantOut {
-			// 		assert.Equal(t, wantOut[idx], gotEvents.At(idx).Name())
-			// 	}
-			// }
+			for i, spanEventName := range test.outSES {
+				assert.Equal(t, spanEventName, gotEvents.At(i).Name())
+			}
 			assert.NoError(t, flp.Shutdown(ctx))
 		})
 	}
@@ -381,6 +361,8 @@ func testSpanEvents(sewas []spanEventWithAttributes) pdata.Traces {
 	ilSpans := rSpans.InstrumentationLibrarySpans().AppendEmpty()
 	spans := ilSpans.Spans()
 	span := spans.AppendEmpty()
+	span.SetName("test")
+	span.Events().EnsureCapacity(len(sewas))
 
 	for _, sewa := range sewas {
 		es := span.Events()
@@ -388,9 +370,6 @@ func testSpanEvents(sewas []spanEventWithAttributes) pdata.Traces {
 		e.SetName(sewa.spanEventName)
 		e.SetTimestamp(pdata.NewTimestampFromTime(time.Now()))
 		e.Attributes().InitFromMap(sewa.eventAttributes)
-		fmt.Println("HHMMMMMMMMMMMMMMMMMMM")
-		fmt.Println(spans.At(1).Events().Len())
-
 	}
 
 	return td

--- a/processor/filterprocessor/filter_processor_span_events_test.go
+++ b/processor/filterprocessor/filter_processor_span_events_test.go
@@ -1,0 +1,443 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterprocessor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/model/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterconfig"
+)
+
+type spanEventNameTest struct {
+	name     string
+	inc      *SpanEventMatchProperties
+	exc      *SpanEventMatchProperties
+	inTraces pdata.Traces
+	outSES   []string // output span events
+}
+
+type spanEventWithAttributes struct {
+	spanEventName   string
+	eventAttributes map[string]pdata.AttributeValue
+}
+
+var (
+	inSpanEventNames = "random"
+
+	// inSpanEventForResourceTest = []spanEventWithAttributes{
+	// 	{
+	// 		spanEventNames: []string{"log1", "log2"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr1": pdata.NewAttributeValueString("attr1/val1"),
+	// 			"attr2": pdata.NewAttributeValueString("attr2/val2"),
+	// 			"attr3": pdata.NewAttributeValueString("attr3/val3"),
+	// 		},
+	// 	},
+	// }
+
+	// inSpanEventForTwoResource = []spanEventWithAttributes{
+	// 	{
+	// 		spanEventNames: []string{"log1", "log2"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr1": pdata.NewAttributeValueString("attr1/val1"),
+	// 		},
+	// 	},
+	// 	{
+	// 		spanEventNames: []string{"log3", "log4"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr1": pdata.NewAttributeValueString("attr1/val2"),
+	// 		},
+	// 	},
+	// }
+
+	// inSpanEventForTwoResourceWithRecordAttributes = []spanEventWithAttributes{
+	// 	{
+	// 		spanEventNames: []string{"log1", "log2"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr1": pdata.NewAttributeValueString("attr1/val1"),
+	// 		},
+	// 	},
+	// 	{
+	// 		spanEventNames: []string{"log3", "log4"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr1": pdata.NewAttributeValueString("attr1/val2"),
+	// 		},
+	// 	},
+	// }
+	// inSpanEventForThreeResourceWithRecordAttributes = []spanEventWithAttributes{
+	// 	{
+	// 		spanEventNames: []string{"log1", "log2"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr1": pdata.NewAttributeValueString("attr1/val1"),
+	// 		},
+	// 	},
+	// 	{
+	// 		spanEventNames: []string{"log3", "log4"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr1": pdata.NewAttributeValueString("attr1/val2"),
+	// 		},
+	// 	},
+	// 	{
+	// 		spanEventNames: []string{"log5"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr1": pdata.NewAttributeValueString("attr1/val5"),
+	// 		},
+	// 	},
+	// }
+
+	// inSpanEventForFourResource = []spanEventWithAttributes{
+	// 	{
+	// 		spanEventNames: []string{"log1"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr": pdata.NewAttributeValueString("attr/val1"),
+	// 		},
+	// 	},
+	// 	{
+	// 		spanEventNames: []string{"log2"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr": pdata.NewAttributeValueString("attr/val2"),
+	// 		},
+	// 	},
+	// 	{
+	// 		spanEventNames: []string{"log3"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr": pdata.NewAttributeValueString("attr/val3"),
+	// 		},
+	// 	},
+	// 	{
+	// 		spanEventNames: []string{"log4"},
+	// 		eventAttributes: map[string]pdata.AttributeValue{
+	// 			"attr": pdata.NewAttributeValueString("attr/val4"),
+	// 		},
+	// 	},
+	// }
+
+	standardSpanEventTests = []spanEventNameTest{
+		{
+			name:     "emptyFilterInclude",
+			inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+			inTraces: testSpanEvents([]spanEventWithAttributes{{spanEventName: inSpanEventNames}}),
+			outSES:   []string{inSpanEventNames},
+		},
+		// {
+		// 	name:     "includeNilWithResourceAttributes",
+		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+		// 	inTraces: testSpanEvents(inSpanEventForResourceTest),
+		// 	outSES: [][]string{
+		// 		{"log1", "log2"},
+		// 	},
+		// },
+		// {
+		// 	name:     "includeAllWithMissingResourceAttributes",
+		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val2"}}},
+		// 	inTraces: testSpanEvents(inSpanEventForTwoResource),
+		// 	outSES: [][]string{
+		// 		{"log3", "log4"},
+		// 	},
+		// },
+		// {
+		// 	name:     "emptyFilterExclude",
+		// 	exc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+		// 	inTraces: testSpanEvents([]spanEventWithAttributes{{spanEventNames: inSpanEventNames}}),
+		// 	outSES:   [][]string{inSpanEventNames},
+		// },
+		// {
+		// 	name:     "excludeNilWithResourceAttributes",
+		// 	exc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+		// 	inTraces: testSpanEvents(inSpanEventForResourceTest),
+		// 	outSES: [][]string{
+		// 		{"log1", "log2"},
+		// 	},
+		// },
+		// {
+		// 	name:     "excludeAllWithMissingResourceAttributes",
+		// 	exc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}}},
+		// 	inTraces: testSpanEvents(inSpanEventForTwoResource),
+		// 	outSES: [][]string{
+		// 		{"log3", "log4"},
+		// 	},
+		// },
+		// {
+		// 	name:     "emptyFilterIncludeAndExclude",
+		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+		// 	exc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+		// 	inTraces: testSpanEvents([]spanEventWithAttributes{{spanEventNames: inSpanEventNames}}),
+		// 	outSES:   [][]string{inSpanEventNames},
+		// },
+		// {
+		// 	name:     "nilWithResourceAttributesIncludeAndExclude",
+		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+		// 	exc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{}},
+		// 	inTraces: testSpanEvents([]spanEventWithAttributes{{spanEventNames: inSpanEventNames}}),
+		// 	outSES:   [][]string{inSpanEventNames},
+		// },
+		// {
+		// 	name:     "allWithMissingResourceAttributesIncludeAndExclude",
+		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val2"}}},
+		// 	exc:      &SpanEventMatchProperties{SpanEventMatchType: Strict, EventAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}}},
+		// 	inTraces: testSpanEvents(inSpanEventForTwoResource),
+		// 	outSES: [][]string{
+		// 		{"log3", "log4"},
+		// 	},
+		// },
+		// {
+		// 	name:     "matchAttributesWithRegexpInclude",
+		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Regexp, EventAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val2"}}},
+		// 	inTraces: testSpanEvents(inSpanEventForFourResource),
+		// 	outSES: [][]string{
+		// 		{"log2"},
+		// 	},
+		// },
+		// {
+		// 	name:     "matchAttributesWithRegexpInclude2",
+		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Regexp, EventAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val(2|3)"}}},
+		// 	inTraces: testSpanEvents(inSpanEventForFourResource),
+		// 	outSES: [][]string{
+		// 		{"log2"},
+		// 		{"log3"},
+		// 	},
+		// },
+		// {
+		// 	name:     "matchAttributesWithRegexpInclude3",
+		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Regexp, EventAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val[234]"}}},
+		// 	inTraces: testSpanEvents(inSpanEventForFourResource),
+		// 	outSES: [][]string{
+		// 		{"log2"},
+		// 		{"log3"},
+		// 		{"log4"},
+		// 	},
+		// },
+		// {
+		// 	name:     "matchAttributesWithRegexpInclude4",
+		// 	inc:      &SpanEventMatchProperties{SpanEventMatchType: Regexp, EventAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val.*"}}},
+		// 	inTraces: testSpanEvents(inSpanEventForFourResource),
+		// 	outSES: [][]string{
+		// 		{"log1"},
+		// 		{"log2"},
+		// 		{"log3"},
+		// 		{"log4"},
+		// 	},
+		// },
+		// {
+		// 	name:     "matchAttributesWithRegexpExclude",
+		// 	exc:      &SpanEventMatchProperties{SpanEventMatchType: Regexp, EventAttributes: []filterconfig.Attribute{{Key: "attr", Value: "attr/val[23]"}}},
+		// 	inTraces: testSpanEvents(inSpanEventForFourResource),
+		// 	outSES: [][]string{
+		// 		{"log1"},
+		// 		{"log4"},
+		// 	},
+		// },
+		// {
+		// 	name: "matchRecordAttributeWithRegexp1",
+		// 	inc: &SpanEventMatchProperties{
+		// 		SpanEventMatchType: Regexp,
+		// 		EventAttributes: []filterconfig.Attribute{
+		// 			{
+		// 				Key:   "rec",
+		// 				Value: "rec/val[1]",
+		// 			},
+		// 		},
+		// 	},
+		// 	inTraces: testSpanEvents(inSpanEventForTwoResourceWithRecordAttributes),
+		// 	outSES: [][]string{
+		// 		{"log1", "log2"},
+		// 	},
+		// },
+		// {
+		// 	name: "matchRecordAttributeWithRegexp2",
+		// 	inc: &SpanEventMatchProperties{
+		// 		SpanEventMatchType: Regexp,
+		// 		EventAttributes: []filterconfig.Attribute{
+		// 			{
+		// 				Key:   "rec",
+		// 				Value: "rec/val[^2]",
+		// 			},
+		// 		},
+		// 	},
+		// 	inTraces: testSpanEvents(inSpanEventForTwoResourceWithRecordAttributes),
+		// 	outSES: [][]string{
+		// 		{"log1", "log2"},
+		// 	},
+		// },
+		// {
+		// 	name: "matchRecordAttributeWithRegexp2",
+		// 	inc: &SpanEventMatchProperties{
+		// 		SpanEventMatchType: Regexp,
+		// 		EventAttributes: []filterconfig.Attribute{
+		// 			{
+		// 				Key:   "rec",
+		// 				Value: "rec/val[1|2]",
+		// 			},
+		// 		},
+		// 	},
+		// 	inTraces: testSpanEvents(inSpanEventForTwoResourceWithRecordAttributes),
+		// 	outSES: [][]string{
+		// 		{"log1", "log2"},
+		// 		{"log3", "log4"},
+		// 	},
+		// },
+		// {
+		// 	name: "matchRecordAttributeWithRegexp3",
+		// 	inc: &SpanEventMatchProperties{
+		// 		SpanEventMatchType: Regexp,
+		// 		EventAttributes: []filterconfig.Attribute{
+		// 			{
+		// 				Key:   "rec",
+		// 				Value: "rec/val[1|5]",
+		// 			},
+		// 		},
+		// 	},
+		// 	inTraces: testSpanEvents(inSpanEventForThreeResourceWithRecordAttributes),
+		// 	outSES: [][]string{
+		// 		{"log1", "log2"},
+		// 		{"log5"},
+		// 	},
+		// },
+	}
+)
+
+func TestFilterSpanEventProcessor(t *testing.T) {
+	for _, test := range standardSpanEventTests {
+		t.Run(test.name, func(t *testing.T) {
+			// next stores the results of the filter log processor
+			next := new(consumertest.TracesSink)
+			cfg := &Config{
+				ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
+				SpanEvents: SpanEventFilters{
+					Include: test.inc,
+					Exclude: test.exc,
+				},
+			}
+			factory := NewFactory()
+			flp, err := factory.CreateTracesProcessor(
+				context.Background(),
+				componenttest.NewNopProcessorCreateSettings(),
+				cfg,
+				next,
+			)
+			assert.NotNil(t, flp)
+			assert.Nil(t, err)
+
+			caps := flp.Capabilities()
+			assert.True(t, caps.MutatesData)
+			ctx := context.Background()
+			assert.NoError(t, flp.Start(ctx, nil))
+
+			cErr := flp.ConsumeTraces(context.Background(), test.inTraces)
+			assert.Nil(t, cErr)
+			got := next.AllTraces()
+
+			require.Len(t, got, 1)
+			rTraces := got[0].ResourceSpans()
+			assert.Equal(t, 1, rTraces.Len())
+
+			ilSpans := rTraces.At(0).InstrumentationLibrarySpans().At(0).Spans()
+			fmt.Println("TRACES LENGTH: ")
+			fmt.Println(rTraces.Len())
+			fmt.Println("SPANS LENGHT: ")
+			fmt.Println(ilSpans.Len())
+			fmt.Println("EVENTS LENGHT: ")
+			fmt.Println(ilSpans.At(0).Events().Len())
+			gotEvents := ilSpans.At(0).Events()
+			assert.Equal(t, len(test.outSES), gotEvents.Len())
+			// for i, wantOut := range test.outSES {
+			// 	fmt.Println("EVENTS LENGHT: ")
+			// 	fmt.Println(gotEvents.Len())
+
+			// 	for idx := range wantOut {
+			// 		assert.Equal(t, wantOut[idx], gotEvents.At(idx).Name())
+			// 	}
+			// }
+			assert.NoError(t, flp.Shutdown(ctx))
+		})
+	}
+}
+
+func testSpanEvents(sewas []spanEventWithAttributes) pdata.Traces {
+	td := pdata.NewTraces()
+	rSpans := td.ResourceSpans().AppendEmpty()
+	ilSpans := rSpans.InstrumentationLibrarySpans().AppendEmpty()
+	spans := ilSpans.Spans()
+	span := spans.AppendEmpty()
+
+	for _, sewa := range sewas {
+		es := span.Events()
+		e := es.AppendEmpty()
+		e.SetName(sewa.spanEventName)
+		e.SetTimestamp(pdata.NewTimestampFromTime(time.Now()))
+		e.Attributes().InitFromMap(sewa.eventAttributes)
+		fmt.Println("HHMMMMMMMMMMMMMMMMMMM")
+		fmt.Println(spans.At(1).Events().Len())
+
+	}
+
+	return td
+}
+
+// func TestNilResourceLogs(t *testing.T) {
+// 	logs := pdata.NewLogs()
+// 	rls := logs.ResourceLogs()
+// 	rls.AppendEmpty()
+// 	requireNotPanicsLogs(t, logs)
+// }
+
+// func TestNilILL(t *testing.T) {
+// 	logs := pdata.NewLogs()
+// 	rls := logs.ResourceLogs()
+// 	rl := rls.AppendEmpty()
+// 	ills := rl.InstrumentationLibraryLogs()
+// 	ills.AppendEmpty()
+// 	requireNotPanicsLogs(t, logs)
+// }
+
+// func TestNilLog(t *testing.T) {
+// 	logs := pdata.NewLogs()
+// 	rls := logs.ResourceLogs()
+// 	rl := rls.AppendEmpty()
+// 	ills := rl.InstrumentationLibraryLogs()
+// 	ill := ills.AppendEmpty()
+// 	ls := ill.Logs()
+// 	ls.AppendEmpty()
+// 	requireNotPanicsLogs(t, logs)
+// }
+
+// func requireNotPanicsLogs(t *testing.T, logs pdata.Logs) {
+// 	factory := NewFactory()
+// 	cfg := factory.CreateDefaultConfig()
+// 	pcfg := cfg.(*Config)
+// 	pcfg.Logs = LogFilters{
+// 		Exclude: nil,
+// 	}
+// 	ctx := context.Background()
+// 	proc, _ := factory.CreateLogsProcessor(
+// 		ctx,
+// 		componenttest.NewNopProcessorCreateSettings(),
+// 		cfg,
+// 		consumertest.NewNop(),
+// 	)
+// 	require.NotPanics(t, func() {
+// 		_ = proc.ConsumeLogs(ctx, logs)
+// 	})
+// }

--- a/processor/filterprocessor/testdata/config_span_events_regexp.yaml
+++ b/processor/filterprocessor/testdata/config_span_events_regexp.yaml
@@ -1,0 +1,66 @@
+receivers:
+    nop:
+
+processors:
+    filter/empty:
+        span_events:
+            include:
+                match_type: regexp
+    filter/include:
+        span_events:
+            # any span events NOT matching filters are excluded from remainder of pipeline
+            include:
+                match_type: regexp
+                event_attributes:
+                    - key: should_include
+                      value: "(true|probably_true)"
+    filter/exclude:
+        span_events:
+            # any span events matching filters are excluded from remainder of pipeline
+            exclude:
+                match_type: regexp
+                event_attributes:
+                    - key: should_exclude
+                      value: "(probably_false|false)"
+    filter/includeexclude:
+        span_events:
+            # if both include and exclude are specified, include filters are applied first
+            # the following configuration would only allow span events with resource attributes
+            # "should_include" to pass through
+            include:
+                match_type: regexp
+                event_attributes:
+                    - key: should_include
+                      value: "(true|probably_true)"
+            exclude:
+                match_type: regexp
+                event_attributes:
+                    - key: should_exclude
+                      value: "(probably_false|false)"
+    filter/includeexcludewithnames:
+        span_events:
+            # if both include and exclude are specified, include filters are applied first
+            # the following configuration would only allow span events with resource attributes
+            # "should_include" to pass through
+            include:
+                match_type: regexp
+                event_attributes:
+                    - key: should_include
+                      value: "(true|probably_true)"
+                event_names: ["(true|probably_true)"]
+            exclude:
+                match_type: regexp
+                event_attributes:
+                    - key: should_exclude
+                      value: "(probably_false|false)"
+                event_names: ["(probably_false|false)"]
+
+exporters:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [filter/empty, filter/include, filter/exclude, filter/includeexclude]
+            exporters: [nop]

--- a/processor/filterprocessor/testdata/config_span_events_strict.yaml
+++ b/processor/filterprocessor/testdata/config_span_events_strict.yaml
@@ -1,0 +1,70 @@
+receivers:
+    nop:
+
+processors:
+    filter/empty:
+        span_events:
+            include:
+                match_type: strict
+    filter/include:
+        span_events:
+            # any span events NOT matching filters are excluded from remainder of pipeline
+            include:
+                match_type: strict
+                event_attributes:
+                    - key: should_include
+                      value: "true"
+    filter/exclude:
+        span_events:
+            # any span events matching filters are excluded from remainder of pipeline
+            exclude:
+                match_type: strict
+                event_attributes:
+                    - key: should_exclude
+                      value: "true"
+    filter/includeexclude:
+        span_events:
+            # if both include and exclude are specified, include filters are applied first
+            # the following configuration would only allow span events with resource attributes
+            # "should_include" to pass through
+            include:
+                match_type: strict
+                event_attributes:
+                    - key: should_include
+                      value: "true"
+            exclude:
+                match_type: strict
+                event_attributes:
+                    - key: should_exclude
+                      value: "true"
+    filter/includeexcludewithnames:
+        span_events:
+            # if both include and exclude are specified, include filters are applied first
+            # the following configuration would only allow span events with resource attributes
+            # "should_include" to pass through
+            include:
+                match_type: strict
+                event_attributes:
+                    - key: should_include
+                      value: "true"
+                event_names: ["name1", "name2"]
+            exclude:
+                match_type: strict
+                event_attributes:
+                    - key: should_exclude
+                      value: "true"
+                event_names: ["name3", "name4"]
+
+exporters:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [filter/empty, filter/include, filter/exclude, filter/includeexclude]
+            exporters: [nop]
+        logs:
+            receivers: [nop]
+            processors: [filter/empty]
+            exporters: [nop]

--- a/processor/spanprocessor/config.go
+++ b/processor/spanprocessor/config.go
@@ -34,7 +34,8 @@ type Config struct {
 	// configured.
 	// Note: The field name is `Rename` to avoid collision with the Name() method
 	// from config.NamedEntity
-	Rename Name `mapstructure:"name"`
+	Rename Name   `mapstructure:"name"`
+	Events Events `mapstructure:"name"`
 }
 
 // Name specifies the attributes to use to re-name a span.

--- a/processor/spanprocessor/config.go
+++ b/processor/spanprocessor/config.go
@@ -34,8 +34,7 @@ type Config struct {
 	// configured.
 	// Note: The field name is `Rename` to avoid collision with the Name() method
 	// from config.NamedEntity
-	Rename Name   `mapstructure:"name"`
-	Events Events `mapstructure:"name"`
+	Rename Name `mapstructure:"name"`
 }
 
 // Name specifies the attributes to use to re-name a span.


### PR DESCRIPTION
**Description:** Span event filter processor
Adds a new filter to the filterprocessor which allows filtering span events

The span events can be filtered by attributes and names

**Testing:**
* Added tests for the processor logic
* Added tests for config

**Documentation:**
The documentation was updated with an example and there are examples in `testdata`