### PR TITLE
`build`: ensure executable flag is set.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -376,6 +376,7 @@ jobs:
         with:
           name: collector-binaries
           path: ./bin/
+      - run: chmod +x bin/*
       - name: Download Packages
         uses: actions/download-artifact@v2
         with:
@@ -430,6 +431,7 @@ jobs:
         with:
           name: collector-binaries
           path: ./bin/
+      - run: chmod +x bin/*
       - name: Download Packages
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
After downloading the binaries from artifacts, ensure the executable flag is set on them.

Fixes #6343