### PR TITLE
[processor/metricstransform] Update delete label value example in readme

### DIFF
--- a/processor/metricstransformprocessor/README.md
+++ b/processor/metricstransformprocessor/README.md
@@ -220,9 +220,9 @@ operations:
         new_value: sunreclaimable
 ```
 
-### Delete label value
+### Delete by label value
 ```yaml
-# delete the label value 'idle' of the label 'state'
+# deletes all data points with the label value 'idle' of the label 'state'
 include: system.cpu.usage
 action: update
 operation:


### PR DESCRIPTION
The current text is a little misleading, this helps clarify that the
`delete_label_value` operation deletes all data points that match the
label key/value. The `delete_label_value` operation does *not* just
delete a label.