### PR TITLE
[receiver/redis] Add missing description fields to keyspace metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `mysqlreceiver`: Add Integration test (#6916)
 - `datadogexporter`: Add compatibility with ECS Fargate semantic conventions (#6670)
 - `k8s_observer`: discover k8s.node endpoints (#6820)
+- `redisreceiver`: Add missing description fields to keyspace metrics (#6940)
 
 ## 🛑 Breaking changes 🛑
 

--- a/receiver/redisreceiver/pdata.go
+++ b/receiver/redisreceiver/pdata.go
@@ -32,6 +32,7 @@ func initKeyspaceKeysMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 		name:   "redis.db.keys",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
+		desc:   "Number of keyspace keys",
 	}
 	initIntMetric(m, int64(k.keys), t, dest)
 }
@@ -41,6 +42,7 @@ func initKeyspaceExpiresMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 		name:   "redis.db.expires",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
+		desc:   "Number of keyspace keys with an expiration",
 	}
 	initIntMetric(m, int64(k.expires), t, dest)
 }
@@ -51,6 +53,7 @@ func initKeyspaceTTLMetric(k *keyspace, t *timeBundle, dest pdata.Metric) {
 		units:  "ms",
 		labels: map[string]pdata.AttributeValue{"db": pdata.NewAttributeValueString(k.db)},
 		pdType: pdata.MetricDataTypeGauge,
+		desc:   "Average keyspace keys TTL",
 	}
 	initIntMetric(m, int64(k.avgTTL), t, dest)
 }


### PR DESCRIPTION
To make sure that https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6938 doesn't have any functional changes on metrics output. Description is required for mdatagen. Most of the metrics already have it except for these three.