### PR TITLE
Tidying up references to OTLP JSON

### DIFF
--- a/exporter/awskinesisexporter/README.md
+++ b/exporter/awskinesisexporter/README.md
@@ -16,7 +16,8 @@ The following settings can be optionally configured:
     - `region` (default = us-west-2): the region that the kinesis stream is deployed in
     - `role` (no default): The role to be used in order to send data to the kinesis stream
 - `encoding`
-    - `name` (default = otlp): defines the export type to be used to send to kinesis (available is `otlp-proto`, `otlp-json`, `zipkin-proto`, `zipkin-json`, `jaeger`)
+    - `name` (default = otlp): defines the export type to be used to send to kinesis (available is `otlp_proto`, `otlp_json`, `zipkin_proto`, `zipkin_json`, `jaeger`)
+      - **Note** : `otlp_json` is considered experimental and _should not_ be used for production environments. 
     - `compression` (default = none): allows to set the compression type (defaults BestSpeed for all) before forwarding to kinesis (available is `flate`, `gzip`, `zlib` or `none`)
 - `max_records_per_batch` (default = 500, PutRecords limit): The number of records that can be batched together then sent to kinesis.
 - `max_record_size` (default = 1Mb, PutRecord(s) limit on record size): The max allowed size that can be exported to kinesis

--- a/exporter/awskinesisexporter/exporter.go
+++ b/exporter/awskinesisexporter/exporter.go
@@ -86,6 +86,10 @@ func createExporter(c config.Exporter, log *zap.Logger) (*Exporter, error) {
 		return nil, err
 	}
 
+	if conf.Encoding.Name == "otlp_json" {
+		log.Info("otlp_json is considered experimental and should not be used in a production environment")
+	}
+
 	return &Exporter{
 		producer: producer,
 		batcher:  encoder,

--- a/exporter/awskinesisexporter/internal/batch/encode_marshaler_test.go
+++ b/exporter/awskinesisexporter/internal/batch/encode_marshaler_test.go
@@ -63,7 +63,7 @@ func TestMarshalEncoder_Metrics(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			scenario:      "valid zipkin json encoder, does not implement metrics",
+			scenario:      "valid zipkin JSON encoder, does not implement metrics",
 			encoding:      "zipkin_json",
 			batchSize:     10,
 			recordSize:    1000,
@@ -82,7 +82,7 @@ func TestMarshalEncoder_Metrics(t *testing.T) {
 			expectedChunks: 2,
 		},
 		{
-			scenario:       "valid otlp json encoder that implements metrics",
+			scenario:       "valid otlp JSON encoder that implements metrics",
 			encoding:       "otlp_json",
 			batchSize:      10,
 			recordSize:     100000,
@@ -158,7 +158,7 @@ func TestMarshalEncoder_Traces(t *testing.T) {
 			expectedChunks: 1,
 		},
 		{
-			scenario:       "valid zipkin json encoder",
+			scenario:       "valid zipkin JSON encoder",
 			encoding:       "zipkin_json",
 			batchSize:      10,
 			recordSize:     1000,
@@ -176,7 +176,7 @@ func TestMarshalEncoder_Traces(t *testing.T) {
 			expectedChunks: 2,
 		},
 		{
-			scenario:       "valid otlp json encoder",
+			scenario:       "valid otlp JSON encoder",
 			encoding:       "otlp_json",
 			batchSize:      10,
 			recordSize:     100000,
@@ -248,7 +248,7 @@ func TestMarshalEncoder_Logs(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			scenario:      "valid zipkin json encoder, does not implement logs",
+			scenario:      "valid zipkin JSON encoder, does not implement logs",
 			encoding:      "zipkin_json",
 			batchSize:     10,
 			recordSize:    1000,
@@ -267,7 +267,7 @@ func TestMarshalEncoder_Logs(t *testing.T) {
 			expectedChunks: 2,
 		},
 		{
-			scenario:       "valid otlp json encoder that implements logs",
+			scenario:       "valid otlp JSON encoder that implements logs",
 			encoding:       "otlp_json",
 			batchSize:      10,
 			recordSize:     100000,

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -12,7 +12,7 @@ The following settings can be optionally configured:
 - `topic` (default = otlp_spans for traces, otlp_metrics for metrics, otlp_logs for logs): The name of the kafka topic to export to.
 - `encoding` (default = otlp_proto): The encoding of the traces sent to kafka. All available encodings:
   - `otlp_proto`: payload is Protobuf serialized from `ExportTraceServiceRequest` if set as a traces exporter or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs.
-  - `otlp_json`:  ** EXPERIMENTAL ** payload is Json serialized from `ExportTraceServiceRequest` if set as a traces exporter or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs. 
+  - `otlp_json`:  ** EXPERIMENTAL ** payload is JSON serialized from `ExportTraceServiceRequest` if set as a traces exporter or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs. 
   - The following encodings are valid *only* for **traces**.
     - `jaeger_proto`: the payload is serialized to a single Jaeger proto `Span`, and keyed by TraceID.
     - `jaeger_json`: the payload is serialized to a single Jaeger JSON Span using `jsonpb`, and keyed by TraceID.


### PR DESCRIPTION
**Description:** 
Updating kinesis exporter to include a user warning that otlp json is not intended production use and is experimental.
Fixing up some of the settings within readme that were not correct.

**Link to tracking Issue:**
I did not create one for this since it was a simple documentation fix.

**Testing:** 
NA

**Documentation:** 
Updated as needed.