### PR TITLE
[Minor] Refactor the client Authenticators  for the new "ClientAuthenticator" interfaces

### DIFF
--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -16,7 +16,9 @@ package bearertokenauthextension
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configauth"
@@ -47,7 +49,10 @@ type BearerTokenAuth struct {
 	logger      *zap.Logger
 }
 
-var _ configauth.GRPCClientAuthenticator = (*BearerTokenAuth)(nil)
+var (
+	_                             configauth.ClientAuthenticator = (*BearerTokenAuth)(nil)
+	errNotHTTPClientAuthenticator                                = errors.New("requested authenticator is not a HTTP client authenticator")
+)
 
 func newBearerTokenAuth(cfg *Config, logger *zap.Logger) *BearerTokenAuth {
 	return &BearerTokenAuth{
@@ -71,4 +76,9 @@ func (b *BearerTokenAuth) PerRPCCredentials() (credentials.PerRPCCredentials, er
 	return &PerRPCAuth{
 		metadata: map[string]string{"authorization": fmt.Sprintf("Bearer %s", b.tokenString)},
 	}, nil
+}
+
+// RoundTripper is not implemented by BearerTokenAuth
+func (b *BearerTokenAuth) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
+	return nil, errNotHTTPClientAuthenticator
 }

--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -49,10 +49,8 @@ type BearerTokenAuth struct {
 	logger      *zap.Logger
 }
 
-var (
-	_                             configauth.ClientAuthenticator = (*BearerTokenAuth)(nil)
-	errNotHTTPClientAuthenticator                                = errors.New("requested authenticator is not a HTTP client authenticator")
-)
+var _ configauth.ClientAuthenticator = (*BearerTokenAuth)(nil)
+var errNotHTTPClientAuthenticator = errors.New("requested authenticator is not a HTTP client authenticator")
 
 func newBearerTokenAuth(cfg *Config, logger *zap.Logger) *BearerTokenAuth {
 	return &BearerTokenAuth{

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -52,6 +52,10 @@ func TestBearerAuthenticator(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, credential)
 
+	c, err := bauth.RoundTripper(nil)
+	assert.ErrorIs(t, err, errNotHTTPClientAuthenticator)
+	assert.Nil(t, c)
+
 	md, err := credential.GetRequestMetadata(context.Background())
 	expectedMd := map[string]string{
 		"authorization": fmt.Sprintf("Bearer %s", cfg.BearerToken),

--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -36,9 +36,7 @@ type ClientCredentialsAuthenticator struct {
 }
 
 // ClientCredentialsAuthenticator implements ClientAuthenticator
- var (
-	_ configauth.ClientAuthenticator = (*ClientCredentialsAuthenticator)(nil)
- )
+var _ configauth.ClientAuthenticator = (*ClientCredentialsAuthenticator)(nil)
 
 func newClientCredentialsExtension(cfg *Config, logger *zap.Logger) (*ClientCredentialsAuthenticator, error) {
 	if cfg.ClientID == "" {

--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -35,11 +35,10 @@ type ClientCredentialsAuthenticator struct {
 	client            *http.Client
 }
 
-// ClientCredentialsAuthenticator implements both HTTPClientAuth and GRPCClientAuth
-var (
-	_ configauth.HTTPClientAuthenticator = (*ClientCredentialsAuthenticator)(nil)
-	_ configauth.GRPCClientAuthenticator = (*ClientCredentialsAuthenticator)(nil)
-)
+// ClientCredentialsAuthenticator implements ClientAuthenticator
+ var (
+	_ configauth.ClientAuthenticator = (*ClientCredentialsAuthenticator)(nil)
+ )
 
 func newClientCredentialsExtension(cfg *Config, logger *zap.Logger) (*ClientCredentialsAuthenticator, error) {
 	if cfg.ClientID == "" {


### PR DESCRIPTION
**Description:** 

As a part of Removing protocol specific client authentication interfaces (open-telemetry/opentelemetry-collector#4239) client authenticators will have to implement top level "ClientAuthenticator" which now comprises of all the protocol interfaces.

This PR does some minor adjustments to implementations and removes explicit references to old protocol specific interface types and implements NoOps for missing methods 

**Link to tracking Issue:**  #5904

**Testing**
-  Minor refactoring - Unit Tests

Note that this PR can be merged regardless of the [core PR ](https://github.com/open-telemetry/opentelemetry-collector/pull/4255) because of Go's implicit way of treating interfaces. 
