### PR TITLE
[receiver/zookeeper] Validate scraper test results using scrapertest.CompareMetricSlices

### DIFF
--- a/receiver/zookeeperreceiver/go.mod
+++ b/receiver/zookeeperreceiver/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.41.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.41.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest v0.41.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.41.1-0.20211210184707-4dcb3388a168
 	go.opentelemetry.io/collector/model v0.41.1-0.20211210184707-4dcb3388a168
@@ -50,3 +51,5 @@ require (
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest => ../../internal/scrapertest

--- a/receiver/zookeeperreceiver/go.sum
+++ b/receiver/zookeeperreceiver/go.sum
@@ -830,6 +830,7 @@ go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/collector v0.41.1-0.20211210184707-4dcb3388a168 h1:fcQl8iYpfiPOEERWcdq38k8saI/0basWaIeR9NUy2H0=
 go.opentelemetry.io/collector v0.41.1-0.20211210184707-4dcb3388a168/go.mod h1:gDB73Qn8xl4zm29krVahgBLHyM+8CUX9FbnmBqFriX0=
+go.opentelemetry.io/collector/model v0.36.1-0.20211004155959-190f8fbb2b9a/go.mod h1:ESh1oWDNdS4fTg9sTFoYuiuvs8QuaX8yNGTPix3JZc8=
 go.opentelemetry.io/collector/model v0.41.0/go.mod h1:dXqjAeml+cB+YzJ3kUnd3v5/JvGAKl3MqHXfgSWRIo8=
 go.opentelemetry.io/collector/model v0.41.1-0.20211210184707-4dcb3388a168 h1:Mxbgv1PG8fYCOu19m59IRSl4f2pohgNL9t3YwVrIgok=
 go.opentelemetry.io/collector/model v0.41.1-0.20211210184707-4dcb3388a168/go.mod h1:dXqjAeml+cB+YzJ3kUnd3v5/JvGAKl3MqHXfgSWRIo8=
@@ -1271,6 +1272,7 @@ google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.json
@@ -1,0 +1,219 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "otelcol/zookeeper"
+               },
+               "metrics": [
+                  {
+                     "description": "Average time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.avg",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Maximum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.max",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Minimum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.min",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets received by a server.",
+                     "name": "zookeeper.packets.received",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets sent by a server.",
+                     "name": "zookeeper.packets.sent",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.connections_alive",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of currently executing requests.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.outstanding_requests",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.znodes",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.watches",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.ephemeral_nodes",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "27",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.approximate_date_size",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "26",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.open_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.max_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of times fsync duration has exceeded warning threshold.",
+                     "name": "zookeeper.fsync_threshold_exceeds",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349819599000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  }
+               ]
+            }
+         ],
+         "resource": {
+            "attributes": [
+               {
+                  "key": "zk.version",
+                  "value": {
+                     "stringValue": "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf"
+                  }
+               },
+               {
+                  "key": "server.state",
+                  "value": {
+                     "stringValue": "standalone"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.json
@@ -1,0 +1,243 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "otelcol/zookeeper"
+               },
+               "metrics": [
+                  {
+                     "description": "Average time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.avg",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Maximum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.max",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Minimum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.min",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets received by a server.",
+                     "name": "zookeeper.packets.received",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets sent by a server.",
+                     "name": "zookeeper.packets.sent",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.connections_alive",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of currently executing requests.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.outstanding_requests",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "5",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.znodes",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.watches",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.ephemeral_nodes",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "107",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.approximate_date_size",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "54",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.open_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.max_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of followers in sync with the leader. Only exposed by the leader.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.followers",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of followers in sync with the leader. Only exposed by the leader.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.synced_followers",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of pending syncs from the followers. Only exposed by the leader.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349824550000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.pending_syncs",
+                     "unit": "1"
+                  }
+               ]
+            }
+         ],
+         "resource": {
+            "attributes": [
+               {
+                  "key": "zk.version",
+                  "value": {
+                     "stringValue": "3.5.5-390fe37ea45dee01bf87dc1c042b5e3dcce88653"
+                  }
+               },
+               {
+                  "key": "server.state",
+                  "value": {
+                     "stringValue": "leader"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/receiver/zookeeperreceiver/testdata/scraper/disable-watches.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/disable-watches.json
@@ -1,0 +1,219 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "otelcol/zookeeper"
+               },
+               "metrics": [
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "27",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.approximate_date_size",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.connections_alive",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.ephemeral_nodes",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of times fsync duration has exceeded warning threshold.",
+                     "name": "zookeeper.fsync_threshold_exceeds",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Average time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.avg",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Maximum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.max",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Minimum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.min",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.max_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "26",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.open_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of currently executing requests.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.outstanding_requests",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets received by a server.",
+                     "name": "zookeeper.packets.received",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets sent by a server.",
+                     "name": "zookeeper.packets.sent",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "startTimeUnixNano": "1639420804654952000",
+                              "timeUnixNano": "1639420804655313000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.znodes",
+                     "unit": "1"
+                  }
+               ]
+            }
+         ],
+         "resource": {
+            "attributes": [
+               {
+                  "key": "zk.version",
+                  "value": {
+                     "stringValue": "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf"
+                  }
+               },
+               {
+                  "key": "server.state",
+                  "value": {
+                     "stringValue": "standalone"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.json
@@ -1,0 +1,219 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "otelcol/zookeeper"
+               },
+               "metrics": [
+                  {
+                     "description": "Average time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.avg",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Maximum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.max",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Minimum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.min",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets received by a server.",
+                     "name": "zookeeper.packets.received",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets sent by a server.",
+                     "name": "zookeeper.packets.sent",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.connections_alive",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of currently executing requests.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.outstanding_requests",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.znodes",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.watches",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.ephemeral_nodes",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "27",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.approximate_date_size",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "26",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.open_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.max_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of times fsync duration has exceeded warning threshold.",
+                     "name": "zookeeper.fsync_threshold_exceeds",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349835472000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  }
+               ]
+            }
+         ],
+         "resource": {
+            "attributes": [
+               {
+                  "key": "zk.version",
+                  "value": {
+                     "stringValue": "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf"
+                  }
+               },
+               {
+                  "key": "server.state",
+                  "value": {
+                     "stringValue": "standalone"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.json
@@ -1,0 +1,219 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "otelcol/zookeeper"
+               },
+               "metrics": [
+                  {
+                     "description": "Average time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.avg",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Maximum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.max",
+                     "unit": "ms"
+                  },
+                  {
+                     "description": "Minimum time in milliseconds for requests to be processed.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.latency.min",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets received by a server.",
+                     "name": "zookeeper.packets.received",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ZooKeeper packets sent by a server.",
+                     "name": "zookeeper.packets.sent",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.connections_alive",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of currently executing requests.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.outstanding_requests",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.znodes",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.watches",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.ephemeral_nodes",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "27",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.approximate_date_size",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "26",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.open_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.max_file_descriptors",
+                     "unit": "1"
+                  },
+                  {
+                     "description": "Number of times fsync duration has exceeded warning threshold.",
+                     "name": "zookeeper.fsync_threshold_exceeds",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "timeUnixNano": "1638801349833222000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  }
+               ]
+            }
+         ],
+         "resource": {
+            "attributes": [
+               {
+                  "key": "zk.version",
+                  "value": {
+                     "stringValue": "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf"
+                  }
+               },
+               {
+                  "key": "server.state",
+                  "value": {
+                     "stringValue": "standalone"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}


### PR DESCRIPTION
Resolves #6814 

The new scrapertest package provides a clearer and more traceable
mechanism for defining expected metric results. This refactors the
existing scraper tests into the scrapertest pattern, without
making any other changes.
