### PR TITLE
Allow integration tests for individual components to last up to 120s

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -15,7 +15,7 @@ ALL_PKGS := $(shell go list $(sort $(dir $(ALL_SRC))) 2>/dev/null)
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
-GOTEST_INTEGRATION_OPT?= -race -timeout 60s
+GOTEST_INTEGRATION_OPT?= -race -timeout 120s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOTEST=go test


### PR DESCRIPTION
Resolves #7118.

The mysqlreceiver integration test builds a docker image that contains an 
instance of mysql. This follows the same pattern as other scrapers, such as
nginxreceiver. However, I believe that the mysql image must take a slightly 
longer time to build, and that the 60s limit is just a bit too short on rare
occasion. 

This change doubles the max timeout for integration tests from 60s to 120s.
Obviously there are downsides to extending test duration limits, but it
appears these tests are currently running much faster than parallel jobs, 
so this won't typically add any time to the CI process. In the longer term, if
we wish to add many more containerized integration tests, we might consider
batching them into parallel jobs. 

![image](https://user-images.githubusercontent.com/5255616/148833825-45c67ea6-67c6-4aef-9f31-506088cd5017.png)
