### PR TITLE
Remove Owais Lone from the approvers' list

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -17,7 +17,6 @@ assigneeGroups:
     - dmitryax
     - jpkrohling
     - mx-psi
-    - owais
     - bogdandrutu
     - tigrannajaryan
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs
 - [Daniel Jaglowski](https://github.com/djaglowski), observIQ
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
 - [Pablo Baeyens](https://github.com/mx-psi), DataDog
-- [Owais Lone](https://github.com/owais), Splunk
 
 Maintainers ([@open-telemetry/collector-contrib-maintainer](https://github.com/orgs/open-telemetry/teams/collector-contrib-maintainer)):
 


### PR DESCRIPTION
Owais is currently not able to allocate much time to the Collector.

Thank you for your contributions, Owais. I hope to see you back when you have more time!
