### PR TITLE
[filterprocessor] Resource-attributes only filtering

### DIFF
--- a/internal/coreinternal/processor/filtermetric/config.go
+++ b/internal/coreinternal/processor/filtermetric/config.go
@@ -55,3 +55,24 @@ type MatchProperties struct {
 	// A match occurs if any resource attribute matches all expressions in this given list.
 	ResourceAttributes []filterconfig.Attribute `mapstructure:"resource_attributes"`
 }
+
+// ChecksMetrics returns whether or not the check should iterate through all the metrics
+func (mp *MatchProperties) ChecksMetrics() bool {
+	if mp == nil {
+		return false
+	}
+
+	if mp.MatchType == Expr {
+		return len(mp.Expressions) > 0
+	}
+	return len(mp.MetricNames) > 0
+}
+
+// ChecksResourceAtributes returns whether or not it checks the resource_attributes
+func (mp *MatchProperties) ChecksResourceAtributes() bool {
+	if mp == nil {
+		return false
+	}
+
+	return len(mp.ResourceAttributes) > 0
+}

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -202,3 +202,5 @@ processors:
           - Key: container.name
             Value: (app_container_1|app_container_1)
 ```
+
+In case the no metric names are provided, `matric_names` being empty, the filtering is only done at resource level.

--- a/processor/filterprocessor/filter_processor_test.go
+++ b/processor/filterprocessor/filter_processor_test.go
@@ -279,15 +279,50 @@ var (
 			inc: &filtermetric.MatchProperties{
 				MatchType: filtermetric.Regexp,
 				MetricNames: []string{
-					"metric1",
-					"metric3",
+					".*",
 				},
-				ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "(attr1/val1|attr1/val2)"}},
+				ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}},
 			},
 			inMetrics: testResourceMetrics(inMetricForTwoResource),
 			outMN: [][]string{
-				{"metric1"},
-				{"metric3"},
+				{"metric1", "metric2"},
+			},
+		},
+		{
+			name: "includeWithRegexResourceAttributesOnly",
+			inc: &filtermetric.MatchProperties{
+				MatchType:          filtermetric.Regexp,
+				ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}},
+			},
+			inMetrics: testResourceMetrics(inMetricForTwoResource),
+			outMN: [][]string{
+				{"metric1", "metric2"},
+			},
+		},
+		{
+			name: "includeWithStrictResourceAttributes",
+			inc: &filtermetric.MatchProperties{
+				MatchType: filtermetric.Strict,
+				MetricNames: []string{
+					"metric1",
+					"metric2",
+				},
+				ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}},
+			},
+			inMetrics: testResourceMetrics(inMetricForTwoResource),
+			outMN: [][]string{
+				{"metric1", "metric2"},
+			},
+		},
+		{
+			name: "includeWithStrictResourceAttributesOnly",
+			inc: &filtermetric.MatchProperties{
+				MatchType:          filtermetric.Strict,
+				ResourceAttributes: []filterconfig.Attribute{{Key: "attr1", Value: "attr1/val1"}},
+			},
+			inMetrics: testResourceMetrics(inMetricForTwoResource),
+			outMN: [][]string{
+				{"metric1", "metric2"},
 			},
 		},
 	}


### PR DESCRIPTION
**Description:** Adds possibility to define include resource-attributes
based filters without the need of specifying and checking
metric names.

**Link to tracking Issue:** N/A

**Testing:** Local, no regressions observed

**Documentation:** README.md updated