### PR TITLE
Add CODEOWNER for kafkaexporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,6 +36,7 @@ exporter/humioexporter/                              @open-telemetry/collector-c
 exporter/influxdbexporter/                           @open-telemetry/collector-contrib-approvers @jacobmarble @8none1
 exporter/jaegerexporter/                             @open-telemetry/collector-contrib-approvers @jpkrohling
 exporter/jaegerthrifthttpexporter/                   @open-telemetry/collector-contrib-approvers @jpkrohling @pavolloffay
+exporter/kafkaexporter/                              @open-telemetry/collector-contrib-approvers @pavolloffay
 exporter/loadbalancingexporter/                      @open-telemetry/collector-contrib-approvers @jpkrohling
 exporter/logzioexporter/                             @open-telemetry/collector-contrib-approvers @jkowall @Doron-Bargo @yotamloe
 exporter/lokiexporter/                               @open-telemetry/collector-contrib-approvers @gramidt @jpkrohling

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,6 +108,7 @@ receiver/jmxreceiver/                                @open-telemetry/collector-c
 receiver/k8sclusterreceiver/                         @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/k8seventsreceiver/                          @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/kafkametricsreceiver/                       @open-telemetry/collector-contrib-approvers @dmitryax
+receiver/kafkareceiver/                              @open-telemetry/collector-contrib-approvers @pavolloffay
 receiver/kubeletstatsreceiver/                       @open-telemetry/collector-contrib-approvers @pmcollins @dmitryax
 receiver/memcachedreceiver/                          @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/mongodbatlasreceiver/                       @open-telemetry/collector-contrib-approvers @zenmoto


### PR DESCRIPTION
**Description:** 

Add @pavolloffay as CODEOWNER of kafkaexporter, per https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3870#issuecomment-989747329

**Link to tracking Issue:** #3870
