### PR TITLE
Set unprivileged user to container image

### DIFF
--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -1,12 +1,11 @@
 FROM alpine:latest as prep
 RUN apk --update add ca-certificates
 
-ARG USER_UID=10001
-
 RUN mkdir -p /tmp
 
 FROM scratch
 
+ARG USER_UID=10001
 USER ${USER_UID}
 
 COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
Set unprivileged user to container image. This change was initially introduced in #2925 but further change moved ARG before FROM, making ARG inaccessible to USER command.

**Description:** Set unprivileged user to container image.

**Link to tracking Issue:** 

**Testing:** Ensuring that after change USER is 10001
```
$ make docker-otelcontribcol
...
$ docker history --no-trunc otelcontribcol:latest
IMAGE                                                                     CREATED         CREATED BY                                                                                                                            SIZE      COMMENT
sha256:6fbf77de67e02d9607763212092490fadd86ab03c0a2cbe1928a59bd138e001b   6 seconds ago   /bin/sh -c #(nop)  CMD ["--config" "/etc/otel/config.yaml"]                                                                           0B        
sha256:6ca69687aac33e0e758db95cef8b37c66879e79c08b493df7251913a40426760   6 seconds ago   /bin/sh -c #(nop)  ENTRYPOINT ["/otelcontribcol"]                                                                                     0B        
sha256:506a53b74599115344a32d4ae87bd283900719f93c6d09a0bd83fbcfd55051f0   7 seconds ago   /bin/sh -c #(nop)  EXPOSE 4317 55679 55680                                                                                            0B        
sha256:05f1322f75fe8a324acef0fe507090ba62da5f57aa548600ae9d8b5656d2b841   7 seconds ago   /bin/sh -c #(nop) COPY file:a8c7c967dae8ebf2fd99c1cd3944a4921cf45ef898d0b1ba8526c12edd26971e in /                                     146MB     
sha256:cfdfd172035a2f822d5264eaf54e1fa377fec03779f3947aa30d0415c6cdfd84   9 seconds ago   /bin/sh -c #(nop) COPY file:c8f727cb8b17c5a8735e609a9b9f333f20765e36c457d0557ed48693a6694880 in /etc/ssl/certs/ca-certificates.crt    214kB     
sha256:3870cebd539bf3125dc38b47d764a369f23d4a9a7fd447cf32f15b5c9ea22e85   9 seconds ago   /bin/sh -c #(nop)  USER 10001                                                                                                         0B        
sha256:da78b72e55f99552cfdc2d9a6f3118c373527801948a0348e82688c8a30ae827   9 seconds ago   /bin/sh -c #(nop)  ARG USER_UID=10001                                                                                                 0B        
```

**Documentation:**