### PR TITLE
Add Resource Poller Before TestBed Runs (#5671)

### DIFF
--- a/testbed/testbed/child_process_collector.go
+++ b/testbed/testbed/child_process_collector.go
@@ -308,6 +308,18 @@ func (cp *childProcessCollector) WatchResourceConsumption() error {
 	ticker := time.NewTicker(cp.resourceSpec.ResourceCheckPeriod)
 	defer ticker.Stop()
 
+	//on first start must be under the cpu and ram max usage add a max minute delay
+	for start := time.Now(); time.Since(start) < time.Minute; {
+		cp.fetchRAMUsage()
+		cp.fetchCPUUsage()
+		if err := cp.checkAllowedResourceUsage(); err != nil {
+			log.Printf("Allowed usage of resources is too high before test starts wait for one second : %v", err)
+			time.Sleep(time.Second)
+		} else {
+			break
+		}
+	}
+
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
**Description:** 
Bug fix of flakey tests that fail before run due to cpu resource usage 

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5671

**Testing:** 
Ran test on laptop

**Documentation:** 
None