### PR TITLE
Added obsrecv to Google Cloud Spanner receiver instead of error logging in collectData().

### DIFF
--- a/receiver/googlecloudspannerreceiver/factory.go
+++ b/receiver/googlecloudspannerreceiver/factory.go
@@ -60,5 +60,5 @@ func createMetricsReceiver(
 
 	rCfg := baseCfg.(*Config)
 	logger := params.Logger
-	return newGoogleCloudSpannerReceiver(logger, rCfg, consumer)
+	return newGoogleCloudSpannerReceiver(logger, rCfg, consumer, params)
 }

--- a/receiver/googlecloudspannerreceiver/factory_test.go
+++ b/receiver/googlecloudspannerreceiver/factory_test.go
@@ -51,6 +51,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, receiver, "failed to create metrics receiver")
 
-	_, err = factory.CreateTracesReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), receiverConfig, nil)
+	_, err = factory.CreateMetricsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), receiverConfig, nil)
 	require.Error(t, err)
 }

--- a/receiver/googlecloudspannerreceiver/receiver_test.go
+++ b/receiver/googlecloudspannerreceiver/receiver_test.go
@@ -66,7 +66,7 @@ func TestNewGoogleCloudSpannerReceiver(t *testing.T) {
 	nextConsumer := consumertest.NewNop()
 	cfg := createDefaultConfig().(*Config)
 
-	receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer)
+	receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer, componenttest.NewNopReceiverCreateSettings())
 	receiverCasted := receiver.(*googleCloudSpannerReceiver)
 
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestNewGoogleCloudSpannerReceiver(t *testing.T) {
 func TestNewGoogleCloudSpannerReceiver_NilConsumer(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 
-	metricsReceiver, err := newGoogleCloudSpannerReceiver(zap.NewNop(), cfg, nil)
+	metricsReceiver, err := newGoogleCloudSpannerReceiver(zap.NewNop(), cfg, nil, componenttest.NewNopReceiverCreateSettings())
 
 	require.NotNil(t, err)
 	require.Nil(t, metricsReceiver)
@@ -122,7 +122,7 @@ func TestStart(t *testing.T) {
 
 			host := componenttest.NewNopHost()
 
-			receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer)
+			receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer, componenttest.NewNopReceiverCreateSettings())
 			receiverCasted := receiver.(*googleCloudSpannerReceiver)
 
 			require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestStartInitializesDataCollectionWithCollectDataError(t *testing.T) {
 	cfg := createConfig(serviceAccountValidPath)
 	cfg.CollectionInterval = 10 * time.Millisecond
 	host := componenttest.NewNopHost()
-	receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer)
+	receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer, componenttest.NewNopReceiverCreateSettings())
 	receiverCasted := receiver.(*googleCloudSpannerReceiver)
 
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestStartWithContextDone(t *testing.T) {
 	ctx := context.Background()
 	host := componenttest.NewNopHost()
 
-	receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer)
+	receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer, componenttest.NewNopReceiverCreateSettings())
 	receiverCasted := receiver.(*googleCloudSpannerReceiver)
 
 	require.NoError(t, err)
@@ -202,7 +202,7 @@ func TestInitializeProjectReaders(t *testing.T) {
 			nextConsumer := consumertest.NewNop()
 			cfg := createConfig(testCase.serviceAccountPath)
 
-			receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer)
+			receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, nextConsumer, componenttest.NewNopReceiverCreateSettings())
 			receiverCasted := receiver.(*googleCloudSpannerReceiver)
 
 			require.NoError(t, err)
@@ -276,7 +276,7 @@ func TestCollectData(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cfg := createDefaultConfig().(*Config)
 
-			receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, testCase.nextConsumer)
+			receiver, err := newGoogleCloudSpannerReceiver(logger, cfg, testCase.nextConsumer, componenttest.NewNopReceiverCreateSettings())
 
 			require.NoError(t, err)
 			require.NotNil(t, receiver)
@@ -311,21 +311,4 @@ func TestGoogleCloudSpannerReceiver_Shutdown(t *testing.T) {
 	err := receiver.Shutdown(ctx)
 
 	require.NoError(t, err)
-}
-
-func TestMetricName(t *testing.T) {
-	md := pdata.NewMetrics()
-	rms := md.ResourceMetrics()
-	rm := rms.AppendEmpty()
-
-	ilms := rm.InstrumentationLibraryMetrics()
-	ilm := ilms.AppendEmpty()
-	metric := ilm.Metrics().AppendEmpty()
-	metric.SetName("testMetric1")
-	metric = ilm.Metrics().AppendEmpty()
-	metric.SetName("testMetric2")
-
-	metricName := metricName(md)
-
-	assert.Equal(t, "testMetric1,testMetric2", metricName)
 }


### PR DESCRIPTION
Fixed TODO made in previous MR. As it was requested by @tigrannajaryan:

This can flood the logs: https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md#logging

Use obsreport instead to make the component observable and emit metrics on errors. See for example how OTLP receiver does it: https://github.com/open-telemetry/opentelemetry-collector/blob/55700930f9a3dc272b431cdbe2435f250cd5b5e0/receiver/otlpreceiver/internal/metrics/otlp.go#L63