### PR TITLE
[exporter/datadogexporter] Correct default value for `send_count_sum_metrics`

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -98,4 +98,4 @@ There are a number of optional settings for configuring how to send your metrics
 | `delta_ttl` | Maximum number of seconds values from cumulative monotonic metrics are kept in memory. | 3600 |
 | `report_quantiles` | Whether to report quantile values for summary type metrics. | `true` |
 | `histograms::mode` | Mode for histograms. Valid values are `nobuckets` (no bucket metrics), `counters` (one metric per bucket) and `distributions` (send as Datadog distributions, recommended). | `distributions` |
-| `histograms::send_count_sum_metrics` | Whether to report sum and count for histograms as separate metrics. | `true` |
+| `histograms::send_count_sum_metrics` | Whether to report sum and count for histograms as separate metrics. | `false` |

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -108,10 +108,10 @@ exporters:
         #
         # mode: distributions
       
-        ## @param send_count_sum_metrics - boolean - optional - default: true
+        ## @param send_count_sum_metrics - boolean - optional - default: false
         ## Whether to report sum and count as separate histogram metrics.
         #
-        # send_count_sum_metrics: true
+        # send_count_sum_metrics: false
 
     ## @param traces - custom object - optional
     ## Trace exporter specific configuration.


### PR DESCRIPTION
**Description:** 

Follow up to #5885. We forgot to update the docs.

**Link to tracking Issue:** n/a, customer report
