### PR TITLE
Fix duplicated metrics from processed spans.

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -264,6 +264,7 @@ func (p *processorImp) collectLatencyMetrics(ilm pdata.InstrumentationLibraryMet
 		setLatencyExemplars(p.latencyExemplarsData[key], timestamp, dpLatency.Exemplars())
 
 		p.metricKeyToDimensions[key].CopyTo(dpLatency.Attributes())
+		delete(p.latencyCount, key)
 	}
 }
 
@@ -283,6 +284,7 @@ func (p *processorImp) collectCallMetrics(ilm pdata.InstrumentationLibraryMetric
 		dpCalls.SetIntVal(p.callSum[key])
 
 		p.metricKeyToDimensions[key].CopyTo(dpCalls.Attributes())
+		delete(p.callSum, key)
 	}
 }
 


### PR DESCRIPTION
**Description:**
Fixing a bug - The current implementation is not correct. It will keep generating metrics
from all the previous spans.

The fix will remove the already processed spans from the processor, which
avoid duplicated metrics.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** 
The new test `TestProcessorConsumeBatchesOfTraces` is added to assert metrics are valid from batches of spans.

**Documentation:** <Describe the documentation added.>