### PR TITLE
kafkareceiver: register kafka metrics

### DIFF
--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
@@ -80,6 +81,8 @@ func WithLogsUnmarshalers(logsUnmarshalers ...LogsUnmarshaler) FactoryOption {
 
 // NewFactory creates Kafka receiver factory.
 func NewFactory(options ...FactoryOption) component.ReceiverFactory {
+	_ = view.Register(MetricViews()...)
+
 	f := &kafkaReceiverFactory{
 		tracesUnmarshalers:  defaultTracesUnmarshalers(),
 		metricsUnmarshalers: defaultMetricsUnmarshalers(),

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -127,6 +127,7 @@ func TestTracesReceiver_error(t *testing.T) {
 }
 
 func TestTracesConsumerGroupHandler(t *testing.T) {
+	view.Unregister(MetricViews()...)
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
@@ -314,6 +315,7 @@ func TestMetricsReceiver_error(t *testing.T) {
 }
 
 func TestMetricsConsumerGroupHandler(t *testing.T) {
+	view.Unregister(MetricViews()...)
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)
@@ -500,6 +502,7 @@ func TestLogsReceiver_error(t *testing.T) {
 }
 
 func TestLogsConsumerGroupHandler(t *testing.T) {
+	view.Unregister(MetricViews()...)
 	views := MetricViews()
 	require.NoError(t, view.Register(views...))
 	defer view.Unregister(views...)


### PR DESCRIPTION
**Description:**
Fixing a bug
Kafka metrics are not being generated for the kafka receiver component.

This was happening back in `v0.33.0` of the collector, but the kafka receiver has since been removed from the main collector repository https://github.com/open-telemetry/opentelemetry-collector/blob/v0.33.0/service/telemetry.go#L67

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6365

**Testing:**
Ran these commands locally
https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md#creating-a-pr

**Documentation:**
N/A