### PR TITLE
[WIP] zipkinreceiver: Fix span status translation

### DIFF
--- a/pkg/translator/zipkin/zipkinv2/from_translator_test.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator_test.go
@@ -169,7 +169,7 @@ func zipkinOneSpan() *zipkinmodel.SpanModel {
 		},
 		Tags: map[string]string{
 			"resource-attr":                   "resource-attr-val-1",
-			conventions.OtelStatusCode:        "STATUS_CODE_ERROR",
+			conventions.OtelStatusCode:        "ERROR",
 			conventions.OtelStatusDescription: "status-cancelled",
 		},
 		Name:      "operationA",

--- a/pkg/translator/zipkin/zipkinv2/to_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/to_translator.go
@@ -472,7 +472,7 @@ func unmarshalJSON(dst []byte, src []byte) error {
 
 // TODO: Find a way to avoid this duplicate code. Consider to expose this in model/pdata.
 var statusCodeValue = map[string]int32{
-	"STATUS_CODE_UNSET": 0,
-	"STATUS_CODE_OK":    1,
-	"STATUS_CODE_ERROR": 2,
+	"UNSET": 0,
+	"OK":    1,
+	"ERROR": 2,
 }

--- a/receiver/zipkinreceiver/testdata/sample3.json
+++ b/receiver/zipkinreceiver/testdata/sample3.json
@@ -1,0 +1,35 @@
+[
+  {
+    "traceId": "4d1e00c0db9010db86154a4ba6e91385",
+    "parentId": "86154a4ba6e91385",
+    "id": "4d1e00c0db9010db",
+    "kind": "CLIENT",
+    "name": "get",
+    "timestamp": 1472470996199000,
+    "duration": 207000,
+    "localEndpoint": {
+      "ipv6": "7::0.128.128.127"
+    },
+    "remoteEndpoint": {
+      "serviceName": "backend",
+      "ipv4": "192.168.99.101",
+      "port": 9000
+    },
+    "annotations": [
+      {
+        "timestamp": 1472470996238000,
+        "value": "foo"
+      },
+      {
+        "timestamp": 1472470996403000,
+        "value": "bar"
+      }
+    ],
+    "tags": {
+      "http.path": "/api",
+      "clnt/finagle.version": "6.45.0",
+      "otel.status_code": "ERROR",
+      "otel.status_description": "Something failed"
+    }
+  }
+]


### PR DESCRIPTION
**Description:** Fix the span status code translation according to spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/non-otlp.md#span-status

Currently, it maps only `STATUS_CODE_OK` and `STATUS_CODE_ERROR` values of `otel.status_code` attribute which is not correct. It should map `OK` and `ERROR` values instead.

WIP:

```
--- FAIL: TestInternalTracesToZipkinSpans (0.00s)
    --- FAIL: TestInternalTracesToZipkinSpans/oneSpan (0.00s)
        from_translator_test.go:81: 
                Error Trace:    from_translator_test.go:81
                Error:          Not equal: 
                                expected: []*model.SpanModel{(*model.SpanModel)(0xc0000fa300)}
                                actual  : []*model.SpanModel{(*model.SpanModel)(0xc0000fa480)}
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -50,3 +50,3 @@
                                   Tags: (map[string]string) (len=3) {
                                -   (string) (len=16) "otel.status_code": (string) (len=5) "ERROR",
                                +   (string) (len=16) "otel.status_code": (string) (len=17) "STATUS_CODE_ERROR",
                                    (string) (len=23) "otel.status_description": (string) (len=16) "status-cancelled",
                Test:           TestInternalTracesToZipkinSpans/oneSpan
--- FAIL: TestProtobufMarshalUnmarshal (0.00s)
    protobuf_test.go:32: 
                Error Trace:    protobuf_test.go:32
                Error:          Not equal: 
                                expected: pdata.Traces{orig:(*v1.ExportTraceServiceRequest)(0xc0017c2378)}
                                actual  : pdata.Traces{orig:(*v1.ExportTraceServiceRequest)(0xc0017c2348)}
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -43,5 +43,5 @@
                                         Status: (v1.Status) {
                                -         DeprecatedCode: (v1.Status_DeprecatedStatusCode) 2,
                                +         DeprecatedCode: (v1.Status_DeprecatedStatusCode) 0,
                                          Message: (string) "",
                                -         Code: (v1.Status_StatusCode) 2
                                +         Code: (v1.Status_StatusCode) 0
                                         }
                Test:           TestProtobufMarshalUnmarshal
```

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>