### PR TITLE
[mdatagen] Add support for unstable metric sources to new metrics builder

### DIFF
--- a/cmd/mdatagen/metrics_v2.tmpl
+++ b/cmd/mdatagen/metrics_v2.tmpl
@@ -106,7 +106,7 @@ func NewMetricsBuilder(config MetricsSettings, options ...metricBuilderOption) *
 // defined in metadata and user configuration, e.g. delta/cumulative translation.
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
 	{{- range $name, $metric := .Metrics }}
-	if mb.config.{{- $name.Render }}.Enabled {
+	if mb.config.{{ $name.Render }}.Enabled && mb.metrics.{{ $name.Render }}.{{ $metric.Data.Type }}().DataPoints().Len() > 0 {
 		mb.metrics.{{- $name.Render }}.CopyTo(metrics.AppendEmpty())
 	}
 	{{- end }}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
@@ -99,7 +99,7 @@ func NewMetricsBuilder(config MetricsSettings, options ...metricBuilderOption) *
 // another set of data points. This function will be doing all transformations required to produce metric representation
 // defined in metadata and user configuration, e.g. delta/cumulative translation.
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	if mb.config.SystemCPUTime.Enabled {
+	if mb.config.SystemCPUTime.Enabled && mb.metrics.SystemCPUTime.Sum().DataPoints().Len() > 0 {
 		mb.metrics.SystemCPUTime.CopyTo(metrics.AppendEmpty())
 	}
 


### PR DESCRIPTION
Some metrics scrapers cannot guarantee that all metrics are available on every scrape. This change adds support for such metric sources in the new metrics builder, so it doesn't emit metrics that didn't receive any data points.

Tracking issue: https://github.com/open-telemetry/opentelemetry-collector/issues/10904