### PR TITLE
[receiver/ elasticsearch | postgresql | rabbitmq] Minor refactoring of scraper naming convention

### DIFF
--- a/receiver/elasticsearchreceiver/scraper.go
+++ b/receiver/elasticsearchreceiver/scraper.go
@@ -32,10 +32,10 @@ const instrumentationLibraryName = "otelcol/elasticsearch"
 var errUnknownClusterStatus = errors.New("unknown cluster status")
 
 type elasticsearchScraper struct {
-	client         elasticsearchClient
-	settings       component.TelemetrySettings
-	cfg            *Config
-	metricsBuilder *metadata.MetricsBuilder
+	client   elasticsearchClient
+	settings component.TelemetrySettings
+	cfg      *Config
+	mb       *metadata.MetricsBuilder
 }
 
 func newElasticSearchScraper(
@@ -43,9 +43,9 @@ func newElasticSearchScraper(
 	cfg *Config,
 ) *elasticsearchScraper {
 	return &elasticsearchScraper{
-		settings:       settings,
-		cfg:            cfg,
-		metricsBuilder: metadata.NewMetricsBuilder(cfg.Metrics),
+		settings: settings,
+		cfg:      cfg,
+		mb:       metadata.NewMetricsBuilder(cfg.Metrics),
 	}
 }
 
@@ -89,88 +89,88 @@ func (r *elasticsearchScraper) scrapeNodeMetrics(ctx context.Context, now pdata.
 		ilms := rm.InstrumentationLibraryMetrics().AppendEmpty()
 		ilms.InstrumentationLibrary().SetName(instrumentationLibraryName)
 
-		r.metricsBuilder.RecordElasticsearchNodeCacheMemoryUsageDataPoint(now, info.Indices.FieldDataCache.MemorySizeInBy, metadata.AttributeCacheName.Fielddata)
-		r.metricsBuilder.RecordElasticsearchNodeCacheMemoryUsageDataPoint(now, info.Indices.QueryCache.MemorySizeInBy, metadata.AttributeCacheName.Query)
+		r.mb.RecordElasticsearchNodeCacheMemoryUsageDataPoint(now, info.Indices.FieldDataCache.MemorySizeInBy, metadata.AttributeCacheName.Fielddata)
+		r.mb.RecordElasticsearchNodeCacheMemoryUsageDataPoint(now, info.Indices.QueryCache.MemorySizeInBy, metadata.AttributeCacheName.Query)
 
-		r.metricsBuilder.RecordElasticsearchNodeCacheEvictionsDataPoint(now, info.Indices.FieldDataCache.Evictions, metadata.AttributeCacheName.Fielddata)
-		r.metricsBuilder.RecordElasticsearchNodeCacheEvictionsDataPoint(now, info.Indices.QueryCache.Evictions, metadata.AttributeCacheName.Query)
+		r.mb.RecordElasticsearchNodeCacheEvictionsDataPoint(now, info.Indices.FieldDataCache.Evictions, metadata.AttributeCacheName.Fielddata)
+		r.mb.RecordElasticsearchNodeCacheEvictionsDataPoint(now, info.Indices.QueryCache.Evictions, metadata.AttributeCacheName.Query)
 
-		r.metricsBuilder.RecordElasticsearchNodeFsDiskAvailableDataPoint(now, info.FS.Total.AvailableBytes)
+		r.mb.RecordElasticsearchNodeFsDiskAvailableDataPoint(now, info.FS.Total.AvailableBytes)
 
-		r.metricsBuilder.RecordElasticsearchNodeClusterIoDataPoint(now, info.TransportStats.ReceivedBytes, metadata.AttributeDirection.Received)
-		r.metricsBuilder.RecordElasticsearchNodeClusterIoDataPoint(now, info.TransportStats.SentBytes, metadata.AttributeDirection.Sent)
+		r.mb.RecordElasticsearchNodeClusterIoDataPoint(now, info.TransportStats.ReceivedBytes, metadata.AttributeDirection.Received)
+		r.mb.RecordElasticsearchNodeClusterIoDataPoint(now, info.TransportStats.SentBytes, metadata.AttributeDirection.Sent)
 
-		r.metricsBuilder.RecordElasticsearchNodeClusterConnectionsDataPoint(now, info.TransportStats.OpenConnections)
+		r.mb.RecordElasticsearchNodeClusterConnectionsDataPoint(now, info.TransportStats.OpenConnections)
 
-		r.metricsBuilder.RecordElasticsearchNodeHTTPConnectionsDataPoint(now, info.HTTPStats.OpenConnections)
+		r.mb.RecordElasticsearchNodeHTTPConnectionsDataPoint(now, info.HTTPStats.OpenConnections)
 
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.IndexingOperations.IndexTotal, metadata.AttributeOperation.Index)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.IndexingOperations.DeleteTotal, metadata.AttributeOperation.Delete)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.GetOperation.Total, metadata.AttributeOperation.Get)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.SearchOperations.QueryTotal, metadata.AttributeOperation.Query)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.SearchOperations.FetchTotal, metadata.AttributeOperation.Fetch)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.SearchOperations.ScrollTotal, metadata.AttributeOperation.Scroll)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.SearchOperations.SuggestTotal, metadata.AttributeOperation.Suggest)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.MergeOperations.Total, metadata.AttributeOperation.Merge)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.RefreshOperations.Total, metadata.AttributeOperation.Refresh)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.FlushOperations.Total, metadata.AttributeOperation.Flush)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.WarmerOperations.Total, metadata.AttributeOperation.Warmer)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.IndexingOperations.IndexTotal, metadata.AttributeOperation.Index)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.IndexingOperations.DeleteTotal, metadata.AttributeOperation.Delete)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.GetOperation.Total, metadata.AttributeOperation.Get)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.SearchOperations.QueryTotal, metadata.AttributeOperation.Query)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.SearchOperations.FetchTotal, metadata.AttributeOperation.Fetch)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.SearchOperations.ScrollTotal, metadata.AttributeOperation.Scroll)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.SearchOperations.SuggestTotal, metadata.AttributeOperation.Suggest)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.MergeOperations.Total, metadata.AttributeOperation.Merge)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.RefreshOperations.Total, metadata.AttributeOperation.Refresh)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.FlushOperations.Total, metadata.AttributeOperation.Flush)
+		r.mb.RecordElasticsearchNodeOperationsCompletedDataPoint(now, info.Indices.WarmerOperations.Total, metadata.AttributeOperation.Warmer)
 
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.IndexingOperations.IndexTimeInMs, metadata.AttributeOperation.Index)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.IndexingOperations.DeleteTimeInMs, metadata.AttributeOperation.Delete)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.GetOperation.TotalTimeInMs, metadata.AttributeOperation.Get)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.SearchOperations.QueryTimeInMs, metadata.AttributeOperation.Query)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.SearchOperations.FetchTimeInMs, metadata.AttributeOperation.Fetch)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.SearchOperations.ScrollTimeInMs, metadata.AttributeOperation.Scroll)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.SearchOperations.SuggestTimeInMs, metadata.AttributeOperation.Suggest)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.MergeOperations.TotalTimeInMs, metadata.AttributeOperation.Merge)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.RefreshOperations.TotalTimeInMs, metadata.AttributeOperation.Refresh)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.FlushOperations.TotalTimeInMs, metadata.AttributeOperation.Flush)
-		r.metricsBuilder.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.WarmerOperations.TotalTimeInMs, metadata.AttributeOperation.Warmer)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.IndexingOperations.IndexTimeInMs, metadata.AttributeOperation.Index)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.IndexingOperations.DeleteTimeInMs, metadata.AttributeOperation.Delete)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.GetOperation.TotalTimeInMs, metadata.AttributeOperation.Get)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.SearchOperations.QueryTimeInMs, metadata.AttributeOperation.Query)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.SearchOperations.FetchTimeInMs, metadata.AttributeOperation.Fetch)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.SearchOperations.ScrollTimeInMs, metadata.AttributeOperation.Scroll)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.SearchOperations.SuggestTimeInMs, metadata.AttributeOperation.Suggest)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.MergeOperations.TotalTimeInMs, metadata.AttributeOperation.Merge)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.RefreshOperations.TotalTimeInMs, metadata.AttributeOperation.Refresh)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.FlushOperations.TotalTimeInMs, metadata.AttributeOperation.Flush)
+		r.mb.RecordElasticsearchNodeOperationsTimeDataPoint(now, info.Indices.WarmerOperations.TotalTimeInMs, metadata.AttributeOperation.Warmer)
 
-		r.metricsBuilder.RecordElasticsearchNodeShardsSizeDataPoint(now, info.Indices.StoreInfo.SizeInBy)
+		r.mb.RecordElasticsearchNodeShardsSizeDataPoint(now, info.Indices.StoreInfo.SizeInBy)
 
 		for tpName, tpInfo := range info.ThreadPoolInfo {
-			r.metricsBuilder.RecordElasticsearchNodeThreadPoolThreadsDataPoint(now, tpInfo.ActiveThreads, tpName, metadata.AttributeThreadState.Active)
-			r.metricsBuilder.RecordElasticsearchNodeThreadPoolThreadsDataPoint(now, tpInfo.TotalThreads-tpInfo.ActiveThreads, tpName, metadata.AttributeThreadState.Idle)
+			r.mb.RecordElasticsearchNodeThreadPoolThreadsDataPoint(now, tpInfo.ActiveThreads, tpName, metadata.AttributeThreadState.Active)
+			r.mb.RecordElasticsearchNodeThreadPoolThreadsDataPoint(now, tpInfo.TotalThreads-tpInfo.ActiveThreads, tpName, metadata.AttributeThreadState.Idle)
 
-			r.metricsBuilder.RecordElasticsearchNodeThreadPoolTasksQueuedDataPoint(now, tpInfo.QueuedTasks, tpName)
+			r.mb.RecordElasticsearchNodeThreadPoolTasksQueuedDataPoint(now, tpInfo.QueuedTasks, tpName)
 
-			r.metricsBuilder.RecordElasticsearchNodeThreadPoolTasksFinishedDataPoint(now, tpInfo.CompletedTasks, tpName, metadata.AttributeTaskState.Completed)
-			r.metricsBuilder.RecordElasticsearchNodeThreadPoolTasksFinishedDataPoint(now, tpInfo.RejectedTasks, tpName, metadata.AttributeTaskState.Rejected)
+			r.mb.RecordElasticsearchNodeThreadPoolTasksFinishedDataPoint(now, tpInfo.CompletedTasks, tpName, metadata.AttributeTaskState.Completed)
+			r.mb.RecordElasticsearchNodeThreadPoolTasksFinishedDataPoint(now, tpInfo.RejectedTasks, tpName, metadata.AttributeTaskState.Rejected)
 		}
 
-		r.metricsBuilder.RecordElasticsearchNodeDocumentsDataPoint(now, info.Indices.DocumentStats.ActiveCount, metadata.AttributeDocumentState.Active)
-		r.metricsBuilder.RecordElasticsearchNodeDocumentsDataPoint(now, info.Indices.DocumentStats.DeletedCount, metadata.AttributeDocumentState.Deleted)
+		r.mb.RecordElasticsearchNodeDocumentsDataPoint(now, info.Indices.DocumentStats.ActiveCount, metadata.AttributeDocumentState.Active)
+		r.mb.RecordElasticsearchNodeDocumentsDataPoint(now, info.Indices.DocumentStats.DeletedCount, metadata.AttributeDocumentState.Deleted)
 
-		r.metricsBuilder.RecordElasticsearchNodeOpenFilesDataPoint(now, info.ProcessStats.OpenFileDescriptorsCount)
+		r.mb.RecordElasticsearchNodeOpenFilesDataPoint(now, info.ProcessStats.OpenFileDescriptorsCount)
 
-		r.metricsBuilder.RecordJvmClassesLoadedDataPoint(now, info.JVMInfo.ClassInfo.CurrentLoadedCount)
+		r.mb.RecordJvmClassesLoadedDataPoint(now, info.JVMInfo.ClassInfo.CurrentLoadedCount)
 
-		r.metricsBuilder.RecordJvmGcCollectionsCountDataPoint(now, info.JVMInfo.JVMGCInfo.Collectors.Young.CollectionCount, "young")
-		r.metricsBuilder.RecordJvmGcCollectionsCountDataPoint(now, info.JVMInfo.JVMGCInfo.Collectors.Old.CollectionCount, "old")
+		r.mb.RecordJvmGcCollectionsCountDataPoint(now, info.JVMInfo.JVMGCInfo.Collectors.Young.CollectionCount, "young")
+		r.mb.RecordJvmGcCollectionsCountDataPoint(now, info.JVMInfo.JVMGCInfo.Collectors.Old.CollectionCount, "old")
 
-		r.metricsBuilder.RecordJvmGcCollectionsElapsedDataPoint(now, info.JVMInfo.JVMGCInfo.Collectors.Young.CollectionTimeInMillis, "young")
-		r.metricsBuilder.RecordJvmGcCollectionsElapsedDataPoint(now, info.JVMInfo.JVMGCInfo.Collectors.Old.CollectionTimeInMillis, "old")
+		r.mb.RecordJvmGcCollectionsElapsedDataPoint(now, info.JVMInfo.JVMGCInfo.Collectors.Young.CollectionTimeInMillis, "young")
+		r.mb.RecordJvmGcCollectionsElapsedDataPoint(now, info.JVMInfo.JVMGCInfo.Collectors.Old.CollectionTimeInMillis, "old")
 
-		r.metricsBuilder.RecordJvmMemoryHeapMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MaxHeapInBy)
-		r.metricsBuilder.RecordJvmMemoryHeapUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapUsedInBy)
-		r.metricsBuilder.RecordJvmMemoryHeapCommittedDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapCommittedInBy)
+		r.mb.RecordJvmMemoryHeapMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MaxHeapInBy)
+		r.mb.RecordJvmMemoryHeapUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapUsedInBy)
+		r.mb.RecordJvmMemoryHeapCommittedDataPoint(now, info.JVMInfo.JVMMemoryInfo.HeapCommittedInBy)
 
-		r.metricsBuilder.RecordJvmMemoryNonheapUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.NonHeapUsedInBy)
-		r.metricsBuilder.RecordJvmMemoryNonheapCommittedDataPoint(now, info.JVMInfo.JVMMemoryInfo.NonHeapComittedInBy)
+		r.mb.RecordJvmMemoryNonheapUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.NonHeapUsedInBy)
+		r.mb.RecordJvmMemoryNonheapCommittedDataPoint(now, info.JVMInfo.JVMMemoryInfo.NonHeapComittedInBy)
 
-		r.metricsBuilder.RecordJvmMemoryPoolUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Young.MemUsedBy, "young")
-		r.metricsBuilder.RecordJvmMemoryPoolUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Survivor.MemUsedBy, "survivor")
-		r.metricsBuilder.RecordJvmMemoryPoolUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Old.MemUsedBy, "old")
+		r.mb.RecordJvmMemoryPoolUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Young.MemUsedBy, "young")
+		r.mb.RecordJvmMemoryPoolUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Survivor.MemUsedBy, "survivor")
+		r.mb.RecordJvmMemoryPoolUsedDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Old.MemUsedBy, "old")
 
-		r.metricsBuilder.RecordJvmMemoryPoolMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Young.MemMaxBy, "young")
-		r.metricsBuilder.RecordJvmMemoryPoolMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Survivor.MemMaxBy, "survivor")
-		r.metricsBuilder.RecordJvmMemoryPoolMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Old.MemMaxBy, "old")
+		r.mb.RecordJvmMemoryPoolMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Young.MemMaxBy, "young")
+		r.mb.RecordJvmMemoryPoolMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Survivor.MemMaxBy, "survivor")
+		r.mb.RecordJvmMemoryPoolMaxDataPoint(now, info.JVMInfo.JVMMemoryInfo.MemoryPools.Old.MemMaxBy, "old")
 
-		r.metricsBuilder.RecordJvmThreadsCountDataPoint(now, info.JVMInfo.JVMThreadInfo.Count)
+		r.mb.RecordJvmThreadsCountDataPoint(now, info.JVMInfo.JVMThreadInfo.Count)
 
-		r.metricsBuilder.EmitNodeMetrics(ilms.Metrics())
+		r.mb.EmitNodeMetrics(ilms.Metrics())
 	}
 }
 
@@ -192,31 +192,31 @@ func (r *elasticsearchScraper) scrapeClusterMetrics(ctx context.Context, now pda
 	ilms := rm.InstrumentationLibraryMetrics().AppendEmpty()
 	ilms.InstrumentationLibrary().SetName(instrumentationLibraryName)
 
-	r.metricsBuilder.RecordElasticsearchClusterNodesDataPoint(now, clusterHealth.NodeCount)
+	r.mb.RecordElasticsearchClusterNodesDataPoint(now, clusterHealth.NodeCount)
 
-	r.metricsBuilder.RecordElasticsearchClusterDataNodesDataPoint(now, clusterHealth.DataNodeCount)
+	r.mb.RecordElasticsearchClusterDataNodesDataPoint(now, clusterHealth.DataNodeCount)
 
-	r.metricsBuilder.RecordElasticsearchClusterShardsDataPoint(now, clusterHealth.ActiveShards, metadata.AttributeShardState.Active)
-	r.metricsBuilder.RecordElasticsearchClusterShardsDataPoint(now, clusterHealth.InitializingShards, metadata.AttributeShardState.Initializing)
-	r.metricsBuilder.RecordElasticsearchClusterShardsDataPoint(now, clusterHealth.RelocatingShards, metadata.AttributeShardState.Relocating)
-	r.metricsBuilder.RecordElasticsearchClusterShardsDataPoint(now, clusterHealth.UnassignedShards, metadata.AttributeShardState.Unassigned)
+	r.mb.RecordElasticsearchClusterShardsDataPoint(now, clusterHealth.ActiveShards, metadata.AttributeShardState.Active)
+	r.mb.RecordElasticsearchClusterShardsDataPoint(now, clusterHealth.InitializingShards, metadata.AttributeShardState.Initializing)
+	r.mb.RecordElasticsearchClusterShardsDataPoint(now, clusterHealth.RelocatingShards, metadata.AttributeShardState.Relocating)
+	r.mb.RecordElasticsearchClusterShardsDataPoint(now, clusterHealth.UnassignedShards, metadata.AttributeShardState.Unassigned)
 
 	switch clusterHealth.Status {
 	case "green":
-		r.metricsBuilder.RecordElasticsearchClusterHealthDataPoint(now, 1, metadata.AttributeHealthStatus.Green)
-		r.metricsBuilder.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Yellow)
-		r.metricsBuilder.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Red)
+		r.mb.RecordElasticsearchClusterHealthDataPoint(now, 1, metadata.AttributeHealthStatus.Green)
+		r.mb.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Yellow)
+		r.mb.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Red)
 	case "yellow":
-		r.metricsBuilder.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Green)
-		r.metricsBuilder.RecordElasticsearchClusterHealthDataPoint(now, 1, metadata.AttributeHealthStatus.Yellow)
-		r.metricsBuilder.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Red)
+		r.mb.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Green)
+		r.mb.RecordElasticsearchClusterHealthDataPoint(now, 1, metadata.AttributeHealthStatus.Yellow)
+		r.mb.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Red)
 	case "red":
-		r.metricsBuilder.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Green)
-		r.metricsBuilder.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Yellow)
-		r.metricsBuilder.RecordElasticsearchClusterHealthDataPoint(now, 1, metadata.AttributeHealthStatus.Red)
+		r.mb.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Green)
+		r.mb.RecordElasticsearchClusterHealthDataPoint(now, 0, metadata.AttributeHealthStatus.Yellow)
+		r.mb.RecordElasticsearchClusterHealthDataPoint(now, 1, metadata.AttributeHealthStatus.Red)
 	default:
 		errs.AddPartial(1, fmt.Errorf("health status %s: %w", clusterHealth.Status, errUnknownClusterStatus))
 	}
 
-	r.metricsBuilder.EmitClusterMetrics(ilms.Metrics())
+	r.mb.EmitClusterMetrics(ilms.Metrics())
 }

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -44,7 +44,7 @@ type testCase struct {
 
 func TestPostgreSQLIntegration(t *testing.T) {
 	testCases := []testCase{
-		testCase{
+		{
 			name: "single_db",
 			cfg: func(hostname string) *Config {
 				f := NewFactory()
@@ -58,7 +58,7 @@ func TestPostgreSQLIntegration(t *testing.T) {
 			},
 			expectedFile: filepath.Join("testdata", "integration", "expected_single_db.json"),
 		},
-		testCase{
+		{
 			name: "multi_db",
 			cfg: func(hostname string) *Config {
 				f := NewFactory()
@@ -72,7 +72,7 @@ func TestPostgreSQLIntegration(t *testing.T) {
 			},
 			expectedFile: filepath.Join("testdata", "integration", "expected_multi_db.json"),
 		},
-		testCase{
+		{
 			name: "all_db",
 			cfg: func(hostname string) *Config {
 				f := NewFactory()

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -30,7 +30,7 @@ type postgreSQLScraper struct {
 	logger         *zap.Logger
 	config         *Config
 	clientFactory  postgreSQLClientFactory
-	metricsBuilder *metadata.MetricsBuilder
+	mb *metadata.MetricsBuilder
 }
 
 type postgreSQLClientFactory interface {
@@ -58,7 +58,7 @@ func newPostgreSQLScraper(
 		logger:         logger,
 		config:         config,
 		clientFactory:  clientFactory,
-		metricsBuilder: metadata.NewMetricsBuilder(config.Metrics),
+		mb: metadata.NewMetricsBuilder(config.Metrics),
 	}
 }
 
@@ -106,7 +106,7 @@ func (p *postgreSQLScraper) scrape(ctx context.Context) (pdata.Metrics, error) {
 		p.collectDatabaseTableMetrics(ctx, now, dbClient, errors)
 	}
 
-	p.metricsBuilder.Emit(ilm.Metrics())
+	p.mb.Emit(ilm.Metrics())
 	return md, errors.Combine()
 }
 
@@ -133,7 +133,7 @@ func (p *postgreSQLScraper) collectBlockReads(
 				errors.AddPartial(0, err)
 				continue
 			}
-			p.metricsBuilder.RecordPostgresqlBlocksReadDataPoint(now, i, table.database, table.table, k)
+			p.mb.RecordPostgresqlBlocksReadDataPoint(now, i, table.database, table.table, k)
 		}
 	}
 }
@@ -166,7 +166,7 @@ func (p *postgreSQLScraper) collectDatabaseTableMetrics(
 				errors.AddPartial(0, err)
 				continue
 			}
-			p.metricsBuilder.RecordPostgresqlRowsDataPoint(now, i, table.database, table.table, key)
+			p.mb.RecordPostgresqlRowsDataPoint(now, i, table.database, table.table, key)
 		}
 
 		for _, key := range []string{"ins", "upd", "del", "hot_upd"} {
@@ -180,7 +180,7 @@ func (p *postgreSQLScraper) collectDatabaseTableMetrics(
 				errors.AddPartial(0, err)
 				continue
 			}
-			p.metricsBuilder.RecordPostgresqlOperationsDataPoint(now, i, table.database, table.table, key)
+			p.mb.RecordPostgresqlOperationsDataPoint(now, i, table.database, table.table, key)
 		}
 	}
 }
@@ -208,7 +208,7 @@ func (p *postgreSQLScraper) collectCommitsAndRollbacks(
 			errors.AddPartial(0, err)
 			continue
 		} else {
-			p.metricsBuilder.RecordPostgresqlCommitsDataPoint(now, i, metric.database)
+			p.mb.RecordPostgresqlCommitsDataPoint(now, i, metric.database)
 		}
 
 		rollbackValue := metric.stats["xact_rollback"]
@@ -216,7 +216,7 @@ func (p *postgreSQLScraper) collectCommitsAndRollbacks(
 			errors.AddPartial(0, err)
 			continue
 		} else {
-			p.metricsBuilder.RecordPostgresqlRollbacksDataPoint(now, i, metric.database)
+			p.mb.RecordPostgresqlRollbacksDataPoint(now, i, metric.database)
 		}
 	}
 }
@@ -245,7 +245,7 @@ func (p *postgreSQLScraper) collectDatabaseSize(
 				errors.AddPartial(0, err)
 				continue
 			}
-			p.metricsBuilder.RecordPostgresqlDbSizeDataPoint(now, i, metric.database)
+			p.mb.RecordPostgresqlDbSizeDataPoint(now, i, metric.database)
 		}
 	}
 }
@@ -274,7 +274,7 @@ func (p *postgreSQLScraper) collectBackends(
 				errors.AddPartial(0, err)
 				continue
 			}
-			p.metricsBuilder.RecordPostgresqlBackendsDataPoint(now, i, metric.database)
+			p.mb.RecordPostgresqlBackendsDataPoint(now, i, metric.database)
 		}
 	}
 }

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -27,10 +27,10 @@ import (
 )
 
 type postgreSQLScraper struct {
-	logger         *zap.Logger
-	config         *Config
-	clientFactory  postgreSQLClientFactory
-	mb *metadata.MetricsBuilder
+	logger        *zap.Logger
+	config        *Config
+	clientFactory postgreSQLClientFactory
+	mb            *metadata.MetricsBuilder
 }
 
 type postgreSQLClientFactory interface {
@@ -55,10 +55,10 @@ func newPostgreSQLScraper(
 	clientFactory postgreSQLClientFactory,
 ) *postgreSQLScraper {
 	return &postgreSQLScraper{
-		logger:         logger,
-		config:         config,
-		clientFactory:  clientFactory,
-		mb: metadata.NewMetricsBuilder(config.Metrics),
+		logger:        logger,
+		config:        config,
+		clientFactory: clientFactory,
+		mb:            metadata.NewMetricsBuilder(config.Metrics),
 	}
 }
 

--- a/receiver/rabbitmqreceiver/scraper.go
+++ b/receiver/rabbitmqreceiver/scraper.go
@@ -53,7 +53,7 @@ type rabbitmqScraper struct {
 	logger         *zap.Logger
 	cfg            *Config
 	settings       component.TelemetrySettings
-	metricsBuilder *metadata.MetricsBuilder
+	mb *metadata.MetricsBuilder
 }
 
 // newScraper creates a new scraper
@@ -62,7 +62,7 @@ func newScraper(logger *zap.Logger, cfg *Config, settings component.TelemetrySet
 		logger:         logger,
 		cfg:            cfg,
 		settings:       settings,
-		metricsBuilder: metadata.NewMetricsBuilder(cfg.Metrics),
+		mb: metadata.NewMetricsBuilder(cfg.Metrics),
 	}
 }
 
@@ -109,9 +109,9 @@ func (r *rabbitmqScraper) collectQueue(queue *models.Queue, now pdata.Timestamp,
 	ilms := resourceMetric.InstrumentationLibraryMetrics().AppendEmpty()
 	ilms.InstrumentationLibrary().SetName(instrumentationLibraryName)
 
-	r.metricsBuilder.RecordRabbitmqConsumerCountDataPoint(now, queue.Consumers)
-	r.metricsBuilder.RecordRabbitmqMessageCurrentDataPoint(now, queue.UnacknowledgedMessages, metadata.AttributeMessageState.Unacknowledged)
-	r.metricsBuilder.RecordRabbitmqMessageCurrentDataPoint(now, queue.ReadyMessages, metadata.AttributeMessageState.Ready)
+	r.mb.RecordRabbitmqConsumerCountDataPoint(now, queue.Consumers)
+	r.mb.RecordRabbitmqMessageCurrentDataPoint(now, queue.UnacknowledgedMessages, metadata.AttributeMessageState.Unacknowledged)
+	r.mb.RecordRabbitmqMessageCurrentDataPoint(now, queue.ReadyMessages, metadata.AttributeMessageState.Ready)
 
 	for _, messageStatMetric := range messageStatMetrics {
 		// Get metric value
@@ -132,17 +132,17 @@ func (r *rabbitmqScraper) collectQueue(queue *models.Queue, now pdata.Timestamp,
 
 		switch messageStatMetric {
 		case deliverStat:
-			r.metricsBuilder.RecordRabbitmqMessageDeliveredDataPoint(now, val64)
+			r.mb.RecordRabbitmqMessageDeliveredDataPoint(now, val64)
 		case publishStat:
-			r.metricsBuilder.RecordRabbitmqMessagePublishedDataPoint(now, val64)
+			r.mb.RecordRabbitmqMessagePublishedDataPoint(now, val64)
 		case ackStat:
-			r.metricsBuilder.RecordRabbitmqMessageAcknowledgedDataPoint(now, val64)
+			r.mb.RecordRabbitmqMessageAcknowledgedDataPoint(now, val64)
 		case dropUnroutableStat:
-			r.metricsBuilder.RecordRabbitmqMessageDroppedDataPoint(now, val64)
+			r.mb.RecordRabbitmqMessageDroppedDataPoint(now, val64)
 
 		}
 	}
-	r.metricsBuilder.Emit(ilms.Metrics())
+	r.mb.Emit(ilms.Metrics())
 }
 
 // convertValToInt64 values from message state unmarshal as float64s but should be int64.

--- a/receiver/rabbitmqreceiver/scraper.go
+++ b/receiver/rabbitmqreceiver/scraper.go
@@ -49,20 +49,20 @@ var messageStatMetrics = []string{
 
 // rabbitmqScraper handles scraping of RabbitMQ metrics
 type rabbitmqScraper struct {
-	client         client
-	logger         *zap.Logger
-	cfg            *Config
-	settings       component.TelemetrySettings
-	mb *metadata.MetricsBuilder
+	client   client
+	logger   *zap.Logger
+	cfg      *Config
+	settings component.TelemetrySettings
+	mb       *metadata.MetricsBuilder
 }
 
 // newScraper creates a new scraper
 func newScraper(logger *zap.Logger, cfg *Config, settings component.TelemetrySettings) *rabbitmqScraper {
 	return &rabbitmqScraper{
-		logger:         logger,
-		cfg:            cfg,
-		settings:       settings,
-		mb: metadata.NewMetricsBuilder(cfg.Metrics),
+		logger:   logger,
+		cfg:      cfg,
+		settings: settings,
+		mb:       metadata.NewMetricsBuilder(cfg.Metrics),
 	}
 }
 


### PR DESCRIPTION
Some scrapers called their metrics builder 'mb'
while others called it 'metricsBuilder'. This just
standardizes on 'mb' for brevity.