### PR TITLE
disable docker_stats lifecycle for receivers component test

### DIFF
--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -78,7 +78,7 @@ func TestDefaultReceivers(t *testing.T) {
 		},
 		{
 			receiver:     "docker_stats",
-			skipLifecyle: runtime.GOOS == "windows", // Unable to start docker client on windows
+			skipLifecyle: true,
 		},
 		{
 			receiver:     "dotnet_diagnostics",


### PR DESCRIPTION
**Description:**
Fixing a bug - per https://github.com/open-telemetry/opentelemetry-collector/pull/4643#issuecomment-1006095568 the core's contrib test circleci-based go container likely isn't able to access the docker domain socket without an entrypoint or similar env requirement. Disabling the lifecycle verification for now.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7023
