### PR TITLE
Improve performance of metric expression matcher

### DIFF
--- a/internal/coreinternal/processor/filterexpr/matcher_test.go
+++ b/internal/coreinternal/processor/filterexpr/matcher_test.go
@@ -30,7 +30,7 @@ func TestCompileExprError(t *testing.T) {
 func TestRunExprError(t *testing.T) {
 	matcher, err := NewMatcher("foo")
 	require.NoError(t, err)
-	matched, _ := matcher.match(env{})
+	matched, _ := matcher.match(&env{})
 	require.False(t, matched)
 }
 


### PR DESCRIPTION
Refactored env struct to avoid creating closure functions for every
expression evaluation operation. This reduced the allocations and
increased the speed.

Improvements:

```
$ benchstat old.txt new.txt
name          old time/op    new time/op    delta
ExprFilter-8     537µs ± 2%     476µs ± 1%  -11.33%  (p=0.000 n=9+10)

name          old alloc/op   new alloc/op   delta
ExprFilter-8     151kB ± 0%     102kB ± 0%  -32.43%  (p=0.000 n=8+8)

name          old allocs/op  new allocs/op  delta
ExprFilter-8     8.44k ± 0%     6.39k ± 0%  -24.24%  (p=0.000 n=10+10)
```