### PR TITLE
[receiver/prometheusreceiver] Do not add `host.name` to metrics from localhost/unspecified targets

### DIFF
--- a/receiver/prometheusreceiver/internal/prom_to_otlp.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp.go
@@ -40,7 +40,8 @@ func isDiscernibleHost(host string) bool {
 	return true
 }
 
-func createNodeAndResourcePdata(job, instance, scheme string) pdata.Resource {
+// CreateNodeAndResourcePdata creates the resource data added to OTLP payloads.
+func CreateNodeAndResourcePdata(job, instance, scheme string) pdata.Resource {
 	host, port, err := net.SplitHostPort(instance)
 	if err != nil {
 		host = instance

--- a/receiver/prometheusreceiver/internal/prom_to_otlp.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp.go
@@ -21,12 +21,12 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 )
 
-// isAllowedHost returns if a host can be used as a value for the 'host.name' key.
-// localhost-like hosts and unspecified (0.0.0.0) hosts are not allowed.
-func isAllowedHost(host string) bool {
+// isDiscernibleHost checks if a host can be used as a value for the 'host.name' key.
+// localhost-like hosts and unspecified (0.0.0.0) hosts are not discernible.
+func isDiscernibleHost(host string) bool {
 	ip := net.ParseIP(host)
 	if ip != nil {
-		// An IP is allowed if
+		// An IP is discernible if
 		//  - it's not local (e.g. belongs to 127.0.0.0/8 or ::1/128) and
 		//  - it's not unspecficied (e.g. the 0.0.0.0 address).
 		return !ip.IsLoopback() && !ip.IsUnspecified()
@@ -36,7 +36,7 @@ func isAllowedHost(host string) bool {
 		return false
 	}
 
-	// not an IP, not 'localhost', assume it is allowed.
+	// not an IP, not 'localhost', assume it is discernible.
 	return true
 }
 
@@ -48,7 +48,7 @@ func createNodeAndResourcePdata(job, instance, scheme string) pdata.Resource {
 	resource := pdata.NewResource()
 	attrs := resource.Attributes()
 	attrs.UpsertString(conventions.AttributeServiceName, job)
-	if isAllowedHost(host) {
+	if isDiscernibleHost(host) {
 		attrs.UpsertString(conventions.AttributeHostName, host)
 	}
 	attrs.UpsertString(jobAttr, job)

--- a/receiver/prometheusreceiver/internal/prom_to_otlp.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp.go
@@ -21,11 +21,24 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 )
 
+const (
+	localHostIPv4 = "127.0.0.1"
+	anyIPIPv4     = "0.0.0.0"
+)
+
+func sanitizeHost(host string) string {
+	if host == anyIPIPv4 {
+		return localHostIPv4
+	}
+	return host
+}
+
 func createNodeAndResourcePdata(job, instance, scheme string) pdata.Resource {
 	host, port, err := net.SplitHostPort(instance)
 	if err != nil {
 		host = instance
 	}
+	host = sanitizeHost(host)
 	resource := pdata.NewResource()
 	attrs := resource.Attributes()
 	attrs.UpsertString(conventions.AttributeServiceName, job)

--- a/receiver/prometheusreceiver/internal/prom_to_otlp.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp.go
@@ -28,7 +28,7 @@ func isDiscernibleHost(host string) bool {
 	if ip != nil {
 		// An IP is discernible if
 		//  - it's not local (e.g. belongs to 127.0.0.0/8 or ::1/128) and
-		//  - it's not unspecficied (e.g. the 0.0.0.0 address).
+		//  - it's not unspecified (e.g. the 0.0.0.0 address).
 		return !ip.IsLoopback() && !ip.IsUnspecified()
 	}
 

--- a/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
@@ -108,6 +108,13 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 				"job", "", "", "http", "",
 			}),
 		},
+		{
+			name: "0.0.0.0 address",
+			job:  "job", instance: "0.0.0.0:8888", scheme: "http",
+			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
+				"job", "0.0.0.0:8888", "127.0.0.1", "http", "8888",
+			}),
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
@@ -43,7 +43,7 @@ func TestCreateNodeAndResourceEquivalence(t *testing.T) {
 	)
 
 	fromOCResource := mdFromOC.ResourceMetrics().At(0).Resource().Attributes().Sort()
-	byDirectOTLPResource := createNodeAndResourcePdata(job, instance, scheme).Attributes().Sort()
+	byDirectOTLPResource := CreateNodeAndResourcePdata(job, instance, scheme).Attributes().Sort()
 
 	require.Equal(t, byDirectOTLPResource, fromOCResource)
 }
@@ -129,7 +129,7 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := createNodeAndResourcePdata(tt.job, tt.instance, tt.scheme)
+			got := CreateNodeAndResourcePdata(tt.job, tt.instance, tt.scheme)
 			require.Equal(t, got, tt.want)
 		})
 	}

--- a/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
@@ -77,9 +77,9 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 	}{
 		{
 			name: "all attributes proper",
-			job:  "job", instance: "localhost:8888", scheme: "http",
+			job:  "job", instance: "hostname:8888", scheme: "http",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
-				"job", "localhost:8888", "localhost", "http", "8888",
+				"job", "hostname:8888", "hostname", "http", "8888",
 			}, false),
 		},
 		{
@@ -115,6 +115,13 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 			job:  "job", instance: "0.0.0.0:8888", scheme: "http",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "0.0.0.0:8888", "", "http", "8888",
+			}, true),
+		},
+		{
+			name: "localhost",
+			job:  "job", instance: "localhost:8888", scheme: "http",
+			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
+				"job", "localhost:8888", "", "http", "8888",
 			}, true),
 		},
 	}

--- a/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
@@ -52,13 +52,13 @@ type jobInstanceDefinition struct {
 	job, instance, host, scheme, port string
 }
 
-func makeResourceWithJobInstanceScheme(def *jobInstanceDefinition, noHost bool) pdata.Resource {
+func makeResourceWithJobInstanceScheme(def *jobInstanceDefinition, hasHost bool) pdata.Resource {
 	resource := pdata.NewResource()
 	attrs := resource.Attributes()
 	// Using hardcoded values to assert on outward expectations so that
 	// when variables change, these tests will fail and we'll have reports.
 	attrs.UpsertString("service.name", def.job)
-	if !noHost {
+	if hasHost {
 		attrs.UpsertString("host.name", def.host)
 	}
 	attrs.UpsertString("job", def.job)
@@ -80,49 +80,49 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 			job:  "job", instance: "hostname:8888", scheme: "http",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
-			}, false),
+			}, true),
 		},
 		{
 			name: "missing port",
 			job:  "job", instance: "myinstance", scheme: "https",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "myinstance", "myinstance", "https", "",
-			}, false),
+			}, true),
 		},
 		{
 			name: "blank scheme",
 			job:  "job", instance: "myinstance:443", scheme: "",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "myinstance:443", "myinstance", "", "443",
-			}, false),
+			}, true),
 		},
 		{
 			name: "blank instance, blank scheme",
 			job:  "job", instance: "", scheme: "",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "", "", "", "",
-			}, false),
+			}, true),
 		},
 		{
 			name: "blank instance, non-blank scheme",
 			job:  "job", instance: "", scheme: "http",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "", "", "http", "",
-			}, false),
+			}, true),
 		},
 		{
 			name: "0.0.0.0 address",
 			job:  "job", instance: "0.0.0.0:8888", scheme: "http",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "0.0.0.0:8888", "", "http", "8888",
-			}, true),
+			}, false),
 		},
 		{
 			name: "localhost",
 			job:  "job", instance: "localhost:8888", scheme: "http",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "localhost:8888", "", "http", "8888",
-			}, true),
+			}, false),
 		},
 	}
 

--- a/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
@@ -52,13 +52,15 @@ type jobInstanceDefinition struct {
 	job, instance, host, scheme, port string
 }
 
-func makeResourceWithJobInstanceScheme(def *jobInstanceDefinition) pdata.Resource {
+func makeResourceWithJobInstanceScheme(def *jobInstanceDefinition, noHost bool) pdata.Resource {
 	resource := pdata.NewResource()
 	attrs := resource.Attributes()
 	// Using hardcoded values to assert on outward expectations so that
 	// when variables change, these tests will fail and we'll have reports.
 	attrs.UpsertString("service.name", def.job)
-	attrs.UpsertString("host.name", def.host)
+	if !noHost {
+		attrs.UpsertString("host.name", def.host)
+	}
 	attrs.UpsertString("job", def.job)
 	attrs.UpsertString("instance", def.instance)
 	attrs.UpsertString("port", def.port)
@@ -78,42 +80,42 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 			job:  "job", instance: "localhost:8888", scheme: "http",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "localhost:8888", "localhost", "http", "8888",
-			}),
+			}, false),
 		},
 		{
 			name: "missing port",
 			job:  "job", instance: "myinstance", scheme: "https",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "myinstance", "myinstance", "https", "",
-			}),
+			}, false),
 		},
 		{
 			name: "blank scheme",
 			job:  "job", instance: "myinstance:443", scheme: "",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "myinstance:443", "myinstance", "", "443",
-			}),
+			}, false),
 		},
 		{
 			name: "blank instance, blank scheme",
 			job:  "job", instance: "", scheme: "",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "", "", "", "",
-			}),
+			}, false),
 		},
 		{
 			name: "blank instance, non-blank scheme",
 			job:  "job", instance: "", scheme: "http",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "", "", "http", "",
-			}),
+			}, false),
 		},
 		{
 			name: "0.0.0.0 address",
 			job:  "job", instance: "0.0.0.0:8888", scheme: "http",
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
-				"job", "0.0.0.0:8888", "127.0.0.1", "http", "8888",
-			}),
+				"job", "0.0.0.0:8888", "", "http", "8888",
+			}, true),
 		},
 	}
 

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -247,7 +247,7 @@ func createNodeAndResource(job, instance, scheme string) (*commonpb.Node, *resou
 		ServiceInfo: &commonpb.ServiceInfo{Name: job},
 	}
 
-	if isAllowedHost(host) {
+	if isDiscernibleHost(host) {
 		node.Identifier = &commonpb.ProcessIdentifier{
 			HostName: host,
 		}

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -242,7 +242,11 @@ func createNodeAndResource(job, instance, scheme string) (*commonpb.Node, *resou
 	if err != nil {
 		host = instance
 	}
-	host = sanitizeHost(host)
+
+	if !isAllowedHost(host) {
+		host = ""
+	}
+
 	node := &commonpb.Node{
 		ServiceInfo: &commonpb.ServiceInfo{Name: job},
 		Identifier: &commonpb.ProcessIdentifier{

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -243,16 +243,16 @@ func createNodeAndResource(job, instance, scheme string) (*commonpb.Node, *resou
 		host = instance
 	}
 
-	if !isAllowedHost(host) {
-		host = ""
-	}
-
 	node := &commonpb.Node{
 		ServiceInfo: &commonpb.ServiceInfo{Name: job},
-		Identifier: &commonpb.ProcessIdentifier{
-			HostName: host,
-		},
 	}
+
+	if isAllowedHost(host) {
+		node.Identifier = &commonpb.ProcessIdentifier{
+			HostName: host,
+		}
+	}
+
 	resource := &resourcepb.Resource{
 		Labels: map[string]string{
 			jobAttr:      job,

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -242,6 +242,7 @@ func createNodeAndResource(job, instance, scheme string) (*commonpb.Node, *resou
 	if err != nil {
 		host = instance
 	}
+	host = sanitizeHost(host)
 	node := &commonpb.Node{
 		ServiceInfo: &commonpb.ServiceInfo{Name: job},
 		Identifier: &commonpb.ProcessIdentifier{


### PR DESCRIPTION
**Description:** 

Do not add `host.name` for Prometheus receiver metrics that come from scraping a localhost or unspecified (`0.0.0.0`) target.

**Link to tracking Issue:** Fixes #6465.

**Testing:** Amended unit test. Ran example on linked issue to manually check this fixed the problem:

<details>

<summary>logging exporter when running example on linked issue</summary>

```
Resource labels:
     -> service.name: STRING(otelcol)
     -> job: STRING(otelcol)
     -> instance: STRING(0.0.0.0:8888)
     -> port: STRING(8888)
     -> scheme: STRING(http)
InstrumentationLibraryMetrics #0
InstrumentationLibrary  
Metric #0
Descriptor:
     -> Name: otelcol_exporter_enqueue_failed_log_records
     -> Description: Number of log records failed to be added to the sending queue.
     -> Unit: 
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: AGGREGATION_TEMPORALITY_CUMULATIVE
NumberDataPoints #0
Data point attributes:
     -> exporter: STRING(logging)
     -> service_instance_id: STRING(dd14a920-f022-4e27-a638-3f2dd8327716)
     -> service_version: STRING(latest)
StartTimestamp: 2021-12-06 11:46:20.958 +0000 UTC
Timestamp: 2021-12-06 11:46:20.958 +0000 UTC
Value: 0.000000
```

</details>
