### PR TITLE
Ensure hostmetricsreceiver sets SchemaURL

### DIFF
--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -21,6 +21,9 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumerhelper"
+	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/zap"
@@ -93,12 +96,38 @@ func createMetricsReceiver(
 		return nil, err
 	}
 
+	schemaURLSetterConsumer, err := wrapBySchemaURLSetterConsumer(consumer)
+	if err != nil {
+		return nil, err
+	}
+
 	return scraperhelper.NewScraperControllerReceiver(
 		&oCfg.ScraperControllerSettings,
 		set,
-		consumer,
+		schemaURLSetterConsumer,
 		addScraperOptions...,
 	)
+}
+
+// This function wraps the consumer and returns a new consumer such that the schema URL
+// of all metrics that pass through the new consumer is set correctly.
+func wrapBySchemaURLSetterConsumer(consumer consumer.Metrics) (consumer.Metrics, error) {
+	return consumerhelper.NewMetrics(func(ctx context.Context, md pdata.Metrics) error {
+		rms := md.ResourceMetrics()
+		for i := 0; i < rms.Len(); i++ {
+			rm := rms.At(i)
+			if rm.SchemaUrl() == "" {
+				// If no specific SchemaURL is set we assume all collected host metrics
+				// confirm to our default SchemaURL. The assumption here is that
+				// the code that produces these metrics uses semantic conventions
+				// defined in package "conventions".
+				rm.SetSchemaUrl(conventions.SchemaURL)
+			}
+			// Else if the SchemaURL is set we assume the producer of the metric knows
+			// what it does. We won't touch it.
+		}
+		return consumer.ConsumeMetrics(ctx, md)
+	})
 }
 
 func createAddScraperOptions(

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/zap"
 
@@ -153,6 +154,8 @@ func assertIncludesExpectedMetrics(t *testing.T, got pdata.Metrics) {
 		rm := rms.At(i)
 		metrics := getMetricSlice(t, rm)
 		returnedMetricNames := getReturnedMetricNames(metrics)
+		assert.EqualValues(t, conventions.SchemaURL, rm.SchemaUrl(),
+			"SchemaURL is incorrect for metrics: %v", returnedMetricNames)
 		if rm.Resource().Attributes().Len() == 0 {
 			appendMapInto(returnedMetrics, returnedMetricNames)
 		} else {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
@@ -102,6 +103,7 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 	rms.EnsureCapacity(len(metadata))
 	for _, md := range metadata {
 		rm := rms.AppendEmpty()
+		rm.SetSchemaUrl(conventions.SchemaURL)
 		md.initializeResource(rm.Resource())
 		metrics := rm.InstrumentationLibraryMetrics().AppendEmpty().Metrics()
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -70,12 +70,20 @@ func TestScrape(t *testing.T) {
 	}
 
 	require.Greater(t, md.ResourceMetrics().Len(), 1)
+	assertSchemaIsSet(t, md.ResourceMetrics())
 	assertProcessResourceAttributesExist(t, md.ResourceMetrics())
 	assertCPUTimeMetricValid(t, md.ResourceMetrics(), expectedStartTime)
 	assertMemoryUsageMetricValid(t, metadata.Metrics.ProcessMemoryPhysicalUsage.New(), md.ResourceMetrics())
 	assertMemoryUsageMetricValid(t, metadata.Metrics.ProcessMemoryVirtualUsage.New(), md.ResourceMetrics())
 	assertDiskIOMetricValid(t, md.ResourceMetrics(), expectedStartTime)
 	assertSameTimeStampForAllMetricsWithinResource(t, md.ResourceMetrics())
+}
+
+func assertSchemaIsSet(t *testing.T, resourceMetrics pdata.ResourceMetricsSlice) {
+	for i := 0; i < resourceMetrics.Len(); i++ {
+		rm := resourceMetrics.At(0)
+		assert.EqualValues(t, conventions.SchemaURL, rm.SchemaUrl())
+	}
 }
 
 func assertProcessResourceAttributesExist(t *testing.T, resourceMetrics pdata.ResourceMetricsSlice) {


### PR DESCRIPTION
This changes ensures that all metrics produced by hostmetricsreceiver
set the SchemaURL.

If no specific SchemaURL is set we assume all collected host metrics
confirm to our default SchemaURL. The assumption is that the code that
produces these metrics uses semantic conventions defined in
package "conventions".

This is a remake of closed PR https://github.com/open-telemetry/opentelemetry-collector/pull/3819