### PR TITLE
kafkaexporter: Add otlp json encoding

### DIFF
--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -12,6 +12,7 @@ The following settings can be optionally configured:
 - `topic` (default = otlp_spans for traces, otlp_metrics for metrics, otlp_logs for logs): The name of the kafka topic to export to.
 - `encoding` (default = otlp_proto): The encoding of the traces sent to kafka. All available encodings:
   - `otlp_proto`: payload is Protobuf serialized from `ExportTraceServiceRequest` if set as a traces exporter or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs.
+  - `otlp_json`:  ** EXPERIMENTAL ** payload is Json serialized from `ExportTraceServiceRequest` if set as a traces exporter or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs. 
   - The following encodings are valid *only* for **traces**.
     - `jaeger_proto`: the payload is serialized to a single Jaeger proto `Span`, and keyed by TraceID.
     - `jaeger_json`: the payload is serialized to a single Jaeger JSON Span using `jsonpb`, and keyed by TraceID.

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -110,6 +110,9 @@ func (f *kafkaExporterFactory) createTracesExporter(
 	if oCfg.Topic == "" {
 		oCfg.Topic = defaultTracesTopic
 	}
+	if oCfg.Encoding == "otlp_json" {
+		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
+	}
 	exp, err := newTracesExporter(*oCfg, set, f.tracesMarshalers)
 	if err != nil {
 		return nil, err
@@ -136,6 +139,9 @@ func (f *kafkaExporterFactory) createMetricsExporter(
 	if oCfg.Topic == "" {
 		oCfg.Topic = defaultMetricsTopic
 	}
+	if oCfg.Encoding == "otlp_json" {
+		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
+	}
 	exp, err := newMetricsExporter(*oCfg, set, f.metricsMarshalers)
 	if err != nil {
 		return nil, err
@@ -161,6 +167,9 @@ func (f *kafkaExporterFactory) createLogsExporter(
 	oCfg := cfg.(*Config)
 	if oCfg.Topic == "" {
 		oCfg.Topic = defaultLogsTopic
+	}
+	if oCfg.Encoding == "otlp_json" {
+		set.Logger.Info("otlp_json is considered experimental and should not be used in a production environment")
 	}
 	exp, err := newLogsExporter(*oCfg, set, f.logsMarshalers)
 	if err != nil {

--- a/exporter/kafkaexporter/marshaler.go
+++ b/exporter/kafkaexporter/marshaler.go
@@ -50,10 +50,12 @@ type LogsMarshaler interface {
 // tracesMarshalers returns map of supported encodings with TracesMarshaler.
 func tracesMarshalers() map[string]TracesMarshaler {
 	otlpPb := newPdataTracesMarshaler(otlp.NewProtobufTracesMarshaler(), defaultEncoding)
+	otlpJSON := newPdataTracesMarshaler(otlp.NewJSONTracesMarshaler(), "otlp_json")
 	jaegerProto := jaegerMarshaler{marshaler: jaegerProtoSpanMarshaler{}}
 	jaegerJSON := jaegerMarshaler{marshaler: newJaegerJSONMarshaler()}
 	return map[string]TracesMarshaler{
 		otlpPb.Encoding():      otlpPb,
+		otlpJSON.Encoding():    otlpJSON,
 		jaegerProto.Encoding(): jaegerProto,
 		jaegerJSON.Encoding():  jaegerJSON,
 	}
@@ -62,15 +64,19 @@ func tracesMarshalers() map[string]TracesMarshaler {
 // metricsMarshalers returns map of supported encodings and MetricsMarshaler
 func metricsMarshalers() map[string]MetricsMarshaler {
 	otlpPb := newPdataMetricsMarshaler(otlp.NewProtobufMetricsMarshaler(), defaultEncoding)
+	otlpJSON := newPdataMetricsMarshaler(otlp.NewJSONMetricsMarshaler(), "otlp_json")
 	return map[string]MetricsMarshaler{
-		otlpPb.Encoding(): otlpPb,
+		otlpPb.Encoding():   otlpPb,
+		otlpJSON.Encoding(): otlpJSON,
 	}
 }
 
 // logsMarshalers returns map of supported encodings and LogsMarshaler
 func logsMarshalers() map[string]LogsMarshaler {
 	otlpPb := newPdataLogsMarshaler(otlp.NewProtobufLogsMarshaler(), defaultEncoding)
+	otlpJSON := newPdataLogsMarshaler(otlp.NewJSONLogsMarshaler(), "otlp_json")
 	return map[string]LogsMarshaler{
-		otlpPb.Encoding(): otlpPb,
+		otlpPb.Encoding():   otlpPb,
+		otlpJSON.Encoding(): otlpJSON,
 	}
 }


### PR DESCRIPTION
**Description:**
Adds the ability to export OTLP as json instead of just protobuf.

**Link to tracking Issue:**
I hadn't looked if there was a related issued.

**Testing:**
Follows the same testing as what has been already used.

**Documentation:**

Updated exporter readme to include that `otlp_json` is supported.