### PR TITLE
Update google cloud exporter to correctly close the metric exporter

### DIFF
--- a/exporter/googlecloudexporter/googlecloud.go
+++ b/exporter/googlecloudexporter/googlecloud.go
@@ -53,7 +53,7 @@ func (te *traceExporter) Shutdown(ctx context.Context) error {
 func (me *metricsExporter) Shutdown(context.Context) error {
 	me.mexporter.Flush()
 	me.mexporter.StopMetricsExporter()
-	return nil
+	return me.mexporter.Close()
 }
 
 func setVersionInUserAgent(cfg *Config, version string) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This closes the grpc client connections used by the googlecloud exporter when it is shutdown.  This avoids memory leaks if the googlecloud exporter component is re-built.

**Testing:** <Describe what testing was performed and which tests were added.>
I implemented the [config.WatchableRetrieved](https://github.com/open-telemetry/opentelemetry-collector/blob/e168df568418e1f8e4eb47fdac4c6dfad0c4a7bc/config/provider.go#L43) interface, and repeatedly changed the configuration.  Prior to this change, this would leak resources and OOM.  With this change, it no longer leaks memory.

~This requires updating the opencensus stackdriver exporter dependency to pick up https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/pull/295, which allows closing the grpc connections through the Close() method.~ Dependabot beat me to the punch.