### PR TITLE
Increase TestIdleMode RAM limits

### DIFF
--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -54,7 +54,7 @@ func TestIdleMode(t *testing.T) {
 		cp,
 		&testbed.PerfTestValidator{},
 		performanceResultsSummary,
-		testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 20, ExpectedMaxRAM: 70}),
+		testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 20, ExpectedMaxRAM: 83}),
 	)
 	tc.StartAgent()
 


### PR DESCRIPTION
The limits very very close to acual max (last "main" run was70MB) so have to increase
to avoid sporadic failures, such as this: https://github.com/open-telemetry/opentelemetry-collector-contrib/runs/4249484312?check_suite_focus=true
