### PR TITLE
[datadogexporter] Allow omitting hostname from exported telemetry data

### DIFF
--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -33,6 +33,7 @@ var (
 	errUnsetAPIKey = errors.New("api.key is not set")
 	errNoMetadata  = errors.New("only_metadata can't be enabled when send_metadata or use_resource_metadata is disabled")
 	errBuckets     = errors.New("can't use 'metrics::report_buckets' and 'metrics::histograms::mode' at the same time")
+	errNoHostname  = errors.New("can't set hostname when disable_hostname is enabled")
 )
 
 // TODO: Import these from translator when we eliminate cyclic dependency.
@@ -301,6 +302,10 @@ func (c *Config) Sanitize(logger *zap.Logger) error {
 }
 
 func (c *Config) Validate() error {
+	if c.DisableHostname && c.Hostname != "" {
+		return errNoHostname
+	}
+
 	if c.Traces.IgnoreResources != nil {
 		for _, entry := range c.Traces.IgnoreResources {
 			_, err := regexp.Compile(entry)

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -221,6 +221,10 @@ type Config struct {
 	// Traces defines the Traces exporter specific configuration
 	Traces TracesConfig `mapstructure:"traces"`
 
+	// DisableHostname defines whether to omit the hostname
+	// from being exported alongside telemetry data.
+	DisableHostname bool `mapstructure:"disable_hostname"`
+
 	// SendMetadata defines whether to send host metadata
 	// This is undocumented and only used for unit testing.
 	//

--- a/exporter/datadogexporter/config/config_test.go
+++ b/exporter/datadogexporter/config/config_test.go
@@ -150,6 +150,16 @@ func TestCensorAPIKey(t *testing.T) {
 	)
 }
 
+func TestDisableHostnameValidation(t *testing.T) {
+	validCfg := Config{DisableHostname: true, TagsConfig: TagsConfig{Hostname: ""}}
+	invalidCfg := Config{DisableHostname: true, TagsConfig: TagsConfig{Hostname: "test"}}
+
+	noErr := validCfg.Validate()
+	err := invalidCfg.Validate()
+	require.NoError(t, noErr)
+	require.ErrorIs(t, err, errNoHostname)
+}
+
 func TestIgnoreResourcesValidation(t *testing.T) {
 	validCfg := Config{Traces: TracesConfig{IgnoreResources: []string{"[123]"}}}
 	invalidCfg := Config{Traces: TracesConfig{IgnoreResources: []string{"[123"}}}

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -40,7 +40,7 @@ exporters:
 
     ## @param disable_hostname - boolean - optional - default: false
     ## Whether to omit hostname from exported telemetry data. This is
-    ## useful for
+    ## useful for avoiding the registration of a new host.
     #
     # disable_hostname: false
 

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -38,10 +38,18 @@ exporters:
     #
     # tags: []
 
+    ## @param disable_hostname - boolean - optional - default: false
+    ## Whether to omit hostname from exported telemetry data. This is
+    ## useful for
+    #
+    # disable_hostname: false
+
     ## @param only_metadata - boolean - optional - default: false
     ## Whether to send only metadata. This is useful for agent-collector
     ## setups, so that metadata about a host is sent to the backend even
     ## when telemetry data is reported via a different host.
+    #
+    # only_metadata: false
 
     ## @param api - custom object - required.
     ## Specific API configuration.

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -91,6 +91,7 @@ func createDefaultConfig() config.Exporter {
 		},
 
 		SendMetadata:        true,
+		DisableHostname:     false,
 		UseResourceMetadata: true,
 	}
 }

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -171,7 +171,7 @@ func createTracesExporter(
 
 	cfg := c.(*ddconfig.Config)
 
-	set.Logger.Info("sanitizing Datadog metrics exporter configuration")
+	set.Logger.Info("sanitizing Datadog traces exporter configuration")
 	if err := cfg.Sanitize(set.Logger); err != nil {
 		return nil, err
 	}

--- a/exporter/datadogexporter/internal/metadata/host.go
+++ b/exporter/datadogexporter/internal/metadata/host.go
@@ -31,6 +31,10 @@ import (
 // 3. EC2 instance metadata
 // 4. System
 func GetHost(logger *zap.Logger, cfg *config.Config) string {
+	if cfg.DisableHostname {
+		return ""
+	}
+
 	if cfg.Hostname != "" {
 		return cfg.Hostname
 	}

--- a/exporter/datadogexporter/internal/translator/config.go
+++ b/exporter/datadogexporter/internal/translator/config.go
@@ -24,6 +24,7 @@ type translatorConfig struct {
 	SendMonotonic                        bool
 	ResourceAttributesAsTags             bool
 	InstrumentationLibraryMetadataAsTags bool
+	DisableHostname                      bool
 
 	// cache configuration
 	sweepInterval int64
@@ -81,6 +82,14 @@ func WithResourceAttributesAsTags() Option {
 func WithInstrumentationLibraryMetadataAsTags() Option {
 	return func(t *translatorConfig) error {
 		t.InstrumentationLibraryMetadataAsTags = true
+		return nil
+	}
+}
+
+// WithDisableHostname omits the hostname from being exported.
+func WithDisableHostname() Option {
+	return func(t *translatorConfig) error {
+		t.DisableHostname = true
 		return nil
 	}
 }

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -63,6 +63,10 @@ func translatorFromConfig(logger *zap.Logger, cfg *config.Config) (*translator.T
 		translator.WithFallbackHostnameProvider(&hostProvider{logger, cfg}),
 	}
 
+	if cfg.DisableHostname {
+		options = append(options, translator.WithDisableHostname())
+	}
+
 	if cfg.Metrics.HistConfig.SendCountSum {
 		options = append(options, translator.WithCountSumMetrics())
 	}

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -26,12 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
+	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/testutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator"
-	"gopkg.in/zorkian/go-datadog-api.v2"
 )
 
 func TestNewExporter(t *testing.T) {

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -102,7 +102,7 @@ func TestDisableHostnameExporter(t *testing.T) {
 				assert.Empty(t, *metric.Host)
 			}
 		}
-
+		rw.WriteHeader(http.StatusAccepted)
 	}))
 	defer server.Close()
 

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -88,9 +88,14 @@ func convertToDatadogTd(td pdata.Traces, fallbackHost string, cfg *config.Config
 
 	for i := 0; i < resourceSpans.Len(); i++ {
 		rs := resourceSpans.At(i)
-		host, ok := attributes.HostnameFromAttributes(rs.Resource().Attributes())
-		if !ok {
-			host = fallbackHost
+
+		var host string
+		if !cfg.DisableHostname {
+			var ok bool
+			host, ok = attributes.HostnameFromAttributes(rs.Resource().Attributes())
+			if !ok {
+				host = fallbackHost
+			}
 		}
 
 		seenHosts[host] = struct{}{}


### PR DESCRIPTION
**Description:** This adds the `disable_hostname` option for omitting the host when exporting telemetry data to Datadog. This is useful for sending purely telemetry data to Datadog without registering an entirely new host.

**Testing:** Unit tests were added to confirm the correctness of this feature in `metrics_exporter_test.go` and `traces_exporter_test.go`.

**Documentation:** This option is documented in the example config.