### PR TITLE
Added support of Bearer Auth for HTTP Exporters

### DIFF
--- a/extension/bearertokenauthextension/README.md
+++ b/extension/bearertokenauthextension/README.md
@@ -36,11 +36,16 @@ exporters:
     auth:
       authenticator: bearertokenauth
 
+  otlphttp/withauth:
+    endpoint: http://localhost:9000
+    auth:
+      authenticator: bearertokenauth
+
 service:
   extensions: [bearertokenauth]
   pipelines:
     metrics:
       receivers: [hostmetrics]
       processors: []
-      exporters: [otlp/withauth]
+      exporters: [otlp/withauth, otlphttp/withauth]
 ```

--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -81,22 +81,23 @@ func (b *BearerTokenAuth) bearerToken() string {
 // RoundTripper is not implemented by BearerTokenAuth
 func (b *BearerTokenAuth) RoundTripper(base http.RoundTripper) (http.RoundTripper, error) {
 	return &BearerAuthRoundTripper{
-		transport:   base,
-		bearerToken: b.bearerToken(),
+		baseTransport: base,
+		bearerToken:   b.bearerToken(),
 	}, nil
 }
 
 // BearerAuthRoundTripper intercepts and adds Bearer token Authorization headers to each http request.
 type BearerAuthRoundTripper struct {
-	transport   http.RoundTripper
-	bearerToken string
+	baseTransport http.RoundTripper
+	bearerToken   string
 }
 
 // RoundTrip modifies the original request and adds Bearer token Authorization headers.
 func (interceptor *BearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.Header == nil {
-		req.Header = map[string][]string{}
+	req2 := req.Clone(req.Context())
+	if req2.Header == nil {
+		req2.Header = make(http.Header)
 	}
-	req.Header.Set("Authorization", interceptor.bearerToken)
-	return interceptor.transport.RoundTrip(req)
+	req2.Header.Set("Authorization", interceptor.bearerToken)
+	return interceptor.baseTransport.RoundTrip(req2)
 }

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -17,6 +17,7 @@ package bearertokenauthextension
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +40,35 @@ func TestPerRPCAuth(t *testing.T) {
 	assert.True(t, ok)
 }
 
+type mockRoundTripper struct{}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp := &http.Response{StatusCode: http.StatusOK, Header: map[string][]string{}}
+	for k, v := range req.Header {
+		resp.Header.Set(k, v[0])
+	}
+	return resp, nil
+}
+
+func TestBearerAuthenticatorHttp(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.BearerToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+
+	bauth := newBearerTokenAuth(cfg, nil)
+	assert.NotNil(t, bauth)
+
+	base := &mockRoundTripper{}
+	c, err := bauth.RoundTripper(base)
+	assert.NoError(t, err)
+	assert.NotNil(t, c)
+
+	request := &http.Request{Method: "Get"}
+	resp, err := c.RoundTrip(request)
+	assert.NoError(t, err)
+	authHeaderValue := resp.Header.Get("Authorization")
+	assert.Equal(t, authHeaderValue, fmt.Sprintf("Bearer %s", cfg.BearerToken))
+}
+
 func TestBearerAuthenticator(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.BearerToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
@@ -52,17 +82,25 @@ func TestBearerAuthenticator(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, credential)
 
-	c, err := bauth.RoundTripper(nil)
-	assert.ErrorIs(t, err, errNotHTTPClientAuthenticator)
-	assert.Nil(t, c)
-
 	md, err := credential.GetRequestMetadata(context.Background())
 	expectedMd := map[string]string{
 		"authorization": fmt.Sprintf("Bearer %s", cfg.BearerToken),
 	}
 	assert.Equal(t, md, expectedMd)
 	assert.NoError(t, err)
-
 	assert.True(t, credential.RequireTransportSecurity())
+
+	roundTripper, _ := bauth.RoundTripper(&mockRoundTripper{})
+	orgHeaders := map[string][]string{
+		"foo": {"bar"},
+	}
+	expectedHeaders := map[string][]string{
+		"foo":           {"bar"},
+		"Authorization": {bauth.bearerToken()},
+	}
+
+	resp, err := roundTripper.RoundTrip(&http.Request{Header: orgHeaders})
+	assert.NoError(t, err)
+	assert.Equal(t, resp.Header, expectedHeaders)
 	assert.Nil(t, bauth.Shutdown(context.Background()))
 }

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -91,16 +91,16 @@ func TestBearerAuthenticator(t *testing.T) {
 	assert.True(t, credential.RequireTransportSecurity())
 
 	roundTripper, _ := bauth.RoundTripper(&mockRoundTripper{})
-	orgHeaders := map[string][]string{
-		"foo": {"bar"},
+	orgHeaders := http.Header{
+		"Foo": {"bar"},
 	}
-	expectedHeaders := map[string][]string{
-		"foo":           {"bar"},
+	expectedHeaders := http.Header{
+		"Foo":           {"bar"},
 		"Authorization": {bauth.bearerToken()},
 	}
 
 	resp, err := roundTripper.RoundTrip(&http.Request{Header: orgHeaders})
 	assert.NoError(t, err)
-	assert.Equal(t, resp.Header, expectedHeaders)
+	assert.Equal(t, expectedHeaders, resp.Header)
 	assert.Nil(t, bauth.Shutdown(context.Background()))
 }


### PR DESCRIPTION
Current implementation for Bearer token auth only supports gRPC clients. This implementation enables the functionality for HTTP clients as well.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5927

**Testing:** :  Unit tests and verfied on the mock server Auth headers were set properly. 

**Documentation:**  Updated README.md with new path as well. 