### PR TITLE
[processor/tailsampling] Keep original resource/instrumentation data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 
 - `sumologicexporter`: Move validation to Config (#7936)
 - `elasticsearchexporter`: Fix crash with batch processor (#7953).
+- `processor/tailsampling`: Keep original resource/instrumentation data (#7771)
 - `splunkhecexporter`: Batch metrics payloads (#7760)
 - `tanzuobservabilityexporter`: Add internal SDK metric tag (#7826)
 - `hostreceiver/processscraper`: Migrate the scraper to the mdatagen metrics builder (#7287)

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -319,7 +319,7 @@ func (tsp *tailSamplingSpanProcessor) groupResourceSpansByTraceID(rsSource pdata
 	// split by trace ID
 	for traceID := range idToResourceSpans {
 		rs := idToResourceSpans[traceID]
-		rsSource.Resource().CopyTo(rs.Resource())
+		rsSource.Resource().MoveTo(rs.Resource())
 		rs.SetSchemaUrl(rsSource.SchemaUrl())
 
 		ilss := rsSource.InstrumentationLibrarySpans()
@@ -327,7 +327,7 @@ func (tsp *tailSamplingSpanProcessor) groupResourceSpansByTraceID(rsSource pdata
 			ilsSource := ilss.At(i)
 
 			ils := pdata.NewInstrumentationLibrarySpans()
-			ilsSource.InstrumentationLibrary().CopyTo(ils.InstrumentationLibrary())
+			ilsSource.InstrumentationLibrary().MoveTo(ils.InstrumentationLibrary())
 			ils.SetSchemaUrl(ilsSource.SchemaUrl())
 
 			spansSource := ilsSource.Spans()


### PR DESCRIPTION
Closes #7050 by splitting the incoming resource spans into one resource span per trace, keeping them in the original instrumentation libraries.

DRAFT: in this first draft, I implemented only the splitting function that would be the core of this change. If this seems acceptable, I'll change the other parts of the processor to keep the new map type in memory instead of the current one. There might be performance optimization opportunities here as well. For now, I would just like to validate the idea and see if this is worth pursuing at all.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
