### PR TITLE
Add a new test case that demonstrates bug

### DIFF
--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -68,6 +68,30 @@ var (
 			},
 		},
 		{
+			name: "metric_name_update_double_with_value",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
+					setLabels([]string{"label1"}).
+					addTimeseries(1, []string{"value1"}).
+					addDoublePoint(0, 0, 2).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("new/metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
+					setLabels([]string{"label1"}).
+					addTimeseries(1, []string{"value1"}).
+					addDoublePoint(0, 0, 2).build(),
+			},
+		},
+		{
 			name: "metric_name_update_chained",
 			transforms: []internalTransform{
 				{

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -50,6 +50,24 @@ var (
 			},
 		},
 		{
+			name: "metric_name_update_double",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+					Action:              Update,
+					NewName:             "new/metric1",
+				},
+			},
+			in: []*metricspb.Metric{
+				metricBuilder().setName("metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).build(),
+			},
+			out: []*metricspb.Metric{
+				metricBuilder().setName("new/metric1").
+					setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).build(),
+			},
+		},
+		{
 			name: "metric_name_update_chained",
 			transforms: []internalTransform{
 				{


### PR DESCRIPTION
When the metricstransform processor updates a metric name,
it can fail to retain the correct data type. This change adds
a new test case that is exactly the same as another, except the
metric being renamed has a double datatype instead of int.