### PR TITLE
[internal/stanza] Use hash instead of json encoded string

### DIFF
--- a/internal/stanza/converter.go
+++ b/internal/stanza/converter.go
@@ -572,31 +572,31 @@ var sevTextMap = map[entry.Severity]string{
 	entry.Fatal4:  "Fatal4",
 }
 
-// pair_sep is chosen to be an invalid byte for a utf-8 sequence
+// pairSep is chosen to be an invalid byte for a utf-8 sequence
 // making it more unlikely to be hit
-var pair_sep = []byte{0xfe}
+var pairSep = []byte{0xfe}
 
 func getResourceID(resource map[string]string) uint64 {
 	var fnvHash = fnv.New64a()
 	var fnvHashOut = make([]byte, 0, 16)
-	var key_slice = make([]string, 0, len(resource))
+	var keySlice = make([]string, 0, len(resource))
 	var escapedSlice = make([]byte, 0, 64)
 
 	for k := range resource {
-		key_slice = append(key_slice, k)
+		keySlice = append(keySlice, k)
 	}
 
 	// In order for this to be deterministic, we need to sort the map. Using range, like above,
 	// has no guarantee about order.
-	sort.Strings(key_slice)
-	for _, k := range key_slice {
+	sort.Strings(keySlice)
+	for _, k := range keySlice {
 		escapedSlice = appendEscapedPairSeparator(escapedSlice[:0], k)
 		fnvHash.Write(escapedSlice)
-		fnvHash.Write(pair_sep)
+		fnvHash.Write(pairSep)
 
 		escapedSlice = appendEscapedPairSeparator(escapedSlice[:0], resource[k])
 		fnvHash.Write(escapedSlice)
-		fnvHash.Write(pair_sep)
+		fnvHash.Write(pairSep)
 	}
 
 	fnvHashOut = fnvHash.Sum(fnvHashOut)
@@ -606,21 +606,21 @@ func getResourceID(resource map[string]string) uint64 {
 // appendEscapedPairSeparator escapes (prefixes) "pair_sep" and byte '0xff' with byte '0xff', and appends it to the
 // incoming buffer. It returns the appended buffer.
 func appendEscapedPairSeparator(buf []byte, s string) []byte {
-	const escape_byte byte = '\xff'
+	const escapeByte byte = '\xff'
 
 	if len(s) > cap(buf) {
-		new_buf := make([]byte, len(s))
-		copy(new_buf, buf)
-		buf = new_buf
+		newBuf := make([]byte, len(s))
+		copy(newBuf, buf)
+		buf = newBuf
 	}
 
 	sBytes := []byte(s)
 	for _, b := range sBytes {
 		switch b {
-		case escape_byte:
+		case escapeByte:
 			fallthrough
-		case pair_sep[0]:
-			buf = append(buf, escape_byte)
+		case pairSep[0]:
+			buf = append(buf, escapeByte)
 		}
 
 		buf = append(buf, b)

--- a/internal/stanza/converter.go
+++ b/internal/stanza/converter.go
@@ -594,9 +594,12 @@ func getResourceID(resource map[string]string) uint64 {
 		keySlice = append(keySlice, k)
 	}
 
-	// In order for this to be deterministic, we need to sort the map. Using range, like above,
-	// has no guarantee about order.
-	sort.Strings(keySlice)
+	if len(keySlice) > 1 {
+		// In order for this to be deterministic, we need to sort the map. Using range, like above,
+		// has no guarantee about order.
+		sort.Strings(keySlice)
+	}
+
 	for _, k := range keySlice {
 		escapedSlice = appendEscapedPairSeparator(escapedSlice[:0], k)
 		fnvHash.Write(escapedSlice)

--- a/internal/stanza/converter.go
+++ b/internal/stanza/converter.go
@@ -576,7 +576,15 @@ var sevTextMap = map[entry.Severity]string{
 // making it more unlikely to be hit
 var pairSep = []byte{0xfe}
 
+// emptyResourceID is the ID returned by getResourceID when it is passed an empty resource.
+// This specific number is chosen as it is the starting offset of fnv64.
+const emptyResourceID uint64 = 14695981039346656037
+
 func getResourceID(resource map[string]string) uint64 {
+	if len(resource) == 0 {
+		return emptyResourceID
+	}
+
 	var fnvHash = fnv.New64a()
 	var fnvHashOut = make([]byte, 0, 16)
 	var keySlice = make([]string, 0, len(resource))
@@ -609,7 +617,7 @@ func appendEscapedPairSeparator(buf []byte, s string) []byte {
 	const escapeByte byte = '\xff'
 
 	if len(s) > cap(buf) {
-		newBuf := make([]byte, len(s))
+		newBuf := make([]byte, 2*len(s))
 		copy(newBuf, buf)
 		buf = newBuf
 	}
@@ -617,9 +625,7 @@ func appendEscapedPairSeparator(buf []byte, s string) []byte {
 	sBytes := []byte(s)
 	for _, b := range sBytes {
 		switch b {
-		case escapeByte:
-			fallthrough
-		case pairSep[0]:
+		case escapeByte, pairSep[0]:
 			buf = append(buf, escapeByte)
 		}
 

--- a/internal/stanza/converter_test.go
+++ b/internal/stanza/converter_test.go
@@ -746,6 +746,24 @@ func BenchmarkGetResourceID(b *testing.B) {
 	}
 }
 
+func BenchmarkGetResourceIDEmptyResource(b *testing.B) {
+	res := map[string]string{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		getResourceID(res)
+	}
+}
+
+func BenchmarkGetResourceIDSingleResource(b *testing.B) {
+	res := map[string]string{
+		"resource": "value",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		getResourceID(res)
+	}
+}
+
 func getResource() map[string]string {
 	return map[string]string{
 		"file.name":        "filename.log",

--- a/internal/stanza/converter_test.go
+++ b/internal/stanza/converter_test.go
@@ -806,13 +806,6 @@ func TestGetResourceID(t *testing.T) {
 			input: getResource(),
 		},
 		{
-			name: "Resource with non-utf bytes",
-			input: map[string]string{
-				"SomeKey":  "Value\xc0\xc1\xd4\xff\xfe",
-				"\xff\xfe": "Ooops",
-			},
-		},
-		{
 			name: "Empty value/key",
 			input: map[string]string{
 				"SomeKey": "",
@@ -838,20 +831,6 @@ func TestGetResourceID(t *testing.T) {
 			input: map[string]string{
 				"ABC": "DE",
 				"F":   "G",
-			},
-		},
-		{
-			name: "Ambiguous map 3",
-			input: map[string]string{
-				"ABC": "DE\xfe",
-				"F":   "G",
-			},
-		},
-		{
-			name: "Ambiguous map 4",
-			input: map[string]string{
-				"ABC":   "DE",
-				"\xfeF": "G",
 			},
 		},
 		{

--- a/internal/stanza/converter_test.go
+++ b/internal/stanza/converter_test.go
@@ -17,6 +17,7 @@ package stanza
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 	"testing"
@@ -734,4 +735,138 @@ func BenchmarkConverter(b *testing.B) {
 			}
 		})
 	}
+}
+
+func BenchmarkGetResourceID(b *testing.B) {
+	b.StopTimer()
+	res := getResource()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		getResourceID(res)
+	}
+}
+
+func getResource() map[string]string {
+	return map[string]string{
+		"file.name":        "filename.log",
+		"file.directory":   "/some_directory",
+		"host.name":        "localhost",
+		"host.ip":          "192.168.1.12",
+		"k8s.pod.name":     "test-pod-123zwe1",
+		"k8s.node.name":    "aws-us-east-1.asfasf.aws.com",
+		"k8s.container.id": "192end1yu823aocajsiocjnasd",
+		"k8s.cluster.name": "my-cluster",
+	}
+}
+
+type resourceIDOutput struct {
+	name   string
+	output uint64
+}
+
+type resourceIDOutputSlice []resourceIDOutput
+
+func (o resourceIDOutputSlice) Len() int {
+	return len(o)
+}
+
+func (x resourceIDOutputSlice) Less(i, j int) bool {
+	return x[i].output < x[j].output
+}
+
+func (o resourceIDOutputSlice) Swap(i, j int) {
+	o[i], o[j] = o[j], o[i]
+}
+
+func TestGetResourceID(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input map[string]string
+	}{
+		{
+			name:  "Typical Resource",
+			input: getResource(),
+		},
+		{
+			name: "Resource with non-utf bytes",
+			input: map[string]string{
+				"SomeKey":  "Value\xc0\xc1\xd4\xff\xfe",
+				"\xff\xfe": "Ooops",
+			},
+		},
+		{
+			name: "Empty value/key",
+			input: map[string]string{
+				"SomeKey": "",
+				"":        "Ooops",
+			},
+		},
+		{
+			name: "Empty value/key (reversed)",
+			input: map[string]string{
+				"":      "SomeKey",
+				"Ooops": "",
+			},
+		},
+		{
+			name: "Ambiguous map 1",
+			input: map[string]string{
+				"AB": "CD",
+				"EF": "G",
+			},
+		},
+		{
+			name: "Ambiguous map 2",
+			input: map[string]string{
+				"ABC": "DE",
+				"F":   "G",
+			},
+		},
+		{
+			name: "Ambiguous map 3",
+			input: map[string]string{
+				"ABC": "DE\xfe",
+				"F":   "G",
+			},
+		},
+		{
+			name: "Ambiguous map 4",
+			input: map[string]string{
+				"ABC":   "DE",
+				"\xfeF": "G",
+			},
+		},
+		{
+			name:  "nil resource",
+			input: nil,
+		},
+		{
+			name: "Long resource value",
+			input: map[string]string{
+				"key": "This is a really long resource value; It's so long that the internal pre-allocated buffer doesn't hold it.",
+			},
+		},
+	}
+
+	outputs := resourceIDOutputSlice{}
+	for _, testCase := range testCases {
+		outputs = append(outputs, resourceIDOutput{
+			name:   testCase.name,
+			output: getResourceID(testCase.input),
+		})
+	}
+
+	// Ensure every output is unique
+	sort.Sort(outputs)
+	for i := 1; i < len(outputs); i++ {
+		if outputs[i].output == outputs[i-1].output {
+			t.Errorf("Test case %s and %s had the same output", outputs[i].name, outputs[i-1].name)
+		}
+	}
+}
+
+func TestGetResourceIDEmptyAndNilAreEqual(t *testing.T) {
+	nilID := getResourceID(nil)
+	emptyID := getResourceID(map[string]string{})
+	require.Equal(t, nilID, emptyID)
 }

--- a/internal/stanza/converter_test.go
+++ b/internal/stanza/converter_test.go
@@ -766,16 +766,16 @@ type resourceIDOutput struct {
 
 type resourceIDOutputSlice []resourceIDOutput
 
-func (o resourceIDOutputSlice) Len() int {
-	return len(o)
+func (r resourceIDOutputSlice) Len() int {
+	return len(r)
 }
 
-func (x resourceIDOutputSlice) Less(i, j int) bool {
-	return x[i].output < x[j].output
+func (r resourceIDOutputSlice) Less(i, j int) bool {
+	return r[i].output < r[j].output
 }
 
-func (o resourceIDOutputSlice) Swap(i, j int) {
-	o[i], o[j] = o[j], o[i]
+func (r resourceIDOutputSlice) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
 }
 
 func TestGetResourceID(t *testing.T) {

--- a/internal/stanza/integration_test.go
+++ b/internal/stanza/integration_test.go
@@ -1,0 +1,134 @@
+package stanza
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-log-collection/agent"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator/builtin/transformer/noop"
+	"github.com/open-telemetry/opentelemetry-log-collection/pipeline"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/consumer"
+	"go.uber.org/zap"
+)
+
+func createNoopReceiver(workerCount int, nextConsumer consumer.Logs) (*receiver, error) {
+	emitter := NewLogEmitter(zap.NewNop().Sugar())
+	logAgent, err := agent.NewBuilder(zap.NewNop().Sugar()).
+		WithConfig(&agent.Config{Pipeline: pipeline.Config{
+			operator.Config{
+				Builder: noop.NewNoopOperatorConfig(""),
+			},
+		}}).
+		WithDefaultOutput(emitter).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	opts := []ConverterOption{
+		WithLogger(zap.NewNop()),
+	}
+
+	if workerCount > 0 {
+		opts = append(opts, WithWorkerCount(workerCount))
+	}
+
+	converter := NewConverter(opts...)
+
+	return &receiver{
+		id:        config.NewComponentID("testReceiver"),
+		agent:     logAgent,
+		emitter:   emitter,
+		consumer:  nextConsumer,
+		logger:    zap.NewNop(),
+		converter: converter,
+	}, nil
+}
+
+// BenchmarkEmitterToConsumer serves as a benchmark for entries going from the emitter to consumer,
+// which follows this path: emitter -> receiver -> converter -> receiver -> consumer
+func BenchmarkEmitterToConsumer(b *testing.B) {
+	const (
+		entryCount = 1_000_000
+		hostsCount = 4
+	)
+
+	var (
+		workerCounts = []int{1, 2, 4, 6, 8}
+		entries      = complexEntriesForNDifferentHosts(entryCount, hostsCount)
+	)
+
+	for _, wc := range workerCounts {
+		b.Run(fmt.Sprintf("worker_count=%d", wc), func(b *testing.B) {
+			consumer := &mockLogsConsumer{}
+			logsReceiver, err := createNoopReceiver(wc, consumer)
+			require.NoError(b, err)
+
+			err = logsReceiver.Start(context.Background(), componenttest.NewNopHost())
+			require.NoError(b, err)
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				consumer.ResetReceivedCount()
+
+				go func() {
+					ctx := context.Background()
+					for _, e := range entries {
+						_ = logsReceiver.emitter.Process(ctx, e)
+					}
+				}()
+
+				require.Eventually(b,
+					func() bool {
+						return consumer.Received() == entryCount
+					},
+					30*time.Second, 5*time.Millisecond, "Did not receive all logs (only received %d)", consumer.Received(),
+				)
+			}
+		})
+	}
+}
+
+func TestEmitterToConsumer(t *testing.T) {
+	const (
+		entryCount  = 1_000
+		hostsCount  = 4
+		workerCount = 2
+	)
+
+	entries := complexEntriesForNDifferentHosts(entryCount, hostsCount)
+
+	consumer := &mockLogsConsumer{}
+	logsReceiver, err := createNoopReceiver(workerCount, consumer)
+	require.NoError(t, err)
+
+	err = logsReceiver.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+
+	consumer.ResetReceivedCount()
+
+	go func() {
+		ctx := context.Background()
+		for _, e := range entries {
+			require.NoError(t, logsReceiver.emitter.Process(ctx, e))
+		}
+	}()
+
+	require.Eventually(t,
+		func() bool {
+			return consumer.Received() == entryCount
+		},
+		5*time.Second, 5*time.Millisecond, "Did not receive all logs (only received %d)", consumer.Received(),
+	)
+
+	<-time.After(500 * time.Millisecond)
+
+	require.Equal(t, entryCount, consumer.Received())
+}

--- a/internal/stanza/integration_test.go
+++ b/internal/stanza/integration_test.go
@@ -140,6 +140,7 @@ func TestEmitterToConsumer(t *testing.T) {
 		5*time.Second, 5*time.Millisecond, "Did not receive all logs (only received %d)", consumer.Received(),
 	)
 
+	// Wait for a small bit of time in order to let any potential extra entries drain out of the pipeline
 	<-time.After(500 * time.Millisecond)
 
 	require.Equal(t, entryCount, consumer.Received())

--- a/internal/stanza/integration_test.go
+++ b/internal/stanza/integration_test.go
@@ -1,3 +1,17 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package stanza
 
 import (

--- a/internal/stanza/integration_test.go
+++ b/internal/stanza/integration_test.go
@@ -126,8 +126,6 @@ func TestEmitterToConsumer(t *testing.T) {
 	err = logsReceiver.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 
-	consumer.ResetReceivedCount()
-
 	go func() {
 		ctx := context.Background()
 		for _, e := range entries {

--- a/internal/stanza/mocks_test.go
+++ b/internal/stanza/mocks_test.go
@@ -85,13 +85,17 @@ func (m *mockLogsConsumer) Capabilities() consumer.Capabilities {
 }
 
 func (m *mockLogsConsumer) ConsumeLogs(ctx context.Context, ld pdata.Logs) error {
-	atomic.AddInt32(&m.received, 1)
+	atomic.AddInt32(&m.received, int32(ld.LogRecordCount()))
 	return nil
 }
 
 func (m *mockLogsConsumer) Received() int {
 	ret := atomic.LoadInt32(&m.received)
 	return int(ret)
+}
+
+func (m *mockLogsConsumer) ResetReceivedCount() {
+	atomic.StoreInt32(&m.received, 0)
 }
 
 type mockLogsRejecter struct {


### PR DESCRIPTION
**Description:**
* Increase performance of internal/stanza converter by using a hash-based resource identifier, instead of json-based.
* Add in an "integration benchmark" and "integration test" that tests/benchmarks log ingestion through multiple components of the package (this will help with giving some confidence with future performance improvements) 

**Testing:**
Using the existing benchmark (BenchmarkConverter), I see a performance improvement:

Before:
```
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkConverter/worker_count=1-12         	       1	7253762089 ns/op	3326649368 B/op	67065109 allocs/op
BenchmarkConverter/worker_count=2-12         	       1	4751685572 ns/op	3326629080 B/op	67064759 allocs/op
BenchmarkConverter/worker_count=4-12         	       1	3505273174 ns/op	3326596144 B/op	67064529 allocs/op
BenchmarkConverter/worker_count=6-12         	       1	3250629410 ns/op	3326593848 B/op	67064483 allocs/op
BenchmarkConverter/worker_count=8-12         	       1	3254775348 ns/op	3326586600 B/op	67064483 allocs/op
PASS
```
After:
```
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkConverter/worker_count=1-12         	       1	6505129031 ns/op	3086660096 B/op	62064955 allocs/op
BenchmarkConverter/worker_count=2-12         	       1	4252483367 ns/op	3086591384 B/op	62064612 allocs/op
BenchmarkConverter/worker_count=4-12         	       1	3254180768 ns/op	3086582832 B/op	62064457 allocs/op
BenchmarkConverter/worker_count=6-12         	       1	3003439848 ns/op	3086572256 B/op	62064309 allocs/op
BenchmarkConverter/worker_count=8-12         	       1	3002254049 ns/op	3086593296 B/op	62064374 allocs/op
PASS
```
