### PR TITLE
[processor/tailsampling] Add new policies to composite policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - `signalfxexporter`: Don't use syscall to avoid compilation errors on some platforms (#7062)
 - `k8sattributeprocessor`: Parse IP out of net.Addr to correctly tag k8s.pod.ip (#7077)
 - `k8sattributeprocessor`: Process IP correctly for net.Addr instances that are not typed (#7133)
+- `tailsamplingprocessor`: Add support for new policies as composite sub-policies (#6975)
 
 ## 💡 Enhancements 💡
 

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -59,9 +59,18 @@ func getSubPolicyEvaluator(logger *zap.Logger, cfg *SubPolicyCfg) (sampling.Poli
 	switch cfg.Type {
 	case AlwaysSample:
 		return sampling.NewAlwaysSample(logger), nil
+	case Latency:
+		lfCfg := cfg.LatencyCfg
+		return sampling.NewLatency(logger, lfCfg.ThresholdMs), nil
 	case NumericAttribute:
 		nafCfg := cfg.NumericAttributeCfg
 		return sampling.NewNumericAttributeFilter(logger, nafCfg.Key, nafCfg.MinValue, nafCfg.MaxValue), nil
+	case Probabilistic:
+		pfCfg := cfg.ProbabilisticCfg
+		return sampling.NewProbabilisticSampler(logger, pfCfg.HashSalt, pfCfg.SamplingPercentage), nil
+	case StatusCode:
+		scCfg := cfg.StatusCodeCfg
+		return sampling.NewStatusCodeFilter(logger, scCfg.StatusCodes)
 	case StringAttribute:
 		safCfg := cfg.StringAttributeCfg
 		return sampling.NewStringAttributeFilter(logger, safCfg.Key, safCfg.Values, safCfg.EnabledRegexMatching, safCfg.CacheMaxSize, safCfg.InvertMatch), nil

--- a/processor/tailsamplingprocessor/composite_helper_test.go
+++ b/processor/tailsamplingprocessor/composite_helper_test.go
@@ -35,7 +35,7 @@ func TestCompositeHelper(t *testing.T) {
 				Type: Composite,
 				CompositeCfg: CompositeCfg{
 					MaxTotalSpansPerSecond: 1000,
-					PolicyOrder:            []string{"test-composite-policy-1", "test-composite-policy-2", "test-composite-policy-3", "test-composite-policy-4", "test-composite-policy-5"},
+					PolicyOrder:            []string{"test-composite-policy-1", "test-composite-policy-2", "test-composite-policy-3", "test-composite-policy-4", "test-composite-policy-5", "test-composite-policy-6", "test-composite-policy-7", "test-composite-policy-8"},
 					SubPolicyCfg: []SubPolicyCfg{
 						{
 							Name:                "test-composite-policy-1",
@@ -53,11 +53,26 @@ func TestCompositeHelper(t *testing.T) {
 							RateLimitingCfg: RateLimitingCfg{SpansPerSecond: 10},
 						},
 						{
-							Name: "test-composite-policy-4",
+							Name:             "test-composite-policy-4",
+							Type:             Probabilistic,
+							ProbabilisticCfg: ProbabilisticCfg{HashSalt: "salt", SamplingPercentage: 10},
+						},
+						{
+							Name:       "test-composite-policy-5",
+							Type:       Latency,
+							LatencyCfg: LatencyCfg{ThresholdMs: 10},
+						},
+						{
+							Name:          "test-composite-policy-6",
+							Type:          StatusCode,
+							StatusCodeCfg: StatusCodeCfg{StatusCodes: []string{"200", "404"}},
+						},
+						{
+							Name: "test-composite-policy-7",
 							Type: AlwaysSample,
 						},
 						{
-							Name: "test-composite-policy-5",
+							Name: "test-composite-policy-8",
 						},
 					},
 					RateAllocation: []RateAllocationCfg{

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -50,16 +50,18 @@ type SubPolicyCfg struct {
 	Name string `mapstructure:"name"`
 	// Type of the policy this will be used to match the proper configuration of the policy.
 	Type PolicyType `mapstructure:"type"`
+	// Configs for latency filter sampling policy evaluator.
+	LatencyCfg LatencyCfg `mapstructure:"latency"`
 	// Configs for numeric attribute filter sampling policy evaluator.
 	NumericAttributeCfg NumericAttributeCfg `mapstructure:"numeric_attribute"`
+	// Configs for probabilistic sampling policy evaluator.
+	ProbabilisticCfg ProbabilisticCfg `mapstructure:"probabilistic"`
+	// Configs for status code filter sampling policy evaluator.
+	StatusCodeCfg StatusCodeCfg `mapstructure:"status_code"`
 	// Configs for string attribute filter sampling policy evaluator.
 	StringAttributeCfg StringAttributeCfg `mapstructure:"string_attribute"`
 	// Configs for rate limiting filter sampling policy evaluator.
 	RateLimitingCfg RateLimitingCfg `mapstructure:"rate_limiting"`
-	// Configs for latency filter sampling policy evaluator.
-	LatencyCfg LatencyCfg `mapstructure:"latency"`
-	// Configs for status code filter sampling policy evaluator.
-	StatusCodeCfg StatusCodeCfg `mapstructure:"status_code"`
 }
 
 // CompositeCfg holds the configurable settings to create a composite


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Extend composite sub-policy option list to include the latest added policies. The following policies were missing from the composite sub-policy list:

- Latency
- StatusCode
- Probabilistic