### PR TITLE
Remove promexample prefix

### DIFF
--- a/examples/demo/otel-collector-config.yaml
+++ b/examples/demo/otel-collector-config.yaml
@@ -6,7 +6,6 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
-    namespace: promexample
     const_labels:
       label1: value1
   logging:

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -8,25 +8,25 @@ Aggregates Request, Error and Duration (R.E.D) metrics from span data.
 **Request** counts are computed as the number of spans seen per unique set of dimensions, including Errors.
 For example, the following metric shows 142 calls:
 ```
-promexample_calls{http_method="GET",http_status_code="200",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET"} 142
+calls{http_method="GET",http_status_code="200",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET"} 142
 ```
 Multiple metrics can be aggregated if, for instance, a user wishes to view call counts just on `service_name` and `operation`.
 
 **Error** counts are computed from the Request counts which have an "Error" Status Code metric dimension.
 For example, the following metric indicates 220 errors:
 ```
-promexample_calls{http_method="GET",http_status_code="503",operation="/checkout",service_name="frontend",span_kind="SPAN_KIND_CLIENT",status_code="STATUS_CODE_ERROR"} 220
+calls{http_method="GET",http_status_code="503",operation="/checkout",service_name="frontend",span_kind="SPAN_KIND_CLIENT",status_code="STATUS_CODE_ERROR"} 220
 ```
 
 **Duration** is computed from the difference between the span start and end times and inserted into the
 relevant latency histogram time bucket for each unique set dimensions.
 For example, the following latency buckets indicate the vast majority of spans (9K) have a 100ms latency:
 ```
-promexample_latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="2"} 327
-promexample_latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="6"} 751
-promexample_latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="10"} 1195
-promexample_latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="100"} 10180
-promexample_latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="250"} 10180
+latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="2"} 327
+latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="6"} 751
+latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="10"} 1195
+latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="100"} 10180
+latency_bucket{http_method="GET",http_status_code="200",label1="value1",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET",le="250"} 10180
 ...
 ```
 
@@ -102,7 +102,6 @@ exporters:
 
   prometheus:
     endpoint: "0.0.0.0:8889"
-    namespace: promexample
 
 service:
   pipelines:

--- a/processor/spanmetricsprocessor/testdata/config-2-pipelines.yaml
+++ b/processor/spanmetricsprocessor/testdata/config-2-pipelines.yaml
@@ -17,7 +17,6 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
-    namespace: promexample
 
   jaeger:
     endpoint: "localhost:14250"

--- a/processor/spanmetricsprocessor/testdata/config-3-pipelines.yaml
+++ b/processor/spanmetricsprocessor/testdata/config-3-pipelines.yaml
@@ -25,7 +25,6 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
-    namespace: promexample
 
   jaeger:
     endpoint: "localhost:14250"

--- a/processor/spanmetricsprocessor/testdata/config-exporter-not-found.yaml
+++ b/processor/spanmetricsprocessor/testdata/config-exporter-not-found.yaml
@@ -15,7 +15,6 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
-    namespace: promexample
 
   jaeger:
     endpoint: "localhost:14250"

--- a/processor/spanmetricsprocessor/testdata/config-full.yaml
+++ b/processor/spanmetricsprocessor/testdata/config-full.yaml
@@ -20,7 +20,6 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
-    namespace: promexample
 
   jaeger:
     endpoint: "localhost:14250"
@@ -48,15 +47,15 @@ processors:
       # If the span is missing http.method, the processor will insert
       # the http.method dimension with value 'GET'.
       # For example, in the following scenario, http.method is not present in a span and so will be added as a dimension to the metric with value "GET":
-      # - promexample_calls{http_method="GET",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET"} 1
+      # - calls{http_method="GET",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET"} 1
       - name: http.method
         default: GET
 
       # If a default is not provided, the http.status_code dimension will be omitted
       # if the span does not contain http.status_code.
       # For example, consider a scenario with two spans, one span having http.status_code=200 and another missing http.status_code. Two metrics would result with this configuration, one with the http_status_code omitted and the other included:
-      # - promexample_calls{http_status_code="200",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET"} 1
-      # - promexample_calls{operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET"} 1
+      # - calls{http_status_code="200",operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET"} 1
+      # - calls{operation="/Address",service_name="shippingservice",span_kind="SPAN_KIND_SERVER",status_code="STATUS_CODE_UNSET"} 1
       - name: http.status_code
 
 service:

--- a/processor/spanmetricsprocessor/testdata/config-simplest.yaml
+++ b/processor/spanmetricsprocessor/testdata/config-simplest.yaml
@@ -15,7 +15,6 @@ receivers:
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
-    namespace: promexample
 
   jaeger:
     endpoint: "localhost:14250"


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

**Description:** 
Removes the `promexample` namespace from config which is an unnecessary distraction from the spanmetrics processor. 

Moreover, Jaeger reads from metrics produced by spanmetrics processor and, currently, does not expect a metric namespace.

**Documentation:** 
Updated relevant config examples and README.