### PR TITLE
[build] load test results were stored with a single archive name

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -106,17 +106,19 @@ jobs:
         run: make -C testbed run-tests 
         env:
           TEST_ARGS: "-test.run=${{ matrix.test }}"
-      - name: Create Test Result Archive # some test results have invalid characters
+      - name: Set results filename
+        id: filename
+        run: echo "::set-output name=name::$(echo '${{ matrix.test }}' | sed -e 's/|/_/g')"
+      - name: Create Test Result Archive
         if: ${{ failure() || success() }}
         continue-on-error: true
-        run: tar -cvf test_results.tar testbed/tests/results
+        run: tar -cvf test_results_${{steps.filename.outputs.name}}.tar testbed/tests/results
       - name: Upload Test Results
         if: ${{ failure() || success() }}
         continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
-          name: test-results
-          path: test_results.tar
+          path: ./*.tar
       - name: GitHub Issue Generator
         if: ${{ failure() && github.ref == 'ref/head/main' }}
         run: issuegenerator $TEST_RESULTS


### PR DESCRIPTION
The archive contained whichever test finish last's data, making it impossible to see the data for all tests.
