### PR TITLE
[exporter and receiver/signalfx] Remove LogRecord Name field usage

### DIFF
--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -473,7 +473,6 @@ func makeSampleResourceLogs() pdata.Logs {
 	out := pdata.NewLogs()
 	l := out.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty().LogRecords().AppendEmpty()
 
-	l.SetName("shutdown")
 	l.SetTimestamp(pdata.Timestamp(1000))
 	attrs := l.Attributes()
 
@@ -490,6 +489,7 @@ func makeSampleResourceLogs() pdata.Logs {
 	propMap.Sort()
 	attrs.Insert("com.splunk.signalfx.event_properties", propMapVal)
 	attrs.Insert("com.splunk.signalfx.event_category", pdata.NewAttributeValueInt(int64(sfxpb.EventCategory_USER_DEFINED)))
+	attrs.Insert("com.splunk.signalfx.event_type", pdata.NewAttributeValueString("shutdown"))
 
 	l.Attributes().Sort()
 
@@ -515,7 +515,9 @@ func TestConsumeEventData(t *testing.T) {
 			name: "no_event_attribute",
 			resourceLogs: func() pdata.Logs {
 				out := makeSampleResourceLogs()
-				out.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).LogRecords().At(0).Attributes().Delete("com.splunk.signalfx.event_category")
+				attrs := out.ResourceLogs().At(0).InstrumentationLibraryLogs().At(0).LogRecords().At(0).Attributes()
+				attrs.Delete("com.splunk.signalfx.event_category")
+				attrs.Delete("com.splunk.signalfx.event_type")
 				return out
 			}(),
 			reqTestFunc:          nil,
@@ -713,7 +715,6 @@ func generateLargeEventBatch() pdata.Logs {
 	ts := time.Now()
 	for i := 0; i < batchSize; i++ {
 		lr := logs.AppendEmpty()
-		lr.SetName("test_" + strconv.Itoa(i))
 		lr.Attributes().InsertString("k0", "k1")
 		lr.Attributes().InsertNull("com.splunk.signalfx.event_category")
 		lr.SetTimestamp(pdata.NewTimestampFromTime(ts))

--- a/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
+++ b/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
@@ -89,7 +89,15 @@ func convertLogRecord(lr pdata.LogRecord, resourceAttrs pdata.AttributeMap, logg
 
 	addDimension := func(k string, v pdata.AttributeValue) bool {
 		// Skip internal attributes
-		if k == splunk.SFxEventCategoryKey || k == splunk.SFxEventPropertiesKey {
+		switch k {
+		case splunk.SFxEventCategoryKey:
+			return true
+		case splunk.SFxEventPropertiesKey:
+			return true
+		case splunk.SFxEventType:
+			if v.Type() == pdata.AttributeValueTypeString {
+				event.EventType = v.StringVal()
+			}
 			return true
 		}
 
@@ -108,7 +116,6 @@ func convertLogRecord(lr pdata.LogRecord, resourceAttrs pdata.AttributeMap, logg
 	resourceAttrsForDimensions.Range(addDimension)
 	attrs.Range(addDimension)
 
-	event.EventType = lr.Name()
 	// Convert nanoseconds to nearest milliseconds, which is the unit of
 	// SignalFx event timestamps.
 	event.Timestamp = int64(lr.Timestamp()) / 1e6

--- a/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2_test.go
+++ b/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2_test.go
@@ -63,7 +63,6 @@ func TestLogDataToSignalFxEvents(t *testing.T) {
 		logSlice := ilLogs.AppendEmpty().LogRecords()
 
 		l := logSlice.AppendEmpty()
-		l.SetName("shutdown")
 		l.SetTimestamp(pdata.NewTimestampFromTime(now.Truncate(time.Millisecond)))
 		attrs := l.Attributes()
 
@@ -80,6 +79,7 @@ func TestLogDataToSignalFxEvents(t *testing.T) {
 		propMap.Sort()
 		attrs.Insert("com.splunk.signalfx.event_properties", propMapVal)
 		attrs.Insert("com.splunk.signalfx.event_category", pdata.NewAttributeValueInt(int64(sfxpb.EventCategory_USER_DEFINED)))
+		attrs.Insert("com.splunk.signalfx.event_type", pdata.NewAttributeValueString("shutdown"))
 
 		l.Attributes().Sort()
 

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -26,6 +26,7 @@ const (
 	SFxAccessTokenLabel        = "com.splunk.signalfx.access_token" // #nosec
 	SFxEventCategoryKey        = "com.splunk.signalfx.event_category"
 	SFxEventPropertiesKey      = "com.splunk.signalfx.event_properties"
+	SFxEventType               = "com.splunk.signalfx.event_type"
 	DefaultSourceTypeLabel     = "com.splunk.sourcetype"
 	DefaultSourceLabel         = "com.splunk.source"
 	DefaultIndexLabel          = "com.splunk.index"

--- a/receiver/signalfxreceiver/signalfxv2_event_to_logdata_test.go
+++ b/receiver/signalfxreceiver/signalfxv2_event_to_logdata_test.go
@@ -51,9 +51,9 @@ func TestSignalFxV2EventsToLogData(t *testing.T) {
 	buildDefaultLogs := func() pdata.LogRecordSlice {
 		logSlice := pdata.NewLogRecordSlice()
 		l := logSlice.AppendEmpty()
-		l.SetName("shutdown")
 		l.SetTimestamp(pdata.NewTimestampFromTime(now.Truncate(time.Millisecond)))
 		attrs := l.Attributes()
+		attrs.InsertString("com.splunk.signalfx.event_type", "shutdown")
 		attrs.InsertString("k0", "v0")
 		attrs.InsertString("k1", "v1")
 		attrs.InsertString("k2", "v2")


### PR DESCRIPTION
The LogRecord Name field [is removed](https://github.com/open-telemetry/opentelemetry-specification/pull/2271) from the specification and is [going to be removed](https://github.com/open-telemetry/opentelemetry-proto/pull/357) from the OTLP.
