### PR TITLE
[extension/observer/k8s] Add k8s.node discovery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,7 @@ extension/httpforwarder/                             @open-telemetry/collector-c
 extension/oauth2clientauthextension/                 @open-telemetry/collector-contrib-approvers @jpkrohling @pavankrish123
 extension/observer/                                  @open-telemetry/collector-contrib-approvers @asuresh4 @jrcamp
 extension/observer/ecstaskobserver/                  @open-telemetry/collector-contrib-approvers @rmfitzpatrick
+extension/observer/k8sobserver/                      @open-telemetry/collector-contrib-approvers @rmfitzpatrick @dmitryax
 extension/oidcauthextension/                         @open-telemetry/collector-contrib-approvers @jpkrohling
 
 internal/aws/                                        @open-telemetry/collector-contrib-approvers @anuraaga @mxiamxia

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `prometheusremotewriteexporter`: Handling Staleness flag from OTLP (#6679)
 - `datadogexporter`: Add compatibility with ECS Fargate semantic conventions (#6670)
+- `k8s_observer`: discover k8s.node endpoints (#6820)
 
 ## 🛑 Breaking changes 🛑
 

--- a/extension/observer/endpoints.go
+++ b/extension/observer/endpoints.go
@@ -229,15 +229,6 @@ type K8sNode struct {
 	Labels map[string]string
 	// KubeletEndpointPort is the node status object's DaemonEndpoints.KubeletEndpoint.Port value
 	KubeletEndpointPort uint16
-	// Spec represents the node Spec object.
-	// It is a json object that is equivalent to the output of `kubectl get node <node> -o jsonpath='{.spec}'`
-	Spec map[string]interface{}
-	// Metadata represents the node ObjectMeta object.
-	// It is a json object that is equivalent to the output of `kubectl get node <node> -o jsonpath='{.metadata}'`
-	Metadata map[string]interface{}
-	// Status represents the node Status object.
-	// It is a json object that is equivalent to the output of `kubectl get node <node> -o jsonpath='{.status}'`
-	Status map[string]interface{}
 }
 
 func (n *K8sNode) Env() EndpointEnv {
@@ -246,9 +237,6 @@ func (n *K8sNode) Env() EndpointEnv {
 		"uid":                   n.UID,
 		"annotations":           n.Annotations,
 		"labels":                n.Labels,
-		"metadata":              n.Metadata,
-		"spec":                  n.Spec,
-		"status":                n.Status,
 		"hostname":              n.Hostname,
 		"external_ip":           n.ExternalIP,
 		"internal_ip":           n.InternalIP,

--- a/extension/observer/endpoints_test.go
+++ b/extension/observer/endpoints_test.go
@@ -180,15 +180,6 @@ func TestEndpointEnv(t *testing.T) {
 						"label_key": "label_val",
 					},
 					KubeletEndpointPort: 1234,
-					Spec: map[string]interface{}{
-						"spec": "spec_val",
-					},
-					Metadata: map[string]interface{}{
-						"metadata": "metadata_val",
-					},
-					Status: map[string]interface{}{
-						"status": "status_val",
-					},
 				},
 			},
 			want: EndpointEnv{
@@ -207,15 +198,6 @@ func TestEndpointEnv(t *testing.T) {
 				},
 				"labels": map[string]string{
 					"label_key": "label_val",
-				},
-				"spec": map[string]interface{}{
-					"spec": "spec_val",
-				},
-				"metadata": map[string]interface{}{
-					"metadata": "metadata_val",
-				},
-				"status": map[string]interface{}{
-					"status": "status_val",
 				},
 			},
 			wantErr: false,

--- a/extension/observer/k8sobserver/config.go
+++ b/extension/observer/k8sobserver/config.go
@@ -15,6 +15,8 @@
 package k8sobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/config"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
@@ -50,5 +52,8 @@ type Config struct {
 
 // Validate checks if the extension configuration is valid
 func (cfg *Config) Validate() error {
+	if !cfg.ObservePods && !cfg.ObserveNodes {
+		return fmt.Errorf("one of observe_pods and observe_nodes must be true")
+	}
 	return cfg.APIConfig.Validate()
 }

--- a/extension/observer/k8sobserver/config.go
+++ b/extension/observer/k8sobserver/config.go
@@ -25,8 +25,10 @@ type Config struct {
 	config.ExtensionSettings `mapstructure:",squash"`
 	k8sconfig.APIConfig      `mapstructure:",squash"`
 
-	// Node should be set to the node name to limit discovered endpoints to. For example, node name can
-	// be set using the downward API inside the collector pod spec as follows:
+	// Node is the node name to limit the discovery of pod, port, and node endpoints.
+	// Providing no value (the default) results in discovering endpoints for all available nodes.
+	// For example, node name can be set using the downward API inside the collector
+	// pod spec as follows:
 	//
 	// env:
 	//   - name: K8S_NODE_NAME
@@ -36,6 +38,14 @@ type Config struct {
 	//
 	// Then set this value to ${K8S_NODE_NAME} in the configuration.
 	Node string `mapstructure:"node"`
+	// ObservePods determines whether to report observer pod and port endpoints. If `true` and Node is specified
+	// it will only discover pod and port endpoints whose `spec.nodeName` matches the provided node name. If `true` and
+	// Node isn't specified, it will discover all available pod and port endpoints. `true` by default.
+	ObservePods bool `mapstructure:"observe_pods"`
+	// ObserveNodes determines whether to report observer k8s.node endpoints. If `true` and Node is specified
+	// it will only discover node endpoints whose `metadata.name` matches the provided node name. If `true` and
+	// Node isn't specified, it will discover all available node endpoints. `false` by default.
+	ObserveNodes bool `mapstructure:"observe_nodes"`
 }
 
 // Validate checks if the extension configuration is valid

--- a/extension/observer/k8sobserver/config_test.go
+++ b/extension/observer/k8sobserver/config_test.go
@@ -35,35 +35,44 @@ func TestLoadConfig(t *testing.T) {
 	factories.Extensions[typeStr] = factory
 	cfg, err := configtest.LoadConfigAndValidate(path.Join(".", "testdata", "config.yaml"), factories)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	require.Len(t, cfg.Extensions, 2)
+	require.Len(t, cfg.Extensions, 3)
 
-	ext0 := cfg.Extensions[config.NewComponentID(typeStr)]
-	assert.EqualValues(t, factory.CreateDefaultConfig(), ext0)
+	defaultConfig := cfg.Extensions[config.NewComponentID(typeStr)]
+	assert.EqualValues(t, factory.CreateDefaultConfig(), defaultConfig)
 
-	ext1 := cfg.Extensions[config.NewComponentIDWithName(typeStr, "1")]
+	ownNodeOnly := cfg.Extensions[config.NewComponentIDWithName(typeStr, "own-node-only")]
 	assert.EqualValues(t,
 		&Config{
-			ExtensionSettings: config.NewExtensionSettings(config.NewComponentIDWithName(typeStr, "1")),
+			ExtensionSettings: config.NewExtensionSettings(config.NewComponentIDWithName(typeStr, "own-node-only")),
 			Node:              "node-1",
 			APIConfig:         k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeKubeConfig},
+			ObservePods:       true,
 		},
-		ext1)
+		ownNodeOnly)
+
+	observeAll := cfg.Extensions[config.NewComponentIDWithName(typeStr, "observe-all")]
+	assert.EqualValues(t,
+		&Config{
+			ExtensionSettings: config.NewExtensionSettings(config.NewComponentIDWithName(typeStr, "observe-all")),
+			Node:              "",
+			APIConfig:         k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeNone},
+			ObservePods:       true,
+			ObserveNodes:      true,
+		},
+		observeAll)
+
 }
 
-func TestValidate(t *testing.T) {
-	cfg := &Config{
-		ExtensionSettings: config.NewExtensionSettings(config.NewComponentIDWithName(typeStr, "1")),
-		Node:              "node-1",
-		APIConfig:         k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeKubeConfig},
-	}
+func TestInvalidAuth(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
 
-	err := cfg.Validate()
-	require.Nil(t, err)
-
-	cfg.APIConfig.AuthType = "invalid"
-	err = cfg.Validate()
-	require.NotNil(t, err)
+	factory := NewFactory()
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigAndValidate(path.Join("testdata/invalid_auth.yaml"), factories)
+	require.NotNil(t, cfg)
+	require.EqualError(t, err, `extension "k8s_observer" has invalid configuration: invalid authType for kubernetes: not a real auth type`)
 }

--- a/extension/observer/k8sobserver/config_test.go
+++ b/extension/observer/k8sobserver/config_test.go
@@ -76,3 +76,14 @@ func TestInvalidAuth(t *testing.T) {
 	require.NotNil(t, cfg)
 	require.EqualError(t, err, `extension "k8s_observer" has invalid configuration: invalid authType for kubernetes: not a real auth type`)
 }
+
+func TestInvalidNoObserving(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	assert.NoError(t, err)
+
+	factory := NewFactory()
+	factories.Extensions[typeStr] = factory
+	cfg, err := configtest.LoadConfigAndValidate(path.Join("testdata/invalid_no_observing.yaml"), factories)
+	require.NotNil(t, cfg)
+	require.EqualError(t, err, `extension "k8s_observer" has invalid configuration: one of observe_pods and observe_nodes must be true`)
+}

--- a/extension/observer/k8sobserver/extension_test.go
+++ b/extension/observer/k8sobserver/extension_test.go
@@ -16,41 +16,65 @@ package k8sobserver
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.uber.org/zap"
 	framework "k8s.io/client-go/tools/cache/testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 )
 
+const (
+	serviceHostEnv = "KUBERNETES_SERVICE_HOST"
+	servicePortEnv = "KUBERNETES_SERVICE_PORT"
+)
+
+func mockServiceHost(c *Config) func() {
+	c.AuthType = k8sconfig.AuthTypeNone
+	host, port := os.Getenv(serviceHostEnv), os.Getenv(servicePortEnv)
+	os.Setenv(serviceHostEnv, "mock")
+	os.Setenv(servicePortEnv, "12345")
+	return func() {
+		os.Setenv(serviceHostEnv, host)
+		os.Setenv(servicePortEnv, port)
+	}
+}
+
 func TestNewExtension(t *testing.T) {
-	listWatch := framework.NewFakeControllerSource()
 	factory := NewFactory()
-	ext, err := newObserver(zap.NewNop(), factory.CreateDefaultConfig().(*Config), listWatch)
+	config := factory.CreateDefaultConfig().(*Config)
+	defer mockServiceHost(config)()
+
+	ext, err := newObserver(config, componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.NotNil(t, ext)
 }
 
-func TestExtensionObserve(t *testing.T) {
-	listWatch := framework.NewFakeControllerSource()
+func TestExtensionObservePods(t *testing.T) {
 	factory := NewFactory()
-	ext, err := newObserver(zap.NewNop(), factory.CreateDefaultConfig().(*Config), listWatch)
+	config := factory.CreateDefaultConfig().(*Config)
+	defer mockServiceHost(config)()
+
+	ext, err := newObserver(config, componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.NotNil(t, ext)
-	obs := ext.(*k8sObserver)
 
-	listWatch.Add(pod1V1)
+	obs := ext.(*k8sObserver)
+	podListerWatcher := framework.NewFakeControllerSource()
+	obs.podListerWatcher = podListerWatcher
+
+	podListerWatcher.Add(pod1V1)
 
 	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
 
 	sink := &endpointSink{}
 	obs.ListAndWatch(sink)
 
-	assertSink(t, sink, func() bool {
+	requireSink(t, sink, func() bool {
 		return len(sink.added) == 1
 	})
 
@@ -67,9 +91,9 @@ func TestExtensionObserve(t *testing.T) {
 		},
 	}, sink.added[0])
 
-	listWatch.Delete(pod1V2)
+	podListerWatcher.Delete(pod1V2)
 
-	assertSink(t, sink, func() bool {
+	requireSink(t, sink, func() bool {
 		return len(sink.removed) == 1
 	})
 
@@ -83,6 +107,189 @@ func TestExtensionObserve(t *testing.T) {
 			Labels: map[string]string{
 				"env":         "prod",
 				"pod-version": "2",
+			},
+		},
+	}, sink.removed[0])
+
+	require.NoError(t, ext.Shutdown(context.Background()))
+}
+
+func TestExtensionObserveNodes(t *testing.T) {
+	factory := NewFactory()
+	config := factory.CreateDefaultConfig().(*Config)
+	defer mockServiceHost(config)()
+
+	ext, err := newObserver(config, componenttest.NewNopTelemetrySettings())
+	require.NoError(t, err)
+	require.NotNil(t, ext)
+
+	obs := ext.(*k8sObserver)
+	nodeListerWatcher := framework.NewFakeControllerSource()
+	obs.nodeListerWatcher = nodeListerWatcher
+
+	nodeListerWatcher.Add(node1V1)
+
+	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
+
+	sink := &endpointSink{}
+	obs.ListAndWatch(sink)
+
+	requireSink(t, sink, func() bool {
+		return len(sink.added) == 1
+	})
+
+	assert.Equal(t, observer.Endpoint{
+		ID:     "k8s_observer/node1-uid",
+		Target: "internalIP",
+		Details: &observer.K8sNode{
+			UID:                 "uid",
+			Annotations:         map[string]string{"annotation-key": "annotation-value"},
+			Labels:              map[string]string{"label-key": "label-value"},
+			Name:                "node1",
+			InternalIP:          "internalIP",
+			InternalDNS:         "internalDNS",
+			Hostname:            "localhost",
+			ExternalIP:          "externalIP",
+			ExternalDNS:         "externalDNS",
+			KubeletEndpointPort: 1234,
+			Metadata: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"annotation-key": "annotation-value",
+				},
+				"creationTimestamp": nil,
+				"labels": map[string]interface{}{
+					"label-key": "label-value",
+				},
+				"name":      "node1",
+				"namespace": "namespace",
+				"uid":       "uid",
+			},
+			Spec: map[string]interface{}{},
+			Status: map[string]interface{}{
+				"addresses": []interface{}{
+					map[string]interface{}{
+						"address": "localhost",
+						"type":    "Hostname",
+					},
+					map[string]interface{}{
+						"address": "externalDNS",
+						"type":    "ExternalDNS",
+					},
+					map[string]interface{}{
+						"address": "externalIP",
+						"type":    "ExternalIP",
+					},
+					map[string]interface{}{
+						"address": "internalDNS",
+						"type":    "InternalDNS",
+					},
+					map[string]interface{}{
+						"address": "internalIP",
+						"type":    "InternalIP",
+					},
+				},
+				"daemonEndpoints": map[string]interface{}{
+					"kubeletEndpoint": map[string]interface{}{
+						// float64 is a product of json unmarshalling
+						"Port": float64(1234),
+					},
+				},
+				"nodeInfo": map[string]interface{}{
+					"architecture":            "architecture",
+					"bootID":                  "boot-id",
+					"containerRuntimeVersion": "runtime-version",
+					"kernelVersion":           "kernel-version",
+					"kubeProxyVersion":        "kube-proxy-version",
+					"kubeletVersion":          "kubelet-version",
+					"machineID":               "machine-id",
+					"operatingSystem":         "operating-system",
+					"osImage":                 "os-image",
+					"systemUUID":              "system-uuid",
+				},
+				"phase": "Running",
+			},
+		},
+	}, sink.added[0])
+
+	nodeListerWatcher.Delete(node1V2)
+
+	requireSink(t, sink, func() bool {
+		return len(sink.removed) == 1
+	})
+
+	assert.Equal(t, observer.Endpoint{
+		ID:     "k8s_observer/node1-uid",
+		Target: "internalIP",
+		Details: &observer.K8sNode{
+			UID:         "uid",
+			Annotations: map[string]string{"annotation-key": "annotation-value"},
+			Labels: map[string]string{
+				"label-key":    "label-value",
+				"node-version": "2",
+			},
+			Name:                "node1",
+			InternalIP:          "internalIP",
+			InternalDNS:         "internalDNS",
+			Hostname:            "localhost",
+			ExternalIP:          "externalIP",
+			ExternalDNS:         "externalDNS",
+			KubeletEndpointPort: 1234,
+			Metadata: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"annotation-key": "annotation-value",
+				},
+				"creationTimestamp": nil,
+				"labels": map[string]interface{}{
+					"label-key":    "label-value",
+					"node-version": "2",
+				},
+				"name":      "node1",
+				"namespace": "namespace",
+				"uid":       "uid",
+			},
+			Spec: map[string]interface{}{},
+			Status: map[string]interface{}{
+				"addresses": []interface{}{
+					map[string]interface{}{
+						"address": "localhost",
+						"type":    "Hostname",
+					},
+					map[string]interface{}{
+						"address": "externalDNS",
+						"type":    "ExternalDNS",
+					},
+					map[string]interface{}{
+						"address": "externalIP",
+						"type":    "ExternalIP",
+					},
+					map[string]interface{}{
+						"address": "internalDNS",
+						"type":    "InternalDNS",
+					},
+					map[string]interface{}{
+						"address": "internalIP",
+						"type":    "InternalIP",
+					},
+				},
+				"daemonEndpoints": map[string]interface{}{
+					"kubeletEndpoint": map[string]interface{}{
+						// float64 is a product of json unmarshalling
+						"Port": float64(1234),
+					},
+				},
+				"nodeInfo": map[string]interface{}{
+					"architecture":            "architecture",
+					"bootID":                  "boot-id",
+					"containerRuntimeVersion": "runtime-version",
+					"kernelVersion":           "kernel-version",
+					"kubeProxyVersion":        "kube-proxy-version",
+					"kubeletVersion":          "kubelet-version",
+					"machineID":               "machine-id",
+					"operatingSystem":         "operating-system",
+					"osImage":                 "os-image",
+					"systemUUID":              "system-uuid",
+				},
+				"phase": "Running",
 			},
 		},
 	}, sink.removed[0])

--- a/extension/observer/k8sobserver/extension_test.go
+++ b/extension/observer/k8sobserver/extension_test.go
@@ -152,62 +152,6 @@ func TestExtensionObserveNodes(t *testing.T) {
 			ExternalIP:          "externalIP",
 			ExternalDNS:         "externalDNS",
 			KubeletEndpointPort: 1234,
-			Metadata: map[string]interface{}{
-				"annotations": map[string]interface{}{
-					"annotation-key": "annotation-value",
-				},
-				"creationTimestamp": nil,
-				"labels": map[string]interface{}{
-					"label-key": "label-value",
-				},
-				"name":      "node1",
-				"namespace": "namespace",
-				"uid":       "uid",
-			},
-			Spec: map[string]interface{}{},
-			Status: map[string]interface{}{
-				"addresses": []interface{}{
-					map[string]interface{}{
-						"address": "localhost",
-						"type":    "Hostname",
-					},
-					map[string]interface{}{
-						"address": "externalDNS",
-						"type":    "ExternalDNS",
-					},
-					map[string]interface{}{
-						"address": "externalIP",
-						"type":    "ExternalIP",
-					},
-					map[string]interface{}{
-						"address": "internalDNS",
-						"type":    "InternalDNS",
-					},
-					map[string]interface{}{
-						"address": "internalIP",
-						"type":    "InternalIP",
-					},
-				},
-				"daemonEndpoints": map[string]interface{}{
-					"kubeletEndpoint": map[string]interface{}{
-						// float64 is a product of json unmarshalling
-						"Port": float64(1234),
-					},
-				},
-				"nodeInfo": map[string]interface{}{
-					"architecture":            "architecture",
-					"bootID":                  "boot-id",
-					"containerRuntimeVersion": "runtime-version",
-					"kernelVersion":           "kernel-version",
-					"kubeProxyVersion":        "kube-proxy-version",
-					"kubeletVersion":          "kubelet-version",
-					"machineID":               "machine-id",
-					"operatingSystem":         "operating-system",
-					"osImage":                 "os-image",
-					"systemUUID":              "system-uuid",
-				},
-				"phase": "Running",
-			},
 		},
 	}, sink.added[0])
 
@@ -234,63 +178,6 @@ func TestExtensionObserveNodes(t *testing.T) {
 			ExternalIP:          "externalIP",
 			ExternalDNS:         "externalDNS",
 			KubeletEndpointPort: 1234,
-			Metadata: map[string]interface{}{
-				"annotations": map[string]interface{}{
-					"annotation-key": "annotation-value",
-				},
-				"creationTimestamp": nil,
-				"labels": map[string]interface{}{
-					"label-key":    "label-value",
-					"node-version": "2",
-				},
-				"name":      "node1",
-				"namespace": "namespace",
-				"uid":       "uid",
-			},
-			Spec: map[string]interface{}{},
-			Status: map[string]interface{}{
-				"addresses": []interface{}{
-					map[string]interface{}{
-						"address": "localhost",
-						"type":    "Hostname",
-					},
-					map[string]interface{}{
-						"address": "externalDNS",
-						"type":    "ExternalDNS",
-					},
-					map[string]interface{}{
-						"address": "externalIP",
-						"type":    "ExternalIP",
-					},
-					map[string]interface{}{
-						"address": "internalDNS",
-						"type":    "InternalDNS",
-					},
-					map[string]interface{}{
-						"address": "internalIP",
-						"type":    "InternalIP",
-					},
-				},
-				"daemonEndpoints": map[string]interface{}{
-					"kubeletEndpoint": map[string]interface{}{
-						// float64 is a product of json unmarshalling
-						"Port": float64(1234),
-					},
-				},
-				"nodeInfo": map[string]interface{}{
-					"architecture":            "architecture",
-					"bootID":                  "boot-id",
-					"containerRuntimeVersion": "runtime-version",
-					"kernelVersion":           "kernel-version",
-					"kubeProxyVersion":        "kube-proxy-version",
-					"kubeletVersion":          "kubelet-version",
-					"machineID":               "machine-id",
-					"operatingSystem":         "operating-system",
-					"osImage":                 "os-image",
-					"systemUUID":              "system-uuid",
-				},
-				"phase": "Running",
-			},
 		},
 	}, sink.removed[0])
 

--- a/extension/observer/k8sobserver/handler_test.go
+++ b/extension/observer/k8sobserver/handler_test.go
@@ -170,62 +170,6 @@ func TestNodeEndpointsAdded(t *testing.T) {
 				ExternalIP:          "externalIP",
 				ExternalDNS:         "externalDNS",
 				KubeletEndpointPort: 1234,
-				Metadata: map[string]interface{}{
-					"annotations": map[string]interface{}{
-						"annotation-key": "annotation-value",
-					},
-					"creationTimestamp": nil,
-					"labels": map[string]interface{}{
-						"label-key": "label-value",
-					},
-					"name":      "node1",
-					"namespace": "namespace",
-					"uid":       "uid",
-				},
-				Spec: map[string]interface{}{},
-				Status: map[string]interface{}{
-					"addresses": []interface{}{
-						map[string]interface{}{
-							"address": "localhost",
-							"type":    "Hostname",
-						},
-						map[string]interface{}{
-							"address": "externalDNS",
-							"type":    "ExternalDNS",
-						},
-						map[string]interface{}{
-							"address": "externalIP",
-							"type":    "ExternalIP",
-						},
-						map[string]interface{}{
-							"address": "internalDNS",
-							"type":    "InternalDNS",
-						},
-						map[string]interface{}{
-							"address": "internalIP",
-							"type":    "InternalIP",
-						},
-					},
-					"daemonEndpoints": map[string]interface{}{
-						"kubeletEndpoint": map[string]interface{}{
-							// float64 is a product of json unmarshalling
-							"Port": float64(1234),
-						},
-					},
-					"nodeInfo": map[string]interface{}{
-						"architecture":            "architecture",
-						"bootID":                  "boot-id",
-						"containerRuntimeVersion": "runtime-version",
-						"kernelVersion":           "kernel-version",
-						"kubeProxyVersion":        "kube-proxy-version",
-						"kubeletVersion":          "kubelet-version",
-						"machineID":               "machine-id",
-						"operatingSystem":         "operating-system",
-						"osImage":                 "os-image",
-						"systemUUID":              "system-uuid",
-					},
-					"phase": "Running",
-				},
 			},
 		},
 	}, th.sink.added)
@@ -251,62 +195,6 @@ func TestNodeEndpointsRemoved(t *testing.T) {
 				ExternalIP:          "externalIP",
 				ExternalDNS:         "externalDNS",
 				KubeletEndpointPort: 1234,
-				Metadata: map[string]interface{}{
-					"annotations": map[string]interface{}{
-						"annotation-key": "annotation-value",
-					},
-					"creationTimestamp": nil,
-					"labels": map[string]interface{}{
-						"label-key": "label-value",
-					},
-					"name":      "node1",
-					"namespace": "namespace",
-					"uid":       "uid",
-				},
-				Spec: map[string]interface{}{},
-				Status: map[string]interface{}{
-					"addresses": []interface{}{
-						map[string]interface{}{
-							"address": "localhost",
-							"type":    "Hostname",
-						},
-						map[string]interface{}{
-							"address": "externalDNS",
-							"type":    "ExternalDNS",
-						},
-						map[string]interface{}{
-							"address": "externalIP",
-							"type":    "ExternalIP",
-						},
-						map[string]interface{}{
-							"address": "internalDNS",
-							"type":    "InternalDNS",
-						},
-						map[string]interface{}{
-							"address": "internalIP",
-							"type":    "InternalIP",
-						},
-					},
-					"daemonEndpoints": map[string]interface{}{
-						"kubeletEndpoint": map[string]interface{}{
-							// float64 is a product of json unmarshalling
-							"Port": float64(1234),
-						},
-					},
-					"nodeInfo": map[string]interface{}{
-						"architecture":            "architecture",
-						"bootID":                  "boot-id",
-						"containerRuntimeVersion": "runtime-version",
-						"kernelVersion":           "kernel-version",
-						"kubeProxyVersion":        "kube-proxy-version",
-						"kubeletVersion":          "kubelet-version",
-						"machineID":               "machine-id",
-						"operatingSystem":         "operating-system",
-						"osImage":                 "os-image",
-						"systemUUID":              "system-uuid",
-					},
-					"phase": "Running",
-				},
 			},
 		},
 	}, th.sink.removed)
@@ -357,63 +245,6 @@ func TestNodeEndpointsChanged(t *testing.T) {
 				ExternalIP:          "externalIP",
 				ExternalDNS:         "externalDNS",
 				KubeletEndpointPort: 1234,
-				Metadata: map[string]interface{}{
-					"annotations": map[string]interface{}{
-						"annotation-key": "annotation-value",
-					},
-					"creationTimestamp": nil,
-					"labels": map[string]interface{}{
-						"label-key": "label-value",
-						"new-label": "value",
-					},
-					"name":      "node1",
-					"namespace": "namespace",
-					"uid":       "uid",
-				},
-				Spec: map[string]interface{}{},
-				Status: map[string]interface{}{
-					"addresses": []interface{}{
-						map[string]interface{}{
-							"address": "localhost",
-							"type":    "Hostname",
-						},
-						map[string]interface{}{
-							"address": "externalDNS",
-							"type":    "ExternalDNS",
-						},
-						map[string]interface{}{
-							"address": "externalIP",
-							"type":    "ExternalIP",
-						},
-						map[string]interface{}{
-							"address": "internalDNS",
-							"type":    "InternalDNS",
-						},
-						map[string]interface{}{
-							"address": "internalIP",
-							"type":    "InternalIP",
-						},
-					},
-					"daemonEndpoints": map[string]interface{}{
-						"kubeletEndpoint": map[string]interface{}{
-							// float64 is a product of json unmarshalling
-							"Port": float64(1234),
-						},
-					},
-					"nodeInfo": map[string]interface{}{
-						"architecture":            "architecture",
-						"bootID":                  "boot-id",
-						"containerRuntimeVersion": "runtime-version",
-						"kernelVersion":           "kernel-version",
-						"kubeProxyVersion":        "kube-proxy-version",
-						"kubeletVersion":          "kubelet-version",
-						"machineID":               "machine-id",
-						"operatingSystem":         "operating-system",
-						"osImage":                 "os-image",
-						"systemUUID":              "system-uuid",
-					},
-					"phase": "Running",
-				},
 			},
 		},
 	}, th.sink.changed)

--- a/extension/observer/k8sobserver/handler_test.go
+++ b/extension/observer/k8sobserver/handler_test.go
@@ -18,18 +18,31 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
 
-func TestEndpointsAdded(t *testing.T) {
-	sink := endpointSink{}
-	h := handler{
-		idNamespace: "test-1",
-		watcher:     &sink,
+type testHandler struct {
+	h    *handler
+	sink *endpointSink
+}
+
+func newTestHandler() testHandler {
+	sink := &endpointSink{}
+	return testHandler{
+		h: &handler{
+			idNamespace: "test-1",
+			listener:    sink,
+			logger:      zap.NewNop(),
+		},
+		sink: sink,
 	}
-	h.OnAdd(podWithNamedPorts)
+}
+
+func TestPodEndpointsAdded(t *testing.T) {
+	th := newTestHandler()
+	th.h.OnAdd(podWithNamedPorts)
 	assert.ElementsMatch(t, []observer.Endpoint{
 		{
 			ID:     "test-1/pod-2-UID",
@@ -54,18 +67,14 @@ func TestEndpointsAdded(t *testing.T) {
 				Port:      443,
 				Transport: observer.ProtocolTCP,
 			},
-		}}, sink.added)
-	assert.Nil(t, sink.removed)
-	assert.Nil(t, sink.changed)
+		}}, th.sink.added)
+	assert.Nil(t, th.sink.removed)
+	assert.Nil(t, th.sink.changed)
 }
 
-func TestEndpointsRemoved(t *testing.T) {
-	sink := endpointSink{}
-	h := handler{
-		idNamespace: "test-1",
-		watcher:     &sink,
-	}
-	h.OnDelete(podWithNamedPorts)
+func TestPodEndpointsRemoved(t *testing.T) {
+	th := newTestHandler()
+	th.h.OnDelete(podWithNamedPorts)
 	assert.ElementsMatch(t, []observer.Endpoint{
 		{
 			ID:     "test-1/pod-2-UID",
@@ -90,41 +99,36 @@ func TestEndpointsRemoved(t *testing.T) {
 				Port:      443,
 				Transport: observer.ProtocolTCP,
 			},
-		}}, sink.removed)
-	assert.Nil(t, sink.added)
-	assert.Nil(t, sink.changed)
+		}}, th.sink.removed)
+	assert.Nil(t, th.sink.added)
+	assert.Nil(t, th.sink.changed)
 }
 
-func TestEndpointsChanged(t *testing.T) {
-	sink := endpointSink{}
-	h := handler{
-		idNamespace: "test-1",
-		watcher:     &sink,
-	}
+func TestPodEndpointsChanged(t *testing.T) {
+	th := newTestHandler()
 	// Nothing changed.
-	h.OnUpdate(podWithNamedPorts, podWithNamedPorts)
-	assert.Nil(t, sink.added)
-	assert.Nil(t, sink.changed)
-	assert.Nil(t, sink.removed)
+	th.h.OnUpdate(podWithNamedPorts, podWithNamedPorts)
+	assert.Nil(t, th.sink.added)
+	assert.Nil(t, th.sink.changed)
+	assert.Nil(t, th.sink.removed)
 
 	// Labels changed.
 	changedLabels := podWithNamedPorts.DeepCopy()
 	changedLabels.Labels["new-label"] = "value"
-	h.OnUpdate(podWithNamedPorts, changedLabels)
+	th.h.OnUpdate(podWithNamedPorts, changedLabels)
 
-	assert.Nil(t, sink.added)
-	assert.Nil(t, sink.removed)
+	assert.Nil(t, th.sink.added)
+	assert.Nil(t, th.sink.removed)
 	assert.ElementsMatch(t,
 		[]observer.EndpointID{"test-1/pod-2-UID", "test-1/pod-2-UID/https(443)"},
-		[]observer.EndpointID{sink.changed[0].ID, sink.changed[1].ID})
+		[]observer.EndpointID{th.sink.changed[0].ID, th.sink.changed[1].ID})
 
 	// Running state changed, one added and one removed.
-	sink = endpointSink{}
 	updatedPod := podWithNamedPorts.DeepCopy()
 	updatedPod.Labels["updated-label"] = "true"
-	h.OnUpdate(podWithNamedPorts, updatedPod)
-	assert.Nil(t, sink.added)
-	assert.Nil(t, sink.removed)
+	th.h.OnUpdate(podWithNamedPorts, updatedPod)
+	assert.Nil(t, th.sink.added)
+	assert.Nil(t, th.sink.removed)
 	assert.ElementsMatch(t, []observer.Endpoint{
 		{
 			ID:     "test-1/pod-2-UID",
@@ -145,45 +149,272 @@ func TestEndpointsChanged(t *testing.T) {
 					Labels:    map[string]string{"env": "prod", "updated-label": "true"}},
 				Port:      443,
 				Transport: observer.ProtocolTCP}},
-	}, sink.changed)
+	}, th.sink.changed)
 }
 
-func TestEndpointsPodNotRunning(t *testing.T) {
-	sink := endpointSink{}
-	h := handler{
-		idNamespace: "test-1",
-		watcher:     &sink,
-	}
-
-	completedPod := podWithNamedPorts.DeepCopy()
-	completedPod.Status.Phase = v1.PodSucceeded
-
-	h.OnUpdate(podWithNamedPorts, completedPod)
+func TestNodeEndpointsAdded(t *testing.T) {
+	th := newTestHandler()
+	th.h.OnAdd(node1V1)
 	assert.ElementsMatch(t, []observer.Endpoint{
 		{
-			ID:     "test-1/pod-2-UID",
-			Target: "1.2.3.4",
-			Details: &observer.Pod{
-				Name:      "pod-2",
-				Namespace: "default",
-				UID:       "pod-2-UID",
-				Labels:    map[string]string{"env": "prod"},
-			},
-		}, {
-			ID:     "test-1/pod-2-UID/https(443)",
-			Target: "1.2.3.4:443",
-			Details: &observer.Port{
-				Name: "https",
-				Pod: observer.Pod{
-					Namespace: "default",
-					UID:       "pod-2-UID",
-					Name:      "pod-2",
-					Labels:    map[string]string{"env": "prod"},
+			ID:     "test-1/node1-uid",
+			Target: "internalIP",
+			Details: &observer.K8sNode{
+				UID:                 "uid",
+				Annotations:         map[string]string{"annotation-key": "annotation-value"},
+				Labels:              map[string]string{"label-key": "label-value"},
+				Name:                "node1",
+				InternalIP:          "internalIP",
+				InternalDNS:         "internalDNS",
+				Hostname:            "localhost",
+				ExternalIP:          "externalIP",
+				ExternalDNS:         "externalDNS",
+				KubeletEndpointPort: 1234,
+				Metadata: map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"annotation-key": "annotation-value",
+					},
+					"creationTimestamp": nil,
+					"labels": map[string]interface{}{
+						"label-key": "label-value",
+					},
+					"name":      "node1",
+					"namespace": "namespace",
+					"uid":       "uid",
 				},
-				Port:      443,
-				Transport: observer.ProtocolTCP,
+				Spec: map[string]interface{}{},
+				Status: map[string]interface{}{
+					"addresses": []interface{}{
+						map[string]interface{}{
+							"address": "localhost",
+							"type":    "Hostname",
+						},
+						map[string]interface{}{
+							"address": "externalDNS",
+							"type":    "ExternalDNS",
+						},
+						map[string]interface{}{
+							"address": "externalIP",
+							"type":    "ExternalIP",
+						},
+						map[string]interface{}{
+							"address": "internalDNS",
+							"type":    "InternalDNS",
+						},
+						map[string]interface{}{
+							"address": "internalIP",
+							"type":    "InternalIP",
+						},
+					},
+					"daemonEndpoints": map[string]interface{}{
+						"kubeletEndpoint": map[string]interface{}{
+							// float64 is a product of json unmarshalling
+							"Port": float64(1234),
+						},
+					},
+					"nodeInfo": map[string]interface{}{
+						"architecture":            "architecture",
+						"bootID":                  "boot-id",
+						"containerRuntimeVersion": "runtime-version",
+						"kernelVersion":           "kernel-version",
+						"kubeProxyVersion":        "kube-proxy-version",
+						"kubeletVersion":          "kubelet-version",
+						"machineID":               "machine-id",
+						"operatingSystem":         "operating-system",
+						"osImage":                 "os-image",
+						"systemUUID":              "system-uuid",
+					},
+					"phase": "Running",
+				},
 			},
-		}}, sink.removed)
-	assert.Nil(t, sink.changed)
-	assert.Nil(t, sink.added)
+		},
+	}, th.sink.added)
+	assert.Nil(t, th.sink.removed)
+	assert.Nil(t, th.sink.changed)
+}
+
+func TestNodeEndpointsRemoved(t *testing.T) {
+	th := newTestHandler()
+	th.h.OnDelete(node1V1)
+	assert.ElementsMatch(t, []observer.Endpoint{
+		{
+			ID:     "test-1/node1-uid",
+			Target: "internalIP",
+			Details: &observer.K8sNode{
+				UID:                 "uid",
+				Annotations:         map[string]string{"annotation-key": "annotation-value"},
+				Labels:              map[string]string{"label-key": "label-value"},
+				Name:                "node1",
+				InternalIP:          "internalIP",
+				InternalDNS:         "internalDNS",
+				Hostname:            "localhost",
+				ExternalIP:          "externalIP",
+				ExternalDNS:         "externalDNS",
+				KubeletEndpointPort: 1234,
+				Metadata: map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"annotation-key": "annotation-value",
+					},
+					"creationTimestamp": nil,
+					"labels": map[string]interface{}{
+						"label-key": "label-value",
+					},
+					"name":      "node1",
+					"namespace": "namespace",
+					"uid":       "uid",
+				},
+				Spec: map[string]interface{}{},
+				Status: map[string]interface{}{
+					"addresses": []interface{}{
+						map[string]interface{}{
+							"address": "localhost",
+							"type":    "Hostname",
+						},
+						map[string]interface{}{
+							"address": "externalDNS",
+							"type":    "ExternalDNS",
+						},
+						map[string]interface{}{
+							"address": "externalIP",
+							"type":    "ExternalIP",
+						},
+						map[string]interface{}{
+							"address": "internalDNS",
+							"type":    "InternalDNS",
+						},
+						map[string]interface{}{
+							"address": "internalIP",
+							"type":    "InternalIP",
+						},
+					},
+					"daemonEndpoints": map[string]interface{}{
+						"kubeletEndpoint": map[string]interface{}{
+							// float64 is a product of json unmarshalling
+							"Port": float64(1234),
+						},
+					},
+					"nodeInfo": map[string]interface{}{
+						"architecture":            "architecture",
+						"bootID":                  "boot-id",
+						"containerRuntimeVersion": "runtime-version",
+						"kernelVersion":           "kernel-version",
+						"kubeProxyVersion":        "kube-proxy-version",
+						"kubeletVersion":          "kubelet-version",
+						"machineID":               "machine-id",
+						"operatingSystem":         "operating-system",
+						"osImage":                 "os-image",
+						"systemUUID":              "system-uuid",
+					},
+					"phase": "Running",
+				},
+			},
+		},
+	}, th.sink.removed)
+	assert.Nil(t, th.sink.added)
+	assert.Nil(t, th.sink.changed)
+}
+
+func TestNodeEndpointsChanged(t *testing.T) {
+	th := newTestHandler()
+	// Nothing changed.
+	th.h.OnUpdate(node1V1, node1V1)
+	assert.Nil(t, th.sink.added)
+	assert.Nil(t, th.sink.changed)
+	assert.Nil(t, th.sink.removed)
+
+	// Labels changed.
+	changedLabels := node1V1.DeepCopy()
+	changedLabels.Labels["new-label"] = "value"
+	th.h.OnUpdate(node1V1, changedLabels)
+
+	assert.Nil(t, th.sink.added)
+	assert.Nil(t, th.sink.removed)
+	assert.ElementsMatch(t,
+		[]observer.EndpointID{"test-1/node1-uid"},
+		[]observer.EndpointID{th.sink.changed[0].ID})
+
+	// Running state changed, one added and one removed.
+	updatedNode := node1V1.DeepCopy()
+	updatedNode.Labels["updated-label"] = "true"
+	th.h.OnUpdate(podWithNamedPorts, updatedNode)
+	assert.Nil(t, th.sink.added)
+	assert.Nil(t, th.sink.removed)
+	assert.ElementsMatch(t, []observer.Endpoint{
+		{
+			ID:     "test-1/node1-uid",
+			Target: "internalIP",
+			Details: &observer.K8sNode{
+				UID:         "uid",
+				Annotations: map[string]string{"annotation-key": "annotation-value"},
+				Labels: map[string]string{
+					"label-key": "label-value",
+					"new-label": "value",
+				},
+				Name:                "node1",
+				InternalIP:          "internalIP",
+				InternalDNS:         "internalDNS",
+				Hostname:            "localhost",
+				ExternalIP:          "externalIP",
+				ExternalDNS:         "externalDNS",
+				KubeletEndpointPort: 1234,
+				Metadata: map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"annotation-key": "annotation-value",
+					},
+					"creationTimestamp": nil,
+					"labels": map[string]interface{}{
+						"label-key": "label-value",
+						"new-label": "value",
+					},
+					"name":      "node1",
+					"namespace": "namespace",
+					"uid":       "uid",
+				},
+				Spec: map[string]interface{}{},
+				Status: map[string]interface{}{
+					"addresses": []interface{}{
+						map[string]interface{}{
+							"address": "localhost",
+							"type":    "Hostname",
+						},
+						map[string]interface{}{
+							"address": "externalDNS",
+							"type":    "ExternalDNS",
+						},
+						map[string]interface{}{
+							"address": "externalIP",
+							"type":    "ExternalIP",
+						},
+						map[string]interface{}{
+							"address": "internalDNS",
+							"type":    "InternalDNS",
+						},
+						map[string]interface{}{
+							"address": "internalIP",
+							"type":    "InternalIP",
+						},
+					},
+					"daemonEndpoints": map[string]interface{}{
+						"kubeletEndpoint": map[string]interface{}{
+							// float64 is a product of json unmarshalling
+							"Port": float64(1234),
+						},
+					},
+					"nodeInfo": map[string]interface{}{
+						"architecture":            "architecture",
+						"bootID":                  "boot-id",
+						"containerRuntimeVersion": "runtime-version",
+						"kernelVersion":           "kernel-version",
+						"kubeProxyVersion":        "kube-proxy-version",
+						"kubeletVersion":          "kubelet-version",
+						"machineID":               "machine-id",
+						"operatingSystem":         "operating-system",
+						"osImage":                 "os-image",
+						"systemUUID":              "system-uuid",
+					},
+					"phase": "Running",
+				},
+			},
+		},
+	}, th.sink.changed)
 }

--- a/extension/observer/k8sobserver/k8s_fixtures_test.go
+++ b/extension/observer/k8sobserver/k8s_fixtures_test.go
@@ -114,3 +114,53 @@ var podWithNamedPorts = func() *v1.Pod {
 func pointerBool(val bool) *bool {
 	return &val
 }
+
+// NewNode is a helper function for creating Nodes for testing.
+func NewNode(name, hostname string) *v1.Node {
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "namespace",
+			Name:      name,
+			UID:       "uid",
+			Labels: map[string]string{
+				"label-key": "label-value",
+			},
+			Annotations: map[string]string{
+				"annotation-key": "annotation-value",
+			},
+		},
+		Spec: v1.NodeSpec{
+			Taints: []v1.Taint{},
+		},
+		Status: v1.NodeStatus{
+			Phase: v1.NodeRunning,
+			Addresses: []v1.NodeAddress{
+				{Type: v1.NodeHostName, Address: hostname},
+				{Type: v1.NodeExternalDNS, Address: "externalDNS"},
+				{Type: v1.NodeExternalIP, Address: "externalIP"},
+				{Type: v1.NodeInternalDNS, Address: "internalDNS"},
+				{Type: v1.NodeInternalIP, Address: "internalIP"},
+			},
+			DaemonEndpoints: v1.NodeDaemonEndpoints{KubeletEndpoint: v1.DaemonEndpoint{Port: 1234}},
+			NodeInfo: v1.NodeSystemInfo{
+				Architecture:            "architecture",
+				BootID:                  "boot-id",
+				ContainerRuntimeVersion: "runtime-version",
+				KernelVersion:           "kernel-version",
+				KubeProxyVersion:        "kube-proxy-version",
+				KubeletVersion:          "kubelet-version",
+				MachineID:               "machine-id",
+				OperatingSystem:         "operating-system",
+				OSImage:                 "os-image",
+				SystemUUID:              "system-uuid",
+			},
+		},
+	}
+}
+
+var node1V1 = NewNode("node1", "localhost")
+var node1V2 = func() *v1.Node {
+	node := node1V1.DeepCopy()
+	node.Labels["node-version"] = "2"
+	return node
+}()

--- a/extension/observer/k8sobserver/mocks_test.go
+++ b/extension/observer/k8sobserver/mocks_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
@@ -51,8 +51,8 @@ func (e *endpointSink) OnChange(changed []observer.Endpoint) {
 
 var _ observer.Notify = (*endpointSink)(nil)
 
-func assertSink(t *testing.T, sink *endpointSink, f func() bool) {
-	assert.Eventually(t, func() bool {
+func requireSink(t *testing.T, sink *endpointSink, f func() bool) {
+	require.Eventually(t, func() bool {
 		sink.Lock()
 		defer sink.Unlock()
 		return f()

--- a/extension/observer/k8sobserver/node_endpoint.go
+++ b/extension/observer/k8sobserver/node_endpoint.go
@@ -1,0 +1,106 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.opentelemetry.io/collector/config"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+// convertNodeToEndpoint converts a node instance into a k8s.node observer.Endpoint. It will determine the
+// Target by the first address match of InternalIP, InternalDNS, HostName, ExternalIP, and ExternalDNS in that
+// order.
+func convertNodeToEndpoint(idNamespace string, node *v1.Node) observer.Endpoint {
+	nodeID := observer.EndpointID(fmt.Sprintf("%s/%s-%s", idNamespace, node.Name, node.UID))
+
+	var internalIP, internalDNS, hostname, externalIP, externalDNS string
+
+	for _, addr := range node.Status.Addresses {
+		switch addr.Type {
+		case v1.NodeInternalIP:
+			internalIP = addr.Address
+		case v1.NodeInternalDNS:
+			internalDNS = addr.Address
+		case v1.NodeHostName:
+			hostname = addr.Address
+		case v1.NodeExternalIP:
+			externalIP = addr.Address
+		case v1.NodeExternalDNS:
+			externalDNS = addr.Address
+		}
+	}
+
+	var target string
+	for _, candidate := range []string{internalIP, internalDNS, hostname, externalIP, externalDNS} {
+		if candidate != "" {
+			target = candidate
+			break
+		}
+	}
+
+	// These fields are cleared to prevent excessive endpoint churn/receiver cycling
+	node.ResourceVersion = ""
+	for i := range node.Status.Conditions {
+		node.Status.Conditions[i].LastHeartbeatTime = metav1.Time{}
+		node.Status.Conditions[i].LastTransitionTime = metav1.Time{}
+	}
+
+	var metadata, spec, status map[string]interface{}
+	for _, item := range []struct {
+		src interface{}
+		tgt *map[string]interface{}
+	}{
+		{node.ObjectMeta, &metadata}, {node.Spec, &spec}, {node.Status, &status},
+	} {
+		var jsonMap map[string]interface{}
+		if marshaled, err := json.Marshal(item.src); err == nil {
+			if err := json.Unmarshal(marshaled, &jsonMap); err == nil {
+				configMap := config.NewMap()
+				for k, v := range jsonMap {
+					configMap.Set(k, v)
+				}
+				*(item.tgt) = configMap.ToStringMap()
+			}
+		}
+	}
+
+	nodeDetails := observer.K8sNode{
+		UID:                 string(node.UID),
+		Annotations:         node.Annotations,
+		Labels:              node.Labels,
+		Name:                node.Name,
+		InternalIP:          internalIP,
+		InternalDNS:         internalDNS,
+		Hostname:            hostname,
+		ExternalIP:          externalIP,
+		ExternalDNS:         externalDNS,
+		KubeletEndpointPort: uint16(node.Status.DaemonEndpoints.KubeletEndpoint.Port),
+		Metadata:            metadata,
+		Spec:                spec,
+		Status:              status,
+	}
+
+	return observer.Endpoint{
+		ID:      nodeID,
+		Target:  target,
+		Details: &nodeDetails,
+	}
+}

--- a/extension/observer/k8sobserver/node_endpoint_test.go
+++ b/extension/observer/k8sobserver/node_endpoint_test.go
@@ -1,0 +1,101 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sobserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+func TestNodeObjectToK8sNodeEndpoint(t *testing.T) {
+	expectedNode := observer.Endpoint{
+		ID:     "namespace/name-uid",
+		Target: "internalIP",
+		Details: &observer.K8sNode{
+			UID:                 "uid",
+			Annotations:         map[string]string{"annotation-key": "annotation-value"},
+			Labels:              map[string]string{"label-key": "label-value"},
+			Name:                "name",
+			InternalIP:          "internalIP",
+			InternalDNS:         "internalDNS",
+			Hostname:            "hostname",
+			ExternalIP:          "externalIP",
+			ExternalDNS:         "externalDNS",
+			KubeletEndpointPort: 1234,
+			Metadata: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"annotation-key": "annotation-value",
+				},
+				"creationTimestamp": nil,
+				"labels": map[string]interface{}{
+					"label-key": "label-value",
+				},
+				"name":      "name",
+				"namespace": "namespace",
+				"uid":       "uid",
+			},
+			Spec: map[string]interface{}{},
+			Status: map[string]interface{}{
+				"addresses": []interface{}{
+					map[string]interface{}{
+						"address": "hostname",
+						"type":    "Hostname",
+					},
+					map[string]interface{}{
+						"address": "externalDNS",
+						"type":    "ExternalDNS",
+					},
+					map[string]interface{}{
+						"address": "externalIP",
+						"type":    "ExternalIP",
+					},
+					map[string]interface{}{
+						"address": "internalDNS",
+						"type":    "InternalDNS",
+					},
+					map[string]interface{}{
+						"address": "internalIP",
+						"type":    "InternalIP",
+					},
+				},
+				"daemonEndpoints": map[string]interface{}{
+					"kubeletEndpoint": map[string]interface{}{
+						// float64 is a product of json unmarshalling
+						"Port": float64(1234),
+					},
+				},
+				"nodeInfo": map[string]interface{}{
+					"architecture":            "architecture",
+					"bootID":                  "boot-id",
+					"containerRuntimeVersion": "runtime-version",
+					"kernelVersion":           "kernel-version",
+					"kubeProxyVersion":        "kube-proxy-version",
+					"kubeletVersion":          "kubelet-version",
+					"machineID":               "machine-id",
+					"operatingSystem":         "operating-system",
+					"osImage":                 "os-image",
+					"systemUUID":              "system-uuid",
+				},
+				"phase": "Running",
+			},
+		},
+	}
+
+	endpoint := convertNodeToEndpoint("namespace", NewNode("name", "hostname"))
+	require.Equal(t, expectedNode, endpoint)
+}

--- a/extension/observer/k8sobserver/node_endpoint_test.go
+++ b/extension/observer/k8sobserver/node_endpoint_test.go
@@ -37,62 +37,6 @@ func TestNodeObjectToK8sNodeEndpoint(t *testing.T) {
 			ExternalIP:          "externalIP",
 			ExternalDNS:         "externalDNS",
 			KubeletEndpointPort: 1234,
-			Metadata: map[string]interface{}{
-				"annotations": map[string]interface{}{
-					"annotation-key": "annotation-value",
-				},
-				"creationTimestamp": nil,
-				"labels": map[string]interface{}{
-					"label-key": "label-value",
-				},
-				"name":      "name",
-				"namespace": "namespace",
-				"uid":       "uid",
-			},
-			Spec: map[string]interface{}{},
-			Status: map[string]interface{}{
-				"addresses": []interface{}{
-					map[string]interface{}{
-						"address": "hostname",
-						"type":    "Hostname",
-					},
-					map[string]interface{}{
-						"address": "externalDNS",
-						"type":    "ExternalDNS",
-					},
-					map[string]interface{}{
-						"address": "externalIP",
-						"type":    "ExternalIP",
-					},
-					map[string]interface{}{
-						"address": "internalDNS",
-						"type":    "InternalDNS",
-					},
-					map[string]interface{}{
-						"address": "internalIP",
-						"type":    "InternalIP",
-					},
-				},
-				"daemonEndpoints": map[string]interface{}{
-					"kubeletEndpoint": map[string]interface{}{
-						// float64 is a product of json unmarshalling
-						"Port": float64(1234),
-					},
-				},
-				"nodeInfo": map[string]interface{}{
-					"architecture":            "architecture",
-					"bootID":                  "boot-id",
-					"containerRuntimeVersion": "runtime-version",
-					"kernelVersion":           "kernel-version",
-					"kubeProxyVersion":        "kube-proxy-version",
-					"kubeletVersion":          "kubelet-version",
-					"machineID":               "machine-id",
-					"operatingSystem":         "operating-system",
-					"osImage":                 "os-image",
-					"systemUUID":              "system-uuid",
-				},
-				"phase": "Running",
-			},
 		},
 	}
 

--- a/extension/observer/k8sobserver/pod_endpoint.go
+++ b/extension/observer/k8sobserver/pod_endpoint.go
@@ -1,0 +1,96 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+// convertPodToEndpoints converts a pod instance into a slice of endpoints. The endpoints
+// include the pod itself as well as an endpoint for each container port that is mapped
+// to a container that is in a running state.
+func convertPodToEndpoints(idNamespace string, pod *v1.Pod) []observer.Endpoint {
+	podID := observer.EndpointID(fmt.Sprintf("%s/%s", idNamespace, pod.UID))
+	podIP := pod.Status.PodIP
+
+	podDetails := observer.Pod{
+		UID:         string(pod.UID),
+		Annotations: pod.Annotations,
+		Labels:      pod.Labels,
+		Name:        pod.Name,
+		Namespace:   pod.Namespace,
+	}
+
+	// Return no endpoints if the Pod is not running
+	if pod.Status.Phase != v1.PodRunning {
+		return nil
+	}
+
+	endpoints := []observer.Endpoint{{
+		ID:      podID,
+		Target:  podIP,
+		Details: &podDetails,
+	}}
+
+	// Map of running containers by name.
+	containerRunning := map[string]bool{}
+
+	for _, container := range pod.Status.ContainerStatuses {
+		if container.State.Running != nil {
+			containerRunning[container.Name] = true
+		}
+	}
+
+	// Create endpoint for each named container port.
+	for _, container := range pod.Spec.Containers {
+		if !containerRunning[container.Name] {
+			continue
+		}
+
+		for _, port := range container.Ports {
+			endpointID := observer.EndpointID(
+				fmt.Sprintf(
+					"%s/%s(%d)", podID, port.Name, port.ContainerPort,
+				),
+			)
+			endpoints = append(endpoints, observer.Endpoint{
+				ID:     endpointID,
+				Target: fmt.Sprintf("%s:%d", podIP, port.ContainerPort),
+				Details: &observer.Port{
+					Pod:       podDetails,
+					Name:      port.Name,
+					Port:      uint16(port.ContainerPort),
+					Transport: getTransport(port.Protocol),
+				},
+			})
+		}
+	}
+
+	return endpoints
+}
+
+func getTransport(protocol v1.Protocol) observer.Transport {
+	switch protocol {
+	case v1.ProtocolTCP:
+		return observer.ProtocolTCP
+	case v1.ProtocolUDP:
+		return observer.ProtocolUDP
+	}
+	return observer.ProtocolUnknown
+}

--- a/extension/observer/k8sobserver/pod_endpoint_test.go
+++ b/extension/observer/k8sobserver/pod_endpoint_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sobserver // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+func TestPodObjectToPortEndpoint(t *testing.T) {
+	expectedEndpoints := []observer.Endpoint{
+		{
+			ID:     "namespace/pod-2-UID",
+			Target: "1.2.3.4",
+			Details: &observer.Pod{
+				Name:      "pod-2",
+				Namespace: "default",
+				UID:       "pod-2-UID",
+				Labels:    map[string]string{"env": "prod"}}},
+		{
+			ID:     "namespace/pod-2-UID/https(443)",
+			Target: "1.2.3.4:443",
+			Details: &observer.Port{
+				Name: "https", Pod: observer.Pod{
+					Name:      "pod-2",
+					Namespace: "default",
+					UID:       "pod-2-UID",
+					Labels:    map[string]string{"env": "prod"}},
+				Port:      443,
+				Transport: observer.ProtocolTCP}},
+	}
+
+	endpoints := convertPodToEndpoints("namespace", podWithNamedPorts)
+	require.Equal(t, expectedEndpoints, endpoints)
+
+}

--- a/extension/observer/k8sobserver/testdata/invalid_auth.yaml
+++ b/extension/observer/k8sobserver/testdata/invalid_auth.yaml
@@ -1,18 +1,10 @@
 extensions:
   k8s_observer:
-  k8s_observer/own-node-only:
-    node: node-1
-    auth_type: kubeConfig
-  k8s_observer/observe-all:
-    auth_type: none
-    observe_nodes: true
-    observe_pods: true
+    auth_type: not a real auth type
 
 service:
   extensions:
     - k8s_observer
-    - k8s_observer/own-node-only
-    - k8s_observer/observe-all
   pipelines:
     traces:
       receivers: [nop]

--- a/extension/observer/k8sobserver/testdata/invalid_no_observing.yaml
+++ b/extension/observer/k8sobserver/testdata/invalid_no_observing.yaml
@@ -1,0 +1,21 @@
+extensions:
+  k8s_observer:
+    observe_nodes: false
+    observe_pods: false
+
+service:
+  extensions:
+    - k8s_observer
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [nop]
+
+# Data pipeline is required to load the config.
+receivers:
+  nop:
+processors:
+  nop:
+exporters:
+  nop:

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -170,9 +170,6 @@ targeting it will have different variables available.
 | annotations           | A key-value map of non-identifying, user-specified node metadata                                                       |
 | labels                | A key-value map of user-specified node metadata                                                                        |
 | kubelet_endpoint_port | The node Status object's DaemonEndpoints.KubeletEndpoint.Port value                                                    |
-| spec                  | The node Spec json object that's equivalent to the output of `kubectl get node <node> -o jsonpath='{.spec}'`           |
-| metadata              | The node ObjectMeta json object that's equivalent to the output of `kubectl get node <node> -o jsonpath='{.metadata}'` |
-| status                | The node Status json object that's equivalent to the output of `kubectl get node <node> -o jsonpath='{.status}'`       |
 
 ## Examples
 

--- a/receiver/receivercreator/fixtures_test.go
+++ b/receiver/receivercreator/fixtures_test.go
@@ -98,49 +98,8 @@ var k8sNodeEndpoint = observer.Endpoint{
 			"beta.kubernetes.io/arch": "amd64",
 			"beta.kubernetes.io/os":   "linux",
 		},
-		Metadata: map[string]interface{}{
-			"annotations": map[string]string{
-				"node.alpha.kubernetes.io/ttl":                           "0",
-				"volumes.kubernetes.io/controller-managed-attach-detach": "true",
-			},
-			"labels": map[string]string{
-				"beta.kubernetes.io/arch": "amd64",
-				"beta.kubernetes.io/os":   "linux",
-			},
-			"name":            "a.name",
-			"resourceVersion": "1",
-			"uid":             "b344f2a7-1ec1-40f0-8557-8a9bfd8b6f99",
-		},
 		Name: "a.name",
-		Spec: map[string]interface{}{
-			"taints": []string{},
-		},
-		Status: map[string]interface{}{
-			"addresses": []map[string]interface{}{
-				{"address": "2.3.4.5", "type": "InternalIP"},
-			},
-			"allocatable": map[string]interface{}{},
-			"capacity":    map[string]interface{}{"cpu": "2", "pods": "1"},
-			"daemonEndpoints": map[string]interface{}{
-				"kubeletEndpoint": map[string]interface{}{"Port": "10250"},
-			},
-			"images": []map[string]interface{}{
-				{
-					"names":     []string{"an.image:latest", "another.image:latest"},
-					"sizeBytes": 15747069,
-				},
-				{
-					"names":     []string{"an.image.name"},
-					"sizeBytes": 685708,
-				},
-			},
-			"nodeInfo": map[string]interface{}{
-				"architecture":            "amd64",
-				"containerRuntimeVersion": "containerd://0.0.1",
-				"kubeletVersion":          "v1.2.3",
-			},
-		},
-		UID: "b344f2a7-1ec1-40f0-8557-8a9bfd8b6f99",
+		UID:  "b344f2a7-1ec1-40f0-8557-8a9bfd8b6f99",
 	},
 }
 

--- a/receiver/receivercreator/rules_test.go
+++ b/receiver/receivercreator/rules_test.go
@@ -49,8 +49,7 @@ func Test_ruleEval(t *testing.T) {
 		{"basic pod", args{`type == "pod" && labels["region"] == "west-1"`, podEndpoint}, true, false},
 		{"annotations", args{`type == "pod" && annotations["scrape"] == "true"`, podEndpoint}, true, false},
 		{"basic container", args{`type == "container" && labels["region"] == "east-1"`, containerEndpoint}, true, false},
-		{"from k8s.node status maps in slices", args{`type == "k8s.node" && status["images"][0]["names"][0] == "an.image:latest"`, k8sNodeEndpoint}, true, false},
-		{"from k8s.node nested status maps", args{`type == "k8s.node" && status["daemonEndpoints"]["kubeletEndpoint"]["Port"] == "10250"`, k8sNodeEndpoint}, true, false},
+		{"basic k8s.node", args{`type == "k8s.node" && kubelet_endpoint_port == 10250`, k8sNodeEndpoint}, true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:** Adding a feature -
These changes adopt the new `k8s.node` endpoint type in the k8s_observer and provide new config fields `observe_nodes` and `observe_pods` to toggle desired Endpoint type discovery. The existing `node` config field is no longer mandatory and missing values will result in all available nodes and pods in being reported.

They do not include adoption in the receiver creator, as that will be addressed in a subsequent PR.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6540

**Testing:**
Added unit tests for endpoint conversion and `observer.Observable` methods.

**Documentation:**
Updated readme with usage and config improvements, though they are dependent on separate receiver creator adoption.