### PR TITLE
Enable components tests for splunk hex, sapm, signalfx exporters and receivers

### DIFF
--- a/internal/components/exporters_test.go
+++ b/internal/components/exporters_test.go
@@ -37,6 +37,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testutil"
 )
@@ -134,6 +137,33 @@ func TestDefaultExporters(t *testing.T) {
 			exporter: "prometheusremotewrite",
 		},
 		{
+			exporter: "sapm",
+			getConfigFn: func() config.Exporter {
+				cfg := expFactories["sapm"].CreateDefaultConfig().(*sapmexporter.Config)
+				cfg.Endpoint = "http://" + endpoint
+				return cfg
+			},
+		},
+		{
+			exporter: "signalfx",
+			getConfigFn: func() config.Exporter {
+				cfg := expFactories["signalfx"].CreateDefaultConfig().(*signalfxexporter.Config)
+				cfg.AccessToken = "my_fake_token"
+				cfg.IngestURL = "http://" + endpoint
+				cfg.APIURL = "http://" + endpoint
+				return cfg
+			},
+		},
+		{
+			exporter: "splunk_hec",
+			getConfigFn: func() config.Exporter {
+				cfg := expFactories["splunk_hec"].CreateDefaultConfig().(*splunkhecexporter.Config)
+				cfg.Token = "my_fake_token"
+				cfg.Endpoint = "http://" + endpoint
+				return cfg
+			},
+		},
+		{
 			exporter: "zipkin",
 			getConfigFn: func() config.Exporter {
 				cfg := expFactories["zipkin"].CreateDefaultConfig().(*zipkinexporter.Config)
@@ -143,7 +173,7 @@ func TestDefaultExporters(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, len(tests)+28 /* not tested */, len(expFactories))
+	assert.Equal(t, len(tests)+25 /* not tested */, len(expFactories))
 	for _, tt := range tests {
 		t.Run(string(tt.exporter), func(t *testing.T) {
 			factory, ok := expFactories[tt.exporter]

--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -43,6 +43,11 @@ func TestDefaultReceivers(t *testing.T) {
 		getConfigFn  getReceiverConfigFn
 	}{
 		{
+			receiver: "awscontainerinsightreceiver",
+			// TODO: skipped since it will only function in a container environment with procfs in expected location.
+			skipLifecyle: true,
+		},
+		{
 			receiver: "hostmetrics",
 		},
 		{
@@ -51,6 +56,9 @@ func TestDefaultReceivers(t *testing.T) {
 		{
 			receiver:     "kafka",
 			skipLifecyle: true, // TODO: It needs access to internals to successful start.
+		},
+		{
+			receiver: "mongodbatlas",
 		},
 		{
 			receiver:     "opencensus",
@@ -72,19 +80,20 @@ func TestDefaultReceivers(t *testing.T) {
 			},
 		},
 		{
+			receiver: "sapm",
+		},
+		{
+			receiver: "signalfx",
+		},
+		{
+			receiver: "splunk_hec",
+		},
+		{
 			receiver: "zipkin",
-		},
-		{
-			receiver: "mongodbatlas",
-		},
-		{
-			receiver: "awscontainerinsightreceiver",
-			// TODO: skipped since it will only function in a container environment with procfs in expected location.
-			skipLifecyle: true,
 		},
 	}
 
-	assert.Equal(t, len(tests)+31 /* not tested */, len(rcvrFactories))
+	assert.Equal(t, len(tests)+28 /* not tested */, len(rcvrFactories))
 	for _, tt := range tests {
 		t.Run(string(tt.receiver), func(t *testing.T) {
 			factory, ok := rcvrFactories[tt.receiver]

--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -78,12 +78,12 @@ var (
 
 // sfxReceiver implements the component.MetricsReceiver for SignalFx metric protocol.
 type sfxReceiver struct {
-	sync.Mutex
 	settings        component.ReceiverCreateSettings
 	config          *Config
 	metricsConsumer consumer.Metrics
 	logsConsumer    consumer.Logs
 	server          *http.Server
+	shutdownWG      sync.WaitGroup
 	obsrecv         *obsreport.Receiver
 }
 
@@ -112,16 +112,10 @@ func newReceiver(
 }
 
 func (r *sfxReceiver) RegisterMetricsConsumer(mc consumer.Metrics) {
-	r.Lock()
-	defer r.Unlock()
-
 	r.metricsConsumer = mc
 }
 
 func (r *sfxReceiver) RegisterLogsConsumer(lc consumer.Logs) {
-	r.Lock()
-	defer r.Unlock()
-
 	r.logsConsumer = lc
 }
 
@@ -129,9 +123,6 @@ func (r *sfxReceiver) RegisterLogsConsumer(lc consumer.Logs) {
 // By convention the consumer of the received data is set when the receiver
 // instance is created.
 func (r *sfxReceiver) Start(_ context.Context, host component.Host) error {
-	r.Lock()
-	defer r.Unlock()
-
 	if r.metricsConsumer == nil && r.logsConsumer == nil {
 		return componenterror.ErrNilNextConsumer
 	}
@@ -153,7 +144,9 @@ func (r *sfxReceiver) Start(_ context.Context, host component.Host) error {
 	r.server.ReadHeaderTimeout = defaultServerTimeout
 	r.server.WriteTimeout = defaultServerTimeout
 
+	r.shutdownWG.Add(1)
 	go func() {
+		defer r.shutdownWG.Done()
 		if errHTTP := r.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			host.ReportFatalError(errHTTP)
 		}
@@ -164,10 +157,9 @@ func (r *sfxReceiver) Start(_ context.Context, host component.Host) error {
 // Shutdown tells the receiver that should stop reception,
 // giving it a chance to perform any necessary clean-up.
 func (r *sfxReceiver) Shutdown(context.Context) error {
-	r.Lock()
-	defer r.Unlock()
-
-	return r.server.Close()
+	err := r.server.Close()
+	r.shutdownWG.Wait()
+	return err
 }
 
 func (r *sfxReceiver) readBody(ctx context.Context, resp http.ResponseWriter, req *http.Request) ([]byte, bool) {

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -79,6 +79,7 @@ type splunkReceiver struct {
 	logsConsumer    consumer.Logs
 	metricsConsumer consumer.Metrics
 	server          *http.Server
+	shutdownWG      sync.WaitGroup
 	obsrecv         *obsreport.Receiver
 	gzipReaderPool  *sync.Pool
 }
@@ -190,7 +191,9 @@ func (r *splunkReceiver) Start(_ context.Context, host component.Host) error {
 	r.server.ReadHeaderTimeout = defaultServerTimeout
 	r.server.WriteTimeout = defaultServerTimeout
 
+	r.shutdownWG.Add(1)
 	go func() {
+		defer r.shutdownWG.Done()
 		if errHTTP := r.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
 			host.ReportFatalError(errHTTP)
 		}
@@ -202,7 +205,9 @@ func (r *splunkReceiver) Start(_ context.Context, host component.Host) error {
 // Shutdown tells the receiver that should stop reception,
 // giving it a chance to perform any necessary clean-up.
 func (r *splunkReceiver) Shutdown(context.Context) error {
-	return r.server.Close()
+	err := r.server.Close()
+	r.shutdownWG.Wait()
+	return err
 }
 
 func (r *splunkReceiver) handleRawReq(resp http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
