### PR TITLE
`hostmetrics`: Upgrade to use gopsutil/v3

### DIFF
--- a/receiver/hostmetricsreceiver/go.mod
+++ b/receiver/hostmetricsreceiver/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/leoluk/perflib_exporter v0.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.39.0
-	github.com/shirou/gopsutil v3.21.10+incompatible
+	github.com/shirou/gopsutil/v3 v3.21.10
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.39.1-0.20211117203239-e23c9d0a0183
 	go.opentelemetry.io/collector/model v0.39.1-0.20211117203239-e23c9d0a0183
@@ -22,6 +22,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/knadh/koanf v1.3.2 // indirect
+	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect

--- a/receiver/hostmetricsreceiver/go.sum
+++ b/receiver/hostmetricsreceiver/go.sum
@@ -282,6 +282,7 @@ github.com/leoluk/perflib_exporter v0.1.0 h1:fXe/mDaf9jR+Zk8FjFlcCSksACuIj2VNN4G
 github.com/leoluk/perflib_exporter v0.1.0/go.mod h1:rpV0lYj7lemdTm31t7zpCqYqPnw7xs86f+BaaNBVYFM=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
@@ -377,8 +378,7 @@ github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIH
 github.com/sanity-io/litter v1.2.0/go.mod h1:JF6pZUFgu2Q0sBZ+HSV35P8TVPI1TTzEwyu9FXAw2W4=
 github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmRB/DWZxSMfCXPyD8=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/shirou/gopsutil v3.21.10+incompatible h1:AL2kpVykjkqeN+MFe1WcwSBVUjGjvdU8/ubvCuXAjrU=
-github.com/shirou/gopsutil v3.21.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil/v3 v3.21.10 h1:flTg1DrnV/UVrBqjLgVgDJzx6lf+91rC64/dBHmO2IA=
 github.com/shirou/gopsutil/v3 v3.21.10/go.mod h1:t75NhzCZ/dYyPQjyQmrAYP6c8+LCdFANeBMdLPCNnew=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/host"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
@@ -18,7 +18,7 @@
 package cpuscraper
 
 import (
-	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"go.opentelemetry.io/collector/model/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata"

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
@@ -18,7 +18,7 @@
 package cpuscraper
 
 import (
-	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"go.opentelemetry.io/collector/model/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata"

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -20,7 +20,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/shirou/gopsutil/disk"
-	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/shirou/gopsutil/v3/host"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_fallback.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_fallback.go
@@ -18,7 +18,7 @@
 package diskscraper
 
 import (
-	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/v3/disk"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
@@ -18,7 +18,7 @@
 package diskscraper
 
 import (
-	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/v3/disk"
 	"go.opentelemetry.io/collector/model/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata"

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/v3/host"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -16,10 +16,9 @@ package filesystemscraper
 
 import (
 	"context"
-	"strings"
 	"time"
 
-	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/v3/disk"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 
@@ -119,11 +118,10 @@ func initializeFileSystemUsageDataPoint(dataPoint pdata.NumberDataPoint, now pda
 	dataPoint.SetIntVal(value)
 }
 
-func getMountMode(opts string) string {
-	splitOptions := strings.Split(opts, ",")
-	if exists(splitOptions, "rw") {
+func getMountMode(opts []string) string {
+	if exists(opts, "rw") {
 		return "rw"
-	} else if exists(splitOptions, "ro") {
+	} else if exists(opts, "ro") {
 		return "ro"
 	}
 	return "unknown"

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -20,7 +20,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/shirou/gopsutil/disk"
+	"github.com/shirou/gopsutil/v3/disk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/v3/load"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_others.go
@@ -20,7 +20,7 @@ package loadscraper
 import (
 	"context"
 
-	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/v3/load"
 	"go.uber.org/zap"
 )
 

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/v3/load"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/v3/load"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/perfcounters"

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/mem"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
@@ -18,7 +18,7 @@
 package memoryscraper
 
 import (
-	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/mem"
 	"go.opentelemetry.io/collector/model/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata"

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
@@ -18,7 +18,7 @@
 package memoryscraper
 
 import (
-	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/mem"
 	"go.opentelemetry.io/collector/model/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata"

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -20,7 +20,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
@@ -18,7 +18,7 @@
 package memoryscraper
 
 import (
-	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/mem"
 	"go.opentelemetry.io/collector/model/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata"

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/shirou/gopsutil/host"
-	"github.com/shirou/gopsutil/net"
+	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/net"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/shirou/gopsutil/net"
+	"github.com/shirou/gopsutil/v3/net"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_others.go
@@ -17,7 +17,7 @@
 
 package pagingscraper
 
-import "github.com/shirou/gopsutil/mem"
+import "github.com/shirou/gopsutil/v3/mem"
 
 func getPageFileStats() ([]*pageFileStats, error) {
 	vmem, err := mem.VirtualMemory()

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
@@ -21,8 +21,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/shirou/gopsutil/host"
-	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/mem"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/shirou/gopsutil/mem"
+	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/v3/host"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/shirou/gopsutil/host"
-	"github.com/shirou/gopsutil/load"
-	"github.com/shirou/gopsutil/process"
+	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/load"
+	"github.com/shirou/gopsutil/v3/process"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
@@ -51,7 +51,7 @@ type scraper struct {
 
 // for mocking out gopsutil process.Process
 type proc interface {
-	Status() (string, error)
+	Status() ([]string, error)
 }
 
 type processesMetadata struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
@@ -20,7 +20,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/shirou/gopsutil/load"
+	"github.com/shirou/gopsutil/v3/load"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/model/pdata"
@@ -181,14 +181,14 @@ var fakeProcessesData = []proc{
 
 type errProcess struct{}
 
-func (e errProcess) Status() (string, error) {
-	return "", errors.New("errProcess")
+func (e errProcess) Status() ([]string, error) {
+	return []string{""}, errors.New("errProcess")
 }
 
 type fakeProcess string
 
-func (f fakeProcess) Status() (string, error) {
-	return string(f), nil
+func (f fakeProcess) Status() ([]string, error) {
+	return []string{string(f)}, nil
 }
 
 func validateFakeData(t *testing.T, metrics pdata.MetricSlice) {

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_unix.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_unix.go
@@ -34,14 +34,14 @@ func (s *scraper) getProcessesMetadata() (processesMetadata, error) {
 
 	countByStatus := map[string]int64{}
 	for _, process := range processes {
-		var status string
+		var status []string
 		status, err = process.Status()
 		if err != nil {
 			// We expect an error in the case that a process has
 			// been terminated as we run this code.
 			continue
 		}
-		state, ok := charToState[status]
+		state, ok := toAttributeStatus(status)
 		if !ok {
 			countByStatus[metadata.AttributeStatus.Unknown]++
 			continue
@@ -78,6 +78,14 @@ func (s *scraper) getProcessesMetadata() (processesMetadata, error) {
 		countByStatus:    countByStatus,
 		processesCreated: procsCreated,
 	}, nil
+}
+
+func toAttributeStatus(status []string) (string, bool) {
+	if len(status) == 0 || len(status[0]) == 0 {
+		return "", false
+	}
+	state, ok := charToState[status[0][0:1]]
+	return state, ok
 }
 
 var charToState = map[string]string{

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -17,8 +17,8 @@ package processscraper
 import (
 	"strings"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/process"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/process"
 	"go.opentelemetry.io/collector/model/pdata"
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 )

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/host"
-	"github.com/shirou/gopsutil/process"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/process"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/receiver/scrapererror"

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_linux.go
@@ -18,7 +18,7 @@
 package processscraper
 
 import (
-	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"go.opentelemetry.io/collector/model/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
@@ -18,7 +18,7 @@
 package processscraper
 
 import (
-	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -21,8 +21,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/shirou/gopsutil/cpu"
-	"github.com/shirou/gopsutil/process"
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/process"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_windows.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/v3/cpu"
 	"go.opentelemetry.io/collector/model/pdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"


### PR DESCRIPTION
This removes the dependency on the older gopsutil library.
