### PR TITLE
Migrated Google Cloud Spanner receiver to scraper approach.

### DIFF
--- a/receiver/googlecloudspannerreceiver/factory_test.go
+++ b/receiver/googlecloudspannerreceiver/factory_test.go
@@ -51,6 +51,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, receiver, "failed to create metrics receiver")
 
-	_, err = factory.CreateTracesReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), receiverConfig, nil)
+	_, err = factory.CreateMetricsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), receiverConfig, nil)
 	require.Error(t, err)
 }

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
@@ -17,6 +17,8 @@ package metadata
 import (
 	"sort"
 	"strings"
+
+	"go.opentelemetry.io/collector/model/pdata"
 )
 
 type LabelValueMetadata interface {
@@ -26,6 +28,7 @@ type LabelValueMetadata interface {
 type LabelValue interface {
 	LabelValueMetadata
 	Value() interface{}
+	SetValueTo(attributes pdata.AttributeMap)
 }
 
 type queryLabelValueMetadata struct {
@@ -133,6 +136,10 @@ func (value stringLabelValue) Value() interface{} {
 	return value.value
 }
 
+func (value stringLabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertString(value.name, value.value)
+}
+
 func newStringLabelValue(metadata StringLabelValueMetadata, valueHolder interface{}) stringLabelValue {
 	return stringLabelValue{
 		StringLabelValueMetadata: metadata,
@@ -148,6 +155,10 @@ func (metadata Int64LabelValueMetadata) ValueHolder() interface{} {
 
 func (value int64LabelValue) Value() interface{} {
 	return value.value
+}
+
+func (value int64LabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertInt(value.name, value.value)
 }
 
 func newInt64LabelValue(metadata Int64LabelValueMetadata, valueHolder interface{}) int64LabelValue {
@@ -167,6 +178,10 @@ func (value boolLabelValue) Value() interface{} {
 	return value.value
 }
 
+func (value boolLabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertBool(value.name, value.value)
+}
+
 func newBoolLabelValue(metadata BoolLabelValueMetadata, valueHolder interface{}) boolLabelValue {
 	return boolLabelValue{
 		BoolLabelValueMetadata: metadata,
@@ -182,6 +197,10 @@ func (metadata StringSliceLabelValueMetadata) ValueHolder() interface{} {
 
 func (value stringSliceLabelValue) Value() interface{} {
 	return value.value
+}
+
+func (value stringSliceLabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertString(value.name, value.value)
 }
 
 func newStringSliceLabelValue(metadata StringSliceLabelValueMetadata, valueHolder interface{}) stringSliceLabelValue {
@@ -205,6 +224,10 @@ func (metadata ByteSliceLabelValueMetadata) ValueHolder() interface{} {
 
 func (value byteSliceLabelValue) Value() interface{} {
 	return value.value
+}
+
+func (value byteSliceLabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertString(value.name, value.value)
 }
 
 func newByteSliceLabelValue(metadata ByteSliceLabelValueMetadata, valueHolder interface{}) byteSliceLabelValue {

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
 )
 
 func TestStringLabelValueMetadata(t *testing.T) {
@@ -108,14 +109,22 @@ func TestStringLabelValue(t *testing.T) {
 		},
 	}
 
-	labelValue :=
-		stringLabelValue{
-			StringLabelValueMetadata: metadata,
-			value:                    stringValue,
-		}
+	labelValue := stringLabelValue{
+		StringLabelValueMetadata: metadata,
+		value:                    stringValue,
+	}
 
 	assert.Equal(t, metadata, labelValue.StringLabelValueMetadata)
 	assert.Equal(t, stringValue, labelValue.Value())
+
+	attributes := pdata.NewAttributeMap()
+
+	labelValue.SetValueTo(attributes)
+
+	attributeValue, exists := attributes.Get(labelName)
+
+	assert.True(t, exists)
+	assert.Equal(t, stringValue, attributeValue.StringVal())
 }
 
 func TestInt64LabelValue(t *testing.T) {
@@ -126,14 +135,22 @@ func TestInt64LabelValue(t *testing.T) {
 		},
 	}
 
-	labelValue :=
-		int64LabelValue{
-			Int64LabelValueMetadata: metadata,
-			value:                   int64Value,
-		}
+	labelValue := int64LabelValue{
+		Int64LabelValueMetadata: metadata,
+		value:                   int64Value,
+	}
 
 	assert.Equal(t, metadata, labelValue.Int64LabelValueMetadata)
 	assert.Equal(t, int64Value, labelValue.Value())
+
+	attributes := pdata.NewAttributeMap()
+
+	labelValue.SetValueTo(attributes)
+
+	attributeValue, exists := attributes.Get(labelName)
+
+	assert.True(t, exists)
+	assert.Equal(t, int64Value, attributeValue.IntVal())
 }
 
 func TestBoolLabelValue(t *testing.T) {
@@ -144,14 +161,22 @@ func TestBoolLabelValue(t *testing.T) {
 		},
 	}
 
-	labelValue :=
-		boolLabelValue{
-			BoolLabelValueMetadata: metadata,
-			value:                  boolValue,
-		}
+	labelValue := boolLabelValue{
+		BoolLabelValueMetadata: metadata,
+		value:                  boolValue,
+	}
 
 	assert.Equal(t, metadata, labelValue.BoolLabelValueMetadata)
 	assert.Equal(t, boolValue, labelValue.Value())
+
+	attributes := pdata.NewAttributeMap()
+
+	labelValue.SetValueTo(attributes)
+
+	attributeValue, exists := attributes.Get(labelName)
+
+	assert.True(t, exists)
+	assert.Equal(t, boolValue, attributeValue.BoolVal())
 }
 
 func TestStringSliceLabelValue(t *testing.T) {
@@ -162,14 +187,22 @@ func TestStringSliceLabelValue(t *testing.T) {
 		},
 	}
 
-	labelValue :=
-		stringSliceLabelValue{
-			StringSliceLabelValueMetadata: metadata,
-			value:                         stringValue,
-		}
+	labelValue := stringSliceLabelValue{
+		StringSliceLabelValueMetadata: metadata,
+		value:                         stringValue,
+	}
 
 	assert.Equal(t, metadata, labelValue.StringSliceLabelValueMetadata)
 	assert.Equal(t, stringValue, labelValue.Value())
+
+	attributes := pdata.NewAttributeMap()
+
+	labelValue.SetValueTo(attributes)
+
+	attributeValue, exists := attributes.Get(labelName)
+
+	assert.True(t, exists)
+	assert.Equal(t, stringValue, attributeValue.StringVal())
 }
 
 func TestByteSliceLabelValue(t *testing.T) {
@@ -180,14 +213,22 @@ func TestByteSliceLabelValue(t *testing.T) {
 		},
 	}
 
-	labelValue :=
-		byteSliceLabelValue{
-			ByteSliceLabelValueMetadata: metadata,
-			value:                       stringValue,
-		}
+	labelValue := byteSliceLabelValue{
+		ByteSliceLabelValueMetadata: metadata,
+		value:                       stringValue,
+	}
 
 	assert.Equal(t, metadata, labelValue.ByteSliceLabelValueMetadata)
 	assert.Equal(t, stringValue, labelValue.Value())
+
+	attributes := pdata.NewAttributeMap()
+
+	labelValue.SetValueTo(attributes)
+
+	attributeValue, exists := attributes.Get(labelName)
+
+	assert.True(t, exists)
+	assert.Equal(t, stringValue, attributeValue.StringVal())
 }
 
 func TestNewQueryLabelValueMetadata(t *testing.T) {

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
@@ -1,0 +1,92 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"sort"
+
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+const instrumentationLibraryName = "otelcol/googlecloudspannermetrics"
+
+type MetricsBuilder struct {
+	// TODO It is empty now but there will be fields soon
+}
+
+func (b *MetricsBuilder) Build(dataPoints []*MetricsDataPoint) pdata.Metrics {
+	var metrics pdata.Metrics
+
+	groupedDataPoints := group(dataPoints)
+
+	if len(groupedDataPoints) > 0 {
+		metrics = pdata.NewMetrics()
+		rms := metrics.ResourceMetrics()
+		rm := rms.AppendEmpty()
+
+		ilms := rm.InstrumentationLibraryMetrics()
+		ilm := ilms.AppendEmpty()
+		ilm.InstrumentationLibrary().SetName(instrumentationLibraryName)
+
+		for key, points := range groupedDataPoints {
+			metric := ilm.Metrics().AppendEmpty()
+			metric.SetName(key.MetricName)
+			metric.SetUnit(key.MetricUnit)
+			metric.SetDataType(key.MetricDataType.MetricDataType())
+
+			var dataPointSlice pdata.NumberDataPointSlice
+
+			switch key.MetricDataType.MetricDataType() {
+			case pdata.MetricDataTypeGauge:
+				dataPointSlice = metric.Gauge().DataPoints()
+			case pdata.MetricDataTypeSum:
+				metric.Sum().SetAggregationTemporality(key.MetricDataType.AggregationTemporality())
+				metric.Sum().SetIsMonotonic(key.MetricDataType.IsMonotonic())
+				dataPointSlice = metric.Sum().DataPoints()
+			}
+
+			for _, point := range points {
+				point.CopyTo(dataPointSlice.AppendEmpty())
+			}
+		}
+	}
+
+	return metrics
+}
+
+func group(dataPoints []*MetricsDataPoint) map[MetricsDataPointKey][]*MetricsDataPoint {
+	if len(dataPoints) == 0 {
+		return nil
+	}
+
+	groupedDataPoints := make(map[MetricsDataPointKey][]*MetricsDataPoint)
+
+	for _, dataPoint := range dataPoints {
+		groupingKey := dataPoint.GroupingKey()
+		groupedDataPoints[groupingKey] = append(groupedDataPoints[groupingKey], dataPoint)
+	}
+
+	// TODO Apply cardinality filtering somewhere here for each group of dataPoints and rename method to groupAndFilter()
+
+	// Sorting points by metric name and timestamp
+	for _, points := range groupedDataPoints {
+		sort.Slice(points, func(i, j int) bool {
+			return points[i].timestamp.Before(points[j].timestamp)
+		})
+
+	}
+
+	return groupedDataPoints
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
@@ -1,0 +1,181 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+const (
+	metricName1 = "metricName1"
+	metricName2 = "metricName2"
+)
+
+type testData struct {
+	dataPoints           []*MetricsDataPoint
+	expectedGroupingKeys []MetricsDataPointKey
+	expectedGroups       map[MetricsDataPointKey][]*MetricsDataPoint
+}
+
+func TestMetricsBuilder_Build(t *testing.T) {
+	testCases := map[string]struct {
+		metricsDataType pdata.MetricDataType
+	}{
+		"Gauge": {pdata.MetricDataTypeGauge},
+		"Sum":   {pdata.MetricDataTypeSum},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			testMetricsBuilderBuild(t, testCase.metricsDataType)
+		})
+	}
+}
+
+func testMetricsBuilderBuild(t *testing.T, metricDataType pdata.MetricDataType) {
+	dataForTesting := generateTestData(metricDataType)
+	metricsBuilder := &MetricsBuilder{}
+	expectedGroupingKeysByMetricName := make(map[string]MetricsDataPointKey, len(dataForTesting.expectedGroupingKeys))
+
+	for _, expectedGroupingKey := range dataForTesting.expectedGroupingKeys {
+		expectedGroupingKeysByMetricName[expectedGroupingKey.MetricName] = expectedGroupingKey
+	}
+
+	metric := metricsBuilder.Build(dataForTesting.dataPoints)
+
+	assert.Equal(t, len(dataForTesting.dataPoints), metric.DataPointCount())
+	assert.Equal(t, len(dataForTesting.expectedGroups), metric.MetricCount())
+	assert.Equal(t, 1, metric.ResourceMetrics().At(0).InstrumentationLibraryMetrics().Len())
+	assert.Equal(t, len(dataForTesting.expectedGroups), metric.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Len())
+	require.Equal(t, instrumentationLibraryName, metric.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).InstrumentationLibrary().Name())
+
+	for i := 0; i < len(dataForTesting.expectedGroups); i++ {
+		ilMetric := metric.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(i)
+		expectedGroupingKey := expectedGroupingKeysByMetricName[ilMetric.Name()]
+		expectedDataPoints := dataForTesting.expectedGroups[expectedGroupingKey]
+
+		for dataPointIndex, expectedDataPoint := range expectedDataPoints {
+			assert.Equal(t, expectedDataPoint.metricName, ilMetric.Name())
+			assert.Equal(t, expectedDataPoint.metricValue.Unit(), ilMetric.Unit())
+			assert.Equal(t, expectedDataPoint.metricValue.DataType().MetricDataType(), ilMetric.DataType())
+
+			var dataPoint pdata.NumberDataPoint
+
+			if metricDataType == pdata.MetricDataTypeGauge {
+				assert.NotNil(t, ilMetric.Gauge())
+				assert.Equal(t, len(expectedDataPoints), ilMetric.Gauge().DataPoints().Len())
+				dataPoint = ilMetric.Gauge().DataPoints().At(dataPointIndex)
+			} else {
+				assert.NotNil(t, ilMetric.Sum())
+				assert.Equal(t, pdata.MetricAggregationTemporalityDelta, ilMetric.Sum().AggregationTemporality())
+				assert.True(t, ilMetric.Sum().IsMonotonic())
+				assert.Equal(t, len(expectedDataPoints), ilMetric.Sum().DataPoints().Len())
+				dataPoint = ilMetric.Sum().DataPoints().At(dataPointIndex)
+			}
+
+			assertMetricValue(t, expectedDataPoint.metricValue, dataPoint)
+
+			assert.Equal(t, pdata.NewTimestampFromTime(expectedDataPoint.timestamp), dataPoint.Timestamp())
+			// Adding +3 here because we'll always have 3 labels added for each metric: project_id, instance_id, database
+			assert.Equal(t, 3+len(expectedDataPoint.labelValues), dataPoint.Attributes().Len())
+
+			attributesMap := dataPoint.Attributes()
+
+			assertDefaultLabels(t, attributesMap, expectedDataPoint.databaseID)
+			assertNonDefaultLabels(t, attributesMap, expectedDataPoint.labelValues)
+		}
+	}
+}
+
+func TestGroup(t *testing.T) {
+	dataForTesting := generateTestData(metricDataType)
+
+	groupedDataPoints := group(dataForTesting.dataPoints)
+
+	assert.Equal(t, len(dataForTesting.expectedGroups), len(groupedDataPoints))
+
+	for expectedGroupingKey, expectedGroupPoints := range dataForTesting.expectedGroups {
+		dataPointsByKey := groupedDataPoints[expectedGroupingKey]
+
+		assert.Equal(t, len(expectedGroupPoints), len(dataPointsByKey))
+
+		for i, point := range expectedGroupPoints {
+			assert.Equal(t, point, dataPointsByKey[i])
+		}
+	}
+}
+
+func TestGroup_NilDataPoints(t *testing.T) {
+	groupedDataPoints := group(nil)
+
+	assert.Equal(t, 0, len(groupedDataPoints))
+}
+
+func generateTestData(metricDataType pdata.MetricDataType) testData {
+	timestamp1 := time.Now().UTC()
+	timestamp2 := timestamp1.Add(time.Minute)
+	labelValues := allPossibleLabelValues()
+	metricValues := allPossibleMetricValues(metricDataType)
+
+	dataPoints := []*MetricsDataPoint{
+		newMetricDataPoint(metricName1, timestamp1, labelValues, metricValues[0]),
+		newMetricDataPoint(metricName1, timestamp1, labelValues, metricValues[1]),
+		newMetricDataPoint(metricName2, timestamp1, labelValues, metricValues[0]),
+		newMetricDataPoint(metricName2, timestamp1, labelValues, metricValues[1]),
+		newMetricDataPoint(metricName1, timestamp2, labelValues, metricValues[0]),
+		newMetricDataPoint(metricName1, timestamp2, labelValues, metricValues[1]),
+		newMetricDataPoint(metricName2, timestamp2, labelValues, metricValues[0]),
+		newMetricDataPoint(metricName2, timestamp2, labelValues, metricValues[1]),
+	}
+
+	expectedGroupingKeys := []MetricsDataPointKey{
+		{
+			MetricName:     metricName1,
+			MetricDataType: metricValues[0].DataType(),
+			MetricUnit:     metricValues[0].Unit(),
+		},
+		{
+			MetricName:     metricName2,
+			MetricDataType: metricValues[0].DataType(),
+			MetricUnit:     metricValues[0].Unit(),
+		},
+	}
+
+	expectedGroups := map[MetricsDataPointKey][]*MetricsDataPoint{
+		expectedGroupingKeys[0]: {
+			dataPoints[0], dataPoints[1], dataPoints[4], dataPoints[5],
+		},
+		expectedGroupingKeys[1]: {
+			dataPoints[2], dataPoints[3], dataPoints[6], dataPoints[7],
+		},
+	}
+
+	return testData{dataPoints: dataPoints, expectedGroupingKeys: expectedGroupingKeys, expectedGroups: expectedGroups}
+}
+
+func newMetricDataPoint(metricName string, timestamp time.Time, labelValues []LabelValue, metricValue MetricValue) *MetricsDataPoint {
+	return &MetricsDataPoint{
+		metricName:  metricName,
+		timestamp:   timestamp,
+		databaseID:  databaseID(),
+		labelValues: labelValues,
+		metricValue: metricValue,
+	}
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint.go
@@ -1,0 +1,61 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/model/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
+)
+
+type MetricsDataPointKey struct {
+	MetricName     string
+	MetricUnit     string
+	MetricDataType MetricDataType
+}
+
+type MetricsDataPoint struct {
+	metricName  string
+	timestamp   time.Time
+	databaseID  *datasource.DatabaseID
+	labelValues []LabelValue
+	metricValue MetricValue
+}
+
+func (mdp *MetricsDataPoint) CopyTo(dataPoint pdata.NumberDataPoint) {
+	dataPoint.SetTimestamp(pdata.NewTimestampFromTime(mdp.timestamp))
+
+	mdp.metricValue.SetValueTo(dataPoint)
+
+	attributes := dataPoint.Attributes()
+
+	for _, labelValue := range mdp.labelValues {
+		labelValue.SetValueTo(attributes)
+	}
+
+	dataPoint.Attributes().InsertString(projectIDLabelName, mdp.databaseID.ProjectID())
+	dataPoint.Attributes().InsertString(instanceIDLabelName, mdp.databaseID.InstanceID())
+	dataPoint.Attributes().InsertString(databaseLabelName, mdp.databaseID.DatabaseName())
+}
+
+func (mdp *MetricsDataPoint) GroupingKey() MetricsDataPointKey {
+	return MetricsDataPointKey{
+		MetricName:     mdp.metricName,
+		MetricUnit:     mdp.metricValue.Unit(),
+		MetricDataType: mdp.metricValue.DataType(),
+	}
+}

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
@@ -14,6 +14,8 @@
 
 package metadata
 
+import "go.opentelemetry.io/collector/model/pdata"
+
 type MetricValueMetadata interface {
 	ValueMetadata
 	DataType() MetricDataType
@@ -23,6 +25,7 @@ type MetricValueMetadata interface {
 type MetricValue interface {
 	MetricValueMetadata
 	Value() interface{}
+	SetValueTo(ndp pdata.NumberDataPoint)
 }
 
 type queryMetricValueMetadata struct {
@@ -111,6 +114,14 @@ func (value int64MetricValue) Value() interface{} {
 
 func (value float64MetricValue) Value() interface{} {
 	return value.value
+}
+
+func (value int64MetricValue) SetValueTo(point pdata.NumberDataPoint) {
+	point.SetIntVal(value.value)
+}
+
+func (value float64MetricValue) SetValueTo(point pdata.NumberDataPoint) {
+	point.SetDoubleVal(value.value)
 }
 
 func newInt64MetricValue(metadata Int64MetricValueMetadata, valueHolder interface{}) int64MetricValue {

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
 )
 
 func TestInt64MetricValueMetadata(t *testing.T) {
@@ -81,6 +82,12 @@ func TestInt64MetricValue(t *testing.T) {
 
 	assert.Equal(t, metadata, metricValue.Int64MetricValueMetadata)
 	assert.Equal(t, int64Value, metricValue.Value())
+
+	dataPoint := pdata.NewNumberDataPoint()
+
+	metricValue.SetValueTo(dataPoint)
+
+	assert.Equal(t, int64Value, dataPoint.IntVal())
 }
 
 func TestFloat64MetricValue(t *testing.T) {
@@ -102,6 +109,12 @@ func TestFloat64MetricValue(t *testing.T) {
 
 	assert.Equal(t, metadata, metricValue.Float64MetricValueMetadata)
 	assert.Equal(t, float64Value, metricValue.Value())
+
+	dataPoint := pdata.NewNumberDataPoint()
+
+	metricValue.SetValueTo(dataPoint)
+
+	assert.Equal(t, float64Value, dataPoint.DoubleVal())
 }
 
 func TestNewQueryMetricValueMetadata(t *testing.T) {

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/projectreader.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"strings"
 
-	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
 )
 
 type ProjectReader struct {
@@ -42,14 +43,19 @@ func (projectReader *ProjectReader) Shutdown() {
 	}
 }
 
-func (projectReader *ProjectReader) Read(ctx context.Context) []pdata.Metrics {
-	var projectMetrics []pdata.Metrics
+func (projectReader *ProjectReader) Read(ctx context.Context) ([]*metadata.MetricsDataPoint, error) {
+	var result []*metadata.MetricsDataPoint
 
 	for _, databaseReader := range projectReader.databaseReaders {
-		projectMetrics = append(projectMetrics, databaseReader.Read(ctx)...)
+		dataPoints, err := databaseReader.Read(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, dataPoints...)
 	}
 
-	return projectMetrics
+	return result, nil
 }
 
 func (projectReader *ProjectReader) Name() string {

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
@@ -17,7 +17,7 @@ package statsreader
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/model/pdata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/metadata"
 )
 
 type ReaderConfig struct {
@@ -27,16 +27,14 @@ type ReaderConfig struct {
 
 type Reader interface {
 	Name() string
-	Read(ctx context.Context) ([]pdata.Metrics, error)
+	Read(ctx context.Context) ([]*metadata.MetricsDataPoint, error)
 }
 
 // CompositeReader - this interface is used for the composition of multiple Reader(s).
-// Main differences between it and Reader are:
-// - Read method doesn't return error;
-// - this interface also has Shutdown method for performing some additional cleanup necessary for each Reader instance.
+// Main difference between it and Reader - this interface also has Shutdown method for performing some additional
+// cleanup necessary for each Reader instance.
 type CompositeReader interface {
-	Name() string
-	Read(ctx context.Context) []pdata.Metrics
+	Reader
 	// Shutdown Use this method to perform any additional cleanup of underlying components.
 	Shutdown()
 }


### PR DESCRIPTION
Intent of this MR is to migrate receiver implementation to scraper approach - this also will automatically add obsreporting.

These changes were requested by @bogdandrutu in scope of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5831 MR.

FYI: @tigrannajaryan , @jpkrohling 