### PR TITLE
`lokiexporter`: add complete log record to body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## 💡 Enhancements 💡
 
+- `lokiexporter`: add complete log record to body (#6619)
+
 ## v0.41.0
 
 ## 🛑 Breaking changes 🛑

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -51,9 +51,9 @@ func newExporter(config *Config, logger *zap.Logger) *lokiExporter {
 		logger: logger,
 	}
 	if config.Format == "json" {
-		lokiexporter.convert = convertLogToJSONEntry
+		lokiexporter.convert = lokiexporter.convertLogToJSONEntry
 	} else {
-		lokiexporter.convert = convertLogBodyToEntry
+		lokiexporter.convert = lokiexporter.convertLogBodyToEntry
 	}
 	return lokiexporter
 }
@@ -227,14 +227,50 @@ func (l *lokiExporter) convertAttributesToLabels(attributes pdata.AttributeMap, 
 	return ls
 }
 
-func convertLogBodyToEntry(lr pdata.LogRecord, res pdata.Resource) (*logproto.Entry, error) {
+func (l *lokiExporter) convertLogBodyToEntry(lr pdata.LogRecord, res pdata.Resource) (*logproto.Entry, error) {
+	body := lr.Body().StringVal()
+
+	if len(lr.Name()) > 0 {
+		body = fmt.Sprintf("name=%s %s", lr.Name(), body)
+	}
+	if len(lr.SeverityText()) > 0 {
+		body = fmt.Sprintf("severity=%s %s", lr.SeverityText(), body)
+	}
+	if lr.SeverityNumber() > 0 {
+		body = fmt.Sprintf("severityN=%d %s", lr.SeverityNumber(), body)
+	}
+	if !lr.TraceID().IsEmpty() {
+		body = fmt.Sprintf("traceID=%s %s", lr.TraceID().HexString(), body)
+	}
+	if !lr.SpanID().IsEmpty() {
+		body = fmt.Sprintf("spanID=%s %s", lr.SpanID().HexString(), body)
+	}
+
+	// fields not added to the accept-list as part of the component's config
+	// are added to the body, so that they can still be seen under "detected fields"
+	lr.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
+		if _, found := l.config.Labels.Attributes[k]; !found {
+			body = fmt.Sprintf("%s=%s %s", k, v.AsString(), body)
+		}
+		return true
+	})
+
+	// same for resources: include all, except the ones that are explicitly added
+	// as part of the config, which are showing up at the top-level already
+	res.Attributes().Range(func(k string, v pdata.AttributeValue) bool {
+		if _, found := l.config.Labels.ResourceAttributes[k]; !found {
+			body = fmt.Sprintf("%s=%s %s", k, v.AsString(), body)
+		}
+		return true
+	})
+
 	return &logproto.Entry{
 		Timestamp: time.Unix(0, int64(lr.Timestamp())),
-		Line:      lr.Body().StringVal(),
+		Line:      body,
 	}, nil
 }
 
-func convertLogToJSONEntry(lr pdata.LogRecord, res pdata.Resource) (*logproto.Entry, error) {
+func (l *lokiExporter) convertLogToJSONEntry(lr pdata.LogRecord, res pdata.Resource) (*logproto.Entry, error) {
 	line, err := encodeJSON(lr, res)
 	if err != nil {
 		return nil, err

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -473,18 +473,33 @@ func TestExporter_convertAttributesToLabels(t *testing.T) {
 }
 
 func TestExporter_convertLogBodyToEntry(t *testing.T) {
-	ts := pdata.Timestamp(int64(1) * time.Millisecond.Nanoseconds())
-	lr := pdata.NewLogRecord()
-	lr.Body().SetStringVal("log message")
-	lr.SetTimestamp(ts)
 	res := pdata.NewResource()
 	res.Attributes().Insert("host.name", pdata.NewAttributeValueString("something"))
+	res.Attributes().Insert("pod.name", pdata.NewAttributeValueString("something123"))
 
-	entry, _ := convertLogBodyToEntry(lr, res)
+	lr := pdata.NewLogRecord()
+	lr.SetName("Checkout")
+	lr.Body().SetStringVal("Payment succeeded")
+	lr.SetTraceID(pdata.NewTraceID([16]byte{1, 2, 3, 4}))
+	lr.SetSpanID(pdata.NewSpanID([8]byte{5, 6, 7, 8}))
+	lr.SetSeverityText("DEBUG")
+	lr.SetSeverityNumber(pdata.SeverityNumberDEBUG)
+	lr.Attributes().Insert("payment_method", pdata.NewAttributeValueString("credit_card"))
+
+	ts := pdata.Timestamp(int64(1) * time.Millisecond.Nanoseconds())
+	lr.SetTimestamp(ts)
+
+	exp := newExporter(&Config{
+		Labels: LabelsConfig{
+			Attributes:         map[string]string{"payment_method": "payment_method"},
+			ResourceAttributes: map[string]string{"pod.name": "pod.name"},
+		},
+	}, zap.NewNop())
+	entry, _ := exp.convertLogBodyToEntry(lr, res)
 
 	expEntry := &logproto.Entry{
 		Timestamp: time.Unix(0, int64(lr.Timestamp())),
-		Line:      "log message",
+		Line:      "host.name=something spanID=0506070800000000 traceID=01020304000000000000000000000000 severityN=5 severity=DEBUG name=Checkout Payment succeeded",
 	}
 	require.NotNil(t, entry)
 	require.Equal(t, expEntry, entry)
@@ -587,7 +602,8 @@ func TestExporter_convertLogtoJSONEntry(t *testing.T) {
 	res := pdata.NewResource()
 	res.Attributes().Insert("host.name", pdata.NewAttributeValueString("something"))
 
-	entry, err := convertLogToJSONEntry(lr, res)
+	exp := newExporter(&Config{}, zap.NewNop())
+	entry, err := exp.convertLogToJSONEntry(lr, res)
 	expEntry := &logproto.Entry{
 		Timestamp: time.Unix(0, int64(lr.Timestamp())),
 		Line:      `{"body":"log message","resources":{"host.name":"something"}}`,

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -499,7 +499,7 @@ func TestExporter_convertLogBodyToEntry(t *testing.T) {
 
 	expEntry := &logproto.Entry{
 		Timestamp: time.Unix(0, int64(lr.Timestamp())),
-		Line:      "host.name=something spanID=0506070800000000 traceID=01020304000000000000000000000000 severityN=5 severity=DEBUG name=Checkout Payment succeeded",
+		Line:      "name=Checkout severity=DEBUG severityN=5 traceID=01020304000000000000000000000000 spanID=0506070800000000 host.name=something Payment succeeded",
 	}
 	require.NotNil(t, entry)
 	require.Equal(t, expEntry, entry)


### PR DESCRIPTION
Fixes #6618 by adding most fields, as well as the attributes and resource attributes not present in the config as part of the log body.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
