### PR TITLE
[mdatagen] Refactor new metrics builder internal structures

### DIFF
--- a/cmd/mdatagen/metrics_v2.tmpl
+++ b/cmd/mdatagen/metrics_v2.tmpl
@@ -44,44 +44,81 @@ func DefaultMetricsSettings() MetricsSettings {
 	}
 }
 
-// metric holds data for generated metric and keeps track of data points slice capacity.
-type metric struct {
-	data     pdata.Metric // data buffer for generated metric.
-	capacity int          // max observed number of data points added to the metric.
+{{ range $name, $metric := .Metrics -}}
+type metric{{ $name.Render }} struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
 }
 
-func (m *metric) updateCapacity(dpLen int) {
-	if dpLen > m.capacity {
-		m.capacity = dpLen
-	}
-}
-
-func newMetric() metric {
-	return metric{data: pdata.NewMetric()}
-}
-
-type metrics struct {
-	{{- range $name, $metric := .Metrics }}
-	{{ $name.RenderUnexported }} metric
+// init fills {{ $name }} metric with initial data.
+func (m *metric{{ $name.Render }}) init() {
+	m.data.SetName("{{ $name }}")
+	m.data.SetDescription("{{ $metric.Description }}")
+	m.data.SetUnit("{{ $metric.Unit }}")
+	m.data.SetDataType(pdata.MetricDataType{{ $metric.Data.Type }})
+	{{- if $metric.Data.HasMonotonic }}
+	m.data.{{ $metric.Data.Type }}().SetIsMonotonic({{ $metric.Data.Monotonic }})
+	{{- end }}
+	{{- if $metric.Data.HasAggregated }}
+	m.data.{{ $metric.Data.Type }}().SetAggregationTemporality({{ $metric.Data.Aggregated.Type }})
+	{{- end }}
+	{{- if $metric.Attributes }}
+	m.data.{{ $metric.Data.Type }}().DataPoints().EnsureCapacity(m.capacity)
 	{{- end }}
 }
 
-func newMetrics(config MetricsSettings) metrics {
-	ms := metrics{}
-	{{- range $name, $metric := .Metrics }}
-	if config.{{ $name.Render }}.Enabled {
-		ms.{{ $name.RenderUnexported }} = newMetric()
+func (m *metric{{ $name.Render }}) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp
+{{- if $metric.Data.HasMetricValueType }}, val {{ $metric.Data.MetricValueType.BasicType }}{{ end }}
+{{- range $metric.Attributes -}}, {{ .RenderUnexported }}AttributeValue string {{ end }}) {
+	if !m.settings.Enabled {
+		return
 	}
+	dp := m.data.{{ $metric.Data.Type }}().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	{{- if $metric.Data.HasMetricValueType }}
+	dp.Set{{ $metric.Data.MetricValueType }}Val(val)
 	{{- end }}
-	return ms
+	{{- range $metric.Attributes }}
+	dp.Attributes().Insert(A.{{ .Render }}, pdata.NewAttributeValueString({{ .RenderUnexported }}AttributeValue))
+	{{- end }}
 }
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metric{{ $name.Render }}) updateCapacity() {
+	if m.data.{{ $metric.Data.Type }}().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.{{ $metric.Data.Type }}().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metric{{ $name.Render }}) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.{{ $metric.Data.Type }}().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetric{{ $name.Render }}(settings MetricSettings) metric{{ $name.Render }} {
+	m := metric{{ $name.Render }}{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+{{ end -}}
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user configuration.
+// required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	config    MetricsSettings
-	startTime pdata.Timestamp
-	metrics   metrics
+	startTime                pdata.Timestamp
+	{{- range $name, $metric := .Metrics }}
+	metric{{ $name.Render }} metric{{ $name.Render }}
+	{{- end }}
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -94,87 +131,36 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 	}
 }
 
-func NewMetricsBuilder(config MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
+func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:    config,
-		startTime: pdata.NewTimestampFromTime(time.Now()),
-		metrics:   newMetrics(config),
+		startTime:                pdata.NewTimestampFromTime(time.Now()),
+		{{- range $name, $metric := .Metrics }}
+		metric{{ $name.Render }}: newMetric{{ $name.Render }}(settings.{{ $name.Render }}),
+		{{- end }}
 	}
-
 	for _, op := range options {
 		op(mb)
 	}
-
-	mb.initMetrics()
 	return mb
 }
 
 // Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
 // another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user configuration, e.g. delta/cumulative translation.
+// defined in metadata and user settings, e.g. delta/cumulative translation.
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
 	{{- range $name, $metric := .Metrics }}
-	if mb.config.{{ $name.Render }}.Enabled && mb.metrics.{{ $name.RenderUnexported }}.data.{{ $metric.Data.Type }}().DataPoints().Len() > 0 {
-		mb.metrics.{{- $name.RenderUnexported }}.updateCapacity(mb.metrics.{{ $name.RenderUnexported }}.data.{{ $metric.Data.Type }}().DataPoints().Len())
-		mb.metrics.{{- $name.RenderUnexported }}.data.MoveTo(metrics.AppendEmpty())
-	}
-	{{- end }}
-
-	// Reset metric data points collection.
-	mb.initMetrics()
-}
-
-{{ range $name, $metric := .Metrics -}}
-// init{{ $name.Render }}Metric builds new {{ $name }} metric.
-func (mb *MetricsBuilder) init{{ $name.Render }}Metric() {
-	metric := mb.metrics.{{ $name.RenderUnexported }}
-	metric.data.SetName("{{ $name }}")
-	metric.data.SetDescription("{{ $metric.Description }}")
-	metric.data.SetUnit("{{ $metric.Unit }}")
-	metric.data.SetDataType(pdata.MetricDataType{{ $metric.Data.Type }})
-	{{- if $metric.Data.HasMonotonic }}
-	metric.data.{{ $metric.Data.Type }}().SetIsMonotonic({{ $metric.Data.Monotonic }})
-	{{- end }}
-	{{- if $metric.Data.HasAggregated }}
-	metric.data.{{ $metric.Data.Type }}().SetAggregationTemporality({{ $metric.Data.Aggregated.Type }})
-	{{- end }}
-	{{- if $metric.Attributes }}
-	metric.data.{{ $metric.Data.Type }}().DataPoints().EnsureCapacity(metric.capacity)
-	{{- end }}
-}
-
-{{ end -}}
-
-// initMetrics initializes metrics.
-func (mb *MetricsBuilder) initMetrics() {
-	{{- range $name, $metric := .Metrics }}
-	if mb.config.{{- $name.Render }}.Enabled {
-		// TODO: Use metric.data.{{ $metric.Data.Type }}().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.init{{ $name.Render }}Metric()
-	}
+	mb.metric{{- $name.Render }}.emit(metrics)
 	{{- end }}
 }
 
 {{ range $name, $metric := .Metrics -}}
 // Record{{ $name.Render }}DataPoint adds a data point to {{ $name }} metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) Record{{ $name.Render }}DataPoint(ts pdata.Timestamp
 	{{- if $metric.Data.HasMetricValueType }}, val {{ $metric.Data.MetricValueType.BasicType }}{{ end }}
-	{{- range $metric.Attributes -}}, {{ .RenderUnexported }}AttributeValue string {{ end }}) {
-	if !mb.config.{{- $name.Render }}.Enabled {
-		return
-	}
-
-	dp := mb.metrics.{{ $name.RenderUnexported }}.data.{{ $metric.Data.Type }}().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	{{- if $metric.Data.HasMetricValueType }}
-	dp.Set{{ $metric.Data.MetricValueType }}Val(val)
-	{{- end }}
-	{{ range $metric.Attributes -}}
-	dp.Attributes().Insert(A.{{ .Render }}, pdata.NewAttributeValueString({{ .RenderUnexported }}AttributeValue))
-	{{ end -}}
+	{{- range $metric.Attributes -}} , {{ .RenderUnexported }}AttributeValue string{{ end }}) {
+	mb.metric{{ $name.Render }}.recordDataPoint(mb.startTime, ts
+		{{- if $metric.Data.HasMetricValueType }}, val {{ end }}
+		{{- range $metric.Attributes -}} , {{ .RenderUnexported }}AttributeValue{{ end }})
 }
 {{ end }}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
@@ -40,40 +40,65 @@ func DefaultMetricsSettings() MetricsSettings {
 	}
 }
 
-// metric holds data for generated metric and keeps track of data points slice capacity.
-type metric struct {
-	data     pdata.Metric // data buffer for generated metric.
-	capacity int          // max observed number of data points added to the metric.
+type metricSystemCPUTime struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
 }
 
-func (m *metric) updateCapacity(dpLen int) {
-	if dpLen > m.capacity {
-		m.capacity = dpLen
+// init fills system.cpu.time metric with initial data.
+func (m *metricSystemCPUTime) init() {
+	m.data.SetName("system.cpu.time")
+	m.data.SetDescription("Total CPU seconds broken down by different states.")
+	m.data.SetUnit("s")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricSystemCPUTime) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleVal(val)
+	dp.Attributes().Insert(A.Cpu, pdata.NewAttributeValueString(cpuAttributeValue))
+	dp.Attributes().Insert(A.State, pdata.NewAttributeValueString(stateAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSystemCPUTime) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
-func newMetric() metric {
-	return metric{data: pdata.NewMetric()}
-}
-
-type metrics struct {
-	systemCPUTime metric
-}
-
-func newMetrics(config MetricsSettings) metrics {
-	ms := metrics{}
-	if config.SystemCPUTime.Enabled {
-		ms.systemCPUTime = newMetric()
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSystemCPUTime) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
 	}
-	return ms
+}
+
+func newMetricSystemCPUTime(settings MetricSettings) metricSystemCPUTime {
+	m := metricSystemCPUTime{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user configuration.
+// required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	config    MetricsSettings
-	startTime pdata.Timestamp
-	metrics   metrics
+	startTime           pdata.Timestamp
+	metricSystemCPUTime metricSystemCPUTime
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -86,68 +111,27 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 	}
 }
 
-func NewMetricsBuilder(config MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
+func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:    config,
-		startTime: pdata.NewTimestampFromTime(time.Now()),
-		metrics:   newMetrics(config),
+		startTime:           pdata.NewTimestampFromTime(time.Now()),
+		metricSystemCPUTime: newMetricSystemCPUTime(settings.SystemCPUTime),
 	}
-
 	for _, op := range options {
 		op(mb)
 	}
-
-	mb.initMetrics()
 	return mb
 }
 
 // Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
 // another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user configuration, e.g. delta/cumulative translation.
+// defined in metadata and user settings, e.g. delta/cumulative translation.
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	if mb.config.SystemCPUTime.Enabled && mb.metrics.systemCPUTime.data.Sum().DataPoints().Len() > 0 {
-		mb.metrics.systemCPUTime.updateCapacity(mb.metrics.systemCPUTime.data.Sum().DataPoints().Len())
-		mb.metrics.systemCPUTime.data.MoveTo(metrics.AppendEmpty())
-	}
-
-	// Reset metric data points collection.
-	mb.initMetrics()
-}
-
-// initSystemCPUTimeMetric builds new system.cpu.time metric.
-func (mb *MetricsBuilder) initSystemCPUTimeMetric() {
-	metric := mb.metrics.systemCPUTime
-	metric.data.SetName("system.cpu.time")
-	metric.data.SetDescription("Total CPU seconds broken down by different states.")
-	metric.data.SetUnit("s")
-	metric.data.SetDataType(pdata.MetricDataTypeSum)
-	metric.data.Sum().SetIsMonotonic(true)
-	metric.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
-	metric.data.Sum().DataPoints().EnsureCapacity(metric.capacity)
-}
-
-// initMetrics initializes metrics.
-func (mb *MetricsBuilder) initMetrics() {
-	if mb.config.SystemCPUTime.Enabled {
-		// TODO: Use metric.data.Sum().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initSystemCPUTimeMetric()
-	}
+	mb.metricSystemCPUTime.emit(metrics)
 }
 
 // RecordSystemCPUTimeDataPoint adds a data point to system.cpu.time metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordSystemCPUTimeDataPoint(ts pdata.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue string) {
-	if !mb.config.SystemCPUTime.Enabled {
-		return
-	}
-
-	dp := mb.metrics.systemCPUTime.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Cpu, pdata.NewAttributeValueString(cpuAttributeValue))
-	dp.Attributes().Insert(A.State, pdata.NewAttributeValueString(stateAttributeValue))
+	mb.metricSystemCPUTime.recordDataPoint(mb.startTime, ts, val, cpuAttributeValue, stateAttributeValue)
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
@@ -104,104 +104,866 @@ func DefaultMetricsSettings() MetricsSettings {
 	}
 }
 
-// metric holds data for generated metric and keeps track of data points slice capacity.
-type metric struct {
-	data     pdata.Metric // data buffer for generated metric.
-	capacity int          // max observed number of data points added to the metric.
+type metricZookeeperApproximateDateSize struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
 }
 
-func (m *metric) updateCapacity(dpLen int) {
-	if dpLen > m.capacity {
-		m.capacity = dpLen
+// init fills zookeeper.approximate_date_size metric with initial data.
+func (m *metricZookeeperApproximateDateSize) init() {
+	m.data.SetName("zookeeper.approximate_date_size")
+	m.data.SetDescription("Size of data in bytes that a ZooKeeper server has in its data tree.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperApproximateDateSize) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperApproximateDateSize) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
 }
 
-func newMetric() metric {
-	return metric{data: pdata.NewMetric()}
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperApproximateDateSize) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
 }
 
-type metrics struct {
-	zookeeperApproximateDateSize   metric
-	zookeeperConnectionsAlive      metric
-	zookeeperEphemeralNodes        metric
-	zookeeperFollowers             metric
-	zookeeperFsyncThresholdExceeds metric
-	zookeeperLatencyAvg            metric
-	zookeeperLatencyMax            metric
-	zookeeperLatencyMin            metric
-	zookeeperMaxFileDescriptors    metric
-	zookeeperOpenFileDescriptors   metric
-	zookeeperOutstandingRequests   metric
-	zookeeperPacketsReceived       metric
-	zookeeperPacketsSent           metric
-	zookeeperPendingSyncs          metric
-	zookeeperSyncedFollowers       metric
-	zookeeperWatches               metric
-	zookeeperZnodes                metric
+func newMetricZookeeperApproximateDateSize(settings MetricSettings) metricZookeeperApproximateDateSize {
+	m := metricZookeeperApproximateDateSize{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
 }
 
-func newMetrics(config MetricsSettings) metrics {
-	ms := metrics{}
-	if config.ZookeeperApproximateDateSize.Enabled {
-		ms.zookeeperApproximateDateSize = newMetric()
+type metricZookeeperConnectionsAlive struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.connections_alive metric with initial data.
+func (m *metricZookeeperConnectionsAlive) init() {
+	m.data.SetName("zookeeper.connections_alive")
+	m.data.SetDescription("Number of active clients connected to a ZooKeeper server.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperConnectionsAlive) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
 	}
-	if config.ZookeeperConnectionsAlive.Enabled {
-		ms.zookeeperConnectionsAlive = newMetric()
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperConnectionsAlive) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
-	if config.ZookeeperEphemeralNodes.Enabled {
-		ms.zookeeperEphemeralNodes = newMetric()
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperConnectionsAlive) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
 	}
-	if config.ZookeeperFollowers.Enabled {
-		ms.zookeeperFollowers = newMetric()
+}
+
+func newMetricZookeeperConnectionsAlive(settings MetricSettings) metricZookeeperConnectionsAlive {
+	m := metricZookeeperConnectionsAlive{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
 	}
-	if config.ZookeeperFsyncThresholdExceeds.Enabled {
-		ms.zookeeperFsyncThresholdExceeds = newMetric()
+	return m
+}
+
+type metricZookeeperEphemeralNodes struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.ephemeral_nodes metric with initial data.
+func (m *metricZookeeperEphemeralNodes) init() {
+	m.data.SetName("zookeeper.ephemeral_nodes")
+	m.data.SetDescription("Number of ephemeral nodes that a ZooKeeper server has in its data tree.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperEphemeralNodes) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
 	}
-	if config.ZookeeperLatencyAvg.Enabled {
-		ms.zookeeperLatencyAvg = newMetric()
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperEphemeralNodes) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
-	if config.ZookeeperLatencyMax.Enabled {
-		ms.zookeeperLatencyMax = newMetric()
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperEphemeralNodes) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
 	}
-	if config.ZookeeperLatencyMin.Enabled {
-		ms.zookeeperLatencyMin = newMetric()
+}
+
+func newMetricZookeeperEphemeralNodes(settings MetricSettings) metricZookeeperEphemeralNodes {
+	m := metricZookeeperEphemeralNodes{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
 	}
-	if config.ZookeeperMaxFileDescriptors.Enabled {
-		ms.zookeeperMaxFileDescriptors = newMetric()
+	return m
+}
+
+type metricZookeeperFollowers struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.followers metric with initial data.
+func (m *metricZookeeperFollowers) init() {
+	m.data.SetName("zookeeper.followers")
+	m.data.SetDescription("The number of followers in sync with the leader. Only exposed by the leader.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperFollowers) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
 	}
-	if config.ZookeeperOpenFileDescriptors.Enabled {
-		ms.zookeeperOpenFileDescriptors = newMetric()
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperFollowers) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
 	}
-	if config.ZookeeperOutstandingRequests.Enabled {
-		ms.zookeeperOutstandingRequests = newMetric()
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperFollowers) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
 	}
-	if config.ZookeeperPacketsReceived.Enabled {
-		ms.zookeeperPacketsReceived = newMetric()
+}
+
+func newMetricZookeeperFollowers(settings MetricSettings) metricZookeeperFollowers {
+	m := metricZookeeperFollowers{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
 	}
-	if config.ZookeeperPacketsSent.Enabled {
-		ms.zookeeperPacketsSent = newMetric()
+	return m
+}
+
+type metricZookeeperFsyncThresholdExceeds struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.fsync_threshold_exceeds metric with initial data.
+func (m *metricZookeeperFsyncThresholdExceeds) init() {
+	m.data.SetName("zookeeper.fsync_threshold_exceeds")
+	m.data.SetDescription("Number of times fsync duration has exceeded warning threshold.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricZookeeperFsyncThresholdExceeds) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
 	}
-	if config.ZookeeperPendingSyncs.Enabled {
-		ms.zookeeperPendingSyncs = newMetric()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperFsyncThresholdExceeds) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
-	if config.ZookeeperSyncedFollowers.Enabled {
-		ms.zookeeperSyncedFollowers = newMetric()
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperFsyncThresholdExceeds) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
 	}
-	if config.ZookeeperWatches.Enabled {
-		ms.zookeeperWatches = newMetric()
+}
+
+func newMetricZookeeperFsyncThresholdExceeds(settings MetricSettings) metricZookeeperFsyncThresholdExceeds {
+	m := metricZookeeperFsyncThresholdExceeds{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
 	}
-	if config.ZookeeperZnodes.Enabled {
-		ms.zookeeperZnodes = newMetric()
+	return m
+}
+
+type metricZookeeperLatencyAvg struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.latency.avg metric with initial data.
+func (m *metricZookeeperLatencyAvg) init() {
+	m.data.SetName("zookeeper.latency.avg")
+	m.data.SetDescription("Average time in milliseconds for requests to be processed.")
+	m.data.SetUnit("ms")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperLatencyAvg) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
 	}
-	return ms
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperLatencyAvg) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperLatencyAvg) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperLatencyAvg(settings MetricSettings) metricZookeeperLatencyAvg {
+	m := metricZookeeperLatencyAvg{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperLatencyMax struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.latency.max metric with initial data.
+func (m *metricZookeeperLatencyMax) init() {
+	m.data.SetName("zookeeper.latency.max")
+	m.data.SetDescription("Maximum time in milliseconds for requests to be processed.")
+	m.data.SetUnit("ms")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperLatencyMax) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperLatencyMax) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperLatencyMax) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperLatencyMax(settings MetricSettings) metricZookeeperLatencyMax {
+	m := metricZookeeperLatencyMax{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperLatencyMin struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.latency.min metric with initial data.
+func (m *metricZookeeperLatencyMin) init() {
+	m.data.SetName("zookeeper.latency.min")
+	m.data.SetDescription("Minimum time in milliseconds for requests to be processed.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperLatencyMin) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperLatencyMin) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperLatencyMin) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperLatencyMin(settings MetricSettings) metricZookeeperLatencyMin {
+	m := metricZookeeperLatencyMin{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperMaxFileDescriptors struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.max_file_descriptors metric with initial data.
+func (m *metricZookeeperMaxFileDescriptors) init() {
+	m.data.SetName("zookeeper.max_file_descriptors")
+	m.data.SetDescription("Maximum number of file descriptors that a ZooKeeper server can open.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperMaxFileDescriptors) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperMaxFileDescriptors) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperMaxFileDescriptors) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperMaxFileDescriptors(settings MetricSettings) metricZookeeperMaxFileDescriptors {
+	m := metricZookeeperMaxFileDescriptors{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperOpenFileDescriptors struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.open_file_descriptors metric with initial data.
+func (m *metricZookeeperOpenFileDescriptors) init() {
+	m.data.SetName("zookeeper.open_file_descriptors")
+	m.data.SetDescription("Number of file descriptors that a ZooKeeper server has open.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperOpenFileDescriptors) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperOpenFileDescriptors) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperOpenFileDescriptors) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperOpenFileDescriptors(settings MetricSettings) metricZookeeperOpenFileDescriptors {
+	m := metricZookeeperOpenFileDescriptors{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperOutstandingRequests struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.outstanding_requests metric with initial data.
+func (m *metricZookeeperOutstandingRequests) init() {
+	m.data.SetName("zookeeper.outstanding_requests")
+	m.data.SetDescription("Number of currently executing requests.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperOutstandingRequests) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperOutstandingRequests) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperOutstandingRequests) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperOutstandingRequests(settings MetricSettings) metricZookeeperOutstandingRequests {
+	m := metricZookeeperOutstandingRequests{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperPacketsReceived struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.packets.received metric with initial data.
+func (m *metricZookeeperPacketsReceived) init() {
+	m.data.SetName("zookeeper.packets.received")
+	m.data.SetDescription("Number of ZooKeeper packets received by a server.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricZookeeperPacketsReceived) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperPacketsReceived) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperPacketsReceived) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperPacketsReceived(settings MetricSettings) metricZookeeperPacketsReceived {
+	m := metricZookeeperPacketsReceived{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperPacketsSent struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.packets.sent metric with initial data.
+func (m *metricZookeeperPacketsSent) init() {
+	m.data.SetName("zookeeper.packets.sent")
+	m.data.SetDescription("Number of ZooKeeper packets sent by a server.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricZookeeperPacketsSent) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperPacketsSent) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperPacketsSent) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperPacketsSent(settings MetricSettings) metricZookeeperPacketsSent {
+	m := metricZookeeperPacketsSent{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperPendingSyncs struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.pending_syncs metric with initial data.
+func (m *metricZookeeperPendingSyncs) init() {
+	m.data.SetName("zookeeper.pending_syncs")
+	m.data.SetDescription("The number of pending syncs from the followers. Only exposed by the leader.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperPendingSyncs) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperPendingSyncs) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperPendingSyncs) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperPendingSyncs(settings MetricSettings) metricZookeeperPendingSyncs {
+	m := metricZookeeperPendingSyncs{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperSyncedFollowers struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.synced_followers metric with initial data.
+func (m *metricZookeeperSyncedFollowers) init() {
+	m.data.SetName("zookeeper.synced_followers")
+	m.data.SetDescription("The number of followers in sync with the leader. Only exposed by the leader.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperSyncedFollowers) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperSyncedFollowers) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperSyncedFollowers) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperSyncedFollowers(settings MetricSettings) metricZookeeperSyncedFollowers {
+	m := metricZookeeperSyncedFollowers{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperWatches struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.watches metric with initial data.
+func (m *metricZookeeperWatches) init() {
+	m.data.SetName("zookeeper.watches")
+	m.data.SetDescription("Number of watches placed on Z-Nodes on a ZooKeeper server.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperWatches) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperWatches) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperWatches) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperWatches(settings MetricSettings) metricZookeeperWatches {
+	m := metricZookeeperWatches{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperZnodes struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.znodes metric with initial data.
+func (m *metricZookeeperZnodes) init() {
+	m.data.SetName("zookeeper.znodes")
+	m.data.SetDescription("Number of z-nodes that a ZooKeeper server has in its data tree.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperZnodes) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperZnodes) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperZnodes) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperZnodes(settings MetricSettings) metricZookeeperZnodes {
+	m := metricZookeeperZnodes{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user configuration.
+// required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	config    MetricsSettings
-	startTime pdata.Timestamp
-	metrics   metrics
+	startTime                            pdata.Timestamp
+	metricZookeeperApproximateDateSize   metricZookeeperApproximateDateSize
+	metricZookeeperConnectionsAlive      metricZookeeperConnectionsAlive
+	metricZookeeperEphemeralNodes        metricZookeeperEphemeralNodes
+	metricZookeeperFollowers             metricZookeeperFollowers
+	metricZookeeperFsyncThresholdExceeds metricZookeeperFsyncThresholdExceeds
+	metricZookeeperLatencyAvg            metricZookeeperLatencyAvg
+	metricZookeeperLatencyMax            metricZookeeperLatencyMax
+	metricZookeeperLatencyMin            metricZookeeperLatencyMin
+	metricZookeeperMaxFileDescriptors    metricZookeeperMaxFileDescriptors
+	metricZookeeperOpenFileDescriptors   metricZookeeperOpenFileDescriptors
+	metricZookeeperOutstandingRequests   metricZookeeperOutstandingRequests
+	metricZookeeperPacketsReceived       metricZookeeperPacketsReceived
+	metricZookeeperPacketsSent           metricZookeeperPacketsSent
+	metricZookeeperPendingSyncs          metricZookeeperPendingSyncs
+	metricZookeeperSyncedFollowers       metricZookeeperSyncedFollowers
+	metricZookeeperWatches               metricZookeeperWatches
+	metricZookeeperZnodes                metricZookeeperZnodes
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -214,565 +976,139 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 	}
 }
 
-func NewMetricsBuilder(config MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
+func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:    config,
-		startTime: pdata.NewTimestampFromTime(time.Now()),
-		metrics:   newMetrics(config),
+		startTime:                            pdata.NewTimestampFromTime(time.Now()),
+		metricZookeeperApproximateDateSize:   newMetricZookeeperApproximateDateSize(settings.ZookeeperApproximateDateSize),
+		metricZookeeperConnectionsAlive:      newMetricZookeeperConnectionsAlive(settings.ZookeeperConnectionsAlive),
+		metricZookeeperEphemeralNodes:        newMetricZookeeperEphemeralNodes(settings.ZookeeperEphemeralNodes),
+		metricZookeeperFollowers:             newMetricZookeeperFollowers(settings.ZookeeperFollowers),
+		metricZookeeperFsyncThresholdExceeds: newMetricZookeeperFsyncThresholdExceeds(settings.ZookeeperFsyncThresholdExceeds),
+		metricZookeeperLatencyAvg:            newMetricZookeeperLatencyAvg(settings.ZookeeperLatencyAvg),
+		metricZookeeperLatencyMax:            newMetricZookeeperLatencyMax(settings.ZookeeperLatencyMax),
+		metricZookeeperLatencyMin:            newMetricZookeeperLatencyMin(settings.ZookeeperLatencyMin),
+		metricZookeeperMaxFileDescriptors:    newMetricZookeeperMaxFileDescriptors(settings.ZookeeperMaxFileDescriptors),
+		metricZookeeperOpenFileDescriptors:   newMetricZookeeperOpenFileDescriptors(settings.ZookeeperOpenFileDescriptors),
+		metricZookeeperOutstandingRequests:   newMetricZookeeperOutstandingRequests(settings.ZookeeperOutstandingRequests),
+		metricZookeeperPacketsReceived:       newMetricZookeeperPacketsReceived(settings.ZookeeperPacketsReceived),
+		metricZookeeperPacketsSent:           newMetricZookeeperPacketsSent(settings.ZookeeperPacketsSent),
+		metricZookeeperPendingSyncs:          newMetricZookeeperPendingSyncs(settings.ZookeeperPendingSyncs),
+		metricZookeeperSyncedFollowers:       newMetricZookeeperSyncedFollowers(settings.ZookeeperSyncedFollowers),
+		metricZookeeperWatches:               newMetricZookeeperWatches(settings.ZookeeperWatches),
+		metricZookeeperZnodes:                newMetricZookeeperZnodes(settings.ZookeeperZnodes),
 	}
-
 	for _, op := range options {
 		op(mb)
 	}
-
-	mb.initMetrics()
 	return mb
 }
 
 // Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
 // another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user configuration, e.g. delta/cumulative translation.
+// defined in metadata and user settings, e.g. delta/cumulative translation.
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	if mb.config.ZookeeperApproximateDateSize.Enabled && mb.metrics.zookeeperApproximateDateSize.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperApproximateDateSize.updateCapacity(mb.metrics.zookeeperApproximateDateSize.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperApproximateDateSize.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperConnectionsAlive.Enabled && mb.metrics.zookeeperConnectionsAlive.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperConnectionsAlive.updateCapacity(mb.metrics.zookeeperConnectionsAlive.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperConnectionsAlive.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperEphemeralNodes.Enabled && mb.metrics.zookeeperEphemeralNodes.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperEphemeralNodes.updateCapacity(mb.metrics.zookeeperEphemeralNodes.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperEphemeralNodes.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperFollowers.Enabled && mb.metrics.zookeeperFollowers.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperFollowers.updateCapacity(mb.metrics.zookeeperFollowers.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperFollowers.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperFsyncThresholdExceeds.Enabled && mb.metrics.zookeeperFsyncThresholdExceeds.data.Sum().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperFsyncThresholdExceeds.updateCapacity(mb.metrics.zookeeperFsyncThresholdExceeds.data.Sum().DataPoints().Len())
-		mb.metrics.zookeeperFsyncThresholdExceeds.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperLatencyAvg.Enabled && mb.metrics.zookeeperLatencyAvg.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperLatencyAvg.updateCapacity(mb.metrics.zookeeperLatencyAvg.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperLatencyAvg.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperLatencyMax.Enabled && mb.metrics.zookeeperLatencyMax.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperLatencyMax.updateCapacity(mb.metrics.zookeeperLatencyMax.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperLatencyMax.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperLatencyMin.Enabled && mb.metrics.zookeeperLatencyMin.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperLatencyMin.updateCapacity(mb.metrics.zookeeperLatencyMin.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperLatencyMin.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperMaxFileDescriptors.Enabled && mb.metrics.zookeeperMaxFileDescriptors.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperMaxFileDescriptors.updateCapacity(mb.metrics.zookeeperMaxFileDescriptors.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperMaxFileDescriptors.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperOpenFileDescriptors.Enabled && mb.metrics.zookeeperOpenFileDescriptors.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperOpenFileDescriptors.updateCapacity(mb.metrics.zookeeperOpenFileDescriptors.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperOpenFileDescriptors.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperOutstandingRequests.Enabled && mb.metrics.zookeeperOutstandingRequests.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperOutstandingRequests.updateCapacity(mb.metrics.zookeeperOutstandingRequests.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperOutstandingRequests.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperPacketsReceived.Enabled && mb.metrics.zookeeperPacketsReceived.data.Sum().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperPacketsReceived.updateCapacity(mb.metrics.zookeeperPacketsReceived.data.Sum().DataPoints().Len())
-		mb.metrics.zookeeperPacketsReceived.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperPacketsSent.Enabled && mb.metrics.zookeeperPacketsSent.data.Sum().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperPacketsSent.updateCapacity(mb.metrics.zookeeperPacketsSent.data.Sum().DataPoints().Len())
-		mb.metrics.zookeeperPacketsSent.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperPendingSyncs.Enabled && mb.metrics.zookeeperPendingSyncs.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperPendingSyncs.updateCapacity(mb.metrics.zookeeperPendingSyncs.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperPendingSyncs.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperSyncedFollowers.Enabled && mb.metrics.zookeeperSyncedFollowers.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperSyncedFollowers.updateCapacity(mb.metrics.zookeeperSyncedFollowers.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperSyncedFollowers.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperWatches.Enabled && mb.metrics.zookeeperWatches.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperWatches.updateCapacity(mb.metrics.zookeeperWatches.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperWatches.data.MoveTo(metrics.AppendEmpty())
-	}
-	if mb.config.ZookeeperZnodes.Enabled && mb.metrics.zookeeperZnodes.data.Gauge().DataPoints().Len() > 0 {
-		mb.metrics.zookeeperZnodes.updateCapacity(mb.metrics.zookeeperZnodes.data.Gauge().DataPoints().Len())
-		mb.metrics.zookeeperZnodes.data.MoveTo(metrics.AppendEmpty())
-	}
-
-	// Reset metric data points collection.
-	mb.initMetrics()
-}
-
-// initZookeeperApproximateDateSizeMetric builds new zookeeper.approximate_date_size metric.
-func (mb *MetricsBuilder) initZookeeperApproximateDateSizeMetric() {
-	metric := mb.metrics.zookeeperApproximateDateSize
-	metric.data.SetName("zookeeper.approximate_date_size")
-	metric.data.SetDescription("Size of data in bytes that a ZooKeeper server has in its data tree.")
-	metric.data.SetUnit("By")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperConnectionsAliveMetric builds new zookeeper.connections_alive metric.
-func (mb *MetricsBuilder) initZookeeperConnectionsAliveMetric() {
-	metric := mb.metrics.zookeeperConnectionsAlive
-	metric.data.SetName("zookeeper.connections_alive")
-	metric.data.SetDescription("Number of active clients connected to a ZooKeeper server.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperEphemeralNodesMetric builds new zookeeper.ephemeral_nodes metric.
-func (mb *MetricsBuilder) initZookeeperEphemeralNodesMetric() {
-	metric := mb.metrics.zookeeperEphemeralNodes
-	metric.data.SetName("zookeeper.ephemeral_nodes")
-	metric.data.SetDescription("Number of ephemeral nodes that a ZooKeeper server has in its data tree.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperFollowersMetric builds new zookeeper.followers metric.
-func (mb *MetricsBuilder) initZookeeperFollowersMetric() {
-	metric := mb.metrics.zookeeperFollowers
-	metric.data.SetName("zookeeper.followers")
-	metric.data.SetDescription("The number of followers in sync with the leader. Only exposed by the leader.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperFsyncThresholdExceedsMetric builds new zookeeper.fsync_threshold_exceeds metric.
-func (mb *MetricsBuilder) initZookeeperFsyncThresholdExceedsMetric() {
-	metric := mb.metrics.zookeeperFsyncThresholdExceeds
-	metric.data.SetName("zookeeper.fsync_threshold_exceeds")
-	metric.data.SetDescription("Number of times fsync duration has exceeded warning threshold.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeSum)
-	metric.data.Sum().SetIsMonotonic(true)
-	metric.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
-}
-
-// initZookeeperLatencyAvgMetric builds new zookeeper.latency.avg metric.
-func (mb *MetricsBuilder) initZookeeperLatencyAvgMetric() {
-	metric := mb.metrics.zookeeperLatencyAvg
-	metric.data.SetName("zookeeper.latency.avg")
-	metric.data.SetDescription("Average time in milliseconds for requests to be processed.")
-	metric.data.SetUnit("ms")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperLatencyMaxMetric builds new zookeeper.latency.max metric.
-func (mb *MetricsBuilder) initZookeeperLatencyMaxMetric() {
-	metric := mb.metrics.zookeeperLatencyMax
-	metric.data.SetName("zookeeper.latency.max")
-	metric.data.SetDescription("Maximum time in milliseconds for requests to be processed.")
-	metric.data.SetUnit("ms")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperLatencyMinMetric builds new zookeeper.latency.min metric.
-func (mb *MetricsBuilder) initZookeeperLatencyMinMetric() {
-	metric := mb.metrics.zookeeperLatencyMin
-	metric.data.SetName("zookeeper.latency.min")
-	metric.data.SetDescription("Minimum time in milliseconds for requests to be processed.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperMaxFileDescriptorsMetric builds new zookeeper.max_file_descriptors metric.
-func (mb *MetricsBuilder) initZookeeperMaxFileDescriptorsMetric() {
-	metric := mb.metrics.zookeeperMaxFileDescriptors
-	metric.data.SetName("zookeeper.max_file_descriptors")
-	metric.data.SetDescription("Maximum number of file descriptors that a ZooKeeper server can open.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperOpenFileDescriptorsMetric builds new zookeeper.open_file_descriptors metric.
-func (mb *MetricsBuilder) initZookeeperOpenFileDescriptorsMetric() {
-	metric := mb.metrics.zookeeperOpenFileDescriptors
-	metric.data.SetName("zookeeper.open_file_descriptors")
-	metric.data.SetDescription("Number of file descriptors that a ZooKeeper server has open.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperOutstandingRequestsMetric builds new zookeeper.outstanding_requests metric.
-func (mb *MetricsBuilder) initZookeeperOutstandingRequestsMetric() {
-	metric := mb.metrics.zookeeperOutstandingRequests
-	metric.data.SetName("zookeeper.outstanding_requests")
-	metric.data.SetDescription("Number of currently executing requests.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperPacketsReceivedMetric builds new zookeeper.packets.received metric.
-func (mb *MetricsBuilder) initZookeeperPacketsReceivedMetric() {
-	metric := mb.metrics.zookeeperPacketsReceived
-	metric.data.SetName("zookeeper.packets.received")
-	metric.data.SetDescription("Number of ZooKeeper packets received by a server.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeSum)
-	metric.data.Sum().SetIsMonotonic(true)
-	metric.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
-}
-
-// initZookeeperPacketsSentMetric builds new zookeeper.packets.sent metric.
-func (mb *MetricsBuilder) initZookeeperPacketsSentMetric() {
-	metric := mb.metrics.zookeeperPacketsSent
-	metric.data.SetName("zookeeper.packets.sent")
-	metric.data.SetDescription("Number of ZooKeeper packets sent by a server.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeSum)
-	metric.data.Sum().SetIsMonotonic(true)
-	metric.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
-}
-
-// initZookeeperPendingSyncsMetric builds new zookeeper.pending_syncs metric.
-func (mb *MetricsBuilder) initZookeeperPendingSyncsMetric() {
-	metric := mb.metrics.zookeeperPendingSyncs
-	metric.data.SetName("zookeeper.pending_syncs")
-	metric.data.SetDescription("The number of pending syncs from the followers. Only exposed by the leader.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperSyncedFollowersMetric builds new zookeeper.synced_followers metric.
-func (mb *MetricsBuilder) initZookeeperSyncedFollowersMetric() {
-	metric := mb.metrics.zookeeperSyncedFollowers
-	metric.data.SetName("zookeeper.synced_followers")
-	metric.data.SetDescription("The number of followers in sync with the leader. Only exposed by the leader.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperWatchesMetric builds new zookeeper.watches metric.
-func (mb *MetricsBuilder) initZookeeperWatchesMetric() {
-	metric := mb.metrics.zookeeperWatches
-	metric.data.SetName("zookeeper.watches")
-	metric.data.SetDescription("Number of watches placed on Z-Nodes on a ZooKeeper server.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initZookeeperZnodesMetric builds new zookeeper.znodes metric.
-func (mb *MetricsBuilder) initZookeeperZnodesMetric() {
-	metric := mb.metrics.zookeeperZnodes
-	metric.data.SetName("zookeeper.znodes")
-	metric.data.SetDescription("Number of z-nodes that a ZooKeeper server has in its data tree.")
-	metric.data.SetUnit("1")
-	metric.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-// initMetrics initializes metrics.
-func (mb *MetricsBuilder) initMetrics() {
-	if mb.config.ZookeeperApproximateDateSize.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperApproximateDateSizeMetric()
-	}
-	if mb.config.ZookeeperConnectionsAlive.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperConnectionsAliveMetric()
-	}
-	if mb.config.ZookeeperEphemeralNodes.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperEphemeralNodesMetric()
-	}
-	if mb.config.ZookeeperFollowers.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperFollowersMetric()
-	}
-	if mb.config.ZookeeperFsyncThresholdExceeds.Enabled {
-		// TODO: Use metric.data.Sum().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperFsyncThresholdExceedsMetric()
-	}
-	if mb.config.ZookeeperLatencyAvg.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperLatencyAvgMetric()
-	}
-	if mb.config.ZookeeperLatencyMax.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperLatencyMaxMetric()
-	}
-	if mb.config.ZookeeperLatencyMin.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperLatencyMinMetric()
-	}
-	if mb.config.ZookeeperMaxFileDescriptors.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperMaxFileDescriptorsMetric()
-	}
-	if mb.config.ZookeeperOpenFileDescriptors.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperOpenFileDescriptorsMetric()
-	}
-	if mb.config.ZookeeperOutstandingRequests.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperOutstandingRequestsMetric()
-	}
-	if mb.config.ZookeeperPacketsReceived.Enabled {
-		// TODO: Use metric.data.Sum().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperPacketsReceivedMetric()
-	}
-	if mb.config.ZookeeperPacketsSent.Enabled {
-		// TODO: Use metric.data.Sum().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperPacketsSentMetric()
-	}
-	if mb.config.ZookeeperPendingSyncs.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperPendingSyncsMetric()
-	}
-	if mb.config.ZookeeperSyncedFollowers.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperSyncedFollowersMetric()
-	}
-	if mb.config.ZookeeperWatches.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperWatchesMetric()
-	}
-	if mb.config.ZookeeperZnodes.Enabled {
-		// TODO: Use metric.data.Gauge().DataPoints().Clear() instead of rebuilding
-		// the metrics once the Clear method is available.
-		mb.initZookeeperZnodesMetric()
-	}
+	mb.metricZookeeperApproximateDateSize.emit(metrics)
+	mb.metricZookeeperConnectionsAlive.emit(metrics)
+	mb.metricZookeeperEphemeralNodes.emit(metrics)
+	mb.metricZookeeperFollowers.emit(metrics)
+	mb.metricZookeeperFsyncThresholdExceeds.emit(metrics)
+	mb.metricZookeeperLatencyAvg.emit(metrics)
+	mb.metricZookeeperLatencyMax.emit(metrics)
+	mb.metricZookeeperLatencyMin.emit(metrics)
+	mb.metricZookeeperMaxFileDescriptors.emit(metrics)
+	mb.metricZookeeperOpenFileDescriptors.emit(metrics)
+	mb.metricZookeeperOutstandingRequests.emit(metrics)
+	mb.metricZookeeperPacketsReceived.emit(metrics)
+	mb.metricZookeeperPacketsSent.emit(metrics)
+	mb.metricZookeeperPendingSyncs.emit(metrics)
+	mb.metricZookeeperSyncedFollowers.emit(metrics)
+	mb.metricZookeeperWatches.emit(metrics)
+	mb.metricZookeeperZnodes.emit(metrics)
 }
 
 // RecordZookeeperApproximateDateSizeDataPoint adds a data point to zookeeper.approximate_date_size metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperApproximateDateSizeDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperApproximateDateSize.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperApproximateDateSize.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperApproximateDateSize.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperConnectionsAliveDataPoint adds a data point to zookeeper.connections_alive metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperConnectionsAliveDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperConnectionsAlive.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperConnectionsAlive.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperConnectionsAlive.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperEphemeralNodesDataPoint adds a data point to zookeeper.ephemeral_nodes metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperEphemeralNodesDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperEphemeralNodes.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperEphemeralNodes.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperEphemeralNodes.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperFollowersDataPoint adds a data point to zookeeper.followers metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperFollowersDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperFollowers.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperFollowers.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperFollowers.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperFsyncThresholdExceedsDataPoint adds a data point to zookeeper.fsync_threshold_exceeds metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperFsyncThresholdExceedsDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperFsyncThresholdExceeds.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperFsyncThresholdExceeds.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperFsyncThresholdExceeds.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperLatencyAvgDataPoint adds a data point to zookeeper.latency.avg metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperLatencyAvgDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperLatencyAvg.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperLatencyAvg.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperLatencyAvg.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperLatencyMaxDataPoint adds a data point to zookeeper.latency.max metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperLatencyMaxDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperLatencyMax.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperLatencyMax.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperLatencyMax.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperLatencyMinDataPoint adds a data point to zookeeper.latency.min metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperLatencyMinDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperLatencyMin.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperLatencyMin.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperLatencyMin.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperMaxFileDescriptorsDataPoint adds a data point to zookeeper.max_file_descriptors metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperMaxFileDescriptorsDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperMaxFileDescriptors.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperMaxFileDescriptors.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperMaxFileDescriptors.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperOpenFileDescriptorsDataPoint adds a data point to zookeeper.open_file_descriptors metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperOpenFileDescriptorsDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperOpenFileDescriptors.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperOpenFileDescriptors.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperOpenFileDescriptors.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperOutstandingRequestsDataPoint adds a data point to zookeeper.outstanding_requests metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperOutstandingRequestsDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperOutstandingRequests.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperOutstandingRequests.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperOutstandingRequests.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperPacketsReceivedDataPoint adds a data point to zookeeper.packets.received metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperPacketsReceivedDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperPacketsReceived.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperPacketsReceived.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperPacketsReceived.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperPacketsSentDataPoint adds a data point to zookeeper.packets.sent metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperPacketsSentDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperPacketsSent.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperPacketsSent.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperPacketsSent.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperPendingSyncsDataPoint adds a data point to zookeeper.pending_syncs metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperPendingSyncsDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperPendingSyncs.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperPendingSyncs.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperPendingSyncs.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperSyncedFollowersDataPoint adds a data point to zookeeper.synced_followers metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperSyncedFollowersDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperSyncedFollowers.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperSyncedFollowers.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperSyncedFollowers.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperWatchesDataPoint adds a data point to zookeeper.watches metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperWatchesDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperWatches.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperWatches.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperWatches.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperZnodesDataPoint adds a data point to zookeeper.znodes metric.
-// Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) RecordZookeeperZnodesDataPoint(ts pdata.Timestamp, val int64) {
-	if !mb.config.ZookeeperZnodes.Enabled {
-		return
-	}
-
-	dp := mb.metrics.zookeeperZnodes.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(mb.startTime)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
+	mb.metricZookeeperZnodes.recordDataPoint(mb.startTime, ts, val)
 }
 
 // Attributes contains the possible metric attributes that can be used.


### PR DESCRIPTION
Move metric specific logic from functions to internal metric struct methods. This encapsulation makes the metrics builder logic cleaner and also allows future evolvement of user settings support.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/10904
