### PR TITLE
[receiver/prometheusexec] Ensure factory test checks for the default intervals

### DIFF
--- a/receiver/prometheusexecreceiver/factory_test.go
+++ b/receiver/prometheusexecreceiver/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
@@ -34,6 +35,11 @@ import (
 )
 
 func TestCreateTraceAndMetricsReceiver(t *testing.T) {
+	// Ensure default values are not 0 to prevent receiver regression error
+	timeZeroValue := model.Duration(0 * time.Second)
+	assert.NotEqual(t, timeZeroValue, defaultCollectionInterval)
+	assert.NotEqual(t, timeZeroValue, defaultTimeoutInterval)
+
 	var (
 		traceReceiver  component.TracesReceiver
 		metricReceiver component.MetricsReceiver

--- a/receiver/prometheusexecreceiver/factory_test.go
+++ b/receiver/prometheusexecreceiver/factory_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
@@ -77,7 +76,8 @@ func TestCreateTraceAndMetricsReceiver(t *testing.T) {
 			PrometheusConfig: &promconfig.Config{
 				ScrapeConfigs: []*promconfig.ScrapeConfig{
 					{
-						ScrapeInterval:  model.Duration(60 * time.Second),
+						ScrapeInterval:  model.Duration(defaultCollectionInterval),
+						ScrapeTimeout:   model.Duration(defaultTimeoutInterval),
 						Scheme:          "http",
 						MetricsPath:     "/metrics",
 						JobName:         "test",

--- a/receiver/prometheusexecreceiver/factory_test.go
+++ b/receiver/prometheusexecreceiver/factory_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/prometheus/common/model"
 	promconfig "github.com/prometheus/prometheus/config"
@@ -35,11 +34,6 @@ import (
 )
 
 func TestCreateTraceAndMetricsReceiver(t *testing.T) {
-	// Ensure default values are not 0 to prevent receiver regression error
-	timeZeroValue := model.Duration(0 * time.Second)
-	assert.NotEqual(t, timeZeroValue, defaultCollectionInterval)
-	assert.NotEqual(t, timeZeroValue, defaultTimeoutInterval)
-
 	var (
 		traceReceiver  component.TracesReceiver
 		metricReceiver component.MetricsReceiver

--- a/receiver/prometheusexecreceiver/factory_test.go
+++ b/receiver/prometheusexecreceiver/factory_test.go
@@ -78,7 +78,6 @@ func TestCreateTraceAndMetricsReceiver(t *testing.T) {
 				ScrapeConfigs: []*promconfig.ScrapeConfig{
 					{
 						ScrapeInterval:  model.Duration(60 * time.Second),
-						ScrapeTimeout:   model.Duration(10 * time.Second),
 						Scheme:          "http",
 						MetricsPath:     "/metrics",
 						JobName:         "test",


### PR DESCRIPTION
**Description:** 

Following up https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7587#discussion_r800863267

Do not set the parameter will fail go test and can prevent future problem as explained in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7586.

cc @jpkrohling sorry for the multiple PRs