### PR TITLE
[dockerobserver] Watch for docker events

### DIFF
--- a/extension/observer/dockerobserver/extension_test.go
+++ b/extension/observer/dockerobserver/extension_test.go
@@ -85,7 +85,7 @@ func TestCollectEndpointsDefaultConfig(t *testing.T) {
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "172.17.0.2:80",
 			Details: &observer.Container{
-				Name:        "/agitated_wu",
+				Name:        "agitated_wu",
 				Image:       "nginx",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
@@ -132,7 +132,7 @@ func TestCollectEndpointsAllConfigSettings(t *testing.T) {
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "127.0.0.1:8080",
 			Details: &observer.Container{
-				Name:        "/agitated_wu",
+				Name:        "agitated_wu",
 				Image:       "nginx",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
@@ -179,7 +179,7 @@ func TestCollectEndpointsUseHostnameIfPresent(t *testing.T) {
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "babc5a6d7af2:80",
 			Details: &observer.Container{
-				Name:        "/agitated_wu",
+				Name:        "agitated_wu",
 				Image:       "nginx",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
@@ -226,7 +226,7 @@ func TestCollectEndpointsUseHostBindings(t *testing.T) {
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "127.0.0.1:8080",
 			Details: &observer.Container{
-				Name:        "/agitated_wu",
+				Name:        "agitated_wu",
 				Image:       "nginx",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
@@ -273,7 +273,7 @@ func TestCollectEndpointsIgnoreNonHostBindings(t *testing.T) {
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "172.17.0.2:80",
 			Details: &observer.Container{
-				Name:        "/agitated_wu",
+				Name:        "agitated_wu",
 				Image:       "nginx",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",

--- a/extension/observer/dockerobserver/go.mod
+++ b/extension/observer/dockerobserver/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
 	go.opentelemetry.io/collector/model v0.41.1-0.20211210184707-4dcb3388a168 // indirect
 	go.opentelemetry.io/otel v1.2.0 // indirect
 	go.opentelemetry.io/otel/metric v0.25.0 // indirect

--- a/extension/observer/dockerobserver/go.sum
+++ b/extension/observer/dockerobserver/go.sum
@@ -757,6 +757,7 @@ github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
**Description:** Adds the functionality of using the Docker client's events stream to process container events to create, update, and remove endpoints. 

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4446

**Testing:** Added integration tests to test removing and updating endpoints

**Documentation:** Updated readme with an example config and endpoints variables exposed to the receiver creator [in a separate PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6420).