### PR TITLE
Fallback to rpc.method for segment operation when aws.operation missing

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -124,10 +124,18 @@ func makeAws(attributes map[string]pdata.AttributeValue, resource pdata.Resource
 		return true
 	})
 
+	if awsOperation, ok := attributes[awsxray.AWSOperationAttribute]; ok {
+		operation = awsOperation.StringVal()
+	} else if rpcMethod, ok := attributes[conventions.AttributeRPCMethod]; ok {
+		operation = rpcMethod.StringVal()
+	}
+
 	for key, value := range attributes {
 		switch key {
+		case conventions.AttributeRPCMethod:
+			// Determinstically handled with if else above
 		case awsxray.AWSOperationAttribute:
-			operation = value.StringVal()
+			// Determinstically handled with if else above
 		case awsxray.AWSAccountAttribute:
 			if value.Type() != pdata.AttributeValueTypeEmpty {
 				account = value.StringVal()

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -218,6 +218,17 @@ func TestAwsWithAwsSqsResources(t *testing.T) {
 	assert.Equal(t, "us-east-2", *awsData.RemoteRegion)
 }
 
+func TestAwsWithRpcAttributes(t *testing.T) {
+	resource := pdata.NewResource()
+	attributes := make(map[string]pdata.AttributeValue)
+	attributes[conventions.AttributeRPCMethod] = pdata.NewAttributeValueString("ListBuckets")
+
+	_, awsData := makeAws(attributes, resource)
+
+	assert.NotNil(t, awsData)
+	assert.Equal(t, "ListBuckets", *awsData.Operation)
+}
+
 func TestAwsWithSqsAlternateAttribute(t *testing.T) {
 	queueURL := "https://sqs.use1.amazonaws.com/Meltdown-Alerts"
 	attributes := make(map[string]pdata.AttributeValue)
@@ -253,6 +264,7 @@ func TestAwsWithAwsDynamoDbResources(t *testing.T) {
 
 	tableName := "WIDGET_TYPES"
 	attributes := make(map[string]pdata.AttributeValue)
+	attributes[conventions.AttributeRPCMethod] = pdata.NewAttributeValueString("IncorrectAWSSDKOperation")
 	attributes[awsxray.AWSOperationAttribute] = pdata.NewAttributeValueString("PutItem")
 	attributes[awsxray.AWSRequestIDAttribute] = pdata.NewAttributeValueString("75107C82-EC8A-4F75-883F-4440B491B0AB")
 	attributes[awsxray.AWSTableNameAttribute] = pdata.NewAttributeValueString(tableName)

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -85,7 +85,7 @@ func TestClientSpanWithLegacyAwsSdkClientAttributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
 	attributes[conventions.AttributeHTTPTarget] = "/"
 	attributes[awsxray.AWSServiceAttribute] = "DynamoDB"
-	attributes[conventions.AttributeRPCMethod] = "FalseAWSOperationAttribute"
+	attributes[conventions.AttributeRPCMethod] = "IncorrectAWSSDKOperation"
 	attributes[awsxray.AWSOperationAttribute] = "GetItem"
 	attributes[awsxray.AWSRequestIDAttribute] = "18BO1FEPJSSAOGNJEDPTPCMIU7VV4KQNSO5AEMVJF66Q9ASUAAJG"
 	attributes[awsxray.AWSTableNameAttribute] = "otel-dev-Testing"

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -62,6 +62,7 @@ func TestClientSpanWithRpcAwsSdkClientAttributes(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, nil, false)
 	assert.Equal(t, "DynamoDB", *segment.Name)
 	assert.Equal(t, conventions.AttributeCloudProviderAWS, *segment.Namespace)
+	assert.Equal(t, "GetItem", *segment.AWS.Operation)
 	assert.Equal(t, "subsegment", *segment.Type)
 
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false)
@@ -69,6 +70,7 @@ func TestClientSpanWithRpcAwsSdkClientAttributes(t *testing.T) {
 	assert.NotNil(t, jsonStr)
 	assert.Nil(t, err)
 	assert.True(t, strings.Contains(jsonStr, "DynamoDB"))
+	assert.True(t, strings.Contains(jsonStr, "GetItem"))
 	assert.False(t, strings.Contains(jsonStr, user))
 	assert.False(t, strings.Contains(jsonStr, "user"))
 }
@@ -83,6 +85,7 @@ func TestClientSpanWithLegacyAwsSdkClientAttributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
 	attributes[conventions.AttributeHTTPTarget] = "/"
 	attributes[awsxray.AWSServiceAttribute] = "DynamoDB"
+	attributes[conventions.AttributeRPCMethod] = "FalseAWSOperationAttribute"
 	attributes[awsxray.AWSOperationAttribute] = "GetItem"
 	attributes[awsxray.AWSRequestIDAttribute] = "18BO1FEPJSSAOGNJEDPTPCMIU7VV4KQNSO5AEMVJF66Q9ASUAAJG"
 	attributes[awsxray.AWSTableNameAttribute] = "otel-dev-Testing"
@@ -92,6 +95,7 @@ func TestClientSpanWithLegacyAwsSdkClientAttributes(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, nil, false)
 	assert.Equal(t, "DynamoDB", *segment.Name)
 	assert.Equal(t, conventions.AttributeCloudProviderAWS, *segment.Namespace)
+	assert.Equal(t, "GetItem", *segment.AWS.Operation)
 	assert.Equal(t, "subsegment", *segment.Type)
 
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false)
@@ -99,6 +103,7 @@ func TestClientSpanWithLegacyAwsSdkClientAttributes(t *testing.T) {
 	assert.NotNil(t, jsonStr)
 	assert.Nil(t, err)
 	assert.True(t, strings.Contains(jsonStr, "DynamoDB"))
+	assert.True(t, strings.Contains(jsonStr, "GetItem"))
 	assert.False(t, strings.Contains(jsonStr, user))
 	assert.False(t, strings.Contains(jsonStr, "user"))
 }


### PR DESCRIPTION
**Description:**

When creating an **AWS segment**, the `exporter/awsxrayexporter/internal/translator/segment.go` file will create the "`AWS`" component of the segment (a map under the "`aws`" key) by reading through the attributes of an **OTel span**.

Span generated for the AWS SDK will either have `aws.operation` according to legacy, or `rpc.method` to describes the "operation" made with the AWS SDK as explained [in the specifications](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#common-attributes).

Because some languages have moved to the new spec-defined `rpc.method`, we update the translator to consider this attribute.

**NOTE**: We do not need to map `rpc.service` to `aws.service` since it is not used by the AWS X-Ray backend.

**Link to tracking Issue:** Fixes #6109 

**Testing:**

Tests mostly make sure the operation (e.g. `GetItem`) is present in the final segment structure regardless if we are using the legacy `aws.operation` or the new `rpc.method`.

In the case where both are defined, the legacy `aws.operation` will take precedence as remarked by the updated legacy unit test which defines both but which takes `aws.operation`.

**Documentation:**

Not a breaking change, so N/A.