### PR TITLE
[zipkinreceiver] Propagate remote IP

### DIFF
--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/config"
@@ -202,6 +203,9 @@ const (
 // unmarshalls them and sends them along to the nextConsumer.
 func (zr *zipkinReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	if c, ok := client.FromHTTP(r); ok {
+		ctx = client.NewContext(ctx, c)
+	}
 
 	// Now deserialize and process the spans.
 	asZipkinv1 := r.URL != nil && strings.Contains(r.URL.Path, "api/v1/spans")


### PR DESCRIPTION
**Description:**
Ensure the remote IP is propagated to the processors - the same way the OTLP receiver works.
For example, the `k8sattribute` processor uses it to find the source pod.