### PR TITLE
Update configuration default values in log receivers docs

### DIFF
--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -17,8 +17,8 @@ Supported pipeline types: logs
 | `start_at`             | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
 | `write_to`             | $body            | The body [field](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/field.md) written to when creating a new log entry                                  |
 | `multiline`            |                  | A `multiline` configuration block. See below for more details                                                      |
-| `force_flush_period`   | `0s`             | Time since last read of data from file, after which currently buffered log should be send to pipeline. Takes [duration](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/duration.md) as value. Zero means waiting for new data forever |
-| `encoding`             | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
+| `force_flush_period`   | `500ms`          | Time since last read of data from file, after which currently buffered log should be send to pipeline. Takes [duration](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/duration.md) as value. Zero means waiting for new data forever |
+| `encoding`             | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `include_file_name`    | `true`           | Whether to add the file name as the label `file_name`                                                              |
 | `include_file_path`    | `false`          | Whether to add the file path as the label `file_path`                                                              |
 | `poll_interval`        | 200ms            | The duration between filesystem polls                                                                              |

--- a/receiver/tcplogreceiver/README.md
+++ b/receiver/tcplogreceiver/README.md
@@ -19,7 +19,7 @@ Supported pipeline types: logs
 | `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                                         |
 | `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
 | `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
-| `encoding`        | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
+| `encoding`        | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `operators`       | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
 
 ### TLS Configuration

--- a/receiver/udplogreceiver/README.md
+++ b/receiver/udplogreceiver/README.md
@@ -17,7 +17,7 @@ Supported pipeline types: logs
 | `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                                         |
 | `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
 | `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
-| `encoding`        | `nop`            | The encoding of the file being read. See the list of supported encodings below for available options               |
+| `encoding`        | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `operators`       | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
 
 ### Operators


### PR DESCRIPTION
Update default values in `filelog`, `tcplog` and `udplog` receivers according to the recent changes in the log-collection library:
- https://github.com/open-telemetry/opentelemetry-log-collection/pull/147
- https://github.com/open-telemetry/opentelemetry-log-collection/pull/261
