### PR TITLE
[exporter/awsprometheusremotewrite] Add an option to configure STS endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## 💡 Enhancements 💡
 
+-  `awsprometheusremotewriteexporter` Add an option to configure STS endpoint (#6713)
+
 ## v0.41.0
 
 ## 🛑 Breaking changes 🛑

--- a/exporter/awsprometheusremotewriteexporter/config.go
+++ b/exporter/awsprometheusremotewriteexporter/config.go
@@ -15,6 +15,8 @@
 package awsprometheusremotewriteexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter"
 
 import (
+	"fmt"
+
 	prw "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter"
 )
 
@@ -37,4 +39,16 @@ type AuthConfig struct {
 
 	// Amazon Resource Name (ARN) of a role to assume. Optional.
 	RoleArn string `mapstructure:"role_arn"`
+
+	// Select which endpoint to use for STS between `legacy` or `regional`. Optional.
+	STSEndpoint string `mapstructure:"sts_endpoint"`
+}
+
+func (c *Config) Validate() error {
+	switch c.AuthConfig.STSEndpoint {
+	case "", "legacy", "regional":
+	default:
+		return fmt.Errorf("invalid value for sts_endpoint")
+	}
+	return nil
 }

--- a/exporter/awsprometheusremotewriteexporter/config_test.go
+++ b/exporter/awsprometheusremotewriteexporter/config_test.go
@@ -86,13 +86,26 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		AuthConfig: AuthConfig{
-			Region:  "us-west-2",
-			Service: "service-name",
-			RoleArn: "arn:aws:iam::123456789012:role/IAMRole",
+			Region:      "us-west-2",
+			Service:     "service-name",
+			RoleArn:     "arn:aws:iam::123456789012:role/IAMRole",
+			STSEndpoint: "regional",
 		},
 	}
 	// testing function equality is not supported in Go hence these will be ignored for this test
 	cfgComplete.HTTPClientSettings.CustomRoundTripper = nil
 	e1.(*Config).HTTPClientSettings.CustomRoundTripper = nil
 	assert.Equal(t, cfgComplete, e1)
+}
+
+// TestInvalidAuth checks whether a misconfigured STS endpoint raised an error.
+func TestInvalidAuth(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Exporters[typeStr] = factory
+	cfg, err := configtest.LoadConfigAndValidate(path.Join(".", "testdata", "invalid_sts_endpoint.yaml"), factories)
+	require.NotNil(t, cfg)
+	require.EqualError(t, err, `exporter "awsprometheusremotewrite" has invalid configuration: invalid value for sts_endpoint`)
 }

--- a/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/awsprometheusremotewriteexporter/testdata/config.yaml
@@ -24,6 +24,7 @@ exporters:
             region: "us-west-2"
             service: "service-name"
             role_arn: "arn:aws:iam::123456789012:role/IAMRole"
+            sts_endpoint: regional
         external_labels:
             key1: value1
             key2: value2

--- a/exporter/awsprometheusremotewriteexporter/testdata/invalid_sts_endpoint.yaml
+++ b/exporter/awsprometheusremotewriteexporter/testdata/invalid_sts_endpoint.yaml
@@ -1,0 +1,19 @@
+receivers:
+    nop:
+
+processors:
+    nop:
+
+exporters:
+    awsprometheusremotewrite:
+        aws_auth:
+            region: "us-west-2"
+            service: "service-name"
+            role_arn: "arn:aws:iam::123456789012:role/IAMRole"
+            sts_endpoint: "wrong-name"
+service:
+    pipelines:
+        metrics:
+            receivers: [nop]
+            processors: [nop]
+            exporters: [awsprometheusremotewrite]


### PR DESCRIPTION
**Description:**
The `awsprometheusremotewriteexporter` currently use the global STS endpoint (`sts.amazonaws.com`) when a role ARN is specified. This is causing some issues when the environment is not connected to the Internet and it would be better to allow the user to choose the regional endpoint (for example `us-east-2.amazonaws.com`) for AWS PrivateLink to work.

**Testing:**
I have built the `aws-otel-collector` with my patch in order to validate the change. It works on an isolated VPC and a VPC endpoint to the regional STS. Here is the configuration used:

```yaml
  awsprometheusremotewrite:
    endpoint: ${endpoint}api/v1/remote_write
    aws_auth:
      region: ${region}
      service: aps
      role_arn: ${role_arn}
      sts_endpoint: regional
```