### PR TITLE
[exporter/datadogexporter] Rely on http.Client's timeout instead of in exporterhelper's

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -154,7 +154,8 @@ func createMetricsExporter(
 		cfg,
 		set,
 		pushMetricsFn,
-		exporterhelper.WithTimeout(cfg.TimeoutSettings),
+		// explicitly disable since we rely on http.Client timeout logic.
+		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0 * time.Second}),
 		exporterhelper.WithRetry(cfg.RetrySettings),
 		exporterhelper.WithQueue(cfg.QueueSettings),
 		exporterhelper.WithShutdown(func(context.Context) error {
@@ -207,7 +208,8 @@ func createTracesExporter(
 		cfg,
 		set,
 		pushTracesFn,
-		exporterhelper.WithTimeout(cfg.TimeoutSettings),
+		// explicitly disable since we rely on http.Client timeout logic.
+		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0 * time.Second}),
 		exporterhelper.WithRetry(cfg.RetrySettings),
 		exporterhelper.WithQueue(cfg.QueueSettings),
 		exporterhelper.WithShutdown(func(context.Context) error {

--- a/exporter/datadogexporter/internal/metadata/metadata.go
+++ b/exporter/datadogexporter/internal/metadata/metadata.go
@@ -154,7 +154,7 @@ func pushMetadata(cfg *config.Config, buildInfo component.BuildInfo, metadata *H
 	req, _ := http.NewRequest(http.MethodPost, path, bytes.NewBuffer(buf))
 	utils.SetDDHeaders(req.Header, buildInfo, cfg.API.Key)
 	utils.SetExtraHeaders(req.Header, utils.JSONHeaders)
-	client := utils.NewHTTPClient(10 * time.Second)
+	client := utils.NewHTTPClient(cfg.TimeoutSettings)
 	resp, err := client.Do(req)
 
 	if err != nil {

--- a/exporter/datadogexporter/internal/utils/http.go
+++ b/exporter/datadogexporter/internal/utils/http.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 var (
@@ -38,9 +39,9 @@ var (
 )
 
 // NewHTTPClient returns a http.Client configured with the Agent options.
-func NewHTTPClient(timeout time.Duration) *http.Client {
+func NewHTTPClient(settings exporterhelper.TimeoutSettings) *http.Client {
 	return &http.Client{
-		Timeout: timeout,
+		Timeout: settings.Timeout,
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -95,7 +95,7 @@ func translatorFromConfig(logger *zap.Logger, cfg *config.Config) (*translator.T
 func newMetricsExporter(ctx context.Context, params component.ExporterCreateSettings, cfg *config.Config) (*metricsExporter, error) {
 	client := utils.CreateClient(cfg.API.Key, cfg.Metrics.TCPAddr.Endpoint)
 	client.ExtraHeader["User-Agent"] = utils.UserAgent(params.BuildInfo)
-	client.HttpClient = utils.NewHTTPClient(10 * time.Second)
+	client.HttpClient = utils.NewHTTPClient(cfg.TimeoutSettings)
 
 	utils.ValidateAPIKey(params.Logger, client)
 

--- a/exporter/datadogexporter/trace_connection.go
+++ b/exporter/datadogexporter/trace_connection.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/exportable/stats"
 	"github.com/gogo/protobuf/proto"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/utils"
 )
@@ -45,19 +46,18 @@ type traceEdgeConnectionImpl struct {
 }
 
 const (
-	traceEdgeTimeout       time.Duration = 10 * time.Second
 	traceEdgeRetryInterval time.Duration = 10 * time.Second
 )
 
 // createTraceEdgeConnection returns a new traceEdgeConnection
-func createTraceEdgeConnection(rootURL, apiKey string, buildInfo component.BuildInfo) traceEdgeConnection {
+func createTraceEdgeConnection(rootURL, apiKey string, buildInfo component.BuildInfo, settings exporterhelper.TimeoutSettings) traceEdgeConnection {
 
 	return &traceEdgeConnectionImpl{
 		traceURL:  rootURL + "/api/v0.2/traces",
 		statsURL:  rootURL + "/api/v0.2/stats",
 		buildInfo: buildInfo,
 		apiKey:    apiKey,
-		client:    utils.NewHTTPClient(traceEdgeTimeout),
+		client:    utils.NewHTTPClient(settings),
 	}
 }
 

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -78,7 +78,7 @@ func newTracesExporter(ctx context.Context, params component.ExporterCreateSetti
 		params:         params,
 		cfg:            cfg,
 		ctx:            ctx,
-		edgeConnection: createTraceEdgeConnection(cfg.Traces.TCPAddr.Endpoint, cfg.API.Key, params.BuildInfo),
+		edgeConnection: createTraceEdgeConnection(cfg.Traces.TCPAddr.Endpoint, cfg.API.Key, params.BuildInfo, cfg.TimeoutSettings),
 		obfuscator:     obfuscator,
 		client:         client,
 		denylister:     denylister,


### PR DESCRIPTION
**Description:** 

Rely on `http.Client` timeout instead of `exporterhelper`'s. 

Since `exporterhelper`'s applies to the whole `push[Trace/Metric]Data` call and we do several network requests per call, it is preferable to do it this way to prevent one network call to cause timeouts in the next one.

This is also required for #6412, since retries inside the push functions increase the time taken.

**Link to tracking Issue:** n/a

**Testing:** Things to test manually

- [x] Check that timeout does occur on network calls.

**Documentation:** none, this should be transparent to the user.
