### PR TITLE
fix #1804, Adjust span transformation to comply with the spec

### DIFF
--- a/internal/coreinternal/tracetranslator/protospan_translation.go
+++ b/internal/coreinternal/tracetranslator/protospan_translation.go
@@ -43,12 +43,13 @@ const (
 type OpenTracingSpanKind string
 
 const (
-	OpenTracingSpanKindUnspecified OpenTracingSpanKind = ""
-	OpenTracingSpanKindClient      OpenTracingSpanKind = "client"
-	OpenTracingSpanKindServer      OpenTracingSpanKind = "server"
-	OpenTracingSpanKindConsumer    OpenTracingSpanKind = "consumer"
-	OpenTracingSpanKindProducer    OpenTracingSpanKind = "producer"
-	OpenTracingSpanKindInternal    OpenTracingSpanKind = "internal"
+	OpenTracingSpanKindUnspecified      OpenTracingSpanKind = ""
+	OpenTracingSpanKindClient           OpenTracingSpanKind = "client"
+	OpenTracingSpanKindServer           OpenTracingSpanKind = "server"
+	OpenTracingSpanKindConsumer         OpenTracingSpanKind = "consumer"
+	OpenTracingSpanKindProducer         OpenTracingSpanKind = "producer"
+	OpenTracingSpanKindInternal         OpenTracingSpanKind = "internal"
+	OpenTracingSpanKindStatusCodePrefix OpenTracingSpanKind = "STATUS_CODE_"
 )
 
 // StatusCodeFromHTTP takes an HTTP status code and return the appropriate OpenTelemetry status code

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-        "strings"
+    "strings"
 	"time"
 
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -158,7 +158,7 @@ func spanToZipkinSpan(
 	removeRedundentTags(redundantKeys, tags)
 
 	status := span.Status()
-	tags[conventions.OtelStatusCode] = status.Code().String()
+	tags[conventions.OtelStatusCode] = strings.TrimPrefix(status.Code().String(), "STATUS_CODE_")
 	if status.Message() != "" {
 		tags[conventions.OtelStatusDescription] = status.Message()
 		if int32(status.Code()) > 0 {

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+        "strings"
 	"time"
 
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -159,7 +159,7 @@ func spanToZipkinSpan(
 	removeRedundentTags(redundantKeys, tags)
 
 	status := span.Status()
-	tags[conventions.OtelStatusCode] = strings.TrimPrefix(status.Code().String(), "STATUS_CODE_")
+	tags[conventions.OtelStatusCode] = strings.TrimPrefix(status.Code().String(), string(tracetranslator.OpenTracingSpanKindStatusCodePrefix))
 	if status.Message() != "" {
 		tags[conventions.OtelStatusDescription] = status.Message()
 		if int32(status.Code()) > 0 {

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-    "strings"
+	"strings"
 	"time"
 
 	zipkinmodel "github.com/openzipkin/zipkin-go/model"

--- a/pkg/translator/zipkin/zipkinv2/to_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/to_translator.go
@@ -157,7 +157,7 @@ func zSpanToInternal(zspan *zipkinmodel.SpanModel, tags map[string]string, dest 
 
 func populateSpanStatus(tags map[string]string, status pdata.SpanStatus) {
 	if value, ok := tags[conventions.OtelStatusCode]; ok {
-		status.SetCode(pdata.StatusCode(statusCodeValue[value]))
+		status.SetCode(pdata.StatusCode(statusCodeValue["STATUS_CODE_" + value]))
 		delete(tags, conventions.OtelStatusCode)
 		if value, ok := tags[conventions.OtelStatusDescription]; ok {
 			status.SetMessage(value)

--- a/pkg/translator/zipkin/zipkinv2/to_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/to_translator.go
@@ -157,7 +157,8 @@ func zSpanToInternal(zspan *zipkinmodel.SpanModel, tags map[string]string, dest 
 
 func populateSpanStatus(tags map[string]string, status pdata.SpanStatus) {
 	if value, ok := tags[conventions.OtelStatusCode]; ok {
-		status.SetCode(pdata.StatusCode(statusCodeValue["STATUS_CODE_" + value]))
+		status.SetCode(pdata.StatusCode(statusCodeValue[string(tracetranslator.
+			OpenTracingSpanKindStatusCodePrefix) + value]))
 		delete(tags, conventions.OtelStatusCode)
 		if value, ok := tags[conventions.OtelStatusDescription]; ok {
 			status.SetMessage(value)

--- a/receiver/zipkinreceiver/testdata/sample3.json
+++ b/receiver/zipkinreceiver/testdata/sample3.json
@@ -1,0 +1,35 @@
+[
+  {
+    "traceId": "4d1e00c0db9010db86154a4ba6e91385",
+    "parentId": "86154a4ba6e91385",
+    "id": "4d1e00c0db9010db",
+    "kind": "CLIENT",
+    "name": "get",
+    "timestamp": 1472470996199000,
+    "duration": 207000,
+    "localEndpoint": {
+      "ipv6": "7::0.128.128.127"
+    },
+    "remoteEndpoint": {
+      "serviceName": "backend",
+      "ipv4": "192.168.99.101",
+      "port": 9000
+    },
+    "annotations": [
+      {
+        "timestamp": 1472470996238000,
+        "value": "foo"
+      },
+      {
+        "timestamp": 1472470996403000,
+        "value": "bar"
+      }
+    ],
+    "tags": {
+      "http.path": "/api",
+      "clnt/finagle.version": "6.45.0",
+      "otel.status_code": "ERROR",
+      "otel.status_description": "Something failed"
+    }
+  }
+]

--- a/receiver/zipkinreceiver/testdata/sample3.json
+++ b/receiver/zipkinreceiver/testdata/sample3.json
@@ -29,7 +29,7 @@
       "http.path": "/api",
       "clnt/finagle.version": "6.45.0",
       "otel.status_code": "ERROR",
-      "otel.status_description": "Something failed"
+      "error": "Something failed"
     }
   }
 ]

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -390,7 +390,7 @@ func TestConvertSpansToTraceSpans_JSONWithOTelErrorStatus(t *testing.T) {
 	assert.Equal(t, "Something failed", gs.Status().Message(), "Expecting to convert the span status description")
 	_, ok := gs.Attributes().Get("otel.status_code")
 	assert.False(t, ok, "Expecting to filter the span status code attribute")
-	_, ok = gs.Attributes().Get("otel.status_description")
+	_, ok = gs.Attributes().Get("error")
 	assert.False(t, ok, "Expecting to filter the span status description attribute")
 }
 


### PR DESCRIPTION
fix #1804 ,Adjust span transformation to comply with the spec
- See
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/non-otlp.md#span-status

Signed-off-by: leroy-chen <leroy.chen.179@gmail.com>

**Description:** 
in spec ,otel.status_code should be either OK or ERROR. MUST NOT be set if the code is UNSET.we should handle the prefix "STATUS_CODE_"
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** #1804

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** See (
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/non-otlp.md#span-status )