### PR TITLE
`build`: Changing the name to describe the windows workflow

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -1,4 +1,4 @@
-name: build-and-test
+name: build-and-test-windows
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Currently there are two build-and-test workflows, this is confusing.
