### PR TITLE
[exporter/splunkhec] Deprecate otel_to_hec_fields.name setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
 - `resourcetotelemetry`: Ensure resource attributes are added to summary
   and exponential histogram data points. (#7523)
 
+## Deprecations
+
+- Deprecated otel_to_hec_fields.name setting from splunkhec exporter. (#7560)
+
 ## v0.43.0
 
 ## 💡 Enhancements 💡

--- a/exporter/splunkhecexporter/exporter.go
+++ b/exporter/splunkhecexporter/exporter.go
@@ -71,6 +71,10 @@ func createExporter(
 		config.SplunkAppVersion = buildinfo.Version
 	}
 
+	if config.HecFields.Name != "" {
+		logger.Warn("otel_to_hec_fields.name setting is deprecated and will be removed soon.")
+	}
+
 	options, err := config.getOptionsFromConfig()
 	if err != nil {
 		return nil,


### PR DESCRIPTION
The LogRecord Name field [is removed](https://github.com/open-telemetry/opentelemetry-specification/pull/2271) from the specification and is [going to be removed](https://github.com/open-telemetry/opentelemetry-proto/pull/357) from the OTLP.
