### PR TITLE
Add @pavankrish123 as codeowner for bearertokenauthextension and oauth2clientauthextension

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,8 @@ exporter/influxdbexporter/                           @open-telemetry/collector-c
 extension/awsproxy/                                  @open-telemetry/collector-contrib-approvers @anuraaga @Aneurysm9 @mxiamxia
 extension/httpforwarder/                             @open-telemetry/collector-contrib-approvers @asuresh4
 extension/observer/                                  @open-telemetry/collector-contrib-approvers @asuresh4 @jrcamp
+extension/bearertokenauthextension/                  @open-telemetry/collector-contrib-approvers @pavankrish123
+extension/oauth2clientauthextension/                 @open-telemetry/collector-contrib-approvers @pavankrish123
 
 internal/aws/                                        @open-telemetry/collector-contrib-approvers @anuraaga @mxiamxia
 internal/docker/                                     @open-telemetry/collector-contrib-approvers @mstumpfx @rmfitzpatrick

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,7 +48,7 @@ exporter/influxdbexporter/                           @open-telemetry/collector-c
 extension/awsproxy/                                  @open-telemetry/collector-contrib-approvers @anuraaga @Aneurysm9 @mxiamxia
 extension/httpforwarder/                             @open-telemetry/collector-contrib-approvers @asuresh4
 extension/observer/                                  @open-telemetry/collector-contrib-approvers @asuresh4 @jrcamp
-extension/bearertokenauthextension/                  @open-telemetry/collector-contrib-approvers @pavankrish123
+extension/bearertokenauthextension/                  @open-telemetry/collector-contrib-approvers @jpkrohling @pavankrish123
 extension/oauth2clientauthextension/                 @open-telemetry/collector-contrib-approvers @pavankrish123
 
 internal/aws/                                        @open-telemetry/collector-contrib-approvers @anuraaga @mxiamxia


### PR DESCRIPTION
PR for #5985

Hello, 

Can I be added to the codeowners list for `extensions/bearertokenauthextension` and `extensions/oauth2clientextension` please.

1.  I have authored oauth2clientextension and have helped refactor bearertokenauth.
2. I have also authored the client side auth framework to the core.  


Thanks, 
Pavan

cc: @jpkrohling