### PR TITLE
Fix metadata fetching when metrics differ by trimmable suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `ecstaskobserver`: Fix "Incorrect conversion between integer types" security issue (#6939)
 - Fix typo in "direction" metrics attribute description (#6949)
 - `zookeeperreceiver`: Fix issue where receiver could panic during shutdown (#7020)
+- `prometheusreceiver`: Fix metadata fetching when metrics differ by trimmable suffixes (#6932)
 
 ## 💡 Enhancements 💡
 

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -44,8 +44,8 @@ var testMetadata = map[string]scrape.MetricMetadata{
 	"summary_test":    {Metric: "summary_test", Type: textparse.MetricTypeSummary, Help: "", Unit: ""},
 	"summary_test2":   {Metric: "summary_test2", Type: textparse.MetricTypeSummary, Help: "", Unit: ""},
 	"unknown_test":    {Metric: "unknown_test", Type: textparse.MetricTypeUnknown, Help: "", Unit: ""},
+	"poor_name":       {Metric: "poor_name", Type: textparse.MetricTypeGauge, Help: "", Unit: ""},
 	"poor_name_count": {Metric: "poor_name_count", Type: textparse.MetricTypeCounter, Help: "", Unit: ""},
-	"up":              {Metric: "up", Type: textparse.MetricTypeCounter, Help: "", Unit: ""},
 	"scrape_foo":      {Metric: "scrape_foo", Type: textparse.MetricTypeCounter, Help: "", Unit: ""},
 	"example_process_start_time_seconds": {Metric: "example_process_start_time_seconds",
 		Type: textparse.MetricTypeGauge, Help: "", Unit: ""},
@@ -242,10 +242,8 @@ func Test_metricBuilder_counters(t *testing.T) {
 				},
 			},
 		},
-		// Some counters such as "python_gc_collections_total" have metadata key as "python_gc_collections" but still need
-		// to be converted using full metric name as "python_gc_collections_total" to match Prometheus functionality
 		{
-			name: "counter-with-metadata-without-total-suffix",
+			name: "counter-with-total-suffix",
 			inputs: []*testScrapedPage{
 				{
 					pts: []*testDataPoint{

--- a/receiver/prometheusreceiver/internal/otlp_metricfamily.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily.go
@@ -21,18 +21,10 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/pkg/labels"
-	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/prometheus/scrape"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
 )
-
-// MetricFamilyPdata is unit which is corresponding to the metrics items which shared the same TYPE/UNIT/... metadata from
-// a single scrape.
-type MetricFamilyPdata interface {
-	Add(metricName string, ls labels.Labels, t int64, v float64) error
-	ToMetricPdata(metrics *pdata.MetricSlice) (int, int)
-}
 
 type metricFamilyPdata struct {
 	mtype             pdata.MetricDataType
@@ -61,41 +53,11 @@ type metricGroupPdata struct {
 	complexValue []*dataPoint
 }
 
-func newMetricFamilyPdata(metricName string, mc MetadataCache, logger *zap.Logger) MetricFamilyPdata {
-	familyName := normalizeMetricName(metricName)
-
-	// lookup metadata based on familyName
-	metadata, ok := mc.Metadata(familyName)
-	if !ok && metricName != familyName {
-		// use the original metricName as metricFamily
-		familyName = metricName
-		// perform a 2nd lookup with the original metric name. it can happen if there's a metric which is not histogram
-		// or summary, but ends with one of those _count/_sum suffixes
-		metadata, ok = mc.Metadata(metricName)
-		// still not found, this can happen when metric has no TYPE HINT
-		if !ok {
-			metadata.Metric = familyName
-			metadata.Type = textparse.MetricTypeUnknown
-		}
-	} else if !ok {
-		if isInternalMetric(metricName) {
-			metadata = defineInternalMetric(metricName, metadata, logger)
-		} else {
-			// Prometheus sends metrics without a type hint as gauges.
-			// MetricTypeUnknown is converted to a gauge in convToOCAMetricType()
-			metadata.Type = textparse.MetricTypeUnknown
-		}
-	}
-
+func newMetricFamilyPdata(metricName string, mc MetadataCache, logger *zap.Logger) *metricFamilyPdata {
+	metadata, familyName := metadataForMetric(metricName, mc)
 	mtype := convToPdataMetricType(metadata.Type)
 	if mtype == pdata.MetricDataTypeNone {
-		logger.Debug(fmt.Sprintf("Invalid metric : %s %+v", metricName, metadata))
-	}
-
-	// If a counter has a _total suffix but metadata is stored without it, keep _total suffix as the name otherwise
-	// the metric sent won't have the suffix
-	if mtype == pdata.MetricDataTypeSum && strings.HasSuffix(metricName, metricSuffixTotal) {
-		familyName = metricName
+		logger.Debug(fmt.Sprintf("Unknown-typed metric : %s %+v", metricName, metadata))
 	}
 
 	return &metricFamilyPdata{
@@ -106,7 +68,7 @@ func newMetricFamilyPdata(metricName string, mc MetadataCache, logger *zap.Logge
 		droppedTimeseries: 0,
 		labelKeys:         make(map[string]bool),
 		labelKeysOrdered:  make([]string, 0),
-		metadata:          &metadata,
+		metadata:          metadata,
 		groupOrders:       make(map[string]int),
 	}
 }
@@ -128,6 +90,18 @@ func (mf *metricFamilyPdata) updateLabelKeys(ls labels.Labels) {
 			}
 		}
 	}
+}
+
+// includesMetric returns true if the metric is part of the family
+func (mf *metricFamilyPdata) includesMetric(metricName string) bool {
+	if mf.isCumulativeTypePdata() {
+		// If it is a merged family type, then it should match the
+		// family name when suffixes are trimmed.
+		return normalizeMetricName(metricName) == mf.name
+	}
+	// If it isn't a merged type, the metricName and family name
+	// should match
+	return metricName == mf.name
 }
 
 func (mf *metricFamilyPdata) getGroupKey(ls labels.Labels) string {

--- a/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily_test.go
@@ -119,7 +119,7 @@ func TestMetricGroupData_toDistributionUnitTest(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			mp := newMetricFamilyPdata(tt.metricName, mc, zap.NewNop()).(*metricFamilyPdata)
+			mp := newMetricFamilyPdata(tt.metricName, mc, zap.NewNop())
 			for _, tv := range tt.scrapes {
 				require.NoError(t, mp.Add(tv.metric, tt.labels.Copy(), tv.at, tv.value))
 			}
@@ -241,7 +241,7 @@ func TestMetricGroupData_toSummaryUnitTest(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			mp := newMetricFamilyPdata(tt.name, mc, zap.NewNop()).(*metricFamilyPdata)
+			mp := newMetricFamilyPdata(tt.name, mc, zap.NewNop())
 			for _, lbs := range tt.labelsScrapes {
 				for _, scrape := range lbs.scrapes {
 					require.NoError(t, mp.Add(scrape.metric, lbs.labels.Copy(), scrape.at, scrape.value))
@@ -323,7 +323,7 @@ func TestMetricGroupData_toNumberDataUnitTest(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			mp := newMetricFamilyPdata(tt.metricKind, mc, zap.NewNop()).(*metricFamilyPdata)
+			mp := newMetricFamilyPdata(tt.metricKind, mc, zap.NewNop())
 			for _, tv := range tt.scrapes {
 				require.NoError(t, mp.Add(tv.metric, tt.labels.Copy(), tv.at, tv.value))
 			}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fix incorrect merging of metric metadata when metrics differ by trimmable suffixes.  Additionally, remove unnecessary interfaces, and simplify the implementation of metadata fetching to make it more readable.

To fix the bug, first always check for metadata using the original metricName _first_.  We need to do this both when looking up the metric family (in metricsbuilder.go), and when looking up metadata when constructing the initial metric family.  Second,  add the `includesMetric()` function to metricFamily, which ensures that we only merge metrics under types that include multiple series.  For example, if there is an existing family `my_metric`, which is a gauge, it does not include metrics `my_metric` + suffix.

To make the newMetricFamily function more readable, split out a `metadataForMetric` function, which is shared between pdata/opencensus implementations.  This allows us to return early once we have found metadata for the metric, and reduces the number of `else` statements (and nesting) needed to handle all cases correctly.  Also, use a map to store internal metric metadata to avoid needing to recreate the same MetricMetadata frequently for internal metrics.

**Link to tracking Issue:** <Issue number if applicable>
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6931

**Testing:** <Describe what testing was performed and which tests were added.>

As described in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6931, the comment prior to `python_gc_collections_total` isn't correct, so I added metadata for `counter_test_total` in the metadata table.

I added metadata for `poor_name` to the testing metadata cash.  Prior to the fixes in this PR, this would cause tests to fail by making `poor_name_count` be incorrectly renamed to `poor_name` and come out as a gauge.

@Aneurysm9 @gracewehner 