### PR TITLE
[mdatagen] Use MoveTo instead of CopyTo in the new metric generator

### DIFF
--- a/cmd/mdatagen/metrics_v2.tmpl
+++ b/cmd/mdatagen/metrics_v2.tmpl
@@ -107,7 +107,7 @@ func NewMetricsBuilder(config MetricsSettings, options ...metricBuilderOption) *
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
 	{{- range $name, $metric := .Metrics }}
 	if mb.config.{{ $name.Render }}.Enabled && mb.metrics.{{ $name.Render }}.{{ $metric.Data.Type }}().DataPoints().Len() > 0 {
-		mb.metrics.{{- $name.Render }}.CopyTo(metrics.AppendEmpty())
+		mb.metrics.{{- $name.Render }}.MoveTo(metrics.AppendEmpty())
 	}
 	{{- end }}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
@@ -100,7 +100,7 @@ func NewMetricsBuilder(config MetricsSettings, options ...metricBuilderOption) *
 // defined in metadata and user configuration, e.g. delta/cumulative translation.
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
 	if mb.config.SystemCPUTime.Enabled && mb.metrics.SystemCPUTime.Sum().DataPoints().Len() > 0 {
-		mb.metrics.SystemCPUTime.CopyTo(metrics.AppendEmpty())
+		mb.metrics.SystemCPUTime.MoveTo(metrics.AppendEmpty())
 	}
 
 	// Reset metric data points collection.


### PR DESCRIPTION
We don't need to keep the metric that was recorded, so instead of copying we can just move them to save some CPU cycles.

Related comment: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6418#discussion_r761493799