### PR TITLE
feat: added support for AWS AppRunner origin

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -39,6 +39,7 @@ const (
 	OriginECSFargate = "AWS::ECS::Fargate"
 	OriginEB         = "AWS::ElasticBeanstalk::Environment"
 	OriginEKS        = "AWS::EKS::Container"
+	OriginAppRunner  = "AWS::AppRunner::Service"
 )
 
 var (
@@ -231,16 +232,17 @@ func determineAwsOrigin(resource pdata.Resource) string {
 		}
 	}
 
-	// TODO(willarmiros): Only use platform for origin resolution once detectors for all AWS environments are
-	// implemented for robustness
 	if is, present := resource.Attributes().Get(conventions.AttributeCloudPlatform); present {
 		switch is.StringVal() {
+		// TODO: Replace with semantic convention const when aws_app_runner is included in an official semconv release
+		case "aws_app_runner":
+			return OriginAppRunner
 		case conventions.AttributeCloudPlatformAWSEKS:
 			return OriginEKS
 		case conventions.AttributeCloudPlatformAWSElasticBeanstalk:
 			return OriginEB
 		case conventions.AttributeCloudPlatformAWSECS:
-			lt, present := resource.Attributes().Get("aws.ecs.launchtype")
+			lt, present := resource.Attributes().Get(conventions.AttributeAWSECSLaunchtype)
 			if !present {
 				return OriginECS
 			}
@@ -255,7 +257,7 @@ func determineAwsOrigin(resource pdata.Resource) string {
 		case conventions.AttributeCloudPlatformAWSEC2:
 			return OriginEC2
 
-		// If infrastructure_service is defined with a non-AWS value, we should not assign it an AWS origin
+		// If cloud_platform is defined with a non-AWS value, we should not assign it an AWS origin
 		default:
 			return ""
 		}


### PR DESCRIPTION
Added the AWS AppRunner origin as a valid choice for X-Ray segment origins, and wired up the logic to parse it out of resource attributes. Also did some minor cleanups.

Spec PR for adding the `aws_app_runner` entry (unreleased at time of writing, which is why it's a hardcoded string): https://github.com/open-telemetry/opentelemetry-specification/pull/2004

cc @Aneurysm9 @NathanielRN 