### PR TITLE
[exporter/datadog] Bump quantile dep to v0.33.0

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.12 // indirect
-	github.com/DataDog/datadog-agent/pkg/quantile v0.32.4 // indirect
+	github.com/DataDog/datadog-agent/pkg/quantile v0.33.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.0.0-20201009092105-58e18918b2db // indirect
 	github.com/DataDog/datadog-go v4.8.2+incompatible // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -149,8 +149,8 @@ github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/agent-payload/v5 v5.0.12 h1:N8hQFq5dDZVauSmf6OrjCEZR9jCDlAlrMWxFRsFL+0g=
 github.com/DataDog/agent-payload/v5 v5.0.12/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-20211129110424-6491aa3bf583/go.mod h1:EP9f4GqaDJyP1F5jTNMtzdIpw3JpNs3rMSJOnYywCiw=
-github.com/DataDog/datadog-agent/pkg/quantile v0.32.4 h1:cPVvKsQ3ENd3FxfeM/yln42czFn+9lRcBIC6xPPKu9I=
-github.com/DataDog/datadog-agent/pkg/quantile v0.32.4/go.mod h1:AJEOJwqKBG7f1e3/jtxjb1tUdW4RG30PhllTgKg1fDc=
+github.com/DataDog/datadog-agent/pkg/quantile v0.33.0 h1:BEGJsmHEaLWyMpQ0SPKvMLFgp3GviuXa5IhKdnuReV4=
+github.com/DataDog/datadog-agent/pkg/quantile v0.33.0/go.mod h1:AJEOJwqKBG7f1e3/jtxjb1tUdW4RG30PhllTgKg1fDc=
 github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02 h1:N2BRKjJ/c+ipDwt5b+ijqEc2EsmK3zXq2lNeIPnSwMI=
 github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02/go.mod h1:EalMiS87Guu6PkLdxz7gmWqi+dRs9sjYLTOyTrM/aVU=
 github.com/DataDog/datadog-agent/pkg/util/log v0.0.0-20201009091607-ce4e57cdf8f4/go.mod h1:cRy7lwapA3jcjnX74kU6NFkXaRGQyB0l/QZA0IwYGEQ=

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.12
-	github.com/DataDog/datadog-agent/pkg/quantile v0.32.4
+	github.com/DataDog/datadog-agent/pkg/quantile v0.33.0
 	github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02
 	github.com/aws/aws-sdk-go v1.42.48
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -54,8 +54,8 @@ github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/agent-payload/v5 v5.0.12 h1:N8hQFq5dDZVauSmf6OrjCEZR9jCDlAlrMWxFRsFL+0g=
 github.com/DataDog/agent-payload/v5 v5.0.12/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-20211129110424-6491aa3bf583/go.mod h1:EP9f4GqaDJyP1F5jTNMtzdIpw3JpNs3rMSJOnYywCiw=
-github.com/DataDog/datadog-agent/pkg/quantile v0.32.4 h1:cPVvKsQ3ENd3FxfeM/yln42czFn+9lRcBIC6xPPKu9I=
-github.com/DataDog/datadog-agent/pkg/quantile v0.32.4/go.mod h1:AJEOJwqKBG7f1e3/jtxjb1tUdW4RG30PhllTgKg1fDc=
+github.com/DataDog/datadog-agent/pkg/quantile v0.33.0 h1:BEGJsmHEaLWyMpQ0SPKvMLFgp3GviuXa5IhKdnuReV4=
+github.com/DataDog/datadog-agent/pkg/quantile v0.33.0/go.mod h1:AJEOJwqKBG7f1e3/jtxjb1tUdW4RG30PhllTgKg1fDc=
 github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02 h1:N2BRKjJ/c+ipDwt5b+ijqEc2EsmK3zXq2lNeIPnSwMI=
 github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02/go.mod h1:EalMiS87Guu6PkLdxz7gmWqi+dRs9sjYLTOyTrM/aVU=
 github.com/DataDog/datadog-agent/pkg/util/log v0.0.0-20201009091607-ce4e57cdf8f4/go.mod h1:cRy7lwapA3jcjnX74kU6NFkXaRGQyB0l/QZA0IwYGEQ=

--- a/go.mod
+++ b/go.mod
@@ -144,7 +144,7 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.12 // indirect
-	github.com/DataDog/datadog-agent/pkg/quantile v0.32.4 // indirect
+	github.com/DataDog/datadog-agent/pkg/quantile v0.33.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.0.0-20201009092105-58e18918b2db // indirect
 	github.com/DataDog/datadog-go v4.8.2+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/agent-payload/v5 v5.0.12 h1:N8hQFq5dDZVauSmf6OrjCEZR9jCDlAlrMWxFRsFL+0g=
 github.com/DataDog/agent-payload/v5 v5.0.12/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-20211129110424-6491aa3bf583/go.mod h1:EP9f4GqaDJyP1F5jTNMtzdIpw3JpNs3rMSJOnYywCiw=
-github.com/DataDog/datadog-agent/pkg/quantile v0.32.4 h1:cPVvKsQ3ENd3FxfeM/yln42czFn+9lRcBIC6xPPKu9I=
-github.com/DataDog/datadog-agent/pkg/quantile v0.32.4/go.mod h1:AJEOJwqKBG7f1e3/jtxjb1tUdW4RG30PhllTgKg1fDc=
+github.com/DataDog/datadog-agent/pkg/quantile v0.33.0 h1:BEGJsmHEaLWyMpQ0SPKvMLFgp3GviuXa5IhKdnuReV4=
+github.com/DataDog/datadog-agent/pkg/quantile v0.33.0/go.mod h1:AJEOJwqKBG7f1e3/jtxjb1tUdW4RG30PhllTgKg1fDc=
 github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02 h1:N2BRKjJ/c+ipDwt5b+ijqEc2EsmK3zXq2lNeIPnSwMI=
 github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02/go.mod h1:EalMiS87Guu6PkLdxz7gmWqi+dRs9sjYLTOyTrM/aVU=
 github.com/DataDog/datadog-agent/pkg/util/log v0.0.0-20201009091607-ce4e57cdf8f4/go.mod h1:cRy7lwapA3jcjnX74kU6NFkXaRGQyB0l/QZA0IwYGEQ=


### PR DESCRIPTION
**Description:** 

Reverts #7253: we re-tagged the offending dependency in the same commit as the Go proxy.

**Link to tracking Issue:** n/a
