### PR TITLE
Fix prometheus job cache expiration by using the longest scrape interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `zookeeperreceiver`: Fix issue where receiver could panic during shutdown (#7020)
 - `prometheusreceiver`: Fix metadata fetching when metrics differ by trimmable suffixes (#6932)
 - Sanitize URLs being logged (#7021)
+- `prometheusreceiver`: Fix start time tracking for long scrape intervals (#7053)
 
 ## 💡 Enhancements 💡
 

--- a/receiver/prometheusreceiver/internal/ocastore.go
+++ b/receiver/prometheusreceiver/internal/ocastore.go
@@ -60,6 +60,7 @@ func NewOcaStore(
 	ctx context.Context,
 	sink consumer.Metrics,
 	set component.ReceiverCreateSettings,
+	gcInterval time.Duration,
 	useStartTimeMetric bool,
 	startTimeMetricRegex string,
 	receiverID config.ComponentID,
@@ -67,7 +68,7 @@ func NewOcaStore(
 	pdataDirect bool) *OcaStore {
 	var jobsMap *JobsMapPdata
 	if !useStartTimeMetric {
-		jobsMap = NewJobsMapPdata(2 * time.Minute)
+		jobsMap = NewJobsMapPdata(gcInterval)
 	}
 	return &OcaStore{
 		running:              runningStateInit,

--- a/receiver/prometheusreceiver/internal/ocastore_test.go
+++ b/receiver/prometheusreceiver/internal/ocastore_test.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/scrape"
@@ -26,7 +27,7 @@ import (
 )
 
 func TestOcaStore(t *testing.T) {
-	o := NewOcaStore(context.Background(), nil, testTelemetry.ToReceiverCreateSettings(), false, "", config.NewComponentID("prometheus"), nil, false)
+	o := NewOcaStore(context.Background(), nil, testTelemetry.ToReceiverCreateSettings(), 2*time.Minute, false, "", config.NewComponentID("prometheus"), nil, false)
 	o.SetScrapeManager(&scrape.Manager{})
 
 	app := o.Appender(context.Background())


### PR DESCRIPTION
**Description:**

Fixes an issue in which the start timestamp of prometheus metrics is reset every scrape if the interval is longer than 2 minutes (the cache garbage collection interval).  It does this by setting the gc interval to the longest scrape interval + 1 minute.

**Link to tracking Issue:**

Fixes: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4756

**Testing:** <Describe what testing was performed and which tests were added.>

Unit test.  I also performed a manual test to show that a 3m scrape interval correctly records start time.
