### PR TITLE
[spanmetricsprocessor] dropping the condition to replace _ with key_ as __ is reserved and _ is not

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -527,7 +527,7 @@ func sanitize(s string) string {
 	if unicode.IsDigit(rune(s[0])) {
 		s = "key_" + s
 	}
-	if s[0] == '_' {
+	if s[0] == '_' && s[1] == '_'{
 		s = "key" + s
 	}
 	return s

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -763,7 +763,8 @@ func TestValidateDimensions(t *testing.T) {
 
 func TestSanitize(t *testing.T) {
 	require.Equal(t, "", sanitize(""), "")
-	require.Equal(t, "key_test", sanitize("_test"))
+	require.Equal(t, "_test", sanitize("_test"))
+	require.Equal(t, "key__test", sanitize("__test"))
 	require.Equal(t, "key_0test", sanitize("0test"))
 	require.Equal(t, "test", sanitize("test"))
 	require.Equal(t, "test__", sanitize("test_/"))


### PR DESCRIPTION
**Description:** the otel spec doesn't prescribe `_` as an unusable prefix for labels. the decision to be able to allow/disallow the usage of the same should be in the hands of exporters based on the nature of the storage that the exporter works with. this PR removes the sanitization for label keys that start with `_`.

**Testing:** 1) emit a metric that has a label starting with _ and it should not be prefixed with key
2) emit a metrics that has a label starting with __ and it should be prefixed with key
