### PR TITLE
fix bug:  Prometheus fails to generate logs when prometheus exporter produced a check exception occurs.

### DIFF
--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -17,8 +17,10 @@ package prometheusexporter // import "github.com/open-telemetry/opentelemetry-co
 import (
 	"context"
 	"errors"
+	"log"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -58,6 +60,7 @@ func newPrometheusExporter(config *Config, set component.ExporterCreateSettings)
 			registry,
 			promhttp.HandlerOpts{
 				ErrorHandling: promhttp.ContinueOnError,
+				ErrorLog:      log.New(os.Stderr, "Prometheus Exporter Check Error ", 0),
 			},
 		),
 	}, nil


### PR DESCRIPTION
Prometheus fails to generate logs when prometheus exporter produced a check exception occurs.

The original log component didn't implement promhttp.Logger, so I used log.logger.