### PR TITLE
fix(dt): do not disable exporter when module temporarily disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `datadogexporter`: Add http.status_code tag to trace stats (#6889)
 - `tanzuobservabilityexporter`: Support delta histograms (#6897)
 - `mysqlreceiver`: Add the receiver to available components (#7078)
+- `dynatraceexporter`: Do not shut down exporter when metrics ingest module is temporarily unavailable (#7161)
 
 ## 🛑 Breaking changes 🛑
 

--- a/exporter/dynatraceexporter/metrics_exporter_test.go
+++ b/exporter/dynatraceexporter/metrics_exporter_test.go
@@ -341,8 +341,8 @@ func Test_exporter_send_NotFound(t *testing.T) {
 		t.Errorf("Expected error to be permanent %v", err)
 		return
 	}
-	if !e.isDisabled {
-		t.Error("Expected exporter to be disabled")
+	if e.isDisabled {
+		t.Error("Expected exporter to not be disabled")
 		return
 	}
 }


### PR DESCRIPTION
Dynatrace returns a 404 error when the metrics ingest module is disabled. Enabling the module in Dynatrace should not require a collector restart to begin receiving metrics.