### PR TITLE
exporter/awsxrayexporter: Fix bug with status code

### DIFF
--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -59,7 +59,7 @@ func newTracesExporter(
 				for j := 0; j < rspans.InstrumentationLibrarySpans().Len(); j++ {
 					spans := rspans.InstrumentationLibrarySpans().At(j).Spans()
 					for k := 0; k < spans.Len(); k++ {
-						document, localErr := translator.MakeSegmentDocumentString(spans.At(k), resource,
+						document, localErr := translator.MakeSegmentDocumentString(logger, spans.At(k), resource,
 							config.(*Config).IndexedAttributes, config.(*Config).IndexAllAttributes)
 						if localErr != nil {
 							logger.Debug("Error translating span.", zap.Error(localErr))

--- a/exporter/awsxrayexporter/internal/translator/cause_test.go
+++ b/exporter/awsxrayexporter/internal/translator/cause_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/model/pdata"
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	"go.uber.org/zap"
 )
 
 func TestCauseWithExceptions(t *testing.T) {
@@ -49,7 +50,7 @@ Caused by: java.lang.IllegalArgumentException: bad argument`)
 	attributes.InsertString(conventions.AttributeExceptionType, "EmptyError")
 	attributes.CopyTo(event2.Attributes())
 
-	filtered, _ := makeHTTP(span)
+	filtered, _ := makeHTTP(zap.L(), span)
 
 	res := pdata.NewResource()
 	res.Attributes().InsertString(conventions.AttributeTelemetrySDKLanguage, "java")
@@ -80,7 +81,7 @@ func TestCauseWithStatusMessage(t *testing.T) {
 	attributes[conventions.AttributeHTTPStatusCode] = 500
 	span := constructExceptionServerSpan(attributes, pdata.StatusCodeError)
 	span.Status().SetMessage(errorMsg)
-	filtered, _ := makeHTTP(span)
+	filtered, _ := makeHTTP(zap.L(), span)
 
 	res := pdata.NewResource()
 	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)
@@ -107,7 +108,7 @@ func TestCauseWithHttpStatusMessage(t *testing.T) {
 	attributes[conventions.AttributeHTTPStatusCode] = 500
 	attributes["http.status_text"] = errorMsg
 	span := constructExceptionServerSpan(attributes, pdata.StatusCodeError)
-	filtered, _ := makeHTTP(span)
+	filtered, _ := makeHTTP(zap.L(), span)
 
 	res := pdata.NewResource()
 	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)
@@ -135,7 +136,7 @@ func TestCauseWithZeroStatusMessage(t *testing.T) {
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, pdata.StatusCodeUnset)
-	filtered, _ := makeHTTP(span)
+	filtered, _ := makeHTTP(zap.L(), span)
 	// Status is used to determine whether an error or not.
 	// This span illustrates incorrect instrumentation,
 	// marking a success status with an error http status code, and status wins.
@@ -159,7 +160,7 @@ func TestCauseWithClientErrorMessage(t *testing.T) {
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, pdata.StatusCodeError)
-	filtered, _ := makeHTTP(span)
+	filtered, _ := makeHTTP(zap.L(), span)
 
 	res := pdata.NewResource()
 	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)
@@ -180,7 +181,7 @@ func TestCauseWithThrottled(t *testing.T) {
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, pdata.StatusCodeError)
-	filtered, _ := makeHTTP(span)
+	filtered, _ := makeHTTP(zap.L(), span)
 
 	res := pdata.NewResource()
 	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)

--- a/exporter/awsxrayexporter/internal/translator/http_test.go
+++ b/exporter/awsxrayexporter/internal/translator/http_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/model/pdata"
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	"go.uber.org/zap"
 )
 
 func TestClientSpanWithURLAttribute(t *testing.T) {
@@ -31,7 +32,7 @@ func TestClientSpanWithURLAttribute(t *testing.T) {
 	attributes[conventions.AttributeHTTPStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
@@ -54,7 +55,7 @@ func TestClientSpanWithSchemeHostTargetAttributes(t *testing.T) {
 	attributes["user.id"] = "junit"
 	span := constructHTTPClientSpan(attributes)
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
@@ -78,7 +79,7 @@ func TestClientSpanWithPeerAttributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
@@ -100,7 +101,7 @@ func TestClientSpanWithHttpPeerAttributes(t *testing.T) {
 	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
 	span := constructHTTPClientSpan(attributes)
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
@@ -117,7 +118,7 @@ func TestClientSpanWithPeerIp4Attributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
 	span := constructHTTPClientSpan(attributes)
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
 	w := testWriters.borrow()
@@ -138,7 +139,7 @@ func TestClientSpanWithPeerIp6Attributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
 	span := constructHTTPClientSpan(attributes)
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
 	w := testWriters.borrow()
@@ -159,7 +160,7 @@ func TestServerSpanWithURLAttribute(t *testing.T) {
 	attributes[conventions.AttributeHTTPStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
@@ -182,7 +183,7 @@ func TestServerSpanWithSchemeHostTargetAttributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
@@ -206,7 +207,7 @@ func TestServerSpanWithSchemeServernamePortTargetAttributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
@@ -232,7 +233,7 @@ func TestServerSpanWithSchemeNamePortTargetAttributes(t *testing.T) {
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 
 	assert.NotNil(t, httpData)
 	assert.NotNil(t, filtered)
@@ -259,7 +260,7 @@ func TestSpanWithNotEnoughHTTPRequestURLAttributes(t *testing.T) {
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
 
-	filtered, httpData := makeHTTP(span)
+	filtered, httpData := makeHTTP(zap.L(), span)
 
 	assert.Nil(t, httpData.Request.URL)
 	assert.Equal(t, "192.168.15.32", *httpData.Request.ClientIP)

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/model/pdata"
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	"go.uber.org/zap"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -59,13 +60,13 @@ func TestClientSpanWithRpcAwsSdkClientAttributes(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 	assert.Equal(t, "DynamoDB", *segment.Name)
 	assert.Equal(t, conventions.AttributeCloudProviderAWS, *segment.Namespace)
 	assert.Equal(t, "GetItem", *segment.AWS.Operation)
 	assert.Equal(t, "subsegment", *segment.Type)
 
-	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false)
+	jsonStr, err := MakeSegmentDocumentString(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, jsonStr)
 	assert.Nil(t, err)
@@ -92,13 +93,13 @@ func TestClientSpanWithLegacyAwsSdkClientAttributes(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 	assert.Equal(t, "DynamoDB", *segment.Name)
 	assert.Equal(t, conventions.AttributeCloudProviderAWS, *segment.Namespace)
 	assert.Equal(t, "GetItem", *segment.AWS.Operation)
 	assert.Equal(t, "subsegment", *segment.Type)
 
-	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false)
+	jsonStr, err := MakeSegmentDocumentString(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, jsonStr)
 	assert.Nil(t, err)
@@ -124,7 +125,7 @@ func TestClientSpanWithPeerService(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, 0, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 	assert.Equal(t, "cats-table", *segment.Name)
 }
 
@@ -147,7 +148,7 @@ func TestServerSpanWithInternalServerError(t *testing.T) {
 	timeEvents := constructTimedEventsWithSentMessageEvent(span.StartTimestamp())
 	timeEvents.CopyTo(span.Events())
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.NotNil(t, segment.Cause)
@@ -174,7 +175,7 @@ func TestServerSpanWithThrottle(t *testing.T) {
 	timeEvents := constructTimedEventsWithSentMessageEvent(span.StartTimestamp())
 	timeEvents.CopyTo(span.Events())
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.NotNil(t, segment.Cause)
@@ -190,7 +191,7 @@ func TestServerSpanNoParentId(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeOk, "OK", nil)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.Empty(t, segment.ParentID)
 }
@@ -205,7 +206,7 @@ func TestSpanNoParentId(t *testing.T) {
 	span.SetStartTimestamp(pdata.NewTimestampFromTime(time.Now()))
 	span.SetEndTimestamp(pdata.NewTimestampFromTime(time.Now().Add(10)))
 	resource := pdata.NewResource()
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.Empty(t, segment.ParentID)
 	assert.Nil(t, segment.Type)
@@ -221,7 +222,7 @@ func TestSpanWithNoStatus(t *testing.T) {
 	span.SetEndTimestamp(pdata.NewTimestampFromTime(time.Now().Add(10)))
 
 	resource := pdata.NewResource()
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 	assert.NotNil(t, segment)
 }
 
@@ -241,7 +242,7 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, pdata.StatusCodeUnset, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.NotNil(t, segment.SQL)
@@ -282,7 +283,7 @@ func TestClientSpanWithHttpHost(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, pdata.StatusCodeUnset, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "foo.com", *segment.Name)
@@ -301,7 +302,7 @@ func TestClientSpanWithoutHttpHost(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, pdata.StatusCodeUnset, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "bar.com", *segment.Name)
@@ -321,7 +322,7 @@ func TestClientSpanWithRpcHost(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, pdata.StatusCodeUnset, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "com.foo.AnimalService", *segment.Name)
@@ -343,7 +344,7 @@ func TestSpanWithInvalidTraceId(t *testing.T) {
 	traceID[0] = 0x11
 	span.SetTraceID(pdata.NewTraceID(traceID))
 
-	_, err := MakeSegmentDocumentString(span, resource, nil, false)
+	_, err := MakeSegmentDocumentString(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, err)
 }
@@ -391,7 +392,7 @@ func TestServerSpanWithNilAttributes(t *testing.T) {
 	timeEvents.CopyTo(span.Events())
 	pdata.NewAttributeMap().CopyTo(span.Attributes())
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.NotNil(t, segment.Cause)
@@ -408,7 +409,7 @@ func TestSpanWithAttributesDefaultNotIndexed(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, 0, len(segment.Annotations))
@@ -435,7 +436,7 @@ func TestSpanWithResourceNotStoredIfSubsegment(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, pdata.StatusCodeError, "ERROR", attributes)
 
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, 0, len(segment.Annotations))
@@ -458,7 +459,7 @@ func TestSpanWithAttributesPartlyIndexed(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{"attr1@1", "not_exist"}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{"attr1@1", "not_exist"}, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, 1, len(segment.Annotations))
@@ -475,7 +476,7 @@ func TestSpanWithAttributesAllIndexed(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeOk, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{"attr1@1", "not_exist"}, true)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{"attr1@1", "not_exist"}, true)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "val1", segment.Annotations["attr1_1"])
@@ -489,7 +490,7 @@ func TestResourceAttributesCanBeIndexed(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{
 		"otel.resource.string.key",
 		"otel.resource.int.key",
 		"otel.resource.double.key",
@@ -521,7 +522,7 @@ func TestResourceAttributesNotIndexedIfSubsegment(t *testing.T) {
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{
 		"otel.resource.string.key",
 		"otel.resource.int.key",
 		"otel.resource.double.key",
@@ -546,7 +547,7 @@ func TestOriginNotAws(t *testing.T) {
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Nil(t, segment.Origin)
@@ -564,7 +565,7 @@ func TestOriginEc2(t *testing.T) {
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, OriginEC2, *segment.Origin)
@@ -583,7 +584,7 @@ func TestOriginEcs(t *testing.T) {
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, OriginECS, *segment.Origin)
@@ -603,7 +604,7 @@ func TestOriginEcsEc2(t *testing.T) {
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, OriginECSEC2, *segment.Origin)
@@ -623,7 +624,7 @@ func TestOriginEcsFargate(t *testing.T) {
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, OriginECSFargate, *segment.Origin)
@@ -643,7 +644,7 @@ func TestOriginEb(t *testing.T) {
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, OriginEB, *segment.Origin)
@@ -675,7 +676,7 @@ func TestOriginEks(t *testing.T) {
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, OriginEKS, *segment.Origin)
@@ -693,7 +694,7 @@ func TestOriginAppRunner(t *testing.T) {
 	parentSpanID := newSegmentID()
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, OriginAppRunner, *segment.Origin)
@@ -709,7 +710,7 @@ func TestOriginBlank(t *testing.T) {
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Nil(t, segment.Origin)
@@ -730,7 +731,7 @@ func TestOriginPrefersInfraService(t *testing.T) {
 	attrs.CopyTo(resource.Attributes())
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, OriginEC2, *segment.Origin)
@@ -763,7 +764,7 @@ func TestFilteredAttributesMetadata(t *testing.T) {
 	span := constructServerSpan(parentSpanID, spanName, pdata.StatusCodeError, "OK", attributes)
 	attrs.CopyTo(span.Attributes())
 
-	segment, _ := MakeSegment(span, resource, []string{}, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, []string{}, false)
 
 	assert.NotNil(t, segment)
 	assert.Nil(t, segment.Metadata["default"]["null_value"])

--- a/exporter/awsxrayexporter/internal/translator/writer_pool_test.go
+++ b/exporter/awsxrayexporter/internal/translator/writer_pool_test.go
@@ -36,7 +36,7 @@ func TestWriterPoolBasic(t *testing.T) {
 	assert.Equal(t, size, w.buffer.Cap())
 	assert.Equal(t, 0, w.buffer.Len())
 	resource := pdata.NewResource()
-	segment, _ := MakeSegment(span, resource, nil, false)
+	segment, _ := MakeSegment(zap.L(), span, resource, nil, false)
 	if err := w.Encode(*segment); err != nil {
 		assert.Fail(t, "invalid json")
 	}
@@ -53,7 +53,7 @@ func BenchmarkWithoutPool(b *testing.B) {
 		b.StartTimer()
 		buffer := bytes.NewBuffer(make([]byte, 0, 2048))
 		encoder := json.NewEncoder(buffer)
-		segment, _ := MakeSegment(span, pdata.NewResource(), nil, false)
+		segment, _ := MakeSegment(zap.L(), span, pdata.NewResource(), nil, false)
 		encoder.Encode(*segment)
 		logger.Info(buffer.String())
 	}
@@ -67,7 +67,7 @@ func BenchmarkWithPool(b *testing.B) {
 		span := constructWriterPoolSpan()
 		b.StartTimer()
 		w := wp.borrow()
-		segment, _ := MakeSegment(span, pdata.NewResource(), nil, false)
+		segment, _ := MakeSegment(zap.L(), span, pdata.NewResource(), nil, false)
 		w.Encode(*segment)
 		logger.Info(w.String())
 	}


### PR DESCRIPTION
This fixes a bug to ensure ensures that if the status code is a string,
that it'll parse it as an int and properly set the status code.

Fixes #6662

Signed-off-by: benjamin_j_powell <benjamin_j_powell@apple.com>