### PR TITLE
`testbed`: increase limit for TestBallastMemory

### DIFF
--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -74,7 +74,7 @@ func TestBallastMemory(t *testing.T) {
 		maxRSS      uint32
 	}{
 		{100, 70},
-		{500, 80},
+		{500, 90},
 		{1000, 110},
 	}
 
@@ -84,43 +84,45 @@ func TestBallastMemory(t *testing.T) {
 	options := testbed.LoadOptions{DataItemsPerSecond: 10_000, ItemsPerBatch: 10}
 	dataProvider := testbed.NewPerfTestDataProvider(options)
 	for _, test := range tests {
-		sender := testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t))
-		receiver := testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t))
-		ballastCfg := createConfigYaml(
-			t, sender, receiver, resultDir, nil,
-			map[string]string{"memory_ballast": fmt.Sprintf(ballastConfig, test.ballastSize)})
-		cp := testbed.NewChildProcessCollector()
-		cleanup, err := cp.PrepareConfig(ballastCfg)
-		require.NoError(t, err)
-		tc := testbed.NewTestCase(
-			t,
-			dataProvider,
-			sender,
-			receiver,
-			cp,
-			&testbed.PerfTestValidator{},
-			performanceResultsSummary,
-			testbed.WithSkipResults(),
-			testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxRAM: test.maxRSS}),
-		)
-		tc.StartAgent()
+		t.Run(fmt.Sprintf("ballast-size-%d", test.ballastSize), func(t *testing.T) {
+			sender := testbed.NewOTLPTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t))
+			receiver := testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t))
+			ballastCfg := createConfigYaml(
+				t, sender, receiver, resultDir, nil,
+				map[string]string{"memory_ballast": fmt.Sprintf(ballastConfig, test.ballastSize)})
+			cp := testbed.NewChildProcessCollector()
+			cleanup, err := cp.PrepareConfig(ballastCfg)
+			require.NoError(t, err)
+			tc := testbed.NewTestCase(
+				t,
+				dataProvider,
+				sender,
+				receiver,
+				cp,
+				&testbed.PerfTestValidator{},
+				performanceResultsSummary,
+				testbed.WithSkipResults(),
+				testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxRAM: test.maxRSS}),
+			)
+			tc.StartAgent()
 
-		var rss, vms uint32
-		// It is possible that the process is not ready or the ballast code path
-		// is not hit immediately so we give the process up to a couple of seconds
-		// to fire up and setup ballast. 2 seconds is a long time for this case but
-		// it is short enough to not be annoying if the test fails repeatedly
-		tc.WaitForN(func() bool {
-			rss, vms, _ = tc.AgentMemoryInfo()
-			return vms > test.ballastSize
-		}, time.Second*2, fmt.Sprintf("VMS must be greater than %d", test.ballastSize))
+			var rss, vms uint32
+			// It is possible that the process is not ready or the ballast code path
+			// is not hit immediately so we give the process up to a couple of seconds
+			// to fire up and setup ballast. 2 seconds is a long time for this case but
+			// it is short enough to not be annoying if the test fails repeatedly
+			tc.WaitForN(func() bool {
+				rss, vms, _ = tc.AgentMemoryInfo()
+				return vms > test.ballastSize
+			}, time.Second*2, fmt.Sprintf("VMS must be greater than %d", test.ballastSize))
 
-		// https://github.com/open-telemetry/opentelemetry-collector/issues/3233
-		// given that the maxRSS isn't an absolute maximum and that the actual maximum might be a bit off,
-		// we give some room here instead of failing when the memory usage isn't that much higher than the max
-		lenientMax := 1.1 * float32(test.maxRSS)
-		assert.LessOrEqual(t, float32(rss), lenientMax)
-		cleanup()
-		tc.Stop()
+			// https://github.com/open-telemetry/opentelemetry-collector/issues/3233
+			// given that the maxRSS isn't an absolute maximum and that the actual maximum might be a bit off,
+			// we give some room here instead of failing when the memory usage isn't that much higher than the max
+			lenientMax := 1.1 * float32(test.maxRSS)
+			assert.LessOrEqual(t, float32(rss), lenientMax, fmt.Sprintf("The RSS memory usage (%d) is >10%% higher than the limit (%d).", rss, test.maxRSS))
+			cleanup()
+			tc.Stop()
+		})
 	}
 }


### PR DESCRIPTION
This also improves the error message, making it clear that the usage is 10% higher than the max.

Fixes #6535

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>