### PR TITLE
Switch nginx scraper test to scrapertest pattern

### DIFF
--- a/receiver/nginxreceiver/go.mod
+++ b/receiver/nginxreceiver/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/nginxinc/nginx-prometheus-exporter v0.8.1-0.20201110005315-f5a5f8086c19
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest v0.40.0
 	github.com/stretchr/testify v1.7.0
 	github.com/testcontainers/testcontainers-go v0.12.0
 	go.opentelemetry.io/collector v0.40.1-0.20211202221455-42566a660aac
@@ -33,7 +34,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/knadh/koanf v1.3.3 // indirect
-	github.com/kr/pretty v0.3.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.2 // indirect
@@ -47,6 +47,7 @@ require (
 	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	github.com/rs/cors v1.8.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
@@ -68,3 +69,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest => ../../internal/scrapertest

--- a/receiver/nginxreceiver/go.sum
+++ b/receiver/nginxreceiver/go.sum
@@ -842,6 +842,7 @@ go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/collector v0.40.1-0.20211202221455-42566a660aac h1:z7pb318aZ8FENczM1L76zl0dcdxEpZvi8jvIrEKSHfk=
 go.opentelemetry.io/collector v0.40.1-0.20211202221455-42566a660aac/go.mod h1:6fswuHfJ2ggGgDvo67PYDCDC3etQVk/ytNkIqccSmQ8=
+go.opentelemetry.io/collector/model v0.36.1-0.20211004155959-190f8fbb2b9a/go.mod h1:ESh1oWDNdS4fTg9sTFoYuiuvs8QuaX8yNGTPix3JZc8=
 go.opentelemetry.io/collector/model v0.40.0/go.mod h1:dXqjAeml+cB+YzJ3kUnd3v5/JvGAKl3MqHXfgSWRIo8=
 go.opentelemetry.io/collector/model v0.40.1-0.20211202221455-42566a660aac h1:8wWhZO/neqUUc9VRkS8rkpPt7wP2NICzH8dvfjh9RAg=
 go.opentelemetry.io/collector/model v0.40.1-0.20211202221455-42566a660aac/go.mod h1:dXqjAeml+cB+YzJ3kUnd3v5/JvGAKl3MqHXfgSWRIo8=
@@ -1093,6 +1094,7 @@ golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210611083646-a4fc73990273/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1281,6 +1283,7 @@ google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc v1.42.0 h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/receiver/nginxreceiver/testdata/scraper/expected.json
+++ b/receiver/nginxreceiver/testdata/scraper/expected.json
@@ -1,0 +1,118 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "otelcol/nginx"
+               },
+               "metrics": [
+                  {
+                     "description": "Total number of requests made to the server since it started",
+                     "name": "nginx.requests",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "31070465",
+                              "timeUnixNano": "1638471548185885000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "requests"
+                  },
+                  {
+                     "description": "The total number of accepted client connections",
+                     "name": "nginx.connections_accepted",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "16630948",
+                              "timeUnixNano": "1638471548185885000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "connections"
+                  },
+                  {
+                     "description": "The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).",
+                     "name": "nginx.connections_handled",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "16630946",
+                              "timeUnixNano": "1638471548185885000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "connections"
+                  },
+                  {
+                     "description": "The current number of nginx connections by state",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "291",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "active"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1638471548185885000"
+                           },
+                           {
+                              "asInt": "6",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "reading"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1638471548185885000"
+                           },
+                           {
+                              "asInt": "179",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "writing"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1638471548185885000"
+                           },
+                           {
+                              "asInt": "106",
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "waiting"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1638471548185885000"
+                           }
+                        ]
+                     },
+                     "name": "nginx.connections_current",
+                     "unit": "connections"
+                  }
+               ]
+            }
+         ],
+         "resource": {}
+      }
+   ]
+}


### PR DESCRIPTION
Depends on #6499 

Adds a golden result file to which the nginx scraper test result
can be compared using the scrapertest package.

Also updates the same test to a potential new standard, pulling in
what seemed to be the best parts of the equivalent apache and mysql
tests. Similar standardization can then be rolled out per receiver.
