### PR TITLE
Remove cluster name from EKS metadata

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -115,7 +115,6 @@ ec2:
 
     * cloud.provider ("aws")
     * cloud.platform ("aws_eks")
-    * k8s.cluster.name (name of the EKS cluster)
     
 * Azure: Queries the [Azure Instance Metadata Service](https://aka.ms/azureimds) to retrieve the following resource attributes:
 


### PR DESCRIPTION
**Description:**
k8s.cluster.name was removed from eks detector, so I'm also removing it from the README.
See related PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/2898.
