### PR TITLE
[receiver/receivercreator] add container endpoint target

### DIFF
--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -78,6 +78,13 @@ Note that the backticks below are not typos--they indicate the value is set dyna
 | k8s.pod.uid        | \`pod.uid\`       |
 | k8s.namespace.name | \`pod.namespace\` |
 
+`type == "container"`
+
+| Resource Attribute   | Default           |
+|----------------------|-------------------|
+| container.name       | \`name\`          |
+| container.image.name | \`image\`         |
+
 `type == "hostport"`
 
 None
@@ -86,7 +93,7 @@ See `redis/2` in [examples](#examples).
 
 ## Rule Expressions
 
-Each rule must start with `type == ("pod"|"port"|"hostport") &&` such that the rule matches
+Each rule must start with `type == ("pod"|"port"|"hostport"|"container") &&` such that the rule matches
 only one endpoint type. Depending on the type of endpoint the rule is
 targeting it will have different variables available.
 
@@ -94,7 +101,7 @@ targeting it will have different variables available.
 
 | Variable    | Description                       |
 |-------------|-----------------------------------|
-| type        | `"pod"`                            |
+| type        | `"pod"`                           |
 | name        | name of the pod                   |
 | namespace   | namespace of the pod              |
 | uid         | unique id of the pod              |
@@ -105,7 +112,7 @@ targeting it will have different variables available.
 
 | Variable        | Description                             |
 |-----------------|-----------------------------------------|
-| type            | `"port"`                                  |
+| type            | `"port"`                                |
 | name            | container port name                     |
 | port            | port number                             |
 | protocol        | The transport protocol ("TCP" or "UDP") |
@@ -119,12 +126,27 @@ targeting it will have different variables available.
 
 | Variable      | Description                                      |
 |---------------|--------------------------------------------------|
-| type          | `"hostport"`                                           |
+| type          | `"hostport"`                                     |
 | process_name  | Name of the process                              |
 | command       | Command line with the used to invoke the process |
 | is_ipv6       | true if endpoint is IPv6, otherwise false        |
 | port          | Port number                                      |
 | transport     | The transport protocol ("TCP" or "UDP")          |
+
+### Container
+
+| Variable       | Description                                                       |
+|----------------|-------------------------------------------------------------------|
+| type           | `"container"`                                                     |
+| name           | Primary name of the container                                     |
+| image          | Name of the container image                                       |
+| port           | Exposed port of the container                                     |
+| alternate_port | Exposed port accessed through redirection, such as a mapped port  |
+| command        | The command used to invoke the process of the container           |
+| container_id   | ID of the container                                               |
+| host           | Hostname or IP of the underlying host the container is running on |
+| transport      | Transport protocol used by the endpoint (TCP or UDP)              |
+| labels         | User-specified metadata labels on the container                   |
 
 ## Examples
 

--- a/receiver/receivercreator/factory.go
+++ b/receiver/receivercreator/factory.go
@@ -54,6 +54,10 @@ func createDefaultConfig() config.Receiver {
 				conventions.AttributeK8SPodUID:        "`pod.uid`",
 				conventions.AttributeK8SNamespaceName: "`pod.namespace`",
 			},
+			observer.ContainerType: map[string]string{
+				conventions.AttributeContainerName:      "`name`",
+				conventions.AttributeContainerImageName: "`image`",
+			},
 		},
 		receiverTemplates: map[string]receiverTemplate{},
 	}

--- a/receiver/receivercreator/fixtures_test.go
+++ b/receiver/receivercreator/fixtures_test.go
@@ -59,6 +59,27 @@ var hostportEndpoint = observer.Endpoint{
 	},
 }
 
+var container = observer.Container{
+	Name:          "otel-agent",
+	Image:         "otelcol",
+	Port:          8080,
+	AlternatePort: 80,
+	Transport:     observer.ProtocolTCP,
+	Command:       "otelcol -c",
+	Host:          "localhost",
+	ContainerID:   "abc123",
+	Labels: map[string]string{
+		"env":    "prod",
+		"region": "east-1",
+	},
+}
+
+var containerEndpoint = observer.Endpoint{
+	ID:      "container-1",
+	Target:  "localhost:1234",
+	Details: &container,
+}
+
 var unsupportedEndpoint = observer.Endpoint{
 	ID:      "endpoint-1",
 	Target:  "localhost:1234",

--- a/receiver/receivercreator/resourceenhancer_test.go
+++ b/receiver/receivercreator/resourceenhancer_test.go
@@ -37,6 +37,11 @@ func Test_newResourceEnhancer(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	cntrEnv, err := containerEndpoint.Env()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cfg := createDefaultConfig().(*Config)
 	type args struct {
 		resources    resourceAttributes
@@ -82,6 +87,23 @@ func Test_newResourceEnhancer(t *testing.T) {
 					"k8s.pod.uid":        "uid-1",
 					"k8s.pod.name":       "pod-1",
 					"k8s.namespace.name": "default",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "container endpoint",
+			args: args{
+				resources:    cfg.ResourceAttributes,
+				env:          cntrEnv,
+				endpoint:     containerEndpoint,
+				nextConsumer: &consumertest.MetricsSink{},
+			},
+			want: &resourceEnhancer{
+				nextConsumer: &consumertest.MetricsSink{},
+				attrs: map[string]string{
+					"container.name":       "otel-agent",
+					"container.image.name": "otelcol",
 				},
 			},
 			wantErr: false,

--- a/receiver/receivercreator/rules.go
+++ b/receiver/receivercreator/rules.go
@@ -16,6 +16,7 @@ package receivercreator // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 
 	"github.com/antonmedv/expr"
@@ -30,7 +31,9 @@ type rule struct {
 }
 
 // ruleRe is used to verify the rule starts type check.
-var ruleRe = regexp.MustCompile(`^type\s*==\s*("pod"|"port"|"hostport")`)
+var ruleRe = regexp.MustCompile(
+	fmt.Sprintf(`^type\s*==\s*(%q|%q|%q|%q)`, observer.PodType, observer.PortType, observer.HostPortType, observer.ContainerType),
+)
 
 // newRule creates a new rule instance.
 func newRule(ruleStr string) (rule, error) {

--- a/receiver/receivercreator/rules_test.go
+++ b/receiver/receivercreator/rules_test.go
@@ -48,6 +48,7 @@ func Test_ruleEval(t *testing.T) {
 		{"basic hostport", args{`type == "hostport" && port == 1234 && process_name == "splunk"`, hostportEndpoint}, true, false},
 		{"basic pod", args{`type == "pod" && labels["region"] == "west-1"`, podEndpoint}, true, false},
 		{"annotations", args{`type == "pod" && annotations["scrape"] == "true"`, podEndpoint}, true, false},
+		{"basic container", args{`type == "container" && labels["region"] == "east-1"`, containerEndpoint}, true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -84,7 +85,8 @@ func Test_newRule(t *testing.T) {
 		{"invalid syntax", args{"port =="}, true},
 		{"valid port", args{`type == "port" && port_name == "http"`}, false},
 		{"valid pod", args{`type=="pod" && port_name == "http"`}, false},
-		{"valid hostport", args{`type ==    "hostport" && port_name == "http"`}, false},
+		{"valid hostport", args{`type == "hostport" && port_name == "http"`}, false},
+		{"valid container", args{`type == "container" && port == 8080`}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:** Adding a new target type for the receiver creator `container`

**Link to tracking Issue:** N/A but needed by a couple of observers that are a work in progress.

**Testing:** Added to existing tests

**Documentation:** Updated README with container resource attributes and variables exposed