### PR TITLE
[receiver/mongodbatlas] Add retry and backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `mongodbreceiver`: Add metric scraping (#7175)
 - `postgresqlreceiver`: add the receiver to available components (#7079)
 - `tanzuobservability exporter`: Support summary metrics (#7121)
+- `mongodbatlasreceiver`: Add retry and backoff to HTTP client (#6943)
 - Use Jaeger gRPC instead of Thrift in the docker-compose example (#7243)
 - `tanzuobservabilityexporter`: Support exponential histograms (#7127)
 - `receiver_creator`: Log added and removed endpoint env structs (#7248)

--- a/receiver/mongodbatlasreceiver/README.md
+++ b/receiver/mongodbatlasreceiver/README.md
@@ -15,8 +15,11 @@ below both values are being pulled from the environment.
 - `public_key`
 - `private_key`
 - `granularity` (default `PT1M` - See [MongoDB Atlas Documentation](https://docs.atlas.mongodb.com/reference/api/process-measurements/))
-- `retry_interval` (in milliseconds, default 750ms)
-- `retry_attempts` (interval doubles with each attempt)
+- `retry_on_failure`
+  - `enabled` (default true)
+  - `initial_interval` (default 5s)
+  - `max_interval` (default 30s)
+  - `max_elapsed_time` (default 5m)
 
 Examples:
 

--- a/receiver/mongodbatlasreceiver/README.md
+++ b/receiver/mongodbatlasreceiver/README.md
@@ -15,6 +15,8 @@ below both values are being pulled from the environment.
 - `public_key`
 - `private_key`
 - `granularity` (default `PT1M` - See [MongoDB Atlas Documentation](https://docs.atlas.mongodb.com/reference/api/process-measurements/))
+- `retry_interval` (in milliseconds, default 750)
+- `retry_attempts` (interval doubles with each attempt)
 
 Examples:
 

--- a/receiver/mongodbatlasreceiver/README.md
+++ b/receiver/mongodbatlasreceiver/README.md
@@ -15,7 +15,7 @@ below both values are being pulled from the environment.
 - `public_key`
 - `private_key`
 - `granularity` (default `PT1M` - See [MongoDB Atlas Documentation](https://docs.atlas.mongodb.com/reference/api/process-measurements/))
-- `retry_interval` (in milliseconds, default 750)
+- `retry_interval` (in milliseconds, default 750ms)
 - `retry_attempts` (interval doubles with each attempt)
 
 Examples:

--- a/receiver/mongodbatlasreceiver/config.go
+++ b/receiver/mongodbatlasreceiver/config.go
@@ -15,9 +15,8 @@
 package mongodbatlasreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver"
 
 import (
-	"time"
-
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 )
 
@@ -25,9 +24,9 @@ var _ config.Receiver = (*Config)(nil)
 
 type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
-	PublicKey                               string        `mapstructure:"public_key"`
-	PrivateKey                              string        `mapstructure:"private_key"`
-	Granularity                             string        `mapstructure:"granularity"`
-	RetryAttempts                           uint64        `mapstructure:"retry_attempts"`
-	RetryInterval                           time.Duration `mapstructure:"retry_interval"`
+	PublicKey                               string `mapstructure:"public_key"`
+	PrivateKey                              string `mapstructure:"private_key"`
+	Granularity                             string `mapstructure:"granularity"`
+
+	RetrySettings exporterhelper.RetrySettings `mapstructure:"retry_on_failure"`
 }

--- a/receiver/mongodbatlasreceiver/config.go
+++ b/receiver/mongodbatlasreceiver/config.go
@@ -26,4 +26,6 @@ type Config struct {
 	PublicKey                               string `mapstructure:"public_key"`
 	PrivateKey                              string `mapstructure:"private_key"`
 	Granularity                             string `mapstructure:"granularity"`
+	RetryAttempts                           int    `mapstructure:"retry_attempts"`
+	RetryInterval                           int    `mapstructure:"retry_interval"`
 }

--- a/receiver/mongodbatlasreceiver/config.go
+++ b/receiver/mongodbatlasreceiver/config.go
@@ -28,6 +28,6 @@ type Config struct {
 	PublicKey                               string        `mapstructure:"public_key"`
 	PrivateKey                              string        `mapstructure:"private_key"`
 	Granularity                             string        `mapstructure:"granularity"`
-	RetryAttempts                           int           `mapstructure:"retry_attempts"`
+	RetryAttempts                           uint64        `mapstructure:"retry_attempts"`
 	RetryInterval                           time.Duration `mapstructure:"retry_interval"`
 }

--- a/receiver/mongodbatlasreceiver/config.go
+++ b/receiver/mongodbatlasreceiver/config.go
@@ -15,6 +15,8 @@
 package mongodbatlasreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver"
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 )
@@ -23,9 +25,9 @@ var _ config.Receiver = (*Config)(nil)
 
 type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
-	PublicKey                               string `mapstructure:"public_key"`
-	PrivateKey                              string `mapstructure:"private_key"`
-	Granularity                             string `mapstructure:"granularity"`
-	RetryAttempts                           int    `mapstructure:"retry_attempts"`
-	RetryInterval                           int    `mapstructure:"retry_interval"`
+	PublicKey                               string        `mapstructure:"public_key"`
+	PrivateKey                              string        `mapstructure:"private_key"`
+	Granularity                             string        `mapstructure:"granularity"`
+	RetryAttempts                           int           `mapstructure:"retry_attempts"`
+	RetryInterval                           time.Duration `mapstructure:"retry_interval"`
 }

--- a/receiver/mongodbatlasreceiver/factory.go
+++ b/receiver/mongodbatlasreceiver/factory.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 )
@@ -59,7 +60,6 @@ func createDefaultConfig() config.Receiver {
 	return &Config{
 		ScraperControllerSettings: scraperhelper.DefaultScraperControllerSettings(typeStr),
 		Granularity:               defaultGranularity,
-		RetryAttempts:             defaultRetryAttempts,
-		RetryInterval:             defaultRetryInterval,
+		RetrySettings:             exporterhelper.DefaultRetrySettings(),
 	}
 }

--- a/receiver/mongodbatlasreceiver/factory.go
+++ b/receiver/mongodbatlasreceiver/factory.go
@@ -27,10 +27,8 @@ import (
 )
 
 const (
-	typeStr              = "mongodbatlas"
-	defaultGranularity   = "PT1M" // 1-minute, as per https://docs.atlas.mongodb.com/reference/api/process-measurements/
-	defaultRetryInterval = 750    // milliseconds
-	defaultRetryAttempts = 5      // interval doubles with each attempt for a request
+	typeStr            = "mongodbatlas"
+	defaultGranularity = "PT1M" // 1-minute, as per https://docs.atlas.mongodb.com/reference/api/process-measurements/
 )
 
 // NewFactory creates a factory for MongoDB Atlas receiver

--- a/receiver/mongodbatlasreceiver/factory.go
+++ b/receiver/mongodbatlasreceiver/factory.go
@@ -26,8 +26,10 @@ import (
 )
 
 const (
-	typeStr            = "mongodbatlas"
-	defaultGranularity = "PT1M" // 1-minute, as per https://docs.atlas.mongodb.com/reference/api/process-measurements/
+	typeStr              = "mongodbatlas"
+	defaultGranularity   = "PT1M" // 1-minute, as per https://docs.atlas.mongodb.com/reference/api/process-measurements/
+	defaultRetryInterval = 750    // milliseconds
+	defaultRetryAttempts = 5      // interval doubles with each attempt for a request
 )
 
 // NewFactory creates a factory for MongoDB Atlas receiver
@@ -57,5 +59,7 @@ func createDefaultConfig() config.Receiver {
 	return &Config{
 		ScraperControllerSettings: scraperhelper.DefaultScraperControllerSettings(typeStr),
 		Granularity:               defaultGranularity,
+		RetryAttempts:             defaultRetryAttempts,
+		RetryInterval:             defaultRetryInterval,
 	}
 }

--- a/receiver/mongodbatlasreceiver/go.mod
+++ b/receiver/mongodbatlasreceiver/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongod
 go 1.17
 
 require (
+	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mongodb-forks/digest v1.0.3
 	github.com/pkg/errors v0.9.1

--- a/receiver/mongodbatlasreceiver/go.sum
+++ b/receiver/mongodbatlasreceiver/go.sum
@@ -80,6 +80,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
+++ b/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
@@ -133,8 +133,8 @@ func NewMongoDBAtlasClient(
 	}, nil
 }
 
-func (c *MongoDBAtlasClient) Shutdown() error {
-	c.roundTripper.Shutdown()
+func (s *MongoDBAtlasClient) Shutdown() error {
+	s.roundTripper.Shutdown()
 	return nil
 }
 

--- a/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
+++ b/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
@@ -52,11 +52,11 @@ func (rt *RetryBackoffRoundTripper) RoundTrip(r *http.Request) (*http.Response, 
 			Stop:                backoff.Stop,
 			Clock:               backoff.SystemClock,
 		}
-		withRetries := backoff.WithMaxRetries(expBackoff, uint64(rt.Attempts))
+		withRetries := backoff.WithMaxRetries(expBackoff, rt.Attempts)
 		withRetries.Reset()
 		attempts := 0
 		for {
-			attempts += 1
+			attempts++
 			delay := expBackoff.NextBackOff()
 			if delay == backoff.Stop {
 				return resp, err

--- a/receiver/mongodbatlasreceiver/receiver.go
+++ b/receiver/mongodbatlasreceiver/receiver.go
@@ -42,7 +42,7 @@ type timeconstraints struct {
 }
 
 func newMongoDBAtlasScraper(log *zap.Logger, cfg *Config) (scraperhelper.Scraper, error) {
-	client, err := internal.NewMongoDBAtlasClient(cfg.PublicKey, cfg.PrivateKey, cfg.RetryAttempts, cfg.RetryInterval, log)
+	client, err := internal.NewMongoDBAtlasClient(cfg.PublicKey, cfg.PrivateKey, cfg.RetrySettings, log)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/mongodbatlasreceiver/receiver.go
+++ b/receiver/mongodbatlasreceiver/receiver.go
@@ -42,7 +42,7 @@ type timeconstraints struct {
 }
 
 func newMongoDBAtlasScraper(log *zap.Logger, cfg *Config) (scraperhelper.Scraper, error) {
-	client, err := internal.NewMongoDBAtlasClient(cfg.PublicKey, cfg.PrivateKey, log)
+	client, err := internal.NewMongoDBAtlasClient(cfg.PublicKey, cfg.PrivateKey, cfg.RetryAttempts, cfg.RetryInterval, log)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/mongodbatlasreceiver/receiver.go
+++ b/receiver/mongodbatlasreceiver/receiver.go
@@ -47,7 +47,7 @@ func newMongoDBAtlasScraper(log *zap.Logger, cfg *Config) (scraperhelper.Scraper
 		return nil, err
 	}
 	recv := &receiver{log: log, cfg: cfg, client: client}
-	return scraperhelper.NewScraper(typeStr, recv.scrape)
+	return scraperhelper.NewScraper(typeStr, recv.scrape, scraperhelper.WithShutdown(recv.shutdown))
 }
 
 func (s *receiver) scrape(ctx context.Context) (pdata.Metrics, error) {
@@ -69,6 +69,10 @@ func (s *receiver) scrape(ctx context.Context) (pdata.Metrics, error) {
 	}
 	s.lastRun = now
 	return metrics, nil
+}
+
+func (s *receiver) shutdown(context.Context) error {
+	return s.client.Shutdown()
 }
 
 func (s *receiver) poll(ctx context.Context, time timeconstraints) (pdata.Metrics, error) {


### PR DESCRIPTION
**Description:** 
This receiver can run into throttling when monitoring a large cluster. This PR adds a round-tripper that intercepts and retries 429 responses.

