### PR TITLE
[cicd] stop publishing artifacts in this repo

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -432,56 +432,13 @@ jobs:
         with:
           path: /home/runner/go/bin
           key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
-      - name: Download Binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: collector-binaries
-          path: ./bin/
-      - run: chmod +x bin/*
-      - name: Download Packages
-        uses: actions/download-artifact@v2
-        with:
-          name: collector-packages
-          path: ./dist/
-      - name: Add Permissions to Tool Binaries
-        run: chmod -R +x ./dist
-      - name: Verify Distribution Files Exist
-        id: check
-        run: ./.github/workflows/scripts/verify-dist-files-exist.sh
       - name: Set Release Tag
         id: github_tag
         run: ./.github/workflows/scripts/set_release_tag.sh
-      # The following step strips the 'v' prefix from the release tag for use in docker tags
-      - name: Set Docker Tag
-        run: echo "DOCKER_TAG=${RELEASE_TAG:1}" >> $GITHUB_ENV
-        env:
-          RELEASE_TAG: ${{ steps.github_tag.outputs.tag }}
-      - name: Build Docker Image
-        if: steps.check.outputs.passed == 'true'
-        run: |
-            make docker-otelcontribcol
-            docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib:$DOCKER_TAG
-            docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib:latest
-      - name: Validate Docker Image
-        if: steps.check.outputs.passed == 'true'
-        run: |
-            docker run otel/opentelemetry-collector-contrib:$DOCKER_TAG --version
-            docker run otel/opentelemetry-collector-contrib:latest --version
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Push Docker Image
-        if: steps.check.outputs.passed == 'true'
-        run: |
-            docker push otel/opentelemetry-collector-contrib:$DOCKER_TAG
-            docker push otel/opentelemetry-collector-contrib:latest
       - name: Create Github Release
         if: steps.check.outputs.passed == 'true'
         run: |
-          cp bin/* dist/
-          cd dist && shasum -a 256 * > checksums.txt && cd ../
+          mkdir -p dist/
           ghr -t $GITHUB_TOKEN -u open-telemetry -r opentelemetry-collector-contrib --replace $RELEASE_TAG dist/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The artifacts for collector contrib are now published in the releases repo: https://github.com/open-telemetry/opentelemetry-collector-releases. This change prevents the artifacts from living in two different places.