### PR TITLE
[spanmetricsprocessor] dropping the condition to replace _ with key_ as __ label is reserved and _ is not

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -527,9 +527,6 @@ func sanitize(s string) string {
 	if unicode.IsDigit(rune(s[0])) {
 		s = "key_" + s
 	}
-	if s[0] == '_' {
-		s = "key" + s
-	}
 	return s
 }
 

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -763,7 +763,7 @@ func TestValidateDimensions(t *testing.T) {
 
 func TestSanitize(t *testing.T) {
 	require.Equal(t, "", sanitize(""), "")
-	require.Equal(t, "key_test", sanitize("_test"))
+	require.Equal(t, "_test", sanitize("_test"))
 	require.Equal(t, "key_0test", sanitize("0test"))
 	require.Equal(t, "test", sanitize("test"))
 	require.Equal(t, "test__", sanitize("test_/"))


### PR DESCRIPTION
__ is a reserved label  and _ is not. Being able to use or not use a certain kind of naming convention would be a decision at the exporter level as the nature of the storage dictates what can and can’t be used. it would be nice if we could ideally relax this check for processors in general and backends that don't mandate it like prometheus.

**Description:** dropped the check to handle labels that start with '_'


**Testing:** All the tests worked fine
