### PR TITLE
Made metadata-related code simplification for Google Cloud Spanner receiver.

### DIFF
--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
@@ -23,10 +23,11 @@ import (
 
 type LabelValueMetadata interface {
 	ValueMetadata
+	NewLabelValue(value interface{}) LabelValue
 }
 
 type LabelValue interface {
-	LabelValueMetadata
+	Metadata() LabelValueMetadata
 	Value() interface{}
 	SetValueTo(attributes pdata.AttributeMap)
 }
@@ -94,113 +95,145 @@ func NewByteSliceLabelValueMetadata(name string, columnName string) ByteSliceLab
 }
 
 type stringLabelValue struct {
-	StringLabelValueMetadata
-	value string
+	metadata StringLabelValueMetadata
+	value    string
 }
 
 type int64LabelValue struct {
-	Int64LabelValueMetadata
-	value int64
+	metadata Int64LabelValueMetadata
+	value    int64
 }
 
 type boolLabelValue struct {
-	BoolLabelValueMetadata
-	value bool
+	metadata BoolLabelValueMetadata
+	value    bool
 }
 
 type stringSliceLabelValue struct {
-	StringSliceLabelValueMetadata
-	value string
+	metadata StringSliceLabelValueMetadata
+	value    string
 }
 
 type byteSliceLabelValue struct {
-	ByteSliceLabelValueMetadata
-	value string
+	metadata ByteSliceLabelValueMetadata
+	value    string
 }
 
-func (metadata queryLabelValueMetadata) Name() string {
-	return metadata.name
+func (m queryLabelValueMetadata) Name() string {
+	return m.name
 }
 
-func (metadata queryLabelValueMetadata) ColumnName() string {
-	return metadata.columnName
+func (m queryLabelValueMetadata) ColumnName() string {
+	return m.columnName
 }
 
-func (metadata StringLabelValueMetadata) ValueHolder() interface{} {
+func (m StringLabelValueMetadata) NewLabelValue(value interface{}) LabelValue {
+	return newStringLabelValue(m, value)
+}
+
+func (m StringLabelValueMetadata) ValueHolder() interface{} {
 	var valueHolder string
 
 	return &valueHolder
 }
 
-func (value stringLabelValue) Value() interface{} {
-	return value.value
+func (v stringLabelValue) Metadata() LabelValueMetadata {
+	return v.metadata
 }
 
-func (value stringLabelValue) SetValueTo(attributes pdata.AttributeMap) {
-	attributes.InsertString(value.name, value.value)
+func (v stringLabelValue) Value() interface{} {
+	return v.value
+}
+
+func (v stringLabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertString(v.metadata.name, v.value)
 }
 
 func newStringLabelValue(metadata StringLabelValueMetadata, valueHolder interface{}) stringLabelValue {
 	return stringLabelValue{
-		StringLabelValueMetadata: metadata,
-		value:                    *valueHolder.(*string),
+		metadata: metadata,
+		value:    *valueHolder.(*string),
 	}
 }
 
-func (metadata Int64LabelValueMetadata) ValueHolder() interface{} {
+func (m Int64LabelValueMetadata) NewLabelValue(value interface{}) LabelValue {
+	return newInt64LabelValue(m, value)
+}
+
+func (m Int64LabelValueMetadata) ValueHolder() interface{} {
 	var valueHolder int64
 
 	return &valueHolder
 }
 
-func (value int64LabelValue) Value() interface{} {
-	return value.value
+func (v int64LabelValue) Metadata() LabelValueMetadata {
+	return v.metadata
 }
 
-func (value int64LabelValue) SetValueTo(attributes pdata.AttributeMap) {
-	attributes.InsertInt(value.name, value.value)
+func (v int64LabelValue) Value() interface{} {
+	return v.value
+}
+
+func (v int64LabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertInt(v.metadata.name, v.value)
 }
 
 func newInt64LabelValue(metadata Int64LabelValueMetadata, valueHolder interface{}) int64LabelValue {
 	return int64LabelValue{
-		Int64LabelValueMetadata: metadata,
-		value:                   *valueHolder.(*int64),
+		metadata: metadata,
+		value:    *valueHolder.(*int64),
 	}
 }
 
-func (metadata BoolLabelValueMetadata) ValueHolder() interface{} {
+func (m BoolLabelValueMetadata) NewLabelValue(value interface{}) LabelValue {
+	return newBoolLabelValue(m, value)
+}
+
+func (m BoolLabelValueMetadata) ValueHolder() interface{} {
 	var valueHolder bool
 
 	return &valueHolder
 }
 
-func (value boolLabelValue) Value() interface{} {
-	return value.value
+func (v boolLabelValue) Metadata() LabelValueMetadata {
+	return v.metadata
 }
 
-func (value boolLabelValue) SetValueTo(attributes pdata.AttributeMap) {
-	attributes.InsertBool(value.name, value.value)
+func (v boolLabelValue) Value() interface{} {
+	return v.value
+}
+
+func (v boolLabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertBool(v.metadata.name, v.value)
 }
 
 func newBoolLabelValue(metadata BoolLabelValueMetadata, valueHolder interface{}) boolLabelValue {
 	return boolLabelValue{
-		BoolLabelValueMetadata: metadata,
-		value:                  *valueHolder.(*bool),
+		metadata: metadata,
+		value:    *valueHolder.(*bool),
 	}
 }
 
-func (metadata StringSliceLabelValueMetadata) ValueHolder() interface{} {
+func (m StringSliceLabelValueMetadata) NewLabelValue(value interface{}) LabelValue {
+	return newStringSliceLabelValue(m, value)
+}
+
+func (m StringSliceLabelValueMetadata) ValueHolder() interface{} {
 	var valueHolder []string
 
 	return &valueHolder
 }
 
-func (value stringSliceLabelValue) Value() interface{} {
-	return value.value
+func (v stringSliceLabelValue) Metadata() LabelValueMetadata {
+	return v.metadata
 }
 
-func (value stringSliceLabelValue) SetValueTo(attributes pdata.AttributeMap) {
-	attributes.InsertString(value.name, value.value)
+func (v stringSliceLabelValue) Value() interface{} {
+	return v.value
+}
+
+func (v stringSliceLabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertString(v.metadata.name, v.value)
 }
 
 func newStringSliceLabelValue(metadata StringSliceLabelValueMetadata, valueHolder interface{}) stringSliceLabelValue {
@@ -211,28 +244,36 @@ func newStringSliceLabelValue(metadata StringSliceLabelValueMetadata, valueHolde
 	sortedAndConstructedValue := strings.Join(value, ",")
 
 	return stringSliceLabelValue{
-		StringSliceLabelValueMetadata: metadata,
-		value:                         sortedAndConstructedValue,
+		metadata: metadata,
+		value:    sortedAndConstructedValue,
 	}
 }
 
-func (metadata ByteSliceLabelValueMetadata) ValueHolder() interface{} {
+func (m ByteSliceLabelValueMetadata) NewLabelValue(value interface{}) LabelValue {
+	return newByteSliceLabelValue(m, value)
+}
+
+func (m ByteSliceLabelValueMetadata) ValueHolder() interface{} {
 	var valueHolder []byte
 
 	return &valueHolder
 }
 
-func (value byteSliceLabelValue) Value() interface{} {
-	return value.value
+func (v byteSliceLabelValue) Metadata() LabelValueMetadata {
+	return v.metadata
 }
 
-func (value byteSliceLabelValue) SetValueTo(attributes pdata.AttributeMap) {
-	attributes.InsertString(value.name, value.value)
+func (v byteSliceLabelValue) Value() interface{} {
+	return v.value
+}
+
+func (v byteSliceLabelValue) SetValueTo(attributes pdata.AttributeMap) {
+	attributes.InsertString(v.metadata.name, v.value)
 }
 
 func newByteSliceLabelValue(metadata ByteSliceLabelValueMetadata, valueHolder interface{}) byteSliceLabelValue {
 	return byteSliceLabelValue{
-		ByteSliceLabelValueMetadata: metadata,
-		value:                       string(*valueHolder.(*[]byte)),
+		metadata: metadata,
+		value:    string(*valueHolder.(*[]byte)),
 	}
 }

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
@@ -110,11 +110,11 @@ func TestStringLabelValue(t *testing.T) {
 	}
 
 	labelValue := stringLabelValue{
-		StringLabelValueMetadata: metadata,
-		value:                    stringValue,
+		metadata: metadata,
+		value:    stringValue,
 	}
 
-	assert.Equal(t, metadata, labelValue.StringLabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, stringValue, labelValue.Value())
 
 	attributes := pdata.NewAttributeMap()
@@ -136,11 +136,11 @@ func TestInt64LabelValue(t *testing.T) {
 	}
 
 	labelValue := int64LabelValue{
-		Int64LabelValueMetadata: metadata,
-		value:                   int64Value,
+		metadata: metadata,
+		value:    int64Value,
 	}
 
-	assert.Equal(t, metadata, labelValue.Int64LabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, int64Value, labelValue.Value())
 
 	attributes := pdata.NewAttributeMap()
@@ -162,11 +162,11 @@ func TestBoolLabelValue(t *testing.T) {
 	}
 
 	labelValue := boolLabelValue{
-		BoolLabelValueMetadata: metadata,
-		value:                  boolValue,
+		metadata: metadata,
+		value:    boolValue,
 	}
 
-	assert.Equal(t, metadata, labelValue.BoolLabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, boolValue, labelValue.Value())
 
 	attributes := pdata.NewAttributeMap()
@@ -188,11 +188,11 @@ func TestStringSliceLabelValue(t *testing.T) {
 	}
 
 	labelValue := stringSliceLabelValue{
-		StringSliceLabelValueMetadata: metadata,
-		value:                         stringValue,
+		metadata: metadata,
+		value:    stringValue,
 	}
 
-	assert.Equal(t, metadata, labelValue.StringSliceLabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, stringValue, labelValue.Value())
 
 	attributes := pdata.NewAttributeMap()
@@ -214,11 +214,11 @@ func TestByteSliceLabelValue(t *testing.T) {
 	}
 
 	labelValue := byteSliceLabelValue{
-		ByteSliceLabelValueMetadata: metadata,
-		value:                       stringValue,
+		metadata: metadata,
+		value:    stringValue,
 	}
 
-	assert.Equal(t, metadata, labelValue.ByteSliceLabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, stringValue, labelValue.Value())
 
 	attributes := pdata.NewAttributeMap()
@@ -286,7 +286,7 @@ func TestNewStringLabelValue(t *testing.T) {
 
 	labelValue := newStringLabelValue(metadata, valueHolder)
 
-	assert.Equal(t, metadata, labelValue.StringLabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, stringValue, labelValue.Value())
 }
 
@@ -303,7 +303,7 @@ func TestNewInt64LabelValue(t *testing.T) {
 
 	labelValue := newInt64LabelValue(metadata, valueHolder)
 
-	assert.Equal(t, metadata, labelValue.Int64LabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, int64Value, labelValue.Value())
 }
 
@@ -320,7 +320,7 @@ func TestNewBoolLabelValue(t *testing.T) {
 
 	labelValue := newBoolLabelValue(metadata, valueHolder)
 
-	assert.Equal(t, metadata, labelValue.BoolLabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, boolValue, labelValue.Value())
 }
 
@@ -338,7 +338,7 @@ func TestNewStringSliceLabelValue(t *testing.T) {
 
 	labelValue := newStringSliceLabelValue(metadata, valueHolder)
 
-	assert.Equal(t, metadata, labelValue.StringSliceLabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, expectedValue, labelValue.Value())
 }
 
@@ -355,6 +355,6 @@ func TestNewByteSliceLabelValue(t *testing.T) {
 
 	labelValue := newByteSliceLabelValue(metadata, valueHolder)
 
-	assert.Equal(t, metadata, labelValue.ByteSliceLabelValueMetadata)
+	assert.Equal(t, metadata, labelValue.Metadata())
 	assert.Equal(t, stringValue, labelValue.Value())
 }

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
@@ -140,8 +140,8 @@ func testMetricsFromDataPointBuilderBuild(t *testing.T, metricDataType pdata.Met
 
 		for dataPointIndex, expectedDataPoint := range expectedDataPoints {
 			assert.Equal(t, expectedDataPoint.metricName, ilMetric.Name())
-			assert.Equal(t, expectedDataPoint.metricValue.Unit(), ilMetric.Unit())
-			assert.Equal(t, expectedDataPoint.metricValue.DataType().MetricDataType(), ilMetric.DataType())
+			assert.Equal(t, expectedDataPoint.metricValue.Metadata().Unit(), ilMetric.Unit())
+			assert.Equal(t, expectedDataPoint.metricValue.Metadata().DataType().MetricDataType(), ilMetric.DataType())
 
 			var dataPoint pdata.NumberDataPoint
 
@@ -312,13 +312,13 @@ func generateTestData(metricDataType pdata.MetricDataType) testData {
 	expectedGroupingKeys := []MetricsDataPointKey{
 		{
 			MetricName:     metricName1,
-			MetricDataType: metricValues[0].DataType(),
-			MetricUnit:     metricValues[0].Unit(),
+			MetricDataType: metricValues[0].Metadata().DataType(),
+			MetricUnit:     metricValues[0].Metadata().Unit(),
 		},
 		{
 			MetricName:     metricName2,
-			MetricDataType: metricValues[0].DataType(),
-			MetricUnit:     metricValues[0].Unit(),
+			MetricDataType: metricValues[0].Metadata().DataType(),
+			MetricUnit:     metricValues[0].Metadata().Unit(),
 		},
 	}
 

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint.go
@@ -76,8 +76,8 @@ func (mdp *MetricsDataPoint) CopyTo(dataPoint pdata.NumberDataPoint) {
 func (mdp *MetricsDataPoint) GroupingKey() MetricsDataPointKey {
 	return MetricsDataPointKey{
 		MetricName:     mdp.metricName,
-		MetricUnit:     mdp.metricValue.Unit(),
-		MetricDataType: mdp.metricValue.DataType(),
+		MetricUnit:     mdp.metricValue.Metadata().Unit(),
+		MetricDataType: mdp.metricValue.Metadata().DataType(),
 	}
 }
 
@@ -104,7 +104,7 @@ func (mdp *MetricsDataPoint) toDataForHashing() dataForHashing {
 
 	labelsIndex := 3
 	for _, labelValue := range mdp.labelValues {
-		labels[labelsIndex] = label{Name: labelValue.Name(), Value: labelValue.Value()}
+		labels[labelsIndex] = label{Name: labelValue.Metadata().Name(), Value: labelValue.Value()}
 		labelsIndex++
 	}
 

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
@@ -38,8 +38,8 @@ func TestMetricsDataPoint_GroupingKey(t *testing.T) {
 
 	assert.NotNil(t, groupingKey)
 	assert.Equal(t, dataPoint.metricName, groupingKey.MetricName)
-	assert.Equal(t, dataPoint.metricValue.Unit(), groupingKey.MetricUnit)
-	assert.Equal(t, dataPoint.metricValue.DataType(), groupingKey.MetricDataType)
+	assert.Equal(t, dataPoint.metricValue.Metadata().Unit(), groupingKey.MetricUnit)
+	assert.Equal(t, dataPoint.metricValue.Metadata().DataType(), groupingKey.MetricDataType)
 }
 
 func TestMetricsDataPoint_ToItem(t *testing.T) {
@@ -65,7 +65,7 @@ func TestMetricsDataPoint_ToDataForHashing(t *testing.T) {
 
 	labelsIndex := 3
 	for _, labelValue := range dataPoint.labelValues {
-		assertLabel(t, actual.Labels[labelsIndex], labelValue.Name(), labelValue.Value())
+		assertLabel(t, actual.Labels[labelsIndex], labelValue.Metadata().Name(), labelValue.Value())
 		labelsIndex++
 	}
 }
@@ -112,31 +112,31 @@ func TestMetricsDataPoint_CopyTo(t *testing.T) {
 
 func allPossibleLabelValues() []LabelValue {
 	strLabelValue := stringLabelValue{
-		StringLabelValueMetadata: StringLabelValueMetadata{
+		metadata: StringLabelValueMetadata{
 			queryLabelValueMetadata: newQueryLabelValueMetadata("stringLabelName", "stringLabelColumnName"),
 		},
 		value: stringValue,
 	}
 	bLabelValue := boolLabelValue{
-		BoolLabelValueMetadata: BoolLabelValueMetadata{
+		metadata: BoolLabelValueMetadata{
 			queryLabelValueMetadata: newQueryLabelValueMetadata("boolLabelName", "boolLabelColumnName"),
 		},
 		value: boolValue,
 	}
 	i64LabelValue := int64LabelValue{
-		Int64LabelValueMetadata: Int64LabelValueMetadata{
+		metadata: Int64LabelValueMetadata{
 			queryLabelValueMetadata: newQueryLabelValueMetadata("int64LabelName", "int64LabelColumnName"),
 		},
 		value: int64Value,
 	}
 	strSliceLabelValue := stringSliceLabelValue{
-		StringSliceLabelValueMetadata: StringSliceLabelValueMetadata{
+		metadata: StringSliceLabelValueMetadata{
 			queryLabelValueMetadata: newQueryLabelValueMetadata("stringSliceLabelName", "stringSliceLabelColumnName"),
 		},
 		value: stringValue,
 	}
 	btSliceLabelValue := byteSliceLabelValue{
-		ByteSliceLabelValueMetadata: ByteSliceLabelValueMetadata{
+		metadata: ByteSliceLabelValueMetadata{
 			queryLabelValueMetadata: newQueryLabelValueMetadata("byteSliceLabelName", "byteSliceLabelColumnName"),
 		},
 		value: stringValue,
@@ -155,14 +155,14 @@ func allPossibleMetricValues(metricDataType pdata.MetricDataType) []MetricValue 
 	dataType := NewMetricDataType(metricDataType, pdata.MetricAggregationTemporalityDelta, true)
 	return []MetricValue{
 		int64MetricValue{
-			Int64MetricValueMetadata: Int64MetricValueMetadata{
+			metadata: Int64MetricValueMetadata{
 				queryMetricValueMetadata: newQueryMetricValueMetadata("int64MetricName",
 					"int64MetricColumnName", dataType, metricUnit),
 			},
 			value: int64Value,
 		},
 		float64MetricValue{
-			Float64MetricValueMetadata: Float64MetricValueMetadata{
+			metadata: Float64MetricValueMetadata{
 				queryMetricValueMetadata: newQueryMetricValueMetadata("float64MetricName",
 					"float64MetricColumnName", dataType, metricUnit),
 			},
@@ -184,7 +184,7 @@ func assertNonDefaultLabels(t *testing.T, attributesMap pdata.AttributeMap, labe
 }
 
 func assertLabelValue(t *testing.T, attributesMap pdata.AttributeMap, labelValue LabelValue) {
-	value, exists := attributesMap.Get(labelValue.Name())
+	value, exists := attributesMap.Get(labelValue.Metadata().Name())
 
 	assert.True(t, exists)
 	switch labelValue.(type) {

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata.go
@@ -72,22 +72,7 @@ func toLabelValue(labelValueMetadata LabelValueMetadata, row *spanner.Row) (Labe
 		return nil, err
 	}
 
-	var value LabelValue
-
-	switch labelValueMetadataCasted := labelValueMetadata.(type) {
-	case StringLabelValueMetadata:
-		value = newStringLabelValue(labelValueMetadataCasted, valueHolder)
-	case Int64LabelValueMetadata:
-		value = newInt64LabelValue(labelValueMetadataCasted, valueHolder)
-	case BoolLabelValueMetadata:
-		value = newBoolLabelValue(labelValueMetadataCasted, valueHolder)
-	case StringSliceLabelValueMetadata:
-		value = newStringSliceLabelValue(labelValueMetadataCasted, valueHolder)
-	case ByteSliceLabelValueMetadata:
-		value = newByteSliceLabelValue(labelValueMetadataCasted, valueHolder)
-	}
-
-	return value, nil
+	return labelValueMetadata.NewLabelValue(valueHolder), nil
 }
 
 func (metadata *MetricsMetadata) toMetricValues(row *spanner.Row) ([]MetricValue, error) {
@@ -112,16 +97,7 @@ func toMetricValue(metricValueMetadata MetricValueMetadata, row *spanner.Row) (M
 		return nil, err
 	}
 
-	var value MetricValue
-
-	switch metricValueMetadataCasted := metricValueMetadata.(type) {
-	case Int64MetricValueMetadata:
-		value = newInt64MetricValue(metricValueMetadataCasted, valueHolder)
-	case Float64MetricValueMetadata:
-		value = newFloat64MetricValue(metricValueMetadataCasted, valueHolder)
-	}
-
-	return value, nil
+	return metricValueMetadata.NewMetricValue(valueHolder), nil
 }
 
 func (metadata *MetricsMetadata) RowToMetricsDataPoints(databaseID *datasource.DatabaseID, row *spanner.Row) ([]*MetricsDataPoint, error) {
@@ -152,7 +128,7 @@ func (metadata *MetricsMetadata) toMetricsDataPoints(databaseID *datasource.Data
 
 	for _, metricValue := range metricValues {
 		dataPoint := &MetricsDataPoint{
-			metricName:  metadata.MetricNamePrefix + metricValue.Name(),
+			metricName:  metadata.MetricNamePrefix + metricValue.Metadata().Name(),
 			timestamp:   timestamp,
 			databaseID:  databaseID,
 			labelValues: labelValues,

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata_test.go
@@ -73,7 +73,7 @@ func TestToLabelValue(t *testing.T) {
 	rowColumnNames := []string{labelColumnName}
 	testCases := map[string]struct {
 		metadata                 LabelValueMetadata
-		expectedType             LabelValueMetadata
+		expectedType             LabelValue
 		expectedValue            interface{}
 		expectedTransformedValue interface{}
 	}{
@@ -91,8 +91,8 @@ func TestToLabelValue(t *testing.T) {
 			labelValue, _ := toLabelValue(testCase.metadata, row)
 
 			assert.IsType(t, testCase.expectedType, labelValue)
-			assert.Equal(t, labelName, labelValue.Name())
-			assert.Equal(t, labelColumnName, labelValue.ColumnName())
+			assert.Equal(t, labelName, labelValue.Metadata().Name())
+			assert.Equal(t, labelColumnName, labelValue.Metadata().ColumnName())
 			if testCase.expectedTransformedValue != nil {
 				assert.Equal(t, testCase.expectedTransformedValue, labelValue.Value())
 			} else {
@@ -179,7 +179,7 @@ func TestToMetricValue(t *testing.T) {
 	rowColumnNames := []string{metricColumnName}
 	testCases := map[string]struct {
 		metadata      MetricValueMetadata
-		expectedType  MetricValueMetadata
+		expectedType  MetricValue
 		expectedValue interface{}
 	}{
 		"Int64 label value metadata": {Int64MetricValueMetadata{queryMetricValueMetadata: metricValueMetadata}, int64MetricValue{}, int64Value},
@@ -193,10 +193,10 @@ func TestToMetricValue(t *testing.T) {
 			metricValue, _ := toMetricValue(testCase.metadata, row)
 
 			assert.IsType(t, testCase.expectedType, metricValue)
-			assert.Equal(t, metricName, metricValue.Name())
-			assert.Equal(t, metricColumnName, metricValue.ColumnName())
-			assert.Equal(t, metricDataType, metricValue.DataType())
-			assert.Equal(t, metricUnit, metricValue.Unit())
+			assert.Equal(t, metricName, metricValue.Metadata().Name())
+			assert.Equal(t, metricColumnName, metricValue.Metadata().ColumnName())
+			assert.Equal(t, metricDataType, metricValue.Metadata().DataType())
+			assert.Equal(t, metricUnit, metricValue.Metadata().Unit())
 			assert.Equal(t, testCase.expectedValue, metricValue.Value())
 		})
 	}
@@ -322,7 +322,7 @@ func TestMetricsMetadata_ToMetricsDataPoints(t *testing.T) {
 	assert.Equal(t, len(metricValues), len(dataPoints))
 
 	for i, dataPoint := range dataPoints {
-		assert.Equal(t, metadata.MetricNamePrefix+metricValues[i].Name(), dataPoint.metricName)
+		assert.Equal(t, metadata.MetricNamePrefix+metricValues[i].Metadata().Name(), dataPoint.metricName)
 		assert.Equal(t, timestamp, dataPoint.timestamp)
 		assert.Equal(t, databaseID, dataPoint.databaseID)
 		assert.Equal(t, labelValues, dataPoint.labelValues)

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue.go
@@ -20,10 +20,11 @@ type MetricValueMetadata interface {
 	ValueMetadata
 	DataType() MetricDataType
 	Unit() string
+	NewMetricValue(value interface{}) MetricValue
 }
 
 type MetricValue interface {
-	MetricValueMetadata
+	Metadata() MetricValueMetadata
 	Value() interface{}
 	SetValueTo(ndp pdata.NumberDataPoint)
 }
@@ -58,6 +59,10 @@ func NewInt64MetricValueMetadata(name string, columnName string, dataType Metric
 	}
 }
 
+func (m Int64MetricValueMetadata) NewMetricValue(valueHolder interface{}) MetricValue {
+	return newInt64MetricValue(m, valueHolder)
+}
+
 type Float64MetricValueMetadata struct {
 	queryMetricValueMetadata
 }
@@ -70,14 +75,18 @@ func NewFloat64MetricValueMetadata(name string, columnName string, dataType Metr
 	}
 }
 
+func (m Float64MetricValueMetadata) NewMetricValue(valueHolder interface{}) MetricValue {
+	return newFloat64MetricValue(m, valueHolder)
+}
+
 type int64MetricValue struct {
-	Int64MetricValueMetadata
-	value int64
+	metadata Int64MetricValueMetadata
+	value    int64
 }
 
 type float64MetricValue struct {
-	Float64MetricValueMetadata
-	value float64
+	metadata Float64MetricValueMetadata
+	value    float64
 }
 
 func (metadata queryMetricValueMetadata) Name() string {
@@ -96,16 +105,24 @@ func (metadata queryMetricValueMetadata) Unit() string {
 	return metadata.unit
 }
 
-func (metadata Int64MetricValueMetadata) ValueHolder() interface{} {
+func (m Int64MetricValueMetadata) ValueHolder() interface{} {
 	var valueHolder int64
 
 	return &valueHolder
 }
 
-func (metadata Float64MetricValueMetadata) ValueHolder() interface{} {
+func (m Float64MetricValueMetadata) ValueHolder() interface{} {
 	var valueHolder float64
 
 	return &valueHolder
+}
+
+func (value int64MetricValue) Metadata() MetricValueMetadata {
+	return value.metadata
+}
+
+func (value float64MetricValue) Metadata() MetricValueMetadata {
+	return value.metadata
 }
 
 func (value int64MetricValue) Value() interface{} {
@@ -126,14 +143,14 @@ func (value float64MetricValue) SetValueTo(point pdata.NumberDataPoint) {
 
 func newInt64MetricValue(metadata Int64MetricValueMetadata, valueHolder interface{}) int64MetricValue {
 	return int64MetricValue{
-		Int64MetricValueMetadata: metadata,
-		value:                    *valueHolder.(*int64),
+		metadata: metadata,
+		value:    *valueHolder.(*int64),
 	}
 }
 
 func newFloat64MetricValue(metadata Float64MetricValueMetadata, valueHolder interface{}) float64MetricValue {
 	return float64MetricValue{
-		Float64MetricValueMetadata: metadata,
-		value:                      *valueHolder.(*float64),
+		metadata: metadata,
+		value:    *valueHolder.(*float64),
 	}
 }

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricvalue_test.go
@@ -76,11 +76,11 @@ func TestInt64MetricValue(t *testing.T) {
 
 	metricValue :=
 		int64MetricValue{
-			Int64MetricValueMetadata: metadata,
-			value:                    int64Value,
+			metadata: metadata,
+			value:    int64Value,
 		}
 
-	assert.Equal(t, metadata, metricValue.Int64MetricValueMetadata)
+	assert.Equal(t, metadata, metricValue.Metadata())
 	assert.Equal(t, int64Value, metricValue.Value())
 
 	dataPoint := pdata.NewNumberDataPoint()
@@ -103,11 +103,11 @@ func TestFloat64MetricValue(t *testing.T) {
 
 	metricValue :=
 		float64MetricValue{
-			Float64MetricValueMetadata: metadata,
-			value:                      float64Value,
+			metadata: metadata,
+			value:    float64Value,
 		}
 
-	assert.Equal(t, metadata, metricValue.Float64MetricValueMetadata)
+	assert.Equal(t, metadata, metricValue.Metadata())
 	assert.Equal(t, float64Value, metricValue.Value())
 
 	dataPoint := pdata.NewNumberDataPoint()
@@ -163,7 +163,7 @@ func TestNewInt64MetricValue(t *testing.T) {
 
 	metricValue := newInt64MetricValue(metadata, valueHolder)
 
-	assert.Equal(t, metadata, metricValue.Int64MetricValueMetadata)
+	assert.Equal(t, metadata, metricValue.Metadata())
 	assert.Equal(t, int64Value, metricValue.Value())
 }
 
@@ -183,6 +183,6 @@ func TestNewFloat64MetricValue(t *testing.T) {
 
 	metricValue := newFloat64MetricValue(metadata, valueHolder)
 
-	assert.Equal(t, metadata, metricValue.Float64MetricValueMetadata)
+	assert.Equal(t, metadata, metricValue.Metadata())
 	assert.Equal(t, float64Value, metricValue.Value())
 }


### PR DESCRIPTION
Got rid of unnecessary inheritance(used composition instead) + reduced amount of switches by type.