### PR TITLE
[internal/scrapertest] Add CompareOption for ignoring attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `hostmetricsreceiver`: Add MuteProcessNameError config flag to mute specific error reading process executable (#7176)
 - `scrapertest`: Improve comparison logic (#7305)
 - `hostmetricsreceiver`: add `cpu_average` option for load scraper to report the average cpu load (#6999)
+- `scrapertest`: Add comparison option to ignore specific attributes (#6519)
 
 ## 🛑 Breaking changes 🛑
 

--- a/internal/scrapertest/compare_test.go
+++ b/internal/scrapertest/compare_test.go
@@ -282,6 +282,111 @@ func TestCompareMetricSlices(t *testing.T) {
 				reason: "An unpredictable data point value will cause failures if not ignored.",
 			},
 		},
+		{
+			name: "ignore-global-attribute-value",
+			compareOptions: []CompareOption{
+				IgnoreAttributeValue("hostname"),
+			},
+			withoutOptions: expectation{
+				err: multierr.Combine(
+					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.two:value B hostname:random]"),
+				),
+				reason: "An unpredictable attribute value will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err:    nil,
+				reason: "The unpredictable attribute was ignored on all metrics that carried it.",
+			},
+		},
+		{
+			name: "ignore-one-attribute-value",
+			compareOptions: []CompareOption{
+				IgnoreAttributeValue("hostname", "gauge.one"),
+			},
+			withoutOptions: expectation{
+				err: multierr.Combine(
+					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.two:value B hostname:random]"),
+				),
+				reason: "An unpredictable attribute will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err: multierr.Combine(
+					errors.New("datapoints for metric: `sum.one`, do not match expected"),
+					errors.New("metric missing expected datapoint with attributes: map[hostname:also unpredictable]"),
+					errors.New("metric has extra datapoint with attributes: map[hostname:also random]"),
+				),
+				reason: "Although the unpredictable attribute was ignored on one metric, it was not ignored on another.",
+			},
+		},
+		{
+			name: "ignore-each-attribute-value",
+			compareOptions: []CompareOption{
+				IgnoreAttributeValue("hostname", "gauge.one", "sum.one"),
+			},
+			withoutOptions: expectation{
+				err: multierr.Combine(
+					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value A hostname:unpredictable]"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.two:value B hostname:unpredictable]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.two:value A hostname:random]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.two:value B hostname:random]"),
+				),
+				reason: "An unpredictable attribute will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err:    nil,
+				reason: "The unpredictable attribute was ignored on each metric that carried it.",
+			},
+		},
+		{
+			name: "ignore-attribute-set-collision",
+			compareOptions: []CompareOption{
+				IgnoreAttributeValue("attribute.one"),
+			},
+			withoutOptions: expectation{
+				err: multierr.Combine(
+					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.one:one attribute.two:same]"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.one:two attribute.two:same]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.one attribute.two:same]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.two attribute.two:same]"),
+				),
+				reason: "An unpredictable attribute will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err:    nil,
+				reason: "Ignoring the unpredictable attribute caused an attribute set collision, but comparison still works.",
+			},
+		},
+		{
+			name: "ignore-attribute-set-collision-order",
+			compareOptions: []CompareOption{
+				IgnoreAttributeValue("attribute.one"),
+			},
+			withoutOptions: expectation{
+				err: multierr.Combine(
+					errors.New("datapoints for metric: `gauge.one`, do not match expected"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.one:unpredictable.one attribute.two:same]"),
+					errors.New("metric missing expected datapoint with attributes: map[attribute.one:unpredictable.two attribute.two:same]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.two attribute.two:same]"),
+					errors.New("metric has extra datapoint with attributes: map[attribute.one:random.one attribute.two:same]"),
+				),
+				reason: "An unpredictable attribute will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err: nil,
+				reason: "Ignoring the unpredictable attribute caused an attribute set collision where the data point values " +
+					"where in different orders in expected vs actual, but comparison ignores order.",
+			},
+		},
 	}
 
 	for _, tc := range tcs {

--- a/internal/scrapertest/testdata/ignore-attribute-set-collision-order/actual.json
+++ b/internal/scrapertest/testdata/ignore-attribute-set-collision-order/actual.json
@@ -1,0 +1,53 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "asInt": 2,
+                                        "attributes": [
+                                            {
+                                                "key": "attribute.one",
+                                                "value": {
+                                                    "stringValue": "random.two"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "same"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "asInt": 1,
+                                        "attributes": [
+                                            {
+                                                "key": "attribute.one",
+                                                "value": {
+                                                    "stringValue": "random.one"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "same"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-attribute-set-collision-order/expected.json
+++ b/internal/scrapertest/testdata/ignore-attribute-set-collision-order/expected.json
@@ -1,0 +1,53 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "asInt": 1,
+                                        "attributes": [
+                                            {
+                                                "key": "attribute.one",
+                                                "value": {
+                                                    "stringValue": "unpredictable.one"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "same"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "asInt": 2,
+                                        "attributes": [
+                                            {
+                                                "key": "attribute.one",
+                                                "value": {
+                                                    "stringValue": "unpredictable.two"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "same"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-attribute-set-collision/actual.json
+++ b/internal/scrapertest/testdata/ignore-attribute-set-collision/actual.json
@@ -1,0 +1,51 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "attribute.one",
+                                                "value": {
+                                                    "stringValue": "random.one"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "same"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "attribute.one",
+                                                "value": {
+                                                    "stringValue": "random.two"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "same"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-attribute-set-collision/expected.json
+++ b/internal/scrapertest/testdata/ignore-attribute-set-collision/expected.json
@@ -1,0 +1,51 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "attribute.one",
+                                                "value": {
+                                                    "stringValue": "one"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "same"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "attribute.one",
+                                                "value": {
+                                                    "stringValue": "two"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "same"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-each-attribute-value/actual.json
+++ b/internal/scrapertest/testdata/ignore-each-attribute-value/actual.json
@@ -1,0 +1,68 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "random"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value A"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "random"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value B"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sum.one",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "randomvalue"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-each-attribute-value/expected.json
+++ b/internal/scrapertest/testdata/ignore-each-attribute-value/expected.json
@@ -1,0 +1,68 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "unpredictable"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value A"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "unpredictable"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value B"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sum.one",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "unpredictable"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-global-attribute-value/actual.json
+++ b/internal/scrapertest/testdata/ignore-global-attribute-value/actual.json
@@ -1,0 +1,68 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "random"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value A"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "random"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value B"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sum.one",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "randomvalue"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-global-attribute-value/expected.json
+++ b/internal/scrapertest/testdata/ignore-global-attribute-value/expected.json
@@ -1,0 +1,68 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "unpredictable"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value A"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "unpredictable"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value B"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sum.one",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "unpredictable"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-one-attribute-value/actual.json
+++ b/internal/scrapertest/testdata/ignore-one-attribute-value/actual.json
@@ -1,0 +1,68 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "random"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value A"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "random"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value B"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sum.one",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "also random"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-one-attribute-value/expected.json
+++ b/internal/scrapertest/testdata/ignore-one-attribute-value/expected.json
@@ -1,0 +1,68 @@
+{
+    "resourceMetrics": [
+        {
+            "instrumentationLibraryMetrics": [
+                {
+                    "metrics": [
+                        {
+                            "name": "gauge.one",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "unpredictable"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value A"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "unpredictable"
+                                                }
+                                            },
+                                            {
+                                                "key": "attribute.two",
+                                                "value": {
+                                                    "stringValue": "value B"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sum.one",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "hostname",
+                                                "value": {
+                                                    "stringValue": "also unpredictable"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Attribute values are sometimes derived from dynamic environments.
In order to support integration tests, this change provides a new
implementation of scrapertest.CompareOption that can be configured
to ignore specific attribute values.

The CompareOption requires that the attribute name is specified.
Optionally, one or more metric names may be specified as well. If
any metric names are specified, than the attribute value will only
be ignored on those metrics.
