### PR TITLE
Update otel-collector image version in k8s deployment example

### DIFF
--- a/examples/kubernetes/otel-collector.yaml
+++ b/examples/kubernetes/otel-collector.yaml
@@ -101,7 +101,7 @@ spec:
     spec:
       containers:
       - name: otel-collector
-        image: otel/opentelemetry-collector-contrib:0.22.0
+        image: otel/opentelemetry-collector-contrib:0.37.1
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
The old image version throws the following errors:
```
2021-10-24T23:44:09.294Z	warn	Running expression returned an error	{"component_kind": "receiver", "component_type": "filelog", "component_name": "filelog", "operator_id": "$.get-format", "operator_type": "router", "error": "interface conversion: interface {} is nil, not string (1:7)\n | $body matches \"^[^ Z]+ \"\n | ......^"}
2021-10-24T23:44:09.294Z	warn	Running expression returned an error	{"component_kind": "receiver", "component_type": "filelog", "component_name": "filelog", "operator_id": "$.get-format", "operator_type": "router", "error": "interface conversion: interface {} is nil, not string (1:7)\n | $body matches \"^[^ Z]+Z\"\n | ......^"}
2021-10-24T23:44:09.294Z	warn	Running expression returned an error	{"component_kind": "receiver", "component_type": "filelog", "component_name": "filelog", "operator_id": "$.get-format", "operator_type": "router", "error": "interface conversion: interface {} is nil, not string (1:7)\n | $body matches \"^\\\\{\"\n | ......^"}
```