### PR TITLE
[exporter/googlecloud] Add gRPC related metrics

### DIFF
--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -16,6 +16,7 @@ package googlecloudexporter // import "github.com/open-telemetry/opentelemetry-c
 
 import (
 	"context"
+	"log"
 	"sync"
 	"time"
         

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"sync"
 	"time"
-        
+
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
@@ -40,10 +40,10 @@ func NewFactory() component.ExporterFactory {
 	// register view for self-observability
 	once.Do(func() {
 		view.Register(viewPointCount)
-		// Register views to collect data. 
-                if err := view.Register(ocgrpc.DefaultClientViews...); err != nil { 
-                        log.Fatal(err) 
-                } 
+		// Register views to collect data.
+		if err := view.Register(ocgrpc.DefaultClientViews...); err != nil {
+			log.Fatal(err)
+		}
 	})
 
 	return exporterhelper.NewFactory(

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -16,7 +16,6 @@ package googlecloudexporter // import "github.com/open-telemetry/opentelemetry-c
 
 import (
 	"context"
-	"log"
 	"sync"
 	"time"
 
@@ -40,10 +39,7 @@ func NewFactory() component.ExporterFactory {
 	// register view for self-observability
 	once.Do(func() {
 		view.Register(viewPointCount)
-		// Register views to collect data.
-		if err := view.Register(ocgrpc.DefaultClientViews...); err != nil {
-			log.Fatal(err)
-		}
+		view.Register(ocgrpc.DefaultClientViews...)
 	})
 
 	return exporterhelper.NewFactory(

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -18,7 +18,8 @@ import (
 	"context"
 	"sync"
 	"time"
-
+        
+	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
@@ -38,6 +39,10 @@ func NewFactory() component.ExporterFactory {
 	// register view for self-observability
 	once.Do(func() {
 		view.Register(viewPointCount)
+		// Register views to collect data. 
+                if err := view.Register(ocgrpc.DefaultClientViews...); err != nil { 
+                        log.Fatal(err) 
+                } 
 	})
 
 	return exporterhelper.NewFactory(

--- a/exporter/googlecloudexporter/googlecloud.go
+++ b/exporter/googlecloudexporter/googlecloud.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
+	
+        "go.opencensus.io/plugin/ocgrpc"
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	cloudtrace "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
@@ -75,7 +76,7 @@ func generateClientOptions(cfg *Config) ([]option.ClientOption, error) {
 			if cfg.UserAgent != "" {
 				dialOpts = append(dialOpts, grpc.WithUserAgent(cfg.UserAgent))
 			}
-			conn, err := grpc.Dial(cfg.Endpoint, append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))...)
+			conn, err := grpc.Dial(cfg.Endpoint, append(dialOpts, grpc.WithStatsHandler(&ocgrpc.ClientHandler{}), grpc.WithTransportCredentials(insecure.NewCredentials()))...)
 			if err != nil {
 				return nil, fmt.Errorf("cannot configure grpc conn: %w", err)
 			}

--- a/exporter/googlecloudexporter/googlecloud.go
+++ b/exporter/googlecloudexporter/googlecloud.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	
-        "go.opencensus.io/plugin/ocgrpc"
+
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	cloudtrace "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"go.opencensus.io/plugin/ocgrpc"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/model/pdata"


### PR DESCRIPTION
**Description:**
This PR is for fixing a missing metrics downstream by our ops-agent: GoogleCloudPlatform/ops-agent#305. This will add grpc related metrics into googlecloud exporter.

**Link to tracking Issue:**  GoogleCloudPlatform/ops-agent#305

**Testing:** 
I vendored this googlecloud module in our agent code, then modified the files with changes in this PR, then built and ran the agent to see grpc metrics were populating as expected

```
sophieyfang_google_com@debian10-meow:~$ curl localhost:8888/metrics  | grep "grpc"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 19659    0 19659    0     0  2742k      0 --:--:-- --:--:-- --:--:-- 2742k
# HELP otelcol_grpc_io_client_completed_rpcs Count of RPCs by method and status.
# TYPE otelcol_grpc_io_client_completed_rpcs counter
otelcol_grpc_io_client_completed_rpcs{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",grpc_client_status="OK",service_version="latest"} 913
# HELP otelcol_grpc_io_client_received_bytes_per_rpc Distribution of bytes received per RPC, by method.
# TYPE otelcol_grpc_io_client_received_bytes_per_rpc histogram
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="1024"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="2048"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="4096"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="16384"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="65536"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="262144"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="1.048576e+06"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="4.194304e+06"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="1.6777216e+07"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="6.7108864e+07"} 913
otelcol_grpc_io_client_received_bytes_per_rpc_bucket{grpc_client_method="google.monitoring.v3.MetricService/CreateTimeSeries",service_version="latest",le="2.68435456e+08"} 913
.
.
.
```