### PR TITLE
[exporter/datadog] Fix README docs for traces config

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -34,8 +34,8 @@ datadog:
 datadog:
   api:
     key: "<API key>"
-    traces:
-      span_name_as_resource_name: true
+  traces:
+    span_name_as_resource_name: true
 ```
 
 The hostname, environment, service and version can be set in the configuration for unified service tagging.


### PR DESCRIPTION
**Documentation:**

The new `span_name_as_resource_name` option goes in the `traces` section nested directly below `datadog` not under `datadog/api`

**Discussion:**

We've observed that the config option doesn't quite work as we were hoping. And we're not really sure how to use it in a way that's useful. _edit: sorry this is super vague, I'll work on getting some screenshots!_