### PR TITLE
[receiver/hostmetrics] Mute process name error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `extension/observers`: Correctly set image and tag on container endpoints (#7279)
 - `tanzuobservabilityexporter`: Document how to enable memory_limiter (#7286)
 - `hostreceiver/networkscraper`: Migrate the scraper to the mdatagen metrics builder (#7048)
+- `hostmetricsreceiver`: Add MuteProcessNameError config flag to mute specific error reading process executable (#7176)
 
 ## 🛑 Breaking changes 🛑
 

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -77,10 +77,10 @@ network:
 
 ```yaml
 process:
-  disk:
-    <include|exclude>:
-      names: [ <process name>, ... ]
-      match_type: <strict|regexp>
+  <include|exclude>:
+    names: [ <process name>, ... ]
+    match_type: <strict|regexp>
+  mute_process_name_error: <true|false>
 ```
 
 ## Advanced Configuration

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	// MuteProcessNameError is a flag that will mute the error encountered when trying to read a process the
 	// collector does not have permission for.
 	// See https://github.com/open-telemetry/opentelemetry-collector/issues/3004 for more information.
-	MuteProcessNameError bool `mapstructure:"mute_process_scrape_errors,omitempty"`
+	MuteProcessNameError bool `mapstructure:"mute_process_name_error,omitempty"`
 }
 
 type MatchConfig struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -28,6 +28,11 @@ type Config struct {
 	// If neither `include` or `exclude` are set, process metrics will be generated for all processes.
 	Include MatchConfig `mapstructure:"include"`
 	Exclude MatchConfig `mapstructure:"exclude"`
+
+	// MuteProcessNameError is a flag that will mute the error encountered when trying to read a process the
+	// collector does not have permission for.
+	// See https://github.com/open-telemetry/opentelemetry-collector/issues/3004 for more information.
+	MuteProcessNameError bool `mapstructure:"mute_process_scrape_errors,omitempty"`
 }
 
 type MatchConfig struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -144,7 +144,9 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 
 		executable, err := getProcessExecutable(handle)
 		if err != nil {
-			errs.AddPartial(1, fmt.Errorf("error reading process name for pid %v: %w", pid, err))
+			if !s.config.MuteProcessNameError {
+				errs.AddPartial(1, fmt.Errorf("error reading process name for pid %v: %w", pid, err))
+			}
 			continue
 		}
 


### PR DESCRIPTION
**Description:** Added field to the hostmetrics process scraper that will mute any "error
reading process name" errors. This was the suggested solution in issue https://github.com/open-telemetry/opentelemetry-collector/issues/3004

**Testing:** Unit tests were added that tested behaviour when the flag was enabled, disabled, or not specified (zero value).

**Documentation:** Added documentation for the new flag in process scraper configuration, and fixed what appeared to be a typo.
