### PR TITLE
Update  prometheusremotewriteexporter Readme

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -34,7 +34,7 @@ As a result, the following parameters are also required under `tls:`:
 
 The following settings can be optionally configured:
 
-- `external_labels`: list of labels to be attached to each metric data point
+- `external_labels`: map of labels names and values to be attached to each metric data point
 - `headers`: additional headers attached to each HTTP request. 
   - *Note the following headers cannot be changed: `Content-Encoding`, `Content-Type`, `X-Prometheus-Remote-Write-Version`, and `User-Agent`.*
 - `namespace`: prefix attached to each exported metric name.
@@ -48,6 +48,17 @@ Example:
 exporters:
   prometheusremotewrite:
     endpoint: "https://my-cortex:7900/api/v1/push"
+```
+
+Example:
+
+```yaml
+exporters:
+  prometheusremotewrite:
+    endpoint: "https://my-cortex:7900/api/v1/push"
+    external_labels:
+      label_name1: label_value1
+      label_name2: label_value2      
 ```
 
 ## Advanced Configuration


### PR DESCRIPTION
**Documentation:** 
Updating prometheusremotewriteexporter Readme file by changing the description for external_labels and adding an example on how to use

