### PR TITLE
Update scrapertest package to include the ability to ignore values

### DIFF
--- a/internal/scrapertest/scrapertest.go
+++ b/internal/scrapertest/scrapertest.go
@@ -24,7 +24,7 @@ import (
 
 // CompareMetricSlices compares each part of two given MetricSlices and returns
 // an error if they don't match. The error describes what didn't match.
-func CompareMetricSlices(expected, actual pdata.MetricSlice) error {
+func CompareMetricSlices(expected, actual pdata.MetricSlice, checkValues bool) error {
 	if actual.Len() != expected.Len() {
 		return fmt.Errorf("metric slices not of same length")
 	}
@@ -91,7 +91,7 @@ func CompareMetricSlices(expected, actual pdata.MetricSlice) error {
 			expectedDataPoints = expectedMetric.Sum().DataPoints()
 		}
 
-		if err := CompareNumberDataPointSlices(actualDataPoints, expectedDataPoints); err != nil {
+		if err := CompareNumberDataPointSlices(actualDataPoints, expectedDataPoints, checkValues); err != nil {
 			return multierr.Combine(fmt.Errorf("datapoints for metric: `%s`, do not match expected", actualMetric.Name()), err)
 		}
 	}
@@ -100,7 +100,7 @@ func CompareMetricSlices(expected, actual pdata.MetricSlice) error {
 
 // CompareNumberDataPointSlices compares each part of two given NumberDataPointSlices and returns
 // an error if they don't match. The error describes what didn't match.
-func CompareNumberDataPointSlices(actual, expected pdata.NumberDataPointSlice) error {
+func CompareNumberDataPointSlices(actual, expected pdata.NumberDataPointSlice, checkValues bool) error {
 	if actual.Len() != expected.Len() {
 		return fmt.Errorf("length of datapoints don't match")
 	}
@@ -145,7 +145,7 @@ func CompareNumberDataPointSlices(actual, expected pdata.NumberDataPointSlice) e
 	}
 
 	for adp, edp := range matchingDPS {
-		if err := CompareNumberDataPoints(adp, edp); err != nil {
+		if err := CompareNumberDataPoints(adp, edp, checkValues); err != nil {
 			return multierr.Combine(fmt.Errorf("datapoint with label(s): %v, does not match expected", adp.Attributes().AsRaw()), err)
 		}
 	}
@@ -154,15 +154,17 @@ func CompareNumberDataPointSlices(actual, expected pdata.NumberDataPointSlice) e
 
 // CompareNumberDataPoints compares each part of two given NumberDataPoints and returns
 // an error if they don't match. The error describes what didn't match.
-func CompareNumberDataPoints(actual, expected pdata.NumberDataPoint) error {
+func CompareNumberDataPoints(actual, expected pdata.NumberDataPoint, checkValues bool) error {
 	if expected.Type() != actual.Type() {
 		return fmt.Errorf("metric datapoint types don't match: expected type: %v, actual type: %v", expected.Type(), actual.Type())
 	}
-	if expected.IntVal() != actual.IntVal() {
-		return fmt.Errorf("metric datapoint IntVal doesn't match expected: %d, actual: %d", expected.IntVal(), actual.IntVal())
-	}
-	if expected.DoubleVal() != actual.DoubleVal() {
-		return fmt.Errorf("metric datapoint DoubleVal doesn't match expected: %f, actual: %f", expected.DoubleVal(), actual.DoubleVal())
+	if checkValues {
+		if expected.IntVal() != actual.IntVal() {
+			return fmt.Errorf("metric datapoint IntVal doesn't match expected: %d, actual: %d", expected.IntVal(), actual.IntVal())
+		}
+		if expected.DoubleVal() != actual.DoubleVal() {
+			return fmt.Errorf("metric datapoint DoubleVal doesn't match expected: %f, actual: %f", expected.DoubleVal(), actual.DoubleVal())
+		}
 	}
 	return nil
 }

--- a/internal/scrapertest/scrapertest.go
+++ b/internal/scrapertest/scrapertest.go
@@ -158,13 +158,14 @@ func CompareNumberDataPoints(actual, expected pdata.NumberDataPoint, checkValues
 	if expected.Type() != actual.Type() {
 		return fmt.Errorf("metric datapoint types don't match: expected type: %v, actual type: %v", expected.Type(), actual.Type())
 	}
-	if checkValues {
-		if expected.IntVal() != actual.IntVal() {
-			return fmt.Errorf("metric datapoint IntVal doesn't match expected: %d, actual: %d", expected.IntVal(), actual.IntVal())
-		}
-		if expected.DoubleVal() != actual.DoubleVal() {
-			return fmt.Errorf("metric datapoint DoubleVal doesn't match expected: %f, actual: %f", expected.DoubleVal(), actual.DoubleVal())
-		}
+	if !checkValues {
+		return nil
+	}
+	if expected.IntVal() != actual.IntVal() {
+		return fmt.Errorf("metric datapoint IntVal doesn't match expected: %d, actual: %d", expected.IntVal(), actual.IntVal())
+	}
+	if expected.DoubleVal() != actual.DoubleVal() {
+		return fmt.Errorf("metric datapoint DoubleVal doesn't match expected: %f, actual: %f", expected.DoubleVal(), actual.DoubleVal())
 	}
 	return nil
 }

--- a/internal/scrapertest/scrapertest_test.go
+++ b/internal/scrapertest/scrapertest_test.go
@@ -347,3 +347,48 @@ func TestCompareMetrics(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareMetricsWithoutComparingValues(t *testing.T) {
+	tcs := []struct {
+		name          string
+		expected      pdata.MetricSlice
+		actual        pdata.MetricSlice
+		expectedError error
+	}{
+		{
+			name: "Wrong doubleVal",
+			actual: func() pdata.MetricSlice {
+				metrics := baseTestMetrics()
+				m := metrics.At(0)
+				dp := m.Gauge().DataPoints().At(0)
+				dp.SetDoubleVal(123)
+				return metrics
+			}(),
+			expected:      baseTestMetrics(),
+			expectedError: nil,
+		},
+		{
+			name: "Wrong intVal",
+			actual: func() pdata.MetricSlice {
+				metrics := baseTestMetrics()
+				m := metrics.At(2)
+				dp := m.Sum().DataPoints().At(0)
+				dp.SetIntVal(123)
+				return metrics
+			}(),
+			expected:      baseTestMetrics(),
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CompareMetricSlices(tc.expected, tc.actual, false)
+			if tc.expectedError != nil {
+				require.Equal(t, tc.expectedError, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/scrapertest/scrapertest_test.go
+++ b/internal/scrapertest/scrapertest_test.go
@@ -338,7 +338,7 @@ func TestCompareMetrics(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := CompareMetricSlices(tc.expected, tc.actual)
+			err := CompareMetricSlices(tc.expected, tc.actual, true)
 			if tc.expectedError != nil {
 				require.Equal(t, tc.expectedError, err)
 			} else {

--- a/internal/scrapertest/scrapertest_test.go
+++ b/internal/scrapertest/scrapertest_test.go
@@ -356,7 +356,7 @@ func TestCompareMetricsWithoutComparingValues(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name: "Wrong doubleVal",
+			name: "Ignore mismatched doubleVal",
 			actual: func() pdata.MetricSlice {
 				metrics := baseTestMetrics()
 				m := metrics.At(0)
@@ -368,7 +368,7 @@ func TestCompareMetricsWithoutComparingValues(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "Wrong intVal",
+			name: "Ignore mismatched intVal",
 			actual: func() pdata.MetricSlice {
 				metrics := baseTestMetrics()
 				m := metrics.At(2)

--- a/receiver/httpdreceiver/scraper_test.go
+++ b/receiver/httpdreceiver/scraper_test.go
@@ -70,7 +70,7 @@ Scoreboard: S_DD_L_GGG_____W__IIII_C________________W___________________________
 	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	aMetricSlice := scrapedRMS.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, true))
 }
 
 func TestScraperFailedStart(t *testing.T) {

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -44,5 +44,5 @@ func TestScrape(t *testing.T) {
 	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	aMetricSlice := scrapedRMS.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, true))
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Added flag to compare functions to ignore comparing the values of a datapoint slice. This will enable these functions to be used within integration tests where we don't necessarily know what the values will be.