### PR TITLE
Fix Error while closing statsd receiver

### DIFF
--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -16,7 +16,9 @@ package statsdreceiver // import "github.com/open-telemetry/opentelemetry-collec
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -90,7 +92,7 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 	ticker := time.NewTicker(r.config.AggregationInterval)
 	r.parser.Initialize(r.config.EnableMetricType, r.config.IsMonotonicCounter, r.config.TimerHistogramMapping)
 	go func() {
-		if err := r.server.ListenAndServe(r.parser, r.nextConsumer, r.reporter, transferChan); err != nil {
+		if err := r.server.ListenAndServe(r.parser, r.nextConsumer, r.reporter, transferChan); !errors.Is(err, net.ErrClosed) {
 			host.ReportFatalError(err)
 		}
 	}()

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -92,8 +92,10 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 	ticker := time.NewTicker(r.config.AggregationInterval)
 	r.parser.Initialize(r.config.EnableMetricType, r.config.IsMonotonicCounter, r.config.TimerHistogramMapping)
 	go func() {
-		if err := r.server.ListenAndServe(r.parser, r.nextConsumer, r.reporter, transferChan); !errors.Is(err, net.ErrClosed) {
-			host.ReportFatalError(err)
+		if err := r.server.ListenAndServe(r.parser, r.nextConsumer, r.reporter, transferChan); err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				host.ReportFatalError(err)
+			}
 		}
 	}()
 	go func() {


### PR DESCRIPTION
**Description:** 
Fix an error while is logged while closing the pipeline, having statsd receiver enabled.
```
2021-12-03T13:48:40.129+0530    error   components/host_wrapper.go:40   Component fatal error   {"kind": "receiver", "name": "statsd", "error": "read udp 127.0.0.1:8125: use of closed network connection"}
go.opentelemetry.io/collector/service/internal/components.(*hostWrapper).ReportFatalError
        /Users/neelay.upadhyaya/golib/pkg/mod/go.opentelemetry.io/collector@v0.40.0/service/internal/components/host_wrapper.go:40
github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver.(*statsdReceiver).Start.func1
        /Users/neelay.upadhyaya/workspace/opentelemetry-collector-contrib/receiver/statsdreceiver/receiver.go:94
```

**Link to tracking Issue:** NA