### PR TITLE
[receiver/mysql] Generate golden files for mysql integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - `awscontainerinsightreceiver`: add full pod name when configured to AWS Container Insights Receiver (#7415)
 - `hostreceiver/loadscraper`: Migrate the scraper to the mdatagen metrics builder (#7288)
 - `awsecscontainermetricsreceiver`: Rename attributes to follow semantic conventions (#7425)
+- `mysqlreceiver`: Add golden files for integration test
+
 ## 🛑 Breaking changes 🛑
 
 ## 🚀 New components 🚀

--- a/receiver/mysqlreceiver/integration_test.go
+++ b/receiver/mysqlreceiver/integration_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest/golden"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver/internal/metadata"
 )
 
 func TestMySqlIntegration(t *testing.T) {
@@ -60,15 +59,15 @@ func TestMySqlIntegration(t *testing.T) {
 		require.Eventuallyf(t, func() bool {
 			return len(consumer.AllMetrics()) > 0
 		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
-
-		md := consumer.AllMetrics()[0]
-		require.Equal(t, 1, md.ResourceMetrics().Len())
-		ilms := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics()
-		require.Equal(t, 1, ilms.Len())
-		metrics := ilms.At(0).Metrics()
 		require.NoError(t, rcvr.Shutdown(context.Background()))
 
-		require.Equal(t, len(metadata.M.Names()), metrics.Len())
+		actualMetrics := consumer.AllMetrics()[0]
+
+		expectedFile := filepath.Join("testdata", "integration", "expected.8_0.json")
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
+
+		scrapertest.CompareMetrics(expectedMetrics, actualMetrics, scrapertest.IgnoreMetricValues())
 	})
 
 	t.Run("Running mysql version 5.7", func(t *testing.T) {
@@ -98,7 +97,7 @@ func TestMySqlIntegration(t *testing.T) {
 
 		actualMetrics := consumer.AllMetrics()[0]
 
-		expectedFile := filepath.Join("testdata", "scraper", "expected.json")
+		expectedFile := filepath.Join("testdata", "integration", "expected.5_7.json")
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
 

--- a/receiver/mysqlreceiver/testdata/integration/expected.5_7.json
+++ b/receiver/mysqlreceiver/testdata/integration/expected.5_7.json
@@ -1,0 +1,971 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "otel/mysql"
+               },
+               "metrics": [
+                  {
+                     "description": "The number of pages in the InnoDB buffer pool.",
+                     "name": "mysql.buffer_pool_pages",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asDouble": 0,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "dirty"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 1130,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "data"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 7058,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "free"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 8192,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 4,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "misc"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 165,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "flushed"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of operations on the InnoDB buffer pool.",
+                     "name": "mysql.buffer_pool_operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "14557",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read_requests"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read_ahead_rnd"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read_ahead"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "986",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "reads"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read_ahead_evicted"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "wait_free"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "1669",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "write_requests"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of bytes in the InnoDB buffer pool.",
+                     "name": "mysql.buffer_pool_size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asDouble": 134217728,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 18513920,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "data"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 0,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "dirty"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of times each type of command has been executed.",
+                     "name": "mysql.commands",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "prepare"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "fetch"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "close"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "reset"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "send_long_data"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "execute"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of requests to various MySQL handlers.",
+                     "name": "mysql.handlers",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "prepare"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "583",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_rnd_next"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "discover"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_prev"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "50",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_first"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "566",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "3963",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_next"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "1682",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_key"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_last"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "314",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "mrr_init"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "savepoint"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "rollback"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "savepoint_rollback"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "6095",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "lock"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_rnd"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "318",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of writes to the InnoDB doublewrite buffer.",
+                     "name": "mysql.double_writes",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "6",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "writes"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "24",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "written"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB log operations.",
+                     "name": "mysql.log_operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "waits"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "652",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "requests"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "44",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "writes"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB operations.",
+                     "name": "mysql.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "239",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "writes"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "1008",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "reads"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "55",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "fsyncs"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB page operations.",
+                     "name": "mysql.page_operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "145",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "created"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "165",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "written"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "985",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB row locks.",
+                     "name": "mysql.row_locks",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "waits"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "time"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB row operations.",
+                     "name": "mysql.row_operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "updated"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "inserted"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "deleted"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of MySQL locks.",
+                     "name": "mysql.locks",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "waited"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "immediate"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of MySQL sorts.",
+                     "name": "mysql.sorts",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "range"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "scan"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "rows"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "merge_passes"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The state of MySQL threads.",
+                     "name": "mysql.threads",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asDouble": 0,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "cached"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 2,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "running"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 1,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "connected"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           },
+                           {
+                              "asDouble": 1,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "created"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792845808815000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  }
+               ]
+            }
+         ],
+         "resource": {}
+      }
+   ]
+}

--- a/receiver/mysqlreceiver/testdata/integration/expected.8_0.json
+++ b/receiver/mysqlreceiver/testdata/integration/expected.8_0.json
@@ -1,0 +1,971 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "otel/mysql"
+               },
+               "metrics": [
+                  {
+                     "description": "The number of pages in the InnoDB buffer pool.",
+                     "name": "mysql.buffer_pool_pages",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asDouble": 433,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "data"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 0,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "misc"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 7759,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "free"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 36,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "flushed"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 8192,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 0,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "dirty"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of operations on the InnoDB buffer pool.",
+                     "name": "mysql.buffer_pool_operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read_ahead_evicted"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read_ahead"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "400",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "reads"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "325",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "write_requests"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "1289",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read_requests"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "wait_free"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read_ahead_rnd"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of bytes in the InnoDB buffer pool.",
+                     "name": "mysql.buffer_pool_size",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asDouble": 134217728,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "total"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 0,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "dirty"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 7094272,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "data"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ]
+                     },
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The number of times each type of command has been executed.",
+                     "name": "mysql.commands",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "close"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "fetch"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "execute"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "send_long_data"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "reset"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "prepare"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of requests to various MySQL handlers.",
+                     "name": "mysql.handlers",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "8",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_key"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "savepoint_rollback"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "update"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "4",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_next"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "6",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "commit"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_rnd"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "prepare"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "savepoint"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "mrr_init"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "rollback"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "discover"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_last"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "276",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_rnd_next"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "11",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_first"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "delete"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "235",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "lock"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "235",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "write"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "read_prev"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of writes to the InnoDB doublewrite buffer.",
+                     "name": "mysql.double_writes",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "written"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "1",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "writes"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB log operations.",
+                     "name": "mysql.log_operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "requests"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "2",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "writes"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "waits"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB operations.",
+                     "name": "mysql.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "424",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "reads"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "7",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "fsyncs"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "53",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "writes"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB page operations.",
+                     "name": "mysql.page_operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "399",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "36",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "written"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "34",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "created"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB row locks.",
+                     "name": "mysql.row_locks",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "time"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "waits"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of InndoDB row operations.",
+                     "name": "mysql.row_operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "updated"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "8",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "read"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "deleted"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "inserted"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of MySQL locks.",
+                     "name": "mysql.locks",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "waited"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "107",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "immediate"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The number of MySQL sorts.",
+                     "name": "mysql.sorts",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "merge_passes"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "scan"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "range"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asInt": "0",
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "rows"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "1"
+                  },
+                  {
+                     "description": "The state of MySQL threads.",
+                     "name": "mysql.threads",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asDouble": 1,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "created"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 1,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "connected"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 0,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "cached"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           },
+                           {
+                              "asDouble": 1,
+                              "attributes": [
+                                 {
+                                    "key": "kind",
+                                    "value": {
+                                       "stringValue": "running"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1642792841241087000"
+                           }
+                        ]
+                     },
+                     "unit": "1"
+                  }
+               ]
+            }
+         ],
+         "resource": {}
+      }
+   ]
+}


### PR DESCRIPTION
These files follow the same pattern used in scraper unit tests,
where an actual metric result is compared to a golden file,
ignoring only the values that are impossible to predict, but 
validating the result in detail otherwise. Changes to the scraper's
output become obvious and easily traceable due to source control
on the golden files.