### PR TITLE
Google Cloud Spanner Receiver: Added fallback to ADC for database connections.

### DIFF
--- a/receiver/googlecloudspannerreceiver/README.md
+++ b/receiver/googlecloudspannerreceiver/README.md
@@ -53,13 +53,13 @@ receivers:
 
 Brief description of configuration properties:
 - **googlecloudspanner** - name of the Cloud Spanner Receiver related section in OpenTelemetry collector configuration file
-- **collection_interval** - this receiver runs periodically. Each time it runs, it queries Google Cloud Spanner, creates metrics, and sends them to the next consumer (default: 1 minute). **It is not recommended change the default value of collection interval, since new values for metrics in the Spanner database appear only once a minute.**
+- **collection_interval** - this receiver runs periodically. Each time it runs, it queries Google Cloud Spanner, creates metrics, and sends them to the next consumer (default: 1 minute). **It is not recommended to change the default value of collection interval, since new values for metrics in the Spanner database appear only once a minute.**
 - **top_metrics_query_max_rows** - max number of rows to fetch from Top N built-in table(100 by default)
 - **backfill_enabled** - turn on/off 1-hour data backfill(by default it is turned off)
 - **cardinality_total_limit** - limit of active series per 24 hours period. If specified, turns on cardinality filtering and handling. If zero or not specified, cardinality is not handled. You can read [this document](cardinality.md) for more information about cardinality handling and filtering.
 - **projects** - list of GCP projects
     - **project_id** - identifier of GCP project
-    - **service_account_key** - path to service account JSON key. It is highly recommended set this property to correct value. In case it is empty [Application Default Credentials](https://google.aip.dev/auth/4110) will be used for database connection.
+    - **service_account_key** - path to service account JSON key It is highly recommended to set this property to the correct value. In case it is empty, the [Application Default Credentials](https://google.aip.dev/auth/4110) will be used for the database connection.
     - **instances** - list of Google Cloud Spanner instance for connection
         - **instance_id** - identifier of Google Cloud Spanner instance
         - **databases** - list of databases used from this instance

--- a/receiver/googlecloudspannerreceiver/README.md
+++ b/receiver/googlecloudspannerreceiver/README.md
@@ -53,13 +53,13 @@ receivers:
 
 Brief description of configuration properties:
 - **googlecloudspanner** - name of the Cloud Spanner Receiver related section in OpenTelemetry collector configuration file
-- **collection_interval** - this receiver runs periodically. Each time it runs, it queries Google Cloud Spanner, creates metrics, and sends them to the next consumer (default: 1 minute). **It is not recommended to change the default value of collection interval, since new values for metrics in the Spanner database appear only once a minute.**
+- **collection_interval** - this receiver runs periodically. Each time it runs, it queries Google Cloud Spanner, creates metrics, and sends them to the next consumer (default: 1 minute). **It is not recommended change the default value of collection interval, since new values for metrics in the Spanner database appear only once a minute.**
 - **top_metrics_query_max_rows** - max number of rows to fetch from Top N built-in table(100 by default)
 - **backfill_enabled** - turn on/off 1-hour data backfill(by default it is turned off)
 - **cardinality_total_limit** - limit of active series per 24 hours period. If specified, turns on cardinality filtering and handling. If zero or not specified, cardinality is not handled. You can read [this document](cardinality.md) for more information about cardinality handling and filtering.
 - **projects** - list of GCP projects
     - **project_id** - identifier of GCP project
-    - **service_account_key** - path to service account JSON key
+    - **service_account_key** - path to service account JSON key. It is highly recommended set this property to correct value. In case it is empty [Application Default Credentials](https://google.aip.dev/auth/4110) will be used for database connection.
     - **instances** - list of Google Cloud Spanner instance for connection
         - **instance_id** - identifier of Google Cloud Spanner instance
         - **databases** - list of databases used from this instance

--- a/receiver/googlecloudspannerreceiver/config.go
+++ b/receiver/googlecloudspannerreceiver/config.go
@@ -15,6 +15,7 @@
 package googlecloudspannerreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver"
 
 import (
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
@@ -81,7 +82,7 @@ func (config *Config) Validate() error {
 
 func (project Project) Validate() error {
 	if project.ID == "" {
-		return fmt.Errorf("field %q is required and cannot be empty for project configuration", "project_id")
+		return errors.New(`field "project_id" is required and cannot be empty for project configuration`)
 	}
 
 	if len(project.Instances) <= 0 {

--- a/receiver/googlecloudspannerreceiver/config.go
+++ b/receiver/googlecloudspannerreceiver/config.go
@@ -16,7 +16,6 @@ package googlecloudspannerreceiver // import "github.com/open-telemetry/opentele
 
 import (
 	"fmt"
-	"strings"
 
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 )
@@ -81,18 +80,8 @@ func (config *Config) Validate() error {
 }
 
 func (project Project) Validate() error {
-	var missingFields []string
-
 	if project.ID == "" {
-		missingFields = append(missingFields, "\"project_id\"")
-	}
-
-	if project.ServiceAccountKey == "" {
-		missingFields = append(missingFields, "\"service_account_key\"")
-	}
-
-	if len(missingFields) > 0 {
-		return fmt.Errorf("field(s) %v is(are) required for project configuration", strings.Join(missingFields, ", "))
+		return fmt.Errorf("field %q is required and cannot be empty for project configuration", "project_id")
 	}
 
 	if len(project.Instances) <= 0 {

--- a/receiver/googlecloudspannerreceiver/config_test.go
+++ b/receiver/googlecloudspannerreceiver/config_test.go
@@ -123,7 +123,7 @@ func TestValidateProject(t *testing.T) {
 	}{
 		"All required fields are populated": {"id", "key", []Instance{instance}, false},
 		"No id":                             {"", "key", []Instance{instance}, true},
-		"No service account key":            {"id", "", []Instance{instance}, true},
+		"No service account key":            {"id", "", []Instance{instance}, false},
 		"No instances":                      {"id", "key", nil, true},
 		"Invalid instance in instances":     {"id", "key", []Instance{{}}, true},
 	}

--- a/receiver/googlecloudspannerreceiver/internal/datasource/database.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/database.go
@@ -35,8 +35,16 @@ func (database *Database) DatabaseID() *DatabaseID {
 }
 
 func NewDatabase(ctx context.Context, databaseID *DatabaseID, credentialsFilePath string) (*Database, error) {
-	credentialsFileClientOption := option.WithCredentialsFile(credentialsFilePath)
-	client, err := spanner.NewClient(ctx, databaseID.ID(), credentialsFileClientOption)
+	var client *spanner.Client
+	var err error
+
+	if credentialsFilePath != "" {
+		credentialsFileClientOption := option.WithCredentialsFile(credentialsFilePath)
+		client, err = spanner.NewClient(ctx, databaseID.ID(), credentialsFileClientOption)
+	} else {
+		// Fallback to Application Default Credentials(https://google.aip.dev/auth/4110)
+		client, err = spanner.NewClient(ctx, databaseID.ID())
+	}
 
 	if err != nil {
 		return nil, err

--- a/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
@@ -53,3 +53,14 @@ func TestNewDatabaseWithError(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, database)
 }
+
+func TestNewDatabaseWithNoCredentialsFilePath(t *testing.T) {
+	ctx := context.Background()
+	databaseID := databaseID()
+
+	database, err := NewDatabase(ctx, databaseID, "")
+
+	assert.Nil(t, err)
+	assert.NotNil(t, database.Client())
+	assert.Equal(t, databaseID, database.DatabaseID())
+}

--- a/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
@@ -16,10 +16,12 @@ package datasource
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"cloud.google.com/go/spanner"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDatabaseFromClient(t *testing.T) {
@@ -57,6 +59,14 @@ func TestNewDatabaseWithError(t *testing.T) {
 func TestNewDatabaseWithNoCredentialsFilePath(t *testing.T) {
 	ctx := context.Background()
 	databaseID := databaseID()
+
+	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "../../testdata/serviceAccount.json")
+	require.NoError(t, err)
+
+	defer func() {
+		err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+		require.NoError(t, err)
+	}()
 
 	database, err := NewDatabase(ctx, databaseID, "")
 


### PR DESCRIPTION
Added fallback to Application Default Credentials(https://google.aip.dev/auth/4110) for database connections in case service account key is not specified explicitly in receiver GCP project configuration.