### PR TITLE
[exporter/datadog] Remove obsolete configuration warning

### DIFF
--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -32,7 +32,6 @@ import (
 var (
 	errUnsetAPIKey = errors.New("api.key is not set")
 	errNoMetadata  = errors.New("only_metadata can't be enabled when send_metadata or use_resource_metadata is disabled")
-	errBuckets     = errors.New("'metrics::report_buckets' is obsolete. Use 'metrics::histograms::mode' instead")
 )
 
 // TODO: Import these from translator when we eliminate cyclic dependency.
@@ -328,12 +327,6 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) Unmarshal(configMap *config.Map) error {
-	// metrics::report_buckets is obsolete, return an error to
-	// tell the user to use metrics::histograms::mode instead.
-	if configMap.IsSet("metrics::report_buckets") {
-		return errBuckets
-	}
-
 	err := configMap.UnmarshalExact(c)
 	if err != nil {
 		return err

--- a/exporter/datadogexporter/config/config_test.go
+++ b/exporter/datadogexporter/config/config_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	colconfig "go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.uber.org/zap"
 )
@@ -165,57 +164,4 @@ func TestSpanNameRemappingsValidation(t *testing.T) {
 	err := invalidCfg.Validate()
 	require.NoError(t, noErr)
 	require.Error(t, err)
-}
-
-func TestErrorReportBuckets(t *testing.T) {
-
-	tests := []struct {
-		name          string
-		stringMap     map[string]interface{}
-		expectedError error
-	}{
-		{
-			name: "report buckets false",
-			stringMap: map[string]interface{}{
-				"api": map[string]interface{}{"key": "aaa"},
-				"metrics": map[string]interface{}{
-					"report_buckets": false,
-				},
-			},
-			expectedError: errBuckets,
-		},
-		{
-			name: "report buckets true",
-			stringMap: map[string]interface{}{
-				"api": map[string]interface{}{"key": "aaa"},
-				"metrics": map[string]interface{}{
-					"report_buckets": true,
-				},
-			},
-			expectedError: errBuckets,
-		},
-		{
-			name: "no report buckets",
-			stringMap: map[string]interface{}{
-				"api": map[string]interface{}{"key": "aaa"},
-			},
-			expectedError: nil,
-		},
-	}
-
-	for _, testInstance := range tests {
-		t.Run(testInstance.name, func(t *testing.T) {
-			// default config for buckets
-			config := Config{Metrics: MetricsConfig{HistConfig: HistogramConfig{Mode: histogramModeDistributions}}}
-			configMap := colconfig.NewMapFromStringMap(testInstance.stringMap)
-			err := config.Unmarshal(configMap)
-
-			if testInstance.expectedError != nil {
-				require.Error(t, err)
-				require.ErrorIs(t, testInstance.expectedError, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
 }

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -117,14 +117,6 @@ func createMetricsExporter(
 		return nil, err
 	}
 
-	// TODO: Remove after two releases
-	if cfg.Metrics.HistConfig.Mode == "counters" {
-		set.Logger.Warn("Histogram bucket metrics now end with .bucket instead of .count_per_bucket")
-	}
-
-	// TODO: Remove after changing the default mode.
-	set.Logger.Info("Histograms configuration now defaults to 'distributions' mode and no .count and .sum metrics.")
-
 	ctx, cancel := context.WithCancel(ctx)
 	var pushMetricsFn consumerhelper.ConsumeMetricsFunc
 


### PR DESCRIPTION
**Description:**

Removes obsolete warnings on configuration that was changed.

**Link to tracking Issue:** Fixes #5873

**Testing:** I removed the unit test for this, since now we have a generic unmarshal error.
