### PR TITLE
Expect ARM RPM package to have a suffix of aarch64.rpm instead of arm64.rpm

### DIFF
--- a/.github/workflows/scripts/verify-dist-files-exist.sh
+++ b/.github/workflows/scripts/verify-dist-files-exist.sh
@@ -4,7 +4,7 @@ files=(
     bin/otelcontribcol_linux_arm64
     bin/otelcontribcol_linux_amd64
     bin/otelcontribcol_windows_amd64.exe
-    dist/otel-contrib-collector-*.arm64.rpm
+    dist/otel-contrib-collector-*.aarch64.rpm
     dist/otel-contrib-collector_*_amd64.deb
     dist/otel-contrib-collector-*.x86_64.rpm
     dist/otel-contrib-collector_*_arm64.deb
@@ -17,7 +17,7 @@ do
     then
         echo "$f does not exist."
         echo "::set-output name=passed::false"
-        exit 0 
+        exit 0
     fi
 done
 echo "::set-output name=passed::true"


### PR DESCRIPTION


**Description:** 

Fixes #6714 introduced by #6635 by changing the `verify-dist-files-exist.sh` script to check for a package with an `aarch64.rpm` suffix rather than a `arm64.rpm` suffix. The package filename's suffix for ARM Linux builds was changed from `arm64.rpm` to `aarch64.rpm` in #6635, however as this script wasn't updated to expect the new suffix the build-and-verify Github action fails on the "Verify Distribution Files Exist" stage and thus doesn't run the "Push Docker Image" or"Create Github Release" steps. 

**Link to tracking Issue:** #6714 

**Testing:** No testing performed on workflow step.

**Documentation:** No documentation changed.