### PR TITLE
[processor/routing] Fix wrong array config in example

### DIFF
--- a/processor/routingprocessor/README.md
+++ b/processor/routingprocessor/README.md
@@ -30,7 +30,8 @@ Example:
 processors:
   routing:
     from_attribute: X-Tenant
-    default_exporters: jaeger
+    default_exporters:
+    - jaeger
     table:
     - value: acme
       exporters: [jaeger/acme]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/routingprocessor/config.go#L29

```golang
DefaultExporters []string `mapstructure:"default_exporters"`
```
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>