### PR TITLE
[nit] fixing ordering in versions.yaml

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -19,158 +19,158 @@ module-sets:
       - github.com/open-telemetry/opentelemetry-collector-contrib
       - github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema
       - github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen
-      - github.com/open-telemetry/opentelemetry-collector-contrib/tracegen
+      - github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/client
+      - github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/f5cloudexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/humioexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerthrifthttpexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/observiqexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/skywalkingexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stackdriverexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tanzuobservabilityexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy
-      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/fluentbitextension
-      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension
-      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
+      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/fluentbitextension
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling
+      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer
-      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
       - github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage
-      - github.com/open-telemetry/opentelemetry-collector-contrib/testbed
-      - github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatareceivers/mockawsxrayreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor
-      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics
-      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight
-      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil
+      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/k8s
-      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleserver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleapp
+      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/metrics
+      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray
+      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleapp
+      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleserver
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/common
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet
+      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk
       - github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza
-      - github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest
-      - github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/server
-      - github.com/open-telemetry/opentelemetry-collector-contrib/examples/demo/client
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver/examples/federation/prom-counter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerthrifthttpexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awscloudwatchlogsexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsprometheusremotewriteexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influxdbexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dynatraceexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/newrelicexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stackdriverexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/humioexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tanzuobservabilityexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/f5cloudexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/observiqexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sumologicexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alibabacloudlogserviceexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/skywalkingexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter
-      - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus
-      - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger
-      - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin
-      - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal
       - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr
+      - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal
       - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata
       - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry
+      - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger
+      - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus
+      - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatorateprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/collectdreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8seventsreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkametricsreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver/examples/federation/prom-counter
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/tcplogreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/wavefrontreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/testbed
+      - github.com/open-telemetry/opentelemetry-collector-contrib/testbed/mockdatareceivers/mockawsxrayreceiver
+      - github.com/open-telemetry/opentelemetry-collector-contrib/tracegen
 excluded-modules:
   - github.com/open-telemetry/opentelemetry-collector-contrib/internal/tools
   


### PR DESCRIPTION
The components in `versions.yaml` were out of order, this fixes that.
