### PR TITLE
[receiver/redis] Set start timestamp uniformly for gauge and sum metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `datadogexporter`: Add compatibility with ECS Fargate semantic conventions (#6670)
 - `k8s_observer`: discover k8s.node endpoints (#6820)
 - `redisreceiver`: Add missing description fields to keyspace metrics (#6940)
+- `redisreceiver`: Set start timestamp uniformly for gauge and sum metrics (#6941)
 - `kafkaexporter`: Allow controlling Kafka acknowledgment behaviour  (#6301)
 
 ## 🛑 Breaking changes 🛑

--- a/receiver/redisreceiver/pdata.go
+++ b/receiver/redisreceiver/pdata.go
@@ -69,9 +69,9 @@ func initIntMetric(m *redisMetric, value int64, t *timeBundle, dest pdata.Metric
 		sum.SetIsMonotonic(m.isMonotonic)
 		sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 		pt = sum.DataPoints().AppendEmpty()
-		pt.SetStartTimestamp(pdata.NewTimestampFromTime(t.serverStart))
 	}
 	pt.SetIntVal(value)
+	pt.SetStartTimestamp(pdata.NewTimestampFromTime(t.serverStart))
 	pt.SetTimestamp(pdata.NewTimestampFromTime(t.current))
 	pdata.NewAttributeMapFromMap(m.labels).CopyTo(pt.Attributes())
 }
@@ -87,9 +87,9 @@ func initDoubleMetric(m *redisMetric, value float64, t *timeBundle, dest pdata.M
 		sum.SetIsMonotonic(m.isMonotonic)
 		sum.SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 		pt = sum.DataPoints().AppendEmpty()
-		pt.SetStartTimestamp(pdata.NewTimestampFromTime(t.serverStart))
 	}
 	pt.SetDoubleVal(value)
+	pt.SetStartTimestamp(pdata.NewTimestampFromTime(t.serverStart))
 	pt.SetTimestamp(pdata.NewTimestampFromTime(t.current))
 	pdata.NewAttributeMapFromMap(m.labels).CopyTo(pt.Attributes())
 }

--- a/receiver/redisreceiver/pdata_test.go
+++ b/receiver/redisreceiver/pdata_test.go
@@ -149,7 +149,7 @@ func TestNewPDM(t *testing.T) {
 
 	pdm := pdata.NewMetric()
 	initIntMetric(&redisMetric{pdType: pdata.MetricDataTypeGauge}, 0, tb, pdm)
-	assert.Equal(t, pdata.Timestamp(0), pdm.Gauge().DataPoints().At(0).StartTimestamp())
+	assert.Equal(t, serverStartTime, pdm.Gauge().DataPoints().At(0).StartTimestamp())
 
 	pdm = pdata.NewMetric()
 	initIntMetric(&redisMetric{pdType: pdata.MetricDataTypeSum}, 0, tb, pdm)
@@ -157,7 +157,7 @@ func TestNewPDM(t *testing.T) {
 
 	pdm = pdata.NewMetric()
 	initDoubleMetric(&redisMetric{pdType: pdata.MetricDataTypeGauge}, 0, tb, pdm)
-	assert.Equal(t, pdata.Timestamp(0), pdm.Gauge().DataPoints().At(0).StartTimestamp())
+	assert.Equal(t, serverStartTime, pdm.Gauge().DataPoints().At(0).StartTimestamp())
 
 	pdm = pdata.NewMetric()
 	initDoubleMetric(&redisMetric{pdType: pdata.MetricDataTypeSum}, 0, tb, pdm)


### PR DESCRIPTION
Currently start time of gauge metrics is set to 0. According to the specification https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#gauge, start time should be set the timestamp when a metric collection system started.

The time when redis server started is already being used for Sum metrics. There is no reason to keep it inconsistent. This change applies the same start timestamp value to both Gauge and Sum metrics uniformly.

This is another change to make sure that https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6938 doesn't introduce functional changes to the metrics output.

Tracking issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6942