### PR TITLE
[receiver/collectd] Initialize StartTimestamp for cumulative metrics

### DIFF
--- a/receiver/collectdreceiver/collectd.go
+++ b/receiver/collectdreceiver/collectd.go
@@ -59,6 +59,13 @@ func (r *collectDRecord) protoTime() *timestamppb.Timestamp {
 	return timestamppb.New(ts)
 }
 
+func (r *collectDRecord) startTimestamp(mdType metricspb.MetricDescriptor_Type) *timestamppb.Timestamp {
+	if mdType == metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION || mdType == metricspb.MetricDescriptor_CUMULATIVE_DOUBLE || mdType == metricspb.MetricDescriptor_CUMULATIVE_INT64 {
+		return timestamppb.New(time.Unix(0, int64(float64(time.Second)**r.Time)-int64(float64(time.Second)**r.Interval)))
+	}
+	return nil
+}
+
 func (r *collectDRecord) appendToMetrics(metrics []*metricspb.Metric, defaultLabels map[string]string) ([]*metricspb.Metric, error) {
 	// Ignore if record is an event instead of data point
 	if r.isEvent() {
@@ -103,15 +110,17 @@ func (r *collectDRecord) newMetric(name string, dsType *string, val *json.Number
 	}
 
 	lKeys, lValues := labelKeysAndValues(labels)
+	metricType := r.metricType(dsType, isDouble)
 	metric.MetricDescriptor = &metricspb.MetricDescriptor{
 		Name:      name,
-		Type:      r.metricType(dsType, isDouble),
+		Type:      metricType,
 		LabelKeys: lKeys,
 	}
 	metric.Timeseries = []*metricspb.TimeSeries{
 		{
-			LabelValues: lValues,
-			Points:      []*metricspb.Point{point},
+			StartTimestamp: r.startTimestamp(metricType),
+			LabelValues:    lValues,
+			Points:         []*metricspb.Point{point},
 		},
 	}
 

--- a/receiver/collectdreceiver/collectd.go
+++ b/receiver/collectdreceiver/collectd.go
@@ -61,7 +61,7 @@ func (r *collectDRecord) protoTime() *timestamppb.Timestamp {
 
 func (r *collectDRecord) startTimestamp(mdType metricspb.MetricDescriptor_Type) *timestamppb.Timestamp {
 	if mdType == metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION || mdType == metricspb.MetricDescriptor_CUMULATIVE_DOUBLE || mdType == metricspb.MetricDescriptor_CUMULATIVE_INT64 {
-		return timestamppb.New(time.Unix(0, int64(float64(time.Second)**r.Time)-int64(float64(time.Second)**r.Interval)))
+		return timestamppb.New(time.Unix(0, int64((*r.Time-*r.Interval)*float64(time.Second))))
 	}
 	return nil
 }

--- a/receiver/collectdreceiver/collectd_test.go
+++ b/receiver/collectdreceiver/collectd_test.go
@@ -251,6 +251,10 @@ var wantMetricsData = []*metricspb.Metric{
 		},
 		Timeseries: []*metricspb.TimeSeries{
 			{
+				StartTimestamp: &timestamppb.Timestamp{
+					Seconds: 1415062567,
+					Nanos:   494999808,
+				},
 				LabelValues: []*metricspb.LabelValue{
 					{Value: "value", HasValue: true},
 					{Value: "df", HasValue: true},

--- a/receiver/collectdreceiver/collectd_test.go
+++ b/receiver/collectdreceiver/collectd_test.go
@@ -437,3 +437,87 @@ func TestLabelsFromName(t *testing.T) {
 		})
 	}
 }
+
+func createPtrFloat64(v float64) *float64 {
+	return &v
+}
+
+func TestStartTimestamp(t *testing.T) {
+	tests := []struct {
+		name                 string
+		record               collectDRecord
+		metricDescriptorType metricspb.MetricDescriptor_Type
+		wantStartTimestamp   *timestamppb.Timestamp
+	}{
+		{
+			name: "metric type cumulative distribution",
+			record: collectDRecord{
+				Time:     createPtrFloat64(10),
+				Interval: createPtrFloat64(5),
+			},
+			metricDescriptorType: metricspb.MetricDescriptor_CUMULATIVE_DISTRIBUTION,
+			wantStartTimestamp: &timestamppb.Timestamp{
+				Seconds: 5,
+				Nanos:   0,
+			},
+		},
+		{
+			name: "metric type cumulative double",
+			record: collectDRecord{
+				Time:     createPtrFloat64(10),
+				Interval: createPtrFloat64(5),
+			},
+			metricDescriptorType: metricspb.MetricDescriptor_CUMULATIVE_DOUBLE,
+			wantStartTimestamp: &timestamppb.Timestamp{
+				Seconds: 5,
+				Nanos:   0,
+			},
+		},
+		{
+			name: "metric type cumulative int64",
+			record: collectDRecord{
+				Time:     createPtrFloat64(10),
+				Interval: createPtrFloat64(5),
+			},
+			metricDescriptorType: metricspb.MetricDescriptor_CUMULATIVE_INT64,
+			wantStartTimestamp: &timestamppb.Timestamp{
+				Seconds: 5,
+				Nanos:   0,
+			},
+		},
+		{
+			name: "non-cumulative gauge distribution metric type",
+			record: collectDRecord{
+				Time:     createPtrFloat64(0),
+				Interval: createPtrFloat64(0),
+			},
+			metricDescriptorType: metricspb.MetricDescriptor_GAUGE_DISTRIBUTION,
+			wantStartTimestamp:   nil,
+		},
+		{
+			name: " metric type non-cumulative gauge int64",
+			record: collectDRecord{
+				Time:     createPtrFloat64(0),
+				Interval: createPtrFloat64(0),
+			},
+			metricDescriptorType: metricspb.MetricDescriptor_GAUGE_INT64,
+			wantStartTimestamp:   nil,
+		},
+		{
+			name: " metric type non-cumulativegauge double",
+			record: collectDRecord{
+				Time:     createPtrFloat64(0),
+				Interval: createPtrFloat64(0),
+			},
+			metricDescriptorType: metricspb.MetricDescriptor_GAUGE_DOUBLE,
+			wantStartTimestamp:   nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStartTimestamp := tc.record.startTimestamp(tc.metricDescriptorType)
+			println(gotStartTimestamp)
+			assert.Equal(t, tc.wantStartTimestamp, gotStartTimestamp)
+		})
+	}
+}

--- a/receiver/collectdreceiver/collectd_test.go
+++ b/receiver/collectdreceiver/collectd_test.go
@@ -486,7 +486,7 @@ func TestStartTimestamp(t *testing.T) {
 			},
 		},
 		{
-			name: "non-cumulative gauge distribution metric type",
+			name: "metric type non-cumulative gauge distribution",
 			record: collectDRecord{
 				Time:     createPtrFloat64(0),
 				Interval: createPtrFloat64(0),
@@ -495,7 +495,7 @@ func TestStartTimestamp(t *testing.T) {
 			wantStartTimestamp:   nil,
 		},
 		{
-			name: " metric type non-cumulative gauge int64",
+			name: "metric type non-cumulative gauge int64",
 			record: collectDRecord{
 				Time:     createPtrFloat64(0),
 				Interval: createPtrFloat64(0),
@@ -504,7 +504,7 @@ func TestStartTimestamp(t *testing.T) {
 			wantStartTimestamp:   nil,
 		},
 		{
-			name: " metric type non-cumulativegauge double",
+			name: "metric type non-cumulativegauge double",
 			record: collectDRecord{
 				Time:     createPtrFloat64(0),
 				Interval: createPtrFloat64(0),
@@ -516,7 +516,6 @@ func TestStartTimestamp(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			gotStartTimestamp := tc.record.startTimestamp(tc.metricDescriptorType)
-			println(gotStartTimestamp)
 			assert.Equal(t, tc.wantStartTimestamp, gotStartTimestamp)
 		})
 	}

--- a/receiver/collectdreceiver/receiver_test.go
+++ b/receiver/collectdreceiver/receiver_test.go
@@ -133,6 +133,10 @@ func TestCollectDServer(t *testing.T) {
 					},
 				},
 				Timeseries: []*metricspb.TimeSeries{{
+					StartTimestamp: &timestamppb.Timestamp{
+						Seconds: 1415062567,
+						Nanos:   494999808,
+					},
 					LabelValues: []*metricspb.LabelValue{
 						{Value: "memory", HasValue: true},
 						{Value: "i-b13d1e5f", HasValue: true},


### PR DESCRIPTION
**Description:**

Fixing a bug – OTel is currently returning the following error `The start time must be before the end time` when handling cumulative type metrics. This PR initializes `TimeSeries.StartTimestamp` by setting this value to Collectd `Interval` number of seconds before the `Point.Timestamp`.

**Link to tracking Issue:**

Fixes #6303

**Testing:** 

```
$ go test -run ^(TestDecodeEvent|TestDecodeMetrics|TestLabelsFromName)$ github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
```

No new test-cases added. I modified the test case `df_complex.free` to accept a non `nil` `StartTimestamp` value.
