### PR TITLE
#7586 add breaking change to 0.42.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@
 - `jaeger` receiver/exporter: Parse/set Jaeger status with OTel spec values (#6682)
 - `awsecscontainermetricsreceiver`: remove tag from `container.image.name` (#6436)
 - `k8sclusterreceiver`: remove tag from `container.image.name` (#6436)
+- `prometheusexecreceiver`: new option `scrape_timeout` must be defined (see #7586) (#7592)
 
 ## 🚀 New components 🚀
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
 - `lokiexporter`: Log the first part of the http body on failed pushes to loki (#6946)
 - `resourcedetectionprocessor`: add the [consul](https://www.consul.io/) detector (#6382)
 - `awsemfexporter`: refactor cw_client logic into separate `cwlogs` package (#7072)
+- `prometheusexecreceiver`: New option `scrape_timeout` available must be defined until #7587 (#7592)
 
 ## 🛑 Breaking changes 🛑
 
@@ -142,7 +143,6 @@
 - `jaeger` receiver/exporter: Parse/set Jaeger status with OTel spec values (#6682)
 - `awsecscontainermetricsreceiver`: remove tag from `container.image.name` (#6436)
 - `k8sclusterreceiver`: remove tag from `container.image.name` (#6436)
-- `prometheusexecreceiver`: new option `scrape_timeout` must be defined (see #7586) (#7592)
 
 ## 🚀 New components 🚀
 


### PR DESCRIPTION
**Description:**

This PR is a proposition to add a breaking change to release notes of 0.42.0 version for PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6159.

As explained in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7586, any configuration of `prometheusexec` before version 0.42 will be broken because:
- given that `scrape_timeout` is a new option, it is not defined
- the golang zero value of int is `0` and `0s` is not a valid default value
So it implies that anybody using this receiver and upgrade from < 0.42 to >= 0.42 will have to set this `option` for example to `10s` to keep the previous behavior or it will get error.

The related PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7587 will make this parameter optional to future version so this should "cancel" this breaking change.

**Link to tracking Issue:** 

#7586