### PR TITLE
[Exporter/Datadog] Added debug flag to print metrics payload

### DIFF
--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -178,7 +178,7 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pdata.Metric
 
 	err = nil
 	if len(ms) > 0 {
-                exp.params.Logger.Debug("exporting payload", zap.Any("metric", ms))
+		exp.params.Logger.Debug("exporting payload", zap.Any("metric", ms))
 		err = multierr.Append(
 			err,
 			exp.retrier.DoWithRetries(ctx, func(context.Context) error {

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -178,6 +178,7 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pdata.Metric
 
 	err = nil
 	if len(ms) > 0 {
+                exp.params.Logger.Debug("exporting payload", zap.Any("metric", ms))
 		err = multierr.Append(
 			err,
 			exp.retrier.DoWithRetries(ctx, func(context.Context) error {


### PR DESCRIPTION
**Description:** Added debug logging to log metrics payload data sent to Datadog. Redo [#5856](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5856) as debug log instead of Info log. Metrics payload data will be logged if collector is started in debug mode. 

**Link to tracking Issue:** #7528 

**Testing:** Started the collector in debug mode to test the output. The metrics payload data only logged if the collector is in debug mode.