### PR TITLE
Rename "label" to "attribute" in expression matcher DSL

### DIFF
--- a/internal/coreinternal/processor/filterexpr/matcher_test.go
+++ b/internal/coreinternal/processor/filterexpr/matcher_test.go
@@ -142,8 +142,18 @@ func TestMatchGaugeDataPointByMetricAndHasLabel(t *testing.T) {
 	assert.True(t, testMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
 }
 
+func TestMatchGaugeDataPointByMetricAndHasAttribute(t *testing.T) {
+	expression := `MetricName == 'my.metric' && HasAttribute("foo")`
+	assert.True(t, testMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
+}
+
 func TestMatchGaugeDataPointByMetricAndLabelValue(t *testing.T) {
 	expression := `MetricName == 'my.metric' && Label("foo") == "bar"`
+	assert.False(t, testMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
+}
+
+func TestMatchGaugeDataPointByMetricAndAttributeValue(t *testing.T) {
+	expression := `MetricName == 'my.metric' && Attribute("foo") == "bar"`
 	assert.False(t, testMatchGauge(t, "my.metric", expression, map[string]pdata.AttributeValue{"foo": pdata.NewAttributeValueString("")}))
 }
 

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -98,12 +98,16 @@ Made available to the expression environment are the following:
 
 * `MetricName`
     a variable containing the current Metric's name
+* `Attribute(name)`
+  a function that takes an attribute name string as an argument and returns a string: the value of an attribute with that
+  name if one exists, or ""
+* `HasAttribute(name)`
+  a function that takes an attribute name string as an argument and returns a boolean: true if the datapoint has an attribute
+  with that name, false otherwise
 * `Label(name)`
-    a function that takes a label name string as an argument and returns a string: the value of a label with that
-    name if one exists, or ""
+  Alias for `Attribute(name)`. Deprecated.
 * `HasLabel(name)`
-    a function that takes a label name string as an argument and returns a boolean: true if the datapoint has a label
-    with that name, false otherwise
+  Alias for `HasLabel(name)`. Deprecated.
 
 Example:
 
@@ -114,11 +118,11 @@ processors:
       exclude:
         match_type: expr
         expressions:
-        - MetricName == "my.metric" && Label("my_label") == "abc123"
+        - MetricName == "my.metric" && Attribute("my_attr") == "abc123"
 ```
 
 The above config will filter out any Metric that both has the name "my.metric" and has at least one datapoint
-with a label of 'my_label="abc123"'.
+with an attribute of 'my_attr="abc123"'.
 
 ### Support for multiple expressions
 


### PR DESCRIPTION
The expression matcher used the old terminology in functions
HasLabel/Label. The current Otel term for metrics dimension is
"attribute".

I renamed the functions to HasAttribute/Attribute and kept HasLabel/Label
as aliases for now to avoid breaking existing configurations. HasLabel/Label
are declared deprecated, we can remove them in a few months / before
declaring the config stable.
