### PR TITLE
[processor/resourcedetection] Update `os.type` attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ## 🛑 Breaking changes 🛑
 
+- `resourcedetectionprocessor`: Update `os.type` attribute values according to semantic conventions (#7544)
+
 ## 🚀 New components 🚀
 
 ## 🧰 Bug fixes 🧰

--- a/exporter/datadogexporter/internal/attributes/attributes_test.go
+++ b/exporter/datadogexporter/internal/attributes/attributes_test.go
@@ -31,7 +31,7 @@ func TestTagsFromAttributes(t *testing.T) {
 		conventions.AttributeProcessCommandLine:    pdata.NewAttributeValueString("cmd/otelcol --config=\"/path/to/config.yaml\""),
 		conventions.AttributeProcessPID:            pdata.NewAttributeValueInt(1),
 		conventions.AttributeProcessOwner:          pdata.NewAttributeValueString("root"),
-		conventions.AttributeOSType:                pdata.NewAttributeValueString("LINUX"),
+		conventions.AttributeOSType:                pdata.NewAttributeValueString("linux"),
 		conventions.AttributeK8SDaemonSetName:      pdata.NewAttributeValueString("daemon_set_name"),
 		conventions.AttributeAWSECSClusterARN:      pdata.NewAttributeValueString("cluster_arn"),
 		"tags.datadoghq.com/service":               pdata.NewAttributeValueString("service_name"),
@@ -40,7 +40,7 @@ func TestTagsFromAttributes(t *testing.T) {
 
 	assert.ElementsMatch(t, []string{
 		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, "otelcol"),
-		fmt.Sprintf("%s:%s", conventions.AttributeOSType, "LINUX"),
+		fmt.Sprintf("%s:%s", conventions.AttributeOSType, "linux"),
 		fmt.Sprintf("%s:%s", "kube_daemon_set", "daemon_set_name"),
 		fmt.Sprintf("%s:%s", "ecs_cluster_name", "cluster_arn"),
 		fmt.Sprintf("%s:%s", "service", "service_name"),

--- a/exporter/datadogexporter/internal/attributes/system_test.go
+++ b/exporter/datadogexporter/internal/attributes/system_test.go
@@ -24,11 +24,11 @@ import (
 
 func TestSystemExtractTags(t *testing.T) {
 	sattrs := systemAttributes{
-		OSType: "WINDOWS",
+		OSType: "windows",
 	}
 
 	assert.Equal(t, []string{
-		fmt.Sprintf("%s:%s", conventions.AttributeOSType, "WINDOWS"),
+		fmt.Sprintf("%s:%s", conventions.AttributeOSType, "windows"),
 	}, sattrs.extractTags())
 }
 

--- a/internal/coreinternal/goldendataset/resource_generator.go
+++ b/internal/coreinternal/goldendataset/resource_generator.go
@@ -125,7 +125,7 @@ func appendExecAttributes(attrMap pdata.AttributeMap) {
 	attrMap.UpsertString(conventions.AttributeProcessExecutablePath, "/usr/local/bin/otelcol")
 	attrMap.UpsertInt(conventions.AttributeProcessPID, 2020)
 	attrMap.UpsertString(conventions.AttributeProcessOwner, "otel")
-	attrMap.UpsertString(conventions.AttributeOSType, "LINUX")
+	attrMap.UpsertString(conventions.AttributeOSType, "linux")
 	attrMap.UpsertString(conventions.AttributeOSDescription,
 		"Linux ubuntu 5.4.0-42-generic #46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux")
 }

--- a/processor/resourcedetectionprocessor/internal/docker/docker_test.go
+++ b/processor/resourcedetectionprocessor/internal/docker/docker_test.go
@@ -44,7 +44,7 @@ func (m *mockMetadata) OSType(context.Context) (string, error) {
 func TestDetect(t *testing.T) {
 	md := &mockMetadata{}
 	md.On("Hostname").Return("hostname", nil)
-	md.On("OSType").Return("DARWIN", nil)
+	md.On("OSType").Return("darwin", nil)
 
 	detector := &Detector{provider: md, logger: zap.NewNop()}
 	res, schemaURL, err := detector.Detect(context.Background())
@@ -55,7 +55,7 @@ func TestDetect(t *testing.T) {
 
 	expected := internal.NewResource(map[string]interface{}{
 		conventions.AttributeHostName: "hostname",
-		conventions.AttributeOSType:   "DARWIN",
+		conventions.AttributeOSType:   "darwin",
 	})
 	expected.Attributes().Sort()
 

--- a/processor/resourcedetectionprocessor/internal/docker/metadata_test.go
+++ b/processor/resourcedetectionprocessor/internal/docker/metadata_test.go
@@ -49,5 +49,5 @@ func TestDocker(t *testing.T) {
 
 	osType, err := provider.OSType(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, "LINUX", osType)
+	assert.Equal(t, "linux", osType)
 }

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -19,7 +19,6 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -218,7 +217,9 @@ func IsEmptyResource(res pdata.Resource) bool {
 func GOOSToOSType(goos string) string {
 	switch goos {
 	case "dragonfly":
-		return "DRAGONFLYBSD"
+		return "dragonflybsd"
+	case "zos":
+		return "z_os"
 	}
-	return strings.ToUpper(goos)
+	return goos
 }

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -269,8 +269,9 @@ func TestAttributesToMap(t *testing.T) {
 }
 
 func TestGOOSToOsType(t *testing.T) {
-	assert.Equal(t, "DARWIN", GOOSToOSType("darwin"))
-	assert.Equal(t, "LINUX", GOOSToOSType("linux"))
-	assert.Equal(t, "WINDOWS", GOOSToOSType("windows"))
-	assert.Equal(t, "DRAGONFLYBSD", GOOSToOSType("dragonfly"))
+	assert.Equal(t, "darwin", GOOSToOSType("darwin"))
+	assert.Equal(t, "linux", GOOSToOSType("linux"))
+	assert.Equal(t, "windows", GOOSToOSType("windows"))
+	assert.Equal(t, "dragonflybsd", GOOSToOSType("dragonfly"))
+	assert.Equal(t, "z_os", GOOSToOSType("zos"))
 }

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -78,7 +78,7 @@ func TestNewDetector(t *testing.T) {
 func TestDetectFQDNAvailable(t *testing.T) {
 	md := &mockMetadata{}
 	md.On("FQDN").Return("fqdn", nil)
-	md.On("OSType").Return("DARWIN", nil)
+	md.On("OSType").Return("darwin", nil)
 
 	detector := &Detector{provider: md, logger: zap.NewNop(), hostnameSources: []string{"dns"}}
 	res, schemaURL, err := detector.Detect(context.Background())
@@ -89,7 +89,7 @@ func TestDetectFQDNAvailable(t *testing.T) {
 
 	expected := internal.NewResource(map[string]interface{}{
 		conventions.AttributeHostName: "fqdn",
-		conventions.AttributeOSType:   "DARWIN",
+		conventions.AttributeOSType:   "darwin",
 	})
 	expected.Attributes().Sort()
 
@@ -101,7 +101,7 @@ func TestFallbackHostname(t *testing.T) {
 	mdHostname := &mockMetadata{}
 	mdHostname.On("Hostname").Return("hostname", nil)
 	mdHostname.On("FQDN").Return("", errors.New("err"))
-	mdHostname.On("OSType").Return("DARWIN", nil)
+	mdHostname.On("OSType").Return("darwin", nil)
 
 	detector := &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"dns", "os"}}
 	res, schemaURL, err := detector.Detect(context.Background())
@@ -112,7 +112,7 @@ func TestFallbackHostname(t *testing.T) {
 
 	expected := internal.NewResource(map[string]interface{}{
 		conventions.AttributeHostName: "hostname",
-		conventions.AttributeOSType:   "DARWIN",
+		conventions.AttributeOSType:   "darwin",
 	})
 	expected.Attributes().Sort()
 
@@ -122,7 +122,7 @@ func TestFallbackHostname(t *testing.T) {
 func TestUseHostname(t *testing.T) {
 	mdHostname := &mockMetadata{}
 	mdHostname.On("Hostname").Return("hostname", nil)
-	mdHostname.On("OSType").Return("DARWIN", nil)
+	mdHostname.On("OSType").Return("darwin", nil)
 
 	detector := &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"os"}}
 	res, schemaURL, err := detector.Detect(context.Background())
@@ -133,7 +133,7 @@ func TestUseHostname(t *testing.T) {
 
 	expected := internal.NewResource(map[string]interface{}{
 		conventions.AttributeHostName: "hostname",
-		conventions.AttributeOSType:   "DARWIN",
+		conventions.AttributeOSType:   "darwin",
 	})
 	expected.Attributes().Sort()
 
@@ -143,7 +143,7 @@ func TestUseHostname(t *testing.T) {
 func TestDetectError(t *testing.T) {
 	// FQDN and hostname fail with 'hostnameSources' set to 'dns'
 	mdFQDN := &mockMetadata{}
-	mdFQDN.On("OSType").Return("WINDOWS", nil)
+	mdFQDN.On("OSType").Return("windows", nil)
 	mdFQDN.On("FQDN").Return("", errors.New("err"))
 	mdFQDN.On("Hostname").Return("", errors.New("err"))
 
@@ -155,7 +155,7 @@ func TestDetectError(t *testing.T) {
 
 	// hostname fail with 'hostnameSources' set to 'os'
 	mdHostname := &mockMetadata{}
-	mdHostname.On("OSType").Return("WINDOWS", nil)
+	mdHostname.On("OSType").Return("windows", nil)
 	mdHostname.On("Hostname").Return("", errors.New("err"))
 
 	detector = &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"os"}}


### PR DESCRIPTION
Update the attribute values according to [the semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/os.md). The update is to make them lowercase for most of the options.

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7522