### PR TITLE
[datadogexporter] Remove obsolete report_buckets config

### DIFF
--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -322,6 +322,8 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) Unmarshal(configMap *config.Map) error {
+	// metrics::report_buckets is obsolete, return an error to
+	// tell the user to use metrics::histograms::mode instead.
 	if configMap.IsSet("metrics::report_buckets") {
 		return errBuckets
 	}

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -32,7 +32,7 @@ import (
 var (
 	errUnsetAPIKey = errors.New("api.key is not set")
 	errNoMetadata  = errors.New("only_metadata can't be enabled when send_metadata or use_resource_metadata is disabled")
-	errBuckets     = errors.New("can't use 'metrics::report_buckets' and 'metrics::histograms::mode' at the same time")
+	errBuckets     = errors.New("'metrics::report_buckets' is obsolete. Use 'metrics::histograms::mode' instead")
 )
 
 // TODO: Import these from translator when we eliminate cyclic dependency.
@@ -70,10 +70,6 @@ func (api *APIConfig) GetCensoredKey() string {
 
 // MetricsConfig defines the metrics exporter specific configuration options
 type MetricsConfig struct {
-	// Buckets states whether to report buckets from histogram metrics.
-	// Deprecated: use `metrics::histograms::mode`.
-	Buckets bool `mapstructure:"report_buckets"`
-
 	// Quantiles states whether to report quantiles from summary metrics.
 	// By default, the minimum, maximum and average are reported.
 	Quantiles bool `mapstructure:"report_quantiles"`
@@ -326,24 +322,13 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) Unmarshal(configMap *config.Map) error {
-	err := configMap.UnmarshalExact(c)
-	if err != nil {
-		return err
-	}
-
-	if configMap.IsSet("metrics::report_buckets") && configMap.IsSet("metrics::histograms::mode") {
+	if configMap.IsSet("metrics::report_buckets") {
 		return errBuckets
 	}
 
-	// Deprecation of `report_buckets`: add warning and set `HistConfig.Mode` instead.
-	if configMap.IsSet("metrics::report_buckets") {
-		if c.Metrics.Buckets {
-			c.warnings = append(c.warnings, fmt.Errorf("'metrics::report_buckets' is deprecated. Set 'metrics::histograms::mode' to 'counters' instead"))
-			c.Metrics.HistConfig.Mode = histogramModeCounters
-		} else {
-			c.warnings = append(c.warnings, fmt.Errorf("'metrics::report_buckets' is deprecated. Set 'metrics::histograms::mode' to 'nobuckets' instead"))
-			c.Metrics.HistConfig.Mode = histogramModeNoBuckets
-		}
+	err := configMap.UnmarshalExact(c)
+	if err != nil {
+		return err
 	}
 
 	switch c.Metrics.HistConfig.Mode {

--- a/exporter/datadogexporter/config/config_test.go
+++ b/exporter/datadogexporter/config/config_test.go
@@ -22,8 +22,6 @@ import (
 	colconfig "go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestHostTags(t *testing.T) {
@@ -169,13 +167,12 @@ func TestSpanNameRemappingsValidation(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestDeprecationReportBuckets(t *testing.T) {
+func TestErrorReportBuckets(t *testing.T) {
 
 	tests := []struct {
-		name             string
-		stringMap        map[string]interface{}
-		expectedMode     string
-		expectedWarnings int
+		name          string
+		stringMap     map[string]interface{}
+		expectedError error
 	}{
 		{
 			name: "report buckets false",
@@ -185,8 +182,7 @@ func TestDeprecationReportBuckets(t *testing.T) {
 					"report_buckets": false,
 				},
 			},
-			expectedMode:     histogramModeNoBuckets,
-			expectedWarnings: 1,
+			expectedError: errBuckets,
 		},
 		{
 			name: "report buckets true",
@@ -196,50 +192,30 @@ func TestDeprecationReportBuckets(t *testing.T) {
 					"report_buckets": true,
 				},
 			},
-			expectedMode:     histogramModeCounters,
-			expectedWarnings: 1,
+			expectedError: errBuckets,
 		},
 		{
 			name: "no report buckets",
 			stringMap: map[string]interface{}{
 				"api": map[string]interface{}{"key": "aaa"},
 			},
-			expectedMode:     histogramModeNoBuckets,
-			expectedWarnings: 0,
+			expectedError: nil,
 		},
 	}
 
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
 			// default config for buckets
-			config := Config{Metrics: MetricsConfig{Buckets: false, HistConfig: HistogramConfig{Mode: histogramModeNoBuckets}}}
+			config := Config{Metrics: MetricsConfig{HistConfig: HistogramConfig{Mode: histogramModeNoBuckets}}}
 			configMap := colconfig.NewMapFromStringMap(testInstance.stringMap)
 			err := config.Unmarshal(configMap)
-			require.NoError(t, err)
-			assert.Equal(t, config.Metrics.HistConfig.Mode, testInstance.expectedMode)
 
-			core, observed := observer.New(zapcore.WarnLevel)
-			testLogger := zap.New(core)
-			config.Sanitize(testLogger)
-			assert.Equal(t, len(observed.AllUntimed()), testInstance.expectedWarnings)
+			if testInstance.expectedError != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, testInstance.expectedError, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
-}
-
-func TestNoBucketsAndHistogram(t *testing.T) {
-	stringMap := map[string]interface{}{
-		"api": map[string]interface{}{"key": "aaa"},
-		"metrics": map[string]interface{}{
-			"report_buckets": false,
-			"histograms": map[string]interface{}{
-				"mode": histogramModeCounters,
-			},
-		},
-	}
-
-	config := Config{Metrics: MetricsConfig{Buckets: false, HistConfig: HistogramConfig{Mode: histogramModeNoBuckets}}}
-	configMap := colconfig.NewMapFromStringMap(stringMap)
-	err := config.Unmarshal(configMap)
-
-	assert.Error(t, errBuckets, err)
 }


### PR DESCRIPTION
**Description:** 

Removes the `metrics::report_buckets` option (the `metrics::histograms::mode` option should be used instead), which has been deprecated for two releases (`v0.36.0` and `v0.37.0`).

**Link to tracking Issue:** n/a

**Testing:** Modified unit tests to fit the new situation.

**Documentation:** Modified inline docs & config examples.