### PR TITLE
[build] example for thrift exporter was using invalid config

### DIFF
--- a/examples/tracing/otel-collector-config.yml
+++ b/examples/tracing/otel-collector-config.yml
@@ -6,7 +6,7 @@ receivers:
 
 exporters:
   jaeger_thrift:
-    url: "http://jaeger:14268/api/traces"
+    endpoint: "http://jaeger:14268/api/traces"
   logging:
   zipkin:
     endpoint: "http://zipkin:9411/api/v2/spans"


### PR DESCRIPTION
This was causing the fpm/deb/msi build targets to fail because examples/tracing/otel-collector-config.yml is used the rpm/deb build https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/050ccc1a723abba703864617d839ebd19cb00f45/.github/workflows/build-and-test.yml#L289.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6092