### PR TITLE
`build`: produce darwin arm64 binaries

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -223,6 +223,7 @@ jobs:
       matrix:
         binary:
           - darwin_amd64
+          - darwin_arm64
           - linux_amd64
           - linux_arm64
           - windows_amd64

--- a/.github/workflows/scripts/verify-dist-files-exist.sh
+++ b/.github/workflows/scripts/verify-dist-files-exist.sh
@@ -1,4 +1,5 @@
 files=(
+    bin/otelcontribcol_darwin_arm64
     bin/otelcontribcol_darwin_amd64
     bin/otelcontribcol_linux_arm64
     bin/otelcontribcol_linux_amd64


### PR DESCRIPTION
This will produce binaries for darwin arm64 by adding a new option in the `cross-compile` build job matrix.