### PR TITLE
[internal/scrapertest] Add comparison function for pdata.Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `scrapertest`: Add comparison option to ignore specific attributes (#6519)
 - `tracegen`: Add option to pass in custom headers to export calls via command line (#7308)
 - `tracegen`: Provide official container images (#7179)
+- `scrapertest`: Add comparison function for pdata.Metrics (#7400)
 
 ## 🛑 Breaking changes 🛑
 

--- a/internal/scrapertest/compare.go
+++ b/internal/scrapertest/compare.go
@@ -25,20 +25,100 @@ import (
 // CompareOption is applied by the CompareMetricSlices function
 // to mutates an expected and/or actual result before comparing.
 type CompareOption interface {
-	apply(expected, actual pdata.MetricSlice)
+	apply(expected, actual pdata.Metrics)
 }
 
-// CompareMetricSlices compares each part of two given MetricSlices and returns
-// an error if they don't match. The error describes what didn't match. The
-// expected and actual values are clones before options are applied.
-func CompareMetricSlices(expected, actual pdata.MetricSlice, options ...CompareOption) error {
-	expected, actual = cloneMetricSlice(expected), cloneMetricSlice(actual)
+func CompareMetrics(expected, actual pdata.Metrics, options ...CompareOption) error {
+	expected, actual = expected.Clone(), actual.Clone()
 
 	for _, option := range options {
 		option.apply(expected, actual)
 	}
 
-	if actual.Len() != expected.Len() {
+	expectedMetrics, actualMetrics := expected.ResourceMetrics(), actual.ResourceMetrics()
+	if expectedMetrics.Len() != actualMetrics.Len() {
+		return fmt.Errorf("number of resources does not match")
+	}
+
+	numResources := expectedMetrics.Len()
+
+	// Keep track of matching resources so that each can only be matched once
+	matchingResources := make(map[pdata.ResourceMetrics]pdata.ResourceMetrics, numResources)
+
+	var errs error
+	for e := 0; e < numResources; e++ {
+		er := expectedMetrics.At(e)
+		var foundMatch bool
+		for a := 0; a < numResources; a++ {
+			ar := actualMetrics.At(a)
+			if _, ok := matchingResources[ar]; ok {
+				continue
+			}
+			if reflect.DeepEqual(er.Resource().Attributes().Sort().AsRaw(), ar.Resource().Attributes().Sort().AsRaw()) {
+				foundMatch = true
+				matchingResources[ar] = er
+				break
+			}
+		}
+
+		if !foundMatch {
+			errs = multierr.Append(errs, fmt.Errorf("missing expected resource with attributes: %v", er.Resource().Attributes().AsRaw()))
+		}
+	}
+
+	for i := 0; i < numResources; i++ {
+		if _, ok := matchingResources[actualMetrics.At(i)]; !ok {
+			errs = multierr.Append(errs, fmt.Errorf("extra resource with attributes: %v", actualMetrics.At(i).Resource().Attributes().AsRaw()))
+		}
+	}
+
+	if errs != nil {
+		return errs
+	}
+
+	for ar, er := range matchingResources {
+		if err := CompareResourceMetrics(er, ar); err != nil {
+			return err
+		}
+	}
+
+	return errs
+}
+
+func CompareResourceMetrics(expected, actual pdata.ResourceMetrics) error {
+	eilms := expected.InstrumentationLibraryMetrics()
+	ailms := actual.InstrumentationLibraryMetrics()
+
+	if eilms.Len() != ailms.Len() {
+		return fmt.Errorf("number of instrumentation libraries does not match")
+	}
+
+	eilms.Sort(sortInstrumentationLibrary)
+	ailms.Sort(sortInstrumentationLibrary)
+
+	for i := 0; i < eilms.Len(); i++ {
+		eilm, ailm := eilms.At(i), ailms.At(i)
+		eil, ail := eilm.InstrumentationLibrary(), ailm.InstrumentationLibrary()
+
+		if eil.Name() != ail.Name() {
+			return fmt.Errorf("instrumentation library Name does not match expected: %s, actual: %s", eil.Name(), ail.Name())
+		}
+		if eil.Version() != ail.Version() {
+			return fmt.Errorf("instrumentation library Version does not match expected: %s, actual: %s", eil.Version(), ail.Version())
+		}
+
+		if err := CompareMetricSlices(eilm.Metrics(), ailm.Metrics()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CompareMetricSlices compares each part of two given MetricSlices and returns
+// an error if they don't match. The error describes what didn't match. The
+// expected and actual values are clones before options are applied.
+func CompareMetricSlices(expected, actual pdata.MetricSlice) error {
+	if expected.Len() != actual.Len() {
 		return fmt.Errorf("metric slices not of same length")
 	}
 

--- a/internal/scrapertest/golden/golden.go
+++ b/internal/scrapertest/golden/golden.go
@@ -16,7 +16,6 @@ package golden // import "github.com/open-telemetry/opentelemetry-collector-cont
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 
 	"go.opentelemetry.io/collector/model/otlp"
@@ -47,37 +46,4 @@ func WriteMetrics(filePath string, metrics pdata.Metrics) error {
 	}
 	b = append(b, []byte("\n")...)
 	return ioutil.WriteFile(filePath, b, 0600)
-}
-
-// ReadMetricSlice reads a file that contains a pdata.Metrics and returns
-// the MetricSlice found within the first Resource and InstrumentationLibrary
-func ReadMetricSlice(filePath string) (pdata.MetricSlice, error) {
-	metrics, err := ReadMetrics(filePath)
-	if err != nil {
-		return pdata.NewMetricSlice(), err
-	}
-
-	rms := metrics.ResourceMetrics()
-	if rms.Len() == 0 {
-		return pdata.NewMetricSlice(), fmt.Errorf("no resource found")
-	}
-
-	ilms := rms.At(0).InstrumentationLibraryMetrics()
-	if ilms.Len() == 0 {
-		return pdata.NewMetricSlice(), fmt.Errorf("no instrumentation library found")
-	}
-
-	return ilms.At(0).Metrics(), nil
-}
-
-// WriteMetricSlice wraps a pdata.MetricSlice in a pdata.Metrics and writes it
-// to the specified file
-func WriteMetricSlice(filePath string, metricSlice pdata.MetricSlice) error {
-	metrics := pdata.NewMetrics()
-	metricSlice.CopyTo(
-		metrics.ResourceMetrics().AppendEmpty().
-			InstrumentationLibraryMetrics().AppendEmpty().
-			Metrics(),
-	)
-	return WriteMetrics(filePath, metrics)
 }

--- a/internal/scrapertest/golden/golden_test.go
+++ b/internal/scrapertest/golden/golden_test.go
@@ -150,5 +150,3 @@ func initSum(metric pdata.Metric, name, desc, unit string, aggr pdata.MetricAggr
 	metric.SetName(name)
 	metric.SetUnit(unit)
 }
-
-// TODO test Read/WriteMetricSlice

--- a/internal/scrapertest/testdata/resource-attributes-mismatch/actual.json
+++ b/internal/scrapertest/testdata/resource-attributes-mismatch/actual.json
@@ -1,0 +1,28 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "one"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "three"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-attributes-mismatch/expected.json
+++ b/internal/scrapertest/testdata/resource-attributes-mismatch/expected.json
@@ -1,0 +1,28 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "one"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "two"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-extra/actual.json
+++ b/internal/scrapertest/testdata/resource-extra/actual.json
@@ -1,0 +1,28 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "one"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "two"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-extra/expected.json
+++ b/internal/scrapertest/testdata/resource-extra/expected.json
@@ -1,0 +1,16 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "one"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-instrumentation-library-extra/actual.json
+++ b/internal/scrapertest/testdata/resource-instrumentation-library-extra/actual.json
@@ -1,0 +1,20 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "one",
+                  "version": "1.0"
+               }
+            },
+            {
+               "instrumentationLibrary": {
+                  "name": "two",
+                  "version": "2.0"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-instrumentation-library-extra/expected.json
+++ b/internal/scrapertest/testdata/resource-instrumentation-library-extra/expected.json
@@ -1,0 +1,14 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "one",
+                  "version": "1.0"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-instrumentation-library-missing/actual.json
+++ b/internal/scrapertest/testdata/resource-instrumentation-library-missing/actual.json
@@ -1,0 +1,14 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "one",
+                  "version": "1.0"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-instrumentation-library-missing/expected.json
+++ b/internal/scrapertest/testdata/resource-instrumentation-library-missing/expected.json
@@ -1,0 +1,20 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "one",
+                  "version": "1.0"
+               }
+            },
+            {
+               "instrumentationLibrary": {
+                  "name": "two",
+                  "version": "2.0"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-instrumentation-library-name-mismatch/actual.json
+++ b/internal/scrapertest/testdata/resource-instrumentation-library-name-mismatch/actual.json
@@ -1,0 +1,14 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "two",
+                  "version": "1.0"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-instrumentation-library-name-mismatch/expected.json
+++ b/internal/scrapertest/testdata/resource-instrumentation-library-name-mismatch/expected.json
@@ -1,0 +1,14 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "one",
+                  "version": "1.0"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-instrumentation-library-version-mismatch/actual.json
+++ b/internal/scrapertest/testdata/resource-instrumentation-library-version-mismatch/actual.json
@@ -1,0 +1,14 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "one",
+                  "version": "2.0"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-instrumentation-library-version-mismatch/expected.json
+++ b/internal/scrapertest/testdata/resource-instrumentation-library-version-mismatch/expected.json
@@ -1,0 +1,14 @@
+{
+   "resourceMetrics": [
+      {
+         "instrumentationLibraryMetrics": [
+            {
+               "instrumentationLibrary": {
+                  "name": "one",
+                  "version": "1.0"
+               }
+            }
+         ]
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-missing/actual.json
+++ b/internal/scrapertest/testdata/resource-missing/actual.json
@@ -1,0 +1,16 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "one"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/internal/scrapertest/testdata/resource-missing/expected.json
+++ b/internal/scrapertest/testdata/resource-missing/expected.json
@@ -1,0 +1,28 @@
+{
+   "resourceMetrics": [
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "one"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "type",
+                  "value": {
+                     "stringValue": "two"
+                  }
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/internal/scrapertest/util.go
+++ b/internal/scrapertest/util.go
@@ -20,12 +20,6 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
-func cloneMetricSlice(metricSlice pdata.MetricSlice) pdata.MetricSlice {
-	clone := pdata.NewMetricSlice()
-	metricSlice.CopyTo(clone)
-	return clone
-}
-
 func metricsByName(metricSlice pdata.MetricSlice) map[string]pdata.Metric {
 	byName := make(map[string]pdata.Metric, metricSlice.Len())
 	for i := 0; i < metricSlice.Len(); i++ {
@@ -46,4 +40,17 @@ func getDataPointSlice(metric pdata.Metric) pdata.NumberDataPointSlice {
 		panic(fmt.Sprintf("data type not supported: %s", metric.DataType()))
 	}
 	return dataPointSlice
+}
+
+func sortInstrumentationLibrary(a, b pdata.InstrumentationLibraryMetrics) bool {
+	if a.SchemaUrl() < b.SchemaUrl() {
+		return true
+	}
+	if a.InstrumentationLibrary().Name() < b.InstrumentationLibrary().Name() {
+		return true
+	}
+	if a.InstrumentationLibrary().Version() < b.InstrumentationLibrary().Version() {
+		return true
+	}
+	return false
 }

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -48,14 +48,12 @@ func TestScraper(t *testing.T) {
 
 	actualMetrics, err := scraper.scrape(context.Background())
 	require.NoError(t, err)
-	aMetricSlice := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
 	expectedFile := filepath.Join("testdata", "scraper", "expected.json")
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
-	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 }
 
 func TestScraperFailedStart(t *testing.T) {

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -50,13 +50,12 @@ func TestScrape(t *testing.T) {
 
 		actualMetrics, err := scraper.scrape(context.Background())
 		require.NoError(t, err)
-		aMetricSlice := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
 		expectedFile := filepath.Join("testdata", "scraper", "expected.json")
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
-		eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
-		require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+
+		require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 	})
 
 	t.Run("scrape from couchdb 3.12", func(t *testing.T) {
@@ -67,13 +66,12 @@ func TestScrape(t *testing.T) {
 
 		actualMetrics, err := scraper.scrape(context.Background())
 		require.NoError(t, err)
-		aMetricSlice := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
 		expectedFile := filepath.Join("testdata", "scraper", "expected.json")
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
-		eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
-		require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+
+		require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 	})
 
 	t.Run("scrape error: failed to connect to client", func(t *testing.T) {

--- a/receiver/memcachedreceiver/integration_test.go
+++ b/receiver/memcachedreceiver/integration_test.go
@@ -51,24 +51,13 @@ func TestIntegration(t *testing.T) {
 	}, 15*time.Second, 1*time.Second, "failed to receive at least 5 metrics")
 	require.NoError(t, rcvr.Shutdown(context.Background()))
 
-	md := consumer.AllMetrics()[0]
-
-	require.Equal(t, 1, md.ResourceMetrics().Len())
-
-	ilms := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics()
-	require.Equal(t, 1, ilms.Len())
-
-	aMetricSlice := ilms.At(0).Metrics()
-	require.Equal(t, 11, aMetricSlice.Len())
+	actualMetrics := consumer.AllMetrics()[0]
 
 	expectedFileBytes, err := ioutil.ReadFile("./testdata/expected_metrics/test_scraper/expected.json")
 	require.NoError(t, err)
-
 	unmarshaller := otlp.NewJSONMetricsUnmarshaler()
 	expectedMetrics, err := unmarshaller.UnmarshalMetrics(expectedFileBytes)
 	require.NoError(t, err)
 
-	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
-
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, scrapertest.IgnoreValues()))
+	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics, scrapertest.IgnoreMetricValues()))
 }

--- a/receiver/memcachedreceiver/scraper_test.go
+++ b/receiver/memcachedreceiver/scraper_test.go
@@ -37,12 +37,10 @@ func TestScraper(t *testing.T) {
 
 	actualMetrics, err := scraper.scrape(context.Background())
 	require.NoError(t, err)
-	aMetricSlice := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
 	expectedFile := filepath.Join("testdata", "expected_metrics", "test_scraper", "expected.json")
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
-	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 }

--- a/receiver/mysqlreceiver/integration_test.go
+++ b/receiver/mysqlreceiver/integration_test.go
@@ -94,20 +94,15 @@ func TestMySqlIntegration(t *testing.T) {
 		require.Eventuallyf(t, func() bool {
 			return len(consumer.AllMetrics()) > 0
 		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
-
-		md := consumer.AllMetrics()[0]
-		require.Equal(t, 1, md.ResourceMetrics().Len())
-		ilms := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics()
-		require.Equal(t, 1, ilms.Len())
-		aMetricSlice := ilms.At(0).Metrics()
 		require.NoError(t, rcvr.Shutdown(context.Background()))
+
+		actualMetrics := consumer.AllMetrics()[0]
 
 		expectedFile := filepath.Join("testdata", "scraper", "expected.json")
 		expectedMetrics, err := golden.ReadMetrics(expectedFile)
 		require.NoError(t, err)
-		eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-		scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice, scrapertest.IgnoreValues())
+		scrapertest.CompareMetrics(expectedMetrics, actualMetrics, scrapertest.IgnoreMetricValues())
 	})
 }
 

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -45,14 +45,12 @@ func TestScrape(t *testing.T) {
 
 	actualMetrics, err := scraper.scrape(context.Background())
 	require.NoError(t, err)
-	aMetricSlice := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
 	expectedFile := filepath.Join("testdata", "scraper", "expected.json")
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
-	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+	require.NoError(t, scrapertest.CompareMetrics(actualMetrics, expectedMetrics))
 }
 
 var _ client = (*mockClient)(nil)

--- a/receiver/nginxreceiver/scraper_test.go
+++ b/receiver/nginxreceiver/scraper_test.go
@@ -47,14 +47,12 @@ func TestScraper(t *testing.T) {
 
 	actualMetrics, err := scraper.scrape(context.Background())
 	require.NoError(t, err)
-	aMetricSlice := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
 	expectedFile := filepath.Join("testdata", "scraper", "expected.json")
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
-	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 }
 
 func TestScraperError(t *testing.T) {

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -36,14 +36,12 @@ func TestScraper(t *testing.T) {
 
 	actualMetrics, err := scraper.scrape(context.Background())
 	require.NoError(t, err)
-	aMetricSlice := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
 	expectedFile := filepath.Join("testdata", "scraper", "otel", "expected.json")
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
-	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 }
 
 func TestScraperNoDatabaseSingle(t *testing.T) {
@@ -54,14 +52,12 @@ func TestScraperNoDatabaseSingle(t *testing.T) {
 
 	actualMetrics, err := scraper.scrape(context.Background())
 	require.NoError(t, err)
-	aMetricSlice := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
 	expectedFile := filepath.Join("testdata", "scraper", "otel", "expected.json")
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
-	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 }
 
 func TestScraperNoDatabaseMultiple(t *testing.T) {
@@ -72,14 +68,12 @@ func TestScraperNoDatabaseMultiple(t *testing.T) {
 
 	actualMetrics, err := scraper.scrape(context.Background())
 	require.NoError(t, err)
-	aMetricSlice := actualMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
 	expectedFile := filepath.Join("testdata", "scraper", "multiple", "expected.json")
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
-	eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-	require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 }
 
 type mockClientFactory struct{ mock.Mock }

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -240,7 +240,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 				z.sendCmd = tt.sendCmd
 			}
 
-			got, err := z.scrape(ctx)
+			actualMetrics, err := z.scrape(ctx)
 			require.NoError(t, z.shutdown(ctx))
 
 			require.Equal(t, len(tt.expectedLogs), observedLogs.Len())
@@ -252,7 +252,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			if tt.expectedNumResourceMetrics == 0 {
 				if tt.wantErr {
 					require.Error(t, err)
-					require.Equal(t, pdata.NewMetrics(), got)
+					require.Equal(t, pdata.NewMetrics(), actualMetrics)
 				}
 
 				require.NoError(t, z.shutdown(ctx))
@@ -262,10 +262,8 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			expectedFile := filepath.Join("testdata", "scraper", fmt.Sprintf("%s.json", tt.expectedMetricsFilename))
 			expectedMetrics, err := golden.ReadMetrics(expectedFile)
 			require.NoError(t, err)
-			eMetricSlice := expectedMetrics.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
-			aMetricSlice := got.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 
-			require.NoError(t, scrapertest.CompareMetricSlices(eMetricSlice, aMetricSlice))
+			require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 		})
 	}
 }


### PR DESCRIPTION
The scrapertest package already provides the
ability to compare pdata.MetricSlices. This PR adds
comparison logic for higher level metric structs,
including resources and their attributes, and their
instrumentation libraries and associated fields.

The PR also removes an unused pair of read/write
functions in the scrapertest/golden package. These
might have been useful in theory, but are much less so
with the addition of direct pdata.Metrics comparisons.

Addresses #6890 