### PR TITLE
[observiqexporter] Allow Dialer timeout to be configured

### DIFF
--- a/exporter/observiqexporter/README.md
+++ b/exporter/observiqexporter/README.md
@@ -16,7 +16,9 @@ The following configuration options can also be configured:
 - `endpoint` (default: `https://nozzle.app.observiq.com/v1/add`): Endpoint where logs are sent to over http(s).
 - `agent_id` (default: uuid generated from os.Hostname): ID for identifying the collector deployment. Ideally, this is a unique uuid, for uniquely identifying specific deployments of the agent. By default, this will be a uuid generated from the hostname. If the hostname cannot be determined, it will be `00000000-0000-0000-0000-000000000000`
 - `agent_name` (default: os.Hostname): Name for identifying the collector deployment. This is the friendly name of the deployment. Defaults to the hostname; If the hostname cannot be determined, `otel collector` will be used as a fallback.
-- `timeout` (default: `10s`): Http timeout when sending data.
+- `timeout` (default: `20s`): Http timeout when sending data.
+- `dialer_timeout` (default: `10s`): TCP Dialer timeout when sending data.
+- `tls_handshake_timeout` (default: `10s`): TLS handshake timeout when sending data.
 - `tls`:
   - `insecure_skip_verify` (default: `false`): Whether to skip checking the certificate of the endpoint when sending data over HTTPS.
   - `ca_file` (no default) Path to the CA cert to verify the server being connected to.

--- a/exporter/observiqexporter/README.md
+++ b/exporter/observiqexporter/README.md
@@ -18,7 +18,6 @@ The following configuration options can also be configured:
 - `agent_name` (default: os.Hostname): Name for identifying the collector deployment. This is the friendly name of the deployment. Defaults to the hostname; If the hostname cannot be determined, `otel collector` will be used as a fallback.
 - `timeout` (default: `20s`): Http timeout when sending data.
 - `dialer_timeout` (default: `10s`): TCP Dialer timeout when sending data.
-- `tls_handshake_timeout` (default: `10s`): TLS handshake timeout when sending data.
 - `tls`:
   - `insecure_skip_verify` (default: `false`): Whether to skip checking the certificate of the endpoint when sending data over HTTPS.
   - `ca_file` (no default) Path to the CA cert to verify the server being connected to.

--- a/exporter/observiqexporter/client.go
+++ b/exporter/observiqexporter/client.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -205,6 +206,10 @@ func buildClient(config *Config, logger *zap.Logger, buildInfo component.BuildIn
 			Transport: &http.Transport{
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: tlsCfg,
+				DialContext: (&net.Dialer{
+					Timeout: config.Timeout,
+				}).DialContext,
+				TLSHandshakeTimeout: config.TLSHandshakeTimeout,
 			},
 		},
 		logger:       logger,

--- a/exporter/observiqexporter/client.go
+++ b/exporter/observiqexporter/client.go
@@ -207,9 +207,8 @@ func buildClient(config *Config, logger *zap.Logger, buildInfo component.BuildIn
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: tlsCfg,
 				DialContext: (&net.Dialer{
-					Timeout: config.Timeout,
+					Timeout: config.DialerTimeout,
 				}).DialContext,
-				TLSHandshakeTimeout: config.TLSHandshakeTimeout,
 			},
 		},
 		logger:       logger,

--- a/exporter/observiqexporter/config.go
+++ b/exporter/observiqexporter/config.go
@@ -47,7 +47,7 @@ type Config struct {
 	// DialerTimeout is the amount of time to wait before aborting establishing the tcp connection when making
 	// an http request
 	DialerTimeout time.Duration `mapstructure:"dialer_timeout"`
-	// DialerTimeout is the amount of time to wait before aborting establishing the connection when performing
+	// TLSHandshakeTimeout is the amount of time to wait before aborting establishing the connection when performing
 	// the tls handshake
 	TLSHandshakeTimeout time.Duration `mapstructure:"tls_handshake_timeout"`
 }

--- a/exporter/observiqexporter/config.go
+++ b/exporter/observiqexporter/config.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/config"
@@ -37,12 +38,18 @@ type Config struct {
 	APIKey string `mapstructure:"api_key"`
 	// Secret key for authenticating with the ingestion endpoint (required if no APIKey)
 	SecretKey string `mapstructure:"secret_key"`
-	// Endpoint URL; Defines the ingestion endpoint (optional)
+	// Endpoint URL; Defines the ingestion endpoint
 	Endpoint string `mapstructure:"endpoint"`
-	// ID that identifies this agent (optional)
+	// ID that identifies this agent
 	AgentID string `mapstructure:"agent_id"`
-	// Name that identifies this agent (optional)
+	// Name that identifies this agent
 	AgentName string `mapstructure:"agent_name"`
+	// DialerTimeout is the amount of time to wait before aborting establishing the tcp connection when making
+	// an http request
+	DialerTimeout time.Duration `mapstructure:"dialer_timeout"`
+	// DialerTimeout is the amount of time to wait before aborting establishing the connection when performing
+	// the tls handshake
+	TLSHandshakeTimeout time.Duration `mapstructure:"tls_handshake_timeout"`
 }
 
 func (c *Config) validateConfig() error {

--- a/exporter/observiqexporter/config.go
+++ b/exporter/observiqexporter/config.go
@@ -32,20 +32,20 @@ type Config struct {
 	exporterhelper.TimeoutSettings `mapstructure:",squash"`
 	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
-	// TLS Settings for http client to use when sending logs to endpoint
+	// TLSSetting is the TLS settings for http client to use when sending logs to endpoint
 	TLSSetting configtls.TLSClientSetting `mapstructure:"tls,omitempty"`
-	// API key for authenticating with ingestion endpoint (required if no SecretKey)
+	// APIkey is the api key for authenticating with ingestion endpoint (required if no SecretKey)
 	APIKey string `mapstructure:"api_key"`
-	// Secret key for authenticating with the ingestion endpoint (required if no APIKey)
+	// SecretKey is the secret key for authenticating with the ingestion endpoint (required if no APIKey)
 	SecretKey string `mapstructure:"secret_key"`
-	// Endpoint URL; Defines the ingestion endpoint
+	// Endpoint is the url that defines the ingestion endpoint (default: "https://nozzle.app.observiq.com/v1/add")
 	Endpoint string `mapstructure:"endpoint"`
-	// ID that identifies this agent
+	// AgentID is the ID that identifies this agent (default: uuid based off os.HostName())
 	AgentID string `mapstructure:"agent_id"`
-	// Name that identifies this agent
+	// AgentName is the name identifies this agent (default: os.HostName())
 	AgentName string `mapstructure:"agent_name"`
 	// DialerTimeout is the amount of time to wait before aborting establishing the tcp connection when making
-	// an http request
+	// an http request (default: 10s)
 	DialerTimeout time.Duration `mapstructure:"dialer_timeout"`
 }
 

--- a/exporter/observiqexporter/config.go
+++ b/exporter/observiqexporter/config.go
@@ -47,9 +47,6 @@ type Config struct {
 	// DialerTimeout is the amount of time to wait before aborting establishing the tcp connection when making
 	// an http request
 	DialerTimeout time.Duration `mapstructure:"dialer_timeout"`
-	// TLSHandshakeTimeout is the amount of time to wait before aborting establishing the connection when performing
-	// the tls handshake
-	TLSHandshakeTimeout time.Duration `mapstructure:"tls_handshake_timeout"`
 }
 
 func (c *Config) validateConfig() error {

--- a/exporter/observiqexporter/config_test.go
+++ b/exporter/observiqexporter/config_test.go
@@ -128,10 +128,12 @@ func TestLoadConfig(t *testing.T) {
 		APIKey:           "11111111-2222-3333-4444-555555555555",
 		Endpoint:         "https://sometest.endpoint",
 		TimeoutSettings: exporterhelper.TimeoutSettings{
-			Timeout: 10 * time.Second,
+			Timeout: 100 * time.Second,
 		},
-		AgentID:   "08e097a6-8580-43f6-b4f5-9d3b4eb2d962",
-		AgentName: "otel-collector-1",
+		DialerTimeout:       30 * time.Second,
+		TLSHandshakeTimeout: 40 * time.Second,
+		AgentID:             "08e097a6-8580-43f6-b4f5-9d3b4eb2d962",
+		AgentName:           "otel-collector-1",
 		TLSSetting: configtls.TLSClientSetting{
 			TLSSetting: configtls.TLSSetting{
 				CAFile:   "",

--- a/exporter/observiqexporter/config_test.go
+++ b/exporter/observiqexporter/config_test.go
@@ -130,10 +130,9 @@ func TestLoadConfig(t *testing.T) {
 		TimeoutSettings: exporterhelper.TimeoutSettings{
 			Timeout: 100 * time.Second,
 		},
-		DialerTimeout:       30 * time.Second,
-		TLSHandshakeTimeout: 40 * time.Second,
-		AgentID:             "08e097a6-8580-43f6-b4f5-9d3b4eb2d962",
-		AgentName:           "otel-collector-1",
+		DialerTimeout: 30 * time.Second,
+		AgentID:       "08e097a6-8580-43f6-b4f5-9d3b4eb2d962",
+		AgentName:     "otel-collector-1",
 		TLSSetting: configtls.TLSClientSetting{
 			TLSSetting: configtls.TLSSetting{
 				CAFile:   "",

--- a/exporter/observiqexporter/factory.go
+++ b/exporter/observiqexporter/factory.go
@@ -25,11 +25,10 @@ import (
 )
 
 const (
-	typeStr                    = "observiq"
-	defaultHTTPTimeout         = 20 * time.Second
-	defaultEndpoint            = "https://nozzle.app.observiq.com/v1/add"
-	defaultTLSHandshakeTimeout = 10 * time.Second
-	defaultDialerTimeout       = 10 * time.Second
+	typeStr              = "observiq"
+	defaultHTTPTimeout   = 20 * time.Second
+	defaultEndpoint      = "https://nozzle.app.observiq.com/v1/add"
+	defaultDialerTimeout = 10 * time.Second
 )
 
 // NewFactory creates a factory for observIQ exporter
@@ -48,12 +47,11 @@ func createDefaultConfig() config.Exporter {
 		TimeoutSettings: exporterhelper.TimeoutSettings{
 			Timeout: defaultHTTPTimeout,
 		},
-		RetrySettings:       exporterhelper.DefaultRetrySettings(),
-		QueueSettings:       exporterhelper.DefaultQueueSettings(),
-		AgentID:             defaultAgentID(),
-		AgentName:           defaultAgentName(),
-		DialerTimeout:       defaultDialerTimeout,
-		TLSHandshakeTimeout: defaultTLSHandshakeTimeout,
+		RetrySettings: exporterhelper.DefaultRetrySettings(),
+		QueueSettings: exporterhelper.DefaultQueueSettings(),
+		AgentID:       defaultAgentID(),
+		AgentName:     defaultAgentName(),
+		DialerTimeout: defaultDialerTimeout,
 	}
 }
 

--- a/exporter/observiqexporter/factory.go
+++ b/exporter/observiqexporter/factory.go
@@ -25,9 +25,11 @@ import (
 )
 
 const (
-	typeStr            = "observiq"
-	defaultHTTPTimeout = 10 * time.Second
-	defaultEndpoint    = "https://nozzle.app.observiq.com/v1/add"
+	typeStr                    = "observiq"
+	defaultHTTPTimeout         = 20 * time.Second
+	defaultEndpoint            = "https://nozzle.app.observiq.com/v1/add"
+	defaultTLSHandshakeTimeout = 10 * time.Second
+	defaultDialerTimeout       = 10 * time.Second
 )
 
 // NewFactory creates a factory for observIQ exporter
@@ -46,10 +48,12 @@ func createDefaultConfig() config.Exporter {
 		TimeoutSettings: exporterhelper.TimeoutSettings{
 			Timeout: defaultHTTPTimeout,
 		},
-		RetrySettings: exporterhelper.DefaultRetrySettings(),
-		QueueSettings: exporterhelper.DefaultQueueSettings(),
-		AgentID:       defaultAgentID(),
-		AgentName:     defaultAgentName(),
+		RetrySettings:       exporterhelper.DefaultRetrySettings(),
+		QueueSettings:       exporterhelper.DefaultQueueSettings(),
+		AgentID:             defaultAgentID(),
+		AgentName:           defaultAgentName(),
+		DialerTimeout:       defaultDialerTimeout,
+		TLSHandshakeTimeout: defaultTLSHandshakeTimeout,
 	}
 }
 

--- a/exporter/observiqexporter/testdata/config.yaml
+++ b/exporter/observiqexporter/testdata/config.yaml
@@ -14,7 +14,6 @@ exporters:
     agent_id: "08e097a6-8580-43f6-b4f5-9d3b4eb2d962"
     agent_name: "otel-collector-1"
     dialer_timeout: 30s
-    tls_handshake_timeout: 40s
     tls:
       ca_file: ""
       cert_file: ""

--- a/exporter/observiqexporter/testdata/config.yaml
+++ b/exporter/observiqexporter/testdata/config.yaml
@@ -10,9 +10,11 @@ exporters:
   observiq/customname:
     api_key: "11111111-2222-3333-4444-555555555555"
     endpoint: "https://sometest.endpoint"
-    timeout: 10s
+    timeout: 100s
     agent_id: "08e097a6-8580-43f6-b4f5-9d3b4eb2d962"
     agent_name: "otel-collector-1"
+    dialer_timeout: 30s
+    tls_handshake_timeout: 40s
     tls:
       ca_file: ""
       cert_file: ""


### PR DESCRIPTION
**Description:** <Describe what has changed.>
* Added in configuration options for some more specific timeouts (dialer & TLS handshake timeouts). This allows finer-grained control of request timeouts, in general.
* Bumped default timeout for overall request from 10 seconds to 20 seconds 
* Modified some comments on the config; They aren't really "optional" in the programmatic API, only for a file-based configuration.

**Link to tracking Issue:** N/A

**Testing:** 
* Unit tests for configuration parsing modified to test new configuration values

**Documentation:** 
* Added/updated README documentation for defaults and new config options.