### PR TITLE
[processor/k8sattributes] Attempt to parse IP for unknown net.Addr implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - `prometheusreceiver`: Fix start time tracking for long scrape intervals (#7053)
 - `signalfxexporter`: Don't use syscall to avoid compilation errors on some platforms (#7062)
 - `k8sattributeprocessor`: Parse IP out of net.Addr to correctly tag k8s.pod.ip (#7077)
+- `k8sattributeprocessor`: Process IP correctly for net.Addr instances that are not typed (#7133)
 
 ## 💡 Enhancements 💡
 

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -104,9 +104,9 @@ func getConnectionIP(ctx context.Context) kube.PodIdentifier {
 	//If this is not a known address type, check for known "untyped" formats.
 	// 1.1.1.1:<port>
 
-	splitIpAndPort := strings.Split(c.Addr.String(), ":")
-	if len(splitIpAndPort) > 1 {
-		ipString := strings.Join(splitIpAndPort[:len(splitIpAndPort)-1], ":")
+	splitIPAndPort := strings.Split(c.Addr.String(), ":")
+	if len(splitIPAndPort) > 1 {
+		ipString := strings.Join(splitIPAndPort[:len(splitIPAndPort)-1], ":")
 		ip := net.ParseIP(ipString)
 		if ip != nil {
 			return kube.PodIdentifier(ip.String())

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -104,9 +104,9 @@ func getConnectionIP(ctx context.Context) kube.PodIdentifier {
 	//If this is not a known address type, check for known "untyped" formats.
 	// 1.1.1.1:<port>
 
-	splitIPAndPort := strings.Split(c.Addr.String(), ":")
-	if len(splitIPAndPort) > 1 {
-		ipString := strings.Join(splitIPAndPort[:len(splitIPAndPort)-1], ":")
+	lastColonIndex := strings.LastIndex(c.Addr.String(), ":")
+	if lastColonIndex != -1 {
+		ipString := c.Addr.String()[:lastColonIndex]
 		ip := net.ParseIP(ipString)
 		if ip != nil {
 			return kube.PodIdentifier(ip.String())

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -17,6 +17,7 @@ package k8sattributesprocessor // import "github.com/open-telemetry/opentelemetr
 import (
 	"context"
 	"net"
+	"strings"
 
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/model/pdata"
@@ -99,6 +100,19 @@ func getConnectionIP(ctx context.Context) kube.PodIdentifier {
 	case *net.IPAddr:
 		return kube.PodIdentifier(addr.IP.String())
 	}
+
+	//If this is not a known address type, check for known "untyped" formats.
+	// 1.1.1.1:<port>
+
+	splitIpAndPort := strings.Split(c.Addr.String(), ":")
+	if len(splitIpAndPort) > 1 {
+		ipString := strings.Join(splitIpAndPort[:len(splitIpAndPort)-1], ":")
+		ip := net.ParseIP(ipString)
+		if ip != nil {
+			return kube.PodIdentifier(ip.String())
+		}
+	}
+
 	return kube.PodIdentifier(c.Addr.String())
 
 }

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -296,6 +296,16 @@ func withContainerRunID(containerRunID string) generateResourceFunc {
 	}
 }
 
+type strAddr string
+
+func (s strAddr) String() string {
+	return "1.1.1.1:3200"
+}
+
+func (strAddr) Network() string {
+	return "tcp"
+}
+
 func TestIPDetectionFromContext(t *testing.T) {
 
 	addresses := []net.Addr{
@@ -310,6 +320,7 @@ func TestIPDetectionFromContext(t *testing.T) {
 			IP:   net.IPv4(1, 1, 1, 1),
 			Port: 3200,
 		},
+		strAddr("1.1.1.1:3200"),
 	}
 	for _, addr := range addresses {
 		m := newMultiTest(t, NewFactory().CreateDefaultConfig(), nil)


### PR DESCRIPTION
Signed-off-by: Jonah Back <jonah@jonahback.com>

**Description:** <Describe what has changed.>
gRPC connections from the Java OpenTelemetry Agent are currently tagged incorrectly. The changes in #7077 did not fix gRPC connections, as the gRPC library passes back an implementation of net.Addr that is really just a string under the hood. (See https://github.com/grpc/grpc-go/blob/master/internal/transport/handler_server.go#L154) 

This PR takes a best-effort approach to parsing the string returned from a generic net.Addr. If and only if it is able to parse an IP from the string, it will use that as the tag instead of the raw string. 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>