### PR TITLE
[receiver/fluentforward] Convert attributes with nil value to AttributeValueTypeEmpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `observiqexporter`: Allow Dialer timeout to be configured (#5906)
 - `routingprocessor`: remove broken debug log fields (#6373)
 - `prometheusremotewriteexporter`: Add exemplars support (#5578) 
+- `fluentforwardreceiver`: Convert attributes with nil value to AttributeValueTypeEmpty (#6630)
 
 ## 🚀 New components 🚀
 

--- a/receiver/fluentforwardreceiver/conversion.go
+++ b/receiver/fluentforwardreceiver/conversion.go
@@ -127,6 +127,8 @@ func parseToAttributeValue(val interface{}) pdata.AttributeValue {
 		return pdata.NewAttributeValueDouble(float64(r))
 	case float64:
 		return pdata.NewAttributeValueDouble(r)
+	case nil:
+		return pdata.NewAttributeValueEmpty()
 	default:
 		return pdata.NewAttributeValueString(fmt.Sprintf("%v", val))
 	}

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -57,7 +57,7 @@ func TestAttributeTypeConversion(t *testing.T) {
 	b = msgp.AppendArrayHeader(b, 3)
 	b = msgp.AppendString(b, "my-tag")
 	b = msgp.AppendInt(b, 5000)
-	b = msgp.AppendMapHeader(b, 15)
+	b = msgp.AppendMapHeader(b, 16)
 	b = msgp.AppendString(b, "a")
 	b = msgp.AppendFloat64(b, 5.0)
 	b = msgp.AppendString(b, "b")
@@ -90,6 +90,8 @@ func TestAttributeTypeConversion(t *testing.T) {
 	b = msgp.AppendString(b, "second")
 	b = msgp.AppendString(b, "o")
 	b, err := msgp.AppendIntf(b, []uint8{99, 100, 101})
+	b = msgp.AppendString(b, "p")
+	b = msgp.AppendNil(b)
 
 	require.NoError(t, err)
 
@@ -128,6 +130,7 @@ func TestAttributeTypeConversion(t *testing.T) {
 				"m":          pdata.NewAttributeValueString("\001e\002"),
 				"n":          nv,
 				"o":          pdata.NewAttributeValueString("cde"),
+				"p":          pdata.NewAttributeValueEmpty(),
 			},
 		},
 	).ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).Logs().At(0), le)


### PR DESCRIPTION
msgpack fields with a nil value are currently being converted to the string `"<nil>"` because they are being caught by the default case `fmt.Sprintf("%v", val)`

Using AttributeValueTypeEmpty would seem like a better mapping.

**context**
I have a source that is sending log messages with fields that have a bool or null value.  When it is null, that is currently being converted into a string which means the field becomes bool or string.  Logging backends such as elasticsearch are fine with bool or null but having a field that is bool or string will not work.  Exporters (that support null values) therefore need to know if a value is supposed to be null and the OpenTelemetry type for that is AttributeValueTypeEmpty.