### PR TITLE
[build] change workflow to prioritize unittest, integration-tests, lint

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -269,7 +269,7 @@ jobs:
 
   cross-compile:
     runs-on: ubuntu-latest
-    needs: [setup-environment]
+    needs: [unittest, integration-tests, lint]
     strategy:
       matrix:
         binary:


### PR DESCRIPTION
This changes the build workflow to only run cross compile once the other jobs have succeeded.