### PR TITLE
[receiver/prometheus]: use pdata conversion path by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - `tanzuobservabilityexporter`: Support exponential histograms (#7127)
 - `receiver_creator`: Log added and removed endpoint env structs (#7248)
 - `prometheusreceiver`: Use the OTLP data conversion path by default. (#TBD)
+  - Use `--feature-gates=-receiver.prometheus.OTLPDirect` to re-enable the 
+    OpenCensus conversion path.
 
 ## 🛑 Breaking changes 🛑
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Use Jaeger gRPC instead of Thrift in the docker-compose example (#7243)
 - `tanzuobservabilityexporter`: Support exponential histograms (#7127)
 - `receiver_creator`: Log added and removed endpoint env structs (#7248)
+- `prometheusreceiver`: Use the OTLP data conversion path by default. (#TBD)
 
 ## 🛑 Breaking changes 🛑
 

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -42,7 +42,7 @@ const (
 
 var pdataPipelineGate = featuregate.Gate{
 	ID:          "receiver.prometheus.OTLPDirect",
-	Enabled:     false,
+	Enabled:     true,
 	Description: "Controls whether to use a new translation directly from Prometheus timeseries to pdata, without an intermediate representation as OpenCensus data.",
 }
 


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

**Description:** Changes the default state of the `receiver.prometheus.OTLPDirect` feature gate to `true`.  This is the second step in deprecating and removing the OpenCensus data conversion path.