### PR TITLE
`dependabot`: update dependabot tidier

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -15,11 +15,15 @@ jobs:
       - uses: actions/setup-go@v2.1.4
         with:
           go-version: '^1.16.0'
-      - uses: evantorrie/mott-the-tidier@v1-beta
+      - uses: codeboten/mott-the-tidier@v1-beta1
         id: modtidy
         with:
           gomods: '**/go.mod'
           gomodsum_only: true
+          remove_gosum: true
+          directives: |
+            1.16
+            1.17
       - uses: stefanzweifel/git-auto-commit-action@v4
         id: autocommit
         with:


### PR DESCRIPTION
This changes the github action used to tidy to a fork of the original tidier, to run the following in order:

- rm go.sum
- go mod tidy -go=1.16
- go mod tidy -go=1.17

Fixes #5971