### PR TITLE
add multimod verify step in lint build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,6 +123,8 @@ jobs:
         run: |
           make generate
           git diff --exit-code ':!*go.sum' || (echo 'Generated code is out of date, please run "make generate" and commit the changes in this PR.' && exit 1)
+      - name: Multimod verify
+        run: make multimod-verify
   unittest:
     runs-on: ubuntu-latest
     needs: [setup-environment]

--- a/Makefile
+++ b/Makefile
@@ -284,3 +284,12 @@ CERT_DIRS := receiver/sapmreceiver/testdata \
 .PHONY: certs
 certs:
 	$(foreach dir, $(CERT_DIRS), $(call exec-command, @internal/buildscripts/gen-certs.sh -o $(dir)))
+
+.PHONY: multimod-verify
+multimod-verify: install-tools
+	@echo "Validating versions.yaml"
+	multimod verify
+
+.PHONY: multimod-prerelease
+multimod-prerelease: install-tools
+	multimod prerelease -v ./versions.yaml -m contrib-base


### PR DESCRIPTION
Adding a step to run `multimod verify` as part of the build. Multimod verify does the following:

```
verify checks that all modules listed in sets are valid by verifying the following properties:
- All modules are contained in exactly one module set.
- Versions conform to semver semantics.
- No more than one set of modules exists for any non-zero major version.
- Script warns if any stable modules depend on any unstable modules.
```

`multimod` is used as part of the release process in combination with `versions.yaml` to update the versions and dependencies. Keeping `versions.yaml` up-to-date ensures a smoother release process.

Fixes #5770 