### PR TITLE
rpc.system has priority to determine aws namespace in awsxrayexporter

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -119,13 +119,23 @@ func MakeSegment(span pdata.Span, resource pdata.Resource, indexedAttrs []string
 		name = peerService.StringVal()
 	}
 
+	if namespace == "" {
+		if rpcSystem, ok := attributes.Get(conventions.AttributeRPCSystem); ok {
+			if rpcSystem.StringVal() == "aws-api" {
+				namespace = conventions.AttributeCloudProviderAWS
+			}
+		}
+	}
+
 	if name == "" {
 		if awsService, ok := attributes.Get(awsxray.AWSServiceAttribute); ok {
 			// Generally spans are named something like "Method" or "Service.Method" but for AWS spans, X-Ray expects spans
 			// to be named "Service"
 			name = awsService.StringVal()
 
-			namespace = "aws"
+			if namespace == "" {
+				namespace = conventions.AttributeCloudProviderAWS
+			}
 		}
 	}
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This PR makes it so that `rpc.system` has the highest priority to set the `namspace` value of the segment. Specifically, it is used to determine if the span was made using an instrumented AWS SDK as defined in the [aws instrumentation spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#common-attributes). If `rpc.system` is set to `aws-api` then the `namespace` is set to `aws`.

This PR aims to be backwards compatible because if `rpc.system` is not set (as it is for some languages today) then it will fallback to checking if `aws.service` is set.

**Link to tracking Issue:**

Fixes #5766 

**Testing:** <Describe what testing was performed and which tests were added.>

The test makes a span which _does not have_ `aws.service` set.

**Documentation:** <Describe the documentation added.>

N/A (this is just following the spec)

cc @mxiamxia @anuraaga 