### PR TITLE
[receiver/apache] Update instrumentation library name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## 🛑 Breaking changes 🛑
 
+- `apachereceiver`: Update instrumentation library name from `otel/apache` to `otelcol/apache` (#7754)
+
 ## 🚩 Deprecations 🚩
 
 - Deprecated log_names setting from filter processor. (#7552)

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -105,7 +105,7 @@ func (r *apacheScraper) scrape(context.Context) (pdata.Metrics, error) {
 
 	md := pdata.NewMetrics()
 	ilm := md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otel/apache")
+	ilm.InstrumentationLibrary().SetName("otelcol/apache")
 	r.mb.Emit(ilm.Metrics())
 	return md, nil
 }

--- a/receiver/apachereceiver/testdata/integration/expected.json
+++ b/receiver/apachereceiver/testdata/integration/expected.json
@@ -4,7 +4,7 @@
          "instrumentationLibraryMetrics": [
             {
                "instrumentationLibrary": {
-                  "name": "otel/apache"
+                  "name": "otelcol/apache"
                },
                "metrics": [
                   {

--- a/receiver/apachereceiver/testdata/scraper/expected.json
+++ b/receiver/apachereceiver/testdata/scraper/expected.json
@@ -5,7 +5,7 @@
       "instrumentationLibraryMetrics": [
         {
           "instrumentationLibrary": {
-            "name": "otel/apache"
+            "name": "otelcol/apache"
           },
           "metrics": [
             {


### PR DESCRIPTION
The instrumentation library name used in other scrapers
is typically prefixed with 'otelcol'. This change just
updates the apachereceiver's name from 'otel/apache' to
'otelcol/apache'