### PR TITLE
CICD: Ensure parent directories are created for Prometheus Compliance

### DIFF
--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -46,7 +46,7 @@ jobs:
           path: compliance
           ref: bc7dd4cb6e88e60b702023c199140281c4dce906
       - name: Copy binary to compliance directory
-        run: mkdir compliance/remote_write_sender/bin && cp ./bin/otelcontribcol_linux_amd64 compliance/remote_write_sender/bin/otelcol_linux_amd64
+        run: mkdir -p compliance/remote_write_sender/bin && cp ./bin/otelcontribcol_linux_amd64 compliance/remote_write_sender/bin/otelcol_linux_amd64
       - name: Run compliance tests
         run: go test --tags=compliance -run "TestRemoteWrite/otel/.+" -v ./
         working-directory: compliance/remote_write_sender


### PR DESCRIPTION
Noticed a few times that the CI was complaining that the directory it had expected wasn't there so I believe this should resolve the issue and help unblock a few of the PRs that are currently blocked by this.