### PR TITLE
[processor/attributes and resource]: Add `from_context` value source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ## 💡 Enhancements 💡
 
 - `tanzuobservabilityexporter`: Turn on metrics exporter (#7281)
+- `attributesprocessor` `resourceprocessor`: Add `from_context` value source
+
+## 🛑 Breaking changes 🛑
+
+## 🚀 New components 🚀
+
+## 🧰 Bug fixes 🧰
 
 ## v0.43.0
 

--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -24,7 +24,7 @@ The supported actions are:
 
 For the actions `insert`, `update` and `upsert`,
  - `key`  is required
- - one of `value` or `from_attribute` is required
+ - one of `value`, `from_attribute` or `from_context` is required
  - `action` is required.
 ```yaml
   # Key specifies the attribute to act upon.
@@ -40,6 +40,15 @@ For the actions `insert`, `update` and `upsert`,
   # FromAttribute specifies the attribute from the span/log to use to populate
   # the value. If the attribute doesn't exist, no action is performed.
   from_attribute: <other key>
+
+  # Key specifies the attribute to act upon.
+- key: <key>
+  action: {insert, update, upsert}
+  # FromContext specifies the context value to use to populate
+  # the value. The values would be searched in client.Info.Metadata.
+  # If the key doesn't exist, no action is performed.
+  # If the key has multiple values the values will be joined with `;` separator.
+  from_context: <other key>
 ```
 
 For the `delete` action,

--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -44,8 +44,9 @@ For the actions `insert`, `update` and `upsert`,
   # Key specifies the attribute to act upon.
 - key: <key>
   action: {insert, update, upsert}
-  # FromContext specifies the context value to use to populate
-  # the value. The values would be searched in client.Info.Metadata.
+  # FromContext specifies the context value to use to populate the attribute value. 
+  # The context values would be searched in receiver's transport protocol additional information
+  # like GRPC Metadata or HTTP Headers. 
   # If the key doesn't exist, no action is performed.
   # If the key has multiple values the values will be joined with `;` separator.
   from_context: <other key>

--- a/processor/attributesprocessor/attributes_log.go
+++ b/processor/attributesprocessor/attributes_log.go
@@ -40,7 +40,7 @@ func newLogAttributesProcessor(attrProc *attraction.AttrProc, include, exclude f
 	}
 }
 
-func (a *logAttributesProcessor) processLogs(_ context.Context, ld pdata.Logs) (pdata.Logs, error) {
+func (a *logAttributesProcessor) processLogs(ctx context.Context, ld pdata.Logs) (pdata.Logs, error) {
 	rls := ld.ResourceLogs()
 	for i := 0; i < rls.Len(); i++ {
 		rs := rls.At(i)
@@ -56,7 +56,7 @@ func (a *logAttributesProcessor) processLogs(_ context.Context, ld pdata.Logs) (
 					continue
 				}
 
-				a.attrProc.Process(lr.Attributes())
+				a.attrProc.Process(ctx, lr.Attributes())
 			}
 		}
 	}

--- a/processor/attributesprocessor/attributes_trace.go
+++ b/processor/attributesprocessor/attributes_trace.go
@@ -40,7 +40,7 @@ func newSpanAttributesProcessor(attrProc *attraction.AttrProc, include, exclude 
 	}
 }
 
-func (a *spanAttributesProcessor) processTraces(_ context.Context, td pdata.Traces) (pdata.Traces, error) {
+func (a *spanAttributesProcessor) processTraces(ctx context.Context, td pdata.Traces) (pdata.Traces, error) {
 	rss := td.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {
 		rs := rss.At(i)
@@ -56,7 +56,7 @@ func (a *spanAttributesProcessor) processTraces(_ context.Context, td pdata.Trac
 					continue
 				}
 
-				a.attrProc.Process(span.Attributes())
+				a.attrProc.Process(ctx, span.Attributes())
 			}
 		}
 	}

--- a/processor/resourceprocessor/resource_processor.go
+++ b/processor/resourceprocessor/resource_processor.go
@@ -26,26 +26,26 @@ type resourceProcessor struct {
 	attrProc *attraction.AttrProc
 }
 
-func (rp *resourceProcessor) processTraces(_ context.Context, td pdata.Traces) (pdata.Traces, error) {
+func (rp *resourceProcessor) processTraces(ctx context.Context, td pdata.Traces) (pdata.Traces, error) {
 	rss := td.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {
-		rp.attrProc.Process(rss.At(i).Resource().Attributes())
+		rp.attrProc.Process(ctx, rss.At(i).Resource().Attributes())
 	}
 	return td, nil
 }
 
-func (rp *resourceProcessor) processMetrics(_ context.Context, md pdata.Metrics) (pdata.Metrics, error) {
+func (rp *resourceProcessor) processMetrics(ctx context.Context, md pdata.Metrics) (pdata.Metrics, error) {
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
-		rp.attrProc.Process(rms.At(i).Resource().Attributes())
+		rp.attrProc.Process(ctx, rms.At(i).Resource().Attributes())
 	}
 	return md, nil
 }
 
-func (rp *resourceProcessor) processLogs(_ context.Context, ld pdata.Logs) (pdata.Logs, error) {
+func (rp *resourceProcessor) processLogs(ctx context.Context, ld pdata.Logs) (pdata.Logs, error) {
 	rls := ld.ResourceLogs()
 	for i := 0; i < rls.Len(); i++ {
-		rp.attrProc.Process(rls.At(i).Resource().Attributes())
+		rp.attrProc.Process(ctx, rls.At(i).Resource().Attributes())
 	}
 	return ld, nil
 }


### PR DESCRIPTION
**Description:** 

Add the ability to use context values to populate protocol specific attributes like resource and datapoint attributes . Currently the values would searched in GRPC metadata only. If/when https://github.com/open-telemetry/opentelemetry-collector/pull/4547 is merged the client info could be used.

 If the provided key doesn't exist, no action is performed. If the provided key has multiple values the values will be joined with `;` separator.

**Link to tracking Issue:** N/A

**Testing:** 
- No regressions in local runes.
- attracton tests ware extended to cover de newly added code.

**Documentation:** Relevant README updated.