### PR TITLE
[examples/kubernetes] Fix mount path to config file

### DIFF
--- a/examples/kubernetes/otel-collector.yaml
+++ b/examples/kubernetes/otel-collector.yaml
@@ -116,7 +116,7 @@ spec:
         - mountPath: /var/lib/docker/containers
           name: varlibdockercontainers
           readOnly: true
-        - mountPath: /etc/otel/config.yaml
+        - mountPath: /etc/otelcol-contrib/config.yaml
           name: data
           subPath: config.yaml
           readOnly: true


### PR DESCRIPTION
**Description:** 

Passing default configuration mount path to docker build
**Link to tracking Issue:** Fixes #7404 