### PR TITLE
[receiver/receivercreator] Adopt k8s.node in receiver creator

### DIFF
--- a/receiver/receivercreator/config_expansion_test.go
+++ b/receiver/receivercreator/config_expansion_test.go
@@ -29,6 +29,13 @@ func Test_expandConfigValue(t *testing.T) {
 	}
 	localhostEnv := map[string]interface{}{
 		"endpoint": "localhost",
+		"nested": map[string]interface{}{
+			"outer": map[string]interface{}{
+				"inner": map[string]interface{}{
+					"value": 123,
+				},
+			},
+		},
 	}
 	tests := []struct {
 		name    string
@@ -54,6 +61,8 @@ func Test_expandConfigValue(t *testing.T) {
 		{"expression in middle", args{localhostEnv, "https://`endpoint`:1234"}, "https://localhost:1234", false},
 		{"expression at end", args{localhostEnv, "https://`endpoint`"}, "https://localhost", false},
 		{"extra whitespace should not impact returned type", args{nil, "`       true ==           true`"}, true, false},
+
+		{"nested map value", args{localhostEnv, "`endpoint`:`nested[\"outer\"]['inner'][\"value\"]`"}, "localhost:123", false},
 
 		// Error cases.
 		{"only backticks", args{observer.EndpointEnv{}, "``"}, nil, true},

--- a/receiver/receivercreator/factory.go
+++ b/receiver/receivercreator/factory.go
@@ -58,6 +58,10 @@ func createDefaultConfig() config.Receiver {
 				conventions.AttributeContainerName:      "`name`",
 				conventions.AttributeContainerImageName: "`image`",
 			},
+			observer.K8sNodeType: map[string]string{
+				conventions.AttributeK8SNodeName: "`name`",
+				conventions.AttributeK8SNodeUID:  "`uid`",
+			},
 		},
 		receiverTemplates: map[string]receiverTemplate{},
 	}

--- a/receiver/receivercreator/fixtures_test.go
+++ b/receiver/receivercreator/fixtures_test.go
@@ -80,6 +80,70 @@ var containerEndpoint = observer.Endpoint{
 	Details: &container,
 }
 
+var k8sNodeEndpoint = observer.Endpoint{
+	ID:     "k8s.node-1",
+	Target: "2.3.4.5",
+	Details: &observer.K8sNode{
+		Annotations: map[string]string{
+			"node.alpha.kubernetes.io/ttl":                           "0",
+			"volumes.kubernetes.io/controller-managed-attach-detach": "true",
+		},
+		ExternalDNS:         "an.external.dns",
+		ExternalIP:          "1.2.3.4",
+		Hostname:            "a.hostname",
+		InternalDNS:         "an.internal.dns",
+		InternalIP:          "2.3.4.5",
+		KubeletEndpointPort: 10250,
+		Labels: map[string]string{
+			"beta.kubernetes.io/arch": "amd64",
+			"beta.kubernetes.io/os":   "linux",
+		},
+		Metadata: map[string]interface{}{
+			"annotations": map[string]string{
+				"node.alpha.kubernetes.io/ttl":                           "0",
+				"volumes.kubernetes.io/controller-managed-attach-detach": "true",
+			},
+			"labels": map[string]string{
+				"beta.kubernetes.io/arch": "amd64",
+				"beta.kubernetes.io/os":   "linux",
+			},
+			"name":            "a.name",
+			"resourceVersion": "1",
+			"uid":             "b344f2a7-1ec1-40f0-8557-8a9bfd8b6f99",
+		},
+		Name: "a.name",
+		Spec: map[string]interface{}{
+			"taints": []string{},
+		},
+		Status: map[string]interface{}{
+			"addresses": []map[string]interface{}{
+				{"address": "2.3.4.5", "type": "InternalIP"},
+			},
+			"allocatable": map[string]interface{}{},
+			"capacity":    map[string]interface{}{"cpu": "2", "pods": "1"},
+			"daemonEndpoints": map[string]interface{}{
+				"kubeletEndpoint": map[string]interface{}{"Port": "10250"},
+			},
+			"images": []map[string]interface{}{
+				{
+					"names":     []string{"an.image:latest", "another.image:latest"},
+					"sizeBytes": 15747069,
+				},
+				{
+					"names":     []string{"an.image.name"},
+					"sizeBytes": 685708,
+				},
+			},
+			"nodeInfo": map[string]interface{}{
+				"architecture":            "amd64",
+				"containerRuntimeVersion": "containerd://0.0.1",
+				"kubeletVersion":          "v1.2.3",
+			},
+		},
+		UID: "b344f2a7-1ec1-40f0-8557-8a9bfd8b6f99",
+	},
+}
+
 var unsupportedEndpoint = observer.Endpoint{
 	ID:      "endpoint-1",
 	Target:  "localhost:1234",

--- a/receiver/receivercreator/rules.go
+++ b/receiver/receivercreator/rules.go
@@ -32,7 +32,7 @@ type rule struct {
 
 // ruleRe is used to verify the rule starts type check.
 var ruleRe = regexp.MustCompile(
-	fmt.Sprintf(`^type\s*==\s*(%q|%q|%q|%q)`, observer.PodType, observer.PortType, observer.HostPortType, observer.ContainerType),
+	fmt.Sprintf(`^type\s*==\s*(%q|%q|%q|%q|%q)`, observer.PodType, observer.PortType, observer.HostPortType, observer.ContainerType, observer.K8sNodeType),
 )
 
 // newRule creates a new rule instance.

--- a/receiver/receivercreator/rules_test.go
+++ b/receiver/receivercreator/rules_test.go
@@ -49,6 +49,8 @@ func Test_ruleEval(t *testing.T) {
 		{"basic pod", args{`type == "pod" && labels["region"] == "west-1"`, podEndpoint}, true, false},
 		{"annotations", args{`type == "pod" && annotations["scrape"] == "true"`, podEndpoint}, true, false},
 		{"basic container", args{`type == "container" && labels["region"] == "east-1"`, containerEndpoint}, true, false},
+		{"from k8s.node status maps in slices", args{`type == "k8s.node" && status["images"][0]["names"][0] == "an.image:latest"`, k8sNodeEndpoint}, true, false},
+		{"from k8s.node nested status maps", args{`type == "k8s.node" && status["daemonEndpoints"]["kubeletEndpoint"]["Port"] == "10250"`, k8sNodeEndpoint}, true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description:**
Adding a feature -
These changes adopt the newly added `k8s.node` endpoint type in the receiver creator.  The actual endpoint discovery implementation is proposed by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6820

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6540

**Testing:**
Added relevant unit tests.

**Documentation:**
Documented new endpoint and its env, as well as fixed some incorrect resource attribute examples.