### PR TITLE
[processor/resourcedetection] Log the error when checking for ec2metadata availability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 - `mdatagen`: Fix validation of `enabled` field in metadata.yaml (#7166)
 - `elasticsearch`: Fix timestamp for each metric being startup time (#7255)
+- `resourcedetection`: Log the error when checking for ec2metadata availability (#7296) 
 
 ## 🚀 New components 🚀
 

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/metadata.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/metadata.go
@@ -24,7 +24,7 @@ import (
 type metadataProvider interface {
 	get(ctx context.Context) (ec2metadata.EC2InstanceIdentityDocument, error)
 	hostname(ctx context.Context) (string, error)
-	available(ctx context.Context) bool
+	instanceID(ctx context.Context) (string, error)
 }
 
 type metadataClient struct {
@@ -39,8 +39,8 @@ func newMetadataClient(sess *session.Session) *metadataClient {
 	}
 }
 
-func (c *metadataClient) available(ctx context.Context) bool {
-	return c.metadata.AvailableWithContext(ctx)
+func (c *metadataClient) instanceID(ctx context.Context) (string, error) {
+	return c.metadata.GetMetadataWithContext(ctx, "instance-id")
 }
 
 func (c *metadataClient) hostname(ctx context.Context) (string, error) {

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/metadata_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/metadata_test.go
@@ -71,19 +71,19 @@ func TestMetadataProvider_available(t *testing.T) {
 		name   string
 		fields fields
 		args   args
-		want   bool
+		want   error
 	}{
 		{
 			name:   "mock session",
 			fields: fields{},
 			args:   args{ctx: context.Background(), sess: mock.Session},
-			want:   true,
+			want:   nil,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newMetadataClient(tt.args.sess)
-			if got := c.available(tt.args.ctx); got != tt.want {
+			if _, got := c.instanceID(tt.args.ctx); got != tt.want {
 				t.Errorf("available() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
**Description:** Added debug logging if an error is returned from the ec2metadata availability check. Changed the `available` function so it is basically https://github.com/aws/aws-sdk-go/blob/main/aws/ec2metadata/api.go#L215-L221

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7293

**Testing:** Updated and ran the unit tests.