### PR TITLE
Update README.md for gcpexporter config

### DIFF
--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -45,7 +45,7 @@ These instructions are to get you up and running quickly with the GCP exporter i
       memory_limiter:
           check_interval: 1s
           limit_mib: 4000
-          spike_limit_mib: 500
+          spike_limit_mib: 800
       batch:
         # Google Cloud Monitoring limits batches to 200 metric points.
         send_batch_max_size: 200

--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -43,7 +43,7 @@ These instructions are to get you up and running quickly with the GCP exporter i
         loglevel: debug
     processors:
       memory_limiter:
-          check_interval: 5s
+          check_interval: 1s
           limit_mib: 4000
           spike_limit_mib: 500
       batch:

--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -43,6 +43,9 @@ These instructions are to get you up and running quickly with the GCP exporter i
         loglevel: debug
     processors:
       memory_limiter:
+          check_interval: 5s
+          limit_mib: 4000
+          spike_limit_mib: 500
       batch:
         # Google Cloud Monitoring limits batches to 200 metric points.
         send_batch_max_size: 200


### PR DESCRIPTION
If `check_interval` is empty, it will throw an error: 
```
collector server run finished with error: cannot build pipelines: error creating processor "memory_limiter" in pipeline "metrics": checkInterval must be greater than zero
```

If `limit_mib` is empty, it will throw an error:
```
Error: cannot build pipelines: error creating processor "memory_limiter" in pipeline "traces": memAllocLimit or memoryLimitPercentage must be greater than zero
```

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>