### PR TITLE
Bump golangci-lint timeout to avoid build failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
   concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
+  timeout: 20m
 
   # exit code when at least one issue was found, default is 1
   issues-exit-code: 1


### PR DESCRIPTION
Currently particular runs of golangci-lint can take up to 15 minutes causing CI build failures. This change bumps the limit to avoid the build failures. The root cause of the issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7183 is still to be resolved.