### PR TITLE
[mdatagen] Add enabled field to all metrics in metadata.yaml

### DIFF
--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -50,7 +50,7 @@ func (mn attributeName) RenderUnexported() (string, error) {
 
 type metric struct {
 	// Enabled defines whether the metric is enabled by default.
-	Enabled bool `yaml:"enabled"`
+	Enabled bool `yaml:"enabled" validate:"required"`
 
 	// Description of the metric.
 	Description string `validate:"required,notblank"`

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -47,6 +47,7 @@ func Test_loadMetadata(t *testing.T) {
 						Value:       "state"}},
 				Metrics: map[metricName]metric{
 					"system.cpu.time": {
+						Enabled:               true,
 						Description:           "Total CPU seconds broken down by different states.",
 						ExtendedDocumentation: "Additional information on CPU Time can be found [here](https://en.wikipedia.org/wiki/CPU_time).",
 						Unit:                  "s",
@@ -73,6 +74,12 @@ func Test_loadMetadata(t *testing.T) {
 			want: metadata{},
 			wantErr: "metric system.cpu.time doesn't have a metric type key, " +
 				"one of the following has to be specified: sum, gauge, histogram",
+		},
+		{
+			name:    "no enabled",
+			yml:     "no_enabled.yaml",
+			want:    metadata{},
+			wantErr: "error validating struct:\n\tmetadata.Metrics[system.cpu.time].Enabled: Enabled is a required field\n",
 		},
 		{
 			name: "two metric types",

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -28,6 +28,7 @@ const (
 name: metricreceiver
 metrics:
   system.cpu.time:
+    enabled: true
     description: Total CPU seconds broken down by different states.
     extended_documentation: Additional information on CPU Time can be found [here](https://en.wikipedia.org/wiki/CPU_time).
     unit: s

--- a/cmd/mdatagen/metric-metadata.yaml
+++ b/cmd/mdatagen/metric-metadata.yaml
@@ -17,6 +17,8 @@ attributes:
 # being described below.
 metrics:
   <metric.name>:
+    # Required: whether the metric is collected by default. Takes effect only with "--experimental-gen" mdatagen flag.
+    enabled: # true | false
     # Required: metric description.
     description:
     # Optional: extended documentation of the metric.

--- a/cmd/mdatagen/testdata/all_options.yaml
+++ b/cmd/mdatagen/testdata/all_options.yaml
@@ -13,6 +13,7 @@ attributes:
 
 metrics:
   system.cpu.time:
+    enabled: true
     description: Total CPU seconds broken down by different states.
     extended_documentation: Additional information on CPU Time can be found [here](https://en.wikipedia.org/wiki/CPU_time).
     unit: s

--- a/cmd/mdatagen/testdata/no_enabled.yaml
+++ b/cmd/mdatagen/testdata/no_enabled.yaml
@@ -1,7 +1,10 @@
 name: metricreceiver
 metrics:
   system.cpu.time:
-    enabled: true
     description: Total CPU seconds broken down by different states.
     unit: s
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation: cumulative
     attributes:

--- a/cmd/mdatagen/testdata/no_value_type.yaml
+++ b/cmd/mdatagen/testdata/no_value_type.yaml
@@ -1,6 +1,7 @@
 name: metricreceiver
 metrics:
   system.cpu.time:
+    enabled: true
     description: Total CPU seconds broken down by different states.
     unit: s
     sum:

--- a/cmd/mdatagen/testdata/two_metric_types.yaml
+++ b/cmd/mdatagen/testdata/two_metric_types.yaml
@@ -1,6 +1,7 @@
 name: metricreceiver
 metrics:
   system.cpu.time:
+    enabled: true
     description: Total CPU seconds broken down by different states.
     unit: s
     gauge:

--- a/cmd/mdatagen/testdata/unknown_metric_attribute.yaml
+++ b/cmd/mdatagen/testdata/unknown_metric_attribute.yaml
@@ -1,6 +1,7 @@
 name: metricreceiver
 metrics:
   system.cpu.time:
+    enabled: true
     description: Total CPU seconds broken down by different states.
     unit: s
     sum:

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -27,6 +27,7 @@ attributes:
 
 metrics:
   apache.uptime:
+    enabled: true
     description: The amount of time that the server has been running in seconds.
     unit: s
     sum:
@@ -35,6 +36,7 @@ metrics:
       aggregation: cumulative
     attributes: [ server_name ]
   apache.current_connections:
+    enabled: true
     description: The number of active connections currently attached to the HTTP server.
     unit: connections
     sum:
@@ -43,6 +45,7 @@ metrics:
       aggregation: cumulative
     attributes: [ server_name ]
   apache.workers:
+    enabled: true
     description: The number of workers currently attached to the HTTP server.
     unit: connections
     sum:
@@ -51,6 +54,7 @@ metrics:
       aggregation: cumulative
     attributes: [ server_name, workers_state]
   apache.requests:
+    enabled: true
     description: The number of requests serviced by the HTTP server per second.
     unit: 1
     sum:
@@ -59,6 +63,7 @@ metrics:
       aggregation: cumulative
     attributes: [ server_name ]
   apache.traffic:
+    enabled: true
     description: Total HTTP server traffic.
     unit: By
     sum:
@@ -67,6 +72,7 @@ metrics:
       aggregation: cumulative
     attributes: [ server_name ]
   apache.scoreboard:
+    enabled: true
     description: The number of connections in each state.
     extended_documentation: >
       The apache scoreboard is an encoded representation of the state of all the server's workers.

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
@@ -10,6 +10,7 @@ attributes:
 
 metrics:
   system.disk.io:
+    enabled: true
     description: Disk bytes transferred.
     unit: By
     sum:
@@ -19,6 +20,7 @@ metrics:
     attributes: [device, direction]
 
   system.disk.operations:
+    enabled: true
     description: Disk operations count.
     unit: "{operations}"
     sum:
@@ -28,6 +30,7 @@ metrics:
     attributes: [device, direction]
 
   system.disk.io_time:
+    enabled: true
     description: Time disk spent activated. On Windows, this is calculated as the inverse of disk idle time.
     unit: s
     sum:
@@ -37,6 +40,7 @@ metrics:
     attributes: [device]
 
   system.disk.operation_time:
+    enabled: true
     description: Time spent in disk operations.
     unit: s
     sum:
@@ -46,6 +50,7 @@ metrics:
     attributes: [device, direction]
 
   system.disk.weighted_io_time:
+    enabled: true
     description: Time disk spent activated multiplied by the queue length.
     unit: s
     sum:
@@ -55,6 +60,7 @@ metrics:
     attributes: [device]
 
   system.disk.pending_operations:
+    enabled: true
     description: The queue size of pending I/O operations.
     unit: "{operations}"
     sum:
@@ -64,6 +70,7 @@ metrics:
     attributes: [device]
 
   system.disk.merged:
+    enabled: true
     description: The number of disk reads merged into single physical disk access operations.
     unit: "{operations}"
     sum:

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -19,6 +19,7 @@ attributes:
 
 metrics:
   system.filesystem.usage:
+    enabled: true
     description: Filesystem bytes used.
     unit: By
     sum:
@@ -28,6 +29,7 @@ metrics:
     attributes: [device, mode, mountpoint, type, state]
 
   system.filesystem.inodes.usage:
+    enabled: true
     description: FileSystem inodes used.
     unit: "{inodes}"
     sum:

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
@@ -4,18 +4,21 @@ attributes:
 
 metrics:
   system.cpu.load_average.1m:
+    enabled: true
     description: Average CPU Load over 1 minute.
     unit: 1
     gauge:
       value_type: double
 
   system.cpu.load_average.5m:
+    enabled: true
     description: Average CPU Load over 5 minutes.
     unit: 1
     gauge:
       value_type: double
 
   system.cpu.load_average.15m:
+    enabled: true
     description: Average CPU Load over 15 minutes.
     unit: 1
     gauge:

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -7,6 +7,7 @@ attributes:
 
 metrics:
   system.memory.usage:
+    enabled: true
     description: Bytes of memory in use.
     unit: By
     sum:

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -17,6 +17,7 @@ attributes:
 
 metrics:
   system.network.packets:
+    enabled: true
     description: The number of packets transferred.
     unit: "{packets}"
     sum:
@@ -26,6 +27,7 @@ metrics:
     attributes: [device, direction]
 
   system.network.dropped:
+    enabled: true
     description: The number of packets dropped.
     unit: "{packets}"
     sum:
@@ -35,6 +37,7 @@ metrics:
     attributes: [device, direction]
 
   system.network.errors:
+    enabled: true
     description: The number of errors encountered.
     unit: "{errors}"
     sum:
@@ -44,6 +47,7 @@ metrics:
     attributes: [device, direction]
 
   system.network.io:
+    enabled: true
     description: The number of bytes transmitted and received.
     unit: "By"
     sum:
@@ -53,6 +57,7 @@ metrics:
     attributes: [device, direction]
 
   system.network.connections:
+    enabled: true
     description: The number of connections.
     unit: "{connections}"
     sum:

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -18,6 +18,7 @@ attributes:
 
 metrics:
   system.paging.usage:
+    enabled: true
     description: Swap (unix) or pagefile (windows) usage.
     unit: By
     sum:
@@ -27,6 +28,7 @@ metrics:
     attributes: [device, state]
 
   system.paging.operations:
+    enabled: true
     description: The number of paging operations.
     unit: "{operations}"
     sum:
@@ -36,6 +38,7 @@ metrics:
     attributes: [direction, type]
 
   system.paging.faults:
+    enabled: true
     description: The number of page faults.
     unit: "{faults}"
     sum:

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -7,6 +7,7 @@ attributes:
 
 metrics:
   system.processes.created:
+    enabled: true
     description: Total number of created processes.
     unit: "{processes}"
     sum:
@@ -15,6 +16,7 @@ metrics:
       monotonic: true
 
   system.processes.count:
+    enabled: true
     description: Total number of processes in each state.
     unit: "{processes}"
     sum:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -11,6 +11,7 @@ attributes:
 
 metrics:
   process.cpu.time:
+    enabled: true
     description: Total CPU seconds broken down by different states.
     unit: s
     sum:
@@ -20,6 +21,7 @@ metrics:
     attributes: [state]
 
   process.memory.physical_usage:
+    enabled: true
     description: The amount of physical memory in use.
     unit: By
     sum:
@@ -28,6 +30,7 @@ metrics:
       monotonic: false
 
   process.memory.virtual_usage:
+    enabled: true
     description: Virtual memory size.
     unit: By
     sum:
@@ -36,6 +39,7 @@ metrics:
       monotonic: false
 
   process.disk.io:
+    enabled: true
     description: Disk bytes transferred.
     unit: By
     sum:

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -11,36 +11,42 @@ attributes:
 metrics:
 #  brokers scraper
   kafka.brokers:
+    enabled: true
     description: Number of brokers in the cluster.
     unit: "{brokers}"
     gauge:
       value_type: int
 #  topics scraper
   kafka.topic.partitions:
+    enabled: true
     description: Number of partitions in topic.
     unit: "{partitions}"
     gauge:
       value_type: int
     attributes: [topic]
   kafka.partition.current_offset:
+    enabled: true
     description: Current offset of partition of topic.
     unit: 1
     gauge:
       value_type: int
     attributes: [topic, partition]
   kafka.partition.oldest_offset:
+    enabled: true
     description: Oldest offset of partition of topic
     unit: 1
     gauge:
       value_type: int
     attributes: [topic, partition]
   kafka.partition.replicas:
+    enabled: true
     description: Number of replicas for partition of topic
     unit: "{replicas}"
     gauge:
       value_type: int
     attributes: [topic, partition]
   kafka.partition.replicas_in_sync:
+    enabled: true
     description: Number of synchronized replicas of partition
     unit: "{replicas}"
     gauge:
@@ -48,30 +54,35 @@ metrics:
     attributes: [topic, partition]
 #  consumers scraper
   kafka.consumer_group.members:
+    enabled: true
     description: Count of members in the consumer group
     unit: "{members}"
     gauge:
       value_type: int
     attributes: [group]
   kafka.consumer_group.offset:
+    enabled: true
     description: Current offset of the consumer group at partition of topic
     unit: 1
     gauge:
       value_type: int
     attributes: [group, topic, partition]
   kafka.consumer_group.offset_sum:
+    enabled: true
     description: Sum of consumer group offset across partitions of topic
     unit: 1
     gauge:
       value_type: int
     attributes: [group, topic]
   kafka.consumer_group.lag:
+    enabled: true
     description: Current approximate lag of consumer group at partition of topic
     unit: 1
     gauge:
       value_type: int
     attributes: [group, topic, partition]
   kafka.consumer_group.lag_sum:
+    enabled: true
     description: Current approximate sum of consumer group lag across all partitions of topic
     unit: 1
     gauge:

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -10,12 +10,14 @@ attributes:
 
 metrics:
   cpu.utilization:
+    enabled: true
     description: "CPU utilization"
     unit: 1
     gauge:
       value_type: double
     attributes: []
   cpu.time:
+    enabled: true
     description: "CPU time"
     unit: s
     sum:
@@ -24,60 +26,70 @@ metrics:
       aggregation: cumulative
     attributes: []
   memory.available:
+    enabled: true
     description: "Memory available"
     unit: By
     gauge:
       value_type: int
     attributes: []
   memory.usage:
+    enabled: true
     description: "Memory usage"
     unit: By
     gauge:
       value_type: int
     attributes: []
   memory.rss:
+    enabled: true
     description: "Memory rss"
     unit: By
     gauge:
       value_type: int
     attributes: []
   memory.working_set:
+    enabled: true
     description: "Memory working_set"
     unit: By
     gauge:
       value_type: int
     attributes: []
   memory.page_faults:
+    enabled: true
     description: "Memory page_faults"
     unit: 1
     gauge:
       value_type: int
     attributes: []
   memory.major_page_faults:
+    enabled: true
     description: "Memory major_page_faults"
     unit: 1
     gauge:
       value_type: int
     attributes: []
   filesystem.available:
+    enabled: true
     description: "Filesystem available"
     unit: By
     gauge:
       value_type: int
     attributes: []
   filesystem.capacity:
+    enabled: true
     description: "Filesystem capacity"
     unit: By
     gauge:
       value_type: int
     attributes: []
   filesystem.usage:
+    enabled: true
     description: "Filesystem usage"
     unit: By
     gauge:
       value_type: int
     attributes: []
   network.io:
+    enabled: true
     description: "Network IO"
     unit: By
     sum:
@@ -86,6 +98,7 @@ metrics:
       aggregation: cumulative
     attributes: ["interface", "direction"]
   network.errors:
+    enabled: true
     description: "Network errors"
     unit: 1
     sum:
@@ -94,30 +107,35 @@ metrics:
       aggregation: cumulative
     attributes: ["interface", "direction"]
   volume.available:
+    enabled: true
     description: "The number of available bytes in the volume."
     unit: By
     gauge:
       value_type: int
     attributes: []
   volume.capacity:
+    enabled: true
     description: "The total capacity in bytes of the volume."
     unit: By
     gauge:
       value_type: int
     attributes: []
   volume.inodes:
+    enabled: true
     description: "The total inodes in the filesystem."
     unit: 1
     gauge:
       value_type: int
     attributes: []
   volume.inodes.free:
+    enabled: true
     description: "The free inodes in the filesystem."
     unit: 1
     gauge:
       value_type: int
     attributes: []
   volume.inodes.used:
+    enabled: true
     description: "The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems."
     unit: 1
     gauge:

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -32,12 +32,14 @@ attributes:
 
 metrics:
   memcached.bytes:
+    enabled: true
     description: Current number of bytes used by this server to store items.
     unit: By
     gauge:
       value_type: int
     attributes: []
   memcached.connections.current:
+    enabled: true
     description: The current number of open connections.
     unit: connections
     sum:
@@ -46,6 +48,7 @@ metrics:
       aggregation: cumulative
     attributes: []
   memcached.connections.total:
+    enabled: true
     description: Total number of connections opened since the server started running.
     unit: connections
     sum:
@@ -54,6 +57,7 @@ metrics:
       aggregation: cumulative
     attributes: []
   memcached.commands:
+    enabled: true
     description: Commands executed.
     unit: 1
     sum:
@@ -62,6 +66,7 @@ metrics:
       aggregation: cumulative
     attributes: [command]
   memcached.current_items:
+    enabled: true
     description: Number of items currently stored in the cache.
     unit: 1
     sum:
@@ -70,6 +75,7 @@ metrics:
       aggregation: cumulative
     attributes: []
   memcached.evictions:
+    enabled: true
     description: Cache item evictions.
     unit: 1
     sum:
@@ -78,6 +84,7 @@ metrics:
       aggregation: cumulative
     attributes: []
   memcached.network:
+    enabled: true
     description: Bytes transferred over the network.
     unit: by
     sum:
@@ -86,7 +93,8 @@ metrics:
       aggregation: cumulative
     attributes: [direction]
   memcached.operations:
-    description:  Operation counts. 
+    enabled: true
+    description:  Operation counts.
     unit: 1
     sum:
       value_type: int
@@ -94,13 +102,15 @@ metrics:
       aggregation: cumulative
     attributes: [type,operation]
   memcached.operation_hit_ratio:
+    enabled: true
     description: Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0.
     unit: '%'
     gauge:
       value_type: double
     attributes: [operation]
   memcached.cpu.usage:
-    description: Accumulated user and system time. 
+    enabled: true
+    description: Accumulated user and system time.
     unit: 1
     sum:
       value_type: double
@@ -108,6 +118,7 @@ metrics:
       aggregation: cumulative
     attributes: [state]
   memcached.threads:
+    enabled: true
     description: Number of threads used by the memcached instance.
     unit: 1
     sum:

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -138,6 +138,7 @@ attributes:
 
 metrics:
   mongodbatlas.process.asserts:
+    enabled: true
     description: Number of assertions per second
     extended_documentation: Aggregate of MongoDB Metrics ASSERT_REGULAR, ASSERT_USER, ASSERT_MSG, ASSERT_WARNING
     unit: "{assertions}/s"
@@ -145,12 +146,14 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.background_flush:
+    enabled: true
     description: Amount of data flushed in the background
     extended_documentation: MongoDB Metric BACKGROUND_FLUSH_AVG
     unit: 1
     gauge:
       value_type: double
   mongodbatlas.process.cache.io:
+    enabled: true
     description: Cache throughput (per second)
     extended_documentation: Aggregate of MongoDB Metrics CACHE_BYTES_READ_INTO, CACHE_BYTES_WRITTEN_FROM
     unit: By
@@ -158,6 +161,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.cache.size:
+    enabled: true
     description: Cache sizes
     extended_documentation: Aggregate of MongoDB Metrics CACHE_USED_BYTES, CACHE_DIRTY_BYTES
     unit: By
@@ -167,6 +171,7 @@ metrics:
       monotonic: false
       aggregation: cumulative
   mongodbatlas.process.connections:
+    enabled: true
     description: Number of current connections
     extended_documentation: MongoDB Metric CONNECTIONS
     unit: "{connections}"
@@ -175,6 +180,7 @@ metrics:
       monotonic: false
       aggregation: cumulative 
   mongodbatlas.process.cpu.usage.max:
+    enabled: true
     description: CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_KERNEL, MAX_PROCESS_CPU_USER
     unit: 1
@@ -182,6 +188,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.cpu.usage.average:
+    enabled: true
     description: CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_KERNEL, PROCESS_CPU_USER
     unit: 1
@@ -189,6 +196,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.cpu.children.usage.max:
+    enabled: true
     description: CPU Usage for child processes (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_CHILDREN_USER, MAX_PROCESS_CPU_CHILDREN_KERNEL
     unit: 1
@@ -196,6 +204,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.cpu.children.usage.average:
+    enabled: true
     description: CPU Usage for child processes (%)
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_CHILDREN_KERNEL, PROCESS_CPU_CHILDREN_USER
     unit: 1
@@ -203,6 +212,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.cpu.children.normalized.usage.max:
+    enabled: true
     description: CPU Usage for child processes, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, MAX_PROCESS_NORMALIZED_CPU_CHILDREN_USER
     unit: 1
@@ -210,6 +220,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.cpu.children.normalized.usage.average:
+    enabled: true
     description: CPU Usage for child processes, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, PROCESS_NORMALIZED_CPU_CHILDREN_USER
     unit: 1
@@ -217,6 +228,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.cpu.normalized.usage.max:
+    enabled: true
     description: CPU Usage, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_USER, MAX_PROCESS_NORMALIZED_CPU_KERNEL
     unit: 1
@@ -224,6 +236,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.cpu.normalized.usage.average:
+    enabled: true
     description: CPU Usage, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_KERNEL, PROCESS_NORMALIZED_CPU_USER
     unit: 1
@@ -231,6 +244,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.cursors:
+    enabled: true
     description: Number of cursors
     extended_documentation: Aggregate of MongoDB Metrics CURSORS_TOTAL_OPEN, CURSORS_TOTAL_TIMED_OUT
     unit: "{cursors}"
@@ -238,6 +252,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.db.storage:
+    enabled: true
     description: Storage used by the database
     extended_documentation: Aggregate of MongoDB Metrics DB_INDEX_SIZE_TOTAL, DB_DATA_SIZE_TOTAL_WO_SYSTEM, DB_STORAGE_TOTAL, DB_DATA_SIZE_TOTAL
     unit: By
@@ -245,6 +260,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.db.document.rate:
+    enabled: true
     description: Document access rates
     extended_documentation: Aggregate of MongoDB Metrics DOCUMENT_METRICS_UPDATED, DOCUMENT_METRICS_DELETED, DOCUMENT_METRICS_RETURNED, DOCUMENT_METRICS_INSERTED
     unit: "{documents}/s"
@@ -252,6 +268,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.fts.cpu.usage:
+    enabled: true
     description: Full text search CPU (%)
     extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
     unit: 1
@@ -259,6 +276,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.global_lock:
+    enabled: true
     description: Number and status of locks
     extended_documentation: Aggregate of MongoDB Metrics GLOBAL_LOCK_CURRENT_QUEUE_WRITERS, GLOBAL_LOCK_CURRENT_QUEUE_READERS, GLOBAL_LOCK_CURRENT_QUEUE_TOTAL
     unit: "{locks}"
@@ -266,12 +284,14 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.index.btree_miss_ratio:
+    enabled: true
     description: Index miss ratio (%)
     extended_documentation: MongoDB Metric INDEX_COUNTERS_BTREE_MISS_RATIO
     unit: 1
     gauge:
       value_type: double
   mongodbatlas.process.index.counters:
+    enabled: true
     description: Indexes
     extended_documentation: Aggregate of MongoDB Metrics INDEX_COUNTERS_BTREE_MISSES, INDEX_COUNTERS_BTREE_ACCESSES, INDEX_COUNTERS_BTREE_HITS
     unit: "{indexes}"
@@ -279,24 +299,28 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.journaling.commits:
+    enabled: true
     description: Journaling commits
     extended_documentation: MongoDB Metric JOURNALING_COMMITS_IN_WRITE_LOCK
     unit: "{commits}"
     gauge:
       value_type: double
   mongodbatlas.process.journaling.data_files:
+    enabled: true
     description: Data file sizes
     extended_documentation: MongoDB Metric JOURNALING_WRITE_DATA_FILES_MB
     unit: MiBy
     gauge:
       value_type: double
   mongodbatlas.process.journaling.written:
+    enabled: true
     description: Journals written
     extended_documentation: MongoDB Metric JOURNALING_MB
     unit: MiBy
     gauge:
       value_type: double
   mongodbatlas.process.memory.usage:
+    enabled: true
     description: Memory Usage
     extended_documentation: Aggregate of MongoDB Metrics MEMORY_MAPPED, MEMORY_VIRTUAL, COMPUTED_MEMORY, MEMORY_RESIDENT
     unit: By
@@ -304,6 +328,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.network.io:
+    enabled: true
     description: Network IO
     extended_documentation: Aggregate of MongoDB Metrics NETWORK_BYTES_OUT, NETWORK_BYTES_IN
     unit: By/s
@@ -311,6 +336,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.network.requests:
+    enabled: true
     description: Network requests
     extended_documentation: MongoDB Metric NETWORK_NUM_REQUESTS
     unit: "{requests}"
@@ -319,6 +345,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
   mongodbatlas.process.oplog.time:
+    enabled: true
     description: Execution time by operation
     extended_documentation: Aggregate of MongoDB Metrics OPLOG_MASTER_TIME, OPLOG_SLAVE_LAG_MASTER_TIME, OPLOG_MASTER_LAG_TIME_DIFF
     unit: s
@@ -326,12 +353,14 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.oplog.rate:
+    enabled: true
     description: Execution rate by operation
     extended_documentation: MongoDB Metric OPLOG_RATE_GB_PER_HOUR
     unit: GiBy/h
     gauge:
       value_type: double
   mongodbatlas.process.db.operations.rate:
+    enabled: true
     description: DB Operation Rates
     extended_documentation: Aggregate of MongoDB Metrics OPCOUNTER_GETMORE, OPERATIONS_SCAN_AND_ORDER, OPCOUNTER_UPDATE, OPCOUNTER_REPL_UPDATE, OPCOUNTER_CMD, OPCOUNTER_DELETE, OPCOUNTER_REPL_DELETE, OPCOUNTER_REPL_CMD, OPCOUNTER_QUERY, OPCOUNTER_REPL_INSERT, OPCOUNTER_INSERT
     unit: "{operations}/s"
@@ -339,6 +368,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.db.operations.time:
+    enabled: true
     description: DB Operation Times
     extended_documentation: Aggregate of MongoDB Metrics OP_EXECUTION_TIME_WRITES, OP_EXECUTION_TIME_COMMANDS, OP_EXECUTION_TIME_READS
     unit: ms
@@ -348,6 +378,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
   mongodbatlas.process.page_faults:
+    enabled: true
     description: Page faults
     extended_documentation: Aggregate of MongoDB Metrics GLOBAL_PAGE_FAULT_EXCEPTIONS_THROWN, EXTRA_INFO_PAGE_FAULTS, GLOBAL_ACCESSES_NOT_IN_MEMORY
     unit: "{faults}/s"
@@ -355,6 +386,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.db.query_executor.scanned:
+    enabled: true
     description: Scanned objects
     extended_documentation: Aggregate of MongoDB Metrics QUERY_EXECUTOR_SCANNED_OBJECTS, QUERY_EXECUTOR_SCANNED
     attributes: [scanned_type]
@@ -362,6 +394,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.db.query_targeting.scanned_per_returned:
+    enabled: true
     description: Scanned objects per returned
     extended_documentation: Aggregate of MongoDB Metrics QUERY_TARGETING_SCANNED_OBJECTS_PER_RETURNED, QUERY_TARGETING_SCANNED_PER_RETURNED
     unit: "{scanned}/{returned}"
@@ -369,12 +402,14 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.restarts:
+    enabled: true
     description: Restarts in last hour
     extended_documentation: Aggregate of MongoDB Metrics RESTARTS_IN_LAST_HOUR
     unit: "{restarts}/h"
     gauge:
       value_type: double
   mongodbatlas.system.paging.usage.max:
+    enabled: true
     description: Swap usage
     extended_documentation: Aggregate of MongoDB Metrics MAX_SWAP_USAGE_FREE, MAX_SWAP_USAGE_USED
     unit: KiBy
@@ -382,6 +417,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.paging.usage.average:
+    enabled: true
     description: Swap usage
     extended_documentation: Aggregate of MongoDB Metrics SWAP_USAGE_FREE, SWAP_USAGE_USED
     unit: KiBy
@@ -389,6 +425,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.paging.io.max:
+    enabled: true
     description: Swap IO
     extended_documentation: Aggregate of MongoDB Metrics MAX_SWAP_IO_IN, MAX_SWAP_IO_OUT
     unit: "{pages}/s"
@@ -396,6 +433,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.paging.io.average:
+    enabled: true
     description: Swap IO
     extended_documentation: Aggregate of MongoDB Metrics SWAP_IO_IN, SWAP_IO_OUT
     unit: "{pages}/s"
@@ -403,6 +441,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.cpu.usage.max:
+    enabled: true
     description: System CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_CPU_SOFTIRQ, MAX_SYSTEM_CPU_IRQ, MAX_SYSTEM_CPU_GUEST, MAX_SYSTEM_CPU_IOWAIT, MAX_SYSTEM_CPU_NICE, MAX_SYSTEM_CPU_KERNEL, MAX_SYSTEM_CPU_USER, MAX_SYSTEM_CPU_STEAL
     attributes: [cpu_state]
@@ -410,6 +449,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.cpu.usage.average:
+    enabled: true
     description: System CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_CPU_USER, SYSTEM_CPU_GUEST, SYSTEM_CPU_SOFTIRQ, SYSTEM_CPU_IRQ, SYSTEM_CPU_KERNEL, SYSTEM_CPU_IOWAIT, SYSTEM_CPU_NICE, SYSTEM_CPU_STEAL
     attributes: [cpu_state]
@@ -417,6 +457,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.memory.usage.max:
+    enabled: true
     description: System Memory Usage
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_MEMORY_CACHED, MAX_SYSTEM_MEMORY_AVAILABLE, MAX_SYSTEM_MEMORY_USED, MAX_SYSTEM_MEMORY_BUFFERS, MAX_SYSTEM_MEMORY_FREE, MAX_SYSTEM_MEMORY_SHARED
     unit: KiBy
@@ -424,6 +465,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.memory.usage.average:
+    enabled: true
     description: System Memory Usage
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_MEMORY_AVAILABLE, SYSTEM_MEMORY_BUFFERS, SYSTEM_MEMORY_USED, SYSTEM_MEMORY_CACHED, SYSTEM_MEMORY_SHARED, SYSTEM_MEMORY_FREE
     unit: KiBy
@@ -431,6 +473,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.network.io.max:
+    enabled: true
     description: System Network IO
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_NETWORK_OUT, MAX_SYSTEM_NETWORK_IN
     unit: By/s
@@ -438,6 +481,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.network.io.average:
+    enabled: true
     description: System Network IO
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_NETWORK_IN, SYSTEM_NETWORK_OUT
     unit: By/s
@@ -445,6 +489,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.cpu.normalized.usage.max:
+    enabled: true
     description: System CPU Normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_NORMALIZED_CPU_USER, MAX_SYSTEM_NORMALIZED_CPU_NICE, MAX_SYSTEM_NORMALIZED_CPU_IOWAIT, MAX_SYSTEM_NORMALIZED_CPU_SOFTIRQ, MAX_SYSTEM_NORMALIZED_CPU_STEAL, MAX_SYSTEM_NORMALIZED_CPU_KERNEL, MAX_SYSTEM_NORMALIZED_CPU_GUEST, MAX_SYSTEM_NORMALIZED_CPU_IRQ
     attributes: [cpu_state]
@@ -452,6 +497,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.cpu.normalized.usage.average:
+    enabled: true
     description: System CPU Normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_NORMALIZED_CPU_IOWAIT, SYSTEM_NORMALIZED_CPU_GUEST, SYSTEM_NORMALIZED_CPU_IRQ, SYSTEM_NORMALIZED_CPU_KERNEL, SYSTEM_NORMALIZED_CPU_STEAL, SYSTEM_NORMALIZED_CPU_SOFTIRQ, SYSTEM_NORMALIZED_CPU_NICE, SYSTEM_NORMALIZED_CPU_USER
     attributes: [cpu_state]
@@ -459,6 +505,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.process.tickets:
+    enabled: true
     description: Tickets
     extended_documentation: Aggregate of MongoDB Metrics TICKETS_AVAILABLE_WRITE, TICKETS_AVAILABLE_READS
     unit: "{tickets}"
@@ -466,6 +513,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.disk.partition.iops.max:
+    enabled: true
     description: Disk partition iops
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_IOPS_WRITE, MAX_DISK_PARTITION_IOPS_TOTAL, MAX_DISK_PARTITION_IOPS_READ
     unit: "{ops}/s"
@@ -473,6 +521,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.disk.partition.iops.average:
+    enabled: true
     description: Disk partition iops
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_IOPS_READ, DISK_PARTITION_IOPS_WRITE, DISK_PARTITION_IOPS_TOTAL
     unit: "{ops}/s"
@@ -480,6 +529,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.disk.partition.usage.max:
+    enabled: true
     description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
     unit: 1
@@ -487,6 +537,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.disk.partition.usage.average:
+    enabled: true
     description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
     unit: 1
@@ -494,18 +545,21 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.disk.partition.utilization.max:
+    enabled: true
     description: Disk partition utilization (%)
     extended_documentation: MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
     unit: 1
     gauge:
       value_type: double
   mongodbatlas.disk.partition.utilization.average:
+    enabled: true
     description: Disk partition utilization (%)
     extended_documentation: MongoDB Metrics DISK_PARTITION_UTILIZATION
     unit: 1
     gauge:
       value_type: double
   mongodbatlas.disk.partition.latency.max:
+    enabled: true
     description: Disk partition latency
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_LATENCY_WRITE, MAX_DISK_PARTITION_LATENCY_READ
     unit: ms
@@ -513,6 +567,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.disk.partition.latency.average:
+    enabled: true
     description: Disk partition latency
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_LATENCY_WRITE, DISK_PARTITION_LATENCY_READ
     unit: ms
@@ -520,6 +575,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.disk.partition.space.max:
+    enabled: true
     description: Disk partition space
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
     unit: By
@@ -527,6 +583,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.disk.partition.space.average:
+    enabled: true
     description: Disk partition space
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USED
     unit: By
@@ -534,6 +591,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.db.size:
+    enabled: true
     description: Database feature size
     extended_documentation: Aggregate of MongoDB Metrics DATABASE_DATA_SIZE, DATABASE_STORAGE_SIZE, DATABASE_INDEX_SIZE, DATABASE_AVERAGE_OBJECT_SIZE
     unit: By
@@ -541,6 +599,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.db.counts:
+    enabled: true
     description: Database feature size
     extended_documentation: Aggregate of MongoDB Metrics DATABASE_EXTENT_COUNT, DATABASE_VIEW_COUNT, DATABASE_COLLECTION_COUNT, DATABASE_OBJECT_COUNT, DATABASE_INDEX_COUNT
     unit: "{objects}"
@@ -548,6 +607,7 @@ metrics:
     gauge:
       value_type: double
   mongodbatlas.system.fts.memory.usage:
+    enabled: true
     description: Full-text search
     extended_documentation: Aggregate of MongoDB Metrics FTS_MEMORY_MAPPED, FTS_PROCESS_SHARED_MEMORY, FTS_PROCESS_RESIDENT_MEMORY, FTS_PROCESS_VIRTUAL_MEMORY
     unit: MiBy
@@ -557,18 +617,21 @@ metrics:
       monotonic: true
       aggregation: cumulative
   mongodbatlas.system.fts.disk.used:
+    enabled: true
     description: Full text search disk usage
     extended_documentation: MongoDB Metric FTS_DISK_USAGE
     unit: By
     gauge:
       value_type: double
   mongodbatlas.system.fts.cpu.usage:
+    enabled: true
     description: Full-text search (%)
     unit: 1
     attributes: [cpu_state]
     gauge:
       value_type: double
   mongodbatlas.system.fts.cpu.normalized.usage:
+    enabled: true
     description: Full text search disk usage (%)
     extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_NORMALIZED_CPU_USER, FTS_PROCESS_NORMALIZED_CPU_KERNEL
     unit: 1

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -60,6 +60,7 @@ attributes:
 
 metrics:
   mysql.buffer_pool_pages:
+    enabled: true
     description: The number of pages in the InnoDB buffer pool.
     unit: 1
     sum:
@@ -68,6 +69,7 @@ metrics:
       aggregation: cumulative
     attributes: [buffer_pool_pages]
   mysql.buffer_pool_operations:
+    enabled: true
     description: The number of operations on the InnoDB buffer pool.
     unit: 1
     sum:
@@ -76,6 +78,7 @@ metrics:
       aggregation: cumulative
     attributes: [buffer_pool_operations]
   mysql.buffer_pool_size:
+    enabled: true
     description: The number of bytes in the InnoDB buffer pool.
     unit: By
     sum:
@@ -84,6 +87,7 @@ metrics:
       aggregation: cumulative
     attributes: [buffer_pool_size]
   mysql.commands:
+    enabled: true
     description: The number of times each type of command has been executed.
     unit: 1
     sum:
@@ -92,6 +96,7 @@ metrics:
       aggregation: cumulative
     attributes: [command]
   mysql.handlers:
+    enabled: true
     description: The number of requests to various MySQL handlers.
     unit: 1
     sum:
@@ -100,6 +105,7 @@ metrics:
       aggregation: cumulative
     attributes: [handler]
   mysql.double_writes:
+    enabled: true
     description: The number of writes to the InnoDB doublewrite buffer.
     unit: 1
     sum:
@@ -108,6 +114,7 @@ metrics:
       aggregation: cumulative
     attributes: [double_writes]
   mysql.log_operations:
+    enabled: true
     description: The number of InndoDB log operations.
     unit: 1
     sum:
@@ -116,6 +123,7 @@ metrics:
       aggregation: cumulative
     attributes: [log_operations]
   mysql.operations:
+    enabled: true
     description: The number of InndoDB operations.
     unit: 1
     sum:
@@ -124,6 +132,7 @@ metrics:
       aggregation: cumulative
     attributes: [operations]
   mysql.page_operations:
+    enabled: true
     description: The number of InndoDB page operations.
     unit: 1
     sum:
@@ -132,6 +141,7 @@ metrics:
       aggregation: cumulative
     attributes: [page_operations]
   mysql.row_locks:
+    enabled: true
     description: The number of InndoDB row locks.
     unit: 1
     sum:
@@ -140,6 +150,7 @@ metrics:
       aggregation: cumulative
     attributes: [row_locks]
   mysql.row_operations:
+    enabled: true
     description: The number of InndoDB row operations.
     unit: 1
     sum:
@@ -148,6 +159,7 @@ metrics:
       aggregation: cumulative
     attributes: [row_operations]
   mysql.locks:
+    enabled: true
     description: The number of MySQL locks.
     unit: 1
     sum:
@@ -156,6 +168,7 @@ metrics:
       aggregation: cumulative
     attributes: [locks]
   mysql.sorts:
+    enabled: true
     description: The number of MySQL sorts.
     unit: 1
     sum:
@@ -164,6 +177,7 @@ metrics:
       aggregation: cumulative
     attributes: [sorts]
   mysql.threads:
+    enabled: true
     description: The state of MySQL threads.
     unit: 1
     sum:

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -11,6 +11,7 @@ attributes:
 
 metrics:
   nginx.requests:
+    enabled: true
     description: Total number of requests made to the server since it started
     unit: requests
     sum:
@@ -19,6 +20,7 @@ metrics:
       aggregation: cumulative
     attributes: []
   nginx.connections_accepted:
+    enabled: true
     description: The total number of accepted client connections
     unit: connections
     sum:
@@ -27,6 +29,7 @@ metrics:
       aggregation: cumulative
     attributes: []
   nginx.connections_handled:
+    enabled: true
     description: The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).
     unit: connections
     sum:
@@ -35,6 +38,7 @@ metrics:
       aggregation: cumulative
     attributes: []
   nginx.connections_current:
+    enabled: true
     description: The current number of nginx connections by state
     unit: connections
     gauge:

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -18,6 +18,7 @@ attributes:
 
 metrics:
   postgresql.blocks_read:
+    enabled: true
     description: The number of blocks read.
     unit: 1
     sum:
@@ -26,6 +27,7 @@ metrics:
       aggregation: cumulative
     attributes: [ database, table, source ]
   postgresql.commits:
+    enabled: true
     description: The number of commits.
     unit: 1
     sum:
@@ -34,6 +36,7 @@ metrics:
       aggregation: cumulative
     attributes: [ database ]
   postgresql.db_size:
+    enabled: true
     description: The database disk usage.
     unit: By
     sum:
@@ -42,6 +45,7 @@ metrics:
       aggregation: cumulative
     attributes: [ database ]
   postgresql.backends:
+    enabled: true
     description: The number of backends.
     unit: 1
     sum:
@@ -50,6 +54,7 @@ metrics:
       aggregation: cumulative
     attributes: [ database ]
   postgresql.rows:
+    enabled: true
     description: The number of rows in the database.
     unit: 1
     sum:
@@ -58,6 +63,7 @@ metrics:
       aggregation: cumulative
     attributes: [ database, table, state ]
   postgresql.operations:
+    enabled: true
     description: The number of db row operations.
     unit: 1
     sum:
@@ -66,6 +72,7 @@ metrics:
       aggregation: cumulative
     attributes: [ database, table, operation ]
   postgresql.rollbacks:
+    enabled: true
     description: The number of rollbacks.
     unit: 1
     sum:


### PR DESCRIPTION
Add "enabled" field in all metadata.yaml files to enable its validation. The field is being used in the new scraper metrics builder.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/10904
