### PR TITLE
Change the way how metric type is specified in metadata.yaml

### DIFF
--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -31,8 +31,7 @@ metrics:
     description: Total CPU seconds broken down by different states.
     extended_description: Additional information on CPU Time can be found [here](https://en.wikipedia.org/wiki/CPU_time).
     unit: s
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
     attributes: []
 `

--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -14,51 +14,11 @@
 
 package main
 
-import (
-	"fmt"
-)
-
 var (
 	_ MetricData = &gauge{}
 	_ MetricData = &sum{}
 	_ MetricData = &histogram{}
 )
-
-type ymlMetricData struct {
-	MetricData `yaml:"-"`
-}
-
-// UnmarshalYAML converts the metrics.data map based on metrics.data.type.
-func (e *ymlMetricData) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var m struct {
-		Type string `yaml:"type"`
-	}
-
-	if err := unmarshal(&m); err != nil {
-		return err
-	}
-
-	var md MetricData
-
-	switch m.Type {
-	case "gauge":
-		md = &gauge{}
-	case "sum":
-		md = &sum{}
-	case "histogram":
-		md = &histogram{}
-	default:
-		return fmt.Errorf("metric data %q type invalid", m.Type)
-	}
-
-	if err := unmarshal(md); err != nil {
-		return fmt.Errorf("unable to unmarshal data for type %q: %v", m.Type, err)
-	}
-
-	e.MetricData = md
-
-	return nil
-}
 
 // MetricData is generic interface for all metric datatypes.
 type MetricData interface {

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -29,40 +29,35 @@ metrics:
   apache.uptime:
     description: The amount of time that the server has been running in seconds.
     unit: s
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [ server_name ]
   apache.current_connections:
     description: The number of active connections currently attached to the HTTP server.
     unit: connections
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: [ server_name ]
   apache.workers:
     description: The number of workers currently attached to the HTTP server.
     unit: connections
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: [ server_name, workers_state]
   apache.requests:
     description: The number of requests serviced by the HTTP server per second.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [ server_name ]
   apache.traffic:
     description: Total HTTP server traffic.
     unit: By
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [ server_name ]
@@ -73,8 +68,7 @@ metrics:
       This metric decodes the scoreboard and presents a count of workers in each state.
       Additional details can be found [here](https://support.cpanel.net/hc/en-us/articles/360052040234-Understanding-the-Apache-scoreboard).
     unit: scoreboard
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: [server_name, scoreboard_state]

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -12,8 +12,7 @@ metrics:
   system.cpu.time:
     description: Total CPU seconds broken down by different states.
     unit: s
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [cpu, state]

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
@@ -12,8 +12,7 @@ metrics:
   system.disk.io:
     description: Disk bytes transferred.
     unit: By
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device, direction]
@@ -21,8 +20,7 @@ metrics:
   system.disk.operations:
     description: Disk operations count.
     unit: "{operations}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device, direction]
@@ -30,8 +28,7 @@ metrics:
   system.disk.io_time:
     description: Time disk spent activated. On Windows, this is calculated as the inverse of disk idle time.
     unit: s
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device]
@@ -39,8 +36,7 @@ metrics:
   system.disk.operation_time:
     description: Time spent in disk operations.
     unit: s
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device, direction]
@@ -48,8 +44,7 @@ metrics:
   system.disk.weighted_io_time:
     description: Time disk spent activated multiplied by the queue length.
     unit: s
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device]
@@ -57,8 +52,7 @@ metrics:
   system.disk.pending_operations:
     description: The queue size of pending I/O operations.
     unit: "{operations}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: false
     attributes: [device]
@@ -66,8 +60,7 @@ metrics:
   system.disk.merged:
     description: The number of disk reads merged into single physical disk access operations.
     unit: "{operations}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device, direction]

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -21,8 +21,7 @@ metrics:
   system.filesystem.usage:
     description: Filesystem bytes used.
     unit: By
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: false
     attributes: [device, mode, mountpoint, type, state]
@@ -30,8 +29,7 @@ metrics:
   system.filesystem.inodes.usage:
     description: FileSystem inodes used.
     unit: "{inodes}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: false
     attributes: [device, mode, mountpoint, type, state]

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
@@ -6,17 +6,14 @@ metrics:
   system.cpu.load_average.1m:
     description: Average CPU Load over 1 minute.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
 
   system.cpu.load_average.5m:
     description: Average CPU Load over 5 minutes.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
 
   system.cpu.load_average.15m:
     description: Average CPU Load over 15 minutes.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -9,8 +9,7 @@ metrics:
   system.memory.usage:
     description: Bytes of memory in use.
     unit: By
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: false
     attributes: [state]

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -19,8 +19,7 @@ metrics:
   system.network.packets:
     description: The number of packets transferred.
     unit: "{packets}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device, direction]
@@ -28,8 +27,7 @@ metrics:
   system.network.dropped:
     description: The number of packets dropped.
     unit: "{packets}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device, direction]
@@ -37,8 +35,7 @@ metrics:
   system.network.errors:
     description: The number of errors encountered.
     unit: "{errors}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device, direction]
@@ -46,8 +43,7 @@ metrics:
   system.network.io:
     description: The number of bytes transmitted and received.
     unit: "By"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [device, direction]
@@ -55,8 +51,7 @@ metrics:
   system.network.connections:
     description: The number of connections.
     unit: "{connections}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: false
     attributes: [protocol, state]

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -20,8 +20,7 @@ metrics:
   system.paging.usage:
     description: Swap (unix) or pagefile (windows) usage.
     unit: By
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: false
     attributes: [device, state]
@@ -29,8 +28,7 @@ metrics:
   system.paging.operations:
     description: The number of paging operations.
     unit: "{operations}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [direction, type]
@@ -38,8 +36,7 @@ metrics:
   system.paging.faults:
     description: The number of page faults.
     unit: "{faults}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [type]

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -9,16 +9,14 @@ metrics:
   system.processes.created:
     description: Total number of created processes.
     unit: "{processes}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
 
   system.processes.count:
     description: Total number of processes in each state.
     unit: "{processes}"
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: false
     attributes: [status]

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -13,8 +13,7 @@ metrics:
   process.cpu.time:
     description: Total CPU seconds broken down by different states.
     unit: s
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [state]
@@ -22,24 +21,21 @@ metrics:
   process.memory.physical_usage:
     description: The amount of physical memory in use.
     unit: By
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: false
 
   process.memory.virtual_usage:
     description: Virtual memory size.
     unit: By
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: false
 
   process.disk.io:
     description: Disk bytes transferred.
     unit: By
-    data:
-      type: sum
+    sum:
       aggregation: cumulative
       monotonic: true
     attributes: [direction]

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -13,67 +13,56 @@ metrics:
   kafka.brokers:
     description: Number of brokers in the cluster.
     unit: "{brokers}"
-    data:
-      type: gauge
+    gauge: {}
 #  topics scraper
   kafka.topic.partitions:
     description: Number of partitions in topic.
     unit: "{partitions}"
-    data:
-      type: gauge
+    gauge: {}
     attributes: [topic]
   kafka.partition.current_offset:
     description: Current offset of partition of topic.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: [topic, partition]
   kafka.partition.oldest_offset:
     description: Oldest offset of partition of topic
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: [topic, partition]
   kafka.partition.replicas:
     description: Number of replicas for partition of topic
     unit: "{replicas}"
-    data:
-      type: gauge
+    gauge: {}
     attributes: [topic, partition]
   kafka.partition.replicas_in_sync:
     description: Number of synchronized replicas of partition
     unit: "{replicas}"
-    data:
-      type: gauge
+    gauge: {}
     attributes: [topic, partition]
 #  consumers scraper
   kafka.consumer_group.members:
     description: Count of members in the consumer group
     unit: "{members}"
-    data:
-      type: gauge
+    gauge: {}
     attributes: [group]
   kafka.consumer_group.offset:
     description: Current offset of the consumer group at partition of topic
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: [group, topic, partition]
   kafka.consumer_group.offset_sum:
     description: Sum of consumer group offset across partitions of topic
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: [group, topic]
   kafka.consumer_group.lag:
     description: Current approximate lag of consumer group at partition of topic
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: [group, topic, partition]
   kafka.consumer_group.lag_sum:
     description: Current approximate sum of consumer group lag across all partitions of topic
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: [group, topic]

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -12,114 +12,96 @@ metrics:
   cpu.utilization:
     description: "CPU utilization"
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   cpu.time:
     description: "CPU time"
     unit: s
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: []
   memory.available:
     description: "Memory available"
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   memory.usage:
     description: "Memory usage"
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   memory.rss:
     description: "Memory rss"
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   memory.working_set:
     description: "Memory working_set"
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   memory.page_faults:
     description: "Memory page_faults"
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   memory.major_page_faults:
     description: "Memory major_page_faults"
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   filesystem.available:
     description: "Filesystem available"
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   filesystem.capacity:
     description: "Filesystem capacity"
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   filesystem.usage:
     description: "Filesystem usage"
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   network.io:
     description: "Network IO"
     unit: By
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: ["interface", "direction"]
   network.errors:
     description: "Network errors"
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: ["interface", "direction"]
   volume.available:
     description: "The number of available bytes in the volume."
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   volume.capacity:
     description: "The total capacity in bytes of the volume."
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   volume.inodes:
     description: "The total inodes in the filesystem."
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   volume.inodes.free:
     description: "The free inodes in the filesystem."
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   volume.inodes.used:
     description: "The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems."
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
     attributes: []

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -34,84 +34,73 @@ metrics:
   memcached.bytes:
     description: Current number of bytes used by this server to store items.
     unit: By
-    data:
-      type: gauge
+    gauge: {}
     attributes: []
   memcached.current_connections:
     description: The current number of open connections.
     unit: connections
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: []
   memcached.total_connections:
     description: Total number of connections opened since the server started running.
     unit: connections
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: []
   memcached.commands:
     description: Commands executed.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [command]
   memcached.current_items:
     description: Number of items currently stored in the cache.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: []
   memcached.evictions:
     description: Cache item evictions.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: []
   memcached.network:
     description: Bytes transferred over the network.
     unit: by
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [direction]
   memcached.operations:
     description:  Operation counts. 
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [type,operation]
   memcached.operation_hit_ratio:
     description: Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0.
     unit: '%'
-    data:
-      type: gauge
+    gauge: {}
     attributes: [operation]
   memcached.rusage:
     description: Accumulated user and system time. 
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [state]
   memcached.threads:
     description: Number of threads used by the memcached instance.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: []

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -142,36 +142,31 @@ metrics:
     extended_documentation: Aggregate of MongoDB Metrics ASSERT_REGULAR, ASSERT_USER, ASSERT_MSG, ASSERT_WARNING
     unit: "{assertions}/s"
     attributes: [assert_type]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.background_flush:
     description: Amount of data flushed in the background
     extended_documentation: MongoDB Metric BACKGROUND_FLUSH_AVG
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cache.io:
     description: Cache throughput (per second)
     extended_documentation: Aggregate of MongoDB Metrics CACHE_BYTES_READ_INTO, CACHE_BYTES_WRITTEN_FROM
     unit: By
     attributes: [cache_direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cache.size:
     description: Cache sizes
     extended_documentation: Aggregate of MongoDB Metrics CACHE_USED_BYTES, CACHE_DIRTY_BYTES
     unit: By
     attributes: [cache_status]
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
   mongodbatlas.process.connections:
     description: Number of current connections
     extended_documentation: MongoDB Metric CONNECTIONS
     unit: "{connections}"
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative 
   mongodbatlas.process.cpu.usage.max:
@@ -179,143 +174,122 @@ metrics:
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_KERNEL, MAX_PROCESS_CPU_USER
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cpu.usage.average:
     description: CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_KERNEL, PROCESS_CPU_USER
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cpu.children.usage.max:
     description: CPU Usage for child processes (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_CHILDREN_USER, MAX_PROCESS_CPU_CHILDREN_KERNEL
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cpu.children.usage.average:
     description: CPU Usage for child processes (%)
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_CHILDREN_KERNEL, PROCESS_CPU_CHILDREN_USER
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cpu.children.normalized.usage.max:
     description: CPU Usage for child processes, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, MAX_PROCESS_NORMALIZED_CPU_CHILDREN_USER
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cpu.children.normalized.usage.average:
     description: CPU Usage for child processes, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, PROCESS_NORMALIZED_CPU_CHILDREN_USER
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cpu.normalized.usage.max:
     description: CPU Usage, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_USER, MAX_PROCESS_NORMALIZED_CPU_KERNEL
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cpu.normalized.usage.average:
     description: CPU Usage, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_KERNEL, PROCESS_NORMALIZED_CPU_USER
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.cursors:
     description: Number of cursors
     extended_documentation: Aggregate of MongoDB Metrics CURSORS_TOTAL_OPEN, CURSORS_TOTAL_TIMED_OUT
     unit: "{cursors}"
     attributes: [cursor_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.db.storage:
     description: Storage used by the database
     extended_documentation: Aggregate of MongoDB Metrics DB_INDEX_SIZE_TOTAL, DB_DATA_SIZE_TOTAL_WO_SYSTEM, DB_STORAGE_TOTAL, DB_DATA_SIZE_TOTAL
     unit: By
     attributes: [storage_status]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.db.document.rate:
     description: Document access rates
     extended_documentation: Aggregate of MongoDB Metrics DOCUMENT_METRICS_UPDATED, DOCUMENT_METRICS_DELETED, DOCUMENT_METRICS_RETURNED, DOCUMENT_METRICS_INSERTED
     unit: "{documents}/s"
     attributes: [document_status]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.fts.cpu.usage:
     description: Full text search CPU (%)
     extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.global_lock:
     description: Number and status of locks
     extended_documentation: Aggregate of MongoDB Metrics GLOBAL_LOCK_CURRENT_QUEUE_WRITERS, GLOBAL_LOCK_CURRENT_QUEUE_READERS, GLOBAL_LOCK_CURRENT_QUEUE_TOTAL
     unit: "{locks}"
     attributes: [global_lock_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.index.btree_miss_ratio:
     description: Index miss ratio (%)
     extended_documentation: MongoDB Metric INDEX_COUNTERS_BTREE_MISS_RATIO
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.index.counters:
     description: Indexes
     extended_documentation: Aggregate of MongoDB Metrics INDEX_COUNTERS_BTREE_MISSES, INDEX_COUNTERS_BTREE_ACCESSES, INDEX_COUNTERS_BTREE_HITS
     unit: "{indexes}"
     attributes: [btree_counter_type]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.journaling.commits:
     description: Journaling commits
     extended_documentation: MongoDB Metric JOURNALING_COMMITS_IN_WRITE_LOCK
     unit: "{commits}"
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.journaling.data_files:
     description: Data file sizes
     extended_documentation: MongoDB Metric JOURNALING_WRITE_DATA_FILES_MB
     unit: MiBy
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.journaling.written:
     description: Journals written
     extended_documentation: MongoDB Metric JOURNALING_MB
     unit: MiBy
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.memory.usage:
     description: Memory Usage
     extended_documentation: Aggregate of MongoDB Metrics MEMORY_MAPPED, MEMORY_VIRTUAL, COMPUTED_MEMORY, MEMORY_RESIDENT
     unit: By
     attributes: [memory_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.network.io:
     description: Network IO
     extended_documentation: Aggregate of MongoDB Metrics NETWORK_BYTES_OUT, NETWORK_BYTES_IN
     unit: By/s
     attributes: [direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.network.requests:
     description: Network requests
     extended_documentation: MongoDB Metric NETWORK_NUM_REQUESTS
     unit: "{requests}"
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
   mongodbatlas.process.oplog.time:
@@ -323,30 +297,24 @@ metrics:
     extended_documentation: Aggregate of MongoDB Metrics OPLOG_MASTER_TIME, OPLOG_SLAVE_LAG_MASTER_TIME, OPLOG_MASTER_LAG_TIME_DIFF
     unit: s
     attributes: [oplog_type]
-    data:
-      type: gauge
-      monotonic: true
-      aggregation: cumulative
+    gauge: {}
   mongodbatlas.process.oplog.rate:
     description: Execution rate by operation
     extended_documentation: MongoDB Metric OPLOG_RATE_GB_PER_HOUR
     unit: GiBy/h
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.db.operations.rate:
     description: DB Operation Rates
     extended_documentation: Aggregate of MongoDB Metrics OPCOUNTER_GETMORE, OPERATIONS_SCAN_AND_ORDER, OPCOUNTER_UPDATE, OPCOUNTER_REPL_UPDATE, OPCOUNTER_CMD, OPCOUNTER_DELETE, OPCOUNTER_REPL_DELETE, OPCOUNTER_REPL_CMD, OPCOUNTER_QUERY, OPCOUNTER_REPL_INSERT, OPCOUNTER_INSERT
     unit: "{operations}/s"
     attributes: [operation, cluster_role]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.db.operations.time:
     description: DB Operation Times
     extended_documentation: Aggregate of MongoDB Metrics OP_EXECUTION_TIME_WRITES, OP_EXECUTION_TIME_COMMANDS, OP_EXECUTION_TIME_READS
     unit: ms
     attributes: [execution_type]
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
   mongodbatlas.process.page_faults:
@@ -354,226 +322,193 @@ metrics:
     extended_documentation: Aggregate of MongoDB Metrics GLOBAL_PAGE_FAULT_EXCEPTIONS_THROWN, EXTRA_INFO_PAGE_FAULTS, GLOBAL_ACCESSES_NOT_IN_MEMORY
     unit: "{faults}/s"
     attributes: [memory_issue_type]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.db.query_executor.scanned:
     description: Scanned objects
     extended_documentation: Aggregate of MongoDB Metrics QUERY_EXECUTOR_SCANNED_OBJECTS, QUERY_EXECUTOR_SCANNED
     attributes: [scanned_type]
     unit: "{objects}/s"
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.db.query_targeting.scanned_per_returned:
     description: Scanned objects per returned
     extended_documentation: Aggregate of MongoDB Metrics QUERY_TARGETING_SCANNED_OBJECTS_PER_RETURNED, QUERY_TARGETING_SCANNED_PER_RETURNED
     unit: "{scanned}/{returned}"
     attributes: [scanned_type]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.restarts:
     description: Restarts in last hour
     extended_documentation: Aggregate of MongoDB Metrics RESTARTS_IN_LAST_HOUR
     unit: "{restarts}/h"
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.paging.usage.max:
     description: Swap usage
     extended_documentation: Aggregate of MongoDB Metrics MAX_SWAP_USAGE_FREE, MAX_SWAP_USAGE_USED
     unit: KiBy
     attributes: [direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.paging.usage.average:
     description: Swap usage
     extended_documentation: Aggregate of MongoDB Metrics SWAP_USAGE_FREE, SWAP_USAGE_USED
     unit: KiBy
     attributes: [direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.paging.io.max:
     description: Swap IO
     extended_documentation: Aggregate of MongoDB Metrics MAX_SWAP_IO_IN, MAX_SWAP_IO_OUT
     unit: "{pages}/s"
     attributes: [direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.paging.io.average:
     description: Swap IO
     extended_documentation: Aggregate of MongoDB Metrics SWAP_IO_IN, SWAP_IO_OUT
     unit: "{pages}/s"
     attributes: [direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.cpu.usage.max:
     description: System CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_CPU_SOFTIRQ, MAX_SYSTEM_CPU_IRQ, MAX_SYSTEM_CPU_GUEST, MAX_SYSTEM_CPU_IOWAIT, MAX_SYSTEM_CPU_NICE, MAX_SYSTEM_CPU_KERNEL, MAX_SYSTEM_CPU_USER, MAX_SYSTEM_CPU_STEAL
     attributes: [cpu_state]
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.cpu.usage.average:
     description: System CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_CPU_USER, SYSTEM_CPU_GUEST, SYSTEM_CPU_SOFTIRQ, SYSTEM_CPU_IRQ, SYSTEM_CPU_KERNEL, SYSTEM_CPU_IOWAIT, SYSTEM_CPU_NICE, SYSTEM_CPU_STEAL
     attributes: [cpu_state]
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.memory.usage.max:
     description: System Memory Usage
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_MEMORY_CACHED, MAX_SYSTEM_MEMORY_AVAILABLE, MAX_SYSTEM_MEMORY_USED, MAX_SYSTEM_MEMORY_BUFFERS, MAX_SYSTEM_MEMORY_FREE, MAX_SYSTEM_MEMORY_SHARED
     unit: KiBy
     attributes: [memory_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.memory.usage.average:
     description: System Memory Usage
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_MEMORY_AVAILABLE, SYSTEM_MEMORY_BUFFERS, SYSTEM_MEMORY_USED, SYSTEM_MEMORY_CACHED, SYSTEM_MEMORY_SHARED, SYSTEM_MEMORY_FREE
     unit: KiBy
     attributes: [memory_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.network.io.max:
     description: System Network IO
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_NETWORK_OUT, MAX_SYSTEM_NETWORK_IN
     unit: By/s
     attributes: [direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.network.io.average:
     description: System Network IO
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_NETWORK_IN, SYSTEM_NETWORK_OUT
     unit: By/s
     attributes: [direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.cpu.normalized.usage.max:
     description: System CPU Normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_NORMALIZED_CPU_USER, MAX_SYSTEM_NORMALIZED_CPU_NICE, MAX_SYSTEM_NORMALIZED_CPU_IOWAIT, MAX_SYSTEM_NORMALIZED_CPU_SOFTIRQ, MAX_SYSTEM_NORMALIZED_CPU_STEAL, MAX_SYSTEM_NORMALIZED_CPU_KERNEL, MAX_SYSTEM_NORMALIZED_CPU_GUEST, MAX_SYSTEM_NORMALIZED_CPU_IRQ
     attributes: [cpu_state]
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.cpu.normalized.usage.average:
     description: System CPU Normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_NORMALIZED_CPU_IOWAIT, SYSTEM_NORMALIZED_CPU_GUEST, SYSTEM_NORMALIZED_CPU_IRQ, SYSTEM_NORMALIZED_CPU_KERNEL, SYSTEM_NORMALIZED_CPU_STEAL, SYSTEM_NORMALIZED_CPU_SOFTIRQ, SYSTEM_NORMALIZED_CPU_NICE, SYSTEM_NORMALIZED_CPU_USER
     attributes: [cpu_state]
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.process.tickets:
     description: Tickets
     extended_documentation: Aggregate of MongoDB Metrics TICKETS_AVAILABLE_WRITE, TICKETS_AVAILABLE_READS
     unit: "{tickets}"
     attributes: [ticket_type]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.iops.max:
     description: Disk partition iops
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_IOPS_WRITE, MAX_DISK_PARTITION_IOPS_TOTAL, MAX_DISK_PARTITION_IOPS_READ
     unit: "{ops}/s"
     attributes: [disk_direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.iops.average:
     description: Disk partition iops
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_IOPS_READ, DISK_PARTITION_IOPS_WRITE, DISK_PARTITION_IOPS_TOTAL
     unit: "{ops}/s"
     attributes: [disk_direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.usage.max:
     description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
     unit: 1
     attributes: [disk_status]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.usage.average:
     description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
     unit: 1
     attributes: [disk_status]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.utilization.max:
     description: Disk partition utilization (%)
     extended_documentation: MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.utilization.average:
     description: Disk partition utilization (%)
     extended_documentation: MongoDB Metrics DISK_PARTITION_UTILIZATION
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.latency.max:
     description: Disk partition latency
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_LATENCY_WRITE, MAX_DISK_PARTITION_LATENCY_READ
     unit: ms
     attributes: [disk_direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.latency.average:
     description: Disk partition latency
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_LATENCY_WRITE, DISK_PARTITION_LATENCY_READ
     unit: ms
     attributes: [disk_direction]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.space.max:
     description: Disk partition space
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
     unit: By
     attributes: [memory_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.disk.partition.space.average:
     description: Disk partition space
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
     unit: By
     attributes: [memory_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.db.size:
     description: Database feature size
     extended_documentation: Aggregate of MongoDB Metrics DATABASE_DATA_SIZE, DATABASE_STORAGE_SIZE, DATABASE_INDEX_SIZE, DATABASE_AVERAGE_OBJECT_SIZE
     unit: By
     attributes: [object_type]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.db.counts:
     description: Database feature size
     extended_documentation: Aggregate of MongoDB Metrics DATABASE_EXTENT_COUNT, DATABASE_VIEW_COUNT, DATABASE_COLLECTION_COUNT, DATABASE_OBJECT_COUNT, DATABASE_INDEX_COUNT
     unit: "{objects}"
     attributes: [object_type]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.fts.memory.usage:
     description: Full-text search
     extended_documentation: Aggregate of MongoDB Metrics FTS_MEMORY_MAPPED, FTS_PROCESS_SHARED_MEMORY, FTS_PROCESS_RESIDENT_MEMORY, FTS_PROCESS_VIRTUAL_MEMORY
     unit: MiBy
     attributes: [memory_state]
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
   mongodbatlas.system.fts.disk.used:
     description: Full text search disk usage
     extended_documentation: MongoDB Metric FTS_DISK_USAGE
     unit: By
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.fts.cpu.usage:
     description: Full-text search (%)
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}
   mongodbatlas.system.fts.cpu.normalized.usage:
     description: Full text search disk usage (%)
     extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_NORMALIZED_CPU_USER, FTS_PROCESS_NORMALIZED_CPU_KERNEL
     unit: 1
     attributes: [cpu_state]
-    data:
-      type: gauge
+    gauge: {}

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -62,112 +62,98 @@ metrics:
   mysql.buffer_pool_pages:
     description: The number of pages in the InnoDB buffer pool.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: [buffer_pool_pages]
   mysql.buffer_pool_operations:
     description: The number of operations on the InnoDB buffer pool.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [buffer_pool_operations]
   mysql.buffer_pool_size:
     description: The number of bytes in the InnoDB buffer pool.
     unit: By
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: [buffer_pool_size]
   mysql.commands:
     description: The number of times each type of command has been executed.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [command]
   mysql.handlers:
     description: The number of requests to various MySQL handlers.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [handler]
   mysql.double_writes:
     description: The number of writes to the InnoDB doublewrite buffer.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [double_writes]
   mysql.log_operations:
     description: The number of InndoDB log operations.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [log_operations]
   mysql.operations:
     description: The number of InndoDB operations.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [operations]
   mysql.page_operations:
     description: The number of InndoDB page operations.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [page_operations]
   mysql.row_locks:
     description: The number of InndoDB row locks.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [row_locks]
   mysql.row_operations:
     description: The number of InndoDB row operations.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [row_operations]
   mysql.locks:
     description: The number of MySQL locks.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [locks]
   mysql.sorts:
     description: The number of MySQL sorts.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [sorts]
   mysql.threads:
     description: The state of MySQL threads.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: [threads]

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -13,30 +13,26 @@ metrics:
   nginx.requests:
     description: Total number of requests made to the server since it started
     unit: requests
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: []
   nginx.connections_accepted:
     description: The total number of accepted client connections
     unit: connections
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: []
   nginx.connections_handled:
     description: The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).
     unit: connections
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: []
   nginx.connections_current:
     description: The current number of nginx connections by state
     unit: connections
-    data:
-      type: gauge
+    gauge: {}
     attributes: [state]

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -20,56 +20,49 @@ metrics:
   postgresql.blocks_read:
     description: The number of blocks read.
     units: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [ database, table, source ]
   postgresql.commits:
     description: The number of commits.
     units: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [ database ]
   postgresql.db_size:
     description: The database disk usage.
     units: By
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: [ database ]
   postgresql.backends:
     description: The number of backends.
     units: 1
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: [ database ]
   postgresql.rows:
     description: The number of rows in the database.
     units: 1
-    data:
-      type: sum
+    sum:
       monotonic: false
       aggregation: cumulative
     attributes: [ database, table, state ]
   postgresql.operations:
     description: The number of db row operations.
     units: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [ database, table, operation ]
   postgresql.rollbacks:
     description: The number of rollbacks.
     units: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
     attributes: [ database ]

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -10,91 +10,74 @@ metrics:
   zookeeper.followers:
     description: The number of followers in sync with the leader. Only exposed by the leader.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.synced_followers:
     description: The number of followers in sync with the leader. Only exposed by the leader.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.pending_syncs:
     description: The number of pending syncs from the followers. Only exposed by the leader.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.latency.avg:
     description: Average time in milliseconds for requests to be processed.
     unit: ms
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.latency.max:
     description: Maximum time in milliseconds for requests to be processed.
     unit: ms
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.latency.min:
     description: Minimum time in milliseconds for requests to be processed.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.connections_alive:
     description: Number of active clients connected to a ZooKeeper server.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.outstanding_requests:
     description: Number of currently executing requests.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.znodes:
     description: Number of z-nodes that a ZooKeeper server has in its data tree.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.watches:
     description: Number of watches placed on Z-Nodes on a ZooKeeper server.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.ephemeral_nodes:
     description: Number of ephemeral nodes that a ZooKeeper server has in its data tree.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.approximate_date_size:
     description: Size of data in bytes that a ZooKeeper server has in its data tree.
     unit: By
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.open_file_descriptors:
     description: Number of file descriptors that a ZooKeeper server has open.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.max_file_descriptors:
     description: Maximum number of file descriptors that a ZooKeeper server can open.
     unit: 1
-    data:
-      type: gauge
+    gauge: {}
   zookeeper.packets.received:
     description: Number of ZooKeeper packets received by a server.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
   zookeeper.packets.sent:
     description: Number of ZooKeeper packets sent by a server.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative
   zookeeper.fsync_threshold_exceeds:
     description: Number of times fsync duration has exceeded warning threshold.
     unit: 1
-    data:
-      type: sum
+    sum:
       monotonic: true
       aggregation: cumulative


### PR DESCRIPTION
To simplify the logic and make it simpler for users to read what properties are accepted for specific types.