### PR TITLE
make flaky test TestStartTimeMetricRegex more reliable

### DIFF
--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1364,18 +1364,19 @@ var startTimeMetricPageStartTimestamp = &timestamppb.Timestamp{Seconds: 400, Nan
 const numStartTimeMetricPageTimeseries = 11
 
 func verifyStartTimeMetricPage(t *testing.T, _ *testData, mds []*agentmetricspb.ExportMetricsServiceRequest) {
+	if len(mds) < 1 {
+		t.Fatal("At least one metric request should be present")
+	}
 	numTimeseries := 0
-	for _, cmd := range mds {
-		for _, metric := range cmd.Metrics {
-			timestamp := startTimeMetricPageStartTimestamp
-			switch metric.GetMetricDescriptor().GetType() {
-			case metricspb.MetricDescriptor_GAUGE_DOUBLE, metricspb.MetricDescriptor_GAUGE_DISTRIBUTION:
-				timestamp = nil
-			}
-			for _, ts := range metric.GetTimeseries() {
-				assert.Equal(t, timestamp.AsTime(), ts.GetStartTimestamp().AsTime(), ts.String())
-				numTimeseries++
-			}
+	for _, metric := range mds[0].Metrics {
+		timestamp := startTimeMetricPageStartTimestamp
+		switch metric.GetMetricDescriptor().GetType() {
+		case metricspb.MetricDescriptor_GAUGE_DOUBLE, metricspb.MetricDescriptor_GAUGE_DISTRIBUTION:
+			timestamp = nil
+		}
+		for _, ts := range metric.GetTimeseries() {
+			assert.Equal(t, timestamp.AsTime(), ts.GetStartTimestamp().AsTime(), ts.String())
+			numTimeseries++
 		}
 	}
 	assert.Equal(t, numStartTimeMetricPageTimeseries, numTimeseries)
@@ -1521,7 +1522,7 @@ func TestStartTimeMetricRegex(t *testing.T) {
 func testEndToEndRegex(t *testing.T, targets []*testData, useStartTimeMetric bool, startTimeMetricRegex string) {
 	// 1. setup mock server
 	mp, cfg, err := setupMockPrometheus(targets...)
-	require.Nilf(t, err, "Failed to create Promtheus config: %v", err)
+	require.Nilf(t, err, "Failed to create Prometheus config: %v", err)
 	defer mp.Close()
 
 	cms := new(consumertest.MetricsSink)

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1364,9 +1364,7 @@ var startTimeMetricPageStartTimestamp = &timestamppb.Timestamp{Seconds: 400, Nan
 const numStartTimeMetricPageTimeseries = 11
 
 func verifyStartTimeMetricPage(t *testing.T, _ *testData, mds []*agentmetricspb.ExportMetricsServiceRequest) {
-	if len(mds) < 1 {
-		t.Fatal("At least one metric request should be present")
-	}
+	require.Greater(t, len(mds), 0, "At least one metric request should be present")
 	numTimeseries := 0
 	for _, metric := range mds[0].Metrics {
 		timestamp := startTimeMetricPageStartTimestamp


### PR DESCRIPTION
**Description:** <Describe what has changed.>
`TestStartTimeMetricRegex` is flaky as it failed in a unit test workflow run according to issue open-telemetry#5752
Unable to reproduce this failure locally by running this test multiple times.
However, based on the error trace in the issue description, the test is flaky as it intermittently generates an additional scrape result with staleness markers.
In order to make this test more reliable, we should only validate the first scrape result and ignore any subsequent scrapes.

**Link to tracking Issue:** <Issue number if applicable>
Resolves #5752 