### PR TITLE
[exporter/datadogexporter] Always add current hostname

### DIFF
--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -164,6 +164,7 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pdata.Metric
 	}
 
 	consumer := metrics.NewConsumer()
+	consumer.ConsumeHost(metadata.GetHost(exp.params.Logger, exp.cfg))
 	pushTime := uint64(time.Now().UTC().UnixNano())
 	err := exp.tr.MapMetrics(ctx, md, consumer)
 	if err != nil {

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -81,6 +81,7 @@ func convertToDatadogTd(td pdata.Traces, fallbackHost string, cfg *config.Config
 	var traces []*pb.TracePayload
 
 	seenHosts := make(map[string]struct{})
+	seenHosts[fallbackHost] = struct{}{}
 	var series []datadog.Metric
 	pushTime := pdata.NewTimestampFromTime(time.Now())
 

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -156,7 +156,7 @@ func TestConvertToDatadogTdNoResourceSpans(t *testing.T) {
 	outputTraces, runningMetrics := convertToDatadogTd(traces, "test-host", &config.Config{}, denylister, buildInfo)
 
 	assert.Equal(t, 0, len(outputTraces))
-	assert.Equal(t, 0, len(runningMetrics))
+	assert.Equal(t, 1, len(runningMetrics))
 }
 
 func TestRunningTraces(t *testing.T) {


### PR DESCRIPTION
**Description:** 

Always add current host hostname to the running metrics.
This is helpful in multi Collector setups, where, until now, the 'last' Collector was ignored.
