### PR TITLE
CI: Change linux distro used in RPM build test

### DIFF
--- a/internal/buildscripts/packaging/fpm/rpm/Dockerfile.test
+++ b/internal/buildscripts/packaging/fpm/rpm/Dockerfile.test
@@ -1,6 +1,6 @@
-# A centos8 image with systemd enabled.  Must be run with:
+# A rockylinux8.5 image with systemd enabled.  Must be run with:
 # `-d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro` flags
-FROM centos:8
+FROM rockylinux:8.5
 
 ENV container docker
 


### PR DESCRIPTION
CI Check `build-and-test / build-package (rpm)` is consistently failing due to `centos 8` now being EOL. This is a just a quick test to see if rockylinux can be substituted in place.