### PR TITLE
exporters/datadogexporter: group "trace_id" under "otel" set of tags instead of "otlp"

### DIFF
--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -233,7 +233,7 @@ func spanToDatadogSpan(s pdata.Span,
 	spanNameMap map[string]string,
 ) *pb.Span {
 	tags := aggregateSpanTags(s, datadogTags)
-	tags["otlp.trace_id"] = s.TraceID().HexString()
+	tags["otel.trace_id"] = s.TraceID().HexString()
 
 	// otel specification resource service.name takes precedence
 	// and configuration DD_SERVICE as fallback if it exists

--- a/exporter/datadogexporter/translate_traces_test.go
+++ b/exporter/datadogexporter/translate_traces_test.go
@@ -260,7 +260,7 @@ func TestBasicTracesTranslation(t *testing.T) {
 	assert.Equal(t, decodeAPMSpanID(mockParentSpanID), datadogPayload.Traces[0].Spans[0].ParentID)
 
 	// ensure original TraceID is preserved
-	assert.Equal(t, pdata.NewTraceID(mockTraceID).HexString(), datadogPayload.Traces[0].Spans[0].Meta["otlp.trace_id"])
+	assert.Equal(t, pdata.NewTraceID(mockTraceID).HexString(), datadogPayload.Traces[0].Spans[0].Meta["otel.trace_id"])
 
 	// ensure that span.resource defaults to otlp span.name
 	assert.Equal(t, "End-To-End Here", datadogPayload.Traces[0].Spans[0].Resource)


### PR DESCRIPTION
This is more consistent with the rest of the code which uses "otel".

Follows after #6158