### PR TITLE
[exporter/signalfx] Don't use `syscall` to avoid compilation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `zookeeperreceiver`: Fix issue where receiver could panic during shutdown (#7020)
 - `prometheusreceiver`: Fix metadata fetching when metrics differ by trimmable suffixes (#6932)
 - Sanitize URLs being logged (#7021)
+- `signalfxexporter`: Don't use syscall to avoid compilation errors on some platforms (#7062)
 
 ## 💡 Enhancements 💡
 

--- a/exporter/signalfxexporter/internal/hostmetadata/host.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/host.go
@@ -18,7 +18,6 @@
 package hostmetadata // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/hostmetadata"
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io/ioutil"
@@ -127,15 +126,6 @@ func (o *hostOS) toStringMap() map[string]string {
 		"host_os_name":        o.HostOSName,
 		"host_linux_version":  o.HostLinuxVersion,
 	}
-}
-
-// int8ArrayToByteArray converts an []int8 to []byte
-func int8ArrayToByteArray(in []int8) []byte {
-	bts := make([]byte, len(in))
-	for i, c := range in {
-		bts[i] = byte(c)
-	}
-	return bytes.Trim(bts, "\x00")
 }
 
 // getOS returns a struct with information about the host os

--- a/exporter/signalfxexporter/internal/hostmetadata/host_linux.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/host_linux.go
@@ -15,36 +15,39 @@
 //go:build linux
 // +build linux
 
-// Taken from https://github.com/signalfx/golib/blob/master/metadata/hostmetadata/host-linux.go as is.
+// Taken from https://github.com/signalfx/golib/blob/master/metadata/hostmetadata/host-linux.go
+// with minor modifications.
 
 package hostmetadata // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/hostmetadata"
 
 import (
-	"syscall"
+	"bytes"
+
+	"golang.org/x/sys/unix"
 )
 
 // syscallUname maps to the golib system call, but can be modified for testing
-var syscallUname = syscall.Uname
+var syscallUname = unix.Uname
 
 func fillPlatformSpecificOSData(info *hostOS) error {
 	info.HostLinuxVersion, _ = getLinuxVersion()
 
-	uname := &syscall.Utsname{}
+	uname := &unix.Utsname{}
 	if err := syscallUname(uname); err != nil {
 		return err
 	}
 
-	info.HostKernelVersion = string(int8ArrayToByteArray(uname.Version[:]))
+	info.HostKernelVersion = string(bytes.Trim(uname.Version[:], "\x00"))
 	return nil
 }
 
 func fillPlatformSpecificCPUData(info *hostCPU) error {
-	uname := &syscall.Utsname{}
+	uname := &unix.Utsname{}
 	if err := syscallUname(uname); err != nil {
 		return err
 	}
 
-	info.HostMachine = string(int8ArrayToByteArray(uname.Machine[:]))
+	info.HostMachine = string(bytes.Trim(uname.Machine[:], "\x00"))
 
 	// according to the python doc platform.Processor usually returns the same
 	// value as platform.Machine

--- a/exporter/signalfxexporter/internal/hostmetadata/host_linux_test.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/host_linux_test.go
@@ -23,13 +23,14 @@ import (
 	"errors"
 	"os"
 	"reflect"
-	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestFillOSSpecificData(t *testing.T) {
 	type args struct {
-		syscallUname func(*syscall.Utsname) error
+		syscallUname func(*unix.Utsname) error
 		etc          string
 	}
 	tests := []struct {
@@ -42,8 +43,8 @@ func TestFillOSSpecificData(t *testing.T) {
 			name: "get uname os information",
 			args: args{
 				etc: "./testdata/lsb-release",
-				syscallUname: func(in *syscall.Utsname) error {
-					in.Version = [65]int8{35, 57, 45, 85, 98, 117, 110, 116,
+				syscallUname: func(in *unix.Utsname) error {
+					in.Version = [65]byte{35, 57, 45, 85, 98, 117, 110, 116,
 						117, 32, 83, 77, 80, 32, 87, 101, 100,
 						32, 77, 97, 121, 32, 49, 54, 32, 49,
 						53, 58, 50, 50, 58, 53, 52, 32, 85,
@@ -60,8 +61,8 @@ func TestFillOSSpecificData(t *testing.T) {
 			name: "get uname os information uname call fails",
 			args: args{
 				etc: "./testdata/lsb-release",
-				syscallUname: func(in *syscall.Utsname) error {
-					in.Version = [65]int8{}
+				syscallUname: func(in *unix.Utsname) error {
+					in.Version = [65]byte{}
 					return errors.New("shouldn't work")
 				},
 			},
@@ -88,13 +89,13 @@ func TestFillOSSpecificData(t *testing.T) {
 			}
 		})
 		os.Unsetenv("HOST_ETC")
-		syscallUname = syscall.Uname
+		syscallUname = unix.Uname
 	}
 }
 
 func TestFillPlatformSpecificCPUData(t *testing.T) {
 	type args struct {
-		syscallUname func(*syscall.Utsname) error
+		syscallUname func(*unix.Utsname) error
 	}
 	tests := []struct {
 		name    string
@@ -105,8 +106,8 @@ func TestFillPlatformSpecificCPUData(t *testing.T) {
 		{
 			name: "get uname cpu information",
 			args: args{
-				syscallUname: func(in *syscall.Utsname) error {
-					in.Machine = [65]int8{120, 56, 54, 95, 54, 52}
+				syscallUname: func(in *unix.Utsname) error {
+					in.Machine = [65]byte{120, 56, 54, 95, 54, 52}
 					return nil
 				},
 			},
@@ -118,8 +119,8 @@ func TestFillPlatformSpecificCPUData(t *testing.T) {
 		{
 			name: "get uname cpu information and the call to uname fails",
 			args: args{
-				syscallUname: func(in *syscall.Utsname) error {
-					in.Machine = [65]int8{}
+				syscallUname: func(in *unix.Utsname) error {
+					in.Machine = [65]byte{}
 					return errors.New("shouldn't work")
 				},
 			},
@@ -142,6 +143,6 @@ func TestFillPlatformSpecificCPUData(t *testing.T) {
 			}
 		})
 		os.Unsetenv("HOST_ETC")
-		syscallUname = syscall.Uname
+		syscallUname = unix.Uname
 	}
 }

--- a/exporter/signalfxexporter/internal/hostmetadata/host_test.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/host_test.go
@@ -318,29 +318,3 @@ func TestEtcPath(t *testing.T) {
 	}
 
 }
-
-func TestInt8ArrayToByteArray(t *testing.T) {
-	type args struct {
-		in []int8
-	}
-	tests := []struct {
-		name string
-		args args
-		want []byte
-	}{
-		{
-			name: "convert int8 array to byte array",
-			args: args{
-				in: []int8{72, 69, 76, 76, 79, 32, 87, 79, 82, 76, 68},
-			},
-			want: []byte{72, 69, 76, 76, 79, 32, 87, 79, 82, 76, 68},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := int8ArrayToByteArray(tt.args.in); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("int8ArrayToByteArray() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/exporter/signalfxexporter/internal/hostmetadata/metadata_linux_test.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/metadata_linux_test.go
@@ -14,11 +14,11 @@
 
 package hostmetadata
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
 func mockSyscallUname() {
-	syscallUname = func(in *syscall.Utsname) error {
-		in.Machine = [65]int8{}
+	syscallUname = func(in *unix.Utsname) error {
+		in.Machine = [65]byte{}
 		return nil
 	}
 }


### PR DESCRIPTION
`syscall` package is deprecated and doesn't guarantee compatibility with all platforms. This change replaces usages of `syscall` with `sys/unix` package to avoid compilation errors on some specific platforms.

Resolves: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6813