### PR TITLE
[exporter/datadogexporter] Do not use attribute localhost-like hostnames

### DIFF
--- a/exporter/datadogexporter/internal/attributes/hostname.go
+++ b/exporter/datadogexporter/internal/attributes/hostname.go
@@ -56,6 +56,26 @@ func getClusterName(attrs pdata.AttributeMap) (string, bool) {
 //
 //  It returns a boolean value indicated if any name was found
 func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
+	// Check if the host is localhost or 0.0.0.0, if so discard it.
+	// We don't do the more strict validation done for metadata,
+	// to avoid breaking users existing invalid-but-accepted hostnames.
+	var invalidHosts = map[string]struct{}{
+		"0.0.0.0":                 {},
+		"127.0.0.1":               {},
+		"localhost":               {},
+		"localhost.localdomain":   {},
+		"localhost6.localdomain6": {},
+		"ip6-localhost":           {},
+	}
+
+	candidateHost, ok := unsanitizedHostnameFromAttributes(attrs)
+	if _, invalid := invalidHosts[candidateHost]; invalid {
+		return "", false
+	}
+	return candidateHost, ok
+}
+
+func unsanitizedHostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
 	// Custom hostname: useful for overriding in k8s/cloud envs
 	if customHostname, ok := attrs.Get(AttributeDatadogHostname); ok {
 		return customHostname.StringVal(), true

--- a/exporter/datadogexporter/internal/attributes/hostname_test.go
+++ b/exporter/datadogexporter/internal/attributes/hostname_test.go
@@ -99,6 +99,13 @@ func TestHostnameFromAttributes(t *testing.T) {
 	hostname, ok = HostnameFromAttributes(attrs)
 	assert.False(t, ok)
 	assert.Empty(t, hostname)
+
+	attrs = testutils.NewAttributeMap(map[string]string{
+		AttributeDatadogHostname: "127.0.0.1",
+	})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.False(t, ok)
+	assert.Empty(t, hostname)
 }
 
 func TestGetClusterName(t *testing.T) {


### PR DESCRIPTION
**Description:** 

Avoid using localhost-like names present in resource attributes as a hostname.

**Link to tracking Issue:** relates to #6465.

**Testing:** Added unit test
