### PR TITLE
[kafkareceiver] Fix log metrics

### DIFF
--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -243,6 +243,7 @@ func (c *kafkaMetricsConsumer) consumeLoop(ctx context.Context, handler sarama.C
 		}
 	}
 }
+
 func (c *kafkaMetricsConsumer) Shutdown(context.Context) error {
 	c.cancelConsumeLoop()
 	return c.consumerGroup.Close()
@@ -539,7 +540,7 @@ func (c *logsConsumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSess
 			session.MarkMessage(message, "")
 		}
 
-		ctx := c.obsrecv.StartTracesOp(session.Context())
+		ctx := c.obsrecv.StartLogsOp(session.Context())
 		_ = stats.RecordWithTags(
 			ctx,
 			[]tag.Mutator{tag.Insert(tagInstanceName, c.id.String())},
@@ -558,7 +559,7 @@ func (c *logsConsumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSess
 
 		err = c.nextConsumer.ConsumeLogs(session.Context(), logs)
 		// TODO
-		c.obsrecv.EndTracesOp(ctx, c.unmarshaler.Encoding(), logs.LogRecordCount(), err)
+		c.obsrecv.EndLogsOp(ctx, c.unmarshaler.Encoding(), logs.LogRecordCount(), err)
 		if err != nil {
 			if c.messageMarking.After && c.messageMarking.OnError {
 				session.MarkMessage(message, "")


### PR DESCRIPTION
**Description:**
Fix the typo in the logs kafkareceiver to use obsrecv LogsOp instead of TracesOp so receiver accepted/refused metrics use the proper type suffix.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6427

**Testing:**
Ran these commands locally: https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md#creating-a-pr

**Documentation:** N/A