### PR TITLE
[build] fix error in github release step

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -467,7 +467,7 @@ jobs:
         if: steps.check.outputs.passed == 'true'
         run: |
           cp bin/* dist/
-          cd dist && shasum -a 256 * > checksums.txt
+          cd dist && shasum -a 256 * > checksums.txt && cd ../
           ghr -t $GITHUB_TOKEN -u "GitHub Action" -r opentelemetry-collector-contrib --replace $RELEASE_TAG dist/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The github release step in `publish-stable` was failing because it was trying to copy the output files from a directory it was already in. Adding a `cd ../` to fix this.

Fixes #6337
