### PR TITLE
Make ALL_MODULES env var confugurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ COMP_REL_PATH=internal/components/components.go
 MOD_NAME=github.com/open-telemetry/opentelemetry-collector-contrib
 
 # ALL_MODULES includes ./* dirs (excludes . dir and example with go code)
-ALL_MODULES := $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep '^./' )
+ALL_MODULES ?= $(shell find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep '^./' )
 # Modules to run integration tests on.
 # XXX: Find a way to automatically populate this. Too slow to run across all modules when there are just a few.
 INTEGRATION_TEST_MODULES := \


### PR DESCRIPTION
Having a way to override ALL_MODULES env var helps a lot in case when you want to run specific make targets on some set of modules and save time when running it against all modules is unnecessary
