### PR TITLE
[datadogexporter] Fix missing resource attributes default mapping when resource_attributes_as_tags: false

### DIFF
--- a/exporter/datadogexporter/internal/translator/metrics_translator.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator.go
@@ -430,6 +430,8 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 			var additionalTags []string
 			if t.cfg.InstrumentationLibraryMetadataAsTags {
 				additionalTags = append(attributeTags, instrumentationlibrary.TagsFromInstrumentationLibraryMetadata(ilm.InstrumentationLibrary())...)
+			} else {
+				additionalTags = attributeTags
 			}
 
 			for k := 0; k < metricsArray.Len(); k++ {

--- a/exporter/datadogexporter/internal/translator/metrics_translator_test.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator_test.go
@@ -1120,8 +1120,8 @@ func newCountWithHostname(name string, val float64, seconds uint64, tags []strin
 	return m
 }
 
-func newSketchWithHostname(name string, summary summary.Summary, seconds uint64, tags []string) sketch {
-	s := newSketch(name, seconds, summary, tags)
+func newSketchWithHostname(name string, summary summary.Summary, tags []string) sketch {
+	s := newSketch(name, 0, summary, tags)
 	s.host = testHostname
 	return s
 }
@@ -1182,7 +1182,7 @@ func TestMapMetrics(t *testing.T) {
 					Sum: 0,
 					Avg: 0,
 					Cnt: 20,
-				}, 0, attrTags),
+				}, attrTags),
 			},
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 2,
@@ -1212,7 +1212,7 @@ func TestMapMetrics(t *testing.T) {
 					Sum: 0,
 					Avg: 0,
 					Cnt: 20,
-				}, 0, []string{}),
+				}, []string{}),
 			},
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 2,
@@ -1242,7 +1242,7 @@ func TestMapMetrics(t *testing.T) {
 					Sum: 0,
 					Avg: 0,
 					Cnt: 20,
-				}, 0, append(attrTags, ilTags...)),
+				}, append(attrTags, ilTags...)),
 			},
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 2,
@@ -1272,7 +1272,7 @@ func TestMapMetrics(t *testing.T) {
 					Sum: 0,
 					Avg: 0,
 					Cnt: 20,
-				}, 0, ilTags),
+				}, ilTags),
 			},
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 2,
@@ -1420,7 +1420,7 @@ func TestNaNMetrics(t *testing.T) {
 			Sum: 0,
 			Avg: 0,
 			Cnt: 20,
-		}, 0, []string{}),
+		}, []string{}),
 	})
 
 	// One metric type was unknown or unsupported

--- a/exporter/datadogexporter/internal/translator/metrics_translator_test.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator_test.go
@@ -116,12 +116,10 @@ func newTranslator(t *testing.T, logger *zap.Logger, resourceAttributesAsTags, i
 	}
 
 	if resourceAttributesAsTags {
-		fmt.Println("Here (resourceAttributesAsTags)")
 		options = append(options, WithResourceAttributesAsTags())
 	}
 
 	if instrumentationLibraryMetadataAsTags {
-		fmt.Println("There (instrumentationLibraryMetadataAsTags)")
 		options = append(options, WithInstrumentationLibraryMetadataAsTags())
 	}
 

--- a/exporter/datadogexporter/internal/translator/metrics_translator_test.go
+++ b/exporter/datadogexporter/internal/translator/metrics_translator_test.go
@@ -960,10 +960,10 @@ func createTestMetrics(additionalAttributes map[string]string, name, version str
 	}
 	ilms := rm.InstrumentationLibraryMetrics()
 
-	metricsArrayMetadata := ilms.AppendEmpty()
-	metricsArrayMetadata.InstrumentationLibrary().SetName(name)
-	metricsArrayMetadata.InstrumentationLibrary().SetVersion(version)
-	metricsArray := metricsArrayMetadata.Metrics()
+	ilm := ilms.AppendEmpty()
+	ilm.InstrumentationLibrary().SetName(name)
+	ilm.InstrumentationLibrary().SetVersion(version)
+	metricsArray := ilm.Metrics()
 	metricsArray.AppendEmpty() // first one is TypeNone to test that it's ignored
 
 	// IntGauge
@@ -1149,11 +1149,11 @@ func TestMapMetrics(t *testing.T) {
 		"env:dev",
 	}
 
-	ILName := "instrumentation_library"
-	ILVersion := "1.0.0"
+	ilName := "instrumentation_library"
+	ilVersion := "1.0.0"
 	ilTags := []string{
-		fmt.Sprintf("instrumentation_library:%s", ILName),
-		fmt.Sprintf("instrumentation_library_version:%s", ILVersion),
+		fmt.Sprintf("instrumentation_library:%s", ilName),
+		fmt.Sprintf("instrumentation_library_version:%s", ilVersion),
 	}
 
 	tests := []struct {
@@ -1289,7 +1289,7 @@ func TestMapMetrics(t *testing.T) {
 
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
-			md := createTestMetrics(attrs, ILName, ILVersion)
+			md := createTestMetrics(attrs, ilName, ilVersion)
 
 			core, observed := observer.New(zapcore.DebugLevel)
 			testLogger := zap.New(core)

--- a/exporter/datadogexporter/internal/translator/sketches_test.go
+++ b/exporter/datadogexporter/internal/translator/sketches_test.go
@@ -105,7 +105,7 @@ func TestHistogramSketches(t *testing.T) {
 	tol := 1e-8
 	cfg := quantile.Default()
 	ctx := context.Background()
-	tr := newTranslator(t, zap.NewNop(), false, false)
+	tr := newTranslator(t, zap.NewNop())
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestInfiniteBounds(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tr := newTranslator(t, zap.NewNop(), false, false)
+	tr := newTranslator(t, zap.NewNop())
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
 			p := testInstance.getHist()

--- a/exporter/datadogexporter/internal/translator/sketches_test.go
+++ b/exporter/datadogexporter/internal/translator/sketches_test.go
@@ -105,7 +105,7 @@ func TestHistogramSketches(t *testing.T) {
 	tol := 1e-8
 	cfg := quantile.Default()
 	ctx := context.Background()
-	tr := newTranslator(t, zap.NewNop())
+	tr := newTranslator(t, zap.NewNop(), false, false)
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestInfiniteBounds(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tr := newTranslator(t, zap.NewNop())
+	tr := newTranslator(t, zap.NewNop(), false, false)
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
 			p := testInstance.getHist()


### PR DESCRIPTION
**Description:**
Since #5431, when `resource_attributes_as_tags: false` and `instrumentation_library_metadata_as_tags: false` (default config), the default resource attributes mapping done by `attributes.TagsFromAttributes` wouldn't be added to the metric tags.

**Link to tracking Issue:** n/a, found during testing.

**Testing:** Added unit tests.

**Documentation:** n/a