### PR TITLE
pkg/resourcetotelemetry: add resource attributes to remaining metric points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - `resourcedetectionprocessor`: fix `meta` allow list excluding keys with nil values (#7424)
 - `postgresqlreceiver`: Fix issue where empty metrics could be returned after failed connection (#7502)
 - `resourcetotelemetry`: Ensure resource attributes are added to summary
-  data points. (#7523)
+  and exponential histogram data points. (#7523)
 
 ## v0.43.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 - `resourcedetectionprocessor`: fix `meta` allow list excluding keys with nil values (#7424)
 - `postgresqlreceiver`: Fix issue where empty metrics could be returned after failed connection (#7502)
+- `resourcetotelemetry`: Ensure resource attributes are added to summary
+  data points. (#7523)
+
 ## v0.43.0
 
 ## 💡 Enhancements 💡

--- a/internal/coreinternal/testdata/metric.go
+++ b/internal/coreinternal/testdata/metric.go
@@ -32,12 +32,13 @@ var (
 )
 
 const (
-	TestGaugeDoubleMetricName     = "gauge-double"
-	TestGaugeIntMetricName        = "gauge-int"
-	TestSumDoubleMetricName       = "counter-double"
-	TestSumIntMetricName          = "counter-int"
-	TestDoubleHistogramMetricName = "double-histogram"
-	TestDoubleSummaryMetricName   = "double-summary"
+	TestGaugeDoubleMetricName          = "gauge-double"
+	TestGaugeIntMetricName             = "gauge-int"
+	TestSumDoubleMetricName            = "counter-double"
+	TestSumIntMetricName               = "counter-int"
+	TestDoubleHistogramMetricName      = "double-histogram"
+	TestDoubleSummaryMetricName        = "double-summary"
+	TestExponentialHistogramMetricName = "exponential-histogram"
 )
 
 func GenerateMetricsOneEmptyResourceMetrics() pdata.Metrics {
@@ -134,6 +135,9 @@ func GenerateMetricsAllTypesEmptyDataPoint() pdata.Metrics {
 	summary := ms.AppendEmpty()
 	initMetric(summary, TestDoubleSummaryMetricName, pdata.MetricDataTypeSummary)
 	summary.Summary().DataPoints().AppendEmpty()
+	exphist := ms.AppendEmpty()
+	initMetric(exphist, TestExponentialHistogramMetricName, pdata.MetricDataTypeExponentialHistogram)
+	exphist.ExponentialHistogram().DataPoints().AppendEmpty()
 	return md
 }
 

--- a/pkg/resourcetotelemetry/resource_to_telemetry.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry.go
@@ -83,6 +83,8 @@ func addAttributesToMetric(metric *pdata.Metric, labelMap pdata.AttributeMap) {
 		addAttributesToNumberDataPoints(metric.Sum().DataPoints(), labelMap)
 	case pdata.MetricDataTypeHistogram:
 		addAttributesToHistogramDataPoints(metric.Histogram().DataPoints(), labelMap)
+	case pdata.MetricDataTypeSummary:
+		addAttributesToSummaryDataPoints(metric.Summary().DataPoints(), labelMap)
 	}
 }
 
@@ -93,6 +95,12 @@ func addAttributesToNumberDataPoints(ps pdata.NumberDataPointSlice, newAttribute
 }
 
 func addAttributesToHistogramDataPoints(ps pdata.HistogramDataPointSlice, newAttributeMap pdata.AttributeMap) {
+	for i := 0; i < ps.Len(); i++ {
+		joinAttributeMaps(newAttributeMap, ps.At(i).Attributes())
+	}
+}
+
+func addAttributesToSummaryDataPoints(ps pdata.SummaryDataPointSlice, newAttributeMap pdata.AttributeMap) {
 	for i := 0; i < ps.Len(); i++ {
 		joinAttributeMaps(newAttributeMap, ps.At(i).Attributes())
 	}

--- a/pkg/resourcetotelemetry/resource_to_telemetry.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry.go
@@ -85,6 +85,8 @@ func addAttributesToMetric(metric *pdata.Metric, labelMap pdata.AttributeMap) {
 		addAttributesToHistogramDataPoints(metric.Histogram().DataPoints(), labelMap)
 	case pdata.MetricDataTypeSummary:
 		addAttributesToSummaryDataPoints(metric.Summary().DataPoints(), labelMap)
+	case pdata.MetricDataTypeExponentialHistogram:
+		addAttributesToExponentialHistogramDataPoints(metric.ExponentialHistogram().DataPoints(), labelMap)
 	}
 }
 
@@ -101,6 +103,12 @@ func addAttributesToHistogramDataPoints(ps pdata.HistogramDataPointSlice, newAtt
 }
 
 func addAttributesToSummaryDataPoints(ps pdata.SummaryDataPointSlice, newAttributeMap pdata.AttributeMap) {
+	for i := 0; i < ps.Len(); i++ {
+		joinAttributeMaps(newAttributeMap, ps.At(i).Attributes())
+	}
+}
+
+func addAttributesToExponentialHistogramDataPoints(ps pdata.ExponentialHistogramDataPointSlice, newAttributeMap pdata.AttributeMap) {
 	for i := 0; i < ps.Len(); i++ {
 		joinAttributeMaps(newAttributeMap, ps.At(i).Attributes())
 	}

--- a/pkg/resourcetotelemetry/resource_to_telemetry_test.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry_test.go
@@ -61,6 +61,7 @@ func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(2).Sum().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).Sum().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
 
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Attributes().Len())
@@ -68,5 +69,6 @@ func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(2).Sum().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).Sum().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
 
 }

--- a/pkg/resourcetotelemetry/resource_to_telemetry_test.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry_test.go
@@ -51,6 +51,8 @@ func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(2).Sum().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).Sum().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
 
 	cloneMd := convertToMetricsAttributes(md)
 
@@ -62,6 +64,7 @@ func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).Sum().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
 
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Attributes().Len())
@@ -70,5 +73,6 @@ func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(3).Sum().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
 
 }


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>