### PR TITLE
 Add retry and timeout for prometheus exporter

### DIFF
--- a/exporter/prometheusexporter/config.go
+++ b/exporter/prometheusexporter/config.go
@@ -19,13 +19,20 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/collector/config"
-
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry"
 )
 
 // Config defines configuration for Prometheus exporter.
 type Config struct {
-	config.ExporterSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	// squash ensures fields are correctly decoded in embedded struct
+	config.ExporterSettings `mapstructure:",squash"`
+
+	//Retry on failure ensures Prometheus Export interfaces are reliable because of HTTP Request relating to network issues, Timeout,...
+	//Documentation: https://pkg.go.dev/go.opentelemetry.io/collector/exporter/exporterhelper#RetrySettings
+	//Default values: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.39.0/exporter/exporterhelper/queued_retry.go#L52
+	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
+	exporterhelper.TimeoutSettings `mapstructure:",squash"`
 
 	// The address on which the Prometheus scrape handler will be run on.
 	Endpoint string `mapstructure:"endpoint"`

--- a/exporter/prometheusexporter/config_test.go
+++ b/exporter/prometheusexporter/config_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -49,6 +50,15 @@ func TestLoadConfig(t *testing.T) {
 			ConstLabels: map[string]string{
 				"label1":        "value1",
 				"another label": "spaced value",
+			},
+			TimeoutSettings: exporterhelper.TimeoutSettings{
+				Timeout: 20 * time.Second,
+			},
+			RetrySettings: exporterhelper.RetrySettings{
+				Enabled:         true,
+				InitialInterval: 10 * time.Second,
+				MaxInterval:     1 * time.Minute,
+				MaxElapsedTime:  10 * time.Minute,
 			},
 			SendTimestamps:   true,
 			MetricExpiration: 60 * time.Minute,

--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -71,6 +72,15 @@ func TestEndToEndSummarySupport(t *testing.T) {
 		Endpoint:         ":8787",
 		SendTimestamps:   true,
 		MetricExpiration: 2 * time.Hour,
+		TimeoutSettings: exporterhelper.TimeoutSettings{
+			Timeout: 20 * time.Second,
+		},
+		RetrySettings: exporterhelper.RetrySettings{
+			Enabled:         true,
+			InitialInterval: 10 * time.Second,
+			MaxInterval:     1 * time.Minute,
+			MaxElapsedTime:  10 * time.Minute,
+		},
 	}
 	exporterFactory := NewFactory()
 	set := componenttest.NewNopExporterCreateSettings()

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -29,6 +29,7 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "prometheus"
+	defaultTimeout = 20 * time.Second
 )
 
 // NewFactory creates a new Prometheus exporter factory.
@@ -42,6 +43,8 @@ func NewFactory() component.ExporterFactory {
 func createDefaultConfig() config.Exporter {
 	return &Config{
 		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
+		TimeoutSettings:  exporterhelper.TimeoutSettings{Timeout: defaultTimeout},
+		RetrySettings:    exporterhelper.DefaultRetrySettings(),
 		ConstLabels:      map[string]string{},
 		SendTimestamps:   false,
 		MetricExpiration: time.Minute * 5,

--- a/exporter/prometheusexporter/testdata/config.yaml
+++ b/exporter/prometheusexporter/testdata/config.yaml
@@ -14,6 +14,12 @@ exporters:
       "another label": spaced value
     send_timestamps: true
     metric_expiration: 60m
+    timeout: 20s
+    retry_on_failure:
+      enabled: true
+      initial_interval: 10s
+      max_interval: 60s
+      max_elapsed_time: 10m
 
 service:
   pipelines:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Instead of letting the Prometheus exporter  use the default setting, let's the customer to setting their own retry. In this way, it can impact the overall retry strategy.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4988

**Documentation:** <Describe the documentation added.>
**Retry Setting:** https://pkg.go.dev/go.opentelemetry.io/collector/exporter/exporterhelper#RetrySettings
**Timeout Setting:** https://pkg.go.dev/go.opentelemetry.io/collector/exporter/exporterhelper#TimeoutSettings