### PR TITLE
Fix flaky awsproxy - TestFactory_CreateExtension Test

### DIFF
--- a/extension/awsproxy/factory_test.go
+++ b/extension/awsproxy/factory_test.go
@@ -24,9 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
@@ -35,6 +32,8 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {

--- a/extension/awsproxy/factory_test.go
+++ b/extension/awsproxy/factory_test.go
@@ -22,8 +22,11 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
@@ -81,10 +84,14 @@ func TestFactory_CreateExtension(t *testing.T) {
 	err = ext.Start(ctx, mh)
 	assert.NoError(t, err)
 
-	resp, err := http.Post(
-		"http://"+address+"/GetSamplingRules",
-		"application/json",
-		strings.NewReader(`{"NextToken": null}`))
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		resp, err = http.Post(
+			"http://"+address+"/GetSamplingRules",
+			"application/json",
+			strings.NewReader(`{"NextToken": null}`))
+		return err == nil
+	}, 3*time.Second, 10*time.Millisecond)
 
 	assert.NoError(t, err)
 

--- a/extension/awsproxy/factory_test.go
+++ b/extension/awsproxy/factory_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
@@ -32,8 +34,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFactory_CreateDefaultConfig(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>

This change aims to improve the reliability of the flaky test outlined in [this issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6147)

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6147

**Testing:** <Describe what testing was performed and which tests were added.>

N/A

**Documentation:** <Describe the documentation added.>

N/A