### PR TITLE
[mdatagen] Fix gauge.NumberDataPoints field to use mapstructure

### DIFF
--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -83,7 +83,7 @@ func (ndp NumberDataPoints) BasicType() string {
 }
 
 type gauge struct {
-	NumberDataPoints `yaml:",inline"`
+	NumberDataPoints `mapstructure:",squash"`
 }
 
 func (d gauge) Type() string {


### PR DESCRIPTION
The field was left not updated due to this PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6460 not rebased before merge.