### PR TITLE
[processor/k8sattributes] Parse IP out of net.Addr to correctly tag k8s.pod.ip 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@
 - Sanitize URLs being logged (#7021)
 - `prometheusreceiver`: Fix start time tracking for long scrape intervals (#7053)
 - `signalfxexporter`: Don't use syscall to avoid compilation errors on some platforms (#7062)
-
+- `k8sattributeprocessor`: Parse IP out of net.Addr to correctly tag k8s.pod.ip
+- 
 ## 💡 Enhancements 💡
 
 - `lokiexporter`: add complete log record to body (#6619)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@
 - `prometheusreceiver`: Fix start time tracking for long scrape intervals (#7053)
 - `signalfxexporter`: Don't use syscall to avoid compilation errors on some platforms (#7062)
 - `k8sattributeprocessor`: Parse IP out of net.Addr to correctly tag k8s.pod.ip
-- 
 ## 💡 Enhancements 💡
 
 - `lokiexporter`: add complete log record to body (#6619)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@
 - Sanitize URLs being logged (#7021)
 - `prometheusreceiver`: Fix start time tracking for long scrape intervals (#7053)
 - `signalfxexporter`: Don't use syscall to avoid compilation errors on some platforms (#7062)
-- `k8sattributeprocessor`: Parse IP out of net.Addr to correctly tag k8s.pod.ip
+- `k8sattributeprocessor`: Parse IP out of net.Addr to correctly tag k8s.pod.ip (#7077)
+
 ## 💡 Enhancements 💡
 
 - `lokiexporter`: add complete log record to body (#6619)

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -91,6 +91,12 @@ func getConnectionIP(ctx context.Context) kube.PodIdentifier {
 	if c.Addr == nil {
 		return ""
 	}
+	switch addr := c.Addr.(type) {
+	case *net.UDPAddr:
+		return kube.PodIdentifier(addr.IP.String())
+	case *net.TCPAddr:
+		return kube.PodIdentifier(addr.IP.String())
+	}
 	return kube.PodIdentifier(c.Addr.String())
 
 }

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -96,6 +96,8 @@ func getConnectionIP(ctx context.Context) kube.PodIdentifier {
 		return kube.PodIdentifier(addr.IP.String())
 	case *net.TCPAddr:
 		return kube.PodIdentifier(addr.IP.String())
+	case *net.IPAddr:
+		return kube.PodIdentifier(addr.IP.String())
 	}
 	return kube.PodIdentifier(c.Addr.String())
 

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -297,82 +297,41 @@ func withContainerRunID(containerRunID string) generateResourceFunc {
 }
 
 func TestIPDetectionFromContext(t *testing.T) {
-	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
 
-	ipCtx := client.NewContext(context.Background(), client.Info{
-		Addr: &net.IPAddr{
-			IP: net.IPv4(1, 1, 1, 1),
+	addresses := []net.Addr{
+		&net.IPAddr{
+				IP: net.IPv4(1, 1, 1, 1),
 		},
-	})
-	m.testConsume(
-		ipCtx,
-		generateTraces(),
-		generateMetrics(),
-		generateLogs(),
-		func(err error) {
-			assert.NoError(t, err)
-		})
-
-	m.assertBatchesLen(1)
-	m.assertResourceObjectLen(0)
-	m.assertResource(0, func(r pdata.Resource) {
-		require.Greater(t, r.Attributes().Len(), 0)
-		assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
-	})
-
-}
-
-func TestIPDetectionFromTCPContext(t *testing.T) {
-	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
-
-	tcpCtx := client.NewContext(context.Background(), client.Info{
-		Addr: &net.TCPAddr{
+		&net.TCPAddr{
 			IP: net.IPv4(1, 1, 1, 1),
 			Port: 3200,
 		},
-	})
-	m.testConsume(
-		tcpCtx,
-		generateTraces(),
-		generateMetrics(),
-		generateLogs(),
-		func(err error) {
-			assert.NoError(t, err)
-		})
-
-	m.assertBatchesLen(1)
-	m.assertResourceObjectLen(0)
-	m.assertResource(0, func(r pdata.Resource) {
-		require.Greater(t, r.Attributes().Len(), 0)
-		assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
-	})
-
-}
-
-func TestIPDetectionFromUDPContext(t *testing.T) {
-	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
-
-	udpCtx := client.NewContext(context.Background(), client.Info{
-		Addr: &net.UDPAddr{
+		&net.UDPAddr{
 			IP: net.IPv4(1, 1, 1, 1),
 			Port: 3200,
 		},
-	})
-	m.testConsume(
-		udpCtx,
-		generateTraces(),
-		generateMetrics(),
-		generateLogs(),
-		func(err error) {
-			assert.NoError(t, err)
+	}
+	for _, addr := range addresses {
+		m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
+		ctx := client.NewContext(context.Background(), client.Info{
+			Addr: addr,
 		})
+		m.testConsume(
+			ctx,
+			generateTraces(),
+			generateMetrics(),
+			generateLogs(),
+			func(err error) {
+				assert.NoError(t, err)
+			})
 
-	m.assertBatchesLen(1)
-	m.assertResourceObjectLen(0)
-	m.assertResource(0, func(r pdata.Resource) {
-		require.Greater(t, r.Attributes().Len(), 0)
-		assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
-	})
+		m.assertBatchesLen(1)
+		m.assertResourceObjectLen(0)
+		m.assertResource(0, func(r pdata.Resource) {
+			require.Greater(t, r.Attributes().Len(), 0)
+			assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
+		})
+	}
 
 }
 

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -300,14 +300,14 @@ func TestIPDetectionFromContext(t *testing.T) {
 
 	addresses := []net.Addr{
 		&net.IPAddr{
-				IP: net.IPv4(1, 1, 1, 1),
+			IP: net.IPv4(1, 1, 1, 1),
 		},
 		&net.TCPAddr{
-			IP: net.IPv4(1, 1, 1, 1),
+			IP:   net.IPv4(1, 1, 1, 1),
 			Port: 3200,
 		},
 		&net.UDPAddr{
-			IP: net.IPv4(1, 1, 1, 1),
+			IP:   net.IPv4(1, 1, 1, 1),
 			Port: 3200,
 		},
 	}

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -349,6 +349,33 @@ func TestIPDetectionFromTCPContext(t *testing.T) {
 
 }
 
+func TestIPDetectionFromUDPContext(t *testing.T) {
+	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
+
+	udpCtx := client.NewContext(context.Background(), client.Info{
+		Addr: &net.UDPAddr{
+			IP: net.IPv4(1, 1, 1, 1),
+			Port: 3200,
+		},
+	})
+	m.testConsume(
+		udpCtx,
+		generateTraces(),
+		generateMetrics(),
+		generateLogs(),
+		func(err error) {
+			assert.NoError(t, err)
+		})
+
+	m.assertBatchesLen(1)
+	m.assertResourceObjectLen(0)
+	m.assertResource(0, func(r pdata.Resource) {
+		require.Greater(t, r.Attributes().Len(), 0)
+		assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
+	})
+
+}
+
 func TestNilBatch(t *testing.T) {
 	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
 	m.testConsume(

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -299,13 +299,13 @@ func withContainerRunID(containerRunID string) generateResourceFunc {
 func TestIPDetectionFromContext(t *testing.T) {
 	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
 
-	ctx := client.NewContext(context.Background(), client.Info{
+	ipCtx := client.NewContext(context.Background(), client.Info{
 		Addr: &net.IPAddr{
 			IP: net.IPv4(1, 1, 1, 1),
 		},
 	})
 	m.testConsume(
-		ctx,
+		ipCtx,
 		generateTraces(),
 		generateMetrics(),
 		generateLogs(),
@@ -319,6 +319,34 @@ func TestIPDetectionFromContext(t *testing.T) {
 		require.Greater(t, r.Attributes().Len(), 0)
 		assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
 	})
+
+}
+
+func TestIPDetectionFromTCPContext(t *testing.T) {
+	m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)
+
+	tcpCtx := client.NewContext(context.Background(), client.Info{
+		Addr: &net.TCPAddr{
+			IP: net.IPv4(1, 1, 1, 1),
+			Port: 3200,
+		},
+	})
+	m.testConsume(
+		tcpCtx,
+		generateTraces(),
+		generateMetrics(),
+		generateLogs(),
+		func(err error) {
+			assert.NoError(t, err)
+		})
+
+	m.assertBatchesLen(1)
+	m.assertResourceObjectLen(0)
+	m.assertResource(0, func(r pdata.Resource) {
+		require.Greater(t, r.Attributes().Len(), 0)
+		assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
+	})
+
 }
 
 func TestNilBatch(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Jonah Back <jonah@jonahback.com>

**Description:** <Describe what has changed.>
This PR changes the handling of IP tagging in the Kubernetes Attribute Processor to correctly parse the IP of the network connection. Currently, the string used looks like "10.17.70.57:51372" - which includes the port, which is not correct and causes additional metadata about the Kubernetes environment to not be tagged correctly. 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>