### PR TITLE
[internal/stanza] Batch in emitter instead of converter

### DIFF
--- a/internal/stanza/converter.go
+++ b/internal/stanza/converter.go
@@ -243,22 +243,23 @@ func (c *Converter) batchLoop() {
 						At(0).InstrumentationLibraryLogs().
 						At(0).Logs().AppendEmpty()
 					wi.LogRecord.CopyTo(lr)
-				} else {
-					pLogs = pdata.NewLogs()
-					logs := pLogs.ResourceLogs()
-					rls := logs.AppendEmpty()
-
-					resource := rls.Resource()
-					resourceAtts := resource.Attributes()
-					resourceAtts.EnsureCapacity(len(wi.Resource))
-					for k, v := range wi.Resource {
-						resourceAtts.InsertString(k, v)
-					}
-
-					ills := rls.InstrumentationLibraryLogs()
-					lr := ills.AppendEmpty().Logs().AppendEmpty()
-					wi.LogRecord.CopyTo(lr)
+					continue
 				}
+
+				pLogs = pdata.NewLogs()
+				logs := pLogs.ResourceLogs()
+				rls := logs.AppendEmpty()
+
+				resource := rls.Resource()
+				resourceAtts := resource.Attributes()
+				resourceAtts.EnsureCapacity(len(wi.Resource))
+				for k, v := range wi.Resource {
+					resourceAtts.InsertString(k, v)
+				}
+
+				ills := rls.InstrumentationLibraryLogs()
+				lr := ills.AppendEmpty().Logs().AppendEmpty()
+				wi.LogRecord.CopyTo(lr)
 
 				c.data[wi.ResourceID] = pLogs
 			}

--- a/internal/stanza/converter.go
+++ b/internal/stanza/converter.go
@@ -24,31 +24,21 @@ import (
 	"runtime"
 	"sort"
 	"sync"
-	"time"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
 )
 
-const (
-	// DefaultFlushInterval is the default flush interval.
-	DefaultFlushInterval = 100 * time.Millisecond
-	// DefaultMaxFlushCount is the default max flush count.
-	DefaultMaxFlushCount = 100
-)
-
-// Converter converts entry.Entry into pdata.Logs aggregating translated
+// Converter converts a batch of entry.Entry into pdata.Logs aggregating translated
 // entries into logs coming from the same Resource.
-// Logs are being sent out based on the flush interval and/or the maximum
-// batch size.
 //
 // The diagram below illustrates the internal communication inside the Converter:
 //
 //            ┌─────────────────────────────────┐
 //            │ Batch()                         │
-//  ┌─────────┤  Ingests log entries and sends  │
-//  │         │  them onto a workerChan         │
+//  ┌─────────┤  Ingests batches of log entries │
+//  │         │  and sends them onto workerChan │
 //  │         └─────────────────────────────────┘
 //  │
 //  │ ┌───────────────────────────────────────────────────┐
@@ -59,16 +49,15 @@ const (
 //  └─┼─┼─► workerLoop()                                      │
 //    └─┤ │   consumes sent log entries from workerChan,      │
 //      │ │   translates received entries to pdata.LogRecords,│
-//      └─┤   marshalls them to JSON and send them onto       │
-//        │   batchChan                                       │
+//      └─┤   hashes them to generate an ID, and sends them   │
+//        │   onto batchChan                                  │
 //        └─────────────────────────┬─────────────────────────┘
 //                                  │
 //                                  ▼
 //      ┌─────────────────────────────────────────────────────┐
-//      │ batchLoop()                                         │
+//      │ aggregationLoop()                                   │
 //      │   consumes from batchChan, aggregates log records   │
-//      │   by marshaled Resource and based on flush interval │
-//      │   and maxFlushCount decides whether to send the     │
+//      │   by marshaled Resource and sends the               │
 //      │   aggregated buffer to flushChan                    │
 //      └───────────────────────────┬─────────────────────────┘
 //                                  │
@@ -81,7 +70,7 @@ const (
 //      └─────────────────────────────────────────────────────┘
 //
 type Converter struct {
-	// pLogsChan is a channel on which batched logs will be sent to.
+	// pLogsChan is a channel on which aggregated logs will be sent to.
 	pLogsChan chan pdata.Logs
 
 	stopOnce sync.Once
@@ -92,11 +81,10 @@ type Converter struct {
 	workerChan chan []*entry.Entry
 	// workerCount configures the amount of workers started.
 	workerCount int
-	// batchChan obtains log entries converted by the pool of workers,
-	// in a form of logRecords grouped by Resource and then after aggregating
-	// them decides based on maxFlushCount if the flush should be triggered.
-	// If also serves the ticker flushes configured by flushInterval.
-	batchChan chan []workerItem
+	// aggregationChan obtains log entries converted by the pool of workers,
+	// in a form of logRecords grouped by Resource and then sends aggregated logs
+	// on flushChan.
+	aggregationChan chan []workerItem
 
 	// flushChan is an internal channel used for transporting batched pdata.Logs.
 	flushChan chan pdata.Logs
@@ -135,14 +123,14 @@ func WithWorkerCount(workerCount int) ConverterOption {
 
 func NewConverter(opts ...ConverterOption) *Converter {
 	c := &Converter{
-		workerChan:  make(chan []*entry.Entry),
-		workerCount: int(math.Max(1, float64(runtime.NumCPU()/4))),
-		batchChan:   make(chan []workerItem),
-		data:        make(map[uint64]pdata.Logs),
-		pLogsChan:   make(chan pdata.Logs),
-		stopChan:    make(chan struct{}),
-		logger:      zap.NewNop(),
-		flushChan:   make(chan pdata.Logs),
+		workerChan:      make(chan []*entry.Entry),
+		workerCount:     int(math.Max(1, float64(runtime.NumCPU()/4))),
+		aggregationChan: make(chan []workerItem),
+		data:            make(map[uint64]pdata.Logs),
+		pLogsChan:       make(chan pdata.Logs),
+		stopChan:        make(chan struct{}),
+		logger:          zap.NewNop(),
+		flushChan:       make(chan pdata.Logs),
 	}
 
 	for _, opt := range opts {
@@ -161,7 +149,7 @@ func (c *Converter) Start() {
 	}
 
 	c.wg.Add(1)
-	go c.batchLoop()
+	go c.aggregationLoop()
 
 	c.wg.Add(1)
 	go c.flushLoop()
@@ -188,7 +176,7 @@ type workerItem struct {
 
 // workerLoop is responsible for obtaining log entries from Batch() calls,
 // converting them to pdata.LogRecords and sending them together with the
-// associated Resource through the batchChan for aggregation.
+// associated Resource through the aggregationChan for aggregation.
 func (c *Converter) workerLoop() {
 	defer c.wg.Done()
 
@@ -216,22 +204,21 @@ func (c *Converter) workerLoop() {
 			}
 
 			select {
-			case c.batchChan <- workerItems:
+			case c.aggregationChan <- workerItems:
 			case <-c.stopChan:
 			}
 		}
 	}
 }
 
-// batchLoop is responsible for receiving the converted log entries and aggregating
+// aggregationLoop is responsible for receiving the converted log entries and aggregating
 // them by Resource.
-// Whenever maxFlushCount is reached or the ticker ticks a flush is triggered.
-func (c *Converter) batchLoop() {
+func (c *Converter) aggregationLoop() {
 	defer c.wg.Done()
 
 	for {
 		select {
-		case workerItems, ok := <-c.batchChan:
+		case workerItems, ok := <-c.aggregationChan:
 			if !ok {
 				return
 			}

--- a/internal/stanza/converter_test.go
+++ b/internal/stanza/converter_test.go
@@ -214,12 +214,12 @@ func TestAllConvertedEntriesAreSentAndReceived(t *testing.T) {
 
 			go func() {
 				entries := complexEntries(tc.entries)
-				for i := 0; i < tc.entries; i += int(tc.maxFlushCount) {
-					if i+int(tc.maxFlushCount) > tc.entries {
-						assert.NoError(t, converter.Batch(entries[i:tc.entries]))
-					} else {
-						assert.NoError(t, converter.Batch(entries[i:i+int(tc.maxFlushCount)]))
+				for from := 0; from < tc.entries; from += int(tc.maxFlushCount) {
+					to := from + int(tc.maxFlushCount)
+					if to > tc.entries {
+						to = tc.entries
 					}
+					assert.NoError(t, converter.Batch(entries[from:to]))
 				}
 			}()
 
@@ -568,12 +568,12 @@ func BenchmarkConverter(b *testing.B) {
 				b.ResetTimer()
 
 				go func() {
-					for i := 0; i < entryCount; i += batchSize {
-						if i+batchSize > entryCount {
-							assert.NoError(b, converter.Batch(entries[i:entryCount]))
-						} else {
-							assert.NoError(b, converter.Batch(entries[i:i+batchSize]))
+					for from := 0; from < entryCount; from += int(batchSize) {
+						to := from + int(batchSize)
+						if to > entryCount {
+							to = entryCount
 						}
+						assert.NoError(b, converter.Batch(entries[from:to]))
 					}
 				}()
 

--- a/internal/stanza/converter_test.go
+++ b/internal/stanza/converter_test.go
@@ -548,7 +548,7 @@ func BenchmarkConverter(b *testing.B) {
 	const (
 		entryCount = 1_000_000
 		hostsCount = 4
-		batchCount = 200
+		batchSize  = 200
 	)
 
 	var (
@@ -568,11 +568,11 @@ func BenchmarkConverter(b *testing.B) {
 				b.ResetTimer()
 
 				go func() {
-					for i := 0; i < entryCount; i += batchCount {
-						if i+batchCount > entryCount {
+					for i := 0; i < entryCount; i += batchSize {
+						if i+batchSize > entryCount {
 							assert.NoError(b, converter.Batch(entries[i:entryCount]))
 						} else {
-							assert.NoError(b, converter.Batch(entries[i:i+batchCount]))
+							assert.NoError(b, converter.Batch(entries[i:i+batchSize]))
 						}
 					}
 				}()

--- a/internal/stanza/converter_test.go
+++ b/internal/stanza/converter_test.go
@@ -208,15 +208,18 @@ func TestAllConvertedEntriesAreSentAndReceived(t *testing.T) {
 
 			converter := NewConverter(
 				WithWorkerCount(1),
-				WithMaxFlushCount(tc.maxFlushCount),
-				WithFlushInterval(10*time.Millisecond), // To minimize time spent in test
 			)
 			converter.Start()
 			defer converter.Stop()
 
 			go func() {
-				for _, ent := range complexEntries(tc.entries) {
-					assert.NoError(t, converter.Batch(ent))
+				entries := complexEntries(tc.entries)
+				for i := 0; i < tc.entries; i += int(tc.maxFlushCount) {
+					if i+int(tc.maxFlushCount) > tc.entries {
+						assert.NoError(t, converter.Batch(entries[i:tc.entries]))
+					} else {
+						assert.NoError(t, converter.Batch(entries[i:i+int(tc.maxFlushCount)]))
+					}
 				}
 			}()
 
@@ -266,127 +269,8 @@ func TestAllConvertedEntriesAreSentAndReceived(t *testing.T) {
 	}
 }
 
-func TestAllConvertedEntriesAreSentAndReceivedWithinAnExpectedTimeDuration(t *testing.T) {
-	t.Parallel()
-
-	testcases := []struct {
-		entries       int
-		hostsCount    int
-		maxFlushCount uint
-		flushInterval time.Duration
-	}{
-		{
-			entries:       10,
-			hostsCount:    1,
-			maxFlushCount: 20,
-			flushInterval: 100 * time.Millisecond,
-		},
-		{
-			entries:       50,
-			hostsCount:    1,
-			maxFlushCount: 51,
-			flushInterval: 100 * time.Millisecond,
-		},
-		{
-			entries:       500,
-			hostsCount:    1,
-			maxFlushCount: 501,
-			flushInterval: 100 * time.Millisecond,
-		},
-		{
-			entries:       500,
-			hostsCount:    1,
-			maxFlushCount: 100,
-			flushInterval: 100 * time.Millisecond,
-		},
-		{
-			entries:       500,
-			hostsCount:    4,
-			maxFlushCount: 501,
-			flushInterval: 100 * time.Millisecond,
-		},
-	}
-
-	for i, tc := range testcases {
-		tc := tc
-
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			t.Parallel()
-
-			converter := NewConverter(
-				WithWorkerCount(1),
-				WithMaxFlushCount(tc.maxFlushCount),
-				WithFlushInterval(tc.flushInterval),
-			)
-			converter.Start()
-			defer converter.Stop()
-
-			go func() {
-				for _, ent := range complexEntriesForNDifferentHosts(tc.entries, tc.hostsCount) {
-					assert.NoError(t, converter.Batch(ent))
-				}
-			}()
-
-			var (
-				actualCount      int
-				actualFlushCount int
-				timeoutTimer     = time.NewTimer(10 * time.Second)
-				ch               = converter.OutChannel()
-			)
-			defer timeoutTimer.Stop()
-
-		forLoop:
-			for start := time.Now(); ; start = time.Now() {
-				if tc.entries == actualCount {
-					break
-				}
-
-				select {
-				case pLogs, ok := <-ch:
-					if !ok {
-						break forLoop
-					}
-
-					assert.WithinDuration(t,
-						start.Add(tc.flushInterval),
-						time.Now(),
-						tc.flushInterval,
-					)
-
-					actualFlushCount++
-
-					rLogs := pLogs.ResourceLogs()
-					require.Equal(t, 1, rLogs.Len())
-
-					rLog := rLogs.At(0)
-					ills := rLog.InstrumentationLibraryLogs()
-					require.Equal(t, 1, ills.Len())
-
-					ill := ills.At(0)
-
-					actualCount += ill.Logs().Len()
-
-					assert.LessOrEqual(t, uint(ill.Logs().Len()), tc.maxFlushCount,
-						"Received more log records in one flush than configured by maxFlushCount",
-					)
-
-				case <-timeoutTimer.C:
-					break forLoop
-				}
-			}
-
-			assert.Equal(t, tc.entries, actualCount,
-				"didn't receive expected number of entries after conversion",
-			)
-		})
-	}
-}
-
 func TestConverterCancelledContextCancellsTheFlush(t *testing.T) {
-	converter := NewConverter(
-		WithMaxFlushCount(1),
-		WithFlushInterval(time.Millisecond),
-	)
+	converter := NewConverter()
 	converter.Start()
 	defer converter.Stop()
 	var wg sync.WaitGroup
@@ -664,6 +548,7 @@ func BenchmarkConverter(b *testing.B) {
 	const (
 		entryCount = 1_000_000
 		hostsCount = 4
+		batchCount = 200
 	)
 
 	var (
@@ -677,16 +562,18 @@ func BenchmarkConverter(b *testing.B) {
 
 				converter := NewConverter(
 					WithWorkerCount(wc),
-					WithMaxFlushCount(1_000),
-					WithFlushInterval(250*time.Millisecond),
 				)
 				converter.Start()
 				defer converter.Stop()
 				b.ResetTimer()
 
 				go func() {
-					for _, ent := range entries {
-						assert.NoError(b, converter.Batch(ent))
+					for i := 0; i < entryCount; i += batchCount {
+						if i+batchCount > entryCount {
+							assert.NoError(b, converter.Batch(entries[i:entryCount]))
+						} else {
+							assert.NoError(b, converter.Batch(entries[i:i+batchCount]))
+						}
 					}
 				}()
 

--- a/internal/stanza/emitter.go
+++ b/internal/stanza/emitter.go
@@ -89,6 +89,7 @@ func NewLogEmitter(opts ...LogEmitterOption) *LogEmitter {
 		maxBatchSize:  defaultMaxBatchSize,
 		batch:         make([]*entry.Entry, 0, defaultMaxBatchSize),
 		flushInterval: defaultFlushInterval,
+		cancel:        func() {},
 	}
 
 	for _, opt := range opts {

--- a/internal/stanza/emitter.go
+++ b/internal/stanza/emitter.go
@@ -112,11 +112,7 @@ func (e *LogEmitter) Start(_ operator.Persister) error {
 func (e *LogEmitter) Stop() error {
 	e.stopOnce.Do(func() {
 		close(e.logChan)
-
-		if e.cancel != nil {
-			e.cancel()
-			e.cancel = nil
-		}
+		e.cancel()
 
 		e.wg.Wait()
 	})

--- a/internal/stanza/emitter.go
+++ b/internal/stanza/emitter.go
@@ -17,8 +17,10 @@ package stanza // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/open-telemetry/opentelemetry-log-collection/entry"
+	"github.com/open-telemetry/opentelemetry-log-collection/operator"
 	"github.com/open-telemetry/opentelemetry-log-collection/operator/helper"
 	"go.uber.org/zap"
 )
@@ -26,31 +28,134 @@ import (
 // LogEmitter is a stanza operator that emits log entries to a channel
 type LogEmitter struct {
 	helper.OutputOperator
-	logChan  chan *entry.Entry
-	stopOnce sync.Once
+	logChan       chan []*entry.Entry
+	stopOnce      sync.Once
+	cancel        context.CancelFunc
+	batchMux      sync.Mutex
+	batch         []*entry.Entry
+	wg            sync.WaitGroup
+	maxBatchSize  uint
+	flushInterval time.Duration
+}
+
+type LogEmitterOption interface {
+	Apply(*LogEmitter)
+}
+
+type logEmitterOptionFunc func(*LogEmitter)
+
+func (leo logEmitterOptionFunc) Apply(le *LogEmitter) {
+	leo(le)
+}
+
+var (
+	defaultFlushInterval      = 100 * time.Millisecond
+	defaultMaxBatchSize  uint = 200
+)
+
+// LogEmitterWithMaxBatchSize returns an option that makes the LogEmitter use the specified max batch size
+func LogEmitterWithMaxBatchSize(maxBatchSize uint) LogEmitterOption {
+	return logEmitterOptionFunc(func(le *LogEmitter) {
+		le.maxBatchSize = maxBatchSize
+		le.batch = make([]*entry.Entry, 0, maxBatchSize)
+	})
+}
+
+// LogEmitterWithFlushInterval returns an option that makes the LogEmitter use the specified flush interval
+func LogEmitterWithFlushInterval(flushInterval time.Duration) LogEmitterOption {
+	return logEmitterOptionFunc(func(le *LogEmitter) {
+		le.flushInterval = flushInterval
+	})
+}
+
+// LogEmitterWithLogger returns an option that makes the LogEmitter use the specified logger
+func LogEmitterWithLogger(logger *zap.SugaredLogger) LogEmitterOption {
+	return logEmitterOptionFunc(func(le *LogEmitter) {
+		le.OutputOperator.BasicOperator.SugaredLogger = logger
+	})
 }
 
 // NewLogEmitter creates a new receiver output
-func NewLogEmitter(logger *zap.SugaredLogger) *LogEmitter {
-	return &LogEmitter{
+func NewLogEmitter(opts ...LogEmitterOption) *LogEmitter {
+	le := &LogEmitter{
 		OutputOperator: helper.OutputOperator{
 			BasicOperator: helper.BasicOperator{
 				OperatorID:    "log_emitter",
 				OperatorType:  "log_emitter",
-				SugaredLogger: logger,
+				SugaredLogger: zap.NewNop().Sugar(),
 			},
 		},
-		logChan: make(chan *entry.Entry),
+		logChan:       make(chan []*entry.Entry),
+		maxBatchSize:  defaultMaxBatchSize,
+		batch:         make([]*entry.Entry, 0, defaultMaxBatchSize),
+		flushInterval: defaultFlushInterval,
 	}
+
+	for _, opt := range opts {
+		opt.Apply(le)
+	}
+
+	return le
+}
+
+func (e *LogEmitter) Start(_ operator.Persister) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	e.cancel = cancel
+
+	e.wg.Add(1)
+	go e.flusher(ctx)
+	return nil
 }
 
 // Process will emit an entry to the output channel
 func (e *LogEmitter) Process(ctx context.Context, ent *entry.Entry) error {
+	e.batchMux.Lock()
+
+	e.batch = append(e.batch, ent)
+	if uint(len(e.batch)) >= e.maxBatchSize {
+		// flushTriggerAmount triggers a blocking flush
+		e.batchMux.Unlock()
+		e.flush(ctx)
+		return nil
+	}
+
+	e.batchMux.Unlock()
+	return nil
+}
+
+func (e *LogEmitter) flusher(ctx context.Context) {
+	defer e.wg.Done()
+
+	ticker := time.NewTicker(e.flushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			e.flush(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (e *LogEmitter) flush(ctx context.Context) {
+	var batch []*entry.Entry
+	e.batchMux.Lock()
+
+	if len(e.batch) == 0 {
+		e.batchMux.Unlock()
+		return
+	}
+	batch = e.batch
+	e.batch = make([]*entry.Entry, 0, e.maxBatchSize)
+
+	e.batchMux.Unlock()
+
 	select {
-	case e.logChan <- ent:
+	case e.logChan <- batch:
 	case <-ctx.Done():
 	}
-	return nil
 }
 
 // Stop will close the log channel
@@ -58,5 +163,12 @@ func (e *LogEmitter) Stop() error {
 	e.stopOnce.Do(func() {
 		close(e.logChan)
 	})
+
+	if e.cancel != nil {
+		e.cancel()
+		e.cancel = nil
+	}
+
+	e.wg.Wait()
 	return nil
 }

--- a/internal/stanza/emitter.go
+++ b/internal/stanza/emitter.go
@@ -115,10 +115,8 @@ func (e *LogEmitter) Stop() error {
 
 // Process will emit an entry to the output channel
 func (e *LogEmitter) Process(ctx context.Context, ent *entry.Entry) error {
-	batchToFlush := e.appendEntry(ent)
-
-	if batchToFlush != nil {
-		e.flush(ctx, batchToFlush)
+	if batch := e.appendEntry(ent); batch != nil {
+		e.flush(ctx, batch)
 	}
 
 	return nil
@@ -149,8 +147,7 @@ func (e *LogEmitter) flusher(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			batch := e.makeNewBatch()
-			if batch != nil {
+			if batch := e.makeNewBatch(); batch != nil {
 				e.flush(ctx, batch)
 			}
 		case <-ctx.Done():

--- a/internal/stanza/emitter.go
+++ b/internal/stanza/emitter.go
@@ -104,10 +104,10 @@ func (e *LogEmitter) Start(_ operator.Persister) error {
 // Stop will close the log channel and stop running goroutines
 func (e *LogEmitter) Stop() error {
 	e.stopOnce.Do(func() {
-		close(e.logChan)
 		e.cancel()
-
 		e.wg.Wait()
+
+		close(e.logChan)
 	})
 
 	return nil

--- a/internal/stanza/emitter.go
+++ b/internal/stanza/emitter.go
@@ -38,15 +38,7 @@ type LogEmitter struct {
 	flushInterval time.Duration
 }
 
-type LogEmitterOption interface {
-	Apply(*LogEmitter)
-}
-
-type logEmitterOptionFunc func(*LogEmitter)
-
-func (leo logEmitterOptionFunc) Apply(le *LogEmitter) {
-	leo(le)
-}
+type LogEmitterOption func(*LogEmitter)
 
 var (
 	defaultFlushInterval      = 100 * time.Millisecond
@@ -55,7 +47,7 @@ var (
 
 // LogEmitterWithMaxBatchSize returns an option that makes the LogEmitter use the specified max batch size
 func LogEmitterWithMaxBatchSize(maxBatchSize uint) LogEmitterOption {
-	return logEmitterOptionFunc(func(le *LogEmitter) {
+	return LogEmitterOption(func(le *LogEmitter) {
 		le.maxBatchSize = maxBatchSize
 		le.batch = make([]*entry.Entry, 0, maxBatchSize)
 	})
@@ -63,14 +55,14 @@ func LogEmitterWithMaxBatchSize(maxBatchSize uint) LogEmitterOption {
 
 // LogEmitterWithFlushInterval returns an option that makes the LogEmitter use the specified flush interval
 func LogEmitterWithFlushInterval(flushInterval time.Duration) LogEmitterOption {
-	return logEmitterOptionFunc(func(le *LogEmitter) {
+	return LogEmitterOption(func(le *LogEmitter) {
 		le.flushInterval = flushInterval
 	})
 }
 
 // LogEmitterWithLogger returns an option that makes the LogEmitter use the specified logger
 func LogEmitterWithLogger(logger *zap.SugaredLogger) LogEmitterOption {
-	return logEmitterOptionFunc(func(le *LogEmitter) {
+	return LogEmitterOption(func(le *LogEmitter) {
 		le.OutputOperator.BasicOperator.SugaredLogger = logger
 	})
 }
@@ -93,7 +85,7 @@ func NewLogEmitter(opts ...LogEmitterOption) *LogEmitter {
 	}
 
 	for _, opt := range opts {
-		opt.Apply(le)
+		opt(le)
 	}
 
 	return le

--- a/internal/stanza/emitter.go
+++ b/internal/stanza/emitter.go
@@ -115,9 +115,7 @@ func (e *LogEmitter) Stop() error {
 
 // Process will emit an entry to the output channel
 func (e *LogEmitter) Process(ctx context.Context, ent *entry.Entry) error {
-	oldBatch := e.appendEntry(ent)
-
-	if len(oldBatch) > 0 {
+	if oldBatch := e.appendEntry(ent); len(oldBatch) > 0 {
 		e.flush(ctx, oldBatch)
 	}
 
@@ -150,9 +148,7 @@ func (e *LogEmitter) flusher(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			oldBatch := e.makeNewBatch()
-
-			if len(oldBatch) > 0 {
+			if oldBatch := e.makeNewBatch(); len(oldBatch) > 0 {
 				e.flush(ctx, oldBatch)
 			}
 		case <-ctx.Done():

--- a/internal/stanza/emitter.go
+++ b/internal/stanza/emitter.go
@@ -50,7 +50,7 @@ func (leo logEmitterOptionFunc) Apply(le *LogEmitter) {
 
 var (
 	defaultFlushInterval      = 100 * time.Millisecond
-	defaultMaxBatchSize  uint = 200
+	defaultMaxBatchSize  uint = 100
 )
 
 // LogEmitterWithMaxBatchSize returns an option that makes the LogEmitter use the specified max batch size

--- a/internal/stanza/emitter_test.go
+++ b/internal/stanza/emitter_test.go
@@ -25,8 +25,12 @@ import (
 )
 
 func TestLogEmitter(t *testing.T) {
+	emitter := NewLogEmitter(
+		LogEmitterWithLogger(zaptest.NewLogger(t).Sugar()),
+	)
 
-	emitter := NewLogEmitter(zaptest.NewLogger(t).Sugar())
+	emitter.Start(nil)
+
 	defer emitter.Stop()
 
 	in := entry.New()
@@ -37,8 +41,114 @@ func TestLogEmitter(t *testing.T) {
 
 	select {
 	case out := <-emitter.logChan:
-		require.Equal(t, in, out)
+		require.Equal(t, in, out[0])
 	case <-time.After(time.Second):
 		require.FailNow(t, "Timed out waiting for output")
+	}
+}
+
+func TestLogEmitterRespectsMaxBatchSize(t *testing.T) {
+	const (
+		numEntries   = 1111
+		maxBatchSize = 100
+		timeout      = time.Second
+	)
+	emitter := NewLogEmitter(
+		LogEmitterWithLogger(zaptest.NewLogger(t).Sugar()),
+		LogEmitterWithMaxBatchSize(maxBatchSize),
+		LogEmitterWithFlushInterval(100*time.Millisecond),
+	)
+
+	emitter.Start(nil)
+	defer emitter.Stop()
+
+	entries := complexEntries(numEntries)
+
+	go func() {
+		ctx := context.Background()
+		for _, e := range entries {
+			emitter.Process(ctx, e)
+		}
+	}()
+
+	entriesReceived := 0
+	timeoutChan := time.After(timeout)
+
+	for entriesReceived < numEntries {
+		select {
+		case recv := <-emitter.logChan:
+			entriesReceived += len(recv)
+			if len(recv) > maxBatchSize {
+				require.FailNow(t, "Expected only %d entries per batch, but got %d", maxBatchSize, entriesReceived)
+			}
+		case <-timeoutChan:
+			require.FailNow(t, "Failed to receive all log entries before timeout")
+		}
+	}
+
+	require.Equal(t, numEntries, entriesReceived)
+}
+
+func TestLogEmitterEmitsOnMaxBatchSize(t *testing.T) {
+	const (
+		maxBatchSize = 100
+		timeout      = time.Second
+	)
+	emitter := NewLogEmitter(
+		LogEmitterWithLogger(zaptest.NewLogger(t).Sugar()),
+		LogEmitterWithMaxBatchSize(maxBatchSize),
+		LogEmitterWithFlushInterval(time.Hour),
+	)
+
+	emitter.Start(nil)
+	defer emitter.Stop()
+
+	entries := complexEntries(maxBatchSize)
+
+	go func() {
+		ctx := context.Background()
+		for _, e := range entries {
+			emitter.Process(ctx, e)
+		}
+	}()
+
+	timeoutChan := time.After(timeout)
+
+	select {
+	case recv := <-emitter.logChan:
+		require.Equal(t, maxBatchSize, len(recv), "Length of received entries was not the same as max batch size!")
+	case <-timeoutChan:
+		require.FailNow(t, "Failed to receive log entries before timeout")
+	}
+}
+
+func TestLogEmitterEmitsOnFlushInterval(t *testing.T) {
+	const (
+		flushInterval = 100 * time.Millisecond
+		timeout       = time.Second
+	)
+	emitter := NewLogEmitter(
+		LogEmitterWithLogger(zaptest.NewLogger(t).Sugar()),
+		LogEmitterWithMaxBatchSize(100),
+		LogEmitterWithFlushInterval(flushInterval),
+	)
+
+	emitter.Start(nil)
+	defer emitter.Stop()
+
+	entry := complexEntry()
+
+	go func() {
+		ctx := context.Background()
+		emitter.Process(ctx, entry)
+	}()
+
+	timeoutChan := time.After(timeout)
+
+	select {
+	case recv := <-emitter.logChan:
+		require.Equal(t, 1, len(recv), "Should have received one entry, got %d instead", len(recv))
+	case <-timeoutChan:
+		require.FailNow(t, "Failed to receive log entry before timeout")
 	}
 }

--- a/internal/stanza/factory.go
+++ b/internal/stanza/factory.go
@@ -62,7 +62,19 @@ func createLogsReceiver(logReceiverType LogReceiverType) receiverhelper.CreateLo
 
 		pipeline := append([]operator.Config{*inputCfg}, operatorCfgs...)
 
-		emitter := NewLogEmitter(params.Logger.Sugar())
+		emitterOpts := []LogEmitterOption{
+			LogEmitterWithLogger(params.Logger.Sugar()),
+		}
+
+		if baseCfg.Converter.MaxFlushCount > 0 {
+			emitterOpts = append(emitterOpts, LogEmitterWithMaxBatchSize(baseCfg.Converter.MaxFlushCount))
+		}
+
+		if baseCfg.Converter.FlushInterval > 0 {
+			emitterOpts = append(emitterOpts, LogEmitterWithFlushInterval(baseCfg.Converter.FlushInterval))
+		}
+
+		emitter := NewLogEmitter(emitterOpts...)
 		logAgent, err := agent.NewBuilder(params.Logger.Sugar()).
 			WithConfig(&agent.Config{Pipeline: pipeline}).
 			WithDefaultOutput(emitter).
@@ -74,12 +86,7 @@ func createLogsReceiver(logReceiverType LogReceiverType) receiverhelper.CreateLo
 		opts := []ConverterOption{
 			WithLogger(params.Logger),
 		}
-		if baseCfg.Converter.MaxFlushCount > 0 {
-			opts = append(opts, WithMaxFlushCount(baseCfg.Converter.MaxFlushCount))
-		}
-		if baseCfg.Converter.FlushInterval > 0 {
-			opts = append(opts, WithFlushInterval(baseCfg.Converter.FlushInterval))
-		}
+
 		if baseCfg.Converter.WorkerCount > 0 {
 			opts = append(opts, WithWorkerCount(baseCfg.Converter.WorkerCount))
 		}

--- a/internal/stanza/integration_test.go
+++ b/internal/stanza/integration_test.go
@@ -32,7 +32,10 @@ import (
 )
 
 func createNoopReceiver(workerCount int, nextConsumer consumer.Logs) (*receiver, error) {
-	emitter := NewLogEmitter(zap.NewNop().Sugar())
+	emitter := NewLogEmitter(
+		LogEmitterWithLogger(zap.NewNop().Sugar()),
+	)
+
 	logAgent, err := agent.NewBuilder(zap.NewNop().Sugar()).
 		WithConfig(&agent.Config{Pipeline: pipeline.Config{
 			operator.Config{

--- a/receiver/filelogreceiver/filelog.go
+++ b/receiver/filelogreceiver/filelog.go
@@ -49,10 +49,7 @@ func createDefaultConfig() *FileLogConfig {
 		BaseConfig: stanza.BaseConfig{
 			ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 			Operators:        stanza.OperatorConfigs{},
-			Converter: stanza.ConverterConfig{
-				MaxFlushCount: stanza.DefaultMaxFlushCount,
-				FlushInterval: stanza.DefaultFlushInterval,
-			},
+			Converter:        stanza.ConverterConfig{},
 		},
 		Input: stanza.InputConfig{},
 	}

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -284,8 +284,8 @@ func testdataConfigYamlAsMap() *FileLogConfig {
 				},
 			},
 			Converter: stanza.ConverterConfig{
-				MaxFlushCount: stanza.DefaultMaxFlushCount,
-				FlushInterval: stanza.DefaultFlushInterval,
+				MaxFlushCount: 100,
+				FlushInterval: 100 * time.Millisecond,
 			},
 		},
 		Input: stanza.InputConfig{
@@ -311,10 +311,7 @@ func testdataRotateTestYamlAsMap(tempDir string) *FileLogConfig {
 					},
 				},
 			},
-			Converter: stanza.ConverterConfig{
-				MaxFlushCount: stanza.DefaultMaxFlushCount,
-				FlushInterval: stanza.DefaultFlushInterval,
-			},
+			Converter: stanza.ConverterConfig{},
 		},
 		Input: stanza.InputConfig{
 			"type": "file_input",

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -88,7 +88,7 @@ func TestReadStaticFile(t *testing.T) {
 	cfg.Converter.MaxFlushCount = 10
 	cfg.Converter.FlushInterval = time.Millisecond
 
-	converter := stanza.NewConverter(stanza.WithFlushInterval(time.Millisecond))
+	converter := stanza.NewConverter()
 	converter.Start()
 	defer converter.Stop()
 
@@ -108,7 +108,7 @@ func TestReadStaticFile(t *testing.T) {
 		e.Set(entry.NewBodyField("msg"), msg)
 		e.Severity = severity
 		e.AddAttribute("file_name", "simple.log")
-		require.NoError(t, c.Batch(e))
+		require.NoError(t, c.Batch([]*entry.Entry{e}))
 	}
 	queueEntry(t, converter, "Something routine", entry.Info)
 	queueEntry(t, converter, "Something bad happened!", entry.Error)
@@ -185,7 +185,7 @@ func (rt *rotationTest) Run(t *testing.T) {
 
 	// Build expected outputs
 	expectedTimestamp, _ := time.ParseInLocation("2006-01-02", "2020-08-25", time.Local)
-	converter := stanza.NewConverter(stanza.WithFlushInterval(time.Millisecond))
+	converter := stanza.NewConverter()
 	converter.Start()
 
 	var wg sync.WaitGroup
@@ -203,7 +203,7 @@ func (rt *rotationTest) Run(t *testing.T) {
 		e := entry.New()
 		e.Timestamp = expectedTimestamp
 		e.Set(entry.NewBodyField("msg"), msg)
-		require.NoError(t, converter.Batch(e))
+		require.NoError(t, converter.Batch([]*entry.Entry{e}))
 
 		// ... and write the logs lines to the actual file consumed by receiver.
 		logger.Print(fmt.Sprintf("2020-08-25 %s", msg))


### PR DESCRIPTION
**Description:** 
* Moved batching in the internal/stanza package from the Converter to the LogEmitter to increase performance.

When the worker pattern was implemented, batching was put after the worker loop in the converter. The problem with this is that the workers have very little work to do per cycle. Ideally, workers have large amounts of work they do before they request more. Otherwise, workers begin to incur a lot of overhead from requesting work constantly (in this case selecting from a channel), which can (and does) cause performance issues under high load.

Instead of a unit of work being a single entry, this PR makes a unit of work a batch of entries, moving the batching logic into the LogEmitter.

**Testing:**
Added tests to LogEmitter to validate MaxBatchSize and FlushInterval are still respected.

Benchmarks of emitter-to-consumer performance:

Before:
```
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkEmitterToConsumer/worker_count=1-12                  10        5860113666 ns/op        3075350700 B/op 61522383 allocs/op
BenchmarkEmitterToConsumer/worker_count=2-12                  10        4330471031 ns/op        3075330906 B/op 61521719 allocs/op
BenchmarkEmitterToConsumer/worker_count=4-12                  10        3720432579 ns/op        3075325519 B/op 61521505 allocs/op
BenchmarkEmitterToConsumer/worker_count=6-12                  10        3540257550 ns/op        3075323456 B/op 61521449 allocs/op
BenchmarkEmitterToConsumer/worker_count=8-12                  10        3540537514 ns/op        3075327725 B/op 61521481 allocs/op
PASS
```

After:
```
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkEmitterToConsumer/worker_count=1-12                  10        3025573325 ns/op        3087150870 B/op 60540716 allocs/op
BenchmarkEmitterToConsumer/worker_count=2-12                  10        1677928788 ns/op        3087136036 B/op 60540400 allocs/op
BenchmarkEmitterToConsumer/worker_count=4-12                  10        1235078416 ns/op        3087130332 B/op 60540275 allocs/op
BenchmarkEmitterToConsumer/worker_count=6-12                  10        1223689228 ns/op        3087129233 B/op 60540246 allocs/op
BenchmarkEmitterToConsumer/worker_count=8-12                  10        1209764305 ns/op        3087128364 B/op 60540240 allocs/op
```