### PR TITLE
Add Unit test for AWS XRay Exporter App Runner Origin

### DIFF
--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -681,6 +681,24 @@ func TestOriginEks(t *testing.T) {
 	assert.Equal(t, OriginEKS, *segment.Origin)
 }
 
+func TestOriginAppRunner(t *testing.T) {
+	attributes := make(map[string]interface{})
+	resource := pdata.NewResource()
+	attrs := pdata.NewAttributeMap()
+	attrs.InsertString(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
+	// TODO: Replace with semantic convention const when aws_app_runner is included in an official semconv release
+	attrs.InsertString(conventions.AttributeCloudPlatform, "aws_app_runner")
+	attrs.CopyTo(resource.Attributes())
+	spanName := "/test"
+	parentSpanID := newSegmentID()
+	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, []string{}, false)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, OriginAppRunner, *segment.Origin)
+}
+
 func TestOriginBlank(t *testing.T) {
 	spanName := "/test"
 	parentSpanID := newSegmentID()


### PR DESCRIPTION
**Description:** 

Follow up to #6141 , add a quick unit test to confirm that setting `conventions.AttributeCloudPlatform` in the attributes as `aws_app_runner` is enough to make the `segment.origin` equal `OriginAppRunner`.

**Link to tracking Issue:**

N/A

**Testing:**

Unit test covers recently added origin.

**Documentation:**

N/A