### PR TITLE
[processor/tailsampling] fix AND policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - `postgresqlreceiver`: Fix issue where empty metrics could be returned after failed connection (#7502)
 - `resourcetotelemetry`: Ensure resource attributes are added to summary
   and exponential histogram data points. (#7523)
-- `tailsamplingprocessor`: And policy only works as a sub policy under a composite policy (#)
+- `tailsamplingprocessor`: And policy only works as a sub policy under a composite policy (#7590)
 
 ## Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@
 - `postgresqlreceiver`: Fix issue where empty metrics could be returned after failed connection (#7502)
 - `resourcetotelemetry`: Ensure resource attributes are added to summary
   and exponential histogram data points. (#7523)
-- `tailsamplingprocessor`: And policy only works as a sub policy under a composite policy (#7590)
 
 ## Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `postgresqlreceiver`: Fix issue where empty metrics could be returned after failed connection (#7502)
 - `resourcetotelemetry`: Ensure resource attributes are added to summary
   and exponential histogram data points. (#7523)
+- `tailsamplingprocessor`: And policy only works as a sub policy under a composite policy (#)
 
 ## Deprecations
 

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -139,6 +139,9 @@ func getPolicyEvaluator(logger *zap.Logger, cfg *PolicyCfg) (sampling.PolicyEval
 	case Composite:
 		rlfCfg := cfg.CompositeCfg
 		return getNewCompositePolicy(logger, rlfCfg)
+	case And:
+		andCfg := cfg.AndCfg
+		return getNewAndPolicy(logger, andCfg)
 	default:
 		return nil, fmt.Errorf("unknown sampling policy type %s", cfg.Type)
 	}


### PR DESCRIPTION
**Description:** 
Fixing a bug - the and policy only works as a sub policy of a composite policy. added the init code to `getPolicyEvaluator` in `processor.go`

**Link to tracking Issue:** Fixes #7589 