### PR TITLE
resource detection: document ec2 proxy info

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -86,6 +86,8 @@ ec2:
         - ^label.*$
 ```
 
+If you are using a proxy server on your EC2 instance, it's important that you exempt requests for instance metadata as [described in the AWS cli user guide](https://github.com/awsdocs/aws-cli-user-guide/blob/a2393582590b64bd2a1d9978af15b350e1f9eb8e/doc_source/cli-configure-proxy.md#using-a-proxy-on-amazon-ec2-instances). Failing to do so can result in proxied or missing instance data.
+
 * Amazon ECS: Queries the [Task Metadata Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) (TMDE) to record information about the current ECS Task. Only TMDE V4 and V3 are supported.
 
     * cloud.provider ("aws")


### PR DESCRIPTION
**Description:**
Proxy users on ec2 instances can experience unexpected resource attributes when using the resource detection processor. These changes add a link to suggested `NO_PROXY` settings.

**Documentation:**
Updated processor readme.