### PR TITLE
fix lint build failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,7 +75,7 @@ jobs:
           path: /home/runner/.cache/go-build
           key: go-build-lint-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
       - name: Lint
-        run: make -j4 golint
+        run: make -j2 golint
       - name: Checks 
         run: make -j4 checkdoc porto
       - name: Codegem


### PR DESCRIPTION
Increasing the number of parallel linters appears to be causing timeouts in the lint job.

Fixes #7169 