### PR TITLE
fix exemplars support

### DIFF
--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/zaptest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -34,6 +32,7 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor/mocks"

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/zaptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -131,7 +133,7 @@ func TestProcessorShutdown(t *testing.T) {
 
 	// Test
 	next := new(consumertest.TracesSink)
-	p, err := newProcessor(zap.NewNop(), cfg, next)
+	p, err := newProcessor(zaptest.NewLogger(t), cfg, next)
 	assert.NoError(t, err)
 	err = p.Shutdown(context.Background())
 
@@ -152,7 +154,7 @@ func TestConfigureLatencyBounds(t *testing.T) {
 
 	// Test
 	next := new(consumertest.TracesSink)
-	p, err := newProcessor(zap.NewNop(), cfg, next)
+	p, err := newProcessor(zaptest.NewLogger(t), cfg, next)
 
 	// Verify
 	assert.NoError(t, err)
@@ -167,7 +169,7 @@ func TestProcessorCapabilities(t *testing.T) {
 
 	// Test
 	next := new(consumertest.TracesSink)
-	p, err := newProcessor(zap.NewNop(), cfg, next)
+	p, err := newProcessor(zaptest.NewLogger(t), cfg, next)
 	assert.NoError(t, err)
 	caps := p.Capabilities()
 
@@ -619,7 +621,7 @@ func TestProcessorDuplicateDimensions(t *testing.T) {
 
 	// Test
 	next := new(consumertest.TracesSink)
-	p, err := newProcessor(zap.NewNop(), cfg, next)
+	p, err := newProcessor(zaptest.NewLogger(t), cfg, next)
 	assert.Error(t, err)
 	assert.Nil(t, p)
 }
@@ -728,7 +730,7 @@ func TestProcessorUpdateLatencyExemplars(t *testing.T) {
 	traceID := traces.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).Spans().At(0).TraceID()
 	key := metricKey("metricKey")
 	next := new(consumertest.TracesSink)
-	p, err := newProcessor(zap.NewNop(), cfg, next)
+	p, err := newProcessor(zaptest.NewLogger(t), cfg, next)
 	value := float64(42)
 
 	// ----- call -------------------------------------------------------------
@@ -747,7 +749,7 @@ func TestProcessorResetExemplarData(t *testing.T) {
 
 	key := metricKey("metricKey")
 	next := new(consumertest.TracesSink)
-	p, err := newProcessor(zap.NewNop(), cfg, next)
+	p, err := newProcessor(zaptest.NewLogger(t), cfg, next)
 
 	// ----- call -------------------------------------------------------------
 	p.resetExemplarData()

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -730,13 +730,29 @@ func TestProcessorUpdateLatencyExemplars(t *testing.T) {
 	next := new(consumertest.TracesSink)
 	p, err := newProcessor(zap.NewNop(), cfg, next)
 	value := float64(42)
-	index := 12
 
 	// ----- call -------------------------------------------------------------
-	p.updateLatencyExemplars(key, value, index, traceID)
+	p.updateLatencyExemplars(key, value, traceID)
 
 	// ----- verify -----------------------------------------------------------
 	assert.NoError(t, err)
 	assert.NotEmpty(t, p.latencyExemplarsData[key])
-	assert.Equal(t, p.latencyExemplarsData[key][index], exemplarData{traceID: traceID, value: value})
+	assert.Equal(t, p.latencyExemplarsData[key][0], exemplarData{traceID: traceID, value: value})
+}
+
+func TestProcessorResetExemplarData(t *testing.T) {
+	// ----- conditions -------------------------------------------------------
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+
+	key := metricKey("metricKey")
+	next := new(consumertest.TracesSink)
+	p, err := newProcessor(zap.NewNop(), cfg, next)
+
+	// ----- call -------------------------------------------------------------
+	p.resetExemplarData()
+
+	// ----- verify -----------------------------------------------------------
+	assert.NoError(t, err)
+	assert.Empty(t, p.latencyExemplarsData[key])
 }


### PR DESCRIPTION
Signed-off-by: Anne-Elisabeth Lelièvre <anneelisabethwlelievre@hotmail.com>

Hello, this is a fix to resolve a problem by adding exemplars to the metrics in the span metrics processor.

When I tried to send the metrics to prometheus , I got  this error: 

```
ts=2021-10-28T20:49:50.703Z caller=write_handler.go:76 level=debug component=web msg="Out of order exemplar" exemplar="{Labels:{} Value:0 Ts:0 HasTs:false}"
ts=2021-10-28T20:49:50.703Z caller=write_handler.go:121 level=warn component=web msg="Error on ingesting out-of-order exemplars" num_dropped=8
```
And when I tried to send to Cortex, I got this error: 

```
{"level":"error","ts":1635446592.7831264,"caller":"exporterhelper/queued_retry.go:199","msg":"Exporting failed. The error is not retryable. Dropping data.","kind":"exporter","name":"prometheusremotewrite/0/metrics/2","error":"Permanent error: remote write returned HTTP status 400 Bad Request; err = <nil>: exemplar missing labels, timestamp: 0 series: 
```
By analyzing these errors, I assumed that there was a problem with the index of the exemplar data map.
So to resolve this issue, instead of adding exemplars to the a specific bucket index, I propose to simply append the exemplar data and reset the entire exemplars map so the next trace will recreate all the data structure. I have retested and everything seems to be sent correctly now on my end.