### PR TITLE
[receiver/awscontainerinsight] Add full pod name metric label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `awscloudwatchlogsexporter`: enable awscloudwatchlogsexporter which accepts and exports log data (#7297)
 - `translator/prometheusremotewrite`: add a new module to help translate data from OTLP to Prometheus Remote Write (#7240)
 - `jmxreceiver`: Added `additional_jars` configuration option to launch JMX Metric Gatherer JAR with extended `CLASSPATH` (#7378)
-
+- `awscontainerinsightreceiver`: add full pod name when configured to AWS Container Insights Receiver (#7415)
 ## 🛑 Breaking changes 🛑
 
 ## 🚀 New components 🚀

--- a/internal/aws/containerinsight/k8sconst.go
+++ b/internal/aws/containerinsight/k8sconst.go
@@ -25,6 +25,7 @@ const (
 	K8sNamespace     = "Namespace"
 	PodIDKey         = "PodId"
 	PodNameKey       = "PodName"
+	FullPodNameKey   = "FullPodName"
 	K8sPodNameKey    = "K8sPodName"
 	ContainerNamekey = "ContainerName"
 	ContainerIDkey   = "ContainerId"

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -24,6 +24,7 @@ receivers:
     container_orchestrator: eks
     add_service_as_attribute: true 
     prefer_full_pod_name: false 
+    add_full_pod_name_metric_label: false 
 ```
 There is no need to provide any parameters since they are all optional. 
 
@@ -42,6 +43,10 @@ Whether to add the associated service name as attribute. The default is true
 **prefer_full_pod_name (optional)**
 
 The "PodName" attribute is set based on the name of the relevant controllers like Daemonset, Job, ReplicaSet, ReplicationController, ... If it can not be set that way and PrefFullPodName is true, the "PodName" attribute is set to the pod's own name. The default value is false.
+
+**add_full_pod_name_metric_label (optional)**
+
+The "FullPodName" attribute is the pod name including suffix. If false FullPodName label is not added. The default value is false
 
 ## Sample configuration for Container Insights 
 This is a sample configuration for AWS Container Insights using the `awscontainerinsightreceiver` and `awsemfexporter` for an EKS cluster:

--- a/receiver/awscontainerinsightreceiver/config.go
+++ b/receiver/awscontainerinsightreceiver/config.go
@@ -37,4 +37,9 @@ type Config struct {
 	// If it can not be set that way and PrefFullPodName is true, the "PodName" attribute is set to the pod's own name.
 	// The default value is false
 	PrefFullPodName bool `mapstructure:"prefer_full_pod_name"`
+
+	// The "FullPodName" attribute is the pod name including suffix
+	// If false FullPodName label is not added
+	// The default value is false
+	AddFullPodNameMetricLabel bool `mapstructure:"add_full_pod_name_metric_label"`
 }

--- a/receiver/awscontainerinsightreceiver/factory.go
+++ b/receiver/awscontainerinsightreceiver/factory.go
@@ -40,6 +40,9 @@ const (
 
 	// Don't use pod full name by default (as the full names contain suffix with random characters)
 	defaultPrefFullPodName = false
+
+	// Don't tag pod full name by default
+	defaultAddFullPodNameMetricLabel = false
 )
 
 // NewFactory creates a factory for AWS container insight receiver
@@ -53,11 +56,12 @@ func NewFactory() component.ReceiverFactory {
 // createDefaultConfig returns a default config for the receiver.
 func createDefaultConfig() config.Receiver {
 	return &Config{
-		ReceiverSettings:      config.NewReceiverSettings(config.NewComponentID(typeStr)),
-		CollectionInterval:    defaultCollectionInterval,
-		ContainerOrchestrator: defaultContainerOrchestrator,
-		TagService:            defaultTagService,
-		PrefFullPodName:       defaultPrefFullPodName,
+		ReceiverSettings:          config.NewReceiverSettings(config.NewComponentID(typeStr)),
+		CollectionInterval:        defaultCollectionInterval,
+		ContainerOrchestrator:     defaultContainerOrchestrator,
+		TagService:                defaultTagService,
+		PrefFullPodName:           defaultPrefFullPodName,
+		AddFullPodNameMetricLabel: defaultAddFullPodNameMetricLabel,
 	}
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/store.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/store.go
@@ -53,7 +53,7 @@ type K8sDecorator struct {
 	ctx context.Context
 }
 
-func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool, logger *zap.Logger) (*K8sDecorator, error) {
+func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool, addFullPodNameMetricLabel bool, logger *zap.Logger) (*K8sDecorator, error) {
 	hostIP := os.Getenv("HOST_IP")
 	if hostIP == "" {
 		return nil, errors.New("environment variable HOST_IP is not set in k8s deployment config")
@@ -63,7 +63,7 @@ func NewK8sDecorator(ctx context.Context, tagService bool, prefFullPodName bool,
 		ctx: ctx,
 	}
 
-	podstore, err := NewPodStore(hostIP, prefFullPodName, logger)
+	podstore, err := NewPodStore(hostIP, prefFullPodName, addFullPodNameMetricLabel, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/awscontainerinsightreceiver/receiver.go
+++ b/receiver/awscontainerinsightreceiver/receiver.go
@@ -76,7 +76,7 @@ func (acir *awsContainerInsightReceiver) Start(ctx context.Context, host compone
 	}
 
 	if acir.config.ContainerOrchestrator == ci.EKS {
-		k8sDecorator, err := stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.settings.Logger)
+		k8sDecorator, err := stores.NewK8sDecorator(ctx, acir.config.TagService, acir.config.PrefFullPodName, acir.config.AddFullPodNameMetricLabel, acir.settings.Logger)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**Description:** 
There is no way to see the container full pod name for daemon sets. This allows us to add a label to the pod level metric. This label can then be used as a dimension. 
Fixes #7415

**Link to tracking Issue:**  Fixes #7415

**Testing:** 
Added unit tests. For manual tests see issue link. If needed I can add an integration test to the aws collector test fw after merged. 