### PR TITLE
removing deprecated call to InitFromMap

### DIFF
--- a/exporter/azuremonitorexporter/conventions_test.go
+++ b/exporter/azuremonitorexporter/conventions_test.go
@@ -45,8 +45,7 @@ func TestHTTPAttributeMapping(t *testing.T) {
 		conventions.AttributeHTTPClientIP:   pdata.NewAttributeValueString(conventions.AttributeHTTPClientIP),
 	}
 
-	attributeMap := pdata.NewAttributeMap()
-	attributeMap.InitFromMap(httpAttributeValues)
+	attributeMap := pdata.NewAttributeMapFromMap(httpAttributeValues)
 
 	// Add all the network attributes
 	appendToAttributeMap(attributeMap, getNetworkAttributes())
@@ -81,8 +80,7 @@ func TestRPCPAttributeMapping(t *testing.T) {
 		conventions.AttributeRPCMethod:  pdata.NewAttributeValueString(conventions.AttributeRPCMethod),
 	}
 
-	attributeMap := pdata.NewAttributeMap()
-	attributeMap.InitFromMap(rpcAttributeValues)
+	attributeMap := pdata.NewAttributeMapFromMap(rpcAttributeValues)
 
 	// Add all the network attributes
 	appendToAttributeMap(attributeMap, getNetworkAttributes())
@@ -112,8 +110,7 @@ func TestDatabaseAttributeMapping(t *testing.T) {
 		conventions.AttributeDBMongoDBCollection:   pdata.NewAttributeValueString(conventions.AttributeDBMongoDBCollection),
 	}
 
-	attributeMap := pdata.NewAttributeMap()
-	attributeMap.InitFromMap(databaseAttributeValues)
+	attributeMap := pdata.NewAttributeMapFromMap(databaseAttributeValues)
 
 	// Add all the network attributes
 	appendToAttributeMap(attributeMap, getNetworkAttributes())
@@ -150,8 +147,7 @@ func TestMessagingAttributeMapping(t *testing.T) {
 		conventions.AttributeMessagingOperation:                         pdata.NewAttributeValueString(conventions.AttributeMessagingOperation),
 	}
 
-	attributeMap := pdata.NewAttributeMap()
-	attributeMap.InitFromMap(messagingAttributeValues)
+	attributeMap := pdata.NewAttributeMapFromMap(messagingAttributeValues)
 
 	// Add all the network attributes
 	appendToAttributeMap(attributeMap, getNetworkAttributes())
@@ -181,8 +177,7 @@ func TestAttributeMappingWithSomeBadValues(t *testing.T) {
 		conventions.AttributeNetPeerPort: pdata.NewAttributeValueString("xx"),
 	}
 
-	attributeMap := pdata.NewAttributeMap()
-	attributeMap.InitFromMap(values)
+	attributeMap := pdata.NewAttributeMapFromMap(values)
 
 	attrs := &NetworkAttributes{}
 	attributeMap.Range(attrs.MapAttribute)

--- a/internal/coreinternal/testdata/common.go
+++ b/internal/coreinternal/testdata/common.go
@@ -58,21 +58,25 @@ func initSpanLinkAttributes(dest pdata.AttributeMap) {
 }
 
 func initMetricAttachment(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestAttachmentKey: pdata.NewAttributeValueString(TestAttachmentValue)})
+	dest.UpsertString(TestAttachmentKey, TestAttachmentValue)
 }
 
 func initMetricAttributes1(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestLabelKey1: pdata.NewAttributeValueString(TestLabelValue1)})
+	dest.UpsertString(TestLabelKey1, TestLabelValue1)
 }
 
 func initMetricAttributes12(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestLabelKey1: pdata.NewAttributeValueString(TestLabelValue1), TestLabelKey2: pdata.NewAttributeValueString(TestLabelValue2)}).Sort()
+	dest.UpsertString(TestLabelKey1, TestLabelValue1)
+	dest.UpsertString(TestLabelKey2, TestLabelValue2)
+	dest.Sort()
 }
 
 func initMetricAttributes13(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestLabelKey1: pdata.NewAttributeValueString(TestLabelValue1), TestLabelKey3: pdata.NewAttributeValueString(TestLabelValue3)}).Sort()
+	dest.UpsertString(TestLabelKey1, TestLabelValue1)
+	dest.UpsertString(TestLabelKey3, TestLabelValue3)
+	dest.Sort()
 }
 
 func initMetricAttributes2(dest pdata.AttributeMap) {
-	dest.InitFromMap(map[string]pdata.AttributeValue{TestLabelKey2: pdata.NewAttributeValueString(TestLabelValue2)})
+	dest.UpsertString(TestLabelKey2, TestLabelValue2)
 }


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-collector/pull/4429
