### PR TITLE
[mdatagen] Sanitize attribute names in metrics builder code generation

### DIFF
--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -44,6 +44,10 @@ func (mn attributeName) Render() (string, error) {
 	return formatIdentifier(string(mn), true)
 }
 
+func (mn attributeName) RenderUnexported() (string, error) {
+	return formatIdentifier(string(mn), false)
+}
+
 type metric struct {
 	// Enabled defines whether the metric is enabled by default.
 	Enabled bool `yaml:"enabled"`

--- a/cmd/mdatagen/metrics_v2.tmpl
+++ b/cmd/mdatagen/metrics_v2.tmpl
@@ -161,7 +161,7 @@ func (mb *MetricsBuilder) initMetrics() {
 // Any attribute of AttributeValueTypeEmpty type will be skipped.
 func (mb *MetricsBuilder) Record{{ $name.Render }}DataPoint(ts pdata.Timestamp
 	{{- if $metric.Data.HasMetricValueType }}, val {{ $metric.Data.MetricValueType.BasicType }}{{ end }}
-	{{- range $metric.Attributes -}}, {{ . }}AttributeValue string {{ end }}) {
+	{{- range $metric.Attributes -}}, {{ .RenderUnexported }}AttributeValue string {{ end }}) {
 	if !mb.config.{{- $name.Render }}.Enabled {
 		return
 	}
@@ -173,7 +173,7 @@ func (mb *MetricsBuilder) Record{{ $name.Render }}DataPoint(ts pdata.Timestamp
 	dp.Set{{ $metric.Data.MetricValueType }}Val(val)
 	{{- end }}
 	{{ range $metric.Attributes -}}
-	dp.Attributes().Insert(A.{{ .Render }}, pdata.NewAttributeValueString({{ . }}AttributeValue))
+	dp.Attributes().Insert(A.{{ .Render }}, pdata.NewAttributeValueString({{ .RenderUnexported }}AttributeValue))
 	{{ end -}}
 }
 {{ end }}


### PR DESCRIPTION
This change fixes metrics builder code generation for attributes with symbols like dots

Fixes: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6896