### PR TITLE
[extension/observers] Set image and tag fields for container observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `prometheusreceiver`: Use the OTLP data conversion path by default. (#TBD)
   - Use `--feature-gates=-receiver.prometheus.OTLPDirect` to re-enable the 
     OpenCensus conversion path.
+- `extension/observers`: Correctly set image and tag on container endpoints (#7279)
 
 ## 🛑 Breaking changes 🛑
 

--- a/extension/observer/dockerobserver/extension.go
+++ b/extension/observer/dockerobserver/extension.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+	dcommon "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/docker"
 	docker "github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker"
 )
 
@@ -308,9 +309,15 @@ func (d *dockerObserver) endpointForPort(portObj nat.Port, c *dtypes.ContainerJS
 		id = observer.EndpointID(fmt.Sprintf("%s:%d", c.ID, port))
 	}
 
+	imageRef, err := dcommon.ParseImageName(c.Config.Image)
+	if err != nil {
+		d.logger.Error("could not parse container image name", zap.Error(err))
+	}
+
 	details := &observer.Container{
 		Name:        strings.TrimPrefix(c.Name, "/"),
-		Image:       c.Config.Image,
+		Image:       imageRef.Repository,
+		Tag:         imageRef.Tag,
 		Command:     strings.Join(c.Config.Cmd, " "),
 		ContainerID: c.ID,
 		Transport:   portProtoToTransport(proto),

--- a/extension/observer/dockerobserver/extension_test.go
+++ b/extension/observer/dockerobserver/extension_test.go
@@ -87,6 +87,7 @@ func TestCollectEndpointsDefaultConfig(t *testing.T) {
 			Details: &observer.Container{
 				Name:        "agitated_wu",
 				Image:       "nginx",
+				Tag:         "1.17",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
 				Transport:   observer.ProtocolTCP,
@@ -134,6 +135,7 @@ func TestCollectEndpointsAllConfigSettings(t *testing.T) {
 			Details: &observer.Container{
 				Name:        "agitated_wu",
 				Image:       "nginx",
+				Tag:         "1.17",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
 				Transport:   observer.ProtocolTCP,
@@ -181,6 +183,7 @@ func TestCollectEndpointsUseHostnameIfPresent(t *testing.T) {
 			Details: &observer.Container{
 				Name:        "agitated_wu",
 				Image:       "nginx",
+				Tag:         "1.17",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
 				Transport:   observer.ProtocolTCP,
@@ -228,6 +231,7 @@ func TestCollectEndpointsUseHostBindings(t *testing.T) {
 			Details: &observer.Container{
 				Name:        "agitated_wu",
 				Image:       "nginx",
+				Tag:         "1.17",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
 				Transport:   observer.ProtocolTCP,
@@ -275,6 +279,7 @@ func TestCollectEndpointsIgnoreNonHostBindings(t *testing.T) {
 			Details: &observer.Container{
 				Name:        "agitated_wu",
 				Image:       "nginx",
+				Tag:         "1.17",
 				Command:     "nginx -g daemon off;",
 				ContainerID: "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c",
 				Transport:   observer.ProtocolTCP,

--- a/extension/observer/dockerobserver/testdata/container.json
+++ b/extension/observer/dockerobserver/testdata/container.json
@@ -178,7 +178,7 @@
             "-g",
             "daemon off;"
         ],
-        "Image": "nginx",
+        "Image": "nginx:1.17",
         "Volumes": null,
         "WorkingDir": "",
         "Entrypoint": [

--- a/extension/observer/ecstaskobserver/extension_test.go
+++ b/extension/observer/ecstaskobserver/extension_test.go
@@ -40,7 +40,8 @@ func TestEndpointsFromTaskMetadata(t *testing.T) {
 			Details: &observer.Container{
 				ContainerID: "5302b3fac16c62951717f444030cb1b8f233f40c03fe5507fc127ca1a70597da",
 				Host:        "172.17.0.3",
-				Image:       "nginx:latest",
+				Image:       "nginx",
+				Tag:         "latest",
 				Labels: map[string]string{
 					"com.amazonaws.ecs.cluster":                 "test200",
 					"com.amazonaws.ecs.container-name":          "nginx100",
@@ -59,7 +60,8 @@ func TestEndpointsFromTaskMetadata(t *testing.T) {
 			Details: &observer.Container{
 				ContainerID: "4a984770705c4f4f95e1267af3623ab0923c602b7cd4ed7d77b7f8356537337f",
 				Host:        "172.17.0.4",
-				Image:       "nginx:latest",
+				Image:       "nginx",
+				Tag:         "latest",
 				Labels: map[string]string{
 					"com.amazonaws.ecs.cluster":                 "test200",
 					"com.amazonaws.ecs.container-name":          "nginx300",

--- a/extension/observer/ecstaskobserver/go.mod
+++ b/extension/observer/ecstaskobserver/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.42.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.42.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.8.2 // indirect

--- a/extension/observer/ecstaskobserver/go.sum
+++ b/extension/observer/ecstaskobserver/go.sum
@@ -377,6 +377,8 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.42.0 h1:5mkzK/sLBrYn/lqPDeOjugHu+qDXka+fbJjX2/2KZvE=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.42.0/go.mod h1:eM7BZiOmi9HL6UCo8AYJ1EsLA4rOMKWpNI7fZnPZ1Ss=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=

--- a/extension/observer/endpoints.go
+++ b/extension/observer/endpoints.go
@@ -171,6 +171,8 @@ type Container struct {
 	Name string
 	// Image is the name of the container image
 	Image string
+	// Tag is the container image tag, e.g. '0.1'
+	Tag string
 	// Port is the exposed port of container
 	Port uint16
 	// AlternatePort is the exposed port accessed through some kind of redirection,
@@ -192,6 +194,7 @@ func (c *Container) Env() EndpointEnv {
 	return map[string]interface{}{
 		"name":           c.Name,
 		"image":          c.Image,
+		"tag":            c.Tag,
 		"port":           c.Port,
 		"alternate_port": c.AlternatePort,
 		"command":        c.Command,

--- a/extension/observer/endpoints_test.go
+++ b/extension/observer/endpoints_test.go
@@ -132,6 +132,7 @@ func TestEndpointEnv(t *testing.T) {
 				Details: &Container{
 					Name:          "otel-collector",
 					Image:         "otel-collector-image",
+					Tag:           "1.0.0",
 					Port:          2379,
 					AlternatePort: 2380,
 					Command:       "./cmd --config config.yaml",
@@ -147,6 +148,7 @@ func TestEndpointEnv(t *testing.T) {
 				"type":           "container",
 				"name":           "otel-collector",
 				"image":          "otel-collector-image",
+				"tag":            "1.0.0",
 				"port":           uint16(2379),
 				"alternate_port": uint16(2380),
 				"command":        "./cmd --config config.yaml",


### PR DESCRIPTION
**Description:**
Conform to the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/resource/container.yaml) for container resources. Adds the `Tag` field to container endpoints and correctly sets the `Image` field.