### PR TITLE
[exporter/dynatrace] Fix docs for TLS settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 💡 Enhancements 💡
 
 - `dynatraceexporter`: Write error logs using plugin logger (#7360)
+- `dynatraceexporter`: Fix docs for TLS settings (#7568)
 - `tanzuobservabilityexporter`: Turn on metrics exporter (#7281)
 - `attributesprocessor` `resourceprocessor`: Add `from_context` value source
 - `resourcedetectionprocessor`: check cluster config to verify resource is on aws for eks resources (#7186)

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -138,7 +138,7 @@ exporters:
     write_buffer_size: 4000
     timeout: 30s
     tls:
-      insecure_skip_verify: false // default
+      insecure_skip_verify: false # (default=false)
     retry_on_failure:
       enabled: true
       initial_interval: 5s

--- a/exporter/dynatraceexporter/README.md
+++ b/exporter/dynatraceexporter/README.md
@@ -137,7 +137,8 @@ exporters:
     read_buffer_size: 4000
     write_buffer_size: 4000
     timeout: 30s
-    insecure_skip_verify: false
+    tls:
+      insecure_skip_verify: false
     retry_on_failure:
       enabled: true
       initial_interval: 5s
@@ -194,9 +195,12 @@ https://golang.org/pkg/net/http/#Client
 
 Default: `0`
 
-### insecure_skip_verify (Optional)
+### tls.insecure_skip_verify (Optional)
 
-Additionally you can configure TLS to be enabled but skip verifying the server's certificate chain. This cannot be combined with insecure since insecure won't use TLS at all.
+Additionally you can configure TLS to be enabled but skip verifying the server's certificate chain.
+This cannot be combined with `insecure` since `insecure` won't use TLS at all.
+More details can be found in the collector readme for
+[configtls](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md#client-configuration).
 
 Default: `false`
 


### PR DESCRIPTION
Seems like it was missed to update this in #5282 and #5428 after the breaking changes in the config structure.

Fixes #7566.