### PR TITLE
[exporter/tanzuobservability] Support summary metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `dynatraceexporter`: Do not shut down exporter when metrics ingest module is temporarily unavailable (#7161)
 - `mongodbreceiver`: Add metric metadata (#7163)
 - `postgresqlreceiver`: add the receiver to available components (#7079)
+- `tanzuobservability exporter`: Support summary metrics (#7121)
 
 ## 🛑 Breaking changes 🛑
 

--- a/exporter/tanzuobservabilityexporter/metrics.go
+++ b/exporter/tanzuobservabilityexporter/metrics.go
@@ -611,7 +611,7 @@ func (regularHistogramConsumerSpec) AsHistogram(metric pdata.Metric) histogramMe
 	}
 }
 
-type summariesConsumer struct {
+type summaryConsumer struct {
 	sender   gaugeSender
 	settings component.TelemetrySettings
 }
@@ -621,14 +621,14 @@ type summariesConsumer struct {
 func newSummaryConsumer(
 	sender gaugeSender, settings component.TelemetrySettings,
 ) typedMetricConsumer {
-	return &summariesConsumer{sender: sender, settings: settings}
+	return &summaryConsumer{sender: sender, settings: settings}
 }
 
-func (s *summariesConsumer) Type() pdata.MetricDataType {
+func (s *summaryConsumer) Type() pdata.MetricDataType {
 	return pdata.MetricDataTypeSummary
 }
 
-func (s *summariesConsumer) Consume(metric pdata.Metric, errs *[]error) {
+func (s *summaryConsumer) Consume(metric pdata.Metric, errs *[]error) {
 	summary := metric.Summary()
 	summaryDataPoints := summary.DataPoints()
 	for i := 0; i < summaryDataPoints.Len(); i++ {
@@ -636,11 +636,12 @@ func (s *summariesConsumer) Consume(metric pdata.Metric, errs *[]error) {
 	}
 }
 
-func (*summariesConsumer) PushInternalMetrics(errs *[]error) {
+// PushInternalMetrics is here so that summaryConsumer implements typedMetricConsumer
+func (*summaryConsumer) PushInternalMetrics(*[]error) {
 	// Do nothing
 }
 
-func (s *summariesConsumer) sendSummaryDataPoint(
+func (s *summaryConsumer) sendSummaryDataPoint(
 	metric pdata.Metric, summaryDataPoint pdata.SummaryDataPoint, errs *[]error,
 ) {
 	name := metric.Name()
@@ -663,7 +664,7 @@ func (s *summariesConsumer) sendSummaryDataPoint(
 	}
 }
 
-func (s *summariesConsumer) sendMetric(
+func (s *summaryConsumer) sendMetric(
 	name string, value float64, ts int64, tags map[string]string, errs *[]error) {
 	err := s.sender.SendMetric(name, value, ts, "", tags)
 	if err != nil {

--- a/exporter/tanzuobservabilityexporter/metrics.go
+++ b/exporter/tanzuobservabilityexporter/metrics.go
@@ -610,3 +610,67 @@ func (regularHistogramConsumerSpec) AsHistogram(metric pdata.Metric) histogramMe
 		HistogramDataPointSlice: aHistogram.DataPoints(),
 	}
 }
+
+type summariesConsumer struct {
+	sender   gaugeSender
+	settings component.TelemetrySettings
+}
+
+// newSummaryConsumer returns a typedMetricConsumer that consumes summary metrics
+// by sending them to tanzu observability.
+func newSummaryConsumer(
+	sender gaugeSender, settings component.TelemetrySettings,
+) typedMetricConsumer {
+	return &summariesConsumer{sender: sender, settings: settings}
+}
+
+func (s *summariesConsumer) Type() pdata.MetricDataType {
+	return pdata.MetricDataTypeSummary
+}
+
+func (s *summariesConsumer) Consume(metric pdata.Metric, errs *[]error) {
+	summary := metric.Summary()
+	summaryDataPoints := summary.DataPoints()
+	for i := 0; i < summaryDataPoints.Len(); i++ {
+		s.sendSummaryDataPoint(metric, summaryDataPoints.At(i), errs)
+	}
+}
+
+func (*summariesConsumer) PushInternalMetrics(errs *[]error) {
+	// Do nothing
+}
+
+func (s *summariesConsumer) sendSummaryDataPoint(
+	metric pdata.Metric, summaryDataPoint pdata.SummaryDataPoint, errs *[]error,
+) {
+	name := metric.Name()
+	ts := summaryDataPoint.Timestamp().AsTime().Unix()
+	tags := attributesToTags(summaryDataPoint.Attributes())
+	count := summaryDataPoint.Count()
+	sum := summaryDataPoint.Sum()
+
+	if quantileTag, ok := tags["quantile"]; ok {
+		tags["_quantile"] = quantileTag
+		delete(tags, "quantile")
+	}
+	s.sendMetric(name+"_count", float64(count), ts, tags, errs)
+	s.sendMetric(name+"_sum", sum, ts, tags, errs)
+	quantileValues := summaryDataPoint.QuantileValues()
+	for i := 0; i < quantileValues.Len(); i++ {
+		quantileValue := quantileValues.At(i)
+		tags["quantile"] = quantileTagValue(quantileValue.Quantile())
+		s.sendMetric(name, quantileValue.Value(), ts, tags, errs)
+	}
+}
+
+func (s *summariesConsumer) sendMetric(
+	name string, value float64, ts int64, tags map[string]string, errs *[]error) {
+	err := s.sender.SendMetric(name, value, ts, "", tags)
+	if err != nil {
+		*errs = append(*errs, err)
+	}
+}
+
+func quantileTagValue(quantile float64) string {
+	return strconv.FormatFloat(quantile, 'f', -1, 64)
+}

--- a/exporter/tanzuobservabilityexporter/metrics_test.go
+++ b/exporter/tanzuobservabilityexporter/metrics_test.go
@@ -761,6 +761,190 @@ func TestDeltaHistogramDataPointConsumerMissingBuckets(t *testing.T) {
 	assert.Equal(t, int64(1), report.Malformed())
 }
 
+func TestSummaries(t *testing.T) {
+	summaryMetric := newMetric("test.summary", pdata.MetricDataTypeSummary)
+	summary := summaryMetric.Summary()
+	dataPoints := summary.DataPoints()
+	dataPoints.EnsureCapacity(2)
+
+	dataPoint := dataPoints.AppendEmpty()
+	setQuantileValues(dataPoint, 0.1, 100.0, 0.5, 200.0, 0.9, 300.0, 0.99, 400.0)
+	setTags(map[string]interface{}{"foo": "bar"}, dataPoint.Attributes())
+	dataPoint.SetCount(10)
+	dataPoint.SetSum(5000.0)
+	setDataPointTimestamp(1645123456, dataPoint)
+
+	dataPoint = dataPoints.AppendEmpty()
+	setQuantileValues(dataPoint, 0.2, 75.0, 0.5, 125.0, 0.8, 175.0, 0.95, 225.0)
+	setTags(map[string]interface{}{"bar": "baz"}, dataPoint.Attributes())
+	dataPoint.SetCount(15)
+	dataPoint.SetSum(3000.0)
+	setDataPointTimestamp(1645123556, dataPoint)
+
+	sender := &mockGaugeSender{}
+	consumer := newSummaryConsumer(sender, componenttest.NewNopTelemetrySettings())
+
+	assert.Equal(t, pdata.MetricDataTypeSummary, consumer.Type())
+
+	var errs []error
+	consumer.Consume(summaryMetric, &errs)
+
+	// Summaries don't have internal metrics, but this is here for 100% test coverage.
+	consumer.PushInternalMetrics(&errs)
+
+	assert.Empty(t, errs)
+
+	expected := []tobsMetric{
+		{
+			Name:  "test.summary",
+			Value: 100.0,
+			Tags:  map[string]string{"foo": "bar", "quantile": "0.1"},
+			Ts:    1645123456,
+		},
+		{
+			Name:  "test.summary",
+			Value: 200.0,
+			Tags:  map[string]string{"foo": "bar", "quantile": "0.5"},
+			Ts:    1645123456,
+		},
+		{
+			Name:  "test.summary",
+			Value: 300.0,
+			Tags:  map[string]string{"foo": "bar", "quantile": "0.9"},
+			Ts:    1645123456,
+		},
+		{
+			Name:  "test.summary",
+			Value: 400.0,
+			Tags:  map[string]string{"foo": "bar", "quantile": "0.99"},
+			Ts:    1645123456,
+		},
+		{
+			Name:  "test.summary_count",
+			Value: 10.0,
+			Tags:  map[string]string{"foo": "bar"},
+			Ts:    1645123456,
+		},
+		{
+			Name:  "test.summary_sum",
+			Value: 5000.0,
+			Tags:  map[string]string{"foo": "bar"},
+			Ts:    1645123456,
+		},
+		{
+			Name:  "test.summary",
+			Value: 75.0,
+			Tags:  map[string]string{"bar": "baz", "quantile": "0.2"},
+			Ts:    1645123556,
+		},
+		{
+			Name:  "test.summary",
+			Value: 125.0,
+			Tags:  map[string]string{"bar": "baz", "quantile": "0.5"},
+			Ts:    1645123556,
+		},
+		{
+			Name:  "test.summary",
+			Value: 175.0,
+			Tags:  map[string]string{"bar": "baz", "quantile": "0.8"},
+			Ts:    1645123556,
+		},
+		{
+			Name:  "test.summary",
+			Value: 225.0,
+			Tags:  map[string]string{"bar": "baz", "quantile": "0.95"},
+			Ts:    1645123556,
+		},
+		{
+			Name:  "test.summary_count",
+			Value: 15.0,
+			Tags:  map[string]string{"bar": "baz"},
+			Ts:    1645123556,
+		},
+		{
+			Name:  "test.summary_sum",
+			Value: 3000.0,
+			Tags:  map[string]string{"bar": "baz"},
+			Ts:    1645123556,
+		},
+	}
+	assert.ElementsMatch(t, expected, sender.metrics)
+}
+
+func TestSummaries_QuantileTagExists(t *testing.T) {
+	summaryMetric := newMetric("test.summary.quantile.tag", pdata.MetricDataTypeSummary)
+	summary := summaryMetric.Summary()
+	dataPoints := summary.DataPoints()
+	dataPoints.EnsureCapacity(1)
+
+	dataPoint := dataPoints.AppendEmpty()
+	setQuantileValues(dataPoint, 0.5, 300.0)
+	setTags(map[string]interface{}{"quantile": "exists"}, dataPoint.Attributes())
+	dataPoint.SetCount(12)
+	dataPoint.SetSum(4000.0)
+	setDataPointTimestamp(1650123456, dataPoint)
+
+	sender := &mockGaugeSender{}
+	consumer := newSummaryConsumer(sender, componenttest.NewNopTelemetrySettings())
+	var errs []error
+	consumer.Consume(summaryMetric, &errs)
+	assert.Empty(t, errs)
+
+	expected := []tobsMetric{
+		{
+			Name:  "test.summary.quantile.tag",
+			Value: 300.0,
+			Tags:  map[string]string{"_quantile": "exists", "quantile": "0.5"},
+			Ts:    1650123456,
+		},
+		{
+			Name:  "test.summary.quantile.tag_count",
+			Value: 12.0,
+			Tags:  map[string]string{"_quantile": "exists"},
+			Ts:    1650123456,
+		},
+		{
+			Name:  "test.summary.quantile.tag_sum",
+			Value: 4000.0,
+			Tags:  map[string]string{"_quantile": "exists"},
+			Ts:    1650123456,
+		},
+	}
+	assert.ElementsMatch(t, expected, sender.metrics)
+}
+
+func TestSummariesConsumer_ErrorSending(t *testing.T) {
+	summaryMetric := newMetric("test.summary.error", pdata.MetricDataTypeSummary)
+	summary := summaryMetric.Summary()
+	dataPoints := summary.DataPoints()
+	dataPoints.EnsureCapacity(1)
+
+	dataPoint := dataPoints.AppendEmpty()
+	dataPoint.SetCount(13)
+	dataPoint.SetSum(3900.0)
+
+	sender := &mockGaugeSender{errorOnSend: true}
+	consumer := newSummaryConsumer(sender, componenttest.NewNopTelemetrySettings())
+	var errs []error
+	consumer.Consume(summaryMetric, &errs)
+	assert.NotEmpty(t, errs)
+}
+
+// Sets quantile values for a summary data point
+func setQuantileValues(dataPoint pdata.SummaryDataPoint, quantileValues ...float64) {
+	if len(quantileValues)%2 != 0 {
+		panic("quantileValues must be quantile, value, quantile, value, ...")
+	}
+	length := len(quantileValues) / 2
+	quantileValuesSlice := dataPoint.QuantileValues()
+	quantileValuesSlice.EnsureCapacity(length)
+	for i := 0; i < length; i++ {
+		quantileValueObj := quantileValuesSlice.AppendEmpty()
+		quantileValueObj.SetQuantile(quantileValues[2*i])
+		quantileValueObj.SetValue(quantileValues[2*i+1])
+	}
+}
+
 // Creates a histogram metric with len(countAttributeForEachDataPoint)
 // datapoints. name is the name of the histogram metric; temporality
 // is the temporality of the histogram metric;

--- a/exporter/tanzuobservabilityexporter/metrics_test.go
+++ b/exporter/tanzuobservabilityexporter/metrics_test.go
@@ -789,9 +789,6 @@ func TestSummaries(t *testing.T) {
 	var errs []error
 	consumer.Consume(summaryMetric, &errs)
 
-	// Summaries don't have internal metrics, but this is here for 100% test coverage.
-	consumer.PushInternalMetrics(&errs)
-
 	assert.Empty(t, errs)
 
 	expected := []tobsMetric{


### PR DESCRIPTION
**Description:**
Support summary metrics in tanzu observability exporter.

**Testing:** 
Unit tests added.
