### PR TITLE
[cmd/mdatagen] Moves metadata docs closer to `mdatagen` tool

### DIFF
--- a/cmd/mdatagen/README.md
+++ b/cmd/mdatagen/README.md
@@ -1,3 +1,19 @@
 # Metadata Generator
 
-Tool that generates metadata.
+Receivers can contain a `metadata.yaml` file that documents the metrics that may be emitted by the receiver.
+
+Current examples:
+
+* hostmetricsreceiver scrapers like the [cpuscraper](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml)
+
+See [metric-metadata.yaml](metric-metadata.yaml) for file format documentation.
+
+If adding a new receiver a `codegen.go` file should also be added to trigger the generation. See below for details.
+
+## Build
+
+When `go generate` is run (it is run automatically in the make build targets) there are a few special build directives in `codegen.go` files:
+
+`make install-tools` results in `cmd/mdatagen` being installed to `GOBIN`
+
+[/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/codegen.go](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/codegen.go) runs `mdatagen` for the `hostmetricsreceiver` metadata.yaml which generates the [/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata) package which has Go files containing metric and label metadata.

--- a/cmd/mdatagen/metric-metadata.yaml
+++ b/cmd/mdatagen/metric-metadata.yaml
@@ -1,0 +1,33 @@
+# Required: name of the receiver.
+name:
+
+# Optional: map of label definitions with the key being the label name and value
+# being described below.
+labels:
+  label.name:
+    # Optional: if the label name as described by the key is not the actual label
+    # value to be reported that value can be overridden here.
+    value:
+    # Required: description of the label.
+    description:
+    # Optional: array of label values if they are static values.
+    enum:
+
+# Required: map of metric names with the key being the metric name and value
+# being described below.
+metrics:
+  metric.name:
+    # Required: metric description
+    description:
+    # Required: metric type as defined by https://ucum.org/ucum.html
+    unit:
+    # Required
+    data:
+      # Required: one of int gauge, int sum, gauge, sum, or histogram.
+      type:
+      # Required for int sum and sum.
+      monotonic: # true | false
+      # Required for int sum, sum, and histogram.
+      aggregation: # delta | cumulative
+    # Optional: array of labels that were defined in the labels section that are emitted by this metric.
+    labels:


### PR DESCRIPTION
**Description:** 

Move metadata documentation to `mdatagen` README.

**Link to tracking Issue:** open-telemetry/opentelemetry-collector#4265
