### PR TITLE
Deprecate log_names setting from filter processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,10 +61,9 @@
 - `resourcetotelemetry`: Ensure resource attributes are added to summary
   and exponential histogram data points. (#7523)
 
-## 🚩 Deprecations 🚩
+## Deprecations
 
 - Deprecated otel_to_hec_fields.name setting from splunkhec exporter. (#7560)
-- Deprecated log_names setting from filter processor. (#7552)
 
 ## v0.43.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@
 
 ## 🚀 New components 🚀
 
-## 🧰 Bug fixes 🧰
-
 ## v0.44.0
 
 ## 💡 Enhancements 💡

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@
 
 ## 🚩 Deprecations 🚩
 
+- Deprecated log_names setting from filter processor. (#7552)
+
 ## 🧰 Bug fixes 🧰
 
  - `tailsamplingprocessor`: "And" policy only works as a sub policy under a composite policy (#7590) 
 
 ## 🚀 New components 🚀
+
+## 🧰 Bug fixes 🧰
 
 ## v0.44.0
 
@@ -57,9 +61,10 @@
 - `resourcetotelemetry`: Ensure resource attributes are added to summary
   and exponential histogram data points. (#7523)
 
-## Deprecations
+## 🚩 Deprecations 🚩
 
 - Deprecated otel_to_hec_fields.name setting from splunkhec exporter. (#7560)
+- Deprecated log_names setting from filter processor. (#7552)
 
 ## v0.43.0
 

--- a/internal/coreinternal/processor/filterconfig/config.go
+++ b/internal/coreinternal/processor/filterconfig/config.go
@@ -89,6 +89,7 @@ type MatchProperties struct {
 
 	// LogNames is a list of strings that the LogRecord's name field must match
 	// against.
+	// Deprecated: the Name field is removed from the log data model.
 	LogNames []string `mapstructure:"log_names"`
 
 	// Attributes specifies the list of attributes to match against.
@@ -128,8 +129,8 @@ func (mp *MatchProperties) ValidateForLogs() error {
 		return errors.New("neither services nor span_names should be specified for log records")
 	}
 
-	if len(mp.LogNames) == 0 && len(mp.Attributes) == 0 && len(mp.Libraries) == 0 && len(mp.Resources) == 0 {
-		return errors.New(`at least one of "log_names", "attributes", "libraries" or "resources" field must be specified`)
+	if len(mp.Attributes) == 0 && len(mp.Libraries) == 0 && len(mp.Resources) == 0 {
+		return errors.New(`at least one of "attributes", "libraries" or "resources" field must be specified`)
 	}
 
 	return nil

--- a/internal/coreinternal/processor/filtermatcher/attributematcher.go
+++ b/internal/coreinternal/processor/filtermatcher/attributematcher.go
@@ -70,8 +70,10 @@ func NewAttributesMatcher(config filterset.Config, attributes []filterconfig.Att
 					return nil, err
 				}
 				entry.StringFilter = filter
-			} else {
+			} else if config.MatchType == filterset.Strict {
 				entry.AttributeValue = &val
+			} else {
+				return nil, filterset.NewUnrecognizedMatchTypeError(config.MatchType)
 			}
 		}
 

--- a/internal/coreinternal/processor/filterset/config.go
+++ b/internal/coreinternal/processor/filterset/config.go
@@ -43,6 +43,10 @@ type Config struct {
 	RegexpConfig *regexp.Config `mapstructure:"regexp"`
 }
 
+func NewUnrecognizedMatchTypeError(matchType MatchType) error {
+	return fmt.Errorf("unrecognized %v: '%v', valid types are: %v", MatchTypeFieldName, matchType, validMatchTypes)
+}
+
 // CreateFilterSet creates a FilterSet from yaml config.
 func CreateFilterSet(filters []string, cfg *Config) (FilterSet, error) {
 	switch cfg.MatchType {
@@ -52,6 +56,6 @@ func CreateFilterSet(filters []string, cfg *Config) (FilterSet, error) {
 		// Strict FilterSets do not have any extra configuration options, so call the constructor directly.
 		return strict.NewFilterSet(filters), nil
 	default:
-		return nil, fmt.Errorf("unrecognized %v: '%v', valid types are: %v", MatchTypeFieldName, cfg.MatchType, validMatchTypes)
+		return nil, NewUnrecognizedMatchTypeError(cfg.MatchType)
 	}
 }

--- a/processor/attributesprocessor/attributes_log_test.go
+++ b/processor/attributesprocessor/attributes_log_test.go
@@ -49,10 +49,12 @@ func runIndividualLogTestCase(t *testing.T, tt logTestCase, tp component.LogsPro
 	})
 }
 
-func generateLogData(logName string, attrs map[string]pdata.AttributeValue) pdata.Logs {
+func generateLogData(resourceName string, attrs map[string]pdata.AttributeValue) pdata.Logs {
 	td := pdata.NewLogs()
-	lr := td.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty().LogRecords().AppendEmpty()
-	lr.SetName(logName)
+	res := td.ResourceLogs().AppendEmpty()
+	res.Resource().Attributes().InsertString("name", resourceName)
+	ill := res.InstrumentationLibraryLogs().AppendEmpty()
+	lr := ill.LogRecords().AppendEmpty()
 	pdata.NewAttributeMapFromMap(attrs).CopyTo(lr.Attributes())
 	lr.Attributes().Sort()
 	return td
@@ -161,8 +163,9 @@ func TestAttributes_FilterLogs(t *testing.T) {
 		{Key: "attribute1", Action: attraction.INSERT, Value: 123},
 	}
 	oCfg.Include = &filterconfig.MatchProperties{
-		LogNames: []string{"^[^i].*"},
-		Config:   *createConfig(filterset.Regexp),
+		Resources: []filterconfig.Attribute{{Key: "name", Value: "^[^i].*"}},
+		//Libraries: []filterconfig.InstrumentationLibrary{{Name: "^[^i].*"}},
+		Config: *createConfig(filterset.Regexp),
 	}
 	oCfg.Exclude = &filterconfig.MatchProperties{
 		Attributes: []filterconfig.Attribute{
@@ -171,7 +174,7 @@ func TestAttributes_FilterLogs(t *testing.T) {
 		Config: *createConfig(filterset.Strict),
 	}
 	tp, err := factory.CreateLogsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {
@@ -188,16 +191,16 @@ func TestAttributes_FilterLogsByNameStrict(t *testing.T) {
 				"attribute1": pdata.NewAttributeValueInt(123),
 			},
 		},
-		{
-			name: "apply",
-			inputAttributes: map[string]pdata.AttributeValue{
-				"NoModification": pdata.NewAttributeValueBool(false),
-			},
-			expectedAttributes: map[string]pdata.AttributeValue{
-				"attribute1":     pdata.NewAttributeValueInt(123),
-				"NoModification": pdata.NewAttributeValueBool(false),
-			},
-		},
+		//{
+		//	name: "apply",
+		//	inputAttributes: map[string]pdata.AttributeValue{
+		//		"NoModification": pdata.NewAttributeValueBool(false),
+		//	},
+		//	expectedAttributes: map[string]pdata.AttributeValue{
+		//		"attribute1":     pdata.NewAttributeValueInt(123),
+		//		"NoModification": pdata.NewAttributeValueBool(false),
+		//	},
+		//},
 		{
 			name:               "incorrect_log_name",
 			inputAttributes:    map[string]pdata.AttributeValue{},
@@ -226,12 +229,12 @@ func TestAttributes_FilterLogsByNameStrict(t *testing.T) {
 		{Key: "attribute1", Action: attraction.INSERT, Value: 123},
 	}
 	oCfg.Include = &filterconfig.MatchProperties{
-		LogNames: []string{"apply", "dont_apply"},
-		Config:   *createConfig(filterset.Strict),
+		Resources: []filterconfig.Attribute{{Key: "name", Value: "apply"}},
+		Config:    *createConfig(filterset.Strict),
 	}
 	oCfg.Exclude = &filterconfig.MatchProperties{
-		LogNames: []string{"dont_apply"},
-		Config:   *createConfig(filterset.Strict),
+		Resources: []filterconfig.Attribute{{Key: "name", Value: "dont_apply"}},
+		Config:    *createConfig(filterset.Strict),
 	}
 	tp, err := factory.CreateLogsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
 	require.Nil(t, err)
@@ -289,12 +292,12 @@ func TestAttributes_FilterLogsByNameRegexp(t *testing.T) {
 		{Key: "attribute1", Action: attraction.INSERT, Value: 123},
 	}
 	oCfg.Include = &filterconfig.MatchProperties{
-		LogNames: []string{"^apply.*"},
-		Config:   *createConfig(filterset.Regexp),
+		Resources: []filterconfig.Attribute{{Key: "name", Value: "^apply.*"}},
+		Config:    *createConfig(filterset.Regexp),
 	}
 	oCfg.Exclude = &filterconfig.MatchProperties{
-		LogNames: []string{".*dont_apply$"},
-		Config:   *createConfig(filterset.Regexp),
+		Resources: []filterconfig.Attribute{{Key: "name", Value: ".*dont_apply$"}},
+		Config:    *createConfig(filterset.Regexp),
 	}
 	tp, err := factory.CreateLogsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
 	require.Nil(t, err)
@@ -397,10 +400,11 @@ func BenchmarkAttributes_FilterLogsByName(b *testing.B) {
 		{Key: "attribute1", Action: attraction.INSERT, Value: 123},
 	}
 	oCfg.Include = &filterconfig.MatchProperties{
-		LogNames: []string{"^apply.*"},
+		Config:    *createConfig(filterset.Regexp),
+		Resources: []filterconfig.Attribute{{Key: "name", Value: "^apply.*"}},
 	}
 	tp, err := factory.CreateLogsProcessor(context.Background(), componenttest.NewNopProcessorCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(b, err)
+	require.NoError(b, err)
 	require.NotNil(b, tp)
 
 	for _, tt := range testCases {

--- a/processor/attributesprocessor/attributes_log_test.go
+++ b/processor/attributesprocessor/attributes_log_test.go
@@ -191,16 +191,16 @@ func TestAttributes_FilterLogsByNameStrict(t *testing.T) {
 				"attribute1": pdata.NewAttributeValueInt(123),
 			},
 		},
-		//{
-		//	name: "apply",
-		//	inputAttributes: map[string]pdata.AttributeValue{
-		//		"NoModification": pdata.NewAttributeValueBool(false),
-		//	},
-		//	expectedAttributes: map[string]pdata.AttributeValue{
-		//		"attribute1":     pdata.NewAttributeValueInt(123),
-		//		"NoModification": pdata.NewAttributeValueBool(false),
-		//	},
-		//},
+		{
+			name: "apply",
+			inputAttributes: map[string]pdata.AttributeValue{
+				"NoModification": pdata.NewAttributeValueBool(false),
+			},
+			expectedAttributes: map[string]pdata.AttributeValue{
+				"attribute1":     pdata.NewAttributeValueInt(123),
+				"NoModification": pdata.NewAttributeValueBool(false),
+			},
+		},
 		{
 			name:               "incorrect_log_name",
 			inputAttributes:    map[string]pdata.AttributeValue{},

--- a/processor/attributesprocessor/factory.go
+++ b/processor/attributesprocessor/factory.go
@@ -83,7 +83,7 @@ func createTracesProcessor(
 
 func createLogProcessor(
 	_ context.Context,
-	_ component.ProcessorCreateSettings,
+	set component.ProcessorCreateSettings,
 	cfg config.Processor,
 	nextConsumer consumer.Logs,
 ) (component.LogsProcessor, error) {
@@ -95,6 +95,11 @@ func createLogProcessor(
 	if err != nil {
 		return nil, fmt.Errorf("error creating \"attributes\" processor: %w of processor %v", err, cfg.ID())
 	}
+
+	if (oCfg.Include != nil && len(oCfg.Include.LogNames) > 0) || (oCfg.Exclude != nil && len(oCfg.Exclude.LogNames) > 0) {
+		set.Logger.Warn("log_names setting is deprecated and will be removed soon")
+	}
+
 	include, err := filterlog.NewMatcher(oCfg.Include)
 	if err != nil {
 		return nil, err

--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -635,6 +635,9 @@ func TestSpanProcessor_setStatusCodeConditionally(t *testing.T) {
 	}
 	// This test numer two include rule for applying rule only for status code 400
 	oCfg.Include = &filterconfig.MatchProperties{
+		Config: filterset.Config{
+			MatchType: filterset.Strict,
+		},
 		Attributes: []filterconfig.Attribute{
 			{Key: "http.status_code", Value: 400},
 		},


### PR DESCRIPTION
The LogRecord Name field [is removed](https://github.com/open-telemetry/opentelemetry-specification/pull/2271) from the specification and is [going to be removed](https://github.com/open-telemetry/opentelemetry-proto/pull/357) from the OTLP.
