### PR TITLE
[receiver/awsecscontainermetrics] Rename attributes to follow semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `jmxreceiver`: Added `additional_jars` configuration option to launch JMX Metric Gatherer JAR with extended `CLASSPATH` (#7378)
 - `awscontainerinsightreceiver`: add full pod name when configured to AWS Container Insights Receiver (#7415)
 - `hostreceiver/loadscraper`: Migrate the scraper to the mdatagen metrics builder (#7288)
+- `awsecscontainermetricsreceiver`: Rename attributes to follow semantic conventions (#7425)
 ## 🛑 Breaking changes 🛑
 
 ## 🚀 New components 🚀

--- a/receiver/awsecscontainermetricsreceiver/README.md
+++ b/receiver/awsecscontainermetricsreceiver/README.md
@@ -142,7 +142,7 @@ aws.ecs.cluster.name | aws.ecs.cluster.name
 aws.ecs.task.family  | aws.ecs.task.family
 aws.ecs.task.arn     | aws.ecs.task.arn
 aws.ecs.task.id      | aws.ecs.task.id
-aws.ecs.task.version | aws.ecs.task.version
+aws.ecs.task.revision | aws.ecs.task.revision
 aws.ecs.service.name | aws.ecs.service.name
 cloud.availability_zone | cloud.availability_zone
 cloud.account.id | cloud.account.id
@@ -150,7 +150,7 @@ cloud.region | cloud.region
 aws.ecs.task.pull_started_at | aws.ecs.container.started_at
 aws.ecs.task.pull_stopped_at | aws.ecs.container.finished_at
 aws.ecs.task.known_status | aws.ecs.container.know_status
-aws.ecs.task.launch_type | aws.ecs.task.launch_type
+aws.ecs.launch_type | aws.ecs.launch_type
 &nbsp; | aws.ecs.container.created_at
 &nbsp; | container.name
 &nbsp; | container.id

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/constant.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/constant.go
@@ -18,9 +18,7 @@ package awsecscontainermetrics // import "github.com/open-telemetry/opentelemetr
 const (
 	attributeECSDockerName        = "aws.ecs.docker.name"
 	attributeECSCluster           = "aws.ecs.cluster.name"
-	attributeECSTaskARN           = "aws.ecs.task.arn"
 	attributeECSTaskID            = "aws.ecs.task.id"
-	attributeECSTaskFamily        = "aws.ecs.task.family"
 	attributeECSTaskRevision      = "aws.ecs.task.version"
 	attributeECSServiceName       = "aws.ecs.service.name"
 	attributeECSTaskPullStartedAt = "aws.ecs.task.pull_started_at"

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource.go
@@ -55,17 +55,30 @@ func taskResource(tm ecsutil.TaskMetadata) pdata.Resource {
 	resource := pdata.NewResource()
 	region, accountID, taskID := getResourceFromARN(tm.TaskARN)
 	resource.Attributes().UpsertString(attributeECSCluster, getNameFromCluster(tm.Cluster))
-	resource.Attributes().UpsertString(attributeECSTaskARN, tm.TaskARN)
+	resource.Attributes().UpsertString(conventions.AttributeAWSECSTaskARN, tm.TaskARN)
 	resource.Attributes().UpsertString(attributeECSTaskID, taskID)
-	resource.Attributes().UpsertString(attributeECSTaskFamily, tm.Family)
+	resource.Attributes().UpsertString(conventions.AttributeAWSECSTaskFamily, tm.Family)
+
+	// Task revision: aws.ecs.task.version and aws.ecs.task.revision
 	resource.Attributes().UpsertString(attributeECSTaskRevision, tm.Revision)
+	resource.Attributes().UpsertString(conventions.AttributeAWSECSTaskRevision, tm.Revision)
+
 	resource.Attributes().UpsertString(attributeECSServiceName, "undefined")
 
 	resource.Attributes().UpsertString(conventions.AttributeCloudAvailabilityZone, tm.AvailabilityZone)
 	resource.Attributes().UpsertString(attributeECSTaskPullStartedAt, tm.PullStartedAt)
 	resource.Attributes().UpsertString(attributeECSTaskPullStoppedAt, tm.PullStoppedAt)
 	resource.Attributes().UpsertString(attributeECSTaskKnownStatus, tm.KnownStatus)
+
+	// Task launchtype: aws.ecs.task.launch_type (raw string) and aws.ecs.launchtype (lowercase)
 	resource.Attributes().UpsertString(attributeECSTaskLaunchType, tm.LaunchType)
+	switch lt := strings.ToLower(tm.LaunchType); lt {
+	case "ec2":
+		resource.Attributes().UpsertString(conventions.AttributeAWSECSLaunchtype, conventions.AttributeAWSECSLaunchtypeEC2)
+	case "fargate":
+		resource.Attributes().UpsertString(conventions.AttributeAWSECSLaunchtype, conventions.AttributeAWSECSLaunchtypeFargate)
+	}
+
 	resource.Attributes().UpsertString(conventions.AttributeCloudRegion, region)
 	resource.Attributes().UpsertString(conventions.AttributeCloudAccountID, accountID)
 

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource_test.go
@@ -110,18 +110,20 @@ func TestTaskResource(t *testing.T) {
 	require.NotNil(t, r)
 
 	attrMap := r.Attributes()
-	require.EqualValues(t, 13, attrMap.Len())
+	require.EqualValues(t, 15, attrMap.Len())
 	expected := map[string]string{
 		attributeECSCluster:                        "cluster-1",
-		attributeECSTaskARN:                        "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c",
+		conventions.AttributeAWSECSTaskARN:         "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c",
 		attributeECSTaskID:                         "158d1c8083dd49d6b527399fd6414f5c",
-		attributeECSTaskFamily:                     "task-def-family-1",
+		conventions.AttributeAWSECSTaskFamily:      "task-def-family-1",
 		attributeECSTaskRevision:                   "v1.2",
+		conventions.AttributeAWSECSTaskRevision:    "v1.2",
 		conventions.AttributeCloudAvailabilityZone: "us-west-2d",
 		attributeECSTaskPullStartedAt:              "2020-10-02T00:43:06.202617438Z",
 		attributeECSTaskPullStoppedAt:              "2020-10-02T00:43:06.31288465Z",
 		attributeECSTaskKnownStatus:                "RUNNING",
 		attributeECSTaskLaunchType:                 "EC2",
+		conventions.AttributeAWSECSLaunchtype:      conventions.AttributeAWSECSLaunchtypeEC2,
 		conventions.AttributeCloudRegion:           "us-west-2",
 		conventions.AttributeCloudAccountID:        "111122223333",
 	}
@@ -145,19 +147,21 @@ func TestTaskResourceWithClusterARN(t *testing.T) {
 	require.NotNil(t, r)
 
 	attrMap := r.Attributes()
-	require.EqualValues(t, 13, attrMap.Len())
+	require.EqualValues(t, 15, attrMap.Len())
 
 	expected := map[string]string{
 		attributeECSCluster:                        "main-cluster",
-		attributeECSTaskARN:                        "arn:aws:ecs:us-west-2:803860917211:cluster/main-cluster/c8083dd49d6b527399fd6414",
+		conventions.AttributeAWSECSTaskARN:         "arn:aws:ecs:us-west-2:803860917211:cluster/main-cluster/c8083dd49d6b527399fd6414",
 		attributeECSTaskID:                         "c8083dd49d6b527399fd6414",
-		attributeECSTaskFamily:                     "task-def-family-1",
+		conventions.AttributeAWSECSTaskFamily:      "task-def-family-1",
 		attributeECSTaskRevision:                   "v1.2",
+		conventions.AttributeAWSECSTaskRevision:    "v1.2",
 		conventions.AttributeCloudAvailabilityZone: "us-west-2d",
 		attributeECSTaskPullStartedAt:              "2020-10-02T00:43:06.202617438Z",
 		attributeECSTaskPullStoppedAt:              "2020-10-02T00:43:06.31288465Z",
 		attributeECSTaskKnownStatus:                "RUNNING",
 		attributeECSTaskLaunchType:                 "EC2",
+		conventions.AttributeAWSECSLaunchtype:      conventions.AttributeAWSECSLaunchtypeEC2,
 		conventions.AttributeCloudRegion:           "us-west-2",
 		conventions.AttributeCloudAccountID:        "803860917211",
 	}


### PR DESCRIPTION
**Description:** 

Add existing attributes with the semantic conventions names so that they can be picked up by other components.

Old names are kept for backwards compatibility.

**Link to tracking Issue:** relates to #7414

**Testing:** Amended unit tests

**Documentation:** Removed old names and added new names in documentation
