### PR TITLE
[receiver/hostmetrics] Add `cpu_average` option to load scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - `tanzuobservabilityexporter`: Document how to enable memory_limiter (#7286)
 - `hostreceiver/networkscraper`: Migrate the scraper to the mdatagen metrics builder (#7048)
 - `hostmetricsreceiver`: Add MuteProcessNameError config flag to mute specific error reading process executable (#7176)
-- `hostmetricsreceiver`: add option for load scraper to average the value per cpus (#6999)
+- `hostmetricsreceiver`: add `cpu_average` option for load scraper to report the average cpu load (#6999)
 
 ## 🛑 Breaking changes 🛑
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `tanzuobservabilityexporter`: Document how to enable memory_limiter (#7286)
 - `hostreceiver/networkscraper`: Migrate the scraper to the mdatagen metrics builder (#7048)
 - `hostmetricsreceiver`: Add MuteProcessNameError config flag to mute specific error reading process executable (#7176)
+- `hostmetricsreceiver`: add option for load scraper to average the value per cpus (#6999)
 
 ## 🛑 Breaking changes 🛑
 

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -69,7 +69,7 @@ filesystem:
 `per_cpu` divides the average load per CPU (default: `false`).
 
 ```yaml
-disk:
+load:
   per_cpu: <false|true>
 ```
 

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -66,11 +66,11 @@ filesystem:
 
 ### Load
 
-`per_cpu` divides the average load per CPU (default: `false`).
+`cpu_average` specifies whether to divide the average load by the reported number of logical CPUs (default: `false`).
 
 ```yaml
 load:
-  per_cpu: <false|true>
+  cpu_average: <false|true>
 ```
 
 ### Network

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -64,6 +64,15 @@ filesystem:
     match_type: <strict|regexp>
 ```
 
+### Load
+
+`per_cpu` divides the average load per CPU (default: `false`).
+
+```yaml
+disk:
+  per_cpu: <false|true>
+```
+
 ### Network
 
 ```yaml

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -69,7 +69,7 @@ func TestLoadConfig(t *testing.T) {
 		Scrapers: map[string]internal.Config{
 			cpuscraper.TypeStr:        (&cpuscraper.Factory{}).CreateDefaultConfig(),
 			diskscraper.TypeStr:       (&diskscraper.Factory{}).CreateDefaultConfig(),
-			loadscraper.TypeStr:       &loadscraper.Config{},
+			loadscraper.TypeStr:       &loadscraper.Config{CPUAverage: true},
 			filesystemscraper.TypeStr: &filesystemscraper.Config{},
 			memoryscraper.TypeStr:     &memoryscraper.Config{},
 			networkscraper.TypeStr: (func() internal.Config {

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/config.go
@@ -19,4 +19,7 @@ import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostm
 // Config relating to Load Metric Scraper.
 type Config struct {
 	internal.ConfigSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+
+	// If true, metrics will be average load per cpu
+	PerCPU bool `mapstructure:"per_cpu"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/config.go
@@ -21,5 +21,5 @@ type Config struct {
 	internal.ConfigSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// If true, metrics will be average load per cpu
-	PerCPU bool `mapstructure:"per_cpu"`
+	CPUAverage bool `mapstructure:"cpu_average"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
@@ -16,6 +16,7 @@ package loadscraper // import "github.com/open-telemetry/opentelemetry-collector
 
 import (
 	"context"
+	"runtime"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/load"
@@ -62,6 +63,13 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 	avgLoadValues, err := s.load()
 	if err != nil {
 		return md, scrapererror.NewPartialScrapeError(err, metricsLen)
+	}
+
+	if s.config.PerCPU {
+		divisor := float64(runtime.NumCPU())
+		avgLoadValues.Load1 = avgLoadValues.Load1 * divisor
+		avgLoadValues.Load5 = avgLoadValues.Load1 * divisor
+		avgLoadValues.Load15 = avgLoadValues.Load1 * divisor
 	}
 
 	metrics.EnsureCapacity(metricsLen)

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
@@ -65,7 +65,7 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 		return md, scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 
-	if s.config.PerCPU {
+	if s.config.CPUAverage {
 		divisor := float64(runtime.NumCPU())
 		avgLoadValues.Load1 = avgLoadValues.Load1 / divisor
 		avgLoadValues.Load5 = avgLoadValues.Load1 / divisor

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
@@ -67,9 +67,9 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 
 	if s.config.PerCPU {
 		divisor := float64(runtime.NumCPU())
-		avgLoadValues.Load1 = avgLoadValues.Load1 * divisor
-		avgLoadValues.Load5 = avgLoadValues.Load1 * divisor
-		avgLoadValues.Load15 = avgLoadValues.Load1 * divisor
+		avgLoadValues.Load1 = avgLoadValues.Load1 / divisor
+		avgLoadValues.Load5 = avgLoadValues.Load1 / divisor
+		avgLoadValues.Load15 = avgLoadValues.Load1 / divisor
 	}
 
 	metrics.EnsureCapacity(metricsLen)

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
@@ -36,11 +36,16 @@ func TestScrape(t *testing.T) {
 		name        string
 		loadFunc    func() (*load.AvgStat, error)
 		expectedErr string
+		perCPU      bool
 	}
 
 	testCases := []testCase{
 		{
 			name: "Standard",
+		},
+		{
+			name:   "PerCPUEnabled",
+			perCPU: true,
 		},
 		{
 			name:        "Load Error",
@@ -51,7 +56,7 @@ func TestScrape(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			scraper := newLoadScraper(context.Background(), zap.NewNop(), &Config{})
+			scraper := newLoadScraper(context.Background(), zap.NewNop(), &Config{PerCPU: test.perCPU})
 			if test.loadFunc != nil {
 				scraper.load = test.loadFunc
 			}

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
@@ -66,7 +66,7 @@ func TestScrape(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			scraper := newLoadScraper(context.Background(), zap.NewNop(), &Config{PerCPU: test.perCPU})
+			scraper := newLoadScraper(context.Background(), zap.NewNop(), &Config{CPUAverage: test.perCPU})
 			if test.loadFunc != nil {
 				scraper.load = test.loadFunc
 			}

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
@@ -17,6 +17,7 @@ package loadscraper
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 
 	"github.com/shirou/gopsutil/v3/load"
@@ -31,21 +32,29 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata"
 )
 
+const (
+	testStandard = "Standard"
+	testAverage  = "PerCPUEnabled"
+)
+
 func TestScrape(t *testing.T) {
 	type testCase struct {
 		name        string
 		loadFunc    func() (*load.AvgStat, error)
 		expectedErr string
 		perCPU      bool
+		saveMetrics bool
 	}
 
 	testCases := []testCase{
 		{
-			name: "Standard",
+			name:        testStandard,
+			saveMetrics: true,
 		},
 		{
-			name:   "PerCPUEnabled",
-			perCPU: true,
+			name:        testAverage,
+			perCPU:      true,
+			saveMetrics: true,
 		},
 		{
 			name:        "Load Error",
@@ -53,6 +62,7 @@ func TestScrape(t *testing.T) {
 			expectedErr: "err1",
 		},
 	}
+	results := make(map[string]pdata.MetricSlice)
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
@@ -89,11 +99,34 @@ func TestScrape(t *testing.T) {
 			assertMetricHasSingleDatapoint(t, metrics.At(2), metadata.Metrics.SystemCPULoadAverage15m.New())
 
 			internal.AssertSameTimeStampForAllMetrics(t, metrics)
+
+			// save metrics for additional tests if flag is enabled
+			if test.saveMetrics {
+				results[test.name] = metrics
+			}
 		})
+	}
+
+	// Additional test for average per CPU
+	numCPU := runtime.NumCPU()
+	for i := 0; i < results[testStandard].Len(); i++ {
+		assertCompareAveragePerCPU(t, results[testAverage].At(i), results[testStandard].At(i), numCPU)
 	}
 }
 
 func assertMetricHasSingleDatapoint(t *testing.T, metric pdata.Metric, descriptor pdata.Metric) {
 	internal.AssertDescriptorEqual(t, descriptor, metric)
 	assert.Equal(t, 1, metric.Gauge().DataPoints().Len())
+}
+
+func assertCompareAveragePerCPU(t *testing.T, average pdata.Metric, standard pdata.Metric, numCPU int) {
+	valAverage := average.Gauge().DataPoints().At(0).DoubleVal()
+	valStandard := standard.Gauge().DataPoints().At(0).DoubleVal()
+	if numCPU == 1 {
+		// For hardware with only 1 cpu, results must be very close
+		assert.InDelta(t, valAverage, valStandard, 0.1)
+	} else {
+		// For hardward with multiple CPU, average per cpu is fatally less than standard
+		assert.Less(t, valAverage, valStandard)
+	}
 }

--- a/receiver/hostmetricsreceiver/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/testdata/config.yaml
@@ -8,6 +8,7 @@ receivers:
       cpu:
       disk:
       load:
+        cpu_average: true
       filesystem:
       memory:
       network:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add `per_cpu` optional option to load scraper of hostmetricsreceiver to produce average load per cpu which should ease the creation of alert for users without to divide themselves the metric (when another one is available for cpu count).

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5243 (original PR)

**Testing:** the test only tests if the metrics generated with this option enabled are lower than the standard ones (when no average is applied)

**Documentation:** added the new `per_cpu` option similar to https://docs.signalfx.com/en/latest/integrations/agent/monitors/load.html