### PR TITLE
Fetch all annotations and labels for pods and namespaces in k8sattributes processor

### DIFF
--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -117,7 +117,10 @@ type ExtractConfig struct {
 type FieldExtractConfig struct {
 	TagName string `mapstructure:"tag_name"`
 	Key     string `mapstructure:"key"`
-	Regex   string `mapstructure:"regex"`
+	// KeyRegex is a regular expression used to extract a Key that matches the regex.
+	// Out of Key or KeyRegex only one option is expected to be configured at a time.
+	KeyRegex string `mapstructure:"key_regex"`
+	Regex    string `mapstructure:"regex"`
 	// From represents the source of the labels/annotations.
 	// Allowed values are "pod" and "namespace". The default is pod.
 	From string `mapstructure:"from"`

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -110,4 +110,26 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		})
+
+	p2 := cfg.Processors[config.NewComponentIDWithName(typeStr, "3")]
+	assert.Equal(t, p2,
+		&Config{
+			ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "3")),
+			APIConfig:         k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeKubeConfig},
+			Passthrough:       false,
+			Extract: ExtractConfig{
+				Annotations: []FieldExtractConfig{
+					{KeyRegex: "opentel.*", From: kube.MetadataFromPod},
+				},
+				Labels: []FieldExtractConfig{
+					{KeyRegex: "opentel.*", From: kube.MetadataFromPod},
+				},
+			},
+			Exclude: ExcludeConfig{
+				Pods: []ExcludePodConfig{
+					{Name: "jaeger-agent"},
+					{Name: "jaeger-collector"},
+				},
+			},
+		})
 }

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -156,6 +156,11 @@ func createKubernetesProcessor(
 
 	warnDeprecatedMetadataConfig(kp.logger, cfg)
 
+	err := errWrongKeyConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	allOptions := append(createProcessorOpts(cfg), options...)
 
 	for _, opt := range allOptions {
@@ -232,4 +237,16 @@ func warnDeprecatedMetadataConfig(logger *zap.Logger, cfg config.Processor) {
 			logger.Warn(fmt.Sprintf("%s has been deprecated in favor of %s for k8s-tagger processor", oldName, newName))
 		}
 	}
+}
+
+func errWrongKeyConfig(cfg config.Processor) error {
+	oCfg := cfg.(*Config)
+
+	for _, r := range append(oCfg.Extract.Labels, oCfg.Extract.Annotations...) {
+		if r.Key != "" && r.KeyRegex != "" {
+			return fmt.Errorf("Out of Key or KeyRegex only one option is expected to be configured at a time, currently Key:%s and KeyRegex:%s", r.Key, r.KeyRegex)
+		}
+	}
+
+	return nil
 }

--- a/processor/k8sattributesprocessor/kube/client.go
+++ b/processor/k8sattributesprocessor/kube/client.go
@@ -313,7 +313,14 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 	for _, r := range c.Rules.Labels {
 		// By default if the From field is not set for labels and annotations we want to extract them from pod
 		if r.From == MetadataFromPod || r.From == "" {
-			if v, ok := pod.Labels[r.Key]; ok {
+			if r.KeyRegex != nil {
+				for k, v := range pod.Labels {
+					if r.KeyRegex.MatchString(k) && v != "" {
+						name := fmt.Sprintf("k8s.pod.labels.%s", k)
+						tags[name] = v
+					}
+				}
+			} else if v, ok := pod.Labels[r.Key]; ok {
 				tags[r.Name] = c.extractField(v, r)
 			}
 		}
@@ -322,7 +329,14 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 	for _, r := range c.Rules.Annotations {
 		// By default if the From field is not set for labels and annotations we want to extract them from pod
 		if r.From == MetadataFromPod || r.From == "" {
-			if v, ok := pod.Annotations[r.Key]; ok {
+			if r.KeyRegex != nil {
+				for k, v := range pod.Annotations {
+					if r.KeyRegex.MatchString(k) && v != "" {
+						name := fmt.Sprintf("k8s.pod.annotations.%s", k)
+						tags[name] = v
+					}
+				}
+			} else if v, ok := pod.Annotations[r.Key]; ok {
 				tags[r.Name] = c.extractField(v, r)
 			}
 		}
@@ -377,7 +391,14 @@ func (c *WatchClient) extractNamespaceAttributes(namespace *api_v1.Namespace) ma
 
 	for _, r := range c.Rules.Labels {
 		if r.From == MetadataFromNamespace {
-			if v, ok := namespace.Labels[r.Key]; ok {
+			if r.KeyRegex != nil {
+				for k, v := range namespace.Labels {
+					if r.KeyRegex.MatchString(k) && v != "" {
+						name := fmt.Sprintf("k8s.namespace.labels.%s", k)
+						tags[name] = v
+					}
+				}
+			} else if v, ok := namespace.Labels[r.Key]; ok {
 				tags[r.Name] = c.extractField(v, r)
 			}
 		}
@@ -385,11 +406,19 @@ func (c *WatchClient) extractNamespaceAttributes(namespace *api_v1.Namespace) ma
 
 	for _, r := range c.Rules.Annotations {
 		if r.From == MetadataFromNamespace {
-			if v, ok := namespace.Annotations[r.Key]; ok {
+			if r.KeyRegex != nil {
+				for k, v := range namespace.Annotations {
+					if r.KeyRegex.MatchString(k) && v != "" {
+						name := fmt.Sprintf("k8s.namespace.annotations.%s", k)
+						tags[name] = v
+					}
+				}
+			} else if v, ok := namespace.Annotations[r.Key]; ok {
 				tags[r.Name] = c.extractField(v, r)
 			}
 		}
 	}
+
 	return tags
 }
 

--- a/processor/k8sattributesprocessor/kube/client_test.go
+++ b/processor/k8sattributesprocessor/kube/client_test.go
@@ -513,6 +513,33 @@ func TestExtractionRules(t *testing.T) {
 			"a1": "av1",
 		},
 	},
+		{
+			name: "all-labels",
+			rules: ExtractionRules{
+				Labels: []FieldExtractionRule{{
+					KeyRegex: regexp.MustCompile("la*"),
+					From:     MetadataFromPod,
+				},
+				},
+			},
+			attributes: map[string]string{
+				"k8s.pod.labels.label1": "lv1",
+				"k8s.pod.labels.label2": "k1=v1 k5=v5 extra!",
+			},
+		},
+		{
+			name: "all-annotations",
+			rules: ExtractionRules{
+				Annotations: []FieldExtractionRule{{
+					KeyRegex: regexp.MustCompile("an*"),
+					From:     MetadataFromPod,
+				},
+				},
+			},
+			attributes: map[string]string{
+				"k8s.pod.annotations.annotation1": "av1",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -577,6 +604,32 @@ func TestNamespaceExtractionRules(t *testing.T) {
 			"a1": "av1",
 		},
 	},
+		{
+			name: "all-labels",
+			rules: ExtractionRules{
+				Labels: []FieldExtractionRule{{
+					KeyRegex: regexp.MustCompile("la*"),
+					From:     MetadataFromNamespace,
+				},
+				},
+			},
+			attributes: map[string]string{
+				"k8s.namespace.labels.label1": "lv1",
+			},
+		},
+		{
+			name: "all-annotations",
+			rules: ExtractionRules{
+				Annotations: []FieldExtractionRule{{
+					KeyRegex: regexp.MustCompile("an*"),
+					From:     MetadataFromNamespace,
+				},
+				},
+			},
+			attributes: map[string]string{
+				"k8s.namespace.annotations.annotation1": "av1",
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/processor/k8sattributesprocessor/kube/kube.go
+++ b/processor/k8sattributesprocessor/kube/kube.go
@@ -157,6 +157,8 @@ type FieldExtractionRule struct {
 	Name string
 	// Key is used to lookup k8s pod fields.
 	Key string
+	// KeyRegex is a regular expression used to extract a Key that matches the regex.
+	KeyRegex *regexp.Regexp
 	// Regex is a regular expression used to extract a sub-part of a field value.
 	// Full value is extracted when no regexp is provided.
 	Regex *regexp.Regexp

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -134,6 +134,42 @@ func TestWithExtractAnnotations(t *testing.T) {
 			},
 			"",
 		},
+		{
+			"basic-pod-keyregex",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+					From:     kube.MetadataFromPod,
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("key*"),
+					From:     kube.MetadataFromPod,
+				},
+			},
+			"",
+		},
+		{
+			"basic-namespace-keyregex",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+					From:     kube.MetadataFromNamespace,
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("key*"),
+					From:     kube.MetadataFromNamespace,
+				},
+			},
+			"",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -213,6 +249,42 @@ func TestWithExtractLabels(t *testing.T) {
 					Name: "tag1",
 					Key:  "key1",
 					From: kube.MetadataFromNamespace,
+				},
+			},
+			"",
+		},
+		{
+			"basic-pod-keyregex",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+					From:     kube.MetadataFromPod,
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("key*"),
+					From:     kube.MetadataFromPod,
+				},
+			},
+			"",
+		},
+		{
+			"basic-namespace",
+			[]FieldExtractConfig{
+				{
+					TagName:  "tag1",
+					KeyRegex: "key*",
+					From:     kube.MetadataFromNamespace,
+				},
+			},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "tag1",
+					KeyRegex: regexp.MustCompile("key*"),
+					From:     kube.MetadataFromNamespace,
 				},
 			},
 			"",
@@ -599,6 +671,24 @@ func Test_extractFieldRules(t *testing.T) {
 			}},
 			[]kube.FieldExtractionRule{},
 			true,
+		},
+		{
+			"match-keyregex",
+			args{"labels", []FieldExtractConfig{
+				{
+					TagName:  "name",
+					KeyRegex: "key*",
+					From:     kube.MetadataFromPod,
+				},
+			}},
+			[]kube.FieldExtractionRule{
+				{
+					Name:     "name",
+					KeyRegex: regexp.MustCompile("key*"),
+					From:     kube.MetadataFromPod,
+				},
+			},
+			false,
 		},
 	}
 	for _, tt := range tests {

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -76,6 +76,16 @@ processors:
         - name: jaeger-agent
         - name: jaeger-collector
 
+  k8sattributes/3:
+    passthrough: false
+    auth_type: "kubeConfig"
+    extract:
+      annotations:
+        - key_regex: opentel.* # extracts Keys & values of annotations matching regex `opentel.*`
+          from: pod
+      labels:
+        - key_regex: opentel.* # extracts Keys & values of labels matching regex `opentel.*`
+          from: pod
 
 exporters:
   nop:

--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -40,7 +40,7 @@ func TestLog10kDPS(t *testing.T) {
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 85,
+				ExpectedMaxRAM: 86,
 			},
 		},
 		{
@@ -58,7 +58,7 @@ func TestLog10kDPS(t *testing.T) {
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 85,
+				ExpectedMaxRAM: 86,
 			},
 		},
 		{

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -53,7 +53,7 @@ func TestMetric10kDPS(t *testing.T) {
 			datareceivers.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 85,
-				ExpectedMaxRAM: 85,
+				ExpectedMaxRAM: 86,
 			},
 		},
 		{


### PR DESCRIPTION
**Description:** 
Added the ability to fetch all annotations and labels from pods and namespace for k8stagger/k8sattributes processor

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4953

**Testing:** Added relevant Unit tests

**Documentation:** Added relevant docs and config examples