### PR TITLE
Rename labels to attributes in metric metadata

### DIFF
--- a/cmd/mdatagen/documentation.tmpl
+++ b/cmd/mdatagen/documentation.tmpl
@@ -15,13 +15,13 @@ These are the metrics available for this scraper.
 | {{ $metricName }} | {{ $metricInfo.Description }} | {{ $metricInfo.Unit }} | {{ $metricInfo.Data.Type }} | <ul>
 {{- end }}
 
-{{- range $index, $labelName := $metricInfo.Labels }} <li>{{ $labelName }}</li> {{- end }} </ul> |
+{{- range $index, $attributeName := $metricInfo.Attributes }} <li>{{ $attributeName }}</li> {{- end }} </ul> |
 {{- end }}
 
 ## Attributes
 
 | Name | Description |
 | ---- | ----------- |
-{{- range $labelName, $labelInfo := .Labels }}
-| {{ $labelName }} | {{ $labelInfo.Description }} |
+{{- range $attributeName, $attributeInfo := .Attributes }}
+| {{ $attributeName }} | {{ $attributeInfo.Description }} |
 {{- end }}

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -33,9 +33,9 @@ func (mn metricName) Render() (string, error) {
 	return formatIdentifier(string(mn), true)
 }
 
-type labelName string
+type attributeName string
 
-func (mn labelName) Render() (string, error) {
+func (mn attributeName) Render() (string, error) {
 	return formatIdentifier(string(mn), true)
 }
 
@@ -55,26 +55,26 @@ type metric struct {
 	// Date is set to generic metric data interface after validating.
 	Data MetricData `yaml:"-"`
 
-	// Labels is the list of labels that the metric emits.
-	Labels []labelName
+	// Attributes is the list of attributes that the metric emits.
+	Attributes []attributeName
 }
 
-type label struct {
-	// Description describes the purpose of the label.
+type attribute struct {
+	// Description describes the purpose of the attribute.
 	Description string `validate:"notblank"`
-	// Value can optionally specify the value this label will have.
-	// For example, the label may have the identifier `MemState` to its
+	// Value can optionally specify the value this attribute will have.
+	// For example, the attribute may have the identifier `MemState` to its
 	// value may be `state` when used.
 	Value string
-	// Enum can optionally describe the set of values to which the label can belong.
+	// Enum can optionally describe the set of values to which the attribute can belong.
 	Enum []string
 }
 
 type metadata struct {
 	// Name of the component.
 	Name string `validate:"notblank"`
-	// Labels emitted by one or more metrics.
-	Labels map[labelName]label `validate:"dive"`
+	// Attributes emitted by one or more metrics.
+	Attributes map[attributeName]attribute `validate:"dive"`
 	// Metrics that can be emitted by the component.
 	Metrics map[metricName]metric `validate:"dive"`
 }
@@ -120,13 +120,13 @@ func validateMetadata(out metadata) error {
 		return fmt.Errorf("failed registering translations: %v", err)
 	}
 
-	if err := v.RegisterTranslation("nosuchlabel", tr, func(ut ut.Translator) error {
-		return ut.Add("nosuchlabel", "unknown label value", true) // see universal-translator for details
+	if err := v.RegisterTranslation("nosuchattribute", tr, func(ut ut.Translator) error {
+		return ut.Add("nosuchattribute", "unknown attribute value", true) // see universal-translator for details
 	}, func(ut ut.Translator, fe validator.FieldError) string {
-		t, _ := ut.T("nosuchlabel", fe.Field())
+		t, _ := ut.T("nosuchattribute", fe.Field())
 		return t
 	}); err != nil {
-		return fmt.Errorf("failed registering nosuchlabel: %v", err)
+		return fmt.Errorf("failed registering nosuchattribute: %v", err)
 	}
 
 	v.RegisterStructValidation(metricValidation, metric{})
@@ -156,13 +156,14 @@ func validateMetadata(out metadata) error {
 
 // metricValidation validates metric structs.
 func metricValidation(sl validator.StructLevel) {
-	// Make sure that the labels are valid.
+	// Make sure that the attributes are valid.
 	md := sl.Top().Interface().(*metadata)
 	cur := sl.Current().Interface().(metric)
 
-	for _, l := range cur.Labels {
-		if _, ok := md.Labels[l]; !ok {
-			sl.ReportError(cur.Labels, fmt.Sprintf("Labels[%s]", string(l)), "Labels", "nosuchlabel", "")
+	for _, l := range cur.Attributes {
+		if _, ok := md.Attributes[l]; !ok {
+			sl.ReportError(cur.Attributes, fmt.Sprintf("Attributes[%s]", string(l)), "Attributes", "nosuchattribute",
+				"")
 		}
 	}
 }

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -23,16 +23,16 @@ import (
 const (
 	allOptions = `
 name: metricreceiver
-labels:
-  freeFormLabel:
-    description: Label that can take on any value.
+attributes:
+  freeFormAttribute:
+    description: Attribute that can take on any value.
 
-  freeFormLabelWithValue:
+  freeFormAttributeWithValue:
     value: state
-    description: Label that has alternate value set.
+    description: Attribute that has alternate value set.
 
-  enumLabel:
-    description: Label with a known set of values.
+  enumAttribute:
+    description: Attribute with a known set of values.
     enum: [red, green, blue]
 
 metrics:
@@ -44,10 +44,10 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [freeFormLabel, freeFormLabelWithValue, enumLabel]
+    attributes: [freeFormAttribute, freeFormAttributeWithValue, enumAttribute]
 `
 
-	unknownMetricLabel = `
+	unknownMetricAttribute = `
 name: metricreceiver
 metrics:
   system.cpu.time:
@@ -57,7 +57,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [missing]
+    attributes: [missing]
 `
 	unknownMetricType = `
 name: metricreceiver
@@ -67,7 +67,7 @@ metrics:
     unit: s
     data:
       type: invalid
-    labels:
+    attributes:
 `
 )
 
@@ -83,16 +83,16 @@ func Test_loadMetadata(t *testing.T) {
 			yml:  allOptions,
 			want: metadata{
 				Name: "metricreceiver",
-				Labels: map[labelName]label{
-					"enumLabel": {
-						Description: "Label with a known set of values.",
+				Attributes: map[attributeName]attribute{
+					"enumAttribute": {
+						Description: "Attribute with a known set of values.",
 						Value:       "",
 						Enum:        []string{"red", "green", "blue"}},
-					"freeFormLabel": {
-						Description: "Label that can take on any value.",
+					"freeFormAttribute": {
+						Description: "Attribute that can take on any value.",
 						Value:       ""},
-					"freeFormLabelWithValue": {
-						Description: "Label that has alternate value set.",
+					"freeFormAttributeWithValue": {
+						Description: "Attribute that has alternate value set.",
 						Value:       "state"}},
 				Metrics: map[metricName]metric{
 					"system.cpu.time": {
@@ -104,14 +104,16 @@ func Test_loadMetadata(t *testing.T) {
 							Mono:       Mono{Monotonic: true},
 						},
 						// YmlData: nil,
-						Labels: []labelName{"freeFormLabel", "freeFormLabelWithValue", "enumLabel"}}},
+						Attributes: []attributeName{"freeFormAttribute", "freeFormAttributeWithValue",
+							"enumAttribute"}}},
 			},
 		},
 		{
-			name:    "unknown metric label",
-			yml:     unknownMetricLabel,
-			want:    metadata{},
-			wantErr: "error validating struct:\n\tmetadata.Metrics[system.cpu.time].Labels[missing]: unknown label value\n",
+			name: "unknown metric attribute",
+			yml:  unknownMetricAttribute,
+			want: metadata{},
+			wantErr: "error validating struct:\n\tmetadata.Metrics[system.cpu.time]." +
+				"Attributes[missing]: unknown attribute value\n",
 		},
 		{
 			name:    "unknownMetricType",

--- a/cmd/mdatagen/metrics.tmpl
+++ b/cmd/mdatagen/metrics.tmpl
@@ -106,15 +106,15 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-{{- /* Renders label names. */}}
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
-    {{- range $name, $info := .Labels }}
+{{- /* Renders attribute names. */}}
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
+    {{- range $name, $info := .Attributes }}
     // {{ $name.Render }} ({{ $info.Description }})
     {{ $name.Render }} string
     {{- end }}
 }{
-    {{- range $name, $info := .Labels }}
+    {{- range $name, $info := .Attributes }}
     {{- if $info.Value }}
     "{{ $info.Value }}",
     {{- else }}
@@ -123,16 +123,15 @@ var Labels = struct {
     {{- end }}
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-{{- /* Renders label enum values. */}}
+{{- /* Renders attribute enum values. */}}
 
-{{ range $name, $info := .Labels }}
+{{ range $name, $info := .Attributes }}
 {{ if $info.Enum }}
-// Label{{ $name.Render }} are the possible values that the label "{{ $name }}" can have.
-var Label{{ $name.Render }} = struct {
+// Attribute{{ $name.Render }} are the possible values that the attribute "{{ $name }}" can have.
+var Attribute{{ $name.Render }} = struct {
     {{- range $info.Enum }}
     {{ . | publicVar }} string
     {{- end }}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -84,9 +84,9 @@ func initializeCPUTimeDataPoint(dataPoint pdata.NumberDataPoint, startTime, now 
 	attributes := dataPoint.Attributes()
 	// ignore cpu attribute if reporting "total" cpu usage
 	if cpuLabel != gopsCPUTotal {
-		attributes.InsertString(metadata.Labels.Cpu, cpuLabel)
+		attributes.InsertString(metadata.Attributes.Cpu, cpuLabel)
 	}
-	attributes.InsertString(metadata.Labels.State, stateLabel)
+	attributes.InsertString(metadata.Attributes.State, stateLabel)
 
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
@@ -27,12 +27,12 @@ import (
 const cpuStatesLen = 8
 
 func appendCPUTimeStateDataPoints(ddps pdata.NumberDataPointSlice, startTime, now pdata.Timestamp, cpuTime cpu.TimesStat) {
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.User, cpuTime.User)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.System, cpuTime.System)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.Idle, cpuTime.Idle)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.Interrupt, cpuTime.Irq)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.Nice, cpuTime.Nice)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.Softirq, cpuTime.Softirq)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.Steal, cpuTime.Steal)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.Wait, cpuTime.Iowait)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.User, cpuTime.User)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.System, cpuTime.System)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.Idle, cpuTime.Idle)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.Interrupt, cpuTime.Irq)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.Nice, cpuTime.Nice)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.Softirq, cpuTime.Softirq)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.Steal, cpuTime.Steal)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.Wait, cpuTime.Iowait)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
@@ -27,8 +27,8 @@ import (
 const cpuStatesLen = 4
 
 func appendCPUTimeStateDataPoints(ddps pdata.NumberDataPointSlice, startTime, now pdata.Timestamp, cpuTime cpu.TimesStat) {
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.User, cpuTime.User)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.System, cpuTime.System)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.Idle, cpuTime.Idle)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.LabelState.Interrupt, cpuTime.Irq)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.User, cpuTime.User)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.System, cpuTime.System)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.Idle, cpuTime.Idle)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.CPU, metadata.AttributeState.Interrupt, cpuTime.Irq)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -113,16 +113,16 @@ func assertCPUMetricValid(t *testing.T, metric pdata.Metric, descriptor pdata.Me
 		internal.AssertSumMetricStartTimeEquals(t, metric, startTime)
 	}
 	assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), 4*runtime.NumCPU())
-	internal.AssertSumMetricHasAttribute(t, metric, 0, metadata.Labels.Cpu)
-	internal.AssertSumMetricHasAttributeValue(t, metric, 0, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.User))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 1, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.System))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 2, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Idle))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 3, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Interrupt))
+	internal.AssertSumMetricHasAttribute(t, metric, 0, metadata.Attributes.Cpu)
+	internal.AssertSumMetricHasAttributeValue(t, metric, 0, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.User))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 1, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.System))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 2, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Idle))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 3, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Interrupt))
 }
 
 func assertCPUMetricHasLinuxSpecificStateLabels(t *testing.T, metric pdata.Metric) {
-	internal.AssertSumMetricHasAttributeValue(t, metric, 4, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Nice))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 5, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Softirq))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 6, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Steal))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 7, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Wait))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 4, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Nice))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 5, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Softirq))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 6, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Steal))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 7, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Wait))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -93,8 +93,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// Cpu (CPU number starting at 0.)
 	Cpu string
 	// State (Breakdown of CPU usage by type.)
@@ -104,12 +104,11 @@ var Labels = struct {
 	"state",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelState are the possible values that the label "state" can have.
-var LabelState = struct {
+// AttributeState are the possible values that the attribute "state" can have.
+var AttributeState = struct {
 	Idle      string
 	Interrupt string
 	Nice      string

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -1,6 +1,6 @@
 name: cpu
 
-labels:
+attributes:
   cpu:
     description: CPU number starting at 0.
 
@@ -16,4 +16,4 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [state]
+    attributes: [state]

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
@@ -115,8 +115,8 @@ func initializeDiskIOMetric(metric pdata.Metric, startTime, now pdata.Timestamp,
 	idps.EnsureCapacity(2 * len(ioCounters))
 
 	for device, ioCounter := range ioCounters {
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.LabelDirection.Read, int64(ioCounter.ReadBytes))
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.LabelDirection.Write, int64(ioCounter.WriteBytes))
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.AttributeDirection.Read, int64(ioCounter.ReadBytes))
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.AttributeDirection.Write, int64(ioCounter.WriteBytes))
 	}
 }
 
@@ -127,8 +127,8 @@ func initializeDiskOperationsMetric(metric pdata.Metric, startTime, now pdata.Ti
 	idps.EnsureCapacity(2 * len(ioCounters))
 
 	for device, ioCounter := range ioCounters {
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.LabelDirection.Read, int64(ioCounter.ReadCount))
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.LabelDirection.Write, int64(ioCounter.WriteCount))
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.AttributeDirection.Read, int64(ioCounter.ReadCount))
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.AttributeDirection.Write, int64(ioCounter.WriteCount))
 	}
 }
 
@@ -150,8 +150,8 @@ func initializeDiskOperationTimeMetric(metric pdata.Metric, startTime, now pdata
 	ddps.EnsureCapacity(2 * len(ioCounters))
 
 	for device, ioCounter := range ioCounters {
-		initializeNumberDataPointAsDouble(ddps.AppendEmpty(), startTime, now, device, metadata.LabelDirection.Read, float64(ioCounter.ReadTime)/1e3)
-		initializeNumberDataPointAsDouble(ddps.AppendEmpty(), startTime, now, device, metadata.LabelDirection.Write, float64(ioCounter.WriteTime)/1e3)
+		initializeNumberDataPointAsDouble(ddps.AppendEmpty(), startTime, now, device, metadata.AttributeDirection.Read, float64(ioCounter.ReadTime)/1e3)
+		initializeNumberDataPointAsDouble(ddps.AppendEmpty(), startTime, now, device, metadata.AttributeDirection.Write, float64(ioCounter.WriteTime)/1e3)
 	}
 }
 
@@ -167,7 +167,7 @@ func initializeDiskPendingOperationsMetric(metric pdata.Metric, now pdata.Timest
 }
 
 func initializeDiskPendingDataPoint(dataPoint pdata.NumberDataPoint, now pdata.Timestamp, deviceLabel string, value int64) {
-	dataPoint.Attributes().InsertString(metadata.Labels.Device, deviceLabel)
+	dataPoint.Attributes().InsertString(metadata.Attributes.Device, deviceLabel)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
@@ -49,7 +49,7 @@ func initializeDiskMergedMetric(metric pdata.Metric, startTime, now pdata.Timest
 	idps.EnsureCapacity(2 * len(ioCounters))
 
 	for device, ioCounter := range ioCounters {
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.LabelDirection.Read, int64(ioCounter.MergedReadCount))
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.LabelDirection.Write, int64(ioCounter.MergedWriteCount))
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.AttributeDirection.Read, int64(ioCounter.MergedReadCount))
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, device, metadata.AttributeDirection.Write, int64(ioCounter.MergedWriteCount))
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -131,8 +131,8 @@ func assertInt64DiskMetricValid(t *testing.T, metric pdata.Metric, expectedDescr
 	assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), 2)
 
 	internal.AssertSumMetricHasAttribute(t, metric, 0, "device")
-	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.Read))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.Write))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.Read))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.Write))
 }
 
 func assertDoubleDiskMetricValid(t *testing.T, metric pdata.Metric, expectedDescriptor pdata.Metric, expectDirectionLabels bool, startTime pdata.Timestamp) {
@@ -149,8 +149,8 @@ func assertDoubleDiskMetricValid(t *testing.T, metric pdata.Metric, expectedDesc
 
 	internal.AssertSumMetricHasAttribute(t, metric, 0, "device")
 	if expectDirectionLabels {
-		internal.AssertSumMetricHasAttributeValue(t, metric, 0, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.Read))
-		internal.AssertSumMetricHasAttributeValue(t, metric, metric.Sum().DataPoints().Len()-1, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.Write))
+		internal.AssertSumMetricHasAttributeValue(t, metric, 0, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.Read))
+		internal.AssertSumMetricHasAttributeValue(t, metric, metric.Sum().DataPoints().Len()-1, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.Write))
 	}
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows.go
@@ -137,8 +137,8 @@ func initializeDiskIOMetric(metric pdata.Metric, startTime, now pdata.Timestamp,
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(2 * len(logicalDiskCounterValues))
 	for _, logicalDiskCounter := range logicalDiskCounterValues {
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.LabelDirection.Read, logicalDiskCounter.Values[readBytesPerSec])
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.LabelDirection.Write, logicalDiskCounter.Values[writeBytesPerSec])
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.AttributeDirection.Read, logicalDiskCounter.Values[readBytesPerSec])
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.AttributeDirection.Write, logicalDiskCounter.Values[writeBytesPerSec])
 	}
 }
 
@@ -148,8 +148,8 @@ func initializeDiskOperationsMetric(metric pdata.Metric, startTime, now pdata.Ti
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(2 * len(logicalDiskCounterValues))
 	for _, logicalDiskCounter := range logicalDiskCounterValues {
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.LabelDirection.Read, logicalDiskCounter.Values[readsPerSec])
-		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.LabelDirection.Write, logicalDiskCounter.Values[writesPerSec])
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.AttributeDirection.Read, logicalDiskCounter.Values[readsPerSec])
+		initializeNumberDataPointAsInt(idps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.AttributeDirection.Write, logicalDiskCounter.Values[writesPerSec])
 	}
 }
 
@@ -170,8 +170,8 @@ func initializeDiskOperationTimeMetric(metric pdata.Metric, startTime, now pdata
 	ddps := metric.Sum().DataPoints()
 	ddps.EnsureCapacity(2 * len(logicalDiskCounterValues))
 	for _, logicalDiskCounter := range logicalDiskCounterValues {
-		initializeNumberDataPointAsDouble(ddps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.LabelDirection.Read, float64(logicalDiskCounter.Values[avgDiskSecsPerRead])/1e7)
-		initializeNumberDataPointAsDouble(ddps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.LabelDirection.Write, float64(logicalDiskCounter.Values[avgDiskSecsPerWrite])/1e7)
+		initializeNumberDataPointAsDouble(ddps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.AttributeDirection.Read, float64(logicalDiskCounter.Values[avgDiskSecsPerRead])/1e7)
+		initializeNumberDataPointAsDouble(ddps.AppendEmpty(), startTime, now, logicalDiskCounter.InstanceName, metadata.AttributeDirection.Write, float64(logicalDiskCounter.Values[avgDiskSecsPerWrite])/1e7)
 	}
 }
 
@@ -186,7 +186,7 @@ func initializeDiskPendingOperationsMetric(metric pdata.Metric, now pdata.Timest
 }
 
 func initializeDiskPendingDataPoint(dataPoint pdata.NumberDataPoint, now pdata.Timestamp, deviceLabel string, value int64) {
-	dataPoint.Attributes().InsertString(metadata.Labels.Device, deviceLabel)
+	dataPoint.Attributes().InsertString(metadata.Attributes.Device, deviceLabel)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
@@ -177,8 +177,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// Device (Name of the disk.)
 	Device string
 	// Direction (Direction of flow of bytes/opertations (read or write).)
@@ -188,12 +188,11 @@ var Labels = struct {
 	"direction",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelDirection are the possible values that the label "direction" can have.
-var LabelDirection = struct {
+// AttributeDirection are the possible values that the attribute "direction" can have.
+var AttributeDirection = struct {
 	Read  string
 	Write string
 }{

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
@@ -1,6 +1,6 @@
 name: disk
 
-labels:
+attributes:
   device:
     description: Name of the disk.
 
@@ -16,7 +16,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device, direction]
+    attributes: [device, direction]
 
   system.disk.operations:
     description: Disk operations count.
@@ -25,7 +25,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device, direction]
+    attributes: [device, direction]
 
   system.disk.io_time:
     description: Time disk spent activated. On Windows, this is calculated as the inverse of disk idle time.
@@ -34,7 +34,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device]
+    attributes: [device]
 
   system.disk.operation_time:
     description: Time spent in disk operations.
@@ -43,7 +43,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device, direction]
+    attributes: [device, direction]
 
   system.disk.weighted_io_time:
     description: Time disk spent activated multiplied by the queue length.
@@ -52,7 +52,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device]
+    attributes: [device]
 
   system.disk.pending_operations:
     description: The queue size of pending I/O operations.
@@ -61,7 +61,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: false
-    labels: [device]
+    attributes: [device]
 
   system.disk.merged:
     description: The number of disk reads merged into single physical disk access operations.
@@ -70,4 +70,4 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device, direction]
+    attributes: [device, direction]

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/utils.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/utils.go
@@ -22,9 +22,9 @@ import (
 
 func initializeNumberDataPointAsInt(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, deviceLabel string, directionLabel string, value int64) {
 	attributes := dataPoint.Attributes()
-	attributes.InsertString(metadata.Labels.Device, deviceLabel)
+	attributes.InsertString(metadata.Attributes.Device, deviceLabel)
 	if directionLabel != "" {
-		attributes.InsertString(metadata.Labels.Direction, directionLabel)
+		attributes.InsertString(metadata.Attributes.Direction, directionLabel)
 	}
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)
@@ -33,9 +33,9 @@ func initializeNumberDataPointAsInt(dataPoint pdata.NumberDataPoint, startTime, 
 
 func initializeNumberDataPointAsDouble(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, deviceLabel string, directionLabel string, value float64) {
 	attributes := dataPoint.Attributes()
-	attributes.InsertString(metadata.Labels.Device, deviceLabel)
+	attributes.InsertString(metadata.Attributes.Device, deviceLabel)
 	if directionLabel != "" {
-		attributes.InsertString(metadata.Labels.Direction, directionLabel)
+		attributes.InsertString(metadata.Attributes.Direction, directionLabel)
 	}
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
@@ -74,32 +74,32 @@ func (cfg *Config) createFilter() (*fsFilter, error) {
 	var err error
 	filter := fsFilter{}
 
-	filter.includeDeviceFilter, err = newIncludeFilterHelper(cfg.IncludeDevices.Devices, &cfg.IncludeDevices.Config, metadata.Labels.Device)
+	filter.includeDeviceFilter, err = newIncludeFilterHelper(cfg.IncludeDevices.Devices, &cfg.IncludeDevices.Config, metadata.Attributes.Device)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.excludeDeviceFilter, err = newExcludeFilterHelper(cfg.ExcludeDevices.Devices, &cfg.ExcludeDevices.Config, metadata.Labels.Device)
+	filter.excludeDeviceFilter, err = newExcludeFilterHelper(cfg.ExcludeDevices.Devices, &cfg.ExcludeDevices.Config, metadata.Attributes.Device)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.includeFSTypeFilter, err = newIncludeFilterHelper(cfg.IncludeFSTypes.FSTypes, &cfg.IncludeFSTypes.Config, metadata.Labels.Type)
+	filter.includeFSTypeFilter, err = newIncludeFilterHelper(cfg.IncludeFSTypes.FSTypes, &cfg.IncludeFSTypes.Config, metadata.Attributes.Type)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.excludeFSTypeFilter, err = newExcludeFilterHelper(cfg.ExcludeFSTypes.FSTypes, &cfg.ExcludeFSTypes.Config, metadata.Labels.Type)
+	filter.excludeFSTypeFilter, err = newExcludeFilterHelper(cfg.ExcludeFSTypes.FSTypes, &cfg.ExcludeFSTypes.Config, metadata.Attributes.Type)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.includeMountPointFilter, err = newIncludeFilterHelper(cfg.IncludeMountPoints.MountPoints, &cfg.IncludeMountPoints.Config, metadata.Labels.Mountpoint)
+	filter.includeMountPointFilter, err = newIncludeFilterHelper(cfg.IncludeMountPoints.MountPoints, &cfg.IncludeMountPoints.Config, metadata.Attributes.Mountpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	filter.excludeMountPointFilter, err = newExcludeFilterHelper(cfg.ExcludeMountPoints.MountPoints, &cfg.ExcludeMountPoints.Config, metadata.Labels.Mountpoint)
+	filter.excludeMountPointFilter, err = newExcludeFilterHelper(cfg.ExcludeMountPoints.MountPoints, &cfg.ExcludeMountPoints.Config, metadata.Attributes.Mountpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -110,11 +110,11 @@ func initializeFileSystemUsageMetric(metric pdata.Metric, now pdata.Timestamp, d
 
 func initializeFileSystemUsageDataPoint(dataPoint pdata.NumberDataPoint, now pdata.Timestamp, partition disk.PartitionStat, stateLabel string, value int64) {
 	attributes := dataPoint.Attributes()
-	attributes.InsertString(metadata.Labels.Device, partition.Device)
-	attributes.InsertString(metadata.Labels.Type, partition.Fstype)
-	attributes.InsertString(metadata.Labels.Mode, getMountMode(partition.Opts))
-	attributes.InsertString(metadata.Labels.Mountpoint, partition.Mountpoint)
-	attributes.InsertString(metadata.Labels.State, stateLabel)
+	attributes.InsertString(metadata.Attributes.Device, partition.Device)
+	attributes.InsertString(metadata.Attributes.Type, partition.Fstype)
+	attributes.InsertString(metadata.Attributes.Mode, getMountMode(partition.Opts))
+	attributes.InsertString(metadata.Attributes.Mountpoint, partition.Mountpoint)
+	attributes.InsertString(metadata.Attributes.State, stateLabel)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
@@ -26,8 +26,8 @@ import (
 const fileSystemStatesLen = 2
 
 func appendFileSystemUsageStateDataPoints(idps pdata.NumberDataPointSlice, now pdata.Timestamp, deviceUsage *deviceUsage) {
-	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.LabelState.Used, int64(deviceUsage.usage.Used))
-	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.LabelState.Free, int64(deviceUsage.usage.Free))
+	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.AttributeState.Used, int64(deviceUsage.usage.Used))
+	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.AttributeState.Free, int64(deviceUsage.usage.Free))
 }
 
 const systemSpecificMetricsLen = 0

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -271,12 +271,12 @@ func assertFileSystemUsageMetricValid(
 	} else {
 		assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), fileSystemStatesLen)
 	}
-	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "state", pdata.NewAttributeValueString(metadata.LabelState.Used))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "state", pdata.NewAttributeValueString(metadata.LabelState.Free))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "state", pdata.NewAttributeValueString(metadata.AttributeState.Used))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "state", pdata.NewAttributeValueString(metadata.AttributeState.Free))
 }
 
 func assertFileSystemUsageMetricHasUnixSpecificStateLabels(t *testing.T, metric pdata.Metric) {
-	internal.AssertSumMetricHasAttributeValue(t, metric, 2, "state", pdata.NewAttributeValueString(metadata.LabelState.Reserved))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 2, "state", pdata.NewAttributeValueString(metadata.AttributeState.Reserved))
 }
 
 func isUnix() bool {

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_unix.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_unix.go
@@ -26,9 +26,9 @@ import (
 const fileSystemStatesLen = 3
 
 func appendFileSystemUsageStateDataPoints(idps pdata.NumberDataPointSlice, now pdata.Timestamp, deviceUsage *deviceUsage) {
-	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.LabelState.Used, int64(deviceUsage.usage.Used))
-	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.LabelState.Free, int64(deviceUsage.usage.Free))
-	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.LabelState.Reserved, int64(deviceUsage.usage.Total-deviceUsage.usage.Used-deviceUsage.usage.Free))
+	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.AttributeState.Used, int64(deviceUsage.usage.Used))
+	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.AttributeState.Free, int64(deviceUsage.usage.Free))
+	initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.AttributeState.Reserved, int64(deviceUsage.usage.Total-deviceUsage.usage.Used-deviceUsage.usage.Free))
 }
 
 const systemSpecificMetricsLen = 1
@@ -40,7 +40,7 @@ func appendSystemSpecificMetrics(metrics pdata.MetricSlice, now pdata.Timestamp,
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(2 * len(deviceUsages))
 	for _, deviceUsage := range deviceUsages {
-		initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.LabelState.Used, int64(deviceUsage.usage.InodesUsed))
-		initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.LabelState.Free, int64(deviceUsage.usage.InodesFree))
+		initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.AttributeState.Used, int64(deviceUsage.usage.InodesUsed))
+		initializeFileSystemUsageDataPoint(idps.AppendEmpty(), now, deviceUsage.partition, metadata.AttributeState.Free, int64(deviceUsage.usage.InodesFree))
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
@@ -107,8 +107,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// Device (Identifier of the filesystem.)
 	Device string
 	// Mode (Mountpoint mode such "ro", "rw", etc.)
@@ -127,12 +127,11 @@ var Labels = struct {
 	"type",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelState are the possible values that the label "state" can have.
-var LabelState = struct {
+// AttributeState are the possible values that the attribute "state" can have.
+var AttributeState = struct {
 	Free     string
 	Reserved string
 	Used     string

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -1,6 +1,6 @@
 name: filesystem
 
-labels:
+attributes:
   device:
     description: Identifier of the filesystem.
 
@@ -25,7 +25,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: false
-    labels: [device, mode, mountpoint, type, state]
+    attributes: [device, mode, mountpoint, type, state]
 
   system.filesystem.inodes.usage:
     description: FileSystem inodes used.
@@ -34,4 +34,4 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: false
-    labels: [device, mode, mountpoint, type, state]
+    attributes: [device, mode, mountpoint, type, state]

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
@@ -115,10 +115,9 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 }{}
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
@@ -1,6 +1,6 @@
 name: load
 
-labels:
+attributes:
 
 metrics:
   system.cpu.load_average.1m:

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
@@ -93,20 +93,19 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// State (Breakdown of memory usage by type.)
 	State string
 }{
 	"state",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelState are the possible values that the label "state" can have.
-var LabelState = struct {
+// AttributeState are the possible values that the attribute "state" can have.
+var AttributeState = struct {
 	Buffered          string
 	Cached            string
 	Inactive          string

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
@@ -64,7 +64,7 @@ func initializeMemoryUsageMetric(metric pdata.Metric, now pdata.Timestamp, memIn
 }
 
 func initializeMemoryUsageDataPoint(dataPoint pdata.NumberDataPoint, now pdata.Timestamp, stateLabel string, value int64) {
-	dataPoint.Attributes().InsertString(metadata.Labels.State, stateLabel)
+	dataPoint.Attributes().InsertString(metadata.Attributes.State, stateLabel)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
@@ -27,10 +27,10 @@ import (
 const memStatesLen = 6
 
 func appendMemoryUsageStateDataPoints(idps pdata.NumberDataPointSlice, now pdata.Timestamp, memInfo *mem.VirtualMemoryStat) {
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.Used, int64(memInfo.Used))
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.Free, int64(memInfo.Free))
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.Buffered, int64(memInfo.Buffers))
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.Cached, int64(memInfo.Cached))
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.SlabReclaimable, int64(memInfo.SReclaimable))
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.SlabUnreclaimable, int64(memInfo.SUnreclaim))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.Used, int64(memInfo.Used))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.Free, int64(memInfo.Free))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.Buffered, int64(memInfo.Buffers))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.Cached, int64(memInfo.Cached))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.SlabReclaimable, int64(memInfo.SReclaimable))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.SlabUnreclaimable, int64(memInfo.SUnreclaim))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
@@ -27,7 +27,7 @@ import (
 const memStatesLen = 3
 
 func appendMemoryUsageStateDataPoints(idps pdata.NumberDataPointSlice, now pdata.Timestamp, memInfo *mem.VirtualMemoryStat) {
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.Used, int64(memInfo.Used))
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.Free, int64(memInfo.Free))
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.Inactive, int64(memInfo.Inactive))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.Used, int64(memInfo.Used))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.Free, int64(memInfo.Free))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.Inactive, int64(memInfo.Inactive))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -77,7 +77,7 @@ func TestScrape(t *testing.T) {
 			if runtime.GOOS == "linux" {
 				assertMemoryUsageMetricHasLinuxSpecificStateLabels(t, metrics.At(0))
 			} else if runtime.GOOS != "windows" {
-				internal.AssertSumMetricHasAttributeValue(t, metrics.At(0), 2, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Inactive))
+				internal.AssertSumMetricHasAttributeValue(t, metrics.At(0), 2, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Inactive))
 			}
 
 			internal.AssertSameTimeStampForAllMetrics(t, metrics)
@@ -88,13 +88,13 @@ func TestScrape(t *testing.T) {
 func assertMemoryUsageMetricValid(t *testing.T, metric pdata.Metric, descriptor pdata.Metric) {
 	internal.AssertDescriptorEqual(t, descriptor, metric)
 	assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), 2)
-	internal.AssertSumMetricHasAttributeValue(t, metric, 0, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Used))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 1, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Free))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 0, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Used))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 1, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Free))
 }
 
 func assertMemoryUsageMetricHasLinuxSpecificStateLabels(t *testing.T, metric pdata.Metric) {
-	internal.AssertSumMetricHasAttributeValue(t, metric, 2, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Buffered))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 3, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.Cached))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 4, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.SlabReclaimable))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 5, metadata.Labels.State, pdata.NewAttributeValueString(metadata.LabelState.SlabUnreclaimable))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 2, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Buffered))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 3, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.Cached))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 4, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.SlabReclaimable))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 5, metadata.Attributes.State, pdata.NewAttributeValueString(metadata.AttributeState.SlabUnreclaimable))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
@@ -27,6 +27,6 @@ import (
 const memStatesLen = 2
 
 func appendMemoryUsageStateDataPoints(idps pdata.NumberDataPointSlice, now pdata.Timestamp, memInfo *mem.VirtualMemoryStat) {
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.Used, int64(memInfo.Used))
-	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.LabelState.Free, int64(memInfo.Available))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.Used, int64(memInfo.Used))
+	initializeMemoryUsageDataPoint(idps.AppendEmpty(), now, metadata.AttributeState.Free, int64(memInfo.Available))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -1,6 +1,6 @@
 name: memory
 
-labels:
+attributes:
   state:
     description: Breakdown of memory usage by type.
     enum: [buffered, cached, inactive, free, slab_reclaimable, slab_unreclaimable, used]
@@ -13,4 +13,4 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: false
-    labels: [state]
+    attributes: [state]

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -149,8 +149,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// Device (Name of the network interface.)
 	Device string
 	// Direction (Direction of flow of bytes/opertations (receive or transmit).)
@@ -166,12 +166,11 @@ var Labels = struct {
 	"state",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelDirection are the possible values that the label "direction" can have.
-var LabelDirection = struct {
+// AttributeDirection are the possible values that the attribute "direction" can have.
+var AttributeDirection = struct {
 	Receive  string
 	Transmit string
 }{
@@ -179,8 +178,8 @@ var LabelDirection = struct {
 	"transmit",
 }
 
-// LabelProtocol are the possible values that the label "protocol" can have.
-var LabelProtocol = struct {
+// AttributeProtocol are the possible values that the attribute "protocol" can have.
+var AttributeProtocol = struct {
 	Tcp string
 }{
 	"tcp",

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -1,6 +1,6 @@
 name: network
 
-labels:
+attributes:
   device:
     description: Name of the network interface.
 
@@ -23,7 +23,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device, direction]
+    attributes: [device, direction]
 
   system.network.dropped:
     description: The number of packets dropped.
@@ -32,7 +32,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device, direction]
+    attributes: [device, direction]
 
   system.network.errors:
     description: The number of errors encountered.
@@ -41,7 +41,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device, direction]
+    attributes: [device, direction]
 
   system.network.io:
     description: The number of bytes transmitted and received.
@@ -50,7 +50,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [device, direction]
+    attributes: [device, direction]
 
   system.network.connections:
     description: The number of connections.
@@ -59,4 +59,4 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: false
-    labels: [protocol, state]
+    attributes: [protocol, state]

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -128,8 +128,8 @@ func initializeNetworkPacketsMetric(metric pdata.Metric, metricIntf metadata.Met
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(2 * len(ioCountersSlice))
 	for _, ioCounters := range ioCountersSlice {
-		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.LabelDirection.Transmit, int64(ioCounters.PacketsSent))
-		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.LabelDirection.Receive, int64(ioCounters.PacketsRecv))
+		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.AttributeDirection.Transmit, int64(ioCounters.PacketsSent))
+		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.AttributeDirection.Receive, int64(ioCounters.PacketsRecv))
 	}
 }
 
@@ -139,8 +139,8 @@ func initializeNetworkDroppedPacketsMetric(metric pdata.Metric, metricIntf metad
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(2 * len(ioCountersSlice))
 	for _, ioCounters := range ioCountersSlice {
-		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.LabelDirection.Transmit, int64(ioCounters.Dropout))
-		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.LabelDirection.Receive, int64(ioCounters.Dropin))
+		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.AttributeDirection.Transmit, int64(ioCounters.Dropout))
+		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.AttributeDirection.Receive, int64(ioCounters.Dropin))
 	}
 }
 
@@ -150,8 +150,8 @@ func initializeNetworkErrorsMetric(metric pdata.Metric, metricIntf metadata.Metr
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(2 * len(ioCountersSlice))
 	for _, ioCounters := range ioCountersSlice {
-		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.LabelDirection.Transmit, int64(ioCounters.Errout))
-		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.LabelDirection.Receive, int64(ioCounters.Errin))
+		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.AttributeDirection.Transmit, int64(ioCounters.Errout))
+		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.AttributeDirection.Receive, int64(ioCounters.Errin))
 	}
 }
 
@@ -161,15 +161,15 @@ func initializeNetworkIOMetric(metric pdata.Metric, metricIntf metadata.MetricIn
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(2 * len(ioCountersSlice))
 	for _, ioCounters := range ioCountersSlice {
-		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.LabelDirection.Transmit, int64(ioCounters.BytesSent))
-		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.LabelDirection.Receive, int64(ioCounters.BytesRecv))
+		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.AttributeDirection.Transmit, int64(ioCounters.BytesSent))
+		initializeNetworkDataPoint(idps.AppendEmpty(), startTime, now, ioCounters.Name, metadata.AttributeDirection.Receive, int64(ioCounters.BytesRecv))
 	}
 }
 
 func initializeNetworkDataPoint(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, deviceLabel, directionLabel string, value int64) {
 	attributes := dataPoint.Attributes()
-	attributes.InsertString(metadata.Labels.Device, deviceLabel)
-	attributes.InsertString(metadata.Labels.Direction, directionLabel)
+	attributes.InsertString(metadata.Attributes.Device, deviceLabel)
+	attributes.InsertString(metadata.Attributes.Direction, directionLabel)
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)
@@ -210,14 +210,14 @@ func initializeNetworkConnectionsMetric(metric pdata.Metric, now pdata.Timestamp
 	idps.EnsureCapacity(len(connectionStateCounts))
 
 	for connectionState, count := range connectionStateCounts {
-		initializeNetworkConnectionsDataPoint(idps.AppendEmpty(), now, metadata.LabelProtocol.Tcp, connectionState, count)
+		initializeNetworkConnectionsDataPoint(idps.AppendEmpty(), now, metadata.AttributeProtocol.Tcp, connectionState, count)
 	}
 }
 
 func initializeNetworkConnectionsDataPoint(dataPoint pdata.NumberDataPoint, now pdata.Timestamp, protocolLabel, stateLabel string, value int64) {
 	attributes := dataPoint.Attributes()
-	attributes.InsertString(metadata.Labels.Protocol, protocolLabel)
-	attributes.InsertString(metadata.Labels.State, stateLabel)
+	attributes.InsertString(metadata.Attributes.Protocol, protocolLabel)
+	attributes.InsertString(metadata.Attributes.State, stateLabel)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -162,13 +162,13 @@ func assertNetworkIOMetricValid(t *testing.T, metric pdata.Metric, descriptor pd
 	}
 	assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), 2)
 	internal.AssertSumMetricHasAttribute(t, metric, 0, "device")
-	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.Transmit))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.Receive))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.Transmit))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.Receive))
 }
 
 func assertNetworkConnectionsMetricValid(t *testing.T, metric pdata.Metric) {
 	internal.AssertDescriptorEqual(t, metadata.Metrics.SystemNetworkConnections.New(), metric)
-	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "protocol", pdata.NewAttributeValueString(metadata.LabelProtocol.Tcp))
+	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "protocol", pdata.NewAttributeValueString(metadata.AttributeProtocol.Tcp))
 	internal.AssertSumMetricHasAttribute(t, metric, 0, "state")
 	assert.Equal(t, 12, metric.Sum().DataPoints().Len())
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
@@ -121,8 +121,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// Device (Name of the page file.)
 	Device string
 	// Direction (Page In or Page Out.)
@@ -138,12 +138,11 @@ var Labels = struct {
 	"type",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelDirection are the possible values that the label "direction" can have.
-var LabelDirection = struct {
+// AttributeDirection are the possible values that the attribute "direction" can have.
+var AttributeDirection = struct {
 	PageIn  string
 	PageOut string
 }{
@@ -151,8 +150,8 @@ var LabelDirection = struct {
 	"page_out",
 }
 
-// LabelState are the possible values that the label "state" can have.
-var LabelState = struct {
+// AttributeState are the possible values that the attribute "state" can have.
+var AttributeState = struct {
 	Cached string
 	Free   string
 	Used   string
@@ -162,8 +161,8 @@ var LabelState = struct {
 	"used",
 }
 
-// LabelType are the possible values that the label "type" can have.
-var LabelType = struct {
+// AttributeType are the possible values that the attribute "type" can have.
+var AttributeType = struct {
 	Major string
 	Minor string
 }{

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -1,6 +1,6 @@
 name: paging
 
-labels:
+attributes:
   device:
     description: Name of the page file.
 
@@ -24,7 +24,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: false
-    labels: [device, state]
+    attributes: [device, state]
 
   system.paging.operations:
     description: The number of paging operations.
@@ -33,7 +33,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [direction, type]
+    attributes: [direction, type]
 
   system.paging.faults:
     description: The number of page faults.
@@ -42,4 +42,4 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [type]
+    attributes: [type]

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
@@ -99,19 +99,19 @@ func initializePagingUsageMetric(metric pdata.Metric, now pdata.Timestamp, pageF
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(3)
 	for _, pageFile := range pageFileStats {
-		initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.LabelState.Used, int64(pageFile.usedBytes))
-		initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.LabelState.Free, int64(pageFile.freeBytes))
+		initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.AttributeState.Used, int64(pageFile.usedBytes))
+		initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.AttributeState.Free, int64(pageFile.freeBytes))
 		if pageFile.cachedBytes != nil {
-			initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.LabelState.Cached, int64(*pageFile.cachedBytes))
+			initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.AttributeState.Cached, int64(*pageFile.cachedBytes))
 		}
 	}
 }
 
 func initializePagingUsageDataPoint(dataPoint pdata.NumberDataPoint, now pdata.Timestamp, deviceLabel, stateLabel string, value int64) {
 	if deviceLabel != "" {
-		dataPoint.Attributes().InsertString(metadata.Labels.Device, deviceLabel)
+		dataPoint.Attributes().InsertString(metadata.Attributes.Device, deviceLabel)
 	}
-	dataPoint.Attributes().InsertString(metadata.Labels.State, stateLabel)
+	dataPoint.Attributes().InsertString(metadata.Attributes.State, stateLabel)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)
 }
@@ -135,16 +135,16 @@ func initializePagingOperationsMetric(metric pdata.Metric, startTime, now pdata.
 
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(4)
-	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.LabelType.Major, metadata.LabelDirection.PageIn, int64(swap.Sin))
-	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.LabelType.Major, metadata.LabelDirection.PageOut, int64(swap.Sout))
-	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.LabelType.Minor, metadata.LabelDirection.PageIn, int64(swap.PgIn))
-	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.LabelType.Minor, metadata.LabelDirection.PageOut, int64(swap.PgOut))
+	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.AttributeType.Major, metadata.AttributeDirection.PageIn, int64(swap.Sin))
+	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.AttributeType.Major, metadata.AttributeDirection.PageOut, int64(swap.Sout))
+	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.AttributeType.Minor, metadata.AttributeDirection.PageIn, int64(swap.PgIn))
+	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.AttributeType.Minor, metadata.AttributeDirection.PageOut, int64(swap.PgOut))
 }
 
 func initializePagingOperationsDataPoint(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, typeLabel string, directionLabel string, value int64) {
 	attributes := dataPoint.Attributes()
-	attributes.InsertString(metadata.Labels.Type, typeLabel)
-	attributes.InsertString(metadata.Labels.Direction, directionLabel)
+	attributes.InsertString(metadata.Attributes.Type, typeLabel)
+	attributes.InsertString(metadata.Attributes.Direction, directionLabel)
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)
@@ -155,12 +155,12 @@ func initializePageFaultsMetric(metric pdata.Metric, startTime, now pdata.Timest
 
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(2)
-	initializePageFaultDataPoint(idps.AppendEmpty(), startTime, now, metadata.LabelType.Major, int64(swap.PgMajFault))
-	initializePageFaultDataPoint(idps.AppendEmpty(), startTime, now, metadata.LabelType.Minor, int64(swap.PgFault-swap.PgMajFault))
+	initializePageFaultDataPoint(idps.AppendEmpty(), startTime, now, metadata.AttributeType.Major, int64(swap.PgMajFault))
+	initializePageFaultDataPoint(idps.AppendEmpty(), startTime, now, metadata.AttributeType.Minor, int64(swap.PgFault-swap.PgMajFault))
 }
 
 func initializePageFaultDataPoint(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, typeLabel string, value int64) {
-	dataPoint.Attributes().InsertString(metadata.Labels.Type, typeLabel)
+	dataPoint.Attributes().InsertString(metadata.Attributes.Type, typeLabel)
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
@@ -106,11 +106,11 @@ func assertPagingUsageMetricValid(t *testing.T, hostPagingUsageMetric pdata.Metr
 	}
 
 	assert.GreaterOrEqual(t, hostPagingUsageMetric.Sum().DataPoints().Len(), expectedDataPoints)
-	internal.AssertSumMetricHasAttributeValue(t, hostPagingUsageMetric, 0, "state", pdata.NewAttributeValueString(metadata.LabelState.Used))
-	internal.AssertSumMetricHasAttributeValue(t, hostPagingUsageMetric, 1, "state", pdata.NewAttributeValueString(metadata.LabelState.Free))
+	internal.AssertSumMetricHasAttributeValue(t, hostPagingUsageMetric, 0, "state", pdata.NewAttributeValueString(metadata.AttributeState.Used))
+	internal.AssertSumMetricHasAttributeValue(t, hostPagingUsageMetric, 1, "state", pdata.NewAttributeValueString(metadata.AttributeState.Free))
 	// Windows and Linux do not support cached state label
 	if runtime.GOOS != "windows" && runtime.GOOS != "linux" {
-		internal.AssertSumMetricHasAttributeValue(t, hostPagingUsageMetric, 2, "state", pdata.NewAttributeValueString(metadata.LabelState.Cached))
+		internal.AssertSumMetricHasAttributeValue(t, hostPagingUsageMetric, 2, "state", pdata.NewAttributeValueString(metadata.AttributeState.Cached))
 	}
 
 	// on Windows and Linux, also expect the page file device name label
@@ -133,15 +133,15 @@ func assertPagingOperationsMetricValid(t *testing.T, pagingMetric pdata.Metric, 
 	}
 	assert.Equal(t, expectedDataPoints, pagingMetric.Sum().DataPoints().Len())
 
-	internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 0, "type", pdata.NewAttributeValueString(metadata.LabelType.Major))
-	internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 0, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.PageIn))
-	internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 1, "type", pdata.NewAttributeValueString(metadata.LabelType.Major))
-	internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 1, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.PageOut))
+	internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 0, "type", pdata.NewAttributeValueString(metadata.AttributeType.Major))
+	internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 0, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.PageIn))
+	internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 1, "type", pdata.NewAttributeValueString(metadata.AttributeType.Major))
+	internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 1, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.PageOut))
 	if runtime.GOOS != "windows" {
-		internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 2, "type", pdata.NewAttributeValueString(metadata.LabelType.Minor))
-		internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 2, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.PageIn))
-		internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 3, "type", pdata.NewAttributeValueString(metadata.LabelType.Minor))
-		internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 3, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.PageOut))
+		internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 2, "type", pdata.NewAttributeValueString(metadata.AttributeType.Minor))
+		internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 2, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.PageIn))
+		internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 3, "type", pdata.NewAttributeValueString(metadata.AttributeType.Minor))
+		internal.AssertSumMetricHasAttributeValue(t, pagingMetric, 3, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.PageOut))
 	}
 }
 
@@ -152,6 +152,6 @@ func assertPageFaultsMetricValid(t *testing.T, pageFaultsMetric pdata.Metric, st
 	}
 
 	assert.Equal(t, 2, pageFaultsMetric.Sum().DataPoints().Len())
-	internal.AssertSumMetricHasAttributeValue(t, pageFaultsMetric, 0, "type", pdata.NewAttributeValueString(metadata.LabelType.Major))
-	internal.AssertSumMetricHasAttributeValue(t, pageFaultsMetric, 1, "type", pdata.NewAttributeValueString(metadata.LabelType.Minor))
+	internal.AssertSumMetricHasAttributeValue(t, pageFaultsMetric, 0, "type", pdata.NewAttributeValueString(metadata.AttributeType.Major))
+	internal.AssertSumMetricHasAttributeValue(t, pageFaultsMetric, 1, "type", pdata.NewAttributeValueString(metadata.AttributeType.Minor))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
@@ -107,15 +107,15 @@ func (s *scraper) initializePagingUsageMetric(metric pdata.Metric, now pdata.Tim
 	idps.EnsureCapacity(2 * len(pageFiles))
 
 	for _, pageFile := range pageFiles {
-		initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.LabelState.Used, int64(pageFile.usedBytes))
-		initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.LabelState.Free, int64((pageFile.freeBytes)))
+		initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.AttributeState.Used, int64(pageFile.usedBytes))
+		initializePagingUsageDataPoint(idps.AppendEmpty(), now, pageFile.deviceName, metadata.AttributeState.Free, int64((pageFile.freeBytes)))
 	}
 }
 
 func initializePagingUsageDataPoint(dataPoint pdata.NumberDataPoint, now pdata.Timestamp, deviceLabel string, stateLabel string, value int64) {
 	attributes := dataPoint.Attributes()
-	attributes.InsertString(metadata.Labels.Device, deviceLabel)
-	attributes.InsertString(metadata.Labels.State, stateLabel)
+	attributes.InsertString(metadata.Attributes.Device, deviceLabel)
+	attributes.InsertString(metadata.Attributes.State, stateLabel)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)
 }
@@ -152,14 +152,14 @@ func initializePagingOperationsMetric(metric pdata.Metric, startTime, now pdata.
 
 	idps := metric.Sum().DataPoints()
 	idps.EnsureCapacity(2)
-	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.LabelDirection.PageIn, memoryCounterValues.Values[pageReadsPerSec])
-	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.LabelDirection.PageOut, memoryCounterValues.Values[pageWritesPerSec])
+	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.AttributeDirection.PageIn, memoryCounterValues.Values[pageReadsPerSec])
+	initializePagingOperationsDataPoint(idps.AppendEmpty(), startTime, now, metadata.AttributeDirection.PageOut, memoryCounterValues.Values[pageWritesPerSec])
 }
 
 func initializePagingOperationsDataPoint(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, directionLabel string, value int64) {
 	attributes := dataPoint.Attributes()
-	attributes.InsertString(metadata.Labels.Type, metadata.LabelType.Major)
-	attributes.InsertString(metadata.Labels.Direction, directionLabel)
+	attributes.InsertString(metadata.Attributes.Type, metadata.AttributeType.Major)
+	attributes.InsertString(metadata.Attributes.Direction, directionLabel)
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
@@ -107,20 +107,19 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// Status (Breakdown status of the processes.)
 	Status string
 }{
 	"status",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelStatus are the possible values that the label "status" can have.
-var LabelStatus = struct {
+// AttributeStatus are the possible values that the attribute "status" can have.
+var AttributeStatus = struct {
 	Blocked  string
 	Daemon   string
 	Detached string

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -1,6 +1,6 @@
 name: processes
 
-labels:
+attributes:
   status:
     description: Breakdown status of the processes.
     enum: [blocked, daemon, detached, orphan, paging, running, sleeping, stopped, system, unknown, zombies]
@@ -21,4 +21,4 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: false
-    labels: [status]
+    attributes: [status]

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
@@ -118,7 +118,7 @@ func setProcessesCountMetric(metric pdata.Metric, startTime, now pdata.Timestamp
 }
 
 func setProcessesCountDataPoint(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, statusLabel string, value int64) {
-	dataPoint.Attributes().InsertString(metadata.Labels.Status, statusLabel)
+	dataPoint.Attributes().InsertString(metadata.Attributes.Status, statusLabel)
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
@@ -136,15 +136,15 @@ func validateRealData(t *testing.T, metrics pdata.MetricSlice) {
 		assertContainsStatus := func(statusVal string) {
 			points := countMetric.Sum().DataPoints()
 			for i := 0; i < points.Len(); i++ {
-				v, ok := points.At(i).Attributes().Get(metadata.Labels.Status)
+				v, ok := points.At(i).Attributes().Get(metadata.Attributes.Status)
 				if ok && v.StringVal() == statusVal {
 					return
 				}
 			}
 			assert.Failf("missing-metric", "metric is missing %q status label", statusVal)
 		}
-		assertContainsStatus(metadata.LabelStatus.Running)
-		assertContainsStatus(metadata.LabelStatus.Blocked)
+		assertContainsStatus(metadata.AttributeStatus.Running)
+		assertContainsStatus(metadata.AttributeStatus.Blocked)
 	}
 
 	if expectProcessesCreatedMetric {
@@ -203,12 +203,12 @@ func validateFakeData(t *testing.T, metrics pdata.MetricSlice) {
 		attrs := map[string]int64{}
 		for i := 0; i < points.Len(); i++ {
 			point := points.At(i)
-			val, ok := point.Attributes().Get(metadata.L.Status)
+			val, ok := point.Attributes().Get(metadata.A.Status)
 			assert.Truef(ok, "Missing status attribute in data point %d", i)
 			attrs[val.StringVal()] = point.IntVal()
 		}
 
-		ls := metadata.LabelStatus
+		ls := metadata.AttributeStatus
 		assert.Equal(attrs, map[string]int64{
 			ls.Blocked:  3,
 			ls.Paging:   1,

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_unix.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_unix.go
@@ -43,7 +43,7 @@ func (s *scraper) getProcessesMetadata() (processesMetadata, error) {
 		}
 		state, ok := charToState[status]
 		if !ok {
-			countByStatus[metadata.LabelStatus.Unknown]++
+			countByStatus[metadata.AttributeStatus.Unknown]++
 			continue
 		}
 		countByStatus[state]++
@@ -63,15 +63,15 @@ func (s *scraper) getProcessesMetadata() (processesMetadata, error) {
 		procsCreated = &v
 	}
 
-	countByStatus[metadata.LabelStatus.Blocked] = int64(miscStat.ProcsBlocked)
-	countByStatus[metadata.LabelStatus.Running] = int64(miscStat.ProcsRunning)
+	countByStatus[metadata.AttributeStatus.Blocked] = int64(miscStat.ProcsBlocked)
+	countByStatus[metadata.AttributeStatus.Running] = int64(miscStat.ProcsRunning)
 
 	totalKnown := int64(0)
 	for _, count := range countByStatus {
 		totalKnown += count
 	}
 	if int64(miscStat.ProcsTotal) > totalKnown {
-		countByStatus[metadata.LabelStatus.Unknown] = int64(miscStat.ProcsTotal) - totalKnown
+		countByStatus[metadata.AttributeStatus.Unknown] = int64(miscStat.ProcsTotal) - totalKnown
 	}
 
 	return processesMetadata{
@@ -81,14 +81,14 @@ func (s *scraper) getProcessesMetadata() (processesMetadata, error) {
 }
 
 var charToState = map[string]string{
-	"A": metadata.LabelStatus.Daemon,
-	"D": metadata.LabelStatus.Blocked,
-	"E": metadata.LabelStatus.Detached,
-	"O": metadata.LabelStatus.Orphan,
-	"R": metadata.LabelStatus.Running,
-	"S": metadata.LabelStatus.Sleeping,
-	"T": metadata.LabelStatus.Stopped,
-	"W": metadata.LabelStatus.Paging,
-	"Y": metadata.LabelStatus.System,
-	"Z": metadata.LabelStatus.Zombies,
+	"A": metadata.AttributeStatus.Daemon,
+	"D": metadata.AttributeStatus.Blocked,
+	"E": metadata.AttributeStatus.Detached,
+	"O": metadata.AttributeStatus.Orphan,
+	"R": metadata.AttributeStatus.Running,
+	"S": metadata.AttributeStatus.Sleeping,
+	"T": metadata.AttributeStatus.Stopped,
+	"W": metadata.AttributeStatus.Paging,
+	"Y": metadata.AttributeStatus.System,
+	"Z": metadata.AttributeStatus.Zombies,
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -135,8 +135,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// Direction (Direction of flow of bytes (read or write).)
 	Direction string
 	// State (Breakdown of CPU usage by type.)
@@ -146,12 +146,11 @@ var Labels = struct {
 	"state",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelDirection are the possible values that the label "direction" can have.
-var LabelDirection = struct {
+// AttributeDirection are the possible values that the attribute "direction" can have.
+var AttributeDirection = struct {
 	Read  string
 	Write string
 }{
@@ -159,8 +158,8 @@ var LabelDirection = struct {
 	"write",
 }
 
-// LabelState are the possible values that the label "state" can have.
-var LabelState = struct {
+// AttributeState are the possible values that the attribute "state" can have.
+var AttributeState = struct {
 	System string
 	User   string
 	Wait   string

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -1,6 +1,6 @@
 name: process
 
-labels:
+attributes:
   direction:
     description: Direction of flow of bytes (read or write).
     enum: [read, write]
@@ -17,7 +17,7 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [state]
+    attributes: [state]
 
   process.memory.physical_usage:
     description: The amount of physical memory in use.
@@ -42,4 +42,4 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    labels: [direction]
+    attributes: [direction]

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -229,12 +229,12 @@ func initializeDiskIOMetric(metric pdata.Metric, startTime, now pdata.Timestamp,
 	metadata.Metrics.ProcessDiskIo.Init(metric)
 
 	idps := metric.Sum().DataPoints()
-	initializeDiskIODataPoint(idps.AppendEmpty(), startTime, now, int64(io.ReadBytes), metadata.LabelDirection.Read)
-	initializeDiskIODataPoint(idps.AppendEmpty(), startTime, now, int64(io.WriteBytes), metadata.LabelDirection.Write)
+	initializeDiskIODataPoint(idps.AppendEmpty(), startTime, now, int64(io.ReadBytes), metadata.AttributeDirection.Read)
+	initializeDiskIODataPoint(idps.AppendEmpty(), startTime, now, int64(io.WriteBytes), metadata.AttributeDirection.Write)
 }
 
 func initializeDiskIODataPoint(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, value int64, directionLabel string) {
-	dataPoint.Attributes().InsertString(metadata.Labels.Direction, directionLabel)
+	dataPoint.Attributes().InsertString(metadata.Attributes.Direction, directionLabel)
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetIntVal(value)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_linux.go
@@ -27,13 +27,13 @@ import (
 const cpuStatesLen = 3
 
 func appendCPUTimeStateDataPoints(ddps pdata.NumberDataPointSlice, startTime, now pdata.Timestamp, cpuTime *cpu.TimesStat) {
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.User, metadata.LabelState.User)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.System, metadata.LabelState.System)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.Iowait, metadata.LabelState.Wait)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.User, metadata.AttributeState.User)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.System, metadata.AttributeState.System)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.Iowait, metadata.AttributeState.Wait)
 }
 
 func initializeCPUTimeDataPoint(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, value float64, stateLabel string) {
-	dataPoint.Attributes().InsertString(metadata.Labels.State, stateLabel)
+	dataPoint.Attributes().InsertString(metadata.Attributes.State, stateLabel)
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetDoubleVal(value)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -96,10 +96,10 @@ func assertCPUTimeMetricValid(t *testing.T, resourceMetrics pdata.ResourceMetric
 	if startTime != 0 {
 		internal.AssertSumMetricStartTimeEquals(t, cpuTimeMetric, startTime)
 	}
-	internal.AssertSumMetricHasAttributeValue(t, cpuTimeMetric, 0, "state", pdata.NewAttributeValueString(metadata.LabelState.User))
-	internal.AssertSumMetricHasAttributeValue(t, cpuTimeMetric, 1, "state", pdata.NewAttributeValueString(metadata.LabelState.System))
+	internal.AssertSumMetricHasAttributeValue(t, cpuTimeMetric, 0, "state", pdata.NewAttributeValueString(metadata.AttributeState.User))
+	internal.AssertSumMetricHasAttributeValue(t, cpuTimeMetric, 1, "state", pdata.NewAttributeValueString(metadata.AttributeState.System))
 	if runtime.GOOS == "linux" {
-		internal.AssertSumMetricHasAttributeValue(t, cpuTimeMetric, 2, "state", pdata.NewAttributeValueString(metadata.LabelState.Wait))
+		internal.AssertSumMetricHasAttributeValue(t, cpuTimeMetric, 2, "state", pdata.NewAttributeValueString(metadata.AttributeState.Wait))
 	}
 }
 
@@ -114,8 +114,8 @@ func assertDiskIOMetricValid(t *testing.T, resourceMetrics pdata.ResourceMetrics
 	if startTime != 0 {
 		internal.AssertSumMetricStartTimeEquals(t, diskIOMetric, startTime)
 	}
-	internal.AssertSumMetricHasAttributeValue(t, diskIOMetric, 0, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.Read))
-	internal.AssertSumMetricHasAttributeValue(t, diskIOMetric, 1, "direction", pdata.NewAttributeValueString(metadata.LabelDirection.Write))
+	internal.AssertSumMetricHasAttributeValue(t, diskIOMetric, 0, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.Read))
+	internal.AssertSumMetricHasAttributeValue(t, diskIOMetric, 1, "direction", pdata.NewAttributeValueString(metadata.AttributeDirection.Write))
 }
 
 func assertSameTimeStampForAllMetricsWithinResource(t *testing.T, resourceMetrics pdata.ResourceMetricsSlice) {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_windows.go
@@ -30,12 +30,12 @@ import (
 const cpuStatesLen = 2
 
 func appendCPUTimeStateDataPoints(ddps pdata.NumberDataPointSlice, startTime, now pdata.Timestamp, cpuTime *cpu.TimesStat) {
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.User, metadata.LabelState.User)
-	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.System, metadata.LabelState.System)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.User, metadata.AttributeState.User)
+	initializeCPUTimeDataPoint(ddps.AppendEmpty(), startTime, now, cpuTime.System, metadata.AttributeState.System)
 }
 
 func initializeCPUTimeDataPoint(dataPoint pdata.NumberDataPoint, startTime, now pdata.Timestamp, value float64, stateLabel string) {
-	dataPoint.Attributes().InsertString(metadata.Labels.State, stateLabel)
+	dataPoint.Attributes().InsertString(metadata.Attributes.State, stateLabel)
 	dataPoint.SetStartTimestamp(startTime)
 	dataPoint.SetTimestamp(now)
 	dataPoint.SetDoubleVal(value)

--- a/receiver/httpdreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/httpdreceiver/internal/metadata/generated_metrics.go
@@ -163,8 +163,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// ScoreboardState (The state of a connection.)
 	ScoreboardState string
 	// ServerName (The name of the Apache HTTP server.)
@@ -177,12 +177,11 @@ var Labels = struct {
 	"state",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelScoreboardState are the possible values that the label "scoreboard_state" can have.
-var LabelScoreboardState = struct {
+// AttributeScoreboardState are the possible values that the attribute "scoreboard_state" can have.
+var AttributeScoreboardState = struct {
 	Open        string
 	Waiting     string
 	Starting    string
@@ -208,8 +207,8 @@ var LabelScoreboardState = struct {
 	"idle_cleanup",
 }
 
-// LabelWorkersState are the possible values that the label "workers_state" can have.
-var LabelWorkersState = struct {
+// AttributeWorkersState are the possible values that the attribute "workers_state" can have.
+var AttributeWorkersState = struct {
 	Busy string
 	Idle string
 }{

--- a/receiver/httpdreceiver/metadata.yaml
+++ b/receiver/httpdreceiver/metadata.yaml
@@ -1,6 +1,6 @@
 name: httpdreceiver
 
-labels:
+attributes:
   server_name:
     description: The name of the Apache HTTP server.
   workers_state:
@@ -33,7 +33,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [ server_name ]
+    attributes: [ server_name ]
   httpd.current_connections:
     description: The number of active connections currently attached to the HTTP server.
     unit: connections
@@ -41,7 +41,7 @@ metrics:
       type: sum
       monotonic: false
       aggregation: cumulative
-    labels: [ server_name ]
+    attributes: [ server_name ]
   httpd.workers:
     description: The number of workers currently attached to the HTTP server.
     unit: connections
@@ -49,7 +49,7 @@ metrics:
       type: sum
       monotonic: false
       aggregation: cumulative
-    labels: [ server_name, workers_state]
+    attributes: [ server_name, workers_state]
   httpd.requests:
     description: The number of requests serviced by the HTTP server per second.
     unit: 1
@@ -57,7 +57,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [ server_name ]
+    attributes: [ server_name ]
   httpd.traffic:
     description: Total HTTP server traffic.
     unit: By
@@ -65,7 +65,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [ server_name ]
+    attributes: [ server_name ]
   httpd.scoreboard:
     description: The number of connections in each state.
     extended_documentation: >
@@ -77,4 +77,4 @@ metrics:
       type: sum
       monotonic: false
       aggregation: cumulative
-    labels: [server_name, scoreboard_state]
+    attributes: [server_name, scoreboard_state]

--- a/receiver/httpdreceiver/scraper.go
+++ b/receiver/httpdreceiver/scraper.go
@@ -94,7 +94,7 @@ func (r *httpdScraper) scrape(context.Context) (pdata.Metrics, error) {
 
 	for metricKey, metricValue := range parseStats(stats) {
 		labels := pdata.NewAttributeMap()
-		labels.Insert(metadata.L.ServerName, pdata.NewAttributeValueString(r.cfg.serverName))
+		labels.Insert(metadata.A.ServerName, pdata.NewAttributeValueString(r.cfg.serverName))
 
 		switch metricKey {
 		case "ServerUptimeSeconds":
@@ -107,12 +107,12 @@ func (r *httpdScraper) scrape(context.Context) (pdata.Metrics, error) {
 			}
 		case "BusyWorkers":
 			if i, ok := r.parseInt(metricKey, metricValue); ok {
-				labels.Insert(metadata.L.WorkersState, pdata.NewAttributeValueString("busy"))
+				labels.Insert(metadata.A.WorkersState, pdata.NewAttributeValueString("busy"))
 				addToIntMetric(workers, labels, i, now)
 			}
 		case "IdleWorkers":
 			if i, ok := r.parseInt(metricKey, metricValue); ok {
-				labels.Insert(metadata.L.WorkersState, pdata.NewAttributeValueString("idle"))
+				labels.Insert(metadata.A.WorkersState, pdata.NewAttributeValueString("idle"))
 				addToIntMetric(workers, labels, i, now)
 			}
 		case "Total Accesses":
@@ -127,7 +127,7 @@ func (r *httpdScraper) scrape(context.Context) (pdata.Metrics, error) {
 		case "Scoreboard":
 			scoreboardMap := parseScoreboard(metricValue)
 			for identifier, score := range scoreboardMap {
-				labels.Upsert(metadata.L.ScoreboardState, pdata.NewAttributeValueString(identifier))
+				labels.Upsert(metadata.A.ScoreboardState, pdata.NewAttributeValueString(identifier))
 				addToIntMetric(scoreboard, labels, score, now)
 			}
 		}

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -126,7 +126,7 @@ func (s *consumerScraper) scrape(context.Context) (pdata.Metrics, error) {
 	ilm.InstrumentationLibrary().SetName(instrumentationLibName)
 	for _, group := range consumerGroups {
 		labels := pdata.NewAttributeMap()
-		labels.UpsertString(metadata.L.Group, group.GroupId)
+		labels.UpsertString(metadata.A.Group, group.GroupId)
 		addIntGauge(ilm.Metrics(), metadata.M.KafkaConsumerGroupMembers.Name(), now, labels, int64(len(group.Members)))
 		groupOffsetFetchResponse, err := s.clusterAdmin.ListConsumerGroupOffsets(group.GroupId, topicPartitions)
 		if err != nil {
@@ -143,12 +143,12 @@ func (s *consumerScraper) scrape(context.Context) (pdata.Metrics, error) {
 					break
 				}
 			}
-			labels.UpsertString(metadata.L.Topic, topic)
+			labels.UpsertString(metadata.A.Topic, topic)
 			if isConsumed {
 				var lagSum int64
 				var offsetSum int64
 				for partition, block := range partitions {
-					labels.UpsertInt(metadata.L.Partition, int64(partition))
+					labels.UpsertInt(metadata.A.Partition, int64(partition))
 					consumerOffset := block.Offset
 					offsetSum += consumerOffset
 					addIntGauge(ilm.Metrics(), metadata.M.KafkaConsumerGroupOffset.Name(), now, labels, consumerOffset)
@@ -163,7 +163,7 @@ func (s *consumerScraper) scrape(context.Context) (pdata.Metrics, error) {
 					}
 					addIntGauge(ilm.Metrics(), metadata.M.KafkaConsumerGroupLag.Name(), now, labels, consumerLag)
 				}
-				labels.Delete(metadata.L.Partition)
+				labels.Delete(metadata.A.Partition)
 				addIntGauge(ilm.Metrics(), metadata.M.KafkaConsumerGroupOffsetSum.Name(), now, labels, offsetSum)
 				addIntGauge(ilm.Metrics(), metadata.M.KafkaConsumerGroupLagSum.Name(), now, labels, lagSum)
 			}

--- a/receiver/kafkametricsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kafkametricsreceiver/internal/metadata/generated_metrics.go
@@ -211,8 +211,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// Group (The ID (string) of a consumer group)
 	Group string
 	// Partition (The number (integer) of the partition)
@@ -225,6 +225,5 @@ var Labels = struct {
 	"topic",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -1,6 +1,6 @@
 name: kafkametricsreceiver
 
-labels:
+attributes:
   topic:
     description: The ID (integer) of a topic
   partition:
@@ -21,59 +21,59 @@ metrics:
     unit: "{partitions}"
     data:
       type: gauge
-    labels: [topic]
+    attributes: [topic]
   kafka.partition.current_offset:
     description: Current offset of partition of topic.
     unit: 1
     data:
       type: gauge
-    labels: [topic, partition]
+    attributes: [topic, partition]
   kafka.partition.oldest_offset:
     description: Oldest offset of partition of topic
     unit: 1
     data:
       type: gauge
-    labels: [topic, partition]
+    attributes: [topic, partition]
   kafka.partition.replicas:
     description: Number of replicas for partition of topic
     unit: "{replicas}"
     data:
       type: gauge
-    labels: [topic, partition]
+    attributes: [topic, partition]
   kafka.partition.replicas_in_sync:
     description: Number of synchronized replicas of partition
     unit: "{replicas}"
     data:
       type: gauge
-    labels: [topic, partition]
+    attributes: [topic, partition]
 #  consumers scraper
   kafka.consumer_group.members:
     description: Count of members in the consumer group
     unit: "{members}"
     data:
       type: gauge
-    labels: [group]
+    attributes: [group]
   kafka.consumer_group.offset:
     description: Current offset of the consumer group at partition of topic
     unit: 1
     data:
       type: gauge
-    labels: [group, topic, partition]
+    attributes: [group, topic, partition]
   kafka.consumer_group.offset_sum:
     description: Sum of consumer group offset across partitions of topic
     unit: 1
     data:
       type: gauge
-    labels: [group, topic]
+    attributes: [group, topic]
   kafka.consumer_group.lag:
     description: Current approximate lag of consumer group at partition of topic
     unit: 1
     data:
       type: gauge
-    labels: [group, topic, partition]
+    attributes: [group, topic, partition]
   kafka.consumer_group.lag_sum:
     description: Current approximate sum of consumer group lag across all partitions of topic
     unit: 1
     data:
       type: gauge
-    labels: [group, topic]
+    attributes: [group, topic]

--- a/receiver/kafkametricsreceiver/topic_scraper.go
+++ b/receiver/kafkametricsreceiver/topic_scraper.go
@@ -81,10 +81,10 @@ func (s *topicScraper) scrape(context.Context) (pdata.Metrics, error) {
 			continue
 		}
 		labels := pdata.NewAttributeMap()
-		labels.UpsertString(metadata.L.Topic, topic)
+		labels.UpsertString(metadata.A.Topic, topic)
 		addIntGauge(ilm.Metrics(), metadata.M.KafkaTopicPartitions.Name(), now, labels, int64(len(partitions)))
 		for _, partition := range partitions {
-			labels.UpsertInt(metadata.L.Partition, int64(partition))
+			labels.UpsertInt(metadata.A.Partition, int64(partition))
 			currentOffset, err := s.client.GetOffset(topic, partition, sarama.OffsetNewest)
 			if err != nil {
 				scrapeErrors.AddPartial(1, err)

--- a/receiver/kubeletstatsreceiver/internal/kubelet/network.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/network.go
@@ -38,8 +38,8 @@ func addNetworkIOMetric(dest pdata.MetricSlice, prefix string, s *stats.NetworkS
 	metadata.M.NetworkIo.Init(m)
 	m.SetName(prefix + m.Name())
 
-	fillNetworkDataPoint(m.Sum().DataPoints(), s.Name, metadata.LabelDirection.Receive, s.RxBytes, startTime, currentTime)
-	fillNetworkDataPoint(m.Sum().DataPoints(), s.Name, metadata.LabelDirection.Transmit, s.TxBytes, startTime, currentTime)
+	fillNetworkDataPoint(m.Sum().DataPoints(), s.Name, metadata.AttributeDirection.Receive, s.RxBytes, startTime, currentTime)
+	fillNetworkDataPoint(m.Sum().DataPoints(), s.Name, metadata.AttributeDirection.Transmit, s.TxBytes, startTime, currentTime)
 }
 
 func addNetworkErrorsMetric(dest pdata.MetricSlice, prefix string, s *stats.NetworkStats, startTime pdata.Timestamp, currentTime pdata.Timestamp) {
@@ -51,8 +51,8 @@ func addNetworkErrorsMetric(dest pdata.MetricSlice, prefix string, s *stats.Netw
 	metadata.M.NetworkErrors.Init(m)
 	m.SetName(prefix + m.Name())
 
-	fillNetworkDataPoint(m.Sum().DataPoints(), s.Name, metadata.LabelDirection.Receive, s.RxErrors, startTime, currentTime)
-	fillNetworkDataPoint(m.Sum().DataPoints(), s.Name, metadata.LabelDirection.Transmit, s.TxErrors, startTime, currentTime)
+	fillNetworkDataPoint(m.Sum().DataPoints(), s.Name, metadata.AttributeDirection.Receive, s.RxErrors, startTime, currentTime)
+	fillNetworkDataPoint(m.Sum().DataPoints(), s.Name, metadata.AttributeDirection.Transmit, s.TxErrors, startTime, currentTime)
 }
 
 func fillNetworkDataPoint(dps pdata.NumberDataPointSlice, interfaceName string, direction string, value *uint64, startTime pdata.Timestamp, currentTime pdata.Timestamp) {
@@ -60,8 +60,8 @@ func fillNetworkDataPoint(dps pdata.NumberDataPointSlice, interfaceName string, 
 		return
 	}
 	dp := dps.AppendEmpty()
-	dp.Attributes().UpsertString(metadata.L.Interface, interfaceName)
-	dp.Attributes().UpsertString(metadata.L.Direction, direction)
+	dp.Attributes().UpsertString(metadata.A.Interface, interfaceName)
+	dp.Attributes().UpsertString(metadata.A.Direction, direction)
 	dp.SetIntVal(int64(*value))
 	dp.SetStartTimestamp(startTime)
 	dp.SetTimestamp(currentTime)

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
@@ -301,8 +301,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// Direction (Direction of flow of bytes/opertations (receive or transmit).)
 	Direction string
 	// Interface (Name of the network interface.)
@@ -312,12 +312,11 @@ var Labels = struct {
 	"interface",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelDirection are the possible values that the label "direction" can have.
-var LabelDirection = struct {
+// AttributeDirection are the possible values that the attribute "direction" can have.
+var AttributeDirection = struct {
 	Receive  string
 	Transmit string
 }{

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -1,6 +1,6 @@
 name: kubeletstatsreceiver
 
-labels:
+attributes:
   interface:
     description: Name of the network interface.
 
@@ -14,7 +14,7 @@ metrics:
     unit: 1
     data:
       type: gauge
-    labels: []
+    attributes: []
   cpu.time:
     description: "CPU time"
     unit: s
@@ -22,61 +22,61 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: []
+    attributes: []
   memory.available:
     description: "Memory available"
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   memory.usage:
     description: "Memory usage"
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   memory.rss:
     description: "Memory rss"
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   memory.working_set:
     description: "Memory working_set"
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   memory.page_faults:
     description: "Memory page_faults"
     unit: 1
     data:
       type: gauge
-    labels: []
+    attributes: []
   memory.major_page_faults:
     description: "Memory major_page_faults"
     unit: 1
     data:
       type: gauge
-    labels: []
+    attributes: []
   filesystem.available:
     description: "Filesystem available"
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   filesystem.capacity:
     description: "Filesystem capacity"
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   filesystem.usage:
     description: "Filesystem usage"
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   network.io:
     description: "Network IO"
     unit: By
@@ -84,7 +84,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: ["interface", "direction"]
+    attributes: ["interface", "direction"]
   network.errors:
     description: "Network errors"
     unit: 1
@@ -92,34 +92,34 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: ["interface", "direction"]
+    attributes: ["interface", "direction"]
   volume.available:
     description: "The number of available bytes in the volume."
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   volume.capacity:
     description: "The total capacity in bytes of the volume."
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   volume.inodes:
     description: "The total inodes in the filesystem."
     unit: 1
     data:
       type: gauge
-    labels: []
+    attributes: []
   volume.inodes.free:
     description: "The free inodes in the filesystem."
     unit: 1
     data:
       type: gauge
-    labels: []
+    attributes: []
   volume.inodes.used:
     description: "The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems."
     unit: 1
     data:
       type: gauge
-    labels: []
+    attributes: []

--- a/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
@@ -145,10 +145,9 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 }{}
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -1,6 +1,6 @@
 name: memcachedreceiver
 
-labels:
+attributes:
 
 metrics:
   memcached.bytes:
@@ -8,13 +8,13 @@ metrics:
     unit: By
     data:
       type: gauge
-    labels: []
+    attributes: []
   memcached.current_connections:
     description: The current number of open connections
     unit: connections
     data:
       type: gauge
-    labels: []
+    attributes: []
   memcached.total_connections:
     description: Total number of connections opened since the server started running
     unit: connections
@@ -22,7 +22,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: []
+    attributes: []
   memcached.get_hits:
     description: Number of keys that have been requested and found present
     unit: connections
@@ -30,7 +30,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: []
+    attributes: []
   memcached.get_misses:
     description: Number of items that have been requested and not found
     unit: connections
@@ -38,4 +38,4 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: []
+    attributes: []

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -275,8 +275,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// BufferPoolOperations (The buffer pool operations types.)
 	BufferPoolOperations string
 	// BufferPoolPages (The buffer pool pages types.)
@@ -322,12 +322,11 @@ var Labels = struct {
 	"kind",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelBufferPoolOperations are the possible values that the label "buffer_pool_operations" can have.
-var LabelBufferPoolOperations = struct {
+// AttributeBufferPoolOperations are the possible values that the attribute "buffer_pool_operations" can have.
+var AttributeBufferPoolOperations = struct {
 	ReadAheadRnd     string
 	ReadAhead        string
 	ReadAheadEvicted string
@@ -345,8 +344,8 @@ var LabelBufferPoolOperations = struct {
 	"write_requests",
 }
 
-// LabelBufferPoolPages are the possible values that the label "buffer_pool_pages" can have.
-var LabelBufferPoolPages = struct {
+// AttributeBufferPoolPages are the possible values that the attribute "buffer_pool_pages" can have.
+var AttributeBufferPoolPages = struct {
 	Data    string
 	Dirty   string
 	Flushed string
@@ -362,8 +361,8 @@ var LabelBufferPoolPages = struct {
 	"total",
 }
 
-// LabelBufferPoolSize are the possible values that the label "buffer_pool_size" can have.
-var LabelBufferPoolSize = struct {
+// AttributeBufferPoolSize are the possible values that the attribute "buffer_pool_size" can have.
+var AttributeBufferPoolSize = struct {
 	Data  string
 	Dirty string
 	Total string
@@ -373,8 +372,8 @@ var LabelBufferPoolSize = struct {
 	"total",
 }
 
-// LabelCommand are the possible values that the label "command" can have.
-var LabelCommand = struct {
+// AttributeCommand are the possible values that the attribute "command" can have.
+var AttributeCommand = struct {
 	Execute      string
 	Close        string
 	Fetch        string
@@ -390,8 +389,8 @@ var LabelCommand = struct {
 	"send_long_data",
 }
 
-// LabelDoubleWrites are the possible values that the label "double_writes" can have.
-var LabelDoubleWrites = struct {
+// AttributeDoubleWrites are the possible values that the attribute "double_writes" can have.
+var AttributeDoubleWrites = struct {
 	PagesWritten string
 	Writes       string
 }{
@@ -399,8 +398,8 @@ var LabelDoubleWrites = struct {
 	"writes",
 }
 
-// LabelHandler are the possible values that the label "handler" can have.
-var LabelHandler = struct {
+// AttributeHandler are the possible values that the attribute "handler" can have.
+var AttributeHandler = struct {
 	Commit            string
 	Delete            string
 	Discover          string
@@ -440,8 +439,8 @@ var LabelHandler = struct {
 	"write",
 }
 
-// LabelLocks are the possible values that the label "locks" can have.
-var LabelLocks = struct {
+// AttributeLocks are the possible values that the attribute "locks" can have.
+var AttributeLocks = struct {
 	Immediate string
 	Waited    string
 }{
@@ -449,8 +448,8 @@ var LabelLocks = struct {
 	"waited",
 }
 
-// LabelLogOperations are the possible values that the label "log_operations" can have.
-var LabelLogOperations = struct {
+// AttributeLogOperations are the possible values that the attribute "log_operations" can have.
+var AttributeLogOperations = struct {
 	Waits         string
 	WriteRequests string
 	Writes        string
@@ -460,8 +459,8 @@ var LabelLogOperations = struct {
 	"writes",
 }
 
-// LabelOperations are the possible values that the label "operations" can have.
-var LabelOperations = struct {
+// AttributeOperations are the possible values that the attribute "operations" can have.
+var AttributeOperations = struct {
 	Fsyncs string
 	Reads  string
 	Writes string
@@ -471,8 +470,8 @@ var LabelOperations = struct {
 	"writes",
 }
 
-// LabelPageOperations are the possible values that the label "page_operations" can have.
-var LabelPageOperations = struct {
+// AttributePageOperations are the possible values that the attribute "page_operations" can have.
+var AttributePageOperations = struct {
 	Created string
 	Read    string
 	Written string
@@ -482,8 +481,8 @@ var LabelPageOperations = struct {
 	"written",
 }
 
-// LabelRowLocks are the possible values that the label "row_locks" can have.
-var LabelRowLocks = struct {
+// AttributeRowLocks are the possible values that the attribute "row_locks" can have.
+var AttributeRowLocks = struct {
 	Waits string
 	Time  string
 }{
@@ -491,8 +490,8 @@ var LabelRowLocks = struct {
 	"time",
 }
 
-// LabelRowOperations are the possible values that the label "row_operations" can have.
-var LabelRowOperations = struct {
+// AttributeRowOperations are the possible values that the attribute "row_operations" can have.
+var AttributeRowOperations = struct {
 	Deleted  string
 	Inserted string
 	Read     string
@@ -504,8 +503,8 @@ var LabelRowOperations = struct {
 	"updated",
 }
 
-// LabelSorts are the possible values that the label "sorts" can have.
-var LabelSorts = struct {
+// AttributeSorts are the possible values that the attribute "sorts" can have.
+var AttributeSorts = struct {
 	MergePasses string
 	Range       string
 	Rows        string
@@ -517,8 +516,8 @@ var LabelSorts = struct {
 	"scan",
 }
 
-// LabelThreads are the possible values that the label "threads" can have.
-var LabelThreads = struct {
+// AttributeThreads are the possible values that the attribute "threads" can have.
+var AttributeThreads = struct {
 	Cached    string
 	Connected string
 	Created   string

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -1,6 +1,6 @@
 name: mysqlreceiver
 
-labels:
+attributes:
   buffer_pool_pages:
     value: kind
     description: The buffer pool pages types.
@@ -66,7 +66,7 @@ metrics:
       type: sum
       monotonic: false
       aggregation: cumulative
-    labels: [buffer_pool_pages]
+    attributes: [buffer_pool_pages]
   mysql.buffer_pool_operations:
     description: The number of operations on the InnoDB buffer pool.
     unit: 1
@@ -74,7 +74,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [buffer_pool_operations]
+    attributes: [buffer_pool_operations]
   mysql.buffer_pool_size:
     description: The number of bytes in the InnoDB buffer pool.
     unit: By
@@ -82,7 +82,7 @@ metrics:
       type: sum
       monotonic: false
       aggregation: cumulative
-    labels: [buffer_pool_size]
+    attributes: [buffer_pool_size]
   mysql.commands:
     description: The number of times each type of command has been executed.
     unit: 1
@@ -90,7 +90,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [command]
+    attributes: [command]
   mysql.handlers:
     description: The number of requests to various MySQL handlers.
     unit: 1
@@ -98,7 +98,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [handler]
+    attributes: [handler]
   mysql.double_writes:
     description: The number of writes to the InnoDB doublewrite buffer.
     unit: 1
@@ -106,7 +106,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [double_writes]
+    attributes: [double_writes]
   mysql.log_operations:
     description: The number of InndoDB log operations.
     unit: 1
@@ -114,7 +114,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [log_operations]
+    attributes: [log_operations]
   mysql.operations:
     description: The number of InndoDB operations.
     unit: 1
@@ -122,7 +122,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [operations]
+    attributes: [operations]
   mysql.page_operations:
     description: The number of InndoDB page operations.
     unit: 1
@@ -130,7 +130,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [page_operations]
+    attributes: [page_operations]
   mysql.row_locks:
     description: The number of InndoDB row locks.
     unit: 1
@@ -138,7 +138,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [row_locks]
+    attributes: [row_locks]
   mysql.row_operations:
     description: The number of InndoDB row operations.
     unit: 1
@@ -146,7 +146,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [row_operations]
+    attributes: [row_operations]
   mysql.locks:
     description: The number of MySQL locks.
     unit: 1
@@ -154,7 +154,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [locks]
+    attributes: [locks]
   mysql.sorts:
     description: The number of MySQL sorts.
     unit: 1
@@ -162,7 +162,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: [sorts]
+    attributes: [sorts]
   mysql.threads:
     description: The state of MySQL threads.
     unit: 1
@@ -170,4 +170,4 @@ metrics:
       type: sum
       monotonic: false
       aggregation: cumulative
-    labels: [threads]
+    attributes: [threads]

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -138,7 +138,7 @@ func (m *mySQLScraper) scrape(context.Context) (pdata.Metrics, error) {
 		}
 		labels := pdata.NewAttributeMap()
 		if f, ok := m.parseFloat(k, v); ok {
-			labels.Insert(metadata.L.BufferPoolSize, pdata.NewAttributeValueString("total"))
+			labels.Insert(metadata.A.BufferPoolSize, pdata.NewAttributeValueString("total"))
 			addToDoubleMetric(bufferPoolSize, labels, f, now)
 		}
 	}
@@ -157,358 +157,358 @@ func (m *mySQLScraper) scrape(context.Context) (pdata.Metrics, error) {
 		// buffer_pool_pages
 		case "Innodb_buffer_pool_pages_data":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolPages, pdata.NewAttributeValueString("data"))
+				labels.Insert(metadata.A.BufferPoolPages, pdata.NewAttributeValueString("data"))
 				addToDoubleMetric(bufferPoolPages, labels, f, now)
 			}
 		case "Innodb_buffer_pool_pages_dirty":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolPages, pdata.NewAttributeValueString("dirty"))
+				labels.Insert(metadata.A.BufferPoolPages, pdata.NewAttributeValueString("dirty"))
 				addToDoubleMetric(bufferPoolPages, labels, f, now)
 			}
 		case "Innodb_buffer_pool_pages_flushed":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolPages, pdata.NewAttributeValueString("flushed"))
+				labels.Insert(metadata.A.BufferPoolPages, pdata.NewAttributeValueString("flushed"))
 				addToDoubleMetric(bufferPoolPages, labels, f, now)
 			}
 		case "Innodb_buffer_pool_pages_free":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolPages, pdata.NewAttributeValueString("free"))
+				labels.Insert(metadata.A.BufferPoolPages, pdata.NewAttributeValueString("free"))
 				addToDoubleMetric(bufferPoolPages, labels, f, now)
 			}
 		case "Innodb_buffer_pool_pages_misc":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolPages, pdata.NewAttributeValueString("misc"))
+				labels.Insert(metadata.A.BufferPoolPages, pdata.NewAttributeValueString("misc"))
 				addToDoubleMetric(bufferPoolPages, labels, f, now)
 			}
 		case "Innodb_buffer_pool_pages_total":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolPages, pdata.NewAttributeValueString("total"))
+				labels.Insert(metadata.A.BufferPoolPages, pdata.NewAttributeValueString("total"))
 				addToDoubleMetric(bufferPoolPages, labels, f, now)
 			}
 
 		// buffer_pool_operations
 		case "Innodb_buffer_pool_read_ahead_rnd":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolOperations, pdata.NewAttributeValueString("read_ahead_rnd"))
+				labels.Insert(metadata.A.BufferPoolOperations, pdata.NewAttributeValueString("read_ahead_rnd"))
 				addToIntMetric(bufferPoolOperations, labels, i, now)
 			}
 		case "Innodb_buffer_pool_read_ahead":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolOperations, pdata.NewAttributeValueString("read_ahead"))
+				labels.Insert(metadata.A.BufferPoolOperations, pdata.NewAttributeValueString("read_ahead"))
 				addToIntMetric(bufferPoolOperations, labels, i, now)
 			}
 		case "Innodb_buffer_pool_read_ahead_evicted":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolOperations, pdata.NewAttributeValueString("read_ahead_evicted"))
+				labels.Insert(metadata.A.BufferPoolOperations, pdata.NewAttributeValueString("read_ahead_evicted"))
 				addToIntMetric(bufferPoolOperations, labels, i, now)
 			}
 		case "Innodb_buffer_pool_read_requests":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolOperations, pdata.NewAttributeValueString("read_requests"))
+				labels.Insert(metadata.A.BufferPoolOperations, pdata.NewAttributeValueString("read_requests"))
 				addToIntMetric(bufferPoolOperations, labels, i, now)
 			}
 		case "Innodb_buffer_pool_reads":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolOperations, pdata.NewAttributeValueString("reads"))
+				labels.Insert(metadata.A.BufferPoolOperations, pdata.NewAttributeValueString("reads"))
 				addToIntMetric(bufferPoolOperations, labels, i, now)
 			}
 		case "Innodb_buffer_pool_wait_free":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolOperations, pdata.NewAttributeValueString("wait_free"))
+				labels.Insert(metadata.A.BufferPoolOperations, pdata.NewAttributeValueString("wait_free"))
 				addToIntMetric(bufferPoolOperations, labels, i, now)
 			}
 		case "Innodb_buffer_pool_write_requests":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolOperations, pdata.NewAttributeValueString("write_requests"))
+				labels.Insert(metadata.A.BufferPoolOperations, pdata.NewAttributeValueString("write_requests"))
 				addToIntMetric(bufferPoolOperations, labels, i, now)
 			}
 
 		// buffer_pool_size
 		case "Innodb_buffer_pool_bytes_data":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolSize, pdata.NewAttributeValueString("data"))
+				labels.Insert(metadata.A.BufferPoolSize, pdata.NewAttributeValueString("data"))
 				addToDoubleMetric(bufferPoolSize, labels, f, now)
 			}
 		case "Innodb_buffer_pool_bytes_dirty":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.BufferPoolSize, pdata.NewAttributeValueString("dirty"))
+				labels.Insert(metadata.A.BufferPoolSize, pdata.NewAttributeValueString("dirty"))
 				addToDoubleMetric(bufferPoolSize, labels, f, now)
 			}
 
 		// commands
 		case "Com_stmt_execute":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Command, pdata.NewAttributeValueString("execute"))
+				labels.Insert(metadata.A.Command, pdata.NewAttributeValueString("execute"))
 				addToIntMetric(commands, labels, i, now)
 			}
 		case "Com_stmt_close":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Command, pdata.NewAttributeValueString("close"))
+				labels.Insert(metadata.A.Command, pdata.NewAttributeValueString("close"))
 				addToIntMetric(commands, labels, i, now)
 			}
 		case "Com_stmt_fetch":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Command, pdata.NewAttributeValueString("fetch"))
+				labels.Insert(metadata.A.Command, pdata.NewAttributeValueString("fetch"))
 				addToIntMetric(commands, labels, i, now)
 			}
 		case "Com_stmt_prepare":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Command, pdata.NewAttributeValueString("prepare"))
+				labels.Insert(metadata.A.Command, pdata.NewAttributeValueString("prepare"))
 				addToIntMetric(commands, labels, i, now)
 			}
 		case "Com_stmt_reset":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Command, pdata.NewAttributeValueString("reset"))
+				labels.Insert(metadata.A.Command, pdata.NewAttributeValueString("reset"))
 				addToIntMetric(commands, labels, i, now)
 			}
 		case "Com_stmt_send_long_data":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Command, pdata.NewAttributeValueString("send_long_data"))
+				labels.Insert(metadata.A.Command, pdata.NewAttributeValueString("send_long_data"))
 				addToIntMetric(commands, labels, i, now)
 			}
 
 		// handlers
 		case "Handler_commit":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("commit"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("commit"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_delete":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("delete"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("delete"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_discover":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("discover"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("discover"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_external_lock":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("lock"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("lock"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_mrr_init":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("mrr_init"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("mrr_init"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_prepare":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("prepare"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("prepare"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_read_first":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("read_first"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("read_first"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_read_key":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("read_key"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("read_key"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_read_last":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("read_last"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("read_last"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_read_next":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("read_next"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("read_next"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_read_prev":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("read_prev"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("read_prev"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_read_rnd":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("read_rnd"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("read_rnd"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_read_rnd_next":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("read_rnd_next"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("read_rnd_next"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_rollback":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("rollback"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("rollback"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_savepoint":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("savepoint"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("savepoint"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_savepoint_rollback":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("savepoint_rollback"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("savepoint_rollback"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_update":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("update"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("update"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 		case "Handler_write":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Handler, pdata.NewAttributeValueString("write"))
+				labels.Insert(metadata.A.Handler, pdata.NewAttributeValueString("write"))
 				addToIntMetric(handlers, labels, i, now)
 			}
 
 		// double_writes
 		case "Innodb_dblwr_pages_written":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.DoubleWrites, pdata.NewAttributeValueString("written"))
+				labels.Insert(metadata.A.DoubleWrites, pdata.NewAttributeValueString("written"))
 				addToIntMetric(doubleWrites, labels, i, now)
 			}
 		case "Innodb_dblwr_writes":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.DoubleWrites, pdata.NewAttributeValueString("writes"))
+				labels.Insert(metadata.A.DoubleWrites, pdata.NewAttributeValueString("writes"))
 				addToIntMetric(doubleWrites, labels, i, now)
 			}
 
 		// log_operations
 		case "Innodb_log_waits":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.LogOperations, pdata.NewAttributeValueString("waits"))
+				labels.Insert(metadata.A.LogOperations, pdata.NewAttributeValueString("waits"))
 				addToIntMetric(logOperations, labels, i, now)
 			}
 		case "Innodb_log_write_requests":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.LogOperations, pdata.NewAttributeValueString("requests"))
+				labels.Insert(metadata.A.LogOperations, pdata.NewAttributeValueString("requests"))
 				addToIntMetric(logOperations, labels, i, now)
 			}
 		case "Innodb_log_writes":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.LogOperations, pdata.NewAttributeValueString("writes"))
+				labels.Insert(metadata.A.LogOperations, pdata.NewAttributeValueString("writes"))
 				addToIntMetric(logOperations, labels, i, now)
 			}
 
 		// operations
 		case "Innodb_data_fsyncs":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Operations, pdata.NewAttributeValueString("fsyncs"))
+				labels.Insert(metadata.A.Operations, pdata.NewAttributeValueString("fsyncs"))
 				addToIntMetric(operations, labels, i, now)
 			}
 		case "Innodb_data_reads":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Operations, pdata.NewAttributeValueString("reads"))
+				labels.Insert(metadata.A.Operations, pdata.NewAttributeValueString("reads"))
 				addToIntMetric(operations, labels, i, now)
 			}
 		case "Innodb_data_writes":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Operations, pdata.NewAttributeValueString("writes"))
+				labels.Insert(metadata.A.Operations, pdata.NewAttributeValueString("writes"))
 				addToIntMetric(operations, labels, i, now)
 			}
 
 		// page_operations
 		case "Innodb_pages_created":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.PageOperations, pdata.NewAttributeValueString("created"))
+				labels.Insert(metadata.A.PageOperations, pdata.NewAttributeValueString("created"))
 				addToIntMetric(pageOperations, labels, i, now)
 			}
 		case "Innodb_pages_read":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.PageOperations, pdata.NewAttributeValueString("read"))
+				labels.Insert(metadata.A.PageOperations, pdata.NewAttributeValueString("read"))
 				addToIntMetric(pageOperations, labels, i, now)
 			}
 		case "Innodb_pages_written":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.PageOperations, pdata.NewAttributeValueString("written"))
+				labels.Insert(metadata.A.PageOperations, pdata.NewAttributeValueString("written"))
 				addToIntMetric(pageOperations, labels, i, now)
 			}
 
 		// row_locks
 		case "Innodb_row_lock_waits":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.RowLocks, pdata.NewAttributeValueString("waits"))
+				labels.Insert(metadata.A.RowLocks, pdata.NewAttributeValueString("waits"))
 				addToIntMetric(rowLocks, labels, i, now)
 			}
 		case "Innodb_row_lock_time":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.RowLocks, pdata.NewAttributeValueString("time"))
+				labels.Insert(metadata.A.RowLocks, pdata.NewAttributeValueString("time"))
 				addToIntMetric(rowLocks, labels, i, now)
 			}
 
 		// row_operations
 		case "Innodb_rows_deleted":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.RowOperations, pdata.NewAttributeValueString("deleted"))
+				labels.Insert(metadata.A.RowOperations, pdata.NewAttributeValueString("deleted"))
 				addToIntMetric(rowOperations, labels, i, now)
 			}
 		case "Innodb_rows_inserted":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.RowOperations, pdata.NewAttributeValueString("inserted"))
+				labels.Insert(metadata.A.RowOperations, pdata.NewAttributeValueString("inserted"))
 				addToIntMetric(rowOperations, labels, i, now)
 			}
 		case "Innodb_rows_read":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.RowOperations, pdata.NewAttributeValueString("read"))
+				labels.Insert(metadata.A.RowOperations, pdata.NewAttributeValueString("read"))
 				addToIntMetric(rowOperations, labels, i, now)
 			}
 		case "Innodb_rows_updated":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.RowOperations, pdata.NewAttributeValueString("updated"))
+				labels.Insert(metadata.A.RowOperations, pdata.NewAttributeValueString("updated"))
 				addToIntMetric(rowOperations, labels, i, now)
 			}
 
 		// locks
 		case "Table_locks_immediate":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Locks, pdata.NewAttributeValueString("immediate"))
+				labels.Insert(metadata.A.Locks, pdata.NewAttributeValueString("immediate"))
 				addToIntMetric(locks, labels, i, now)
 			}
 		case "Table_locks_waited":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Locks, pdata.NewAttributeValueString("waited"))
+				labels.Insert(metadata.A.Locks, pdata.NewAttributeValueString("waited"))
 				addToIntMetric(locks, labels, i, now)
 			}
 
 		// sorts
 		case "Sort_merge_passes":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Sorts, pdata.NewAttributeValueString("merge_passes"))
+				labels.Insert(metadata.A.Sorts, pdata.NewAttributeValueString("merge_passes"))
 				addToIntMetric(sorts, labels, i, now)
 			}
 		case "Sort_range":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Sorts, pdata.NewAttributeValueString("range"))
+				labels.Insert(metadata.A.Sorts, pdata.NewAttributeValueString("range"))
 				addToIntMetric(sorts, labels, i, now)
 			}
 		case "Sort_rows":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Sorts, pdata.NewAttributeValueString("rows"))
+				labels.Insert(metadata.A.Sorts, pdata.NewAttributeValueString("rows"))
 				addToIntMetric(sorts, labels, i, now)
 			}
 		case "Sort_scan":
 			if i, ok := m.parseInt(k, v); ok {
-				labels.Insert(metadata.L.Sorts, pdata.NewAttributeValueString("scan"))
+				labels.Insert(metadata.A.Sorts, pdata.NewAttributeValueString("scan"))
 				addToIntMetric(sorts, labels, i, now)
 			}
 
 		// threads
 		case "Threads_cached":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.Threads, pdata.NewAttributeValueString("cached"))
+				labels.Insert(metadata.A.Threads, pdata.NewAttributeValueString("cached"))
 				addToDoubleMetric(threads, labels, f, now)
 			}
 		case "Threads_connected":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.Threads, pdata.NewAttributeValueString("connected"))
+				labels.Insert(metadata.A.Threads, pdata.NewAttributeValueString("connected"))
 				addToDoubleMetric(threads, labels, f, now)
 			}
 		case "Threads_created":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.Threads, pdata.NewAttributeValueString("created"))
+				labels.Insert(metadata.A.Threads, pdata.NewAttributeValueString("created"))
 				addToDoubleMetric(threads, labels, f, now)
 			}
 		case "Threads_running":
 			if f, ok := m.parseFloat(k, v); ok {
-				labels.Insert(metadata.L.Threads, pdata.NewAttributeValueString("running"))
+				labels.Insert(metadata.A.Threads, pdata.NewAttributeValueString("running"))
 				addToDoubleMetric(threads, labels, f, now)
 			}
 		}

--- a/receiver/nginxreceiver/integration_test.go
+++ b/receiver/nginxreceiver/integration_test.go
@@ -123,13 +123,13 @@ func (suite *NginxIntegrationSuite) TestNginxScraperHappyPath() {
 					continue
 				}
 				switch state.StringVal() {
-				case metadata.LabelState.Active:
+				case metadata.AttributeState.Active:
 					present[state.StringVal()] = true
-				case metadata.LabelState.Reading:
+				case metadata.AttributeState.Reading:
 					present[state.StringVal()] = true
-				case metadata.LabelState.Writing:
+				case metadata.AttributeState.Writing:
 					present[state.StringVal()] = true
-				case metadata.LabelState.Waiting:
+				case metadata.AttributeState.Waiting:
 					present[state.StringVal()] = true
 				default:
 					t.Error(fmt.Sprintf("connections with state %s not expected", state.StringVal()))

--- a/receiver/nginxreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_metrics.go
@@ -133,20 +133,19 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// State (The state of a connection)
 	State string
 }{
 	"state",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes
 
-// LabelState are the possible values that the label "state" can have.
-var LabelState = struct {
+// AttributeState are the possible values that the attribute "state" can have.
+var AttributeState = struct {
 	Active  string
 	Reading string
 	Writing string

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -1,6 +1,6 @@
 name: nginxreceiver
 
-labels:
+attributes:
   state:
     description: The state of a connection
     enum:
@@ -17,7 +17,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: []
+    attributes: []
   nginx.connections_accepted:
     description: The total number of accepted client connections
     unit: connections
@@ -25,7 +25,7 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: []
+    attributes: []
   nginx.connections_handled:
     description: The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).
     unit: connections
@@ -33,10 +33,10 @@ metrics:
       type: sum
       monotonic: true
       aggregation: cumulative
-    labels: []
+    attributes: []
   nginx.connections_current:
     description: The current number of nginx connections by state
     unit: connections
     data:
       type: gauge
-    labels: [state]
+    attributes: [state]

--- a/receiver/nginxreceiver/scraper.go
+++ b/receiver/nginxreceiver/scraper.go
@@ -85,10 +85,10 @@ func (r *nginxScraper) scrape(context.Context) (pdata.Metrics, error) {
 	currConnMetric := ilm.Metrics().AppendEmpty()
 	metadata.M.NginxConnectionsCurrent.Init(currConnMetric)
 	dps := currConnMetric.Gauge().DataPoints()
-	addCurrentConnectionDataPoint(dps, metadata.LabelState.Active, now, stats.Connections.Active)
-	addCurrentConnectionDataPoint(dps, metadata.LabelState.Reading, now, stats.Connections.Reading)
-	addCurrentConnectionDataPoint(dps, metadata.LabelState.Writing, now, stats.Connections.Writing)
-	addCurrentConnectionDataPoint(dps, metadata.LabelState.Waiting, now, stats.Connections.Waiting)
+	addCurrentConnectionDataPoint(dps, metadata.AttributeState.Active, now, stats.Connections.Active)
+	addCurrentConnectionDataPoint(dps, metadata.AttributeState.Reading, now, stats.Connections.Reading)
+	addCurrentConnectionDataPoint(dps, metadata.AttributeState.Writing, now, stats.Connections.Writing)
+	addCurrentConnectionDataPoint(dps, metadata.AttributeState.Waiting, now, stats.Connections.Waiting)
 
 	return md, nil
 }
@@ -103,7 +103,7 @@ func addIntSum(metrics pdata.MetricSlice, initFunc func(pdata.Metric), now pdata
 
 func addCurrentConnectionDataPoint(dps pdata.NumberDataPointSlice, stateValue string, now pdata.Timestamp, value int64) {
 	dp := dps.AppendEmpty()
-	dp.Attributes().UpsertString(metadata.L.State, stateValue)
+	dp.Attributes().UpsertString(metadata.A.State, stateValue)
 	dp.SetTimestamp(now)
 	dp.SetIntVal(value)
 }

--- a/receiver/nginxreceiver/scraper_test.go
+++ b/receiver/nginxreceiver/scraper_test.go
@@ -77,7 +77,7 @@ Reading: 6 Writing: 179 Waiting: 106
 			require.Equal(t, 4, dps.Len())
 			for j := 0; j < dps.Len(); j++ {
 				dp := dps.At(j)
-				state, _ := dp.Attributes().Get(metadata.L.State)
+				state, _ := dp.Attributes().Get(metadata.A.State)
 				label := fmt.Sprintf("%s state:%s", m.Name(), state.StringVal())
 				metricValues[label] = dp.IntVal()
 			}

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics.go
@@ -289,8 +289,8 @@ var Metrics = &metricStruct{
 // manipulating those metrics. M is an alias for Metrics
 var M = Metrics
 
-// Labels contains the possible metric labels that can be used.
-var Labels = struct {
+// Attributes contains the possible metric attributes that can be used.
+var Attributes = struct {
 	// ServerState (State of the Zookeeper server (leader, standalone or follower).)
 	ServerState string
 	// ZkVersion (Zookeeper version of the instance.)
@@ -300,6 +300,5 @@ var Labels = struct {
 	"zk.version",
 }
 
-// L contains the possible metric labels that can be used. L is an alias for
-// Labels.
-var L = Labels
+// A is an alias for Attributes.
+var A = Attributes

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -1,6 +1,6 @@
 name: zookeeperreceiver
 
-labels:
+attributes:
   server.state:
     description: State of the Zookeeper server (leader, standalone or follower).
   zk.version:

--- a/receiver/zookeeperreceiver/scraper.go
+++ b/receiver/zookeeperreceiver/scraper.go
@@ -139,10 +139,10 @@ func (z *zookeeperMetricsScraper) appendMetrics(scanner *bufio.Scanner, rms pdat
 		metricValue := parts[2]
 		switch metricKey {
 		case zkVersionKey:
-			rm.Resource().Attributes().UpsertString(metadata.Labels.ZkVersion, metricValue)
+			rm.Resource().Attributes().UpsertString(metadata.Attributes.ZkVersion, metricValue)
 			continue
 		case serverStateKey:
-			rm.Resource().Attributes().UpsertString(metadata.Labels.ServerState, metricValue)
+			rm.Resource().Attributes().UpsertString(metadata.Attributes.ServerState, metricValue)
 			continue
 		default:
 			// Skip metric if there is no descriptor associated with it.


### PR DESCRIPTION
Labels were replaced by Attributes in the metric model. This change updates mdatagen to use attributes instead of labels in code and metadata.yaml files.