### PR TITLE
Increase memory limit for zipkin testbed test

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -118,7 +118,7 @@ func TestTrace10kSPS(t *testing.T) {
 			datareceivers.NewZipkinDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 80,
-				ExpectedMaxRAM: 100,
+				ExpectedMaxRAM: 120,
 			},
 		},
 	}


### PR DESCRIPTION
Resolves #7251 

The zipkin receiver & exporter do not have codeowners. In the absence of a better solution, I propose we raise the memory tolerance on this test so as not to cause frequent CI failures.