### PR TITLE
Use Go 1.17 on CodeQL action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,9 +13,9 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v2.1.4
         with:
-          go-version: 1.17.2
+          go-version: 1.17
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
**Description:** 

CodeQL is consistently failing since it was added to the main branch at #5956; the reason being that the `go` version available in Github runners does not understand `retract` directives in go.mod files.

This should fix it by forcing to install Go 1.17.2.

Fixes #6118 