### PR TITLE
Change lint to run other linting related commands as well.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,9 +75,9 @@ jobs:
           path: /home/runner/.cache/go-build
           key: go-build-lint-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
       - name: Lint
-        run: make -j2 golint
+        run: make -j4 golint
       - name: Checks 
-        run: make -j4 checklicense misspell checkdoc impi porto
+        run: make -j4 checkdoc porto
       - name: Codegem
         run: |
           make generate

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -91,7 +91,7 @@ fmt:
 	goimports -w  -local github.com/open-telemetry/opentelemetry-collector-contrib ./
 
 .PHONY: lint
-lint:
+lint: checklicense impi misspell
 	$(LINT) run --allow-parallel-runners
 
 .PHONY: porto


### PR DESCRIPTION
**Description:** When running `make lint`, the expectation is that all linting is done at once. Similar to how the `make fmt` command will run both `gofmt` and `goimports`, this change makes it so `make lint` runs the checklicense, impi, and misspell as well as the linter.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6997

**Testing:** Ran it against the misformatted file seen in the issue above and got the same error as the CI.