### PR TITLE
Clean up scrapertest test expectations

### DIFF
--- a/internal/scrapertest/testdata/ignore-data-point-value-double-mismatch/actual.json
+++ b/internal/scrapertest/testdata/ignore-data-point-value-double-mismatch/actual.json
@@ -1,0 +1,22 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "metrics": [
+                  {
+                     "name": "gauge.one",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 654.321
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/ignore-data-point-value-double-mismatch/expected.json
+++ b/internal/scrapertest/testdata/ignore-data-point-value-double-mismatch/expected.json
@@ -1,0 +1,22 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "metrics": [
+                  {
+                     "name": "gauge.one",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 123.456
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/ignore-data-point-value-int-mismatch/actual.json
+++ b/internal/scrapertest/testdata/ignore-data-point-value-int-mismatch/actual.json
@@ -1,0 +1,22 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "metrics": [
+                  {
+                     "name": "sum.one",
+                     "sum": {
+                        "dataPoints": [
+                           {
+                              "asInt": 654
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/ignore-data-point-value-int-mismatch/expected.json
+++ b/internal/scrapertest/testdata/ignore-data-point-value-int-mismatch/expected.json
@@ -1,0 +1,22 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "metrics": [
+                  {
+                     "name": "sum.one",
+                     "sum": {
+                        "dataPoints": [
+                           {
+                              "asInt": 123
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}


### PR DESCRIPTION
This change clarifies some expectations in the scrapertest
package. This was extracted from another effort (#6519) in the
interest of simplifying that PR. This should have no functional change.