### PR TITLE
Google Cloud Spanner Receiver: Added sample lock requests label to the top lock stats metrics.

### DIFF
--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue_test.go
@@ -82,6 +82,18 @@ func TestByteSliceLabelValueMetadata(t *testing.T) {
 	assert.IsType(t, expectedType, metadata.ValueHolder())
 }
 
+func TestLockRequestSliceLabelValueMetadata(t *testing.T) {
+	metadata, _ := NewLabelValueMetadata(labelName, labelColumnName, LockRequestSliceValueType)
+
+	assert.Equal(t, LockRequestSliceValueType, metadata.ValueType())
+	assert.Equal(t, labelName, metadata.Name())
+	assert.Equal(t, labelColumnName, metadata.ColumnName())
+
+	var expectedType *[]*lockRequest
+
+	assert.IsType(t, expectedType, metadata.ValueHolder())
+}
+
 func TestUnknownLabelValueMetadata(t *testing.T) {
 	metadata, err := NewLabelValueMetadata(labelName, labelColumnName, UnknownValueType)
 
@@ -189,6 +201,26 @@ func TestByteSliceLabelValue(t *testing.T) {
 	assert.Equal(t, stringValue, attributeValue.StringVal())
 }
 
+func TestLockRequestSliceLabelValue(t *testing.T) {
+	metadata, _ := NewLabelValueMetadata(labelName, labelColumnName, LockRequestSliceValueType)
+	labelValue := lockRequestSliceLabelValue{
+		metadata: metadata,
+		value:    stringValue,
+	}
+
+	assert.Equal(t, LockRequestSliceValueType, labelValue.Metadata().ValueType())
+	assert.Equal(t, stringValue, labelValue.Value())
+
+	attributes := pdata.NewAttributeMap()
+
+	labelValue.SetValueTo(attributes)
+
+	attributeValue, exists := attributes.Get(labelName)
+
+	assert.True(t, exists)
+	assert.Equal(t, stringValue, attributeValue.StringVal())
+}
+
 func TestNewStringLabelValue(t *testing.T) {
 	metadata, _ := NewLabelValueMetadata(labelName, labelColumnName, StringValueType)
 	value := stringValue
@@ -243,4 +275,19 @@ func TestNewByteSliceLabelValue(t *testing.T) {
 
 	assert.Equal(t, ByteSliceValueType, labelValue.Metadata().ValueType())
 	assert.Equal(t, stringValue, labelValue.Value())
+}
+
+func TestNewLockRequestSliceLabelValue(t *testing.T) {
+	metadata, _ := NewLabelValueMetadata(labelName, labelColumnName, LockRequestSliceValueType)
+	value := []*lockRequest{
+		{LockMode: "lockMode1", Column: "column1", TransactionTag: "tag1"},
+		{LockMode: "lockMode2", Column: "column2", TransactionTag: "tag2"},
+	}
+	expectedValue := "{lockMode1,column1,tag1},{lockMode2,column2,tag2}"
+	valueHolder := &value
+
+	labelValue := newLockRequestSliceLabelValue(metadata, valueHolder)
+
+	assert.Equal(t, LockRequestSliceValueType, labelValue.Metadata().ValueType())
+	assert.Equal(t, expectedValue, labelValue.Value())
 }

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
@@ -28,7 +28,7 @@ import (
 const (
 	// Value was generated using the same library. Intent is to detect that something changed in library implementation
 	// in case we received different value here. For more details inspect tests where this value is used.
-	expectedHashValue = "b519d020edc95bf"
+	expectedHashValue = "29282762c26450b7"
 )
 
 func TestMetricsDataPoint_GroupingKey(t *testing.T) {
@@ -136,6 +136,11 @@ func allPossibleLabelValues() []LabelValue {
 		metadata: btSliceLabelValueMetadata,
 		value:    stringValue,
 	}
+	lckReqSliceLabelValueMetadata, _ := NewLabelValueMetadata("lockRequestSliceLabelName", "lockRequestSliceLabelColumnName", LockRequestSliceValueType)
+	lckReqSliceLabelValue := lockRequestSliceLabelValue{
+		metadata: lckReqSliceLabelValueMetadata,
+		value:    stringValue,
+	}
 
 	return []LabelValue{
 		strLabelValue,
@@ -143,6 +148,7 @@ func allPossibleLabelValues() []LabelValue {
 		i64LabelValue,
 		strSliceLabelValue,
 		btSliceLabelValue,
+		lckReqSliceLabelValue,
 	}
 }
 
@@ -181,7 +187,7 @@ func assertLabelValue(t *testing.T, attributesMap pdata.AttributeMap, labelValue
 
 	assert.True(t, exists)
 	switch labelValue.(type) {
-	case stringLabelValue, stringSliceLabelValue, byteSliceLabelValue:
+	case stringLabelValue, stringSliceLabelValue, byteSliceLabelValue, lockRequestSliceLabelValue:
 		assert.Equal(t, labelValue.Value(), value.StringVal())
 	case boolLabelValue:
 		assert.Equal(t, labelValue.Value(), value.BoolVal())

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata_test.go
@@ -76,11 +76,12 @@ func TestToLabelValue(t *testing.T) {
 		expectedValue            interface{}
 		expectedTransformedValue interface{}
 	}{
-		"String label value metadata":       {StringValueType, stringLabelValue{}, stringValue, nil},
-		"Int64 label value metadata":        {IntValueType, int64LabelValue{}, int64Value, nil},
-		"Bool label value metadata":         {BoolValueType, boolLabelValue{}, boolValue, nil},
-		"String slice label value metadata": {StringSliceValueType, stringSliceLabelValue{}, []string{stringValue, stringValue}, stringValue + "," + stringValue},
-		"Byte slice label value metadata":   {ByteSliceValueType, byteSliceLabelValue{}, []byte(stringValue), stringValue},
+		"String label value metadata":             {StringValueType, stringLabelValue{}, stringValue, nil},
+		"Int64 label value metadata":              {IntValueType, int64LabelValue{}, int64Value, nil},
+		"Bool label value metadata":               {BoolValueType, boolLabelValue{}, boolValue, nil},
+		"String slice label value metadata":       {StringSliceValueType, stringSliceLabelValue{}, []string{stringValue, stringValue}, stringValue + "," + stringValue},
+		"Byte slice label value metadata":         {ByteSliceValueType, byteSliceLabelValue{}, []byte(stringValue), stringValue},
+		"Lock request slice label value metadata": {LockRequestSliceValueType, lockRequestSliceLabelValue{}, []*lockRequest{{"lockMode", "column", "transactionTag"}}, "{lockMode,column,transactionTag}"},
 	}
 
 	for name, testCase := range testCases {
@@ -108,12 +109,14 @@ func TestMetricsMetadata_ToLabelValues_AllPossibleMetadata(t *testing.T) {
 	int64LabelValueMetadata, _ := NewLabelValueMetadata("int64LabelName", "int64LabelColumnName", IntValueType)
 	stringSliceLabelValueMetadata, _ := NewLabelValueMetadata("stringSliceLabelName", "stringSliceLabelColumnName", StringSliceValueType)
 	byteSliceLabelValueMetadata, _ := NewLabelValueMetadata("byteSliceLabelName", "byteSliceLabelColumnName", ByteSliceValueType)
+	lockRequestSliceLabelValueMetadata, _ := NewLabelValueMetadata("lockRequestSliceLabelName", "lockRequestSliceLabelColumnName", LockRequestSliceValueType)
 	queryLabelValuesMetadata := []LabelValueMetadata{
 		stringLabelValueMetadata,
 		boolLabelValueMetadata,
 		int64LabelValueMetadata,
 		stringSliceLabelValueMetadata,
 		byteSliceLabelValueMetadata,
+		lockRequestSliceLabelValueMetadata,
 	}
 	metadata := MetricsMetadata{QueryLabelValuesMetadata: queryLabelValuesMetadata}
 	row, _ := spanner.NewRow(
@@ -123,6 +126,7 @@ func TestMetricsMetadata_ToLabelValues_AllPossibleMetadata(t *testing.T) {
 			int64LabelValueMetadata.ColumnName(),
 			stringSliceLabelValueMetadata.ColumnName(),
 			byteSliceLabelValueMetadata.ColumnName(),
+			lockRequestSliceLabelValueMetadata.ColumnName(),
 		},
 		[]interface{}{
 			stringValue,
@@ -130,6 +134,7 @@ func TestMetricsMetadata_ToLabelValues_AllPossibleMetadata(t *testing.T) {
 			int64Value,
 			[]string{stringValue, stringValue},
 			[]byte(stringValue),
+			[]*lockRequest{{}},
 		})
 
 	labelValues, _ := metadata.toLabelValues(row)
@@ -142,6 +147,7 @@ func TestMetricsMetadata_ToLabelValues_AllPossibleMetadata(t *testing.T) {
 		int64LabelValue{},
 		stringSliceLabelValue{},
 		byteSliceLabelValue{},
+		lockRequestSliceLabelValue{},
 	}
 
 	for i, expectedType := range expectedTypes {

--- a/receiver/googlecloudspannerreceiver/internal/metadata/valuemetadata.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/valuemetadata.go
@@ -17,13 +17,14 @@ package metadata // import "github.com/open-telemetry/opentelemetry-collector-co
 type ValueType string
 
 const (
-	UnknownValueType     ValueType = "unknown"
-	StringValueType      ValueType = "string"
-	IntValueType         ValueType = "int"
-	FloatValueType       ValueType = "float"
-	BoolValueType        ValueType = "bool"
-	StringSliceValueType ValueType = "string_slice"
-	ByteSliceValueType   ValueType = "byte_slice"
+	UnknownValueType          ValueType = "unknown"
+	StringValueType           ValueType = "string"
+	IntValueType              ValueType = "int"
+	FloatValueType            ValueType = "float"
+	BoolValueType             ValueType = "bool"
+	StringSliceValueType      ValueType = "string_slice"
+	ByteSliceValueType        ValueType = "byte_slice"
+	LockRequestSliceValueType ValueType = "lock_request_slice"
 )
 
 type ValueMetadata interface {

--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
@@ -43,6 +43,9 @@ metadata:
       - name: "row_range_start_key"
         column_name: "ROW_RANGE_START_KEY"
         value_type: "byte_slice"
+      - name: "sample_lock_requests"
+        column_name: "SAMPLE_LOCK_REQUESTS"
+        value_type: "lock_request_slice"
     metrics:
       - name: "lock_wait_seconds"
         column_name: "LOCK_WAIT_SECONDS"

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/label_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/label_test.go
@@ -33,12 +33,13 @@ func TestLabel_ToLabelValueMetadata(t *testing.T) {
 		valueType   metadata.ValueType
 		expectError bool
 	}{
-		"Value type is string":       {metadata.StringValueType, false},
-		"Value type is int":          {metadata.IntValueType, false},
-		"Value type is bool":         {metadata.BoolValueType, false},
-		"Value type is string slice": {metadata.StringSliceValueType, false},
-		"Value type is byte slice":   {metadata.ByteSliceValueType, false},
-		"Value type is unknown":      {metadata.UnknownValueType, true},
+		"Value type is string":             {metadata.StringValueType, false},
+		"Value type is int":                {metadata.IntValueType, false},
+		"Value type is bool":               {metadata.BoolValueType, false},
+		"Value type is string slice":       {metadata.StringSliceValueType, false},
+		"Value type is byte slice":         {metadata.ByteSliceValueType, false},
+		"Value type is lock request slice": {metadata.LockRequestSliceValueType, false},
+		"Value type is unknown":            {metadata.UnknownValueType, true},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
You can find more info about data for this label here: https://cloud.google.com/spanner/docs/introspection/lock-statistics
For now data value is transformed into string and exported as string value.