### PR TITLE
[exporter/datadogexporter] Take hostname into account for cache

### DIFF
--- a/exporter/datadogexporter/internal/translator/dimensions.go
+++ b/exporter/datadogexporter/internal/translator/dimensions.go
@@ -45,13 +45,15 @@ func getTags(labels pdata.AttributeMap) []string {
 	return tags
 }
 
-// AddTags to metrics dimensions. The argument may be modified.
+// AddTags to metrics dimensions.
 func (m *metricsDimensions) AddTags(tags ...string) metricsDimensions {
+	// defensively copy the tags
+	newTags := make([]string, 0, len(tags)+len(m.tags))
+	newTags = append(newTags, tags...)
+	newTags = append(newTags, m.tags...)
 	return metricsDimensions{
 		name: m.name,
-		// append the field to the passed argument,
-		// so that the slice we modify is the one we get as an argument.
-		tags: append(tags, m.tags...),
+		tags: newTags,
 		host: m.host,
 	}
 }

--- a/exporter/datadogexporter/internal/translator/dimensions.go
+++ b/exporter/datadogexporter/internal/translator/dimensions.go
@@ -1,0 +1,97 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translator
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/collector/model/pdata"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator/utils"
+)
+
+const (
+	dimensionSeparator = string(byte(0))
+)
+
+type metricsDimensions struct {
+	name string
+	tags []string
+	host string
+}
+
+// getTags maps an attributeMap into a slice of Datadog tags
+func getTags(labels pdata.AttributeMap) []string {
+	tags := make([]string, 0, labels.Len())
+	labels.Range(func(key string, value pdata.AttributeValue) bool {
+		v := value.AsString()
+		tags = append(tags, utils.FormatKeyValueTag(key, v))
+		return true
+	})
+	return tags
+}
+
+// AddTags to metrics dimensions. The argument may be modified.
+func (m *metricsDimensions) AddTags(tags ...string) metricsDimensions {
+	return metricsDimensions{
+		name: m.name,
+		// append the field to the passed argument,
+		// so that the slice we modify is the one we get as an argument.
+		tags: append(tags, m.tags...),
+		host: m.host,
+	}
+}
+
+// WithAttributeMap creates a new metricDimensions struct with additional tags from attributes.
+func (m *metricsDimensions) WithAttributeMap(labels pdata.AttributeMap) metricsDimensions {
+	return m.AddTags(getTags(labels)...)
+}
+
+// WithSuffix creates a new dimensions struct with an extra name suffix.
+func (m *metricsDimensions) WithSuffix(suffix string) metricsDimensions {
+	return metricsDimensions{
+		name: fmt.Sprintf("%s.%s", m.name, suffix),
+		host: m.host,
+		tags: m.tags,
+	}
+}
+
+// Uses a logic similar to what is done in the span processor to build metric keys:
+// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/b2327211df976e0a57ef0425493448988772a16b/processor/spanmetricsprocessor/processor.go#L353-L387
+// TODO: make this a public util function?
+func concatDimensionValue(metricKeyBuilder *strings.Builder, value string) {
+	metricKeyBuilder.WriteString(value)
+	metricKeyBuilder.WriteString(dimensionSeparator)
+}
+
+// String maps dimensions to a string to use as an identifier.
+// The tags order does not matter.
+func (m *metricsDimensions) String() string {
+	var metricKeyBuilder strings.Builder
+
+	dimensions := make([]string, len(m.tags))
+	copy(dimensions, m.tags)
+
+	dimensions = append(dimensions, fmt.Sprintf("name:%s", m.name))
+	dimensions = append(dimensions, fmt.Sprintf("host:%s", m.name))
+	sort.Strings(dimensions)
+
+	for _, dim := range dimensions {
+		concatDimensionValue(&metricKeyBuilder, dim)
+	}
+	return metricKeyBuilder.String()
+}

--- a/exporter/datadogexporter/internal/translator/dimensions.go
+++ b/exporter/datadogexporter/internal/translator/dimensions.go
@@ -89,7 +89,7 @@ func (m *metricsDimensions) String() string {
 	copy(dimensions, m.tags)
 
 	dimensions = append(dimensions, fmt.Sprintf("name:%s", m.name))
-	dimensions = append(dimensions, fmt.Sprintf("host:%s", m.name))
+	dimensions = append(dimensions, fmt.Sprintf("host:%s", m.host))
 	sort.Strings(dimensions)
 
 	for _, dim := range dimensions {

--- a/exporter/datadogexporter/internal/translator/dimensions_test.go
+++ b/exporter/datadogexporter/internal/translator/dimensions_test.go
@@ -36,19 +36,23 @@ func TestWithAttributeMap(t *testing.T) {
 }
 
 func TestMetricDimensionsString(t *testing.T) {
-	getKey := func(name string, tags []string) string {
-		dims := metricsDimensions{name: name, tags: tags}
+	getKey := func(name string, tags []string, host string) string {
+		dims := metricsDimensions{name: name, tags: tags, host: host}
 		return dims.String()
 	}
 	metricName := "metric.name"
-	noTags := getKey(metricName, []string{})
-	someTags := getKey(metricName, []string{"key1:val1", "key2:val2"})
-	sameTags := getKey(metricName, []string{"key2:val2", "key1:val1"})
-	diffTags := getKey(metricName, []string{"key3:val3"})
+	hostOne := "host-one"
+	hostTwo := "host-two"
+	noTags := getKey(metricName, []string{}, hostOne)
+	someTags := getKey(metricName, []string{"key1:val1", "key2:val2"}, hostOne)
+	sameTags := getKey(metricName, []string{"key2:val2", "key1:val1"}, hostOne)
+	diffTags := getKey(metricName, []string{"key3:val3"}, hostOne)
+	diffHost := getKey(metricName, []string{"key1:val1", "key2:val2"}, hostTwo)
 
 	assert.NotEqual(t, noTags, someTags)
 	assert.NotEqual(t, someTags, diffTags)
 	assert.Equal(t, someTags, sameTags)
+	assert.NotEqual(t, someTags, diffHost)
 }
 
 func TestMetricDimensionsStringNoTagsChange(t *testing.T) {

--- a/exporter/datadogexporter/internal/translator/dimensions_test.go
+++ b/exporter/datadogexporter/internal/translator/dimensions_test.go
@@ -1,0 +1,96 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestWithAttributeMap(t *testing.T) {
+	attributes := pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{
+		"key1": pdata.NewAttributeValueString("val1"),
+		"key2": pdata.NewAttributeValueString("val2"),
+		"key3": pdata.NewAttributeValueString(""),
+	})
+
+	dims := metricsDimensions{}
+	assert.ElementsMatch(t,
+		dims.WithAttributeMap(attributes).tags,
+		[...]string{"key1:val1", "key2:val2", "key3:n/a"},
+	)
+}
+
+func TestMetricDimensionsString(t *testing.T) {
+	getKey := func(name string, tags []string) string {
+		dims := metricsDimensions{name: name, tags: tags}
+		return dims.String()
+	}
+	metricName := "metric.name"
+	noTags := getKey(metricName, []string{})
+	someTags := getKey(metricName, []string{"key1:val1", "key2:val2"})
+	sameTags := getKey(metricName, []string{"key2:val2", "key1:val1"})
+	diffTags := getKey(metricName, []string{"key3:val3"})
+
+	assert.NotEqual(t, noTags, someTags)
+	assert.NotEqual(t, someTags, diffTags)
+	assert.Equal(t, someTags, sameTags)
+}
+
+func TestMetricDimensionsStringNoTagsChange(t *testing.T) {
+	// The original metricDimensionsToMapKey had an issue where:
+	// - if the capacity of the tags array passed to it was higher than its length
+	// - and the metric name is earlier (in alphabetical order) than one of the tags
+	// then the original tag array would be modified (without a reallocation, since there is enough capacity),
+	// and would contain a tag labeled as the metric name, while the final tag (in alphabetical order)
+	// would get left out.
+	// This test checks that this doesn't happen anymore.
+
+	originalTags := make([]string, 2, 3)
+	originalTags[0] = "key1:val1"
+	originalTags[1] = "key2:val2"
+
+	dims := metricsDimensions{
+		name: "a.metric.name",
+		tags: originalTags,
+	}
+
+	_ = dims.String()
+	assert.Equal(t, []string{"key1:val1", "key2:val2"}, originalTags)
+
+}
+
+var testDims metricsDimensions = metricsDimensions{
+	name: "test.metric",
+	tags: []string{"key:val"},
+	host: "host",
+}
+
+func TestWithSuffix(t *testing.T) {
+	dimsSuf1 := testDims.WithSuffix("suffixOne")
+	dimsSuf2 := testDims.WithSuffix("suffixTwo")
+
+	assert.Equal(t, "test.metric", testDims.name)
+	assert.Equal(t, "test.metric.suffixOne", dimsSuf1.name)
+	assert.Equal(t, "test.metric.suffixTwo", dimsSuf2.name)
+}
+
+func TestAddTags(t *testing.T) {
+	dimsWithTags := testDims.AddTags("key1:val1", "key2:val2")
+	assert.ElementsMatch(t, []string{"key:val", "key1:val1", "key2:val2"}, dimsWithTags.tags)
+	assert.ElementsMatch(t, []string{"key:val"}, testDims.tags)
+}

--- a/exporter/datadogexporter/internal/translator/metrics_translator.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/attributes"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/instrumentationlibrary"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator/utils"
 )
 
 const metricName string = "metric name"
@@ -67,17 +66,6 @@ func New(logger *zap.Logger, options ...Option) (*Translator, error) {
 	return &Translator{cache, logger, cfg}, nil
 }
 
-// getTags maps an attributeMap into a slice of Datadog tags
-func getTags(labels pdata.AttributeMap) []string {
-	tags := make([]string, 0, labels.Len())
-	labels.Range(func(key string, value pdata.AttributeValue) bool {
-		v := value.AsString()
-		tags = append(tags, utils.FormatKeyValueTag(key, v))
-		return true
-	})
-	return tags
-}
-
 // isCumulativeMonotonic checks if a metric is a cumulative monotonic metric
 func isCumulativeMonotonic(md pdata.Metric) bool {
 	switch md.DataType() {
@@ -102,17 +90,14 @@ func (t *Translator) isSkippable(name string, v float64) bool {
 func (t *Translator) mapNumberMetrics(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	name string,
+	dims metricsDimensions,
 	dt MetricDataType,
 	slice pdata.NumberDataPointSlice,
-	additionalTags []string,
-	host string,
 ) {
 
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
-		tags := getTags(p.Attributes())
-		tags = append(tags, additionalTags...)
+		pointDims := dims.WithAttributeMap(p.Attributes())
 		var val float64
 		switch p.Type() {
 		case pdata.MetricValueTypeDouble:
@@ -121,11 +106,11 @@ func (t *Translator) mapNumberMetrics(
 			val = float64(p.IntVal())
 		}
 
-		if t.isSkippable(name, val) {
+		if t.isSkippable(pointDims.name, val) {
 			continue
 		}
 
-		consumer.ConsumeTimeSeries(ctx, name, dt, uint64(p.Timestamp()), val, tags, host)
+		consumer.ConsumeTimeSeries(ctx, pointDims.name, dt, uint64(p.Timestamp()), val, pointDims.tags, pointDims.host)
 	}
 }
 
@@ -133,17 +118,14 @@ func (t *Translator) mapNumberMetrics(
 func (t *Translator) mapNumberMonotonicMetrics(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	name string,
+	dims metricsDimensions,
 	slice pdata.NumberDataPointSlice,
-	additionalTags []string,
-	host string,
 ) {
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
 		ts := uint64(p.Timestamp())
 		startTs := uint64(p.StartTimestamp())
-		tags := getTags(p.Attributes())
-		tags = append(tags, additionalTags...)
+		pointDims := dims.WithAttributeMap(p.Attributes())
 
 		var val float64
 		switch p.Type() {
@@ -153,12 +135,12 @@ func (t *Translator) mapNumberMonotonicMetrics(
 			val = float64(p.IntVal())
 		}
 
-		if t.isSkippable(name, val) {
+		if t.isSkippable(pointDims.name, val) {
 			continue
 		}
 
-		if dx, ok := t.prevPts.MonotonicDiff(name, tags, startTs, ts, val); ok {
-			consumer.ConsumeTimeSeries(ctx, name, Count, ts, dx, tags, host)
+		if dx, ok := t.prevPts.MonotonicDiff(pointDims, startTs, ts, val); ok {
+			consumer.ConsumeTimeSeries(ctx, pointDims.name, Count, ts, dx, pointDims.tags, pointDims.host)
 		}
 	}
 }
@@ -179,11 +161,9 @@ func getBounds(p pdata.HistogramDataPoint, idx int) (lowerBound float64, upperBo
 func (t *Translator) getSketchBuckets(
 	ctx context.Context,
 	consumer SketchConsumer,
-	name string,
+	pointDims metricsDimensions,
 	p pdata.HistogramDataPoint,
 	delta bool,
-	tags []string,
-	host string,
 ) {
 	startTs := uint64(p.StartTimestamp())
 	ts := uint64(p.Timestamp())
@@ -195,11 +175,10 @@ func (t *Translator) getSketchBuckets(
 		// The bucketTags are computed from the bounds before the InsertInterpolate fix is done,
 		// otherwise in the case where p.ExplicitBounds() has a size of 1 (eg. [0]), the two buckets
 		// would have the same bucketTags (lower_bound:0 and upper_bound:0), resulting in a buggy behavior.
-		bucketTags := []string{
+		bucketDims := pointDims.AddTags(
 			fmt.Sprintf("lower_bound:%s", formatFloat(lowerBound)),
 			fmt.Sprintf("upper_bound:%s", formatFloat(upperBound)),
-		}
-		bucketTags = append(bucketTags, tags...)
+		)
 
 		// InsertInterpolate doesn't work with an infinite bound; insert in to the bucket that contains the non-infinite bound
 		// https://github.com/DataDog/datadog-agent/blob/7.31.0/pkg/aggregator/check_sampler.go#L107-L111
@@ -212,7 +191,7 @@ func (t *Translator) getSketchBuckets(
 		count := p.BucketCounts()[j]
 		if delta {
 			as.InsertInterpolate(lowerBound, upperBound, uint(count))
-		} else if dx, ok := t.prevPts.Diff(name, bucketTags, startTs, ts, float64(count)); ok {
+		} else if dx, ok := t.prevPts.Diff(bucketDims, startTs, ts, float64(count)); ok {
 			as.InsertInterpolate(lowerBound, upperBound, uint(dx))
 		}
 
@@ -220,37 +199,34 @@ func (t *Translator) getSketchBuckets(
 
 	sketch := as.Finish()
 	if sketch != nil {
-		consumer.ConsumeSketch(ctx, name, ts, sketch, tags, host)
+		consumer.ConsumeSketch(ctx, pointDims.name, ts, sketch, pointDims.tags, pointDims.host)
 	}
 }
 
 func (t *Translator) getLegacyBuckets(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	name string,
+	pointDims metricsDimensions,
 	p pdata.HistogramDataPoint,
 	delta bool,
-	tags []string,
-	host string,
 ) {
 	startTs := uint64(p.StartTimestamp())
 	ts := uint64(p.Timestamp())
 	// We have a single metric, 'bucket', which is tagged with the bucket bounds. See:
 	// https://github.com/DataDog/integrations-core/blob/7.30.1/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/histogram.py
-	fullName := fmt.Sprintf("%s.bucket", name)
+	baseBucketDims := pointDims.WithSuffix("bucket")
 	for idx, val := range p.BucketCounts() {
 		lowerBound, upperBound := getBounds(p, idx)
-		bucketTags := []string{
+		bucketDims := baseBucketDims.AddTags(
 			fmt.Sprintf("lower_bound:%s", formatFloat(lowerBound)),
 			fmt.Sprintf("upper_bound:%s", formatFloat(upperBound)),
-		}
-		bucketTags = append(bucketTags, tags...)
+		)
 
 		count := float64(val)
 		if delta {
-			consumer.ConsumeTimeSeries(ctx, fullName, Count, ts, count, bucketTags, host)
-		} else if dx, ok := t.prevPts.Diff(fullName, bucketTags, startTs, ts, count); ok {
-			consumer.ConsumeTimeSeries(ctx, fullName, Count, ts, dx, bucketTags, host)
+			consumer.ConsumeTimeSeries(ctx, bucketDims.name, Count, ts, count, bucketDims.tags, bucketDims.host)
+		} else if dx, ok := t.prevPts.Diff(bucketDims, startTs, ts, count); ok {
+			consumer.ConsumeTimeSeries(ctx, bucketDims.name, Count, ts, dx, bucketDims.tags, bucketDims.host)
 		}
 	}
 }
@@ -271,46 +247,43 @@ func (t *Translator) getLegacyBuckets(
 func (t *Translator) mapHistogramMetrics(
 	ctx context.Context,
 	consumer Consumer,
-	name string,
+	dims metricsDimensions,
 	slice pdata.HistogramDataPointSlice,
 	delta bool,
-	additionalTags []string,
-	host string,
 ) {
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
 		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
-		tags := getTags(p.Attributes())
-		tags = append(tags, additionalTags...)
+		pointDims := dims.WithAttributeMap(p.Attributes())
 
 		if t.cfg.SendCountSum {
 			count := float64(p.Count())
-			countName := fmt.Sprintf("%s.count", name)
+			countDims := pointDims.WithSuffix("count")
 			if delta {
-				consumer.ConsumeTimeSeries(ctx, countName, Count, ts, count, tags, host)
-			} else if dx, ok := t.prevPts.Diff(countName, tags, startTs, ts, count); ok {
-				consumer.ConsumeTimeSeries(ctx, countName, Count, ts, dx, tags, host)
+				consumer.ConsumeTimeSeries(ctx, countDims.name, Count, ts, count, countDims.tags, countDims.host)
+			} else if dx, ok := t.prevPts.Diff(countDims, startTs, ts, count); ok {
+				consumer.ConsumeTimeSeries(ctx, countDims.name, Count, ts, dx, countDims.tags, countDims.host)
 			}
 		}
 
 		if t.cfg.SendCountSum {
 			sum := p.Sum()
-			sumName := fmt.Sprintf("%s.sum", name)
-			if !t.isSkippable(sumName, p.Sum()) {
+			sumDims := pointDims.WithSuffix("sum")
+			if !t.isSkippable(sumDims.name, p.Sum()) {
 				if delta {
-					consumer.ConsumeTimeSeries(ctx, sumName, Count, ts, sum, tags, host)
-				} else if dx, ok := t.prevPts.Diff(sumName, tags, startTs, ts, sum); ok {
-					consumer.ConsumeTimeSeries(ctx, sumName, Count, ts, dx, tags, host)
+					consumer.ConsumeTimeSeries(ctx, sumDims.name, Count, ts, sum, sumDims.tags, sumDims.host)
+				} else if dx, ok := t.prevPts.Diff(sumDims, startTs, ts, sum); ok {
+					consumer.ConsumeTimeSeries(ctx, sumDims.name, Count, ts, dx, sumDims.tags, sumDims.host)
 				}
 			}
 		}
 
 		switch t.cfg.HistMode {
 		case HistogramModeCounters:
-			t.getLegacyBuckets(ctx, consumer, name, p, delta, tags, host)
+			t.getLegacyBuckets(ctx, consumer, pointDims, p, delta)
 		case HistogramModeDistributions:
-			t.getSketchBuckets(ctx, consumer, name, p, delta, tags, host)
+			t.getSketchBuckets(ctx, consumer, pointDims, p, delta)
 		}
 	}
 }
@@ -346,49 +319,45 @@ func getQuantileTag(quantile float64) string {
 func (t *Translator) mapSummaryMetrics(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	name string,
+	dims metricsDimensions,
 	slice pdata.SummaryDataPointSlice,
-	additionalTags []string,
-	host string,
 ) {
 
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
 		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
-		tags := getTags(p.Attributes())
-		tags = append(tags, additionalTags...)
+		pointDims := dims.WithAttributeMap(p.Attributes())
 
 		// count and sum are increasing; we treat them as cumulative monotonic sums.
 		{
-			countName := fmt.Sprintf("%s.count", name)
-			if dx, ok := t.prevPts.Diff(countName, tags, startTs, ts, float64(p.Count())); ok && !t.isSkippable(countName, dx) {
-				consumer.ConsumeTimeSeries(ctx, countName, Count, ts, dx, tags, host)
+			countDims := pointDims.WithSuffix("count")
+			if dx, ok := t.prevPts.Diff(countDims, startTs, ts, float64(p.Count())); ok && !t.isSkippable(countDims.name, dx) {
+				consumer.ConsumeTimeSeries(ctx, countDims.name, Count, ts, dx, countDims.tags, countDims.host)
 			}
 		}
 
 		{
-			sumName := fmt.Sprintf("%s.sum", name)
-			if !t.isSkippable(sumName, p.Sum()) {
-				if dx, ok := t.prevPts.Diff(sumName, tags, startTs, ts, p.Sum()); ok {
-					consumer.ConsumeTimeSeries(ctx, sumName, Count, ts, dx, tags, host)
+			sumDims := pointDims.WithSuffix("sum")
+			if !t.isSkippable(sumDims.name, p.Sum()) {
+				if dx, ok := t.prevPts.Diff(sumDims, startTs, ts, p.Sum()); ok {
+					consumer.ConsumeTimeSeries(ctx, sumDims.name, Count, ts, dx, sumDims.tags, sumDims.host)
 				}
 			}
 		}
 
 		if t.cfg.Quantiles {
-			fullName := fmt.Sprintf("%s.quantile", name)
+			baseQuantileDims := pointDims.WithSuffix("quantile")
 			quantiles := p.QuantileValues()
 			for i := 0; i < quantiles.Len(); i++ {
 				q := quantiles.At(i)
 
-				if t.isSkippable(fullName, q.Value()) {
+				if t.isSkippable(baseQuantileDims.name, q.Value()) {
 					continue
 				}
 
-				quantileTags := []string{getQuantileTag(q.Quantile())}
-				quantileTags = append(quantileTags, tags...)
-				consumer.ConsumeTimeSeries(ctx, fullName, Gauge, ts, q.Value(), quantileTags, host)
+				quantileDims := baseQuantileDims.AddTags(getQuantileTag(q.Quantile()))
+				consumer.ConsumeTimeSeries(ctx, quantileDims.name, Gauge, ts, q.Value(), quantileDims.tags, quantileDims.host)
 			}
 		}
 	}
@@ -436,19 +405,24 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 
 			for k := 0; k < metricsArray.Len(); k++ {
 				md := metricsArray.At(k)
+				baseDims := metricsDimensions{
+					name: md.Name(),
+					tags: additionalTags,
+					host: host,
+				}
 				switch md.DataType() {
 				case pdata.MetricDataTypeGauge:
-					t.mapNumberMetrics(ctx, consumer, md.Name(), Gauge, md.Gauge().DataPoints(), additionalTags, host)
+					t.mapNumberMetrics(ctx, consumer, baseDims, Gauge, md.Gauge().DataPoints())
 				case pdata.MetricDataTypeSum:
 					switch md.Sum().AggregationTemporality() {
 					case pdata.MetricAggregationTemporalityCumulative:
 						if t.cfg.SendMonotonic && isCumulativeMonotonic(md) {
-							t.mapNumberMonotonicMetrics(ctx, consumer, md.Name(), md.Sum().DataPoints(), additionalTags, host)
+							t.mapNumberMonotonicMetrics(ctx, consumer, baseDims, md.Sum().DataPoints())
 						} else {
-							t.mapNumberMetrics(ctx, consumer, md.Name(), Gauge, md.Sum().DataPoints(), additionalTags, host)
+							t.mapNumberMetrics(ctx, consumer, baseDims, Gauge, md.Sum().DataPoints())
 						}
 					case pdata.MetricAggregationTemporalityDelta:
-						t.mapNumberMetrics(ctx, consumer, md.Name(), Count, md.Sum().DataPoints(), additionalTags, host)
+						t.mapNumberMetrics(ctx, consumer, baseDims, Count, md.Sum().DataPoints())
 					default: // pdata.AggregationTemporalityUnspecified or any other not supported type
 						t.logger.Debug("Unknown or unsupported aggregation temporality",
 							zap.String(metricName, md.Name()),
@@ -460,7 +434,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 					switch md.Histogram().AggregationTemporality() {
 					case pdata.MetricAggregationTemporalityCumulative, pdata.MetricAggregationTemporalityDelta:
 						delta := md.Histogram().AggregationTemporality() == pdata.MetricAggregationTemporalityDelta
-						t.mapHistogramMetrics(ctx, consumer, md.Name(), md.Histogram().DataPoints(), delta, additionalTags, host)
+						t.mapHistogramMetrics(ctx, consumer, baseDims, md.Histogram().DataPoints(), delta)
 					default: // pdata.AggregationTemporalityUnspecified or any other not supported type
 						t.logger.Debug("Unknown or unsupported aggregation temporality",
 							zap.String("metric name", md.Name()),
@@ -469,7 +443,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 						continue
 					}
 				case pdata.MetricDataTypeSummary:
-					t.mapSummaryMetrics(ctx, consumer, md.Name(), md.Summary().DataPoints(), additionalTags, host)
+					t.mapSummaryMetrics(ctx, consumer, baseDims, md.Summary().DataPoints())
 				default: // pdata.MetricDataTypeNone or any other not supported type
 					t.logger.Debug("Unknown or unsupported metric type", zap.String(metricName, md.Name()), zap.Any("data type", md.DataType()))
 					continue

--- a/exporter/datadogexporter/internal/translator/sketches_test.go
+++ b/exporter/datadogexporter/internal/translator/sketches_test.go
@@ -106,12 +106,12 @@ func TestHistogramSketches(t *testing.T) {
 	cfg := quantile.Default()
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
-
+	dims := metricsDimensions{name: "test"}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			p := fromCDF(test.cdf)
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, "test", p, true, []string{}, "")
+			tr.getSketchBuckets(ctx, consumer, dims, p, true)
 			sk := consumer.sk
 
 			// Check the minimum is 0.0
@@ -199,11 +199,12 @@ func TestInfiniteBounds(t *testing.T) {
 
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
+	dims := metricsDimensions{name: "test"}
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
 			p := testInstance.getHist()
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, "test", p, true, []string{}, "")
+			tr.getSketchBuckets(ctx, consumer, dims, p, true)
 			sk := consumer.sk
 			assert.InDelta(t, sk.Basic.Sum, p.Sum(), 1)
 			assert.Equal(t, uint64(sk.Basic.Cnt), p.Count())

--- a/exporter/datadogexporter/internal/translator/ttlcache.go
+++ b/exporter/datadogexporter/internal/translator/ttlcache.go
@@ -15,15 +15,9 @@
 package translator
 
 import (
-	"sort"
-	"strings"
 	"time"
 
 	gocache "github.com/patrickmn/go-cache"
-)
-
-const (
-	metricKeySeparator = string(byte(0))
 )
 
 type ttlCache struct {
@@ -43,53 +37,27 @@ func newTTLCache(sweepInterval int64, deltaTTL int64) *ttlCache {
 	return &ttlCache{cache}
 }
 
-// Uses a logic similar to what is done in the span processor to build metric keys:
-// https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/b2327211df976e0a57ef0425493448988772a16b/processor/spanmetricsprocessor/processor.go#L353-L387
-// TODO: make this a public util function?
-func concatDimensionValue(metricKeyBuilder *strings.Builder, value string) {
-	metricKeyBuilder.WriteString(value)
-	metricKeyBuilder.WriteString(metricKeySeparator)
-}
-
-// metricDimensionsToMapKey maps name and tags to a string to use as an identifier
-// The tags order does not matter
-func (*ttlCache) metricDimensionsToMapKey(name string, tags []string) string {
-	var metricKeyBuilder strings.Builder
-
-	dimensions := make([]string, len(tags))
-	copy(dimensions, tags)
-
-	dimensions = append(dimensions, name)
-	sort.Strings(dimensions)
-
-	for _, dim := range dimensions {
-		concatDimensionValue(&metricKeyBuilder, dim)
-	}
-	return metricKeyBuilder.String()
-}
-
 // Diff submits a new value for a given non-monotonic metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
-func (t *ttlCache) Diff(name string, tags []string, startTs, ts uint64, val float64) (float64, bool) {
-	return t.putAndGetDiff(name, tags, false, startTs, ts, val)
+func (t *ttlCache) Diff(dimensions metricsDimensions, startTs, ts uint64, val float64) (float64, bool) {
+	return t.putAndGetDiff(dimensions, false, startTs, ts, val)
 }
 
 // MonotonicDiff submits a new value for a given monotonic metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
-func (t *ttlCache) MonotonicDiff(name string, tags []string, startTs, ts uint64, val float64) (float64, bool) {
-	return t.putAndGetDiff(name, tags, true, startTs, ts, val)
+func (t *ttlCache) MonotonicDiff(dimensions metricsDimensions, startTs, ts uint64, val float64) (float64, bool) {
+	return t.putAndGetDiff(dimensions, true, startTs, ts, val)
 }
 
 // putAndGetDiff submits a new value for a given metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
 func (t *ttlCache) putAndGetDiff(
-	name string,
-	tags []string,
+	dimensions metricsDimensions,
 	monotonic bool,
 	startTs, ts uint64,
 	val float64,
 ) (dx float64, ok bool) {
-	key := t.metricDimensionsToMapKey(name, tags)
+	key := dimensions.String()
 	if c, found := t.cache.Get(key); found {
 		cnt := c.(numberCounter)
 		if cnt.ts > ts {

--- a/exporter/datadogexporter/internal/translator/ttlcache_test.go
+++ b/exporter/datadogexporter/internal/translator/ttlcache_test.go
@@ -25,16 +25,18 @@ func newTestCache() *ttlCache {
 	return cache
 }
 
+var dims metricsDimensions = metricsDimensions{name: "test"}
+
 func TestMonotonicDiffUnknownStart(t *testing.T) {
 	startTs := uint64(0) // equivalent to start being unset
 	prevPts := newTestCache()
-	_, ok := prevPts.MonotonicDiff("test", []string{}, startTs, 1, 5)
+	_, ok := prevPts.MonotonicDiff(dims, startTs, 1, 5)
 	assert.False(t, ok, "expected no diff: first point")
-	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 0, 0)
+	_, ok = prevPts.MonotonicDiff(dims, startTs, 0, 0)
 	assert.False(t, ok, "expected no diff: old point")
-	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 2, 2)
+	_, ok = prevPts.MonotonicDiff(dims, startTs, 2, 2)
 	assert.False(t, ok, "expected no diff: new < old")
-	dx, ok := prevPts.MonotonicDiff("test", []string{}, startTs, 3, 4)
+	dx, ok := prevPts.MonotonicDiff(dims, startTs, 3, 4)
 	assert.True(t, ok, "expected diff: no startTs, old >= new")
 	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
 }
@@ -42,14 +44,14 @@ func TestMonotonicDiffUnknownStart(t *testing.T) {
 func TestDiffUnknownStart(t *testing.T) {
 	startTs := uint64(0) // equivalent to start being unset
 	prevPts := newTestCache()
-	_, ok := prevPts.Diff("test", []string{}, startTs, 1, 5)
+	_, ok := prevPts.Diff(dims, startTs, 1, 5)
 	assert.False(t, ok, "expected no diff: first point")
-	_, ok = prevPts.Diff("test", []string{}, startTs, 0, 0)
+	_, ok = prevPts.Diff(dims, startTs, 0, 0)
 	assert.False(t, ok, "expected no diff: old point")
-	dx, ok := prevPts.Diff("test", []string{}, startTs, 2, 2)
+	dx, ok := prevPts.Diff(dims, startTs, 2, 2)
 	assert.True(t, ok, "expected diff: no startTs, not monotonic")
 	assert.Equal(t, -3.0, dx, "expected diff -3.0 with (0,1,5) value")
-	dx, ok = prevPts.Diff("test", []string{}, startTs, 3, 4)
+	dx, ok = prevPts.Diff(dims, startTs, 3, 4)
 	assert.True(t, ok, "expected diff: no startTs, old >= new")
 	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
 }
@@ -57,27 +59,27 @@ func TestDiffUnknownStart(t *testing.T) {
 func TestMonotonicDiffKnownStart(t *testing.T) {
 	startTs := uint64(1)
 	prevPts := newTestCache()
-	_, ok := prevPts.MonotonicDiff("test", []string{}, startTs, 1, 5)
+	_, ok := prevPts.MonotonicDiff(dims, startTs, 1, 5)
 	assert.False(t, ok, "expected no diff: first point")
-	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 0, 0)
+	_, ok = prevPts.MonotonicDiff(dims, startTs, 0, 0)
 	assert.False(t, ok, "expected no diff: old point")
-	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 2, 2)
+	_, ok = prevPts.MonotonicDiff(dims, startTs, 2, 2)
 	assert.False(t, ok, "expected no diff: new < old")
-	dx, ok := prevPts.MonotonicDiff("test", []string{}, startTs, 3, 4)
+	dx, ok := prevPts.MonotonicDiff(dims, startTs, 3, 4)
 	assert.True(t, ok, "expected diff: same startTs, old >= new")
 	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
 
 	startTs = uint64(4) // simulate reset with startTs = ts
-	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, startTs, 8)
+	_, ok = prevPts.MonotonicDiff(dims, startTs, startTs, 8)
 	assert.False(t, ok, "expected no diff: reset with unknown start")
-	dx, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 5, 9)
+	dx, ok = prevPts.MonotonicDiff(dims, startTs, 5, 9)
 	assert.True(t, ok, "expected diff: same startTs, old >= new")
 	assert.Equal(t, 1.0, dx, "expected diff 1.0 with (4,4,8) value")
 
 	startTs = uint64(6)
-	_, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 7, 1)
+	_, ok = prevPts.MonotonicDiff(dims, startTs, 7, 1)
 	assert.False(t, ok, "expected no diff: reset with known start")
-	dx, ok = prevPts.MonotonicDiff("test", []string{}, startTs, 8, 10)
+	dx, ok = prevPts.MonotonicDiff(dims, startTs, 8, 10)
 	assert.True(t, ok, "expected diff: same startTs, old >= new")
 	assert.Equal(t, 9.0, dx, "expected diff 9.0 with (6,7,1) value")
 }
@@ -85,61 +87,28 @@ func TestMonotonicDiffKnownStart(t *testing.T) {
 func TestDiffKnownStart(t *testing.T) {
 	startTs := uint64(1)
 	prevPts := newTestCache()
-	_, ok := prevPts.Diff("test", []string{}, startTs, 1, 5)
+	_, ok := prevPts.Diff(dims, startTs, 1, 5)
 	assert.False(t, ok, "expected no diff: first point")
-	_, ok = prevPts.Diff("test", []string{}, startTs, 0, 0)
+	_, ok = prevPts.Diff(dims, startTs, 0, 0)
 	assert.False(t, ok, "expected no diff: old point")
-	dx, ok := prevPts.Diff("test", []string{}, startTs, 2, 2)
+	dx, ok := prevPts.Diff(dims, startTs, 2, 2)
 	assert.True(t, ok, "expected diff: same startTs, not monotonic")
 	assert.Equal(t, -3.0, dx, "expected diff -3.0 with (1,1,5) point")
-	dx, ok = prevPts.Diff("test", []string{}, startTs, 3, 4)
+	dx, ok = prevPts.Diff(dims, startTs, 3, 4)
 	assert.True(t, ok, "expected diff: same startTs, not monotonic")
 	assert.Equal(t, 2.0, dx, "expected diff 2.0 with (0,2,2) value")
 
 	startTs = uint64(4) // simulate reset with startTs = ts
-	_, ok = prevPts.Diff("test", []string{}, startTs, startTs, 8)
+	_, ok = prevPts.Diff(dims, startTs, startTs, 8)
 	assert.False(t, ok, "expected no diff: reset with unknown start")
-	dx, ok = prevPts.Diff("test", []string{}, startTs, 5, 9)
+	dx, ok = prevPts.Diff(dims, startTs, 5, 9)
 	assert.True(t, ok, "expected diff: same startTs, not monotonic")
 	assert.Equal(t, 1.0, dx, "expected diff 1.0 with (4,4,8) value")
 
 	startTs = uint64(6)
-	_, ok = prevPts.Diff("test", []string{}, startTs, 7, 1)
+	_, ok = prevPts.Diff(dims, startTs, 7, 1)
 	assert.False(t, ok, "expected no diff: reset with known start")
-	dx, ok = prevPts.Diff("test", []string{}, startTs, 8, 10)
+	dx, ok = prevPts.Diff(dims, startTs, 8, 10)
 	assert.True(t, ok, "expected diff: same startTs, not monotonic")
 	assert.Equal(t, 9.0, dx, "expected diff 9.0 with (6,7,1) value")
-}
-
-func TestMetricDimensionsToMapKey(t *testing.T) {
-	metricName := "metric.name"
-	c := newTestCache()
-	noTags := c.metricDimensionsToMapKey(metricName, []string{})
-	someTags := c.metricDimensionsToMapKey(metricName, []string{"key1:val1", "key2:val2"})
-	sameTags := c.metricDimensionsToMapKey(metricName, []string{"key2:val2", "key1:val1"})
-	diffTags := c.metricDimensionsToMapKey(metricName, []string{"key3:val3"})
-
-	assert.NotEqual(t, noTags, someTags)
-	assert.NotEqual(t, someTags, diffTags)
-	assert.Equal(t, someTags, sameTags)
-}
-
-func TestMetricDimensionsToMapKeyNoTagsChange(t *testing.T) {
-	// The original metricDimensionsToMapKey had an issue where:
-	// - if the capacity of the tags array passed to it was higher than its length
-	// - and the metric name is earlier (in alphabetical order) than one of the tags
-	// then the original tag array would be modified (without a reallocation, since there is enough capacity),
-	// and would contain a tag labeled as the metric name, while the final tag (in alphabetical order)
-	// would get left out.
-	// This test checks that this doesn't happen anymore.
-
-	metricName := "a.metric.name"
-	c := newTestCache()
-
-	originalTags := make([]string, 2, 3)
-	originalTags[0] = "key1:val1"
-	originalTags[1] = "key2:val2"
-	c.metricDimensionsToMapKey(metricName, originalTags)
-	assert.Equal(t, []string{"key1:val1", "key2:val2"}, originalTags)
-
 }


### PR DESCRIPTION
**Description:** 

Fixes a bug where cumulative metrics (histograms, monotonic sums and some summary fields) were not being transformed correctly into deltas in multi-Collector setups, since the hostname was not used as part of the cache key for old points.
This could cause incorrect values on metrics. This issue did not affect users with the `resource_attributes_as_tags` flag enabled (not the default, but seems to be common) or where the tags+host were otherwise sufficient to identify a metric.

To fix this we include the hostname into the cache key, which has been refactored into a `metricsDimensions` struct.

**Workaround for bug in older versions:** Set `resource_attributes_as_tags` to `true`.

**Link to tracking Issue:** n/a, found when working on something else

**Testing:** Added unit tests; will test in end-to-end environment.
