### PR TITLE
[exporter/datadogexporter] Improve reset detection on cumulative metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 🧰 Bug fixes 🧰
+
+- `datadogexporter` improve cumulative metrics reset detection using `StartTimestamp` (#6120)
+
 ## v0.38.0
 
 ## 🛑 Breaking changes 🛑

--- a/exporter/datadogexporter/internal/translator/metrics_translator.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator.go
@@ -141,6 +141,7 @@ func (t *Translator) mapNumberMonotonicMetrics(
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
 		ts := uint64(p.Timestamp())
+		startTs := uint64(p.StartTimestamp())
 		tags := getTags(p.Attributes())
 		tags = append(tags, additionalTags...)
 
@@ -156,7 +157,7 @@ func (t *Translator) mapNumberMonotonicMetrics(
 			continue
 		}
 
-		if dx, ok := t.prevPts.putAndGetDiff(name, tags, ts, val); ok {
+		if dx, ok := t.prevPts.MonotonicDiff(name, tags, startTs, ts, val); ok {
 			consumer.ConsumeTimeSeries(ctx, name, Count, ts, dx, tags, host)
 		}
 	}
@@ -179,6 +180,7 @@ func (t *Translator) getSketchBuckets(
 	ctx context.Context,
 	consumer SketchConsumer,
 	name string,
+	startTs,
 	ts uint64,
 	p pdata.HistogramDataPoint,
 	delta bool,
@@ -210,7 +212,7 @@ func (t *Translator) getSketchBuckets(
 		count := p.BucketCounts()[j]
 		if delta {
 			as.InsertInterpolate(lowerBound, upperBound, uint(count))
-		} else if dx, ok := t.prevPts.putAndGetDiff(name, bucketTags, ts, float64(count)); ok {
+		} else if dx, ok := t.prevPts.Diff(name, bucketTags, startTs, ts, float64(count)); ok {
 			as.InsertInterpolate(lowerBound, upperBound, uint(dx))
 		}
 
@@ -243,10 +245,11 @@ func (t *Translator) getLegacyBuckets(
 		bucketTags = append(bucketTags, tags...)
 
 		count := float64(val)
+		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
 		if delta {
 			consumer.ConsumeTimeSeries(ctx, fullName, Count, ts, count, bucketTags, host)
-		} else if dx, ok := t.prevPts.putAndGetDiff(fullName, bucketTags, ts, count); ok {
+		} else if dx, ok := t.prevPts.Diff(fullName, bucketTags, startTs, ts, count); ok {
 			consumer.ConsumeTimeSeries(ctx, fullName, Count, ts, dx, bucketTags, host)
 		}
 	}
@@ -276,6 +279,7 @@ func (t *Translator) mapHistogramMetrics(
 ) {
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
+		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
 		tags := getTags(p.Attributes())
 		tags = append(tags, additionalTags...)
@@ -285,7 +289,7 @@ func (t *Translator) mapHistogramMetrics(
 			countName := fmt.Sprintf("%s.count", name)
 			if delta {
 				consumer.ConsumeTimeSeries(ctx, countName, Count, ts, count, tags, host)
-			} else if dx, ok := t.prevPts.putAndGetDiff(countName, tags, ts, count); ok {
+			} else if dx, ok := t.prevPts.Diff(countName, tags, startTs, ts, count); ok {
 				consumer.ConsumeTimeSeries(ctx, countName, Count, ts, dx, tags, host)
 			}
 		}
@@ -296,7 +300,7 @@ func (t *Translator) mapHistogramMetrics(
 			if !t.isSkippable(sumName, p.Sum()) {
 				if delta {
 					consumer.ConsumeTimeSeries(ctx, sumName, Count, ts, sum, tags, host)
-				} else if dx, ok := t.prevPts.putAndGetDiff(sumName, tags, ts, sum); ok {
+				} else if dx, ok := t.prevPts.Diff(sumName, tags, startTs, ts, sum); ok {
 					consumer.ConsumeTimeSeries(ctx, sumName, Count, ts, dx, tags, host)
 				}
 			}
@@ -306,7 +310,7 @@ func (t *Translator) mapHistogramMetrics(
 		case HistogramModeCounters:
 			t.getLegacyBuckets(ctx, consumer, name, p, delta, tags, host)
 		case HistogramModeDistributions:
-			t.getSketchBuckets(ctx, consumer, name, ts, p, delta, tags, host)
+			t.getSketchBuckets(ctx, consumer, name, startTs, ts, p, delta, tags, host)
 		}
 	}
 }
@@ -350,6 +354,7 @@ func (t *Translator) mapSummaryMetrics(
 
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
+		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
 		tags := getTags(p.Attributes())
 		tags = append(tags, additionalTags...)
@@ -357,7 +362,7 @@ func (t *Translator) mapSummaryMetrics(
 		// count and sum are increasing; we treat them as cumulative monotonic sums.
 		{
 			countName := fmt.Sprintf("%s.count", name)
-			if dx, ok := t.prevPts.putAndGetDiff(countName, tags, ts, float64(p.Count())); ok && !t.isSkippable(countName, dx) {
+			if dx, ok := t.prevPts.Diff(countName, tags, startTs, ts, float64(p.Count())); ok && !t.isSkippable(countName, dx) {
 				consumer.ConsumeTimeSeries(ctx, countName, Count, ts, dx, tags, host)
 			}
 		}
@@ -365,7 +370,7 @@ func (t *Translator) mapSummaryMetrics(
 		{
 			sumName := fmt.Sprintf("%s.sum", name)
 			if !t.isSkippable(sumName, p.Sum()) {
-				if dx, ok := t.prevPts.putAndGetDiff(sumName, tags, ts, p.Sum()); ok {
+				if dx, ok := t.prevPts.Diff(sumName, tags, startTs, ts, p.Sum()); ok {
 					consumer.ConsumeTimeSeries(ctx, sumName, Count, ts, dx, tags, host)
 				}
 			}

--- a/exporter/datadogexporter/internal/translator/metrics_translator_test.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator_test.go
@@ -865,8 +865,8 @@ func TestMapSummaryMetrics(t *testing.T) {
 
 	newTranslator := func(tags []string, quantiles bool) *Translator {
 		c := newTestCache()
-		c.cache.Set(c.metricDimensionsToMapKey("summary.example.count", tags), numberCounter{0, 1}, gocache.NoExpiration)
-		c.cache.Set(c.metricDimensionsToMapKey("summary.example.sum", tags), numberCounter{0, 1}, gocache.NoExpiration)
+		c.cache.Set(c.metricDimensionsToMapKey("summary.example.count", tags), numberCounter{0, 0, 1}, gocache.NoExpiration)
+		c.cache.Set(c.metricDimensionsToMapKey("summary.example.sum", tags), numberCounter{0, 0, 1}, gocache.NoExpiration)
 		options := []Option{WithFallbackHostnameProvider(testProvider("fallbackHostname"))}
 		if quantiles {
 			options = append(options, WithQuantiles())

--- a/exporter/datadogexporter/internal/translator/sketches_test.go
+++ b/exporter/datadogexporter/internal/translator/sketches_test.go
@@ -111,7 +111,7 @@ func TestHistogramSketches(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			p := fromCDF(test.cdf)
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, "test", 0, p, true, []string{}, "")
+			tr.getSketchBuckets(ctx, consumer, "test", 0, 0, p, true, []string{}, "")
 			sk := consumer.sk
 
 			// Check the minimum is 0.0
@@ -203,7 +203,7 @@ func TestInfiniteBounds(t *testing.T) {
 		t.Run(testInstance.name, func(t *testing.T) {
 			p := testInstance.getHist()
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, "test", 0, p, true, []string{}, "")
+			tr.getSketchBuckets(ctx, consumer, "test", 0, 0, p, true, []string{}, "")
 			sk := consumer.sk
 			assert.InDelta(t, sk.Basic.Sum, p.Sum(), 1)
 			assert.Equal(t, uint64(sk.Basic.Cnt), p.Count())

--- a/exporter/datadogexporter/internal/translator/sketches_test.go
+++ b/exporter/datadogexporter/internal/translator/sketches_test.go
@@ -111,7 +111,7 @@ func TestHistogramSketches(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			p := fromCDF(test.cdf)
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, "test", 0, 0, p, true, []string{}, "")
+			tr.getSketchBuckets(ctx, consumer, "test", p, true, []string{}, "")
 			sk := consumer.sk
 
 			// Check the minimum is 0.0
@@ -203,7 +203,7 @@ func TestInfiniteBounds(t *testing.T) {
 		t.Run(testInstance.name, func(t *testing.T) {
 			p := testInstance.getHist()
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, "test", 0, 0, p, true, []string{}, "")
+			tr.getSketchBuckets(ctx, consumer, "test", p, true, []string{}, "")
 			sk := consumer.sk
 			assert.InDelta(t, sk.Basic.Sum, p.Sum(), 1)
 			assert.Equal(t, uint64(sk.Basic.Cnt), p.Count())

--- a/exporter/datadogexporter/internal/translator/ttlcache.go
+++ b/exporter/datadogexporter/internal/translator/ttlcache.go
@@ -33,8 +33,9 @@ type ttlCache struct {
 // numberCounter keeps the value of a number
 // monotonic counter at a given point in time
 type numberCounter struct {
-	ts    uint64
-	value float64
+	ts      uint64
+	startTs uint64
+	value   float64
 }
 
 func newTTLCache(sweepInterval int64, deltaTTL int64) *ttlCache {
@@ -67,9 +68,27 @@ func (*ttlCache) metricDimensionsToMapKey(name string, tags []string) string {
 	return metricKeyBuilder.String()
 }
 
+// Diff submits a new value for a given non-monotonic metric and returns the difference with the
+// last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
+func (t *ttlCache) Diff(name string, tags []string, startTs, ts uint64, val float64) (float64, bool) {
+	return t.putAndGetDiff(name, tags, false, startTs, ts, val)
+}
+
+// MonotonicDiff submits a new value for a given monotonic metric and returns the difference with the
+// last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
+func (t *ttlCache) MonotonicDiff(name string, tags []string, startTs, ts uint64, val float64) (float64, bool) {
+	return t.putAndGetDiff(name, tags, true, startTs, ts, val)
+}
+
 // putAndGetDiff submits a new value for a given metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
-func (t *ttlCache) putAndGetDiff(name string, tags []string, ts uint64, val float64) (dx float64, ok bool) {
+func (t *ttlCache) putAndGetDiff(
+	name string,
+	tags []string,
+	monotonic bool,
+	startTs, ts uint64,
+	val float64,
+) (dx float64, ok bool) {
 	key := t.metricDimensionsToMapKey(name, tags)
 	if c, found := t.cache.Get(key); found {
 		cnt := c.(numberCounter)
@@ -78,12 +97,37 @@ func (t *ttlCache) putAndGetDiff(name string, tags []string, ts uint64, val floa
 			// We keep the existing point in memory since it is the most recent
 			return 0, false
 		}
-		// if dx < 0, we assume there was a reset, thus we save the point
-		// but don't export it (it's the first one so we can't do a delta)
 		dx = val - cnt.value
-		ok = dx >= 0
+
+		// Determine if this is the first point on a cumulative series:
+		// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/metrics/datamodel.md#resets-and-gaps
+		//
+		// This is written down as an 'if' because I feel it is easier to understand than with a boolean expression.
+		if startTs == 0 {
+			// We don't know the start time, assume the sequence has not been restarted.
+			ok = true
+		} else if startTs != ts && startTs == cnt.startTs {
+			// Since startTs != 0 we know the start time, thus we apply the following rules from the spec:
+			//  - "When StartTimeUnixNano equals TimeUnixNano, a new unbroken sequence of observations begins with a reset at an unknown start time."
+			//  - "[for cumulative series] the StartTimeUnixNano of each point matches the StartTimeUnixNano of the initial observation."
+			ok = true
+		}
+
+		// If sequence is monotonic and diff is negative, there has been a reset.
+		// This must never happen if we know the startTs; we also override the value in this case.
+		if monotonic && dx < 0 {
+			ok = false
+		}
 	}
 
-	t.cache.Set(key, numberCounter{ts, val}, gocache.DefaultExpiration)
+	t.cache.Set(
+		key,
+		numberCounter{
+			startTs: startTs,
+			ts:      ts,
+			value:   val,
+		},
+		gocache.DefaultExpiration,
+	)
 	return
 }

--- a/exporter/datadogexporter/internal/translator/ttlcache_test.go
+++ b/exporter/datadogexporter/internal/translator/ttlcache_test.go
@@ -24,21 +24,91 @@ func newTestCache() *ttlCache {
 	cache := newTTLCache(1800, 3600)
 	return cache
 }
-func TestPutAndGetDiff(t *testing.T) {
+
+func TestMonotonicDiffUnknownStart(t *testing.T) {
+	startTs := uint64(0) // equivalent to start being unset
 	prevPts := newTestCache()
-	_, ok := prevPts.putAndGetDiff("test", []string{}, 1, 5)
-	// no diff since it is the first point
-	assert.False(t, ok)
-	_, ok = prevPts.putAndGetDiff("test", []string{}, 0, 0)
-	// no diff since ts is lower than the stored point
-	assert.False(t, ok)
-	_, ok = prevPts.putAndGetDiff("test", []string{}, 2, 2)
-	// no diff since the value is lower than the stored value
-	assert.False(t, ok)
-	dx, ok := prevPts.putAndGetDiff("test", []string{}, 3, 4)
-	// diff with the most recent point (2,2)
-	assert.True(t, ok)
-	assert.Equal(t, 2.0, dx)
+	_, ok := prevPts.MonotonicDiff("test", []string{}, startTs, 1, 5)
+	assert.False(t, ok, "expected no diff: first point")
+	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 0, 0)
+	assert.False(t, ok, "expected no diff: old point")
+	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 2, 2)
+	assert.False(t, ok, "expected no diff: new < old")
+	dx, ok := prevPts.MonotonicDiff("test", []string{}, startTs, 3, 4)
+	assert.True(t, ok, "expected diff: no startTs, old >= new")
+	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
+}
+
+func TestDiffUnknownStart(t *testing.T) {
+	startTs := uint64(0) // equivalent to start being unset
+	prevPts := newTestCache()
+	_, ok := prevPts.Diff("test", []string{}, startTs, 1, 5)
+	assert.False(t, ok, "expected no diff: first point")
+	_, ok = prevPts.Diff("test", []string{}, startTs, 0, 0)
+	assert.False(t, ok, "expected no diff: old point")
+	dx, ok := prevPts.Diff("test", []string{}, startTs, 2, 2)
+	assert.True(t, ok, "expected diff: no startTs, not monotonic")
+	assert.Equal(t, -3.0, dx, "expected diff -3.0 with (0,1,5) value")
+	dx, ok = prevPts.Diff("test", []string{}, startTs, 3, 4)
+	assert.True(t, ok, "expected diff: no startTs, old >= new")
+	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
+}
+
+func TestMonotonicDiffKnownStart(t *testing.T) {
+	startTs := uint64(1)
+	prevPts := newTestCache()
+	_, ok := prevPts.MonotonicDiff("test", []string{}, startTs, 1, 5)
+	assert.False(t, ok, "expected no diff: first point")
+	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 0, 0)
+	assert.False(t, ok, "expected no diff: old point")
+	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 2, 2)
+	assert.False(t, ok, "expected no diff: new < old")
+	dx, ok := prevPts.MonotonicDiff("test", []string{}, startTs, 3, 4)
+	assert.True(t, ok, "expected diff: same startTs, old >= new")
+	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
+
+	startTs = uint64(4) // simulate reset
+	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 4, 8)
+	assert.False(t, ok, "expected no diff: reset with unknown start")
+	dx, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 5, 9)
+	assert.True(t, ok, "expected diff: same startTs, old >= new")
+	assert.Equal(t, 1.0, dx, "expected diff 1.0 with (4,4,8) value")
+
+	startTs = uint64(6)
+	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 7, 1)
+	assert.False(t, ok, "expected no diff: reset with known start")
+	dx, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 8, 10)
+	assert.True(t, ok, "expected diff: same startTs, old >= new")
+	assert.Equal(t, 9.0, dx, "expected diff 9.0 with (6,7,1) value")
+}
+
+func TestDiffKnownStart(t *testing.T) {
+	startTs := uint64(1)
+	prevPts := newTestCache()
+	_, ok := prevPts.Diff("test", []string{}, startTs, 1, 5)
+	assert.False(t, ok, "expected no diff: first point")
+	_, ok = prevPts.Diff("test", []string{}, startTs, 0, 0)
+	assert.False(t, ok, "expected no diff: old point")
+	dx, ok := prevPts.Diff("test", []string{}, startTs, 2, 2)
+	assert.True(t, ok, "expected diff: same startTs, not monotonic")
+	assert.Equal(t, -3.0, dx, "expected diff -3.0 with (1,1,5) point")
+	dx, ok = prevPts.Diff("test", []string{}, startTs, 3, 4)
+	assert.True(t, ok, "expected diff: same startTs, not monotonic")
+	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
+
+	startTs = uint64(4) // simulate reset
+	_, ok = prevPts.Diff("test", []string{}, startTs, 4, 8)
+	assert.False(t, ok, "expected no diff: reset with unknown start")
+	dx, ok = prevPts.Diff("test", []string{}, startTs, 5, 9)
+	assert.True(t, ok, "expected diff: same startTs, not monotonic")
+	assert.Equal(t, 1.0, dx, "expected diff 1.0 with (4,4,8) value")
+
+	startTs = uint64(6)
+	_, ok = prevPts.Diff("test", []string{}, startTs, 7, 1)
+	assert.False(t, ok, "expected no diff: reset with known start")
+	dx, ok = prevPts.Diff("test", []string{}, startTs, 8, 10)
+	assert.True(t, ok, "expected diff: same startTs, not monotonic")
+	assert.Equal(t, 9.0, dx, "expected diff 9.0 with (6,7,1) value")
 }
 
 func TestMetricDimensionsToMapKey(t *testing.T) {

--- a/exporter/datadogexporter/internal/translator/ttlcache_test.go
+++ b/exporter/datadogexporter/internal/translator/ttlcache_test.go
@@ -67,8 +67,8 @@ func TestMonotonicDiffKnownStart(t *testing.T) {
 	assert.True(t, ok, "expected diff: same startTs, old >= new")
 	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
 
-	startTs = uint64(4) // simulate reset
-	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 4, 8)
+	startTs = uint64(4) // simulate reset with startTs = ts
+	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, startTs, 8)
 	assert.False(t, ok, "expected no diff: reset with unknown start")
 	dx, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 5, 9)
 	assert.True(t, ok, "expected diff: same startTs, old >= new")
@@ -96,8 +96,8 @@ func TestDiffKnownStart(t *testing.T) {
 	assert.True(t, ok, "expected diff: same startTs, not monotonic")
 	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
 
-	startTs = uint64(4) // simulate reset
-	_, ok = prevPts.Diff("test", []string{}, startTs, 4, 8)
+	startTs = uint64(4) // simulate reset with startTs = ts
+	_, ok = prevPts.Diff("test", []string{}, startTs, startTs, 8)
 	assert.False(t, ok, "expected no diff: reset with unknown start")
 	dx, ok = prevPts.Diff("test", []string{}, startTs, 5, 9)
 	assert.True(t, ok, "expected diff: same startTs, not monotonic")


### PR DESCRIPTION
**Description:** 

The Datadog exporter automatically calculates the diff between points on cumulative monotonic sums, cumulative histograms and the fields of summaries that grow cumulatively. Until now we didn't take the start timestamp into account, so we were not detecting certain resets. We were also using monotonic diffs on non-monotonic metrics (e.g. histogram sum or count), which would omit negative values.

This PR updates the reset-detection code to conform to the "Resets and gaps" section of the data model specification.

Note that we don't report the first value we get, to account for Collector restarts.

**Link to tracking Issue:** Relates to #5378 discussion (this can avoid the `.sum` metric being 0 in certain cases)

**Testing:** Added unit tests to test new behavior
