### PR TITLE
[processor/routing] Do not err on failure to build exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `mysqlreceiver`: Add golden files for integration test (#7303)
 - `nginxreceiver`: Standardize integration test (#7515)
 - `mysqlreceiver`: Update to use mdatagen v2 (#7507)
+- `routingprocessor`: Do not err on failure to build exporters (#7423)
 - `postgresqlreceiver`: Add integration tests (#7501)
 - `apachereceiver`: Add integration test (#7517)
 - `mysqlreceiver`: Use scrapererror to report errors (#7513)

--- a/processor/routingprocessor/processor.go
+++ b/processor/routingprocessor/processor.go
@@ -30,6 +30,7 @@ var (
 	errNoExporters                  = errors.New("no exporters defined for the route")
 	errNoTableItems                 = errors.New("the routing table is empty")
 	errNoMissingFromAttribute       = errors.New("the FromAttribute property is empty")
+	errDefaultExporterNotFound      = errors.New("default exporter not found")
 	errExporterNotFound             = errors.New("exporter not found")
 	errNoExportersAfterRegistration = errors.New("provided configuration resulted in no exporter available to accept data")
 )

--- a/processor/routingprocessor/processor_test.go
+++ b/processor/routingprocessor/processor_test.go
@@ -96,7 +96,7 @@ func TestTraces_ErrorRequestedExporterNotFoundForRoute(t *testing.T) {
 	assert.Truef(t, errors.Is(err, errNoExportersAfterRegistration), "got: %v", err)
 }
 
-func TestTraces_ErrorRequestedExporterNotFoundForDefaultRoute(t *testing.T) {
+func TestTraces_RequestedExporterNotFoundForDefaultRoute(t *testing.T) {
 	//  prepare
 	exp := newProcessor(zap.NewNop(), &Config{
 		DefaultExporters: []string{"non-existing"},
@@ -133,7 +133,7 @@ func TestTraces_ErrorRequestedExporterNotFoundForDefaultRoute(t *testing.T) {
 	err = exp.Start(context.Background(), host)
 
 	// verify
-	assert.True(t, errors.Is(err, errExporterNotFound))
+	assert.True(t, errors.Is(err, errNoExportersAfterRegistration))
 }
 
 func TestTraces_InvalidExporter(t *testing.T) {

--- a/processor/routingprocessor/router.go
+++ b/processor/routingprocessor/router.go
@@ -16,12 +16,12 @@ package routingprocessor // import "github.com/open-telemetry/opentelemetry-coll
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/model/pdata"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -316,13 +316,34 @@ func (r *router) routeLogsForContext(ctx context.Context, tl pdata.Logs) routedL
 // registerExporters registers the exporters as per the configured routing table
 // taking into account the provided map of available exporters.
 func (r *router) registerExporters(hostExporters map[config.DataType]map[config.ComponentID]component.Exporter) error {
-	err := multierr.Combine(
-		r.registerTracesExporters(hostExporters[config.TracesDataType]),
-		r.registerMetricsExporters(hostExporters[config.MetricsDataType]),
-		r.registerLogsExporters(hostExporters[config.LogsDataType]),
-	)
-	if err != nil {
-		return err
+	for _, reg := range []struct {
+		registerFunc func(map[config.ComponentID]component.Exporter) error
+		typ          config.Type
+	}{
+		{
+			r.registerTracesExporters,
+			config.TracesDataType,
+		},
+		{
+			r.registerMetricsExporters,
+			config.MetricsDataType,
+		},
+		{
+			r.registerLogsExporters,
+			config.LogsDataType,
+		},
+	} {
+		if err := reg.registerFunc(hostExporters[reg.typ]); err != nil {
+			if errors.Is(err, errDefaultExporterNotFound) {
+				r.logger.Warn("can't find the default exporter for the routing processor for this pipeline type. This is OK if you did not specify this processor for that pipeline type",
+					zap.Any("pipeline_type", reg.typ),
+					zap.Error(err),
+				)
+			} else {
+				// this seems to be more serious than what expected
+				return err
+			}
+		}
 	}
 
 	if len(r.defaultLogsExporters) == 0 &&
@@ -418,7 +439,7 @@ func (r *router) registerExportersForDefaultRoute(available ExporterMap) error {
 		v, ok := available[exp]
 		if !ok {
 			return fmt.Errorf("error registering default exporter %q: %w",
-				exp, errExporterNotFound,
+				exp, errDefaultExporterNotFound,
 			)
 		}
 


### PR DESCRIPTION
When registering the exporters, it is possible that an error is returned when the default exporter isn't found, which is the case when the processor is specified only for one pipeline type for multiple exists.

Given that we can't check in which pipelines the processor is active, we can't do much more than just ignore a possible configuration error.

Fixes #6920

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>