### PR TITLE
[prometheusremotewriteexporter] dropping the condition to replace _ with key_ as __ label is reserved and _ is not

### DIFF
--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -297,9 +297,6 @@ func sanitize(s string) string {
 	if unicode.IsDigit(rune(s[0])) {
 		s = keyStr + "_" + s
 	}
-	if s[0] == '_' {
-		s = keyStr + s
-	}
 	return s
 }
 

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -297,7 +297,7 @@ func sanitize(s string) string {
 	if unicode.IsDigit(rune(s[0])) {
 		s = keyStr + "_" + s
 	}
-	if s[0] == '_' {
+	if s[0] == '_' && s[1] == '_'{
 		s = keyStr + s
 	}
 	return s

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -297,6 +297,9 @@ func sanitize(s string) string {
 	if unicode.IsDigit(rune(s[0])) {
 		s = keyStr + "_" + s
 	}
+	if s[0] == '_' && s[1] == '_' {
+		s = keyStr + s
+	}
 	return s
 }
 

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -217,7 +217,7 @@ func Test_createLabelSet(t *testing.T) {
 			lbs1Dirty,
 			map[string]string{},
 			[]string{label31 + dirty1, value31, label32, value32},
-			getPromLabels(label11+"_", value11, label12, value12, label31+"_", value31, label32, value32),
+			getPromLabels(label11+"_", value11, "_"+label12, value12, label31+"_", value31, label32, value32),
 		},
 		{
 			"no_original_case",

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -217,7 +217,7 @@ func Test_createLabelSet(t *testing.T) {
 			lbs1Dirty,
 			map[string]string{},
 			[]string{label31 + dirty1, value31, label32, value32},
-			getPromLabels(label11+"_", value11, "key_"+label12, value12, label31+"_", value31, label32, value32),
+			getPromLabels(label11+"_", value11, "_"+label12, value12, label31+"_", value31, label32, value32),
 		},
 		{
 			"no_original_case",

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -217,7 +217,7 @@ func Test_createLabelSet(t *testing.T) {
 			lbs1Dirty,
 			map[string]string{},
 			[]string{label31 + dirty1, value31, label32, value32},
-			getPromLabels(label11+"_", value11, "_"+label12, value12, label31+"_", value31, label32, value32),
+			getPromLabels(label11+"_", value11, label12, value12, label31+"_", value31, label32, value32),
 		},
 		{
 			"no_original_case",


### PR DESCRIPTION
__ is a reserved label and _ is not. Being able to use or not use a certain kind of naming convention would be a decision at the exporter level as the nature of the storage dictates what can and can’t be used. it would be nice if we could ideally relax this check for processors in general and backends that don't mandate it like prometheus.

Description: dropped the check to handle labels that start with '_'

Testing: All the tests worked fine