### PR TITLE
Separate scrapertest capabilities

### DIFF
--- a/internal/scrapertest/compare_test.go
+++ b/internal/scrapertest/compare_test.go
@@ -254,52 +254,7 @@ func TestCompareMetrics(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := CompareMetricSlices(tc.expected, tc.actual, true)
-			if tc.expectedError != nil {
-				require.Equal(t, tc.expectedError, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestCompareMetricsWithoutComparingValues(t *testing.T) {
-	tcs := []struct {
-		name          string
-		expected      pdata.MetricSlice
-		actual        pdata.MetricSlice
-		expectedError error
-	}{
-		{
-			name: "Ignore mismatched doubleVal",
-			actual: func() pdata.MetricSlice {
-				metrics := baseTestMetrics()
-				m := metrics.At(0)
-				dp := m.Gauge().DataPoints().At(0)
-				dp.SetDoubleVal(123)
-				return metrics
-			}(),
-			expected:      baseTestMetrics(),
-			expectedError: nil,
-		},
-		{
-			name: "Ignore mismatched intVal",
-			actual: func() pdata.MetricSlice {
-				metrics := baseTestMetrics()
-				m := metrics.At(2)
-				dp := m.Sum().DataPoints().At(0)
-				dp.SetIntVal(123)
-				return metrics
-			}(),
-			expected:      baseTestMetrics(),
-			expectedError: nil,
-		},
-	}
-
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			err := CompareMetricSlices(tc.expected, tc.actual, false)
+			err := CompareMetricSlices(tc.expected, tc.actual)
 			if tc.expectedError != nil {
 				require.Equal(t, tc.expectedError, err)
 			} else {

--- a/internal/scrapertest/mask.go
+++ b/internal/scrapertest/mask.go
@@ -1,0 +1,63 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scrapertest // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+// IgnoreValues is a CompareOption that clears all values
+func IgnoreValues() CompareOption {
+	return ignoreValues{}
+}
+
+type ignoreValues struct{}
+
+func (opt ignoreValues) apply(expected, actual pdata.MetricSlice) {
+	maskMetricSliceValues(expected)
+	maskMetricSliceValues(actual)
+}
+
+// maskMetricSliceValues sets all data point values to zero.
+func maskMetricSliceValues(metrics pdata.MetricSlice) {
+	for i := 0; i < metrics.Len(); i++ {
+		maskMetricValues(metrics.At(i))
+	}
+}
+
+// maskMetricValues sets all data point values to zero.
+func maskMetricValues(metric pdata.Metric) {
+	var dataPoints pdata.NumberDataPointSlice
+	switch metric.DataType() {
+	case pdata.MetricDataTypeGauge:
+		dataPoints = metric.Gauge().DataPoints()
+	case pdata.MetricDataTypeSum:
+		dataPoints = metric.Sum().DataPoints()
+	default:
+		panic(fmt.Sprintf("data type not supported: %s", metric.DataType()))
+	}
+	maskDataPointSliceValues(dataPoints)
+}
+
+// maskDataPointSliceValues sets all data point values to zero.
+func maskDataPointSliceValues(dataPoints pdata.NumberDataPointSlice) {
+	for i := 0; i < dataPoints.Len(); i++ {
+		dataPoint := dataPoints.At(i)
+		dataPoint.SetIntVal(0)
+		dataPoint.SetDoubleVal(0)
+	}
+}

--- a/internal/scrapertest/mask_test.go
+++ b/internal/scrapertest/mask_test.go
@@ -1,0 +1,65 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scrapertest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestIgnoreValues(t *testing.T) {
+	tcs := []struct {
+		name          string
+		expected      pdata.MetricSlice
+		actual        pdata.MetricSlice
+		unmaskedError string
+	}{
+		{
+			name: "Ignore mismatched doubleVal",
+			actual: func() pdata.MetricSlice {
+				metrics := baseTestMetrics()
+				m := metrics.At(0)
+				dp := m.Gauge().DataPoints().At(0)
+				dp.SetDoubleVal(123)
+				return metrics
+			}(),
+			expected:      baseTestMetrics(),
+			unmaskedError: `metric datapoint DoubleVal doesn't match expected`,
+		},
+		{
+			name: "Ignore mismatched intVal",
+			actual: func() pdata.MetricSlice {
+				metrics := baseTestMetrics()
+				m := metrics.At(2)
+				dp := m.Sum().DataPoints().At(0)
+				dp.SetIntVal(123)
+				return metrics
+			}(),
+			expected:      baseTestMetrics(),
+			unmaskedError: `metric datapoint IntVal doesn't match expected`,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CompareMetricSlices(tc.expected, tc.actual)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.unmaskedError)
+			require.NoError(t, CompareMetricSlices(tc.expected, tc.actual, IgnoreValues()))
+		})
+	}
+}

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -70,7 +70,7 @@ Scoreboard: S_DD_L_GGG_____W__IIII_C________________W___________________________
 	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	aMetricSlice := scrapedRMS.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, true))
+	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
 }
 
 func TestScraperFailedStart(t *testing.T) {

--- a/receiver/memcachedreceiver/integration_test.go
+++ b/receiver/memcachedreceiver/integration_test.go
@@ -70,5 +70,5 @@ func TestIntegration(t *testing.T) {
 
 	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, false))
+	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, scrapertest.IgnoreValues()))
 }

--- a/receiver/memcachedreceiver/scraper_test.go
+++ b/receiver/memcachedreceiver/scraper_test.go
@@ -41,5 +41,5 @@ func TestScraper(t *testing.T) {
 
 	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	aMetricSlice := ms.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, true))
+	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
 }

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -47,5 +47,5 @@ func TestScrape(t *testing.T) {
 	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	aMetricSlice := scrapedRMS.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, true))
+	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
 }

--- a/receiver/postgresqlreceiver/go.mod
+++ b/receiver/postgresqlreceiver/go.mod
@@ -37,3 +37,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest => ../../internal/scrapertest

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -42,7 +42,7 @@ func TestScraper(t *testing.T) {
 	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	aMetricSlice := scrapedRMS.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, true))
+	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
 }
 
 func TestScraperNoDatabaseSingle(t *testing.T) {
@@ -60,7 +60,7 @@ func TestScraperNoDatabaseSingle(t *testing.T) {
 	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	aMetricSlice := scrapedRMS.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, true))
+	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
 }
 
 func TestScraperNoDatabaseMultiple(t *testing.T) {
@@ -78,7 +78,7 @@ func TestScraperNoDatabaseMultiple(t *testing.T) {
 	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 	aMetricSlice := scrapedRMS.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, true))
+	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
 }
 
 type mockClientFactory struct{ mock.Mock }


### PR DESCRIPTION
The scrapertest package currently has the ability to ignore
metric values while comparing metrics. This is useful for
integration testing, where exact values cannot necessarily be
anticipated.

This establishes an options pattern which allows use cases like
"ignore values" to be composed in a generic way. The ignore values
use case is now an option, and the implementation of the option
is based on masking the values by setting them to zero.

The masking capability here is specific to masking of values on
data points, but other similar capabilities can be added later.
In the long term, a composable set of such capabilities would
be extremely useful for testing purposes, and perhaps elsewhere.