### PR TITLE
[receiver/zookeeper] Updated metrics to be more in line with OTel specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - `tanzuobservabilityexporter`: Remove status.code
 - `tanzuobservabilityexporter`: Use semantic conventions for status.message (#7126) 
 - `k8sattributesprocessor`: Move `kube` and `observability` packages to `internal` folder (#7159)
-- `zookeeperreceiver`: Refactored metrics to have correct units, types, and combined some metrics via attributes. ()
+- `zookeeperreceiver`: Refactored metrics to have correct units, types, and combined some metrics via attributes. (#7280)
 
 ## 🚀 New components 🚀
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `tanzuobservabilityexporter`: Remove status.code
 - `tanzuobservabilityexporter`: Use semantic conventions for status.message (#7126) 
 - `k8sattributesprocessor`: Move `kube` and `observability` packages to `internal` folder (#7159)
+- `zookeeperreceiver`: Refactored metrics to have correct units, types, and combined some metrics via attributes. ()
 
 ## 🚀 New components 🚀
 

--- a/receiver/zookeeperreceiver/documentation.md
+++ b/receiver/zookeeperreceiver/documentation.md
@@ -18,7 +18,7 @@ These are the metrics available for this scraper.
 | zookeeper.latency.avg | Average time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
 | zookeeper.latency.max | Maximum time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
 | zookeeper.latency.min | Minimum time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
-| zookeeper.packet.count | The number of ZooKeeper packets received or sent by a server. | {packets} | Sum(Int) | <ul> <li>packet.direction</li> </ul> |
+| zookeeper.packet.count | The number of ZooKeeper packets received or sent by a server. | {packets} | Sum(Int) | <ul> <li>direction</li> </ul> |
 | zookeeper.request.active | Number of currently executing requests. | {requests} | Sum(Int) | <ul> </ul> |
 | zookeeper.sync.pending | The number of pending syncs from the followers. Only exposed by the leader. | {syncs} | Sum(Int) | <ul> </ul> |
 | zookeeper.watch.count | Number of watches placed on Z-Nodes on a ZooKeeper server. | {watches} | Sum(Int) | <ul> </ul> |
@@ -28,7 +28,7 @@ These are the metrics available for this scraper.
 
 | Name | Description |
 | ---- | ----------- |
-| packet.direction | State of a packet based on io direction. |
+| direction | State of a packet based on io direction. |
 | server.state | State of the Zookeeper server (leader, standalone or follower). |
 | state | State of followers |
 | zk.version | Zookeeper version of the instance. |

--- a/receiver/zookeeperreceiver/documentation.md
+++ b/receiver/zookeeperreceiver/documentation.md
@@ -8,27 +8,27 @@ These are the metrics available for this scraper.
 
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
-| zookeeper.approximate_date_size | Size of data in bytes that a ZooKeeper server has in its data tree. | By | Gauge(Int) | <ul> </ul> |
-| zookeeper.connections_alive | Number of active clients connected to a ZooKeeper server. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.ephemeral_nodes | Number of ephemeral nodes that a ZooKeeper server has in its data tree. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.followers | The number of followers in sync with the leader. Only exposed by the leader. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.fsync_threshold_exceeds | Number of times fsync duration has exceeded warning threshold. | 1 | Sum(Int) | <ul> </ul> |
+| zookeeper.connection.active | Number of active clients connected to a ZooKeeper server. | {connections} | Sum(Int) | <ul> </ul> |
+| zookeeper.data_tree.ephemeral_node.count | Number of ephemeral nodes that a ZooKeeper server has in its data tree. | {nodes} | Sum(Int) | <ul> </ul> |
+| zookeeper.data_tree.size | Size of data in bytes that a ZooKeeper server has in its data tree. | By | Sum(Int) | <ul> </ul> |
+| zookeeper.file_descriptor.limit | Maximum number of file descriptors that a ZooKeeper server can open. | {file_descriptors} | Gauge(Int) | <ul> </ul> |
+| zookeeper.file_descriptor.open | Number of file descriptors that a ZooKeeper server has open. | {file_descriptors} | Sum(Int) | <ul> </ul> |
+| zookeeper.follower.count | The number of followers. Only exposed by the leader. | {followers} | Sum(Int) | <ul> <li>follower.state</li> </ul> |
+| zookeeper.fsync.exceeded_threshold.count | Number of times fsync duration has exceeded warning threshold. | {events} | Sum(Int) | <ul> </ul> |
 | zookeeper.latency.avg | Average time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
 | zookeeper.latency.max | Maximum time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
-| zookeeper.latency.min | Minimum time in milliseconds for requests to be processed. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.max_file_descriptors | Maximum number of file descriptors that a ZooKeeper server can open. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.open_file_descriptors | Number of file descriptors that a ZooKeeper server has open. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.outstanding_requests | Number of currently executing requests. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.packets.received | Number of ZooKeeper packets received by a server. | 1 | Sum(Int) | <ul> </ul> |
-| zookeeper.packets.sent | Number of ZooKeeper packets sent by a server. | 1 | Sum(Int) | <ul> </ul> |
-| zookeeper.pending_syncs | The number of pending syncs from the followers. Only exposed by the leader. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.synced_followers | The number of followers in sync with the leader. Only exposed by the leader. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.watches | Number of watches placed on Z-Nodes on a ZooKeeper server. | 1 | Gauge(Int) | <ul> </ul> |
-| zookeeper.znodes | Number of z-nodes that a ZooKeeper server has in its data tree. | 1 | Gauge(Int) | <ul> </ul> |
+| zookeeper.latency.min | Minimum time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
+| zookeeper.packet.count | The number of ZooKeeper packets received or sent by a server. | {packets} | Sum(Int) | <ul> <li>packet.state</li> </ul> |
+| zookeeper.request.active | Number of currently executing requests. | {requests} | Sum(Int) | <ul> </ul> |
+| zookeeper.sync.pending | The number of pending syncs from the followers. Only exposed by the leader. | {syncs} | Sum(Int) | <ul> </ul> |
+| zookeeper.watch.count | Number of watches placed on Z-Nodes on a ZooKeeper server. | {watches} | Sum(Int) | <ul> </ul> |
+| zookeeper.znode.count | Number of z-nodes that a ZooKeeper server has in its data tree. | {znodes} | Sum(Int) | <ul> </ul> |
 
 ## Attributes
 
 | Name | Description |
 | ---- | ----------- |
+| follower.state | State of followers |
+| packet.state | State of a packet based on io direction. |
 | server.state | State of the Zookeeper server (leader, standalone or follower). |
 | zk.version | Zookeeper version of the instance. |

--- a/receiver/zookeeperreceiver/documentation.md
+++ b/receiver/zookeeperreceiver/documentation.md
@@ -13,12 +13,12 @@ These are the metrics available for this scraper.
 | zookeeper.data_tree.size | Size of data in bytes that a ZooKeeper server has in its data tree. | By | Sum(Int) | <ul> </ul> |
 | zookeeper.file_descriptor.limit | Maximum number of file descriptors that a ZooKeeper server can open. | {file_descriptors} | Gauge(Int) | <ul> </ul> |
 | zookeeper.file_descriptor.open | Number of file descriptors that a ZooKeeper server has open. | {file_descriptors} | Sum(Int) | <ul> </ul> |
-| zookeeper.follower.count | The number of followers. Only exposed by the leader. | {followers} | Sum(Int) | <ul> <li>follower.state</li> </ul> |
+| zookeeper.follower.count | The number of followers. Only exposed by the leader. | {followers} | Sum(Int) | <ul> <li>state</li> </ul> |
 | zookeeper.fsync.exceeded_threshold.count | Number of times fsync duration has exceeded warning threshold. | {events} | Sum(Int) | <ul> </ul> |
 | zookeeper.latency.avg | Average time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
 | zookeeper.latency.max | Maximum time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
 | zookeeper.latency.min | Minimum time in milliseconds for requests to be processed. | ms | Gauge(Int) | <ul> </ul> |
-| zookeeper.packet.count | The number of ZooKeeper packets received or sent by a server. | {packets} | Sum(Int) | <ul> <li>packet.state</li> </ul> |
+| zookeeper.packet.count | The number of ZooKeeper packets received or sent by a server. | {packets} | Sum(Int) | <ul> <li>packet.direction</li> </ul> |
 | zookeeper.request.active | Number of currently executing requests. | {requests} | Sum(Int) | <ul> </ul> |
 | zookeeper.sync.pending | The number of pending syncs from the followers. Only exposed by the leader. | {syncs} | Sum(Int) | <ul> </ul> |
 | zookeeper.watch.count | Number of watches placed on Z-Nodes on a ZooKeeper server. | {watches} | Sum(Int) | <ul> </ul> |
@@ -28,7 +28,7 @@ These are the metrics available for this scraper.
 
 | Name | Description |
 | ---- | ----------- |
-| follower.state | State of followers |
-| packet.state | State of a packet based on io direction. |
+| packet.direction | State of a packet based on io direction. |
 | server.state | State of the Zookeeper server (leader, standalone or follower). |
+| state | State of followers |
 | zk.version | Zookeeper version of the instance. |

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
@@ -352,7 +352,7 @@ func (m *metricZookeeperFollowerCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricZookeeperFollowerCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, followerStateAttributeValue string) {
+func (m *metricZookeeperFollowerCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, stateAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -360,7 +360,7 @@ func (m *metricZookeeperFollowerCount) recordDataPoint(start pdata.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.FollowerState, pdata.NewAttributeValueString(followerStateAttributeValue))
+	dp.Attributes().Insert(A.State, pdata.NewAttributeValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -603,7 +603,7 @@ func (m *metricZookeeperPacketCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricZookeeperPacketCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, packetStateAttributeValue string) {
+func (m *metricZookeeperPacketCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, packetDirectionAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -611,7 +611,7 @@ func (m *metricZookeeperPacketCount) recordDataPoint(start pdata.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.PacketState, pdata.NewAttributeValueString(packetStateAttributeValue))
+	dp.Attributes().Insert(A.PacketDirection, pdata.NewAttributeValueString(packetDirectionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -946,8 +946,8 @@ func (mb *MetricsBuilder) RecordZookeeperFileDescriptorOpenDataPoint(ts pdata.Ti
 }
 
 // RecordZookeeperFollowerCountDataPoint adds a data point to zookeeper.follower.count metric.
-func (mb *MetricsBuilder) RecordZookeeperFollowerCountDataPoint(ts pdata.Timestamp, val int64, followerStateAttributeValue string) {
-	mb.metricZookeeperFollowerCount.recordDataPoint(mb.startTime, ts, val, followerStateAttributeValue)
+func (mb *MetricsBuilder) RecordZookeeperFollowerCountDataPoint(ts pdata.Timestamp, val int64, stateAttributeValue string) {
+	mb.metricZookeeperFollowerCount.recordDataPoint(mb.startTime, ts, val, stateAttributeValue)
 }
 
 // RecordZookeeperFsyncExceededThresholdCountDataPoint adds a data point to zookeeper.fsync.exceeded_threshold.count metric.
@@ -971,8 +971,8 @@ func (mb *MetricsBuilder) RecordZookeeperLatencyMinDataPoint(ts pdata.Timestamp,
 }
 
 // RecordZookeeperPacketCountDataPoint adds a data point to zookeeper.packet.count metric.
-func (mb *MetricsBuilder) RecordZookeeperPacketCountDataPoint(ts pdata.Timestamp, val int64, packetStateAttributeValue string) {
-	mb.metricZookeeperPacketCount.recordDataPoint(mb.startTime, ts, val, packetStateAttributeValue)
+func (mb *MetricsBuilder) RecordZookeeperPacketCountDataPoint(ts pdata.Timestamp, val int64, packetDirectionAttributeValue string) {
+	mb.metricZookeeperPacketCount.recordDataPoint(mb.startTime, ts, val, packetDirectionAttributeValue)
 }
 
 // RecordZookeeperRequestActiveDataPoint adds a data point to zookeeper.request.active metric.
@@ -1006,38 +1006,38 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 
 // Attributes contains the possible metric attributes that can be used.
 var Attributes = struct {
-	// FollowerState (State of followers)
-	FollowerState string
-	// PacketState (State of a packet based on io direction.)
-	PacketState string
+	// PacketDirection (State of a packet based on io direction.)
+	PacketDirection string
 	// ServerState (State of the Zookeeper server (leader, standalone or follower).)
 	ServerState string
+	// State (State of followers)
+	State string
 	// ZkVersion (Zookeeper version of the instance.)
 	ZkVersion string
 }{
-	"follower.state",
-	"packet.state",
+	"packet.direction",
 	"server.state",
+	"state",
 	"zk.version",
 }
 
 // A is an alias for Attributes.
 var A = Attributes
 
-// AttributeFollowerState are the possible values that the attribute "follower.state" can have.
-var AttributeFollowerState = struct {
-	Synced    string
-	NotSynced string
-}{
-	"synced",
-	"not_synced",
-}
-
-// AttributePacketState are the possible values that the attribute "packet.state" can have.
-var AttributePacketState = struct {
+// AttributePacketDirection are the possible values that the attribute "packet.direction" can have.
+var AttributePacketDirection = struct {
 	Received string
 	Sent     string
 }{
 	"received",
 	"sent",
+}
+
+// AttributeState are the possible values that the attribute "state" can have.
+var AttributeState = struct {
+	Synced   string
+	Unsynced string
+}{
+	"synced",
+	"unsynced",
 }

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
@@ -603,7 +603,7 @@ func (m *metricZookeeperPacketCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricZookeeperPacketCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, packetDirectionAttributeValue string) {
+func (m *metricZookeeperPacketCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, directionAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -611,7 +611,7 @@ func (m *metricZookeeperPacketCount) recordDataPoint(start pdata.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.PacketDirection, pdata.NewAttributeValueString(packetDirectionAttributeValue))
+	dp.Attributes().Insert(A.Direction, pdata.NewAttributeValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -971,8 +971,8 @@ func (mb *MetricsBuilder) RecordZookeeperLatencyMinDataPoint(ts pdata.Timestamp,
 }
 
 // RecordZookeeperPacketCountDataPoint adds a data point to zookeeper.packet.count metric.
-func (mb *MetricsBuilder) RecordZookeeperPacketCountDataPoint(ts pdata.Timestamp, val int64, packetDirectionAttributeValue string) {
-	mb.metricZookeeperPacketCount.recordDataPoint(mb.startTime, ts, val, packetDirectionAttributeValue)
+func (mb *MetricsBuilder) RecordZookeeperPacketCountDataPoint(ts pdata.Timestamp, val int64, directionAttributeValue string) {
+	mb.metricZookeeperPacketCount.recordDataPoint(mb.startTime, ts, val, directionAttributeValue)
 }
 
 // RecordZookeeperRequestActiveDataPoint adds a data point to zookeeper.request.active metric.
@@ -1006,8 +1006,8 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 
 // Attributes contains the possible metric attributes that can be used.
 var Attributes = struct {
-	// PacketDirection (State of a packet based on io direction.)
-	PacketDirection string
+	// Direction (State of a packet based on io direction.)
+	Direction string
 	// ServerState (State of the Zookeeper server (leader, standalone or follower).)
 	ServerState string
 	// State (State of followers)
@@ -1015,7 +1015,7 @@ var Attributes = struct {
 	// ZkVersion (Zookeeper version of the instance.)
 	ZkVersion string
 }{
-	"packet.direction",
+	"direction",
 	"server.state",
 	"state",
 	"zk.version",
@@ -1024,8 +1024,8 @@ var Attributes = struct {
 // A is an alias for Attributes.
 var A = Attributes
 
-// AttributePacketDirection are the possible values that the attribute "packet.direction" can have.
-var AttributePacketDirection = struct {
+// AttributeDirection are the possible values that the attribute "direction" can have.
+var AttributeDirection = struct {
 	Received string
 	Sent     string
 }{

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
@@ -15,40 +15,44 @@ type MetricSettings struct {
 
 // MetricsSettings provides settings for zookeeperreceiver metrics.
 type MetricsSettings struct {
-	ZookeeperApproximateDateSize   MetricSettings `mapstructure:"zookeeper.approximate_date_size"`
-	ZookeeperConnectionsAlive      MetricSettings `mapstructure:"zookeeper.connections_alive"`
-	ZookeeperEphemeralNodes        MetricSettings `mapstructure:"zookeeper.ephemeral_nodes"`
-	ZookeeperFollowers             MetricSettings `mapstructure:"zookeeper.followers"`
-	ZookeeperFsyncThresholdExceeds MetricSettings `mapstructure:"zookeeper.fsync_threshold_exceeds"`
-	ZookeeperLatencyAvg            MetricSettings `mapstructure:"zookeeper.latency.avg"`
-	ZookeeperLatencyMax            MetricSettings `mapstructure:"zookeeper.latency.max"`
-	ZookeeperLatencyMin            MetricSettings `mapstructure:"zookeeper.latency.min"`
-	ZookeeperMaxFileDescriptors    MetricSettings `mapstructure:"zookeeper.max_file_descriptors"`
-	ZookeeperOpenFileDescriptors   MetricSettings `mapstructure:"zookeeper.open_file_descriptors"`
-	ZookeeperOutstandingRequests   MetricSettings `mapstructure:"zookeeper.outstanding_requests"`
-	ZookeeperPacketsReceived       MetricSettings `mapstructure:"zookeeper.packets.received"`
-	ZookeeperPacketsSent           MetricSettings `mapstructure:"zookeeper.packets.sent"`
-	ZookeeperPendingSyncs          MetricSettings `mapstructure:"zookeeper.pending_syncs"`
-	ZookeeperSyncedFollowers       MetricSettings `mapstructure:"zookeeper.synced_followers"`
-	ZookeeperWatches               MetricSettings `mapstructure:"zookeeper.watches"`
-	ZookeeperZnodes                MetricSettings `mapstructure:"zookeeper.znodes"`
+	ZookeeperConnectionActive            MetricSettings `mapstructure:"zookeeper.connection.active"`
+	ZookeeperDataTreeEphemeralNodeCount  MetricSettings `mapstructure:"zookeeper.data_tree.ephemeral_node.count"`
+	ZookeeperDataTreeSize                MetricSettings `mapstructure:"zookeeper.data_tree.size"`
+	ZookeeperFileDescriptorLimit         MetricSettings `mapstructure:"zookeeper.file_descriptor.limit"`
+	ZookeeperFileDescriptorOpen          MetricSettings `mapstructure:"zookeeper.file_descriptor.open"`
+	ZookeeperFollowerCount               MetricSettings `mapstructure:"zookeeper.follower.count"`
+	ZookeeperFsyncExceededThresholdCount MetricSettings `mapstructure:"zookeeper.fsync.exceeded_threshold.count"`
+	ZookeeperLatencyAvg                  MetricSettings `mapstructure:"zookeeper.latency.avg"`
+	ZookeeperLatencyMax                  MetricSettings `mapstructure:"zookeeper.latency.max"`
+	ZookeeperLatencyMin                  MetricSettings `mapstructure:"zookeeper.latency.min"`
+	ZookeeperPacketCount                 MetricSettings `mapstructure:"zookeeper.packet.count"`
+	ZookeeperRequestActive               MetricSettings `mapstructure:"zookeeper.request.active"`
+	ZookeeperSyncPending                 MetricSettings `mapstructure:"zookeeper.sync.pending"`
+	ZookeeperWatchCount                  MetricSettings `mapstructure:"zookeeper.watch.count"`
+	ZookeeperZnodeCount                  MetricSettings `mapstructure:"zookeeper.znode.count"`
 }
 
 func DefaultMetricsSettings() MetricsSettings {
 	return MetricsSettings{
-		ZookeeperApproximateDateSize: MetricSettings{
+		ZookeeperConnectionActive: MetricSettings{
 			Enabled: true,
 		},
-		ZookeeperConnectionsAlive: MetricSettings{
+		ZookeeperDataTreeEphemeralNodeCount: MetricSettings{
 			Enabled: true,
 		},
-		ZookeeperEphemeralNodes: MetricSettings{
+		ZookeeperDataTreeSize: MetricSettings{
 			Enabled: true,
 		},
-		ZookeeperFollowers: MetricSettings{
+		ZookeeperFileDescriptorLimit: MetricSettings{
 			Enabled: true,
 		},
-		ZookeeperFsyncThresholdExceeds: MetricSettings{
+		ZookeeperFileDescriptorOpen: MetricSettings{
+			Enabled: true,
+		},
+		ZookeeperFollowerCount: MetricSettings{
+			Enabled: true,
+		},
+		ZookeeperFsyncExceededThresholdCount: MetricSettings{
 			Enabled: true,
 		},
 		ZookeeperLatencyAvg: MetricSettings{
@@ -60,249 +64,41 @@ func DefaultMetricsSettings() MetricsSettings {
 		ZookeeperLatencyMin: MetricSettings{
 			Enabled: true,
 		},
-		ZookeeperMaxFileDescriptors: MetricSettings{
+		ZookeeperPacketCount: MetricSettings{
 			Enabled: true,
 		},
-		ZookeeperOpenFileDescriptors: MetricSettings{
+		ZookeeperRequestActive: MetricSettings{
 			Enabled: true,
 		},
-		ZookeeperOutstandingRequests: MetricSettings{
+		ZookeeperSyncPending: MetricSettings{
 			Enabled: true,
 		},
-		ZookeeperPacketsReceived: MetricSettings{
+		ZookeeperWatchCount: MetricSettings{
 			Enabled: true,
 		},
-		ZookeeperPacketsSent: MetricSettings{
-			Enabled: true,
-		},
-		ZookeeperPendingSyncs: MetricSettings{
-			Enabled: true,
-		},
-		ZookeeperSyncedFollowers: MetricSettings{
-			Enabled: true,
-		},
-		ZookeeperWatches: MetricSettings{
-			Enabled: true,
-		},
-		ZookeeperZnodes: MetricSettings{
+		ZookeeperZnodeCount: MetricSettings{
 			Enabled: true,
 		},
 	}
 }
 
-type metricZookeeperApproximateDateSize struct {
+type metricZookeeperConnectionActive struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills zookeeper.approximate_date_size metric with initial data.
-func (m *metricZookeeperApproximateDateSize) init() {
-	m.data.SetName("zookeeper.approximate_date_size")
-	m.data.SetDescription("Size of data in bytes that a ZooKeeper server has in its data tree.")
-	m.data.SetUnit("By")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-func (m *metricZookeeperApproximateDateSize) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperApproximateDateSize) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperApproximateDateSize) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricZookeeperApproximateDateSize(settings MetricSettings) metricZookeeperApproximateDateSize {
-	m := metricZookeeperApproximateDateSize{settings: settings}
-	if settings.Enabled {
-		m.data = pdata.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricZookeeperConnectionsAlive struct {
-	data     pdata.Metric   // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills zookeeper.connections_alive metric with initial data.
-func (m *metricZookeeperConnectionsAlive) init() {
-	m.data.SetName("zookeeper.connections_alive")
+// init fills zookeeper.connection.active metric with initial data.
+func (m *metricZookeeperConnectionActive) init() {
+	m.data.SetName("zookeeper.connection.active")
 	m.data.SetDescription("Number of active clients connected to a ZooKeeper server.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-func (m *metricZookeeperConnectionsAlive) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperConnectionsAlive) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperConnectionsAlive) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricZookeeperConnectionsAlive(settings MetricSettings) metricZookeeperConnectionsAlive {
-	m := metricZookeeperConnectionsAlive{settings: settings}
-	if settings.Enabled {
-		m.data = pdata.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricZookeeperEphemeralNodes struct {
-	data     pdata.Metric   // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills zookeeper.ephemeral_nodes metric with initial data.
-func (m *metricZookeeperEphemeralNodes) init() {
-	m.data.SetName("zookeeper.ephemeral_nodes")
-	m.data.SetDescription("Number of ephemeral nodes that a ZooKeeper server has in its data tree.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-func (m *metricZookeeperEphemeralNodes) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperEphemeralNodes) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperEphemeralNodes) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricZookeeperEphemeralNodes(settings MetricSettings) metricZookeeperEphemeralNodes {
-	m := metricZookeeperEphemeralNodes{settings: settings}
-	if settings.Enabled {
-		m.data = pdata.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricZookeeperFollowers struct {
-	data     pdata.Metric   // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills zookeeper.followers metric with initial data.
-func (m *metricZookeeperFollowers) init() {
-	m.data.SetName("zookeeper.followers")
-	m.data.SetDescription("The number of followers in sync with the leader. Only exposed by the leader.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-func (m *metricZookeeperFollowers) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperFollowers) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperFollowers) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricZookeeperFollowers(settings MetricSettings) metricZookeeperFollowers {
-	m := metricZookeeperFollowers{settings: settings}
-	if settings.Enabled {
-		m.data = pdata.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricZookeeperFsyncThresholdExceeds struct {
-	data     pdata.Metric   // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills zookeeper.fsync_threshold_exceeds metric with initial data.
-func (m *metricZookeeperFsyncThresholdExceeds) init() {
-	m.data.SetName("zookeeper.fsync_threshold_exceeds")
-	m.data.SetDescription("Number of times fsync duration has exceeded warning threshold.")
-	m.data.SetUnit("1")
+	m.data.SetUnit("{connections}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricZookeeperFsyncThresholdExceeds) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricZookeeperConnectionActive) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -313,14 +109,14 @@ func (m *metricZookeeperFsyncThresholdExceeds) recordDataPoint(start pdata.Times
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperFsyncThresholdExceeds) updateCapacity() {
+func (m *metricZookeeperConnectionActive) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperFsyncThresholdExceeds) emit(metrics pdata.MetricSlice) {
+func (m *metricZookeeperConnectionActive) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -328,8 +124,314 @@ func (m *metricZookeeperFsyncThresholdExceeds) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricZookeeperFsyncThresholdExceeds(settings MetricSettings) metricZookeeperFsyncThresholdExceeds {
-	m := metricZookeeperFsyncThresholdExceeds{settings: settings}
+func newMetricZookeeperConnectionActive(settings MetricSettings) metricZookeeperConnectionActive {
+	m := metricZookeeperConnectionActive{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperDataTreeEphemeralNodeCount struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.data_tree.ephemeral_node.count metric with initial data.
+func (m *metricZookeeperDataTreeEphemeralNodeCount) init() {
+	m.data.SetName("zookeeper.data_tree.ephemeral_node.count")
+	m.data.SetDescription("Number of ephemeral nodes that a ZooKeeper server has in its data tree.")
+	m.data.SetUnit("{nodes}")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricZookeeperDataTreeEphemeralNodeCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperDataTreeEphemeralNodeCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperDataTreeEphemeralNodeCount) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperDataTreeEphemeralNodeCount(settings MetricSettings) metricZookeeperDataTreeEphemeralNodeCount {
+	m := metricZookeeperDataTreeEphemeralNodeCount{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperDataTreeSize struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.data_tree.size metric with initial data.
+func (m *metricZookeeperDataTreeSize) init() {
+	m.data.SetName("zookeeper.data_tree.size")
+	m.data.SetDescription("Size of data in bytes that a ZooKeeper server has in its data tree.")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricZookeeperDataTreeSize) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperDataTreeSize) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperDataTreeSize) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperDataTreeSize(settings MetricSettings) metricZookeeperDataTreeSize {
+	m := metricZookeeperDataTreeSize{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperFileDescriptorLimit struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.file_descriptor.limit metric with initial data.
+func (m *metricZookeeperFileDescriptorLimit) init() {
+	m.data.SetName("zookeeper.file_descriptor.limit")
+	m.data.SetDescription("Maximum number of file descriptors that a ZooKeeper server can open.")
+	m.data.SetUnit("{file_descriptors}")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+}
+
+func (m *metricZookeeperFileDescriptorLimit) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperFileDescriptorLimit) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperFileDescriptorLimit) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperFileDescriptorLimit(settings MetricSettings) metricZookeeperFileDescriptorLimit {
+	m := metricZookeeperFileDescriptorLimit{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperFileDescriptorOpen struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.file_descriptor.open metric with initial data.
+func (m *metricZookeeperFileDescriptorOpen) init() {
+	m.data.SetName("zookeeper.file_descriptor.open")
+	m.data.SetDescription("Number of file descriptors that a ZooKeeper server has open.")
+	m.data.SetUnit("{file_descriptors}")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricZookeeperFileDescriptorOpen) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperFileDescriptorOpen) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperFileDescriptorOpen) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperFileDescriptorOpen(settings MetricSettings) metricZookeeperFileDescriptorOpen {
+	m := metricZookeeperFileDescriptorOpen{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperFollowerCount struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.follower.count metric with initial data.
+func (m *metricZookeeperFollowerCount) init() {
+	m.data.SetName("zookeeper.follower.count")
+	m.data.SetDescription("The number of followers. Only exposed by the leader.")
+	m.data.SetUnit("{followers}")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricZookeeperFollowerCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, followerStateAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert(A.FollowerState, pdata.NewAttributeValueString(followerStateAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperFollowerCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperFollowerCount) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperFollowerCount(settings MetricSettings) metricZookeeperFollowerCount {
+	m := metricZookeeperFollowerCount{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricZookeeperFsyncExceededThresholdCount struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills zookeeper.fsync.exceeded_threshold.count metric with initial data.
+func (m *metricZookeeperFsyncExceededThresholdCount) init() {
+	m.data.SetName("zookeeper.fsync.exceeded_threshold.count")
+	m.data.SetDescription("Number of times fsync duration has exceeded warning threshold.")
+	m.data.SetUnit("{events}")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+}
+
+func (m *metricZookeeperFsyncExceededThresholdCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricZookeeperFsyncExceededThresholdCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricZookeeperFsyncExceededThresholdCount) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricZookeeperFsyncExceededThresholdCount(settings MetricSettings) metricZookeeperFsyncExceededThresholdCount {
+	m := metricZookeeperFsyncExceededThresholdCount{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -445,7 +547,7 @@ type metricZookeeperLatencyMin struct {
 func (m *metricZookeeperLatencyMin) init() {
 	m.data.SetName("zookeeper.latency.min")
 	m.data.SetDescription("Minimum time in milliseconds for requests to be processed.")
-	m.data.SetUnit("1")
+	m.data.SetUnit("ms")
 	m.data.SetDataType(pdata.MetricDataTypeGauge)
 }
 
@@ -484,48 +586,52 @@ func newMetricZookeeperLatencyMin(settings MetricSettings) metricZookeeperLatenc
 	return m
 }
 
-type metricZookeeperMaxFileDescriptors struct {
+type metricZookeeperPacketCount struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills zookeeper.max_file_descriptors metric with initial data.
-func (m *metricZookeeperMaxFileDescriptors) init() {
-	m.data.SetName("zookeeper.max_file_descriptors")
-	m.data.SetDescription("Maximum number of file descriptors that a ZooKeeper server can open.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
+// init fills zookeeper.packet.count metric with initial data.
+func (m *metricZookeeperPacketCount) init() {
+	m.data.SetName("zookeeper.packet.count")
+	m.data.SetDescription("The number of ZooKeeper packets received or sent by a server.")
+	m.data.SetUnit("{packets}")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricZookeeperMaxFileDescriptors) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricZookeeperPacketCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64, packetStateAttributeValue string) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
+	dp.Attributes().Insert(A.PacketState, pdata.NewAttributeValueString(packetStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperMaxFileDescriptors) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+func (m *metricZookeeperPacketCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperMaxFileDescriptors) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+func (m *metricZookeeperPacketCount) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperMaxFileDescriptors(settings MetricSettings) metricZookeeperMaxFileDescriptors {
-	m := metricZookeeperMaxFileDescriptors{settings: settings}
+func newMetricZookeeperPacketCount(settings MetricSettings) metricZookeeperPacketCount {
+	m := metricZookeeperPacketCount{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -533,121 +639,23 @@ func newMetricZookeeperMaxFileDescriptors(settings MetricSettings) metricZookeep
 	return m
 }
 
-type metricZookeeperOpenFileDescriptors struct {
+type metricZookeeperRequestActive struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills zookeeper.open_file_descriptors metric with initial data.
-func (m *metricZookeeperOpenFileDescriptors) init() {
-	m.data.SetName("zookeeper.open_file_descriptors")
-	m.data.SetDescription("Number of file descriptors that a ZooKeeper server has open.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-func (m *metricZookeeperOpenFileDescriptors) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperOpenFileDescriptors) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperOpenFileDescriptors) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricZookeeperOpenFileDescriptors(settings MetricSettings) metricZookeeperOpenFileDescriptors {
-	m := metricZookeeperOpenFileDescriptors{settings: settings}
-	if settings.Enabled {
-		m.data = pdata.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricZookeeperOutstandingRequests struct {
-	data     pdata.Metric   // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills zookeeper.outstanding_requests metric with initial data.
-func (m *metricZookeeperOutstandingRequests) init() {
-	m.data.SetName("zookeeper.outstanding_requests")
+// init fills zookeeper.request.active metric with initial data.
+func (m *metricZookeeperRequestActive) init() {
+	m.data.SetName("zookeeper.request.active")
 	m.data.SetDescription("Number of currently executing requests.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-func (m *metricZookeeperOutstandingRequests) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperOutstandingRequests) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperOutstandingRequests) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricZookeeperOutstandingRequests(settings MetricSettings) metricZookeeperOutstandingRequests {
-	m := metricZookeeperOutstandingRequests{settings: settings}
-	if settings.Enabled {
-		m.data = pdata.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricZookeeperPacketsReceived struct {
-	data     pdata.Metric   // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills zookeeper.packets.received metric with initial data.
-func (m *metricZookeeperPacketsReceived) init() {
-	m.data.SetName("zookeeper.packets.received")
-	m.data.SetDescription("Number of ZooKeeper packets received by a server.")
-	m.data.SetUnit("1")
+	m.data.SetUnit("{requests}")
 	m.data.SetDataType(pdata.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetIsMonotonic(false)
 	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricZookeeperPacketsReceived) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricZookeeperRequestActive) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -658,14 +666,14 @@ func (m *metricZookeeperPacketsReceived) recordDataPoint(start pdata.Timestamp, 
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperPacketsReceived) updateCapacity() {
+func (m *metricZookeeperRequestActive) updateCapacity() {
 	if m.data.Sum().DataPoints().Len() > m.capacity {
 		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperPacketsReceived) emit(metrics pdata.MetricSlice) {
+func (m *metricZookeeperRequestActive) emit(metrics pdata.MetricSlice) {
 	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
@@ -673,8 +681,8 @@ func (m *metricZookeeperPacketsReceived) emit(metrics pdata.MetricSlice) {
 	}
 }
 
-func newMetricZookeeperPacketsReceived(settings MetricSettings) metricZookeeperPacketsReceived {
-	m := metricZookeeperPacketsReceived{settings: settings}
+func newMetricZookeeperRequestActive(settings MetricSettings) metricZookeeperRequestActive {
+	m := metricZookeeperRequestActive{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -682,99 +690,50 @@ func newMetricZookeeperPacketsReceived(settings MetricSettings) metricZookeeperP
 	return m
 }
 
-type metricZookeeperPacketsSent struct {
+type metricZookeeperSyncPending struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills zookeeper.packets.sent metric with initial data.
-func (m *metricZookeeperPacketsSent) init() {
-	m.data.SetName("zookeeper.packets.sent")
-	m.data.SetDescription("Number of ZooKeeper packets sent by a server.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeSum)
-	m.data.Sum().SetIsMonotonic(true)
-	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
-}
-
-func (m *metricZookeeperPacketsSent) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Sum().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperPacketsSent) updateCapacity() {
-	if m.data.Sum().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Sum().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperPacketsSent) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricZookeeperPacketsSent(settings MetricSettings) metricZookeeperPacketsSent {
-	m := metricZookeeperPacketsSent{settings: settings}
-	if settings.Enabled {
-		m.data = pdata.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricZookeeperPendingSyncs struct {
-	data     pdata.Metric   // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills zookeeper.pending_syncs metric with initial data.
-func (m *metricZookeeperPendingSyncs) init() {
-	m.data.SetName("zookeeper.pending_syncs")
+// init fills zookeeper.sync.pending metric with initial data.
+func (m *metricZookeeperSyncPending) init() {
+	m.data.SetName("zookeeper.sync.pending")
 	m.data.SetDescription("The number of pending syncs from the followers. Only exposed by the leader.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
+	m.data.SetUnit("{syncs}")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricZookeeperPendingSyncs) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricZookeeperSyncPending) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperPendingSyncs) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+func (m *metricZookeeperSyncPending) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperPendingSyncs) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+func (m *metricZookeeperSyncPending) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperPendingSyncs(settings MetricSettings) metricZookeeperPendingSyncs {
-	m := metricZookeeperPendingSyncs{settings: settings}
+func newMetricZookeeperSyncPending(settings MetricSettings) metricZookeeperSyncPending {
+	m := metricZookeeperSyncPending{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -782,97 +741,50 @@ func newMetricZookeeperPendingSyncs(settings MetricSettings) metricZookeeperPend
 	return m
 }
 
-type metricZookeeperSyncedFollowers struct {
+type metricZookeeperWatchCount struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills zookeeper.synced_followers metric with initial data.
-func (m *metricZookeeperSyncedFollowers) init() {
-	m.data.SetName("zookeeper.synced_followers")
-	m.data.SetDescription("The number of followers in sync with the leader. Only exposed by the leader.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
-}
-
-func (m *metricZookeeperSyncedFollowers) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetIntVal(val)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperSyncedFollowers) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperSyncedFollowers) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricZookeeperSyncedFollowers(settings MetricSettings) metricZookeeperSyncedFollowers {
-	m := metricZookeeperSyncedFollowers{settings: settings}
-	if settings.Enabled {
-		m.data = pdata.NewMetric()
-		m.init()
-	}
-	return m
-}
-
-type metricZookeeperWatches struct {
-	data     pdata.Metric   // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills zookeeper.watches metric with initial data.
-func (m *metricZookeeperWatches) init() {
-	m.data.SetName("zookeeper.watches")
+// init fills zookeeper.watch.count metric with initial data.
+func (m *metricZookeeperWatchCount) init() {
+	m.data.SetName("zookeeper.watch.count")
 	m.data.SetDescription("Number of watches placed on Z-Nodes on a ZooKeeper server.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
+	m.data.SetUnit("{watches}")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricZookeeperWatches) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricZookeeperWatchCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperWatches) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+func (m *metricZookeeperWatchCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperWatches) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+func (m *metricZookeeperWatchCount) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperWatches(settings MetricSettings) metricZookeeperWatches {
-	m := metricZookeeperWatches{settings: settings}
+func newMetricZookeeperWatchCount(settings MetricSettings) metricZookeeperWatchCount {
+	m := metricZookeeperWatchCount{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -880,48 +792,50 @@ func newMetricZookeeperWatches(settings MetricSettings) metricZookeeperWatches {
 	return m
 }
 
-type metricZookeeperZnodes struct {
+type metricZookeeperZnodeCount struct {
 	data     pdata.Metric   // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
-// init fills zookeeper.znodes metric with initial data.
-func (m *metricZookeeperZnodes) init() {
-	m.data.SetName("zookeeper.znodes")
+// init fills zookeeper.znode.count metric with initial data.
+func (m *metricZookeeperZnodeCount) init() {
+	m.data.SetName("zookeeper.znode.count")
 	m.data.SetDescription("Number of z-nodes that a ZooKeeper server has in its data tree.")
-	m.data.SetUnit("1")
-	m.data.SetDataType(pdata.MetricDataTypeGauge)
+	m.data.SetUnit("{znodes}")
+	m.data.SetDataType(pdata.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricZookeeperZnodes) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
+func (m *metricZookeeperZnodeCount) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricZookeeperZnodes) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+func (m *metricZookeeperZnodeCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricZookeeperZnodes) emit(metrics pdata.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+func (m *metricZookeeperZnodeCount) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperZnodes(settings MetricSettings) metricZookeeperZnodes {
-	m := metricZookeeperZnodes{settings: settings}
+func newMetricZookeeperZnodeCount(settings MetricSettings) metricZookeeperZnodeCount {
+	m := metricZookeeperZnodeCount{settings: settings}
 	if settings.Enabled {
 		m.data = pdata.NewMetric()
 		m.init()
@@ -932,24 +846,22 @@ func newMetricZookeeperZnodes(settings MetricSettings) metricZookeeperZnodes {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                            pdata.Timestamp
-	metricZookeeperApproximateDateSize   metricZookeeperApproximateDateSize
-	metricZookeeperConnectionsAlive      metricZookeeperConnectionsAlive
-	metricZookeeperEphemeralNodes        metricZookeeperEphemeralNodes
-	metricZookeeperFollowers             metricZookeeperFollowers
-	metricZookeeperFsyncThresholdExceeds metricZookeeperFsyncThresholdExceeds
-	metricZookeeperLatencyAvg            metricZookeeperLatencyAvg
-	metricZookeeperLatencyMax            metricZookeeperLatencyMax
-	metricZookeeperLatencyMin            metricZookeeperLatencyMin
-	metricZookeeperMaxFileDescriptors    metricZookeeperMaxFileDescriptors
-	metricZookeeperOpenFileDescriptors   metricZookeeperOpenFileDescriptors
-	metricZookeeperOutstandingRequests   metricZookeeperOutstandingRequests
-	metricZookeeperPacketsReceived       metricZookeeperPacketsReceived
-	metricZookeeperPacketsSent           metricZookeeperPacketsSent
-	metricZookeeperPendingSyncs          metricZookeeperPendingSyncs
-	metricZookeeperSyncedFollowers       metricZookeeperSyncedFollowers
-	metricZookeeperWatches               metricZookeeperWatches
-	metricZookeeperZnodes                metricZookeeperZnodes
+	startTime                                  pdata.Timestamp
+	metricZookeeperConnectionActive            metricZookeeperConnectionActive
+	metricZookeeperDataTreeEphemeralNodeCount  metricZookeeperDataTreeEphemeralNodeCount
+	metricZookeeperDataTreeSize                metricZookeeperDataTreeSize
+	metricZookeeperFileDescriptorLimit         metricZookeeperFileDescriptorLimit
+	metricZookeeperFileDescriptorOpen          metricZookeeperFileDescriptorOpen
+	metricZookeeperFollowerCount               metricZookeeperFollowerCount
+	metricZookeeperFsyncExceededThresholdCount metricZookeeperFsyncExceededThresholdCount
+	metricZookeeperLatencyAvg                  metricZookeeperLatencyAvg
+	metricZookeeperLatencyMax                  metricZookeeperLatencyMax
+	metricZookeeperLatencyMin                  metricZookeeperLatencyMin
+	metricZookeeperPacketCount                 metricZookeeperPacketCount
+	metricZookeeperRequestActive               metricZookeeperRequestActive
+	metricZookeeperSyncPending                 metricZookeeperSyncPending
+	metricZookeeperWatchCount                  metricZookeeperWatchCount
+	metricZookeeperZnodeCount                  metricZookeeperZnodeCount
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -964,24 +876,22 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		startTime:                            pdata.NewTimestampFromTime(time.Now()),
-		metricZookeeperApproximateDateSize:   newMetricZookeeperApproximateDateSize(settings.ZookeeperApproximateDateSize),
-		metricZookeeperConnectionsAlive:      newMetricZookeeperConnectionsAlive(settings.ZookeeperConnectionsAlive),
-		metricZookeeperEphemeralNodes:        newMetricZookeeperEphemeralNodes(settings.ZookeeperEphemeralNodes),
-		metricZookeeperFollowers:             newMetricZookeeperFollowers(settings.ZookeeperFollowers),
-		metricZookeeperFsyncThresholdExceeds: newMetricZookeeperFsyncThresholdExceeds(settings.ZookeeperFsyncThresholdExceeds),
-		metricZookeeperLatencyAvg:            newMetricZookeeperLatencyAvg(settings.ZookeeperLatencyAvg),
-		metricZookeeperLatencyMax:            newMetricZookeeperLatencyMax(settings.ZookeeperLatencyMax),
-		metricZookeeperLatencyMin:            newMetricZookeeperLatencyMin(settings.ZookeeperLatencyMin),
-		metricZookeeperMaxFileDescriptors:    newMetricZookeeperMaxFileDescriptors(settings.ZookeeperMaxFileDescriptors),
-		metricZookeeperOpenFileDescriptors:   newMetricZookeeperOpenFileDescriptors(settings.ZookeeperOpenFileDescriptors),
-		metricZookeeperOutstandingRequests:   newMetricZookeeperOutstandingRequests(settings.ZookeeperOutstandingRequests),
-		metricZookeeperPacketsReceived:       newMetricZookeeperPacketsReceived(settings.ZookeeperPacketsReceived),
-		metricZookeeperPacketsSent:           newMetricZookeeperPacketsSent(settings.ZookeeperPacketsSent),
-		metricZookeeperPendingSyncs:          newMetricZookeeperPendingSyncs(settings.ZookeeperPendingSyncs),
-		metricZookeeperSyncedFollowers:       newMetricZookeeperSyncedFollowers(settings.ZookeeperSyncedFollowers),
-		metricZookeeperWatches:               newMetricZookeeperWatches(settings.ZookeeperWatches),
-		metricZookeeperZnodes:                newMetricZookeeperZnodes(settings.ZookeeperZnodes),
+		startTime:                                  pdata.NewTimestampFromTime(time.Now()),
+		metricZookeeperConnectionActive:            newMetricZookeeperConnectionActive(settings.ZookeeperConnectionActive),
+		metricZookeeperDataTreeEphemeralNodeCount:  newMetricZookeeperDataTreeEphemeralNodeCount(settings.ZookeeperDataTreeEphemeralNodeCount),
+		metricZookeeperDataTreeSize:                newMetricZookeeperDataTreeSize(settings.ZookeeperDataTreeSize),
+		metricZookeeperFileDescriptorLimit:         newMetricZookeeperFileDescriptorLimit(settings.ZookeeperFileDescriptorLimit),
+		metricZookeeperFileDescriptorOpen:          newMetricZookeeperFileDescriptorOpen(settings.ZookeeperFileDescriptorOpen),
+		metricZookeeperFollowerCount:               newMetricZookeeperFollowerCount(settings.ZookeeperFollowerCount),
+		metricZookeeperFsyncExceededThresholdCount: newMetricZookeeperFsyncExceededThresholdCount(settings.ZookeeperFsyncExceededThresholdCount),
+		metricZookeeperLatencyAvg:                  newMetricZookeeperLatencyAvg(settings.ZookeeperLatencyAvg),
+		metricZookeeperLatencyMax:                  newMetricZookeeperLatencyMax(settings.ZookeeperLatencyMax),
+		metricZookeeperLatencyMin:                  newMetricZookeeperLatencyMin(settings.ZookeeperLatencyMin),
+		metricZookeeperPacketCount:                 newMetricZookeeperPacketCount(settings.ZookeeperPacketCount),
+		metricZookeeperRequestActive:               newMetricZookeeperRequestActive(settings.ZookeeperRequestActive),
+		metricZookeeperSyncPending:                 newMetricZookeeperSyncPending(settings.ZookeeperSyncPending),
+		metricZookeeperWatchCount:                  newMetricZookeeperWatchCount(settings.ZookeeperWatchCount),
+		metricZookeeperZnodeCount:                  newMetricZookeeperZnodeCount(settings.ZookeeperZnodeCount),
 	}
 	for _, op := range options {
 		op(mb)
@@ -993,48 +903,56 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 // another set of data points. This function will be doing all transformations required to produce metric representation
 // defined in metadata and user settings, e.g. delta/cumulative translation.
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricZookeeperApproximateDateSize.emit(metrics)
-	mb.metricZookeeperConnectionsAlive.emit(metrics)
-	mb.metricZookeeperEphemeralNodes.emit(metrics)
-	mb.metricZookeeperFollowers.emit(metrics)
-	mb.metricZookeeperFsyncThresholdExceeds.emit(metrics)
+	mb.metricZookeeperConnectionActive.emit(metrics)
+	mb.metricZookeeperDataTreeEphemeralNodeCount.emit(metrics)
+	mb.metricZookeeperDataTreeSize.emit(metrics)
+	mb.metricZookeeperFileDescriptorLimit.emit(metrics)
+	mb.metricZookeeperFileDescriptorOpen.emit(metrics)
+	mb.metricZookeeperFollowerCount.emit(metrics)
+	mb.metricZookeeperFsyncExceededThresholdCount.emit(metrics)
 	mb.metricZookeeperLatencyAvg.emit(metrics)
 	mb.metricZookeeperLatencyMax.emit(metrics)
 	mb.metricZookeeperLatencyMin.emit(metrics)
-	mb.metricZookeeperMaxFileDescriptors.emit(metrics)
-	mb.metricZookeeperOpenFileDescriptors.emit(metrics)
-	mb.metricZookeeperOutstandingRequests.emit(metrics)
-	mb.metricZookeeperPacketsReceived.emit(metrics)
-	mb.metricZookeeperPacketsSent.emit(metrics)
-	mb.metricZookeeperPendingSyncs.emit(metrics)
-	mb.metricZookeeperSyncedFollowers.emit(metrics)
-	mb.metricZookeeperWatches.emit(metrics)
-	mb.metricZookeeperZnodes.emit(metrics)
+	mb.metricZookeeperPacketCount.emit(metrics)
+	mb.metricZookeeperRequestActive.emit(metrics)
+	mb.metricZookeeperSyncPending.emit(metrics)
+	mb.metricZookeeperWatchCount.emit(metrics)
+	mb.metricZookeeperZnodeCount.emit(metrics)
 }
 
-// RecordZookeeperApproximateDateSizeDataPoint adds a data point to zookeeper.approximate_date_size metric.
-func (mb *MetricsBuilder) RecordZookeeperApproximateDateSizeDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperApproximateDateSize.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperConnectionActiveDataPoint adds a data point to zookeeper.connection.active metric.
+func (mb *MetricsBuilder) RecordZookeeperConnectionActiveDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperConnectionActive.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordZookeeperConnectionsAliveDataPoint adds a data point to zookeeper.connections_alive metric.
-func (mb *MetricsBuilder) RecordZookeeperConnectionsAliveDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperConnectionsAlive.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperDataTreeEphemeralNodeCountDataPoint adds a data point to zookeeper.data_tree.ephemeral_node.count metric.
+func (mb *MetricsBuilder) RecordZookeeperDataTreeEphemeralNodeCountDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperDataTreeEphemeralNodeCount.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordZookeeperEphemeralNodesDataPoint adds a data point to zookeeper.ephemeral_nodes metric.
-func (mb *MetricsBuilder) RecordZookeeperEphemeralNodesDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperEphemeralNodes.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperDataTreeSizeDataPoint adds a data point to zookeeper.data_tree.size metric.
+func (mb *MetricsBuilder) RecordZookeeperDataTreeSizeDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperDataTreeSize.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordZookeeperFollowersDataPoint adds a data point to zookeeper.followers metric.
-func (mb *MetricsBuilder) RecordZookeeperFollowersDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperFollowers.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperFileDescriptorLimitDataPoint adds a data point to zookeeper.file_descriptor.limit metric.
+func (mb *MetricsBuilder) RecordZookeeperFileDescriptorLimitDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperFileDescriptorLimit.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordZookeeperFsyncThresholdExceedsDataPoint adds a data point to zookeeper.fsync_threshold_exceeds metric.
-func (mb *MetricsBuilder) RecordZookeeperFsyncThresholdExceedsDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperFsyncThresholdExceeds.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperFileDescriptorOpenDataPoint adds a data point to zookeeper.file_descriptor.open metric.
+func (mb *MetricsBuilder) RecordZookeeperFileDescriptorOpenDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperFileDescriptorOpen.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordZookeeperFollowerCountDataPoint adds a data point to zookeeper.follower.count metric.
+func (mb *MetricsBuilder) RecordZookeeperFollowerCountDataPoint(ts pdata.Timestamp, val int64, followerStateAttributeValue string) {
+	mb.metricZookeeperFollowerCount.recordDataPoint(mb.startTime, ts, val, followerStateAttributeValue)
+}
+
+// RecordZookeeperFsyncExceededThresholdCountDataPoint adds a data point to zookeeper.fsync.exceeded_threshold.count metric.
+func (mb *MetricsBuilder) RecordZookeeperFsyncExceededThresholdCountDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperFsyncExceededThresholdCount.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordZookeeperLatencyAvgDataPoint adds a data point to zookeeper.latency.avg metric.
@@ -1052,49 +970,29 @@ func (mb *MetricsBuilder) RecordZookeeperLatencyMinDataPoint(ts pdata.Timestamp,
 	mb.metricZookeeperLatencyMin.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordZookeeperMaxFileDescriptorsDataPoint adds a data point to zookeeper.max_file_descriptors metric.
-func (mb *MetricsBuilder) RecordZookeeperMaxFileDescriptorsDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperMaxFileDescriptors.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperPacketCountDataPoint adds a data point to zookeeper.packet.count metric.
+func (mb *MetricsBuilder) RecordZookeeperPacketCountDataPoint(ts pdata.Timestamp, val int64, packetStateAttributeValue string) {
+	mb.metricZookeeperPacketCount.recordDataPoint(mb.startTime, ts, val, packetStateAttributeValue)
 }
 
-// RecordZookeeperOpenFileDescriptorsDataPoint adds a data point to zookeeper.open_file_descriptors metric.
-func (mb *MetricsBuilder) RecordZookeeperOpenFileDescriptorsDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperOpenFileDescriptors.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperRequestActiveDataPoint adds a data point to zookeeper.request.active metric.
+func (mb *MetricsBuilder) RecordZookeeperRequestActiveDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperRequestActive.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordZookeeperOutstandingRequestsDataPoint adds a data point to zookeeper.outstanding_requests metric.
-func (mb *MetricsBuilder) RecordZookeeperOutstandingRequestsDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperOutstandingRequests.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperSyncPendingDataPoint adds a data point to zookeeper.sync.pending metric.
+func (mb *MetricsBuilder) RecordZookeeperSyncPendingDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperSyncPending.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordZookeeperPacketsReceivedDataPoint adds a data point to zookeeper.packets.received metric.
-func (mb *MetricsBuilder) RecordZookeeperPacketsReceivedDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperPacketsReceived.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperWatchCountDataPoint adds a data point to zookeeper.watch.count metric.
+func (mb *MetricsBuilder) RecordZookeeperWatchCountDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperWatchCount.recordDataPoint(mb.startTime, ts, val)
 }
 
-// RecordZookeeperPacketsSentDataPoint adds a data point to zookeeper.packets.sent metric.
-func (mb *MetricsBuilder) RecordZookeeperPacketsSentDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperPacketsSent.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordZookeeperPendingSyncsDataPoint adds a data point to zookeeper.pending_syncs metric.
-func (mb *MetricsBuilder) RecordZookeeperPendingSyncsDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperPendingSyncs.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordZookeeperSyncedFollowersDataPoint adds a data point to zookeeper.synced_followers metric.
-func (mb *MetricsBuilder) RecordZookeeperSyncedFollowersDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperSyncedFollowers.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordZookeeperWatchesDataPoint adds a data point to zookeeper.watches metric.
-func (mb *MetricsBuilder) RecordZookeeperWatchesDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperWatches.recordDataPoint(mb.startTime, ts, val)
-}
-
-// RecordZookeeperZnodesDataPoint adds a data point to zookeeper.znodes metric.
-func (mb *MetricsBuilder) RecordZookeeperZnodesDataPoint(ts pdata.Timestamp, val int64) {
-	mb.metricZookeeperZnodes.recordDataPoint(mb.startTime, ts, val)
+// RecordZookeeperZnodeCountDataPoint adds a data point to zookeeper.znode.count metric.
+func (mb *MetricsBuilder) RecordZookeeperZnodeCountDataPoint(ts pdata.Timestamp, val int64) {
+	mb.metricZookeeperZnodeCount.recordDataPoint(mb.startTime, ts, val)
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,
@@ -1108,14 +1006,38 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 
 // Attributes contains the possible metric attributes that can be used.
 var Attributes = struct {
+	// FollowerState (State of followers)
+	FollowerState string
+	// PacketState (State of a packet based on io direction.)
+	PacketState string
 	// ServerState (State of the Zookeeper server (leader, standalone or follower).)
 	ServerState string
 	// ZkVersion (Zookeeper version of the instance.)
 	ZkVersion string
 }{
+	"follower.state",
+	"packet.state",
 	"server.state",
 	"zk.version",
 }
 
 // A is an alias for Attributes.
 var A = Attributes
+
+// AttributeFollowerState are the possible values that the attribute "follower.state" can have.
+var AttributeFollowerState = struct {
+	Synced    string
+	NotSynced string
+}{
+	"synced",
+	"not_synced",
+}
+
+// AttributePacketState are the possible values that the attribute "packet.state" can have.
+var AttributePacketState = struct {
+	Received string
+	Sent     string
+}{
+	"received",
+	"sent",
+}

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -10,7 +10,7 @@ attributes:
     enum:
       - synced
       - unsynced
-  packet.direction:
+  direction:
     description: State of a packet based on io direction.
     enum:
       - received
@@ -118,7 +118,7 @@ metrics:
     enabled: true
     description: The number of ZooKeeper packets received or sent by a server.
     unit: "{packets}"
-    attributes: [packet.direction]
+    attributes: [direction]
     sum:
       value_type: int
       monotonic: true

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -5,25 +5,34 @@ attributes:
     description: State of the Zookeeper server (leader, standalone or follower).
   zk.version:
     description: Zookeeper version of the instance.
+  follower.state:
+    description: State of followers
+    enum:
+      - synced
+      - not_synced
+  packet.state:
+    description: State of a packet based on io direction.
+    enum:
+      - received
+      - sent
 
 metrics:
-  zookeeper.followers:
+  zookeeper.follower.count:
     enabled: true
-    description: The number of followers in sync with the leader. Only exposed by the leader.
-    unit: 1
-    gauge:
+    description: The number of followers. Only exposed by the leader.
+    unit: "{followers}"
+    attributes: [follower.state]
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-  zookeeper.synced_followers:
-    enabled: true
-    description: The number of followers in sync with the leader. Only exposed by the leader.
-    unit: 1
-    gauge:
-      value_type: int
-  zookeeper.pending_syncs:
+  zookeeper.sync.pending:
     enabled: true
     description: The number of pending syncs from the followers. Only exposed by the leader.
-    unit: 1
-    gauge:
+    unit: "{syncs}"
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
   zookeeper.latency.avg:
     enabled: true
@@ -40,77 +49,84 @@ metrics:
   zookeeper.latency.min:
     enabled: true
     description: Minimum time in milliseconds for requests to be processed.
-    unit: 1
+    unit: ms
     gauge:
       value_type: int
-  zookeeper.connections_alive:
+  zookeeper.connection.active:
     enabled: true
     description: Number of active clients connected to a ZooKeeper server.
-    unit: 1
-    gauge:
+    unit: "{connections}"
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-  zookeeper.outstanding_requests:
+  zookeeper.request.active:
     enabled: true
     description: Number of currently executing requests.
-    unit: 1
-    gauge:
+    unit: "{requests}"
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-  zookeeper.znodes:
+  zookeeper.znode.count:
     enabled: true
     description: Number of z-nodes that a ZooKeeper server has in its data tree.
-    unit: 1
-    gauge:
+    unit: "{znodes}"
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-  zookeeper.watches:
+  zookeeper.watch.count:
     enabled: true
     description: Number of watches placed on Z-Nodes on a ZooKeeper server.
-    unit: 1
-    gauge:
+    unit: "{watches}"
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-  zookeeper.ephemeral_nodes:
+  zookeeper.data_tree.ephemeral_node.count:
     enabled: true
     description: Number of ephemeral nodes that a ZooKeeper server has in its data tree.
-    unit: 1
-    gauge:
+    unit: "{nodes}"
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-  zookeeper.approximate_date_size:
+  zookeeper.data_tree.size:
     enabled: true
     description: Size of data in bytes that a ZooKeeper server has in its data tree.
     unit: By
-    gauge:
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-  zookeeper.open_file_descriptors:
+  zookeeper.file_descriptor.open:
     enabled: true
     description: Number of file descriptors that a ZooKeeper server has open.
-    unit: 1
-    gauge:
+    unit: "{file_descriptors}"
+    sum:
+      monotonic: false
+      aggregation: cumulative
       value_type: int
-  zookeeper.max_file_descriptors:
+  zookeeper.file_descriptor.limit:
     enabled: true
     description: Maximum number of file descriptors that a ZooKeeper server can open.
-    unit: 1
+    unit: "{file_descriptors}"
     gauge:
       value_type: int
-  zookeeper.packets.received:
+  zookeeper.packet.count:
     enabled: true
-    description: Number of ZooKeeper packets received by a server.
-    unit: 1
+    description: The number of ZooKeeper packets received or sent by a server.
+    unit: "{packets}"
+    attributes: [packet.state]
     sum:
       value_type: int
       monotonic: true
       aggregation: cumulative
-  zookeeper.packets.sent:
-    enabled: true
-    description: Number of ZooKeeper packets sent by a server.
-    unit: 1
-    sum:
-      value_type: int
-      monotonic: true
-      aggregation: cumulative
-  zookeeper.fsync_threshold_exceeds:
+  zookeeper.fsync.exceeded_threshold.count:
     enabled: true
     description: Number of times fsync duration has exceeded warning threshold.
-    unit: 1
+    unit: "{events}"
     sum:
       value_type: int
       monotonic: true

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -5,12 +5,12 @@ attributes:
     description: State of the Zookeeper server (leader, standalone or follower).
   zk.version:
     description: Zookeeper version of the instance.
-  follower.state:
+  state:
     description: State of followers
     enum:
       - synced
-      - not_synced
-  packet.state:
+      - unsynced
+  packet.direction:
     description: State of a packet based on io direction.
     enum:
       - received
@@ -21,7 +21,7 @@ metrics:
     enabled: true
     description: The number of followers. Only exposed by the leader.
     unit: "{followers}"
-    attributes: [follower.state]
+    attributes: [state]
     sum:
       monotonic: false
       aggregation: cumulative
@@ -118,7 +118,7 @@ metrics:
     enabled: true
     description: The number of ZooKeeper packets received or sent by a server.
     unit: "{packets}"
-    attributes: [packet.state]
+    attributes: [packet.direction]
     sum:
       value_type: int
       monotonic: true

--- a/receiver/zookeeperreceiver/metrics.go
+++ b/receiver/zookeeperreceiver/metrics.go
@@ -15,7 +15,10 @@
 package zookeeperreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver/internal/metadata"
 )
@@ -46,43 +49,90 @@ const (
 	zkVersionKey   = "zk_version"
 )
 
-func recordDataPointsFunc(mb *metadata.MetricsBuilder, metric string) func(ts pdata.Timestamp, val int64) {
+// metricCreator handles generation of metric and metric recording
+type metricCreator struct {
+	computedMetricStore map[string]int64
+	mb                  *metadata.MetricsBuilder
+}
+
+func newMetricCreator(mb *metadata.MetricsBuilder) *metricCreator {
+	return &metricCreator{
+		computedMetricStore: make(map[string]int64),
+		mb:                  mb,
+	}
+}
+
+func (m *metricCreator) recordDataPointsFunc(metric string) func(ts pdata.Timestamp, val int64) {
 	switch metric {
 	case followersMetricKey:
-		return mb.RecordZookeeperFollowersDataPoint
+		return func(ts pdata.Timestamp, val int64) {
+			m.computedMetricStore[followersMetricKey] = val
+		}
 	case syncedFollowersMetricKey:
-		return mb.RecordZookeeperSyncedFollowersDataPoint
+		return func(ts pdata.Timestamp, val int64) {
+			m.computedMetricStore[syncedFollowersMetricKey] = val
+			m.mb.RecordZookeeperFollowerCountDataPoint(ts, val, metadata.AttributeFollowerState.Synced)
+		}
 	case pendingSyncsMetricKey:
-		return mb.RecordZookeeperPendingSyncsDataPoint
+		return m.mb.RecordZookeeperSyncPendingDataPoint
 	case avgLatencyMetricKey:
-		return mb.RecordZookeeperLatencyAvgDataPoint
+		return m.mb.RecordZookeeperLatencyAvgDataPoint
 	case maxLatencyMetricKey:
-		return mb.RecordZookeeperLatencyMaxDataPoint
+		return m.mb.RecordZookeeperLatencyMaxDataPoint
 	case minLatencyMetricKey:
-		return mb.RecordZookeeperLatencyMinDataPoint
+		return m.mb.RecordZookeeperLatencyMinDataPoint
 	case numAliveConnectionsMetricKey:
-		return mb.RecordZookeeperConnectionsAliveDataPoint
+		return m.mb.RecordZookeeperConnectionActiveDataPoint
 	case outstandingRequestsMetricKey:
-		return mb.RecordZookeeperOutstandingRequestsDataPoint
+		return m.mb.RecordZookeeperRequestActiveDataPoint
 	case zNodeCountMetricKey:
-		return mb.RecordZookeeperZnodesDataPoint
+		return m.mb.RecordZookeeperZnodeCountDataPoint
 	case watchCountMetricKey:
-		return mb.RecordZookeeperWatchesDataPoint
+		return m.mb.RecordZookeeperWatchCountDataPoint
 	case ephemeralsCountMetricKey:
-		return mb.RecordZookeeperEphemeralNodesDataPoint
+		return m.mb.RecordZookeeperDataTreeEphemeralNodeCountDataPoint
 	case approximateDataSizeMetricKey:
-		return mb.RecordZookeeperApproximateDateSizeDataPoint
+		return m.mb.RecordZookeeperDataTreeSizeDataPoint
 	case openFileDescriptorCountMetricKey:
-		return mb.RecordZookeeperOpenFileDescriptorsDataPoint
+		return m.mb.RecordZookeeperFileDescriptorOpenDataPoint
 	case maxFileDescriptorCountMetricKey:
-		return mb.RecordZookeeperMaxFileDescriptorsDataPoint
+		return m.mb.RecordZookeeperFileDescriptorLimitDataPoint
 	case fSyncThresholdExceedCountMetricKey:
-		return mb.RecordZookeeperFsyncThresholdExceedsDataPoint
+		return m.mb.RecordZookeeperFsyncExceededThresholdCountDataPoint
 	case packetsReceivedMetricKey:
-		return mb.RecordZookeeperPacketsReceivedDataPoint
+		return func(ts pdata.Timestamp, val int64) {
+			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributePacketState.Received)
+		}
 	case packetsSentMetricKey:
-		return mb.RecordZookeeperPacketsSentDataPoint
+		return func(ts pdata.Timestamp, val int64) {
+			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributePacketState.Sent)
+		}
 	}
+
+	return nil
+}
+
+func (m *metricCreator) generateComputedMetrics(logger *zap.Logger, ts pdata.Timestamp) {
+	// not_synced Followers Count
+	if err := m.computeNotSyncedFollowersMetric(ts); err != nil {
+		logger.Debug("metric computation failed", zap.Error(err))
+	}
+
+}
+
+func (m *metricCreator) computeNotSyncedFollowersMetric(ts pdata.Timestamp) error {
+	followersTotal, ok := m.computedMetricStore[followersMetricKey]
+	if !ok {
+		return fmt.Errorf("could not compute not_synced follower.count, missing %s", followersMetricKey)
+	}
+
+	syncedFollowers, ok := m.computedMetricStore[syncedFollowersMetricKey]
+	if !ok {
+		return fmt.Errorf("could not compute not_synced follower.count, missing %s", syncedFollowersMetricKey)
+	}
+
+	val := followersTotal - syncedFollowers
+	m.mb.RecordZookeeperFollowerCountDataPoint(ts, val, metadata.AttributeFollowerState.NotSynced)
 
 	return nil
 }

--- a/receiver/zookeeperreceiver/metrics.go
+++ b/receiver/zookeeperreceiver/metrics.go
@@ -101,11 +101,11 @@ func (m *metricCreator) recordDataPointsFunc(metric string) func(ts pdata.Timest
 		return m.mb.RecordZookeeperFsyncExceededThresholdCountDataPoint
 	case packetsReceivedMetricKey:
 		return func(ts pdata.Timestamp, val int64) {
-			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributePacketDirection.Received)
+			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributeDirection.Received)
 		}
 	case packetsSentMetricKey:
 		return func(ts pdata.Timestamp, val int64) {
-			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributePacketDirection.Sent)
+			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributeDirection.Sent)
 		}
 	}
 

--- a/receiver/zookeeperreceiver/metrics.go
+++ b/receiver/zookeeperreceiver/metrics.go
@@ -71,7 +71,7 @@ func (m *metricCreator) recordDataPointsFunc(metric string) func(ts pdata.Timest
 	case syncedFollowersMetricKey:
 		return func(ts pdata.Timestamp, val int64) {
 			m.computedMetricStore[syncedFollowersMetricKey] = val
-			m.mb.RecordZookeeperFollowerCountDataPoint(ts, val, metadata.AttributeFollowerState.Synced)
+			m.mb.RecordZookeeperFollowerCountDataPoint(ts, val, metadata.AttributeState.Synced)
 		}
 	case pendingSyncsMetricKey:
 		return m.mb.RecordZookeeperSyncPendingDataPoint
@@ -101,11 +101,11 @@ func (m *metricCreator) recordDataPointsFunc(metric string) func(ts pdata.Timest
 		return m.mb.RecordZookeeperFsyncExceededThresholdCountDataPoint
 	case packetsReceivedMetricKey:
 		return func(ts pdata.Timestamp, val int64) {
-			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributePacketState.Received)
+			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributePacketDirection.Received)
 		}
 	case packetsSentMetricKey:
 		return func(ts pdata.Timestamp, val int64) {
-			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributePacketState.Sent)
+			m.mb.RecordZookeeperPacketCountDataPoint(ts, val, metadata.AttributePacketDirection.Sent)
 		}
 	}
 
@@ -132,7 +132,7 @@ func (m *metricCreator) computeNotSyncedFollowersMetric(ts pdata.Timestamp) erro
 	}
 
 	val := followersTotal - syncedFollowers
-	m.mb.RecordZookeeperFollowerCountDataPoint(ts, val, metadata.AttributeFollowerState.NotSynced)
+	m.mb.RecordZookeeperFollowerCountDataPoint(ts, val, metadata.AttributeState.Unsynced)
 
 	return nil
 }

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -66,6 +66,12 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 				"server.state": "standalone",
 				"zk.version":   "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf",
 			},
+			expectedLogs: []logMsg{
+				{
+					msg:   "metric computation failed",
+					level: zapcore.DebugLevel,
+				},
+			},
 			expectedNumResourceMetrics: 1,
 		},
 		{
@@ -97,6 +103,10 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 					msg:   "unexpected line in response",
 					level: zapcore.WarnLevel,
 				},
+				{
+					msg:   "metric computation failed",
+					level: zapcore.DebugLevel,
+				},
 			},
 			expectedNumResourceMetrics: 0,
 		},
@@ -106,6 +116,10 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			expectedLogs: []logMsg{
 				{
 					msg:   "non-integer value from mntr",
+					level: zapcore.DebugLevel,
+				},
+				{
+					msg:   "metric computation failed",
 					level: zapcore.DebugLevel,
 				},
 			},
@@ -118,6 +132,10 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 				{
 					msg:   "failed to set deadline on connection",
 					level: zapcore.WarnLevel,
+				},
+				{
+					msg:   "metric computation failed",
+					level: zapcore.DebugLevel,
 				},
 			},
 			expectedMetricsFilename: "error-setting-connection-deadline",
@@ -134,6 +152,10 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			name:                         "Error closing connection",
 			mockedZKOutputSourceFilename: "mntr-3.4.14",
 			expectedLogs: []logMsg{
+				{
+					msg:   "metric computation failed",
+					level: zapcore.DebugLevel,
+				},
 				{
 					msg:   "failed to shutdown connection",
 					level: zapcore.WarnLevel,
@@ -166,7 +188,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			name: "Disable zookeeper.watches metric",
 			metricsSettings: func() metadata.MetricsSettings {
 				ms := metadata.DefaultMetricsSettings()
-				ms.ZookeeperWatches.Enabled = false
+				ms.ZookeeperWatchCount.Enabled = false
 				return ms
 			},
 			mockedZKOutputSourceFilename: "mntr-3.4.14",
@@ -174,6 +196,12 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			expectedResourceAttributes: map[string]string{
 				"server.state": "standalone",
 				"zk.version":   "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf",
+			},
+			expectedLogs: []logMsg{
+				{
+					msg:   "metric computation failed",
+					level: zapcore.DebugLevel,
+				},
 			},
 			expectedNumResourceMetrics: 1,
 		},

--- a/receiver/zookeeperreceiver/testdata/mntr-3.5.5
+++ b/receiver/zookeeperreceiver/testdata/mntr-3.5.5
@@ -13,8 +13,8 @@ zk_ephemerals_count	0
 zk_approximate_data_size	107
 zk_open_file_descriptor_count	54
 zk_max_file_descriptor_count	1048576
-zk_followers	0
-zk_synced_followers	0
+zk_followers	2
+zk_synced_followers	1
 zk_pending_syncs	0
 zk_last_proposal_size	-1
 zk_max_proposal_size	-1

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.json
@@ -8,12 +8,103 @@
                },
                "metrics": [
                   {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "name": "zookeeper.connection.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.ephemeral_node.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
+                           }
+                        ]
+                     },
+                     "unit": "{nodes}"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "27",
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.file_descriptor.limit",
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "name": "zookeeper.file_descriptor.open",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "26",
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
+                           }
+                        ]
+                     },
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of times fsync duration has exceeded warning threshold.",
+                     "name": "zookeeper.fsync.exceeded_threshold.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{events}"
+                  },
+                  {
                      "description": "Average time in milliseconds for requests to be processed.",
                      "gauge": {
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349819599000"
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
                            }
                         ]
                      },
@@ -26,7 +117,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349819599000"
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
                            }
                         ]
                      },
@@ -39,161 +131,95 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349819599000"
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
                            }
                         ]
                      },
                      "name": "zookeeper.latency.min",
-                     "unit": "1"
+                     "unit": "ms"
                   },
                   {
-                     "description": "Number of ZooKeeper packets received by a server.",
-                     "name": "zookeeper.packets.received",
+                     "description": "The number of ZooKeeper packets received or sent by a server.",
+                     "name": "zookeeper.packet.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "timeUnixNano": "1638801349819599000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of ZooKeeper packets sent by a server.",
-                     "name": "zookeeper.packets.sent",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "received"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
+                           },
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349819599000"
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "sent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of active clients connected to a ZooKeeper server.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "timeUnixNano": "1638801349819599000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.connections_alive",
-                     "unit": "1"
+                     "unit": "{packets}"
                   },
                   {
                      "description": "Number of currently executing requests.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349819599000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.outstanding_requests",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "4",
-                              "timeUnixNano": "1638801349819599000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.znodes",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349819599000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.watches",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349819599000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.ephemeral_nodes",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "27",
-                              "timeUnixNano": "1638801349819599000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.approximate_date_size",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Number of file descriptors that a ZooKeeper server has open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "26",
-                              "timeUnixNano": "1638801349819599000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.open_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1048576",
-                              "timeUnixNano": "1638801349819599000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.max_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of times fsync duration has exceeded warning threshold.",
-                     "name": "zookeeper.fsync_threshold_exceeds",
+                     "name": "zookeeper.request.active",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349819599000"
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
                            }
-                        ],
-                        "isMonotonic": true
+                        ]
                      },
-                     "unit": "1"
+                     "unit": "{requests}"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "name": "zookeeper.watch.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
+                           }
+                        ]
+                     },
+                     "unit": "{watches}"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.znode.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "startTimeUnixNano": "1642556716914969000",
+                              "timeUnixNano": "1642556716915205000"
+                           }
+                        ]
+                     },
+                     "unit": "{znodes}"
                   }
                ]
             }

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.json
@@ -149,7 +149,7 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
@@ -162,7 +162,7 @@
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.json
@@ -15,8 +15,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -30,8 +30,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -45,8 +45,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -58,8 +58,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1048576",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -74,8 +74,8 @@
                         "dataPoints": [
                            {
                               "asInt": "26",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -89,8 +89,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ],
                         "isMonotonic": true
@@ -103,8 +103,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -117,8 +117,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -131,8 +131,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -149,27 +149,27 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            },
                            {
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ],
                         "isMonotonic": true
@@ -184,8 +184,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -199,8 +199,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },
@@ -214,8 +214,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1642556716914969000",
-                              "timeUnixNano": "1642556716915205000"
+                              "startTimeUnixNano": "1642685966444471000",
+                              "timeUnixNano": "1642685966444739000"
                            }
                         ]
                      },

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.json
@@ -169,7 +169,7 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
@@ -182,7 +182,7 @@
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.json
@@ -15,8 +15,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -30,8 +30,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -45,8 +45,8 @@
                         "dataPoints": [
                            {
                               "asInt": "107",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -58,8 +58,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1048576",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -74,8 +74,8 @@
                         "dataPoints": [
                            {
                               "asInt": "54",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -91,27 +91,27 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "follower.state",
+                                    "key": "state",
                                     "value": {
                                        "stringValue": "synced"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            },
                            {
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "follower.state",
+                                    "key": "state",
                                     "value": {
-                                       "stringValue": "not_synced"
+                                       "stringValue": "unsynced"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -123,8 +123,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -137,8 +137,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -151,8 +151,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -169,27 +169,27 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            },
                            {
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ],
                         "isMonotonic": true
@@ -204,8 +204,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -219,8 +219,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -234,8 +234,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },
@@ -249,8 +249,8 @@
                         "dataPoints": [
                            {
                               "asInt": "5",
-                              "startTimeUnixNano": "1642556716916898000",
-                              "timeUnixNano": "1642556716917044000"
+                              "startTimeUnixNano": "1642685966447704000",
+                              "timeUnixNano": "1642685966447860000"
                            }
                         ]
                      },

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.json
@@ -8,12 +8,123 @@
                },
                "metrics": [
                   {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "name": "zookeeper.connection.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.ephemeral_node.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           }
+                        ]
+                     },
+                     "unit": "{nodes}"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "107",
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.file_descriptor.limit",
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "name": "zookeeper.file_descriptor.open",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "54",
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           }
+                        ]
+                     },
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "The number of followers. Only exposed by the leader.",
+                     "name": "zookeeper.follower.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "follower.state",
+                                    "value": {
+                                       "stringValue": "synced"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "follower.state",
+                                    "value": {
+                                       "stringValue": "not_synced"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           }
+                        ]
+                     },
+                     "unit": "{followers}"
+                  },
+                  {
                      "description": "Average time in milliseconds for requests to be processed.",
                      "gauge": {
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
                            }
                         ]
                      },
@@ -26,7 +137,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
                            }
                         ]
                      },
@@ -39,185 +151,110 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
                            }
                         ]
                      },
                      "name": "zookeeper.latency.min",
-                     "unit": "1"
+                     "unit": "ms"
                   },
                   {
-                     "description": "Number of ZooKeeper packets received by a server.",
-                     "name": "zookeeper.packets.received",
+                     "description": "The number of ZooKeeper packets received or sent by a server.",
+                     "name": "zookeeper.packet.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of ZooKeeper packets sent by a server.",
-                     "name": "zookeeper.packets.sent",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "received"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           },
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "sent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of active clients connected to a ZooKeeper server.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.connections_alive",
-                     "unit": "1"
+                     "unit": "{packets}"
                   },
                   {
                      "description": "Number of currently executing requests.",
-                     "gauge": {
+                     "name": "zookeeper.request.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
                            }
                         ]
                      },
-                     "name": "zookeeper.outstanding_requests",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "5",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.znodes",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.watches",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.ephemeral_nodes",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "107",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.approximate_date_size",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Number of file descriptors that a ZooKeeper server has open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "54",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.open_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1048576",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.max_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "The number of followers in sync with the leader. Only exposed by the leader.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.followers",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "The number of followers in sync with the leader. Only exposed by the leader.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.synced_followers",
-                     "unit": "1"
+                     "unit": "{requests}"
                   },
                   {
                      "description": "The number of pending syncs from the followers. Only exposed by the leader.",
-                     "gauge": {
+                     "name": "zookeeper.sync.pending",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349824550000"
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
                            }
                         ]
                      },
-                     "name": "zookeeper.pending_syncs",
-                     "unit": "1"
+                     "unit": "{syncs}"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "name": "zookeeper.watch.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           }
+                        ]
+                     },
+                     "unit": "{watches}"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.znode.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "5",
+                              "startTimeUnixNano": "1642556716916898000",
+                              "timeUnixNano": "1642556716917044000"
+                           }
+                        ]
+                     },
+                     "unit": "{znodes}"
                   }
                ]
             }

--- a/receiver/zookeeperreceiver/testdata/scraper/disable-watches.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/disable-watches.json
@@ -15,8 +15,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },
@@ -30,8 +30,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },
@@ -45,8 +45,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },
@@ -58,8 +58,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1048576",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },
@@ -74,8 +74,8 @@
                         "dataPoints": [
                            {
                               "asInt": "26",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },
@@ -89,8 +89,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ],
                         "isMonotonic": true
@@ -103,8 +103,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },
@@ -117,8 +117,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },
@@ -131,8 +131,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },
@@ -149,27 +149,27 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            },
                            {
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ],
                         "isMonotonic": true
@@ -184,8 +184,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },
@@ -199,8 +199,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1642556716923804000",
-                              "timeUnixNano": "1642556716923914000"
+                              "startTimeUnixNano": "1642685966462139000",
+                              "timeUnixNano": "1642685966462251000"
                            }
                         ]
                      },

--- a/receiver/zookeeperreceiver/testdata/scraper/disable-watches.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/disable-watches.json
@@ -8,62 +8,94 @@
                },
                "metrics": [
                   {
-                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "27",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.approximate_date_size",
-                     "unit": "By"
-                  },
-                  {
                      "description": "Number of active clients connected to a ZooKeeper server.",
-                     "gauge": {
+                     "name": "zookeeper.connection.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
                            }
                         ]
                      },
-                     "name": "zookeeper.connections_alive",
-                     "unit": "1"
+                     "unit": "{connections}"
                   },
                   {
                      "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.ephemeral_nodes",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of times fsync duration has exceeded warning threshold.",
-                     "name": "zookeeper.fsync_threshold_exceeds",
+                     "name": "zookeeper.data_tree.ephemeral_node.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
+                           }
+                        ]
+                     },
+                     "unit": "{nodes}"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "27",
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.file_descriptor.limit",
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "name": "zookeeper.file_descriptor.open",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "26",
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
+                           }
+                        ]
+                     },
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of times fsync duration has exceeded warning threshold.",
+                     "name": "zookeeper.fsync.exceeded_threshold.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "unit": "1"
+                     "unit": "{events}"
                   },
                   {
                      "description": "Average time in milliseconds for requests to be processed.",
@@ -71,8 +103,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
                            }
                         ]
                      },
@@ -85,8 +117,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
                            }
                         ]
                      },
@@ -99,101 +131,80 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
                            }
                         ]
                      },
                      "name": "zookeeper.latency.min",
-                     "unit": "1"
+                     "unit": "ms"
                   },
                   {
-                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1048576",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.max_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of file descriptors that a ZooKeeper server has open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "26",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.open_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of currently executing requests.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.outstanding_requests",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of ZooKeeper packets received by a server.",
-                     "name": "zookeeper.packets.received",
+                     "description": "The number of ZooKeeper packets received or sent by a server.",
+                     "name": "zookeeper.packet.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "received"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "sent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "unit": "1"
+                     "unit": "{packets}"
                   },
                   {
-                     "description": "Number of ZooKeeper packets sent by a server.",
-                     "name": "zookeeper.packets.sent",
+                     "description": "Number of currently executing requests.",
+                     "name": "zookeeper.request.active",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "4",
-                              "startTimeUnixNano": "1639420804654952000",
-                              "timeUnixNano": "1639420804655313000"
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
                            }
                         ]
                      },
-                     "name": "zookeeper.znodes",
-                     "unit": "1"
+                     "unit": "{requests}"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.znode.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "startTimeUnixNano": "1642556716923804000",
+                              "timeUnixNano": "1642556716923914000"
+                           }
+                        ]
+                     },
+                     "unit": "{znodes}"
                   }
                ]
             }

--- a/receiver/zookeeperreceiver/testdata/scraper/disable-watches.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/disable-watches.json
@@ -149,7 +149,7 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
@@ -162,7 +162,7 @@
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }

--- a/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.json
@@ -8,12 +8,103 @@
                },
                "metrics": [
                   {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "name": "zookeeper.connection.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.ephemeral_node.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
+                           }
+                        ]
+                     },
+                     "unit": "{nodes}"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "27",
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.file_descriptor.limit",
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "name": "zookeeper.file_descriptor.open",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "26",
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
+                           }
+                        ]
+                     },
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of times fsync duration has exceeded warning threshold.",
+                     "name": "zookeeper.fsync.exceeded_threshold.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{events}"
+                  },
+                  {
                      "description": "Average time in milliseconds for requests to be processed.",
                      "gauge": {
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349835472000"
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
                            }
                         ]
                      },
@@ -26,7 +117,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349835472000"
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
                            }
                         ]
                      },
@@ -39,161 +131,95 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349835472000"
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
                            }
                         ]
                      },
                      "name": "zookeeper.latency.min",
-                     "unit": "1"
+                     "unit": "ms"
                   },
                   {
-                     "description": "Number of ZooKeeper packets received by a server.",
-                     "name": "zookeeper.packets.received",
+                     "description": "The number of ZooKeeper packets received or sent by a server.",
+                     "name": "zookeeper.packet.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "timeUnixNano": "1638801349835472000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of ZooKeeper packets sent by a server.",
-                     "name": "zookeeper.packets.sent",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "received"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
+                           },
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349835472000"
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "sent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of active clients connected to a ZooKeeper server.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "timeUnixNano": "1638801349835472000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.connections_alive",
-                     "unit": "1"
+                     "unit": "{packets}"
                   },
                   {
                      "description": "Number of currently executing requests.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349835472000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.outstanding_requests",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "4",
-                              "timeUnixNano": "1638801349835472000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.znodes",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349835472000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.watches",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349835472000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.ephemeral_nodes",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "27",
-                              "timeUnixNano": "1638801349835472000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.approximate_date_size",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Number of file descriptors that a ZooKeeper server has open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "26",
-                              "timeUnixNano": "1638801349835472000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.open_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1048576",
-                              "timeUnixNano": "1638801349835472000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.max_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of times fsync duration has exceeded warning threshold.",
-                     "name": "zookeeper.fsync_threshold_exceeds",
+                     "name": "zookeeper.request.active",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349835472000"
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
                            }
-                        ],
-                        "isMonotonic": true
+                        ]
                      },
-                     "unit": "1"
+                     "unit": "{requests}"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "name": "zookeeper.watch.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
+                           }
+                        ]
+                     },
+                     "unit": "{watches}"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.znode.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "startTimeUnixNano": "1642556716922492000",
+                              "timeUnixNano": "1642556716922601000"
+                           }
+                        ]
+                     },
+                     "unit": "{znodes}"
                   }
                ]
             }

--- a/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.json
@@ -15,8 +15,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -30,8 +30,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -45,8 +45,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -58,8 +58,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1048576",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -74,8 +74,8 @@
                         "dataPoints": [
                            {
                               "asInt": "26",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -89,8 +89,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ],
                         "isMonotonic": true
@@ -103,8 +103,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -117,8 +117,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -131,8 +131,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -149,27 +149,27 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            },
                            {
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ],
                         "isMonotonic": true
@@ -184,8 +184,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -199,8 +199,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },
@@ -214,8 +214,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1642556716922492000",
-                              "timeUnixNano": "1642556716922601000"
+                              "startTimeUnixNano": "1642685966458919000",
+                              "timeUnixNano": "1642685966459091000"
                            }
                         ]
                      },

--- a/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.json
@@ -149,7 +149,7 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
@@ -162,7 +162,7 @@
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }

--- a/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.json
@@ -15,8 +15,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -30,8 +30,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -45,8 +45,8 @@
                         "dataPoints": [
                            {
                               "asInt": "27",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -58,8 +58,8 @@
                         "dataPoints": [
                            {
                               "asInt": "1048576",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -74,8 +74,8 @@
                         "dataPoints": [
                            {
                               "asInt": "26",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -89,8 +89,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ],
                         "isMonotonic": true
@@ -103,8 +103,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -117,8 +117,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -131,8 +131,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -149,27 +149,27 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            },
                            {
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.state",
+                                    "key": "packet.direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ],
                         "isMonotonic": true
@@ -184,8 +184,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -199,8 +199,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },
@@ -214,8 +214,8 @@
                         "dataPoints": [
                            {
                               "asInt": "4",
-                              "startTimeUnixNano": "1642556716921134000",
-                              "timeUnixNano": "1642556716921242000"
+                              "startTimeUnixNano": "1642685966456266000",
+                              "timeUnixNano": "1642685966456364000"
                            }
                         ]
                      },

--- a/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.json
@@ -8,12 +8,103 @@
                },
                "metrics": [
                   {
+                     "description": "Number of active clients connected to a ZooKeeper server.",
+                     "name": "zookeeper.connection.active",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1",
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.ephemeral_node.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
+                           }
+                        ]
+                     },
+                     "unit": "{nodes}"
+                  },
+                  {
+                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.data_tree.size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "27",
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "1048576",
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
+                           }
+                        ]
+                     },
+                     "name": "zookeeper.file_descriptor.limit",
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of file descriptors that a ZooKeeper server has open.",
+                     "name": "zookeeper.file_descriptor.open",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "26",
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
+                           }
+                        ]
+                     },
+                     "unit": "{file_descriptors}"
+                  },
+                  {
+                     "description": "Number of times fsync duration has exceeded warning threshold.",
+                     "name": "zookeeper.fsync.exceeded_threshold.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{events}"
+                  },
+                  {
                      "description": "Average time in milliseconds for requests to be processed.",
                      "gauge": {
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349833222000"
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
                            }
                         ]
                      },
@@ -26,7 +117,8 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349833222000"
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
                            }
                         ]
                      },
@@ -39,161 +131,95 @@
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349833222000"
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
                            }
                         ]
                      },
                      "name": "zookeeper.latency.min",
-                     "unit": "1"
+                     "unit": "ms"
                   },
                   {
-                     "description": "Number of ZooKeeper packets received by a server.",
-                     "name": "zookeeper.packets.received",
+                     "description": "The number of ZooKeeper packets received or sent by a server.",
+                     "name": "zookeeper.packet.count",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "1",
-                              "timeUnixNano": "1638801349833222000"
-                           }
-                        ],
-                        "isMonotonic": true
-                     },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of ZooKeeper packets sent by a server.",
-                     "name": "zookeeper.packets.sent",
-                     "sum": {
-                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
-                        "dataPoints": [
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "received"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
+                           },
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349833222000"
+                              "attributes": [
+                                 {
+                                    "key": "packet.state",
+                                    "value": {
+                                       "stringValue": "sent"
+                                    }
+                                 }
+                              ],
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
                            }
                         ],
                         "isMonotonic": true
                      },
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of active clients connected to a ZooKeeper server.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1",
-                              "timeUnixNano": "1638801349833222000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.connections_alive",
-                     "unit": "1"
+                     "unit": "{packets}"
                   },
                   {
                      "description": "Number of currently executing requests.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349833222000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.outstanding_requests",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "4",
-                              "timeUnixNano": "1638801349833222000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.znodes",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349833222000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.watches",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of ephemeral nodes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "0",
-                              "timeUnixNano": "1638801349833222000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.ephemeral_nodes",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Size of data in bytes that a ZooKeeper server has in its data tree.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "27",
-                              "timeUnixNano": "1638801349833222000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.approximate_date_size",
-                     "unit": "By"
-                  },
-                  {
-                     "description": "Number of file descriptors that a ZooKeeper server has open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "26",
-                              "timeUnixNano": "1638801349833222000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.open_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Maximum number of file descriptors that a ZooKeeper server can open.",
-                     "gauge": {
-                        "dataPoints": [
-                           {
-                              "asInt": "1048576",
-                              "timeUnixNano": "1638801349833222000"
-                           }
-                        ]
-                     },
-                     "name": "zookeeper.max_file_descriptors",
-                     "unit": "1"
-                  },
-                  {
-                     "description": "Number of times fsync duration has exceeded warning threshold.",
-                     "name": "zookeeper.fsync_threshold_exceeds",
+                     "name": "zookeeper.request.active",
                      "sum": {
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
                               "asInt": "0",
-                              "timeUnixNano": "1638801349833222000"
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
                            }
-                        ],
-                        "isMonotonic": true
+                        ]
                      },
-                     "unit": "1"
+                     "unit": "{requests}"
+                  },
+                  {
+                     "description": "Number of watches placed on Z-Nodes on a ZooKeeper server.",
+                     "name": "zookeeper.watch.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
+                           }
+                        ]
+                     },
+                     "unit": "{watches}"
+                  },
+                  {
+                     "description": "Number of z-nodes that a ZooKeeper server has in its data tree.",
+                     "name": "zookeeper.znode.count",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "startTimeUnixNano": "1642556716921134000",
+                              "timeUnixNano": "1642556716921242000"
+                           }
+                        ]
+                     },
+                     "unit": "{znodes}"
                   }
                ]
             }

--- a/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.json
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.json
@@ -149,7 +149,7 @@
                               "asInt": "1",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "received"
                                     }
@@ -162,7 +162,7 @@
                               "asInt": "0",
                               "attributes": [
                                  {
-                                    "key": "packet.direction",
+                                    "key": "direction",
                                     "value": {
                                        "stringValue": "sent"
                                     }


### PR DESCRIPTION
**Description:**
- Refactored metrics to be more in line with the OTel metric specification. The following types of changes were made:
  - Added correct units instead of `1` where applicable
  - Combined some metrics via attributes
  - Changed some names to utilize namespacing more
  - Updated some descriptions to better reflect the metric
- Added pattern for computed metrics as one of the added metrics is computed

**Link to tracking Issue:** Resolves #7277 

**Testing:** 
Updated units tests for scraper and regenerated golden files.

**Documentation:** Regenerated metric documentation.