### PR TITLE
Receiver Creator: log added and removed endpoint env structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `tanzuobservability exporter`: Support summary metrics (#7121)
 - Use Jaeger gRPC instead of Thrift in the docker-compose example (#7243)
 - `tanzuobservabilityexporter`: Support exponential histograms (#7127)
+- `receiver_creator`: Log added and removed endpoint env structs (#7248)
 
 ## 🛑 Breaking changes 🛑
 


### PR DESCRIPTION
**Description:**
Adding a feature - These changes add debug log statements for receiver creator handled endpoints. It can be difficult to debug configuration issues without seeing all the available endpoint envs from* such logs, and the core endpoint listing observer helpers don't log anything but errors.