### PR TITLE
[receiver/hostmetrics] Fix set of attributes for system.cpu.time metric

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
@@ -8,7 +8,7 @@ These are the metrics available for this scraper.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
-| system.cpu.time | Total CPU seconds broken down by different states. | s | Sum | <ul> <li>state</li> </ul> |
+| system.cpu.time | Total CPU seconds broken down by different states. | s | Sum | <ul> <li>cpu</li> <li>state</li> </ul> |
 
 ## Attributes
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -16,4 +16,4 @@ metrics:
       type: sum
       aggregation: cumulative
       monotonic: true
-    attributes: [state]
+    attributes: [cpu, state]


### PR DESCRIPTION
Define correct set of attributes for system.cpu.time metric in metadata.yaml