### PR TITLE
[receiver/prometheusexec] Set a default value for `scrape_timeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `datadogexporter`: Fix traces exporter's initialization log (#7564)
 - `tailsamplingprocessor`: Add And sampling policy (#6910)
 - `coralogixexporter`: Add Coralogix Exporter (#7383)
+- `prometheusexecreceiver`: Add default value for `scrape_timeout` option (#7587)
 
 ## 🛑 Breaking changes 🛑
 

--- a/receiver/prometheusexecreceiver/config.go
+++ b/receiver/prometheusexecreceiver/config.go
@@ -29,7 +29,7 @@ type Config struct {
 	// ScrapeInterval is the time between each scrape completed by the Receiver
 	ScrapeInterval time.Duration `mapstructure:"scrape_interval,omitempty"`
 	// ScrapeTimeout is the time to wait before throttling a scrape request
-	ScrapeTimeout time.Duration `mapstructure:"scrape_timeout"`
+	ScrapeTimeout time.Duration `mapstructure:"scrape_timeout,omitempty"`
 	// Port is the port assigned to the Receiver, and to the {{port}} template variables
 	Port int `mapstructure:"port"`
 	// SubprocessConfig is the configuration needed for the subprocess

--- a/receiver/prometheusexecreceiver/factory.go
+++ b/receiver/prometheusexecreceiver/factory.go
@@ -32,6 +32,7 @@ const (
 	typeStr = "prometheus_exec"
 
 	defaultCollectionInterval = 60 * time.Second
+	defaultTimeoutInterval    = 10 * time.Second
 )
 
 // NewFactory creates a factory for the prometheusexec receiver
@@ -47,6 +48,7 @@ func createDefaultConfig() config.Receiver {
 	return &Config{
 		ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
 		ScrapeInterval:   defaultCollectionInterval,
+		ScrapeTimeout:    defaultTimeoutInterval,
 		SubprocessConfig: subprocessmanager.SubprocessConfig{
 			Env: []subprocessmanager.EnvConfig{},
 		},


### PR DESCRIPTION
**Description:**
Come back to the behavior before 0.42 where `scrape_timeout` is defined to 10s by default and prevent breaking change.

**Link to tracking Issue:** 

fix #7586

**Testing:**

using `make run` with the configuration provided in the issue.
the log error disappeared and the service works.

**Documentation:**
I also updated the changelog to inform of the change from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6159.
Feel free to modify / drop it.