### PR TITLE
[extensions/observer/ecstaskobserver] Add ecs_task_observer as component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ## 🚀 New components 🚀
 
+- `ecs_task_observer`: Discover running containers in AWS ECS tasks (#6894)
+
 ## 🧰 Bug fixes 🧰
 
 ## 💡 Enhancements 💡

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -229,6 +229,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder v0.41.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.41.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.41.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.41.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.41.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.41.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension v0.41.0 // indirect
@@ -552,6 +553,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/http
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension => ../../extension/oauth2clientauthextension
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer => ../../extension/observer
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver => ../../extension/observer/ecstaskobserver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver => ../../extension/observer/hostobserver
 

--- a/extension/observer/ecstaskobserver/README.md
+++ b/extension/observer/ecstaskobserver/README.md
@@ -11,6 +11,8 @@ value will be attempted to be parsed for each reported container by default.
 
 **An instance of the Collector must be running in the ECS task from which you want to detect containers.**
 
+> :construction: This extension is in alpha and configuration fields are subject to change.
+
 ## Example Config
 
 ```yaml

--- a/extension/observer/endpointswatcher.go
+++ b/extension/observer/endpointswatcher.go
@@ -105,7 +105,9 @@ func (ew *EndpointsWatcher) refreshEndpoints(listener Notify) {
 
 // StopListAndWatch polling the ListEndpoints.
 func (ew *EndpointsWatcher) StopListAndWatch() {
-	close(ew.stop)
+	if ew.stop != nil {
+		close(ew.stop)
+	}
 }
 
 // EndpointsLister that provides a list of endpoints.

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.41.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder v0.41.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.41.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.41.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.41.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.41.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension v0.41.0
@@ -558,6 +559,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaeg
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension => ./extension/oauth2clientauthextension
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer => ./extension/observer
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver => ./extension/observer/ecstaskobserver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver => ./extension/observer/hostobserver
 

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -61,6 +61,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oidcauthextension"
@@ -136,6 +137,7 @@ func Components() (component.Factories, error) {
 		asapauthextension.NewFactory(),
 		awsproxy.NewFactory(),
 		bearertokenauthextension.NewFactory(),
+		ecstaskobserver.NewFactory(),
 		filestorage.NewFactory(),
 		fluentbitextension.NewFactory(),
 		healthcheckextension.NewFactory(),

--- a/internal/components/extensions_test.go
+++ b/internal/components/extensions_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/asapauthextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testutil"
 )
@@ -99,6 +100,14 @@ func TestDefaultExtensions(t *testing.T) {
 					"MccfdZRfVapxKtAZbjXuAgMvnPtTvkVmwvhWLT5Wy0CIQDmfE8Et/pou0Jl6eM0eniT8/8oRzBWgy9ejDGfj86PGQIgWePq" +
 					"IL4OofRBgu0O5TlINI0HPtTNo12U9lbUIslgMdECICXT2RQpLcvqj+cyD7wZLZj6vrHZnTFVrnyR/cL2UyxhAiBswe/MCcD" +
 					"7T7J4QkNrCG+ceQGypc7LsxlIxQuKh5GWYA=="
+				return cfg
+			},
+		},
+		{
+			extension: "ecs_task_observer",
+			getConfigFn: func() config.Extension {
+				cfg := extFactories["ecs_task_observer"].CreateDefaultConfig().(*ecstaskobserver.Config)
+				cfg.Endpoint = "http://localhost"
 				return cfg
 			},
 		},


### PR DESCRIPTION
**Description:** Adding a feature
These changes add the recently implemented ECS Task Observer as an available component. This extension is ready to be used now that the receiver creator [supports container endpoints](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6665).

**Link to tracking Issue:**
resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5316

**Testing:**
Updated extension test and fixed nil pointer bug it 

**Documentation:**
Added alpha component status to existing task observer readme.