### PR TITLE
[processor/k8sattributes] Make options unexported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,11 @@
 - `tanzuobservabilityexporter`: Remove status.code
 - `tanzuobservabilityexporter`: Use semantic conventions for status.message (#7126) 
 - `k8sattributesprocessor`: Move `kube` and `observability` packages to `internal` folder (#7159)
+- `k8sattributesprocessor`: Unexport processor `Option`s (#7311)
 - `zookeeperreceiver`: Refactored metrics to have correct units, types, and combined some metrics via attributes. (#7280)
 - `prometheusremotewriteexporter`: `PRWExporter` struct and `NewPRWExporter()`
   function are now unexported. (#TBD)
 - `newrelicexporter` marked as deprecated (#7284)
-
 
 ## 🚀 New components 🚀
 

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -89,7 +89,7 @@ func createTracesProcessorWithOptions(
 	params component.ProcessorCreateSettings,
 	cfg config.Processor,
 	next consumer.Traces,
-	options ...Option,
+	options ...option,
 ) (component.TracesProcessor, error) {
 	kp, err := createKubernetesProcessor(params, cfg, options...)
 	if err != nil {
@@ -110,7 +110,7 @@ func createMetricsProcessorWithOptions(
 	params component.ProcessorCreateSettings,
 	cfg config.Processor,
 	nextMetricsConsumer consumer.Metrics,
-	options ...Option,
+	options ...option,
 ) (component.MetricsProcessor, error) {
 	kp, err := createKubernetesProcessor(params, cfg, options...)
 	if err != nil {
@@ -131,7 +131,7 @@ func createLogsProcessorWithOptions(
 	params component.ProcessorCreateSettings,
 	cfg config.Processor,
 	nextLogsConsumer consumer.Logs,
-	options ...Option,
+	options ...option,
 ) (component.LogsProcessor, error) {
 	kp, err := createKubernetesProcessor(params, cfg, options...)
 	if err != nil {
@@ -150,7 +150,7 @@ func createLogsProcessorWithOptions(
 func createKubernetesProcessor(
 	params component.ProcessorCreateSettings,
 	cfg config.Processor,
-	options ...Option,
+	options ...option,
 ) (*kubernetesprocessor, error) {
 	kp := &kubernetesprocessor{logger: params.Logger}
 
@@ -180,28 +180,28 @@ func createKubernetesProcessor(
 	return kp, nil
 }
 
-func createProcessorOpts(cfg config.Processor) []Option {
+func createProcessorOpts(cfg config.Processor) []option {
 	oCfg := cfg.(*Config)
-	opts := []Option{}
+	opts := []option{}
 	if oCfg.Passthrough {
-		opts = append(opts, WithPassthrough())
+		opts = append(opts, withPassthrough())
 	}
 
 	// extraction rules
-	opts = append(opts, WithExtractMetadata(oCfg.Extract.Metadata...))
-	opts = append(opts, WithExtractLabels(oCfg.Extract.Labels...))
-	opts = append(opts, WithExtractAnnotations(oCfg.Extract.Annotations...))
+	opts = append(opts, withExtractMetadata(oCfg.Extract.Metadata...))
+	opts = append(opts, withExtractLabels(oCfg.Extract.Labels...))
+	opts = append(opts, withExtractAnnotations(oCfg.Extract.Annotations...))
 
 	// filters
-	opts = append(opts, WithFilterNode(oCfg.Filter.Node, oCfg.Filter.NodeFromEnvVar))
-	opts = append(opts, WithFilterNamespace(oCfg.Filter.Namespace))
-	opts = append(opts, WithFilterLabels(oCfg.Filter.Labels...))
-	opts = append(opts, WithFilterFields(oCfg.Filter.Fields...))
-	opts = append(opts, WithAPIConfig(oCfg.APIConfig))
+	opts = append(opts, withFilterNode(oCfg.Filter.Node, oCfg.Filter.NodeFromEnvVar))
+	opts = append(opts, withFilterNamespace(oCfg.Filter.Namespace))
+	opts = append(opts, withFilterLabels(oCfg.Filter.Labels...))
+	opts = append(opts, withFilterFields(oCfg.Filter.Fields...))
+	opts = append(opts, withAPIConfig(oCfg.APIConfig))
 
-	opts = append(opts, WithExtractPodAssociations(oCfg.Association...))
+	opts = append(opts, withExtractPodAssociations(oCfg.Association...))
 
-	opts = append(opts, WithExcludes(oCfg.Exclude))
+	opts = append(opts, withExcludes(oCfg.Exclude))
 
 	return opts
 }

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -43,31 +43,31 @@ const (
 	metadataPodStartTime = "k8s.pod.start_time"
 )
 
-// Option represents a configuration option that can be passes.
+// option represents a configuration option that can be passes.
 // to the k8s-tagger
-type Option func(*kubernetesprocessor) error
+type option func(*kubernetesprocessor) error
 
-// WithAPIConfig provides k8s API related configuration to the processor.
+// withAPIConfig provides k8s API related configuration to the processor.
 // It defaults the authentication method to in-cluster auth using service accounts.
-func WithAPIConfig(cfg k8sconfig.APIConfig) Option {
+func withAPIConfig(cfg k8sconfig.APIConfig) option {
 	return func(p *kubernetesprocessor) error {
 		p.apiConfig = cfg
 		return p.apiConfig.Validate()
 	}
 }
 
-// WithPassthrough enables passthrough mode. In passthrough mode, the processor
+// withPassthrough enables passthrough mode. In passthrough mode, the processor
 // only detects and tags the pod IP and does not invoke any k8s APIs.
-func WithPassthrough() Option {
+func withPassthrough() option {
 	return func(p *kubernetesprocessor) error {
 		p.passthroughMode = true
 		return nil
 	}
 }
 
-// WithExtractMetadata allows specifying options to control extraction of pod metadata.
+// withExtractMetadata allows specifying options to control extraction of pod metadata.
 // If no fields explicitly provided, all metadata extracted by default.
-func WithExtractMetadata(fields ...string) Option {
+func withExtractMetadata(fields ...string) option {
 	return func(p *kubernetesprocessor) error {
 		if len(fields) == 0 {
 			fields = []string{
@@ -116,8 +116,8 @@ func WithExtractMetadata(fields ...string) Option {
 	}
 }
 
-// WithExtractLabels allows specifying options to control extraction of pod labels.
-func WithExtractLabels(labels ...FieldExtractConfig) Option {
+// withExtractLabels allows specifying options to control extraction of pod labels.
+func withExtractLabels(labels ...FieldExtractConfig) option {
 	return func(p *kubernetesprocessor) error {
 		labels, err := extractFieldRules("labels", labels...)
 		if err != nil {
@@ -128,8 +128,8 @@ func WithExtractLabels(labels ...FieldExtractConfig) Option {
 	}
 }
 
-// WithExtractAnnotations allows specifying options to control extraction of pod annotations tags.
-func WithExtractAnnotations(annotations ...FieldExtractConfig) Option {
+// withExtractAnnotations allows specifying options to control extraction of pod annotations tags.
+func withExtractAnnotations(annotations ...FieldExtractConfig) option {
 	return func(p *kubernetesprocessor) error {
 		annotations, err := extractFieldRules("annotations", annotations...)
 		if err != nil {
@@ -193,8 +193,8 @@ func extractFieldRules(fieldType string, fields ...FieldExtractConfig) ([]kube.F
 	return rules, nil
 }
 
-// WithFilterNode allows specifying options to control filtering pods by a node/host.
-func WithFilterNode(node, nodeFromEnvVar string) Option {
+// withFilterNode allows specifying options to control filtering pods by a node/host.
+func withFilterNode(node, nodeFromEnvVar string) option {
 	return func(p *kubernetesprocessor) error {
 		if nodeFromEnvVar != "" {
 			p.filters.Node = os.Getenv(nodeFromEnvVar)
@@ -205,16 +205,16 @@ func WithFilterNode(node, nodeFromEnvVar string) Option {
 	}
 }
 
-// WithFilterNamespace allows specifying options to control filtering pods by a namespace.
-func WithFilterNamespace(ns string) Option {
+// withFilterNamespace allows specifying options to control filtering pods by a namespace.
+func withFilterNamespace(ns string) option {
 	return func(p *kubernetesprocessor) error {
 		p.filters.Namespace = ns
 		return nil
 	}
 }
 
-// WithFilterLabels allows specifying options to control filtering pods by pod labels.
-func WithFilterLabels(filters ...FieldFilterConfig) Option {
+// withFilterLabels allows specifying options to control filtering pods by pod labels.
+func withFilterLabels(filters ...FieldFilterConfig) option {
 	return func(p *kubernetesprocessor) error {
 		labels := []kube.FieldFilter{}
 		for _, f := range filters {
@@ -246,8 +246,8 @@ func WithFilterLabels(filters ...FieldFilterConfig) Option {
 	}
 }
 
-// WithFilterFields allows specifying options to control filtering pods by pod fields.
-func WithFilterFields(filters ...FieldFilterConfig) Option {
+// withFilterFields allows specifying options to control filtering pods by pod fields.
+func withFilterFields(filters ...FieldFilterConfig) option {
 	return func(p *kubernetesprocessor) error {
 		fields := []kube.FieldFilter{}
 		for _, f := range filters {
@@ -275,8 +275,8 @@ func WithFilterFields(filters ...FieldFilterConfig) Option {
 	}
 }
 
-// WithExtractPodAssociations allows specifying options to associate pod metadata with incoming resource
-func WithExtractPodAssociations(podAssociations ...PodAssociationConfig) Option {
+// withExtractPodAssociations allows specifying options to associate pod metadata with incoming resource
+func withExtractPodAssociations(podAssociations ...PodAssociationConfig) option {
 	return func(p *kubernetesprocessor) error {
 		associations := make([]kube.Association, 0, len(podAssociations))
 		for _, association := range podAssociations {
@@ -290,8 +290,8 @@ func WithExtractPodAssociations(podAssociations ...PodAssociationConfig) Option 
 	}
 }
 
-// WithExcludes allows specifying pods to exclude
-func WithExcludes(podExclude ExcludeConfig) Option {
+// withExcludes allows specifying pods to exclude
+func withExcludes(podExclude ExcludeConfig) option {
 	return func(p *kubernetesprocessor) error {
 		ignoredNames := kube.Excludes{}
 		names := podExclude.Pods

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -31,34 +31,34 @@ import (
 func TestWithAPIConfig(t *testing.T) {
 	p := &kubernetesprocessor{}
 	apiConfig := k8sconfig.APIConfig{AuthType: "test-auth-type"}
-	err := WithAPIConfig(apiConfig)(p)
+	err := withAPIConfig(apiConfig)(p)
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), "invalid authType for kubernetes: test-auth-type")
 
 	apiConfig = k8sconfig.APIConfig{AuthType: "kubeConfig"}
-	err = WithAPIConfig(apiConfig)(p)
+	err = withAPIConfig(apiConfig)(p)
 	assert.NoError(t, err)
 	assert.Equal(t, apiConfig, p.apiConfig)
 }
 
 func TestWithFilterNamespace(t *testing.T) {
 	p := &kubernetesprocessor{}
-	assert.NoError(t, WithFilterNamespace("testns")(p))
+	assert.NoError(t, withFilterNamespace("testns")(p))
 	assert.Equal(t, p.filters.Namespace, "testns")
 }
 
 func TestWithFilterNode(t *testing.T) {
 	p := &kubernetesprocessor{}
-	assert.NoError(t, WithFilterNode("testnode", "")(p))
+	assert.NoError(t, withFilterNode("testnode", "")(p))
 	assert.Equal(t, p.filters.Node, "testnode")
 
 	p = &kubernetesprocessor{}
-	assert.NoError(t, WithFilterNode("testnode", "NODE_NAME")(p))
+	assert.NoError(t, withFilterNode("testnode", "NODE_NAME")(p))
 	assert.Equal(t, p.filters.Node, "")
 
 	os.Setenv("NODE_NAME", "nodefromenv")
 	p = &kubernetesprocessor{}
-	assert.NoError(t, WithFilterNode("testnode", "NODE_NAME")(p))
+	assert.NoError(t, withFilterNode("testnode", "NODE_NAME")(p))
 	assert.Equal(t, p.filters.Node, "nodefromenv")
 
 	os.Unsetenv("NODE_NAME")
@@ -66,7 +66,7 @@ func TestWithFilterNode(t *testing.T) {
 
 func TestWithPassthrough(t *testing.T) {
 	p := &kubernetesprocessor{}
-	assert.NoError(t, WithPassthrough()(p))
+	assert.NoError(t, withPassthrough()(p))
 	assert.True(t, p.passthroughMode)
 }
 
@@ -174,7 +174,7 @@ func TestWithExtractAnnotations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := WithExtractAnnotations(tt.args...)
+			option := withExtractAnnotations(tt.args...)
 			err := option(p)
 			if tt.wantError == "" {
 				assert.NoError(t, err)
@@ -293,7 +293,7 @@ func TestWithExtractLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := WithExtractLabels(tt.args...)
+			option := withExtractLabels(tt.args...)
 			err := option(p)
 			if tt.wantError == "" {
 				assert.NoError(t, err)
@@ -312,7 +312,7 @@ func TestWithExtractLabels(t *testing.T) {
 
 func TestWithExtractMetadata(t *testing.T) {
 	p := &kubernetesprocessor{}
-	assert.NoError(t, WithExtractMetadata()(p))
+	assert.NoError(t, withExtractMetadata()(p))
 	assert.True(t, p.rules.Namespace)
 	assert.True(t, p.rules.PodName)
 	assert.True(t, p.rules.PodUID)
@@ -322,12 +322,12 @@ func TestWithExtractMetadata(t *testing.T) {
 	assert.True(t, p.rules.Node)
 
 	p = &kubernetesprocessor{}
-	err := WithExtractMetadata("randomfield")(p)
+	err := withExtractMetadata("randomfield")(p)
 	assert.Error(t, err)
 	assert.Equal(t, err.Error(), `"randomfield" is not a supported metadata field`)
 
 	p = &kubernetesprocessor{}
-	assert.NoError(t, WithExtractMetadata(conventions.AttributeK8SNamespaceName, conventions.AttributeK8SPodName, conventions.AttributeK8SPodUID)(p))
+	assert.NoError(t, withExtractMetadata(conventions.AttributeK8SNamespaceName, conventions.AttributeK8SPodName, conventions.AttributeK8SPodUID)(p))
 	assert.True(t, p.rules.Namespace)
 	assert.False(t, p.rules.Cluster)
 	assert.True(t, p.rules.PodName)
@@ -451,7 +451,7 @@ func TestWithFilterLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := WithFilterLabels(tt.args...)
+			option := withFilterLabels(tt.args...)
 			err := option(p)
 			if tt.error == "" {
 				assert.NoError(t, err)
@@ -583,7 +583,7 @@ func TestWithFilterFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := WithFilterFields(tt.args...)
+			option := withFilterFields(tt.args...)
 			err := option(p)
 			if tt.error == "" {
 				assert.NoError(t, err)
@@ -735,7 +735,7 @@ func TestWithExtractPodAssociation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := WithExtractPodAssociations(tt.args...)
+			option := withExtractPodAssociations(tt.args...)
 			option(p)
 			assert.Equal(t, tt.want, p.podAssociations)
 		})
@@ -777,7 +777,7 @@ func TestWithExcludes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := WithExcludes(tt.args)
+			option := withExcludes(tt.args)
 			option(p)
 			assert.Equal(t, tt.want, p.podIgnore)
 		})

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -174,8 +174,8 @@ func TestWithExtractAnnotations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := withExtractAnnotations(tt.args...)
-			err := option(p)
+			opt := withExtractAnnotations(tt.args...)
+			err := opt(p)
 			if tt.wantError == "" {
 				assert.NoError(t, err)
 			} else {
@@ -293,8 +293,8 @@ func TestWithExtractLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := withExtractLabels(tt.args...)
-			err := option(p)
+			opt := withExtractLabels(tt.args...)
+			err := opt(p)
 			if tt.wantError == "" {
 				assert.NoError(t, err)
 			} else {
@@ -451,8 +451,8 @@ func TestWithFilterLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := withFilterLabels(tt.args...)
-			err := option(p)
+			opt := withFilterLabels(tt.args...)
+			err := opt(p)
 			if tt.error == "" {
 				assert.NoError(t, err)
 			} else {
@@ -583,8 +583,8 @@ func TestWithFilterFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := withFilterFields(tt.args...)
-			err := option(p)
+			opt := withFilterFields(tt.args...)
+			err := opt(p)
 			if tt.error == "" {
 				assert.NoError(t, err)
 			} else {
@@ -735,8 +735,8 @@ func TestWithExtractPodAssociation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := withExtractPodAssociations(tt.args...)
-			option(p)
+			opt := withExtractPodAssociations(tt.args...)
+			opt(p)
 			assert.Equal(t, tt.want, p.podAssociations)
 		})
 	}
@@ -777,8 +777,8 @@ func TestWithExcludes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &kubernetesprocessor{}
-			option := withExcludes(tt.args)
-			option(p)
+			opt := withExcludes(tt.args)
+			opt(p)
 			assert.Equal(t, tt.want, p.podIgnore)
 		})
 	}

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/kube"
 )
 
-func newTracesProcessor(cfg config.Processor, next consumer.Traces, options ...Option) (component.TracesProcessor, error) {
+func newTracesProcessor(cfg config.Processor, next consumer.Traces, options ...option) (component.TracesProcessor, error) {
 	opts := append(options, withKubeClientProvider(newFakeClient))
 	return createTracesProcessorWithOptions(
 		context.Background(),
@@ -48,7 +48,7 @@ func newTracesProcessor(cfg config.Processor, next consumer.Traces, options ...O
 	)
 }
 
-func newMetricsProcessor(cfg config.Processor, nextMetricsConsumer consumer.Metrics, options ...Option) (component.MetricsProcessor, error) {
+func newMetricsProcessor(cfg config.Processor, nextMetricsConsumer consumer.Metrics, options ...option) (component.MetricsProcessor, error) {
 	opts := append(options, withKubeClientProvider(newFakeClient))
 	return createMetricsProcessorWithOptions(
 		context.Background(),
@@ -59,7 +59,7 @@ func newMetricsProcessor(cfg config.Processor, nextMetricsConsumer consumer.Metr
 	)
 }
 
-func newLogsProcessor(cfg config.Processor, nextLogsConsumer consumer.Logs, options ...Option) (component.LogsProcessor, error) {
+func newLogsProcessor(cfg config.Processor, nextLogsConsumer consumer.Logs, options ...option) (component.LogsProcessor, error) {
 	opts := append(options, withKubeClientProvider(newFakeClient))
 	return createLogsProcessorWithOptions(
 		context.Background(),
@@ -71,14 +71,14 @@ func newLogsProcessor(cfg config.Processor, nextLogsConsumer consumer.Logs, opti
 }
 
 // withKubeClientProvider sets the specific implementation for getting K8s Client instances
-func withKubeClientProvider(kcp kube.ClientProvider) Option {
+func withKubeClientProvider(kcp kube.ClientProvider) option {
 	return func(p *kubernetesprocessor) error {
 		return p.initKubeClient(p.logger, kcp)
 	}
 }
 
 // withExtractKubernetesProcessorInto allows to pull the internal model easily even when processorhelper factory is used
-func withExtractKubernetesProcessorInto(kp **kubernetesprocessor) Option {
+func withExtractKubernetesProcessorInto(kp **kubernetesprocessor) option {
 	return func(p *kubernetesprocessor) error {
 		*kp = p
 		return nil
@@ -105,7 +105,7 @@ func newMultiTest(
 	t *testing.T,
 	cfg config.Processor,
 	errFunc func(err error),
-	options ...Option,
+	options ...option,
 ) *multiTest {
 	m := &multiTest{
 		t:           t,
@@ -365,7 +365,7 @@ func TestProcessorNoAttrs(t *testing.T) {
 		t,
 		NewFactory().CreateDefaultConfig(),
 		nil,
-		WithExtractMetadata(conventions.AttributeK8SPodName),
+		withExtractMetadata(conventions.AttributeK8SPodName),
 	)
 
 	ctx := client.NewContext(context.Background(), client.Info{
@@ -889,7 +889,7 @@ func TestMetricsProcessorHostname(t *testing.T) {
 	p, err := newMetricsProcessor(
 		NewFactory().CreateDefaultConfig(),
 		next,
-		WithExtractMetadata(conventions.AttributeK8SPodName),
+		withExtractMetadata(conventions.AttributeK8SPodName),
 		withExtractKubernetesProcessorInto(&kp),
 	)
 	require.NoError(t, err)
@@ -959,7 +959,7 @@ func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
 	p, err := newMetricsProcessor(
 		NewFactory().CreateDefaultConfig(),
 		next,
-		WithExtractMetadata(conventions.AttributeK8SPodName),
+		withExtractMetadata(conventions.AttributeK8SPodName),
 		withExtractKubernetesProcessorInto(&kp),
 	)
 	require.NoError(t, err)
@@ -1031,7 +1031,7 @@ func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
 
 func TestPassthroughStart(t *testing.T) {
 	next := new(consumertest.TracesSink)
-	opts := []Option{WithPassthrough()}
+	opts := []option{withPassthrough()}
 
 	p, err := newTracesProcessor(
 		NewFactory().CreateDefaultConfig(),
@@ -1054,7 +1054,7 @@ func TestRealClient(t *testing.T) {
 			assert.Equal(t, err.Error(), "unable to load k8s config, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
 		},
 		withKubeClientProvider(kubeClientProvider),
-		WithAPIConfig(k8sconfig.APIConfig{AuthType: "none"}),
+		withAPIConfig(k8sconfig.APIConfig{AuthType: "none"}),
 	)
 }
 


### PR DESCRIPTION
**Description:** 

Since the options can't really be passed to any function on the public API, and they apply to an unexported struct (`kubernetesprocessor`), it is impossible to use them, and therefore can be hidden.

- Unexport the `Option` struct
- Unexport all current options.

**Link to tracking Issue:** fixes #7158 (only remaining public symbols are config and `NewFactory`)
