### PR TITLE
[processor/resourcedetection] fix consul 'meta' field to allow empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ## 🧰 Bug fixes 🧰
 
+- `resourcedetectionprocessor`: fix `meta` allow list excluding keys with nil values (#7424)
+
 ## v0.43.0
 
 ## 💡 Enhancements 💡

--- a/processor/resourcedetectionprocessor/internal/consul/metadata.go
+++ b/processor/resourcedetectionprocessor/internal/consul/metadata.go
@@ -78,7 +78,7 @@ func (d *consulMetadataImpl) Metadata(ctx context.Context) (*consulMetadata, err
 
 	metaMap := make(map[string]string)
 	for k, v := range meta {
-		if d.allowedLabels[k] != nil {
+		if _, ok := d.allowedLabels[k]; ok {
 			metaMap[k] = v.(string)
 		}
 	}

--- a/processor/resourcedetectionprocessor/internal/consul/metadata_test.go
+++ b/processor/resourcedetectionprocessor/internal/consul/metadata_test.go
@@ -48,7 +48,7 @@ func TestConsulHappyPath(t *testing.T) {
 	config.Address = ts.URL
 
 	allowedLabels := map[string]interface{}{
-		"test": "",
+		"test": nil,
 	}
 	client, err := api.NewClient(config)
 	require.NoError(t, err)


### PR DESCRIPTION
**Description:** 
Fixes as bug in the 'meta' key that forces you to have a value for the meta allow list by deriving the allow list of meta keys by checking if the key exists instead of if the key is mapped to a a non-nil value.

the expected configuration for getting the 'deployment_environment' metadata key from consul is:

```yaml
resourcedetection:
  detectors: ["system", "consul"]
  system:
    hostname_sources: ["os"]
  consul:
    meta:
      deployment_environment:
```

; however, a bug in the detector checks if each meta key has a non-nil value forcing the following configuration

```yaml
resourcedetection:
  detectors: ["system", "consul"]
  system:
    hostname_sources: ["os"]
  consul:
    meta:
      deployment_environment: "random_text"
```

**Testing:** 
1. updated the test to use 'nil' for allowedLabels instead of an empty string
2. tested locally using the following configuration
    
    <details>
    <summary>config</summary>
    
    ```yaml
    receivers:
      prometheus:
        config:
          scrape_configs:
            - job_name: "otel-collector"
              scrape_interval: 5s
              static_configs:
                - targets: ["127.0.0.1:8888"]
    processors:
      batch:
    
      resourcedetection:
        detectors: ["system", "consul"]
        system:
          hostname_sources: ["os"]
        consul:
          meta:
            deployment_environment:
    
    exporters:
      logging:
        logLevel: debug
    
    service:
      pipelines:
        # metrics the agent local agent will scrape
        metrics/local_metrics:
          receivers: [prometheus]
          processors: [resourcedetection]
          exporters: [logging]
    ```
    
    </details>