### PR TITLE
[extension/oauth2clientauth] Include token URL in error message for contacting token server

### DIFF
--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -106,7 +106,7 @@ func (o *ClientCredentialsAuthenticator) RoundTripper(base http.RoundTripper) (h
 	return &oauth2.Transport{
 		Source: errorWrappingTokenSource{
 			o.clientCredentials.TokenSource(ctx),
-			fmt.Sprintf("failed to get security token from token endpoint %s: %%w", o.clientCredentials.TokenURL),
+			fmt.Sprintf("failed to get security token from token endpoint %q: %%w", o.clientCredentials.TokenURL),
 		},
 		Base: base,
 	}, nil

--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -50,7 +50,7 @@ var _ oauth2.TokenSource = (*errorWrappingTokenSource)(nil)
 // FailedToGetSecurityToken indicates a problem communicating with OAuth2 server.
 // We support Unwrap() instead of using `%w` so that we can customize the error message
 // to include both the wrapped error and information from the configuration.
-type ErrFailedToGetSecurityToken struct {
+type FailedToGetSecurityTokenError struct {
 	inner  error
 	config *clientcredentials.Config
 }
@@ -102,7 +102,7 @@ func (o *ClientCredentialsAuthenticator) Shutdown(_ context.Context) error {
 func (ewts errorWrappingTokenSource) Token() (*oauth2.Token, error) {
 	tok, err := ewts.ts.Token()
 	if err != nil {
-		err = ErrFailedToGetSecurityToken{
+		err = FailedToGetSecurityTokenError{
 			inner:  err,
 			config: ewts.config,
 		}
@@ -136,7 +136,7 @@ func (o *ClientCredentialsAuthenticator) PerRPCCredentials() (credentials.PerRPC
 }
 
 // Error() marks ErrFailedToGetSecurityToken as an `error` type
-func (e ErrFailedToGetSecurityToken) Error() string {
+func (e FailedToGetSecurityTokenError) Error() string {
 	if e.config == nil {
 		return "unconfigured ErrFailedToGetSecurityToken"
 	}
@@ -145,6 +145,6 @@ func (e ErrFailedToGetSecurityToken) Error() string {
 }
 
 // Unwrap() lets ErrFailedToGetSecurityToken work with errors.Is() and errors.As()
-func (e ErrFailedToGetSecurityToken) Unwrap() error {
+func (e FailedToGetSecurityTokenError) Unwrap() error {
 	return e.inner
 }

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -298,7 +298,7 @@ func TestFailContactingOAuth(t *testing.T) {
 	assert.Nil(t, err)
 
 	_, err = credential.GetRequestMetadata(context.Background())
-	assert.ErrorAs(t, err, &ErrFailedToGetSecurityToken{})
+	assert.ErrorAs(t, err, &FailedToGetSecurityTokenError{})
 	assert.Contains(t, err.Error(), "failed to get security token from token endpoint")
 }
 
@@ -330,6 +330,6 @@ func TestFailContactingOAuthViaHttp(t *testing.T) {
 	req, err := http.NewRequest("POST", setting.Endpoint, nil)
 	assert.NoError(t, err)
 	_, err = client.Do(req)
-	assert.ErrorAs(t, err, &ErrFailedToGetSecurityToken{})
+	assert.ErrorAs(t, err, &FailedToGetSecurityTokenError{})
 	assert.Contains(t, err.Error(), "failed to get security token from token endpoint")
 }

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -300,7 +300,7 @@ func TestFailContactingOAuth(t *testing.T) {
 
 	_, err = credential.GetRequestMetadata(context.Background())
 	assert.ErrorIs(t, err, errFailedToGetSecurityToken)
-	assert.Contains(t, err.Error(), "failed to get security token from token endpoint")
+	assert.Contains(t, err.Error(), serverURL.String())
 
 	// Test for HTTP connections
 	setting := confighttp.HTTPClientSettings{
@@ -315,5 +315,5 @@ func TestFailContactingOAuth(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = client.Do(req)
 	assert.ErrorIs(t, err, errFailedToGetSecurityToken)
-	assert.Contains(t, err.Error(), "failed to get security token from token endpoint")
+	assert.Contains(t, err.Error(), serverURL.String())
 }

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -299,7 +299,7 @@ func TestFailContactingOAuth(t *testing.T) {
 	assert.Nil(t, err)
 
 	_, err = credential.GetRequestMetadata(context.Background())
-	assert.ErrorIs(t, err, ErrFailedToGetSecurityToken)
+	assert.ErrorIs(t, err, errFailedToGetSecurityToken)
 	assert.Contains(t, err.Error(), "failed to get security token from token endpoint")
 
 	// Test for HTTP connections
@@ -314,6 +314,6 @@ func TestFailContactingOAuth(t *testing.T) {
 	req, err := http.NewRequest("POST", setting.Endpoint, nil)
 	assert.NoError(t, err)
 	_, err = client.Do(req)
-	assert.ErrorIs(t, err, ErrFailedToGetSecurityToken)
+	assert.ErrorIs(t, err, errFailedToGetSecurityToken)
 	assert.Contains(t, err.Error(), "failed to get security token from token endpoint")
 }

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -17,9 +17,13 @@ package oauth2clientauthextension
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -271,4 +275,61 @@ func TestOAuthExtensionShutdown(t *testing.T) {
 		}, nil)
 	assert.Nil(t, err)
 	assert.Nil(t, oAuthExtensionAuth.Shutdown(context.Background()))
+}
+
+func TestFailContactingOAuth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("not-json"))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	oauth2Authenticator, err := newClientCredentialsExtension(&Config{
+		ClientID:     "dummy",
+		ClientSecret: "ABC",
+		TokenURL:     serverURL.String(),
+	}, zap.NewNop())
+	assert.Nil(t, err)
+
+	credential, err := oauth2Authenticator.PerRPCCredentials()
+	assert.Nil(t, err)
+
+	_, err = credential.GetRequestMetadata(context.Background())
+	assert.ErrorAs(t, err, &ErrFailedToGetSecurityToken{})
+	assert.Contains(t, err.Error(), "failed to get security token from token endpoint")
+}
+
+func TestFailContactingOAuthViaHttp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("not-json"))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	oauth2Authenticator, err := newClientCredentialsExtension(&Config{
+		ClientID:     "dummy",
+		ClientSecret: "ABC",
+		TokenURL:     serverURL.String(),
+	}, zap.NewNop())
+	assert.Nil(t, err)
+
+	setting := confighttp.HTTPClientSettings{
+		Endpoint: "http://example.com/",
+		CustomRoundTripper: func(next http.RoundTripper) (http.RoundTripper, error) {
+			return oauth2Authenticator.RoundTripper(next)
+		},
+	}
+
+	client, _ := setting.ToClient(componenttest.NewNopHost().GetExtensions())
+	req, err := http.NewRequest("POST", setting.Endpoint, nil)
+	assert.NoError(t, err)
+	_, err = client.Do(req)
+	assert.ErrorAs(t, err, &ErrFailedToGetSecurityToken{})
+	assert.Contains(t, err.Error(), "failed to get security token from token endpoint")
 }

--- a/extension/oauth2clientauthextension/go.mod
+++ b/extension/oauth2clientauthextension/go.mod
@@ -13,9 +13,14 @@ require (
 require (
 	cloud.google.com/go/compute v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/go-logr/logr v1.2.1 // indirect
+	github.com/go-logr/stdr v1.2.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/knadh/koanf v1.4.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
@@ -25,15 +30,21 @@ require (
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rs/cors v1.8.2 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	go.opentelemetry.io/collector/model v0.42.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.28.0 // indirect
 	go.opentelemetry.io/otel v1.3.0 // indirect
+	go.opentelemetry.io/otel/internal/metric v0.26.0 // indirect
 	go.opentelemetry.io/otel/metric v0.26.0 // indirect
 	go.opentelemetry.io/otel/trace v1.3.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
+	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20211221195035-429b39de9b1c // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

**Description:**

Include token URL in error messages.

With the current code, traces can fail to be exported and it isn't clear in the logs if the problem occurred contacting the auth server or the OTLP server.  I became confused when I received the error message

```
info	exporterhelper/queued_retry.go:215	Exporting failed. Will retry the request after interval.
{"kind": "exporter", "name": "otlphttp/withauth",
"error": "failed to make an HTTP request: Post \"http://localhost:9000/v1/traces\": 
invalid character '<' looking for beginning of value", "interval": "26.130242547s"}
```

In this case the system intended to POST to localhost:9000, but it hadn't reached that point yet.  The error message confused me ... I thought localhost:9000 was responding incorrectly.  With this PR, the message becomes

```
info	exporterhelper/queued_retry.go:215	Exporting failed. Will retry the request after interval.
{"kind": "exporter", "name": "otlphttp/withauth",
"error": "failed to make an HTTP request: Post \"http://localhost:9000/v1/traces\": 
failed to get security token from token endpoint \"https://keycloak.example.com/auth/\": 
invalid character '<' looking for beginning of value", "interval": "2.93289963s"}
```

Note that the current error messages make sense if the incorrect TokenURL config generates a 40x error.  My problem was that I was using an incorrect TokenURL with a server that returned HTTP Status 200 and HTML rather than JSON.  Many of the error messages returned by golang.org/x/oauth2 are very short.  This PR should help someone looking at the logs to see that the error relates to authorization.

**Link to tracking Issue:**

None

**Testing:**

None.  I wasn't quite sure how to test this.  If tests are mandatory, please advise and hint at where I might be able to reveal the new behavior through a test.

**Documentation:**

None