### PR TITLE
routingprocessor: remove broken debug log fields

### DIFF
--- a/processor/routingprocessor/router.go
+++ b/processor/routingprocessor/router.go
@@ -394,7 +394,7 @@ func (r *router) registerTracesExporters(hostTracesExporters map[config.Componen
 // registerExportersForRoutes registers exporters according to the configuring
 // routing table, taking into account the provided map of available exporters.
 func (r *router) registerExportersForRoutes(available ExporterMap) error {
-	r.logger.Debug("Registering exporters for routes", zap.Any("exporters", available))
+	r.logger.Debug("Registering exporters for routes")
 
 	// default exporters
 	if err := r.registerExportersForDefaultRoute(available); err != nil {
@@ -442,7 +442,6 @@ func (r *router) registerExportersForDefaultRoute(available ExporterMap) error {
 func (r *router) registerExportersForRoute(route string, available ExporterMap, requested []string) error {
 	r.logger.Debug("Registering exporter for route",
 		zap.String("route", route),
-		zap.Any("available", available),
 		zap.Any("requested", requested),
 	)
 


### PR DESCRIPTION
**Description:** Remove broken debug log fields in routingprocessor

The logger fields that were added as part of the last change introduced the following unwanted log output:

```
2021-11-18T14:51:59.175Z    debug    routingprocessor@v0.38.0/router.go:400    Registering exporters for routes    {"kind": "processor", "name": "routing", "exportersError": "json: unsupported type: componenthelper.StartFunc"}
2021-11-18T14:51:59.175Z    debug    routingprocessor@v0.38.0/router.go:446    Registering exporter for route    {"kind": "processor", "name": "routing", "route": "/prometheus.metrics.apiserver", "availableError": "json: unsupported type: componenthelper.StartFunc", "requested": ["sumologic/apiserver"]}
2021-11-18T14:51:59.175Z    debug    routingprocessor@v0.38.0/router.go:446    Registering exporter for route    {"kind": "processor", "name": "routing", "route": "/prometheus.metrics.container", "availableError": "json: unsupported type: componenthelper.StartFunc", "requested": ["sumologic/kubelet"]}
```

So let's remote them.
