### PR TITLE
remove X-Scope-OrgID header from example

### DIFF
--- a/exporter/awsprometheusremotewriteexporter/README.md
+++ b/exporter/awsprometheusremotewriteexporter/README.md
@@ -66,8 +66,6 @@ exporters:
         role_arn: "arn:aws:iam::123456789012:role/aws-service-role/access"
     ca_file: "/var/lib/mycert.pem"
     write_buffer_size: 524288
-    headers:
-        X-Scope-OrgID: 234
     external_labels:
         key1: value1
         key2: value2


### PR DESCRIPTION
AMP does not require this header to be set by the customer. Remove from the example as its misleading.