### PR TITLE
k8sobserver: only record pod endpoints for running pods

### DIFF
--- a/extension/observer/k8sobserver/handler.go
+++ b/extension/observer/k8sobserver/handler.go
@@ -56,6 +56,11 @@ func (h *handler) convertPodToEndpoints(pod *v1.Pod) []observer.Endpoint {
 		Namespace:   pod.Namespace,
 	}
 
+	// Return no endpoints if the Pod is not running
+	if pod.Status.Phase != v1.PodRunning {
+		return nil
+	}
+
 	endpoints := []observer.Endpoint{{
 		ID:      podID,
 		Target:  podIP,

--- a/extension/observer/k8sobserver/k8s_fixtures_test.go
+++ b/extension/observer/k8sobserver/k8s_fixtures_test.go
@@ -35,6 +35,7 @@ func NewPod(name, host string) *v1.Pod {
 			NodeName: host,
 		},
 		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
 			PodIP: "1.2.3.4",
 			Conditions: []v1.PodCondition{
 				{


### PR DESCRIPTION
**Description:** <Describe what has changed.>

This change updates the k8sobserver to only add a pod level endpoint if the Pod is currently running.

This prevents a situation in which receivers consuming from the k8sobserver would continue to interact with a Pod endpoint after the Pod had completed. In the worst case this would result in misleading results as other running pods could re-use the Pod's IP address and telemetry data would be misattributed.

Specifically, we observed this issue when using the `receivercreator` to scrape prometheus endpoints from pods associated with long running jobs.

*Note*: Should this be a configuration option? Are there ever situation in which a resource would like to track endpoints for non running pods?

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Unit tests.

**Documentation:** <Describe the documentation added.>

Unclear if this is necessary. But will add if needed.