### PR TITLE
Bump loadtest limits to avoid CI failures

### DIFF
--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -40,7 +40,7 @@ func TestLog10kDPS(t *testing.T) {
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 86,
+				ExpectedMaxRAM: 98,
 			},
 		},
 		{
@@ -49,7 +49,7 @@ func TestLog10kDPS(t *testing.T) {
 			receiver: testbed.NewOTLPHTTPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 85,
+				ExpectedMaxRAM: 90,
 			},
 		},
 		{
@@ -58,7 +58,7 @@ func TestLog10kDPS(t *testing.T) {
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 86,
+				ExpectedMaxRAM: 100,
 			},
 		},
 		{
@@ -67,7 +67,7 @@ func TestLog10kDPS(t *testing.T) {
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 86,
+				ExpectedMaxRAM: 100,
 			},
 			extensions: datasenders.NewLocalFileStorageExtension(),
 		},

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -53,7 +53,7 @@ func TestMetric10kDPS(t *testing.T) {
 			datareceivers.NewOCDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 85,
-				ExpectedMaxRAM: 86,
+				ExpectedMaxRAM: 100,
 			},
 		},
 		{
@@ -62,7 +62,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 50,
-				ExpectedMaxRAM: 85,
+				ExpectedMaxRAM: 98,
 			},
 		},
 		{
@@ -71,7 +71,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOTLPHTTPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 50,
-				ExpectedMaxRAM: 85,
+				ExpectedMaxRAM: 92,
 			},
 		},
 		{
@@ -80,7 +80,7 @@ func TestMetric10kDPS(t *testing.T) {
 			datareceivers.NewSFxMetricsDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 120,
-				ExpectedMaxRAM: 95,
+				ExpectedMaxRAM: 98,
 			},
 		},
 	}
@@ -136,7 +136,7 @@ func TestMetricsFromFile(t *testing.T) {
 		agentProc,
 		&testbed.PerfTestValidator{},
 		performanceResultsSummary,
-		testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 120, ExpectedMaxRAM: 85}),
+		testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 120, ExpectedMaxRAM: 94}),
 	)
 	defer tc.Stop()
 

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -236,7 +236,7 @@ func TestTraceBallast1kSPSWithAttrs(t *testing.T) {
 		{
 			attrCount:      0,
 			attrSizeByte:   0,
-			expectedMaxCPU: 30,
+			expectedMaxCPU: 53,
 			expectedMaxRAM: 2200,
 			resultsSummary: performanceResultsSummary,
 		},


### PR DESCRIPTION
See failures https://github.com/open-telemetry/opentelemetry-collector-contrib/runs/4104146149?check_suite_focus=true

Bumped to +15% from observed max.