### PR TITLE
add new attribute action RENDER

### DIFF
--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -16,10 +16,12 @@ package attraction
 
 import (
 	"fmt"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterhelper"
-	"go.opentelemetry.io/collector/model/pdata"
 	"regexp"
 	"strings"
+
+	"go.opentelemetry.io/collector/model/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterhelper"
 )
 
 // Settings specifies the processor settings.

--- a/internal/coreinternal/attraction/attraction_test.go
+++ b/internal/coreinternal/attraction/attraction_test.go
@@ -666,11 +666,11 @@ func TestAttributes_RenderValue(t *testing.T) {
 			name: "RenderAttributeFromOtherExists",
 			inputAttributes: map[string]pdata.AttributeValue{
 				"region_key": pdata.NewAttributeValueString("eu"),
-				"region":  pdata.NewAttributeValueString("europe"),
+				"region":     pdata.NewAttributeValueString("europe"),
 			},
 			expectedAttributes: map[string]pdata.AttributeValue{
 				"region_key": pdata.NewAttributeValueString("eu"),
-				"region":  pdata.NewAttributeValueString("my region is: europe (eu)"),
+				"region":     pdata.NewAttributeValueString("my region is: europe (eu)"),
 			},
 		},
 	}

--- a/processor/attributesprocessor/config.go
+++ b/processor/attributesprocessor/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	filterconfig.MatchConfig `mapstructure:",squash"`
 
 	// Specifies the list of attributes to act on.
-	// The set of actions are {INSERT, UPDATE, UPSERT, DELETE, HASH, EXTRACT}.
+	// The set of actions are {INSERT, UPDATE, UPSERT, DELETE, HASH, EXTRACT, RENDER}.
 	// This is a required field.
 	attraction.Settings `mapstructure:",squash"`
 }


### PR DESCRIPTION
**Description:**
this will add a new action called RENDER where an existing or new attribute is defined based on a given template. The template can contain placeholders for attributes which get replace by the actual value of the attribute. With this new action is is possible to combine multiple attributes to a new one or append content to an existing attribute.