### PR TITLE
Update Redis receiver's metric names

### DIFF
--- a/receiver/redisreceiver/metric_functions.go
+++ b/receiver/redisreceiver/metric_functions.go
@@ -73,7 +73,7 @@ func getDefaultRedisMetrics() []*redisMetric {
 func uptimeInSeconds() *redisMetric {
 	return &redisMetric{
 		key:         "uptime_in_seconds",
-		name:        "redis/uptime",
+		name:        "redis.uptime",
 		units:       "s",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
@@ -85,7 +85,7 @@ func uptimeInSeconds() *redisMetric {
 func usedCPUSys() *redisMetric {
 	return &redisMetric{
 		key:         "used_cpu_sys",
-		name:        "redis/cpu/time",
+		name:        "redis.cpu.time",
 		units:       "s",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeDouble,
@@ -98,7 +98,7 @@ func usedCPUSys() *redisMetric {
 func usedCPUUser() *redisMetric {
 	return &redisMetric{
 		key:         "used_cpu_user",
-		name:        "redis/cpu/time",
+		name:        "redis.cpu.time",
 		units:       "s",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeDouble,
@@ -111,7 +111,7 @@ func usedCPUUser() *redisMetric {
 func usedCPUSysChildren() *redisMetric {
 	return &redisMetric{
 		key:         "used_cpu_sys_children",
-		name:        "redis/cpu/time",
+		name:        "redis.cpu.time",
 		units:       "s",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeDouble,
@@ -124,7 +124,7 @@ func usedCPUSysChildren() *redisMetric {
 func connectedClients() *redisMetric {
 	return &redisMetric{
 		key:         "connected_clients",
-		name:        "redis/clients/connected",
+		name:        "redis.clients.connected",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: false,
@@ -135,7 +135,7 @@ func connectedClients() *redisMetric {
 func clientRecentMaxInputBuffer() *redisMetric {
 	return &redisMetric{
 		key:       "client_recent_max_input_buffer",
-		name:      "redis/clients/max_input_buffer",
+		name:      "redis.clients.max_input_buffer",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
 		desc:      "Biggest input buffer among current client connections",
@@ -145,7 +145,7 @@ func clientRecentMaxInputBuffer() *redisMetric {
 func clientRecentMaxOutputBuffer() *redisMetric {
 	return &redisMetric{
 		key:       "client_recent_max_output_buffer",
-		name:      "redis/clients/max_output_buffer",
+		name:      "redis.clients.max_output_buffer",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
 		desc:      "Longest output list among current client connections",
@@ -155,7 +155,7 @@ func clientRecentMaxOutputBuffer() *redisMetric {
 func blockedClients() *redisMetric {
 	return &redisMetric{
 		key:         "blocked_clients",
-		name:        "redis/clients/blocked",
+		name:        "redis.clients.blocked",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: false,
@@ -166,7 +166,7 @@ func blockedClients() *redisMetric {
 func expiredKeys() *redisMetric {
 	return &redisMetric{
 		key:         "expired_keys",
-		name:        "redis/keys/expired",
+		name:        "redis.keys.expired",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
@@ -177,7 +177,7 @@ func expiredKeys() *redisMetric {
 func evictedKeys() *redisMetric {
 	return &redisMetric{
 		key:         "evicted_keys",
-		name:        "redis/keys/evicted",
+		name:        "redis.keys.evicted",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
@@ -188,7 +188,7 @@ func evictedKeys() *redisMetric {
 func totalConnectionsReceived() *redisMetric {
 	return &redisMetric{
 		key:         "total_connections_received",
-		name:        "redis/connections/received",
+		name:        "redis.connections.received",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
@@ -199,7 +199,7 @@ func totalConnectionsReceived() *redisMetric {
 func rejectedConnections() *redisMetric {
 	return &redisMetric{
 		key:         "rejected_connections",
-		name:        "redis/connections/rejected",
+		name:        "redis.connections.rejected",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
@@ -210,7 +210,7 @@ func rejectedConnections() *redisMetric {
 func usedMemory() *redisMetric {
 	return &redisMetric{
 		key:       "used_memory",
-		name:      "redis/memory/used",
+		name:      "redis.memory.used",
 		units:     "By",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
@@ -221,7 +221,7 @@ func usedMemory() *redisMetric {
 func usedMemoryPeak() *redisMetric {
 	return &redisMetric{
 		key:       "used_memory_peak",
-		name:      "redis/memory/peak",
+		name:      "redis.memory.peak",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
 		units:     "By",
@@ -232,7 +232,7 @@ func usedMemoryPeak() *redisMetric {
 func usedMemoryRss() *redisMetric {
 	return &redisMetric{
 		key:       "used_memory_rss",
-		name:      "redis/memory/rss",
+		name:      "redis.memory.rss",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
 		units:     "By",
@@ -243,7 +243,7 @@ func usedMemoryRss() *redisMetric {
 func usedMemoryLua() *redisMetric {
 	return &redisMetric{
 		key:       "used_memory_lua",
-		name:      "redis/memory/lua",
+		name:      "redis.memory.lua",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
 		units:     "By",
@@ -254,7 +254,7 @@ func usedMemoryLua() *redisMetric {
 func memFragmentationRatio() *redisMetric {
 	return &redisMetric{
 		key:       "mem_fragmentation_ratio",
-		name:      "redis/memory/fragmentation_ratio",
+		name:      "redis.memory.fragmentation_ratio",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeDouble,
 		desc:      "Ratio between used_memory_rss and used_memory",
@@ -264,7 +264,7 @@ func memFragmentationRatio() *redisMetric {
 func rdbChangesSinceLastSave() *redisMetric {
 	return &redisMetric{
 		key:         "rdb_changes_since_last_save",
-		name:        "redis/rdb/changes_since_last_save",
+		name:        "redis.rdb.changes_since_last_save",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: false,
@@ -275,7 +275,7 @@ func rdbChangesSinceLastSave() *redisMetric {
 func instantaneousOpsPerSec() *redisMetric {
 	return &redisMetric{
 		key:       "instantaneous_ops_per_sec",
-		name:      "redis/commands",
+		name:      "redis.commands",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
 		units:     "{ops}/s",
@@ -286,7 +286,7 @@ func instantaneousOpsPerSec() *redisMetric {
 func totalCommandsProcessed() *redisMetric {
 	return &redisMetric{
 		key:         "total_commands_processed",
-		name:        "redis/commands/processed",
+		name:        "redis.commands.processed",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
@@ -297,7 +297,7 @@ func totalCommandsProcessed() *redisMetric {
 func totalNetInputBytes() *redisMetric {
 	return &redisMetric{
 		key:         "total_net_input_bytes",
-		name:        "redis/net/input",
+		name:        "redis.net.input",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
@@ -309,7 +309,7 @@ func totalNetInputBytes() *redisMetric {
 func totalNetOutputBytes() *redisMetric {
 	return &redisMetric{
 		key:         "total_net_output_bytes",
-		name:        "redis/net/output",
+		name:        "redis.net.output",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
@@ -321,7 +321,7 @@ func totalNetOutputBytes() *redisMetric {
 func keyspaceHits() *redisMetric {
 	return &redisMetric{
 		key:         "keyspace_hits",
-		name:        "redis/keyspace/hits",
+		name:        "redis.keyspace.hits",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
@@ -332,7 +332,7 @@ func keyspaceHits() *redisMetric {
 func keyspaceMisses() *redisMetric {
 	return &redisMetric{
 		key:         "keyspace_misses",
-		name:        "redis/keyspace/misses",
+		name:        "redis.keyspace.misses",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: true,
@@ -343,7 +343,7 @@ func keyspaceMisses() *redisMetric {
 func latestForkUsec() *redisMetric {
 	return &redisMetric{
 		key:       "latest_fork_usec",
-		name:      "redis/latest_fork",
+		name:      "redis.latest_fork",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
 		units:     "us",
@@ -354,7 +354,7 @@ func latestForkUsec() *redisMetric {
 func connectedSlaves() *redisMetric {
 	return &redisMetric{
 		key:         "connected_slaves",
-		name:        "redis/slaves/connected",
+		name:        "redis.slaves.connected",
 		pdType:      pdata.MetricDataTypeSum,
 		valueType:   pdata.MetricValueTypeInt,
 		isMonotonic: false,
@@ -365,7 +365,7 @@ func connectedSlaves() *redisMetric {
 func replBacklogFirstByteOffset() *redisMetric {
 	return &redisMetric{
 		key:       "repl_backlog_first_byte_offset",
-		name:      "redis/replication/backlog_first_byte_offset",
+		name:      "redis.replication.backlog_first_byte_offset",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
 		desc:      "The master offset of the replication backlog buffer",
@@ -375,7 +375,7 @@ func replBacklogFirstByteOffset() *redisMetric {
 func masterReplOffset() *redisMetric {
 	return &redisMetric{
 		key:       "master_repl_offset",
-		name:      "redis/replication/offset",
+		name:      "redis.replication.offset",
 		pdType:    pdata.MetricDataTypeGauge,
 		valueType: pdata.MetricValueTypeInt,
 		desc:      "The server's current replication offset",

--- a/receiver/redisreceiver/metric_functions_test.go
+++ b/receiver/redisreceiver/metric_functions_test.go
@@ -26,7 +26,7 @@ func TestDefaultMetrics(t *testing.T) {
 	for _, metric := range getDefaultRedisMetrics() {
 		require.True(t, len(metric.key) > 0)
 		require.True(t, len(metric.name) > 0)
-		require.True(t, strings.HasPrefix(metric.name, "redis/"))
+		require.True(t, strings.HasPrefix(metric.name, "redis."))
 		require.True(
 			t,
 			metric.pdType == pdata.MetricDataTypeSum ||

--- a/receiver/redisreceiver/pdata.go
+++ b/receiver/redisreceiver/pdata.go
@@ -29,7 +29,7 @@ func buildKeyspaceTriplet(k *keyspace, t *timeBundle) pdata.MetricSlice {
 
 func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
-		name:   "db.redis.keys",
+		name:   "redis.db.keys",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
 	}
@@ -38,7 +38,7 @@ func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 
 func initKeyspaceExpiresMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
-		name:   "db.redis.expires",
+		name:   "redis.db.expires",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
 	}
@@ -47,7 +47,7 @@ func initKeyspaceExpiresMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 
 func initKeyspaceTTLMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
-		name:   "db.redis.avg_ttl",
+		name:   "redis.db.avg_ttl",
 		units:  "ms",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,

--- a/receiver/redisreceiver/pdata.go
+++ b/receiver/redisreceiver/pdata.go
@@ -29,7 +29,7 @@ func buildKeyspaceTriplet(k *keyspace, t *timeBundle) pdata.MetricSlice {
 
 func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
-		name:   "redis/db/keys",
+		name:   "redis.db.keys",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
 	}
@@ -38,7 +38,7 @@ func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 
 func initKeyspaceExpiresMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
-		name:   "redis/db/expires",
+		name:   "redis.db.expires",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
 	}
@@ -47,7 +47,7 @@ func initKeyspaceExpiresMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 
 func initKeyspaceTTLMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
-		name:   "redis/db/avg_ttl",
+		name:   "redis.db.avg_ttl",
 		units:  "ms",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,

--- a/receiver/redisreceiver/pdata.go
+++ b/receiver/redisreceiver/pdata.go
@@ -29,7 +29,7 @@ func buildKeyspaceTriplet(k *keyspace, t *timeBundle) pdata.MetricSlice {
 
 func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
-		name:   "redis.db.keys",
+		name:   "db.redis.keys",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
 	}
@@ -38,7 +38,7 @@ func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 
 func initKeyspaceExpiresMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
-		name:   "redis.db.expires",
+		name:   "db.redis.expires",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
 	}
@@ -47,7 +47,7 @@ func initKeyspaceExpiresMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 
 func initKeyspaceTTLMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 	m := &redisMetric{
-		name:   "redis.db.avg_ttl",
+		name:   "db.redis.avg_ttl",
 		units:  "ms",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,

--- a/receiver/redisreceiver/pdata_test.go
+++ b/receiver/redisreceiver/pdata_test.go
@@ -104,7 +104,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, 6, ms.Len())
 
 	const lblKey = "db"
-	const name1 = "redis.db.keys"
+	const name1 = "db.redis.keys"
 
 	lblVal := pdata.NewAttributeValueString("0")
 
@@ -118,7 +118,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
 	assert.Equal(t, int64(1), pt.IntVal())
 
-	const name2 = "redis.db.expires"
+	const name2 = "db.redis.expires"
 
 	pdm = ms.At(1)
 	assert.Equal(t, name2, pdm.Name())
@@ -130,7 +130,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
 	assert.Equal(t, int64(2), pt.IntVal())
 
-	const name3 = "redis.db.avg_ttl"
+	const name3 = "db.redis.avg_ttl"
 
 	pdm = ms.At(2)
 	assert.Equal(t, name3, pdm.Name())

--- a/receiver/redisreceiver/pdata_test.go
+++ b/receiver/redisreceiver/pdata_test.go
@@ -104,7 +104,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, 6, ms.Len())
 
 	const lblKey = "db"
-	const name1 = "db.redis.keys"
+	const name1 = "redis.db.keys"
 
 	lblVal := pdata.NewAttributeValueString("0")
 
@@ -118,7 +118,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
 	assert.Equal(t, int64(1), pt.IntVal())
 
-	const name2 = "db.redis.expires"
+	const name2 = "redis.db.expires"
 
 	pdm = ms.At(1)
 	assert.Equal(t, name2, pdm.Name())
@@ -130,7 +130,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
 	assert.Equal(t, int64(2), pt.IntVal())
 
-	const name3 = "db.redis.avg_ttl"
+	const name3 = "redis.db.avg_ttl"
 
 	pdm = ms.At(2)
 	assert.Equal(t, name3, pdm.Name())

--- a/receiver/redisreceiver/pdata_test.go
+++ b/receiver/redisreceiver/pdata_test.go
@@ -26,7 +26,7 @@ import (
 func TestMemoryMetric(t *testing.T) {
 	rm := testGetMetricData(t, usedMemory())
 
-	const metricName = "redis/memory/used"
+	const metricName = "redis.memory.used"
 	const desc = "Total number of bytes allocated by Redis using its allocator"
 	const units = "By"
 	const ptVal = 854160
@@ -104,7 +104,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, 6, ms.Len())
 
 	const lblKey = "db"
-	const name1 = "redis/db/keys"
+	const name1 = "redis.db.keys"
 
 	lblVal := pdata.NewAttributeValueString("0")
 
@@ -118,7 +118,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
 	assert.Equal(t, int64(1), pt.IntVal())
 
-	const name2 = "redis/db/expires"
+	const name2 = "redis.db.expires"
 
 	pdm = ms.At(1)
 	assert.Equal(t, name2, pdm.Name())
@@ -130,7 +130,7 @@ func TestKeyspaceMetrics(t *testing.T) {
 	assert.Equal(t, pdata.MetricDataTypeGauge, pdm.DataType())
 	assert.Equal(t, int64(2), pt.IntVal())
 
-	const name3 = "redis/db/avg_ttl"
+	const name3 = "redis.db.avg_ttl"
 
 	pdm = ms.At(2)
 	assert.Equal(t, name3, pdm.Name())


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Update Redis receiver to use more common naming convention of using `.` instead of `/` as a separator in metric names.