### PR TITLE
[metrics transform processor] Use null to require absent label

### DIFF
--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -107,6 +107,14 @@ type Transform struct {
 	Operations []Operation `mapstructure:"operations"`
 }
 
+// FilterConfig defines a filter applied to the name and attributes of metric points.
+// For example,
+//
+// 	    match_type: regex
+// 	    include: foo                  # metric name must be 'foo'
+// 	    experimental_match_labels:
+// 	      key_a: pref.*               # attribute 'key_a' must start with 'pref'
+// 	      key_b: null                 # attribute 'key_b' must not be present
 type FilterConfig struct {
 	// Include specifies the metric(s) to operate on.
 	Include string `mapstructure:"include"`
@@ -116,7 +124,7 @@ type FilterConfig struct {
 
 	// MatchLabels specifies the label set against which the metric filter will work.
 	// This field is optional.
-	MatchLabels map[string]string `mapstructure:"experimental_match_labels"`
+	MatchLabels map[string]*string `mapstructure:"experimental_match_labels"`
 }
 
 // Operation defines the specific operation performed on the selected metrics.

--- a/processor/metricstransformprocessor/config_test.go
+++ b/processor/metricstransformprocessor/config_test.go
@@ -25,6 +25,8 @@ import (
 	"go.opentelemetry.io/collector/config/configtest"
 )
 
+func ptr(s string) *string { return &s }
+
 func TestLoadingFullConfig(t *testing.T) {
 	tests := []struct {
 		configFile string
@@ -73,8 +75,9 @@ func TestLoadingFullConfig(t *testing.T) {
 						MetricIncludeFilter: FilterConfig{
 							Include:   "new_name",
 							MatchType: "strict",
-							MatchLabels: map[string]string{
-								"my_label": "my_value",
+							MatchLabels: map[string]*string{
+								"my_label":    ptr("my_value"),
+								"other_label": nil,
 							},
 						},
 						Action:  "insert",
@@ -84,8 +87,9 @@ func TestLoadingFullConfig(t *testing.T) {
 						MetricIncludeFilter: FilterConfig{
 							Include:   "new_name",
 							MatchType: "regexp",
-							MatchLabels: map[string]string{
-								"my_label": ".*label",
+							MatchLabels: map[string]*string{
+								"my_label":    ptr(".*label"),
+								"other_label": nil,
 							},
 						},
 						Action:  "insert",

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -228,10 +228,15 @@ func sliceToSet(slice []string) map[string]bool {
 	return set
 }
 
-func getMatcherMap(strMap map[string]string, ctor func(string) (StringMatcher, error)) (map[string]StringMatcher, error) {
+func getMatcherMap(strMap map[string]*string, ctor func(string) (StringMatcher, error)) (map[string]StringMatcher, error) {
 	out := make(map[string]StringMatcher)
 	for k, v := range strMap {
-		matcher, err := ctor(v)
+		if v == nil {
+			out[k] = nil
+			continue
+		}
+
+		matcher, err := ctor(*v)
 		if err != nil {
 			return nil, err
 		}

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -849,9 +849,14 @@ var (
 			name: "metric_name_insert_with_match_label_strict_missing_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]StringMatcher{"missing_key": strictMatcher("value1")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{
+						include: "metric1",
+						matchLabels: map[string]StringMatcher{
+							"missing_key": strictMatcher("value1"),
+						},
+					},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -918,10 +923,10 @@ var (
 			},
 		},
 		{
-			name: "metric_name_insert_with_match_label_regexp_missing_key_with_empty_expression",
+			name: "metric_name_insert_with_match_label_regexp_missing_key_with_nil_expression",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value1"), "missing_key": regexp.MustCompile("^$")}},
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value1"), "missing_key": nil}},
 					Action:              Insert,
 					NewName:             "new/metric1",
 				},

--- a/processor/metricstransformprocessor/testdata/config_full.yaml
+++ b/processor/metricstransformprocessor/testdata/config_full.yaml
@@ -23,13 +23,13 @@ processors:
         action: insert
         new_name: new_name_copy_1
         match_type: strict
-        experimental_match_labels: {"my_label": "my_value"}
+        experimental_match_labels: {"my_label": "my_value", "other_label": null}
 
       - include: new_name
         action: insert
         new_name: new_name_copy_2
         match_type: regexp
-        experimental_match_labels: {"my_label": ".*label"}
+        experimental_match_labels: {"my_label": ".*label", "other_label": null}
 
       - include: name2
         action: update


### PR DESCRIPTION
**Description:**
Previously, the code checked whether a label should be absent
by checking whether the string/regex matched the empty string.
This is slightly surprising for exact matches and (IMO) very surprising
for regex matches.

This PR changes the label matcher to use YAML null to configure a
label that must be absent. Blank strings and regexes that match
blank strings are no longer treated specially.

This came up while I was reviewing the code for a migration to pdata.
I'm submitting a separate PR because I want to keep functional
changes separate from the change in internal data representation.

**Link to tracking Issue:**
N/A

**Testing:**
Added/modified unit tests

**Documentation:**
Added comments