### PR TITLE
[documentation] template for new component issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_component.md
+++ b/.github/ISSUE_TEMPLATE/new_component.md
@@ -1,0 +1,41 @@
+---
+name: New component proposal
+about: Suggest a new component for the project
+title: ''
+labels: new component
+assignees: ''
+
+---
+
+**The purpose and use-cases of the new component**
+
+*This information can be used later on to populate the README for the component.*
+
+**Example configuration for the component**
+
+*This will be used later on when creating `config.go` and added to README as well.*
+
+**Telemetry data types supported**
+
+*Any combination of traces, metrics and/or logs is valid here.*
+
+**Sponsor**
+
+*A sponsor is an approver who will be in charge of being the official reviewer of the code. For vendor-specific components, it's good to have a volunteer sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor components, having a sponsor means that your use case has been validated.*
+
+**Checklist**
+
+The following is a checklist for tracking the work required when adding a new component:
+
+- [ ] Identify a sponsor
+- [ ] Document README.md with some basic information about your component. It doesn't have to be complete, but should contain at least:
+  - [ ] The purpose of the component
+  - [ ] Use-cases
+- [ ] A complete config.go, which will show how your component will look like to users
+- [ ] Add component to `versions.yaml`
+- [ ] `CODEOWNERS` with at least the sponsor and the component's author
+- [ ] internal/components tests
+- [ ] Add component to `go.mod` at the root of the repository and at `cmd/configschema`
+- [ ] Enable Dependabot for your component by running `make gendependabot`.
+- [ ] The skeleton of the component, potentially using the helpers
+- [ ] Add Makefile

--- a/.github/ISSUE_TEMPLATE/new_component.md
+++ b/.github/ISSUE_TEMPLATE/new_component.md
@@ -1,7 +1,7 @@
 ---
 name: New component proposal
 about: Suggest a new component for the project
-title: ''
+title: 'New component: '
 labels: new component
 assignees: ''
 
@@ -9,33 +9,16 @@ assignees: ''
 
 **The purpose and use-cases of the new component**
 
-*This information can be used later on to populate the README for the component.*
+*This information can be used later on to populate the README for the component. See an example overview [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver#overview).*
 
 **Example configuration for the component**
 
-*This will be used later on when creating `config.go` and added to README as well.*
+*This will be used later on when creating `config.go` and added to README as well. See this receiver as an [example](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver#getting-started).*
 
 **Telemetry data types supported**
 
 *Any combination of traces, metrics and/or logs is valid here.*
 
-**Sponsor**
+**Sponsor (Optional)**
 
 *A sponsor is an approver who will be in charge of being the official reviewer of the code. For vendor-specific components, it's good to have a volunteer sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor components, having a sponsor means that your use case has been validated.*
-
-**Checklist**
-
-The following is a checklist for tracking the work required when adding a new component:
-
-- [ ] Identify a sponsor
-- [ ] Document README.md with some basic information about your component. It doesn't have to be complete, but should contain at least:
-  - [ ] The purpose of the component
-  - [ ] Use-cases
-- [ ] A complete config.go, which will show how your component will look like to users
-- [ ] Add component to `versions.yaml`
-- [ ] `CODEOWNERS` with at least the sponsor and the component's author
-- [ ] internal/components tests
-- [ ] Add component to `go.mod` at the root of the repository and at `cmd/configschema`
-- [ ] Enable Dependabot for your component by running `make gendependabot`.
-- [ ] The skeleton of the component, potentially using the helpers
-- [ ] Add Makefile

--- a/.github/ISSUE_TEMPLATE/new_component.md
+++ b/.github/ISSUE_TEMPLATE/new_component.md
@@ -7,18 +7,24 @@ assignees: ''
 
 ---
 
-**The purpose and use-cases of the new component**
+## The purpose and use-cases of the new component
+<!-- 
+This information can be used later on to populate the README for the component. See an example overview [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver#overview).
+-->
 
-*This information can be used later on to populate the README for the component. See an example overview [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver#overview).*
+## Example configuration for the component
+<!-- 
+This will be used later on when creating `config.go` and added to README as well. See this receiver as an [example](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver#getting-started).
+-->
 
-**Example configuration for the component**
+## Telemetry data types supported
+<!-- 
+Any combination of traces, metrics and/or logs is valid here.
+-->
 
-*This will be used later on when creating `config.go` and added to README as well. See this receiver as an [example](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver#getting-started).*
+## Sponsor (Optional)
+<!-- 
+A sponsor is an approver who will be in charge of being the official reviewer of the code. For vendor-specific components, it's good to have a volunteer sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor components, having a sponsor means that your use case has been validated.
 
-**Telemetry data types supported**
-
-*Any combination of traces, metrics and/or logs is valid here.*
-
-**Sponsor (Optional)**
-
-*A sponsor is an approver who will be in charge of being the official reviewer of the code. For vendor-specific components, it's good to have a volunteer sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor components, having a sponsor means that your use case has been validated.*
+If there are no sponsors yet for the component, it's fine: use the issue as a means to try to find a sponsor for your component.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,13 @@ before you begin your work.
 
 ## Adding New Components
 
+Before any code is written, open an issue providing the following information:
+
+    * Who's the sponsor for your component. A sponsor is an approver who will be in charge of being the official reviewer of the code. For vendor-specific components, it's good to have a volunteer sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor specific components, having a sponsor means that your use case has been validated.
+    * Some information about your component, such as the reasoning behind it, use-cases, telemetry data types supported, and anything else you think it's relevant for us to make a decision about accepting the component
+    * The configuration options your component will accept. This will help us understand what it does and have an idea of how the implementation might look like
+
+
 Any component (receiver, processor, exporter, or extension) needs to implement
 the interfaces defined on the [core
 repository](https://github.com/open-telemetry/opentelemetry-collector).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ before you begin your work.
 
 ## Adding New Components
 
-Before any code is written, open an issue providing the following information:
+**Before** any code is written, [open an issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/new?assignees=&labels=new+component&template=new_component.md&title=New%20component) providing the following information:
 
-    * Who's the sponsor for your component. A sponsor is an approver who will be in charge of being the official reviewer of the code. For vendor-specific components, it's good to have a volunteer sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor specific components, having a sponsor means that your use case has been validated.
-    * Some information about your component, such as the reasoning behind it, use-cases, telemetry data types supported, and anything else you think it's relevant for us to make a decision about accepting the component
-    * The configuration options your component will accept. This will help us understand what it does and have an idea of how the implementation might look like
+* Who's the sponsor for your component. A sponsor is an approver who will be in charge of being the official reviewer of the code and become a code owner for the component. For vendor-specific components, it's good to have a volunteer sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor specific components, having a sponsor means that your use case has been validated.
+* Some information about your component, such as the reasoning behind it, use-cases, telemetry data types supported, and anything else you think it's relevant for us to make a decision about accepting the component
+* The configuration options your component will accept. This will help us understand what it does and have an idea of how the implementation might look like
 
 
 Any component (receiver, processor, exporter, or extension) needs to implement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ before you begin your work.
 **Before** any code is written, [open an issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/new?assignees=&labels=new+component&template=new_component.md&title=New%20component) providing the following information:
 
 * Who's the sponsor for your component. A sponsor is an approver who will be in charge of being the official reviewer of the code and become a code owner for the component. For vendor-specific components, it's good to have a volunteer sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor specific components, having a sponsor means that your use case has been validated.
-* Some information about your component, such as the reasoning behind it, use-cases, telemetry data types supported, and anything else you think it's relevant for us to make a decision about accepting the component
-* The configuration options your component will accept. This will help us understand what it does and have an idea of how the implementation might look like
+* Some information about your component, such as the reasoning behind it, use-cases, telemetry data types supported, and anything else you think is relevant for us to make a decision about accepting the component.
+* The configuration options your component will accept. This will help us understand what it does and have an idea of how the implementation might look like.
 
 
 Any component (receiver, processor, exporter, or extension) needs to implement


### PR DESCRIPTION
Adding a template to use as an experiment in this repository. The workflow is expecting users to open a new component issue when proposing an issue, to reduce unnecessary work both for contributors and maintainers.

Once the template is approved, it can be copied over to the core repository and linked from the docs as well.