### PR TITLE
Add support for per cpu metrics

### DIFF
--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -131,6 +131,18 @@ exporters:
           state: [interrupt, user, system]
 ```
 
+The following `include_metrics` example would instruct the exporter to send only `cpu.interrupt` metrics with a `cpu` dimension value ("per core" datapoints), and both "per core" and aggregate `cpu.idle` metrics:
+
+```
+exporters:
+  signalfx:
+    include_metrics:
+      - metric_name: "cpu.idle"
+      - metric_name: "cpu.interrupt"
+        dimensions:
+          cpu: ["*"]
+```
+
 ## Translation Rules and Metric Transformations
 
 The `translation_rules` metrics configuration field accepts a list of metric-transforming actions to
@@ -180,6 +192,17 @@ The translation rules defined in [`translation/constants.go`](./internal/transla
 * vmpage_io.memory.out
 * vmpage_io.swap.in
 * vmpage_io.swap.out
+
+In addition to the aggregated metrics, the default translation rules make available the following "per core" custom hostmetrics.
+The CPU number is assigned to the dimension `cpu` 
+
+* cpu.interrupt
+* cpu.nice
+* cpu.softirq
+* cpu.steal
+* cpu.system
+* cpu.user
+* cpu.wait
 
 These metrics are intended to be reported directly to Splunk IM by the SignalFx exporter.  Any desired changes to their attributes or values should be made via additional translation rules or from their constituent host metrics.
 

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -272,7 +272,7 @@ func TestCreateMetricsExporterWithDefaultExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 11, len(config.ExcludeMetrics))
+	assert.Equal(t, 12, len(config.ExcludeMetrics))
 }
 
 func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
@@ -292,7 +292,7 @@ func TestCreateMetricsExporterWithExcludeMetrics(t *testing.T) {
 	require.NotNil(t, te)
 
 	// Validate that default excludes are always loaded.
-	assert.Equal(t, 12, len(config.ExcludeMetrics))
+	assert.Equal(t, 13, len(config.ExcludeMetrics))
 }
 
 func TestCreateMetricsExporterWithEmptyExcludeMetrics(t *testing.T) {
@@ -630,11 +630,14 @@ func TestDefaultCPUTranslations(t *testing.T) {
 	cpuUtilPerCore := m["cpu.utilization_per_core"]
 	require.Equal(t, 8, len(cpuUtilPerCore))
 
-	cpuStateMetrics := []string{"cpu.idle", "cpu.interrupt", "cpu.num_processors", "cpu.system", "cpu.user"}
+	cpuNumProcessors := m["cpu.num_processors"]
+	require.Equal(t, 1, len(cpuNumProcessors))
+
+	cpuStateMetrics := []string{"cpu.idle", "cpu.interrupt", "cpu.system", "cpu.user"}
 	for _, metric := range cpuStateMetrics {
 		dps, ok := m[metric]
 		require.True(t, ok, fmt.Sprintf("%s metrics not found", metric))
-		require.Len(t, dps, 1)
+		require.Len(t, dps, 9)
 	}
 }
 

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -130,6 +130,17 @@ translation_rules:
   without_dimensions:
   - cpu
 
+- action: copy_metrics
+  mapping:
+    sf_temp.cpu.idle: sf_temp.cpu.idle_per_core
+    sf_temp.cpu.interrupt: sf_temp.cpu.interrupt_per_core
+    sf_temp.cpu.system: sf_temp.cpu.system_per_core
+    sf_temp.cpu.user: sf_temp.cpu.user_per_core
+    sf_temp.cpu.wait: sf_temp.cpu.wait_per_core
+    sf_temp.cpu.steal: sf_temp.cpu.steal_per_core
+    sf_temp.cpu.softirq: sf_temp.cpu.softirq_per_core
+    sf_temp.cpu.nice: sf_temp.cpu.nice_per_core
+
 - action: aggregate_metric
   metric_name: sf_temp.cpu.idle
   aggregation_method: sum
@@ -399,15 +410,23 @@ translation_rules:
   mapping:
     sf_temp.container_cpu_utilization: container_cpu_utilization
     sf_temp.cpu.idle: cpu.idle
+    sf_temp.cpu.idle_per_core: cpu.idle
     sf_temp.cpu.interrupt: cpu.interrupt
+    sf_temp.cpu.interrupt_per_core: cpu.interrupt
     sf_temp.cpu.nice: cpu.nice
+    sf_temp.cpu.nice_per_core: cpu.nice
     sf_temp.cpu.num_processors: cpu.num_processors
     sf_temp.cpu.softirq: cpu.softirq
+    sf_temp.cpu.softirq_per_core: cpu.softirq
     sf_temp.cpu.steal: cpu.steal
+    sf_temp.cpu.steal_per_core: cpu.steal
     sf_temp.cpu.system: cpu.system
+    sf_temp.cpu.system_per_core: cpu.system
     sf_temp.cpu.user: cpu.user
+    sf_temp.cpu.user_per_core: cpu.user
     sf_temp.cpu.utilization: cpu.utilization
     sf_temp.cpu.wait: cpu.wait
+    sf_temp.cpu.wait_per_core: cpu.wait
     sf_temp.disk.summary_utilization: disk.summary_utilization
     sf_temp.disk.utilization: disk.utilization
     sf_temp.memory.total: memory.total

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -51,6 +51,10 @@ exclude_metrics:
   dimensions:
     state: [interrupt, nice, softirq, steal, system, user, wait]
 
+- metric_name: cpu.idle
+  dimensions:
+    cpu: ["*"]
+
 # Memory metrics.
 - metric_name: system.memory.usage
   dimensions:


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

**Description:**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5243
With this change, the signalfx exporter is able to emit per core cpu metrics.
The dimension `cpu` exists for non-aggregated/per_core metrics

**Link to tracking Issue:** <Issue number if applicable>
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5243

**Documentation:** <Describe the documentation added.>

This config example will emit per core and aggregated `cpu.interrupt` metric

```
  signalfx:
    access_token: "********"
    api_url: "https://api.us0.signalfx.com"
    ingest_url: "https://ingest.us0.signalfx.com"
    include_metrics:
      - metric_name: "cpu.interrupt"
```

This config example will emit per core only `cpu.interrupt` metric
```
 signalfx:
    access_token: "********"
    api_url: "https://api.us0.signalfx.com"
    ingest_url: "https://ingest.us0.signalfx.com"
    include_metrics:
      - metric_name: "cpu.interrupt"
        dimensions:
          cpu: ["*"]
```          