### PR TITLE
Validate docker images before publishing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -393,6 +393,11 @@ jobs:
             make docker-otelcontribcol
             docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
             docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:latest
+      - name: Validate Docker Image
+        if: steps.check.outputs.passed == 'true'
+        run: |
+            docker run otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA --version
+            docker run otel/opentelemetry-collector-contrib-dev:latest --version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -456,6 +461,11 @@ jobs:
             make docker-otelcontribcol
             docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib:$DOCKER_TAG
             docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib:latest
+      - name: Validate Docker Image
+        if: steps.check.outputs.passed == 'true'
+        run: |
+            docker run otel/opentelemetry-collector-contrib:$DOCKER_TAG --version
+            docker run otel/opentelemetry-collector-contrib:latest --version
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
**Description:**
Perform basic validation by ensuring docker images can successfully execute `/otelcontribcol --version`.

**Link to tracking Issue:** #6354

**Testing:**
Tested `docker run` commands on Mac with Docker Desktop. Validated that non-zero exit code is returned with a bad image (based on #6343), and zero exit code is return with a good image.
