### PR TITLE
.github: add action for official prometheus compliance tests

### DIFF
--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -1,0 +1,51 @@
+name: prometheus-compliance-tests
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
+
+jobs:
+  prometheus-compliance-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Cache Tools
+        id: tool-cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-tool-binaries
+        with:
+          path: /home/runner/go/bin
+          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+      - name: Setup Go
+        uses: actions/setup-go@v2.1.4
+        with:
+          go-version: 1.17
+      - name: Setup Go Environment
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+      - name: Cache Go
+        id: module-cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: |
+            /home/runner/go/pkg/mod
+            /home/runner/.cache/go-build
+          key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+      - run: make otelcontribcol
+      - name: Checkout compliance repo
+        uses: actions/checkout@v2
+        with:
+          repository: prometheus/compliance
+          path: compliance
+      - name: Copy binary to compliance directory
+        run: mkdir compliance/remote_write/bin && cp ./bin/otelcontribcol_linux_amd64 compliance/remote_write/bin/otelcol_linux_amd64
+      - name: Run compliance tests
+        run: go test --tags=compliance -run "TestRemoteWrite/otel/.+" -v ./
+        working-directory: compliance/remote_write


### PR DESCRIPTION
**Description:**
This change imports and runs the official Prometheus Remote Write compliance tests from https://github.com/prometheus/compliance against a live collector as a GitHub action.

Example run: https://github.com/kirbyquerby/opentelemetry-collector-contrib/runs/3885368277

**Link to tracking Issue:** Fixes open-telemetry/wg-prometheus/issues/34

**Testing:** This change is a test :)

/cc @Aneurysm9 @odeke-em 