### PR TITLE
Statsdreceiver: remove several unnecessary fields

### DIFF
--- a/receiver/statsdreceiver/protocol/metric_translator.go
+++ b/receiver/statsdreceiver/protocol/metric_translator.go
@@ -67,9 +67,9 @@ func buildGaugeMetric(parsedMetric statsDMetric, timeNow time.Time) pdata.Instru
 	return ilm
 }
 
-func buildSummaryMetric(summary summaryMetric, startTime, timeNow time.Time, percentiles []float64, ilm pdata.InstrumentationLibraryMetrics) {
+func buildSummaryMetric(desc statsDMetricDescription, summary summaryMetric, startTime, timeNow time.Time, percentiles []float64, ilm pdata.InstrumentationLibraryMetrics) {
 	nm := ilm.Metrics().AppendEmpty()
-	nm.SetName(summary.name)
+	nm.SetName(desc.name)
 	nm.SetDataType(pdata.MetricDataTypeSummary)
 
 	dp := nm.Summary().DataPoints().AppendEmpty()
@@ -88,8 +88,8 @@ func buildSummaryMetric(summary summaryMetric, startTime, timeNow time.Time, per
 
 	dp.SetStartTimestamp(pdata.NewTimestampFromTime(startTime))
 	dp.SetTimestamp(pdata.NewTimestampFromTime(timeNow))
-	for i, key := range summary.labelKeys {
-		dp.Attributes().InsertString(key, summary.labelValues[i])
+	for i := desc.attrs.Iter(); i.Next(); {
+		dp.Attributes().InsertString(string(i.Attribute().Key), i.Attribute().Value.AsString())
 	}
 
 	sort.Sort(dualSorter{summary.points, summary.weights})

--- a/receiver/statsdreceiver/protocol/metric_translator.go
+++ b/receiver/statsdreceiver/protocol/metric_translator.go
@@ -42,8 +42,8 @@ func buildCounterMetric(parsedMetric statsDMetric, isMonotonicCounter bool, time
 	dp.SetIntVal(parsedMetric.counterValue())
 	dp.SetStartTimestamp(pdata.NewTimestampFromTime(lastIntervalTime))
 	dp.SetTimestamp(pdata.NewTimestampFromTime(timeNow))
-	for i, key := range parsedMetric.labelKeys {
-		dp.Attributes().InsertString(key, parsedMetric.labelValues[i])
+	for i := parsedMetric.description.attrs.Iter(); i.Next(); {
+		dp.Attributes().InsertString(string(i.Attribute().Key), i.Attribute().Value.AsString())
 	}
 
 	return ilm
@@ -60,8 +60,8 @@ func buildGaugeMetric(parsedMetric statsDMetric, timeNow time.Time) pdata.Instru
 	dp := nm.Gauge().DataPoints().AppendEmpty()
 	dp.SetDoubleVal(parsedMetric.gaugeValue())
 	dp.SetTimestamp(pdata.NewTimestampFromTime(timeNow))
-	for i, key := range parsedMetric.labelKeys {
-		dp.Attributes().InsertString(key, parsedMetric.labelValues[i])
+	for i := parsedMetric.description.attrs.Iter(); i.Next(); {
+		dp.Attributes().InsertString(string(i.Attribute().Key), i.Attribute().Value.AsString())
 	}
 
 	return ilm

--- a/receiver/statsdreceiver/protocol/metric_translator_test.go
+++ b/receiver/statsdreceiver/protocol/metric_translator_test.go
@@ -27,10 +27,10 @@ func TestBuildCounterMetric(t *testing.T) {
 	timeNow := time.Now()
 	lastUpdateInterval := timeNow.Add(-1 * time.Minute)
 	metricDescription := statsDMetricDescription{
-		name: "testCounter",
+		name:  "testCounter",
 		attrs: attribute.NewSet(attribute.String("mykey", "myvalue")),
 	}
-	
+
 	parsedMetric := statsDMetric{
 		description: metricDescription,
 		asFloat:     32,

--- a/receiver/statsdreceiver/protocol/metric_translator_test.go
+++ b/receiver/statsdreceiver/protocol/metric_translator_test.go
@@ -28,13 +28,13 @@ func TestBuildCounterMetric(t *testing.T) {
 	lastUpdateInterval := timeNow.Add(-1 * time.Minute)
 	metricDescription := statsDMetricDescription{
 		name: "testCounter",
+		attrs: attribute.NewSet(attribute.String("mykey", "myvalue")),
 	}
+	
 	parsedMetric := statsDMetric{
 		description: metricDescription,
 		asFloat:     32,
 		unit:        "meter",
-		labelKeys:   []string{"mykey"},
-		labelValues: []string{"myvalue"},
 	}
 	isMonotonicCounter := false
 	metric := buildCounterMetric(parsedMetric, isMonotonicCounter, timeNow, lastUpdateInterval)
@@ -57,13 +57,15 @@ func TestBuildGaugeMetric(t *testing.T) {
 	timeNow := time.Now()
 	metricDescription := statsDMetricDescription{
 		name: "testGauge",
+		attrs: attribute.NewSet(
+			attribute.String("mykey", "myvalue"),
+			attribute.String("mykey2", "myvalue2"),
+		),
 	}
 	parsedMetric := statsDMetric{
 		description: metricDescription,
 		asFloat:     32.3,
 		unit:        "meter",
-		labelKeys:   []string{"mykey", "mykey2"},
-		labelValues: []string{"myvalue", "myvalue2"},
 	}
 	metric := buildGaugeMetric(parsedMetric, timeNow)
 	expectedMetrics := pdata.NewInstrumentationLibraryMetrics()

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -91,8 +91,6 @@ type statsDMetric struct {
 	addition    bool
 	unit        string
 	sampleRate  float64
-	labelKeys   []string
-	labelValues []string
 }
 
 type statsDMetricDescription struct {
@@ -303,8 +301,6 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 				if len(tagParts) != 2 {
 					return result, fmt.Errorf("invalid tag format: %s", tagParts)
 				}
-				result.labelKeys = append(result.labelKeys, tagParts[0])
-				result.labelValues = append(result.labelValues, tagParts[1])
 				kvs = append(kvs, attribute.String(tagParts[0], tagParts[1]))
 			}
 
@@ -321,9 +317,6 @@ func parseMessageToMetric(line string, enableMetricType bool) (statsDMetric, err
 	// add metric_type dimension for all metrics
 	if enableMetricType {
 		metricType := string(result.description.metricType.FullName())
-
-		result.labelKeys = append(result.labelKeys, tagMetricType)
-		result.labelValues = append(result.labelValues, metricType)
 
 		kvs = append(kvs, attribute.String(tagMetricType, metricType))
 	}

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -225,15 +225,11 @@ func (p *StatsDParser) Aggregate(line string) error {
 				p.summaries[parsedMetric.description] = summaryMetric{
 					points:  []float64{raw.value},
 					weights: []float64{raw.count},
-					// labelKeys:   parsedMetric.labelKeys,
-					// labelValues: parsedMetric.labelValues,
 				}
 			} else {
 				p.summaries[parsedMetric.description] = summaryMetric{
 					points:  append(existing.points, raw.value),
 					weights: append(existing.weights, raw.count),
-					// labelKeys:   parsedMetric.labelKeys,
-					// labelValues: parsedMetric.labelValues,
 				}
 			}
 		case DisableObserver:

--- a/receiver/statsdreceiver/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser_test.go
@@ -455,8 +455,6 @@ func testStatsDMetric(
 			addition:    addition,
 			unit:        "",
 			sampleRate:  sampleRate,
-			labelKeys:   labelKeys,
-			labelValues: labelValue,
 		}
 	}
 	return statsDMetric{
@@ -468,8 +466,6 @@ func testStatsDMetric(
 		addition:    addition,
 		unit:        "",
 		sampleRate:  sampleRate,
-		labelKeys:   labelKeys,
-		labelValues: labelValue,
 	}
 }
 

--- a/receiver/statsdreceiver/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser_test.go
@@ -451,10 +451,10 @@ func testStatsDMetric(
 				metricType: metricType,
 				attrs:      attribute.NewSetWithSortable(kvs, &sortable),
 			},
-			asFloat:     asFloat,
-			addition:    addition,
-			unit:        "",
-			sampleRate:  sampleRate,
+			asFloat:    asFloat,
+			addition:   addition,
+			unit:       "",
+			sampleRate: sampleRate,
 		}
 	}
 	return statsDMetric{
@@ -462,10 +462,10 @@ func testStatsDMetric(
 			name:       name,
 			metricType: metricType,
 		},
-		asFloat:     asFloat,
-		addition:    addition,
-		unit:        "",
-		sampleRate:  sampleRate,
+		asFloat:    asFloat,
+		addition:   addition,
+		unit:       "",
+		sampleRate: sampleRate,
 	}
 }
 
@@ -922,8 +922,8 @@ func TestStatsDParser_GetMetricsWithMetricType(t *testing.T) {
 	p.summaries = map[statsDMetricDescription]summaryMetric{
 		testDescription("statsdTestMetric1", "h",
 			[]string{"mykey"}, []string{"myvalue"}): {
-			points:      []float64{1, 1, 10, 20},
-			weights:     []float64{1, 1, 1, 1},
+			points:  []float64{1, 1, 10, 20},
+			weights: []float64{1, 1, 1, 1},
 		}}
 	metrics := p.GetMetrics()
 	assert.Equal(t, 5, metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().Len())

--- a/receiver/statsdreceiver/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser_test.go
@@ -445,12 +445,11 @@ func testStatsDMetric(
 		for n, k := range labelKeys {
 			kvs = append(kvs, attribute.String(k, labelValue[n]))
 		}
-		set := attribute.NewSetWithSortable(kvs, &sortable)
 		return statsDMetric{
-			description: statsDMetricdescription{
+			description: statsDMetricDescription{
 				name:       name,
 				metricType: metricType,
-				labels:     set.Equivalent(),
+				attrs:      attribute.NewSetWithSortable(kvs, &sortable),
 			},
 			asFloat:     asFloat,
 			addition:    addition,
@@ -461,7 +460,7 @@ func testStatsDMetric(
 		}
 	}
 	return statsDMetric{
-		description: statsDMetricdescription{
+		description: statsDMetricDescription{
 			name:       name,
 			metricType: metricType,
 		},
@@ -474,17 +473,16 @@ func testStatsDMetric(
 	}
 }
 
-func testDescription(name string, metricType MetricType, keys []string, values []string) statsDMetricdescription {
+func testDescription(name string, metricType MetricType, keys []string, values []string) statsDMetricDescription {
 	var kvs []attribute.KeyValue
 	var sortable attribute.Sortable
 	for n, k := range keys {
 		kvs = append(kvs, attribute.String(k, values[n]))
 	}
-	set := attribute.NewSetWithSortable(kvs, &sortable)
-	return statsDMetricdescription{
+	return statsDMetricDescription{
 		name:       name,
 		metricType: metricType,
-		labels:     set.Equivalent(),
+		attrs:      attribute.NewSetWithSortable(kvs, &sortable),
 	}
 }
 
@@ -496,8 +494,8 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 	tests := []struct {
 		name             string
 		input            []string
-		expectedGauges   map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
-		expectedCounters map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
+		expectedGauges   map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics
+		expectedCounters map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics
 		expectedTimer    []pdata.InstrumentationLibraryMetrics
 		err              error
 	}{
@@ -526,13 +524,13 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 				"statsdTestMetric2:+5|g|#mykey:myvalue",
 				"statsdTestMetric2:+500|g|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedGauges: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "g",
 					[]string{"mykey"}, []string{"myvalue"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "g", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
 				testDescription("statsdTestMetric2", "g",
 					[]string{"mykey"}, []string{"myvalue"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric2", 507, false, "g", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
 			},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{},
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{},
 			expectedTimer:    []pdata.InstrumentationLibraryMetrics{},
 		},
 		{
@@ -549,13 +547,13 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 				"statsdTestMetric1:-100|g|#mykey:myvalue",
 				"statsdTestMetric1:-1|g|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedGauges: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "g",
 					[]string{"mykey"}, []string{"myvalue"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 4885, false, "g", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
 				testDescription("statsdTestMetric2", "g",
 					[]string{"mykey"}, []string{"myvalue"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric2", 5, false, "g", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
 			},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{},
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{},
 			expectedTimer:    []pdata.InstrumentationLibraryMetrics{},
 		},
 		{
@@ -572,13 +570,13 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 				"statsdTestMetric2:-200|g|#mykey:myvalue",
 				"statsdTestMetric2:200|g|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedGauges: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "g",
 					[]string{"mykey"}, []string{"myvalue"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 4101, false, "g", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
 				testDescription("statsdTestMetric2", "g",
 					[]string{"mykey"}, []string{"myvalue"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric2", 200, false, "g", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
 			},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{},
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{},
 			expectedTimer:    []pdata.InstrumentationLibraryMetrics{},
 		},
 		{
@@ -589,8 +587,8 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
 				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedGauges: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{},
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "c",
 					[]string{"mykey"}, []string{"myvalue"}): buildCounterMetric(testStatsDMetric("statsdTestMetric1", 7000, false, "c", 0, []string{"mykey"}, []string{"myvalue"}), false, time.Unix(711, 0), time.Unix(611, 0)),
 				testDescription("statsdTestMetric2", "c",
@@ -611,11 +609,11 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 				"statsdTestMetric1:+2|g|#mykey:myvalue",
 				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedGauges: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "g",
 					[]string{"mykey"}, []string{"myvalue"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 421, false, "g", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
 			},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "c",
 					[]string{"mykey"}, []string{"myvalue"}): buildCounterMetric(testStatsDMetric("statsdTestMetric1", 7000, false, "c", 0, []string{"mykey"}, []string{"myvalue"}), false, time.Unix(711, 0), time.Unix(611, 0)),
 				testDescription("statsdTestMetric2", "c",
@@ -637,13 +635,13 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 				"statsdTestMetric1:15|c|#mykey:myvalue",
 				"statsdTestMetric2:5|c|@0.2|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedGauges: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "g",
 					[]string{"mykey"}, []string{"myvalue"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 319, false, "g", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
 				testDescription("statsdTestMetric1", "g",
 					[]string{"mykey"}, []string{"myvalue1"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 399, false, "g", 0, []string{"mykey"}, []string{"myvalue1"}), time.Unix(711, 0)),
 			},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "c",
 					[]string{"mykey"}, []string{"myvalue"}): buildCounterMetric(testStatsDMetric("statsdTestMetric1", 215, false, "c", 0, []string{"mykey"}, []string{"myvalue"}), false, time.Unix(711, 0), time.Unix(611, 0)),
 				testDescription("statsdTestMetric2", "c",
@@ -659,8 +657,8 @@ func TestStatsDParser_Aggregate(t *testing.T) {
 				"statsdTestMetric1:300|ms|#mykey:myvalue",
 				"statsdTestMetric1:10|h|@0.1|#mykey:myvalue",
 			},
-			expectedGauges:   map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{},
+			expectedGauges:   map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{},
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{},
 			expectedTimer: []pdata.InstrumentationLibraryMetrics{
 				buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 500, false, "ms", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
 				buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 400, false, "h", 0, []string{"mykey"}, []string{"myvalue"}), time.Unix(711, 0)),
@@ -697,8 +695,8 @@ func TestStatsDParser_AggregateWithMetricType(t *testing.T) {
 	tests := []struct {
 		name             string
 		input            []string
-		expectedGauges   map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
-		expectedCounters map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
+		expectedGauges   map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics
+		expectedCounters map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics
 		err              error
 	}{
 		{
@@ -712,13 +710,13 @@ func TestStatsDParser_AggregateWithMetricType(t *testing.T) {
 				"statsdTestMetric2:+5|g|#mykey:myvalue",
 				"statsdTestMetric2:+500|g|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedGauges: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "g",
 					[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), time.Unix(711, 0)),
 				testDescription("statsdTestMetric2", "g",
 					[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}): buildGaugeMetric(testStatsDMetric("statsdTestMetric2", 507, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), time.Unix(711, 0)),
 			},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{},
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{},
 		},
 
 		{
@@ -729,8 +727,8 @@ func TestStatsDParser_AggregateWithMetricType(t *testing.T) {
 				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
 				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedGauges: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{},
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "c",
 					[]string{"mykey", "metric_type"}, []string{"myvalue", "counter"}): buildCounterMetric(testStatsDMetric("statsdTestMetric1", 7000, false, "c", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "counter"}), false, time.Unix(711, 0), time.Unix(611, 0)),
 				testDescription("statsdTestMetric2", "c",
@@ -765,8 +763,8 @@ func TestStatsDParser_AggregateWithIsMonotonicCounter(t *testing.T) {
 	tests := []struct {
 		name             string
 		input            []string
-		expectedGauges   map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
-		expectedCounters map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics
+		expectedGauges   map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics
+		expectedCounters map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics
 		err              error
 	}{
 		{
@@ -777,8 +775,8 @@ func TestStatsDParser_AggregateWithIsMonotonicCounter(t *testing.T) {
 				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
 				"statsdTestMetric2:20|c|@0.8|#mykey:myvalue",
 			},
-			expectedGauges: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{},
-			expectedCounters: map[statsDMetricdescription]pdata.InstrumentationLibraryMetrics{
+			expectedGauges: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{},
+			expectedCounters: map[statsDMetricDescription]pdata.InstrumentationLibraryMetrics{
 				testDescription("statsdTestMetric1", "c",
 					[]string{"mykey"}, []string{"myvalue"}): buildCounterMetric(testStatsDMetric("statsdTestMetric1", 7000, false, "c", 0, []string{"mykey"}, []string{"myvalue"}), true, time.Unix(711, 0), time.Unix(611, 0)),
 				testDescription("statsdTestMetric2", "c",
@@ -813,7 +811,7 @@ func TestStatsDParser_AggregateTimerWithSummary(t *testing.T) {
 	tests := []struct {
 		name              string
 		input             []string
-		expectedSummaries map[statsDMetricdescription]summaryMetric
+		expectedSummaries map[statsDMetricDescription]summaryMetric
 		err               error
 	}{
 		{
@@ -828,22 +826,16 @@ func TestStatsDParser_AggregateTimerWithSummary(t *testing.T) {
 				"statsdTestMetric2:10|ms|#mykey:myvalue",
 				"statsdTestMetric1:20|ms|#mykey:myvalue",
 			},
-			expectedSummaries: map[statsDMetricdescription]summaryMetric{
+			expectedSummaries: map[statsDMetricDescription]summaryMetric{
 				testDescription("statsdTestMetric1", "ms",
 					[]string{"mykey"}, []string{"myvalue"}): {
-					name:        "statsdTestMetric1",
-					points:      []float64{1, 1, 10, 20, 20},
-					weights:     []float64{1, 1, 1, 1, 1},
-					labelKeys:   []string{"mykey"},
-					labelValues: []string{"myvalue"},
+					points:  []float64{1, 1, 10, 20, 20},
+					weights: []float64{1, 1, 1, 1, 1},
 				},
 				testDescription("statsdTestMetric2", "ms",
 					[]string{"mykey"}, []string{"myvalue"}): {
-					name:        "statsdTestMetric2",
-					points:      []float64{2, 5, 10},
-					weights:     []float64{1, 1, 1},
-					labelKeys:   []string{"mykey"},
-					labelValues: []string{"myvalue"},
+					points:  []float64{2, 5, 10},
+					weights: []float64{1, 1, 1},
 				},
 			},
 		},
@@ -858,22 +850,16 @@ func TestStatsDParser_AggregateTimerWithSummary(t *testing.T) {
 				"statsdTestMetric2:5|h|#mykey:myvalue",
 				"statsdTestMetric2:10|h|#mykey:myvalue",
 			},
-			expectedSummaries: map[statsDMetricdescription]summaryMetric{
+			expectedSummaries: map[statsDMetricDescription]summaryMetric{
 				testDescription("statsdTestMetric1", "h",
 					[]string{"mykey"}, []string{"myvalue"}): {
-					name:        "statsdTestMetric1",
-					points:      []float64{1, 1, 10, 20},
-					weights:     []float64{1, 1, 1, 1},
-					labelKeys:   []string{"mykey"},
-					labelValues: []string{"myvalue"},
+					points:  []float64{1, 1, 10, 20},
+					weights: []float64{1, 1, 1, 1},
 				},
 				testDescription("statsdTestMetric2", "h",
 					[]string{"mykey"}, []string{"myvalue"}): {
-					name:        "statsdTestMetric2",
-					points:      []float64{2, 5, 10},
-					weights:     []float64{1, 1, 1},
-					labelKeys:   []string{"mykey"},
-					labelValues: []string{"myvalue"},
+					points:  []float64{2, 5, 10},
+					weights: []float64{1, 1, 1},
 				},
 			},
 		},
@@ -885,14 +871,11 @@ func TestStatsDParser_AggregateTimerWithSummary(t *testing.T) {
 				"statsdTestMetric1:300|h|@0.1|#mykey:myvalue",
 				"statsdTestMetric1:200|h|@0.01|#mykey:myvalue",
 			},
-			expectedSummaries: map[statsDMetricdescription]summaryMetric{
+			expectedSummaries: map[statsDMetricDescription]summaryMetric{
 				testDescription("statsdTestMetric1", "h",
 					[]string{"mykey"}, []string{"myvalue"}): {
-					name:        "statsdTestMetric1",
-					points:      []float64{300, 100, 300, 200},
-					weights:     []float64{10, 20, 10, 100},
-					labelKeys:   []string{"mykey"},
-					labelValues: []string{"myvalue"},
+					points:  []float64{300, 100, 300, 200},
+					weights: []float64{10, 20, 10, 100},
 				},
 			},
 		},
@@ -917,11 +900,10 @@ func TestStatsDParser_AggregateTimerWithSummary(t *testing.T) {
 func TestStatsDParser_Initialize(t *testing.T) {
 	p := &StatsDParser{}
 	p.Initialize(true, false, []TimerHistogramMapping{{StatsdType: "timer", ObserverType: "gauge"}, {StatsdType: "histogram", ObserverType: "gauge"}})
-	labels := attribute.Distinct{}
-	teststatsdDMetricdescription := statsDMetricdescription{
+	teststatsdDMetricdescription := statsDMetricDescription{
 		name:       "test",
 		metricType: "g",
-		labels:     labels}
+		attrs:      *attribute.EmptySet()}
 	p.gauges[teststatsdDMetricdescription] = pdata.InstrumentationLibraryMetrics{}
 	assert.Equal(t, 1, len(p.gauges))
 	assert.Equal(t, GaugeObserver, p.observeTimer)
@@ -941,14 +923,11 @@ func TestStatsDParser_GetMetricsWithMetricType(t *testing.T) {
 		[]string{"mykey", "metric_type"}, []string{"myvalue", "gauge"})] =
 		buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "g", 0, []string{"mykey", "metric_type"}, []string{"myvalue", "gauge"}), time.Unix(711, 0))
 	p.timersAndDistributions = append(p.timersAndDistributions, buildGaugeMetric(testStatsDMetric("statsdTestMetric1", 10102, false, "ms", 0, []string{"mykey2", "metric_type"}, []string{"myvalue2", "gauge"}), time.Unix(711, 0)))
-	p.summaries = map[statsDMetricdescription]summaryMetric{
+	p.summaries = map[statsDMetricDescription]summaryMetric{
 		testDescription("statsdTestMetric1", "h",
 			[]string{"mykey"}, []string{"myvalue"}): {
-			name:        "statsdTestMetric1",
 			points:      []float64{1, 1, 10, 20},
 			weights:     []float64{1, 1, 1, 1},
-			labelKeys:   []string{"mykey"},
-			labelValues: []string{"myvalue"},
 		}}
 	metrics := p.GetMetrics()
 	assert.Equal(t, 5, metrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().Len())


### PR DESCRIPTION
**Description:** Remove several fields from structs inside the statsdreceiver.

Simplifies existing statsdreceiver code, where there was redundancy. ​No functional changes.

The redundant labelKeys and labelValues are replaced with references to the `attribute.Set`, which contains the same data. The summary struct also had an extra copy of the metric name.