### PR TITLE
Fix issue where zookeeper receiver could panic during shutdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 - `ecstaskobserver`: Fix "Incorrect conversion between integer types" security issue (#6939)
 - Fix typo in "direction" metrics attribute description (#6949)
+- `zookeeperreceiver`: Fix issue where receiver could panic during shutdown (#7020)
 
 ## 💡 Enhancements 💡
 

--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -200,8 +200,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "zipkin",
 		},
 		{
-			receiver:     "zookeeper",
-			skipLifecyle: true, // Panics due to nil pointer on shutdown with the default configuration
+			receiver: "zookeeper",
 		},
 		{
 			receiver: "syslog",

--- a/receiver/zookeeperreceiver/scraper.go
+++ b/receiver/zookeeperreceiver/scraper.go
@@ -73,7 +73,10 @@ func newZookeeperMetricsScraper(logger *zap.Logger, config *Config) (*zookeeperM
 }
 
 func (z *zookeeperMetricsScraper) shutdown(_ context.Context) error {
-	z.cancel()
+	if z.cancel != nil {
+		z.cancel()
+		z.cancel = nil
+	}
 	return nil
 }
 

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -213,6 +213,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			}
 
 			got, err := z.scrape(ctx)
+			require.NoError(t, z.shutdown(ctx))
 
 			require.Equal(t, len(tt.expectedLogs), observedLogs.Len())
 			for i, log := range tt.expectedLogs {
@@ -239,6 +240,13 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
 		})
 	}
+}
+
+func TestZookeeperShutdownBeforeScrape(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	z, err := newZookeeperMetricsScraper(zap.NewNop(), cfg)
+	require.NoError(t, err)
+	require.NoError(t, z.shutdown(context.Background()))
 }
 
 type mockedServer struct {


### PR DESCRIPTION
Resolves #6979 

When the zookeeper receiver is started, and then stopped before
the scrape function is ever called, it does not yet have a cancel
function to call. There was previously an expectation that this
cancel function existed by the time shutdown was called. This
change protects against the scenario where it does not yet exist.
