### PR TITLE
Cleanup prw translator public functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ## 🛑 Breaking changes 🛑
 
 - `resourcedetectionprocessor`: Update `os.type` attribute values according to semantic conventions (#7544)
+- `pkg/translator/prometheusremotewrite`: Cleanup prw translator public functions (#7776)
 
 ## 🚀 New components 🚀
 

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -313,19 +313,17 @@ func Test_export(t *testing.T) {
 			if !tt.serverUp {
 				server.Close()
 			}
-			errs := runExportPipeline(ts1, serverURL)
+			err := runExportPipeline(ts1, serverURL)
 			if tt.returnErrorOnCreate {
-				assert.Error(t, errs[0])
+				assert.Error(t, err)
 				return
 			}
-			assert.Len(t, errs, 0)
+			assert.NoError(t, err)
 		})
 	}
 }
 
-func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) []error {
-	var errs []error
-
+func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 	// First we will construct a TimeSeries array from the testutils package
 	testmap := make(map[string]*prompb.TimeSeries)
 	testmap["test"] = ts
@@ -343,17 +341,14 @@ func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) []error {
 	// after this, instantiate a CortexExporter with the current HTTP client and endpoint set to passed in endpoint
 	prwe, err := newPRWExporter(cfg, set)
 	if err != nil {
-		errs = append(errs, err)
-		return errs
+		return err
 	}
 
 	if err = prwe.Start(context.Background(), componenttest.NewNopHost()); err != nil {
-		errs = append(errs, err)
-		return errs
+		return err
 	}
 
-	errs = append(errs, prwe.export(context.Background(), testmap)...)
-	return errs
+	return prwe.export(context.Background(), testmap)
 }
 
 // Test_PushMetrics checks the number of TimeSeries received by server and the number of metrics dropped is the same as

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -246,11 +246,10 @@ func validateMetrics(metric pdata.Metric) bool {
 
 // addSingleNumberDataPoint converts the metric value stored in pt to a Prometheus sample, and add the sample
 // to its corresponding time series in tsMap
-func addSingleNumberDataPoint(pt pdata.NumberDataPoint, resource pdata.Resource, metric pdata.Metric, namespace string,
-	tsMap map[string]*prompb.TimeSeries, externalLabels map[string]string) {
+func addSingleNumberDataPoint(pt pdata.NumberDataPoint, resource pdata.Resource, metric pdata.Metric, settings Settings, tsMap map[string]*prompb.TimeSeries) {
 	// create parameters for addSample
-	name := getPromMetricName(metric, namespace)
-	labels := createAttributes(resource, pt.Attributes(), externalLabels, nameStr, name)
+	name := getPromMetricName(metric, settings.Namespace)
+	labels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, name)
 	sample := &prompb.Sample{
 		// convert ns to ms
 		Timestamp: convertTimeStamp(pt.Timestamp()),
@@ -269,11 +268,10 @@ func addSingleNumberDataPoint(pt pdata.NumberDataPoint, resource pdata.Resource,
 
 // addSingleHistogramDataPoint converts pt to 2 + min(len(ExplicitBounds), len(BucketCount)) + 1 samples. It
 // ignore extra buckets if len(ExplicitBounds) > len(BucketCounts)
-func addSingleHistogramDataPoint(pt pdata.HistogramDataPoint, resource pdata.Resource, metric pdata.Metric, namespace string,
-	tsMap map[string]*prompb.TimeSeries, externalLabels map[string]string) {
+func addSingleHistogramDataPoint(pt pdata.HistogramDataPoint, resource pdata.Resource, metric pdata.Metric, settings Settings, tsMap map[string]*prompb.TimeSeries) {
 	time := convertTimeStamp(pt.Timestamp())
 	// sum, count, and buckets of the histogram should append suffix to baseName
-	baseName := getPromMetricName(metric, namespace)
+	baseName := getPromMetricName(metric, settings.Namespace)
 	// treat sum as a sample in an individual TimeSeries
 	sum := &prompb.Sample{
 		Value:     pt.Sum(),
@@ -283,7 +281,7 @@ func addSingleHistogramDataPoint(pt pdata.HistogramDataPoint, resource pdata.Res
 		sum.Value = math.Float64frombits(value.StaleNaN)
 	}
 
-	sumlabels := createAttributes(resource, pt.Attributes(), externalLabels, nameStr, baseName+sumStr)
+	sumlabels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, baseName+sumStr)
 	addSample(tsMap, sum, sumlabels, metric)
 
 	// treat count as a sample in an individual TimeSeries
@@ -295,7 +293,7 @@ func addSingleHistogramDataPoint(pt pdata.HistogramDataPoint, resource pdata.Res
 		count.Value = math.Float64frombits(value.StaleNaN)
 	}
 
-	countlabels := createAttributes(resource, pt.Attributes(), externalLabels, nameStr, baseName+countStr)
+	countlabels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, baseName+countStr)
 	addSample(tsMap, count, countlabels, metric)
 
 	// cumulative count for conversion to cumulative histogram
@@ -319,7 +317,7 @@ func addSingleHistogramDataPoint(pt pdata.HistogramDataPoint, resource pdata.Res
 			bucket.Value = math.Float64frombits(value.StaleNaN)
 		}
 		boundStr := strconv.FormatFloat(bound, 'f', -1, 64)
-		labels := createAttributes(resource, pt.Attributes(), externalLabels, nameStr, baseName+bucketStr, leStr, boundStr)
+		labels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, baseName+bucketStr, leStr, boundStr)
 		sig := addSample(tsMap, bucket, labels, metric)
 
 		bucketBounds = append(bucketBounds, bucketBoundsData{sig: sig, bound: bound})
@@ -334,7 +332,7 @@ func addSingleHistogramDataPoint(pt pdata.HistogramDataPoint, resource pdata.Res
 		cumulativeCount += pt.BucketCounts()[len(pt.BucketCounts())-1]
 		infBucket.Value = float64(cumulativeCount)
 	}
-	infLabels := createAttributes(resource, pt.Attributes(), externalLabels, nameStr, baseName+bucketStr, leStr, pInfStr)
+	infLabels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, baseName+bucketStr, leStr, pInfStr)
 	sig := addSample(tsMap, infBucket, infLabels, metric)
 
 	bucketBounds = append(bucketBounds, bucketBoundsData{sig: sig, bound: math.Inf(1)})
@@ -370,11 +368,11 @@ func getPromExemplars(pt pdata.HistogramDataPoint) []prompb.Exemplar {
 }
 
 // addSingleSummaryDataPoint converts pt to len(QuantileValues) + 2 samples.
-func addSingleSummaryDataPoint(pt pdata.SummaryDataPoint, resource pdata.Resource, metric pdata.Metric, namespace string,
-	tsMap map[string]*prompb.TimeSeries, externalLabels map[string]string) {
+func addSingleSummaryDataPoint(pt pdata.SummaryDataPoint, resource pdata.Resource, metric pdata.Metric, settings Settings,
+	tsMap map[string]*prompb.TimeSeries) {
 	time := convertTimeStamp(pt.Timestamp())
 	// sum and count of the summary should append suffix to baseName
-	baseName := getPromMetricName(metric, namespace)
+	baseName := getPromMetricName(metric, settings.Namespace)
 	// treat sum as a sample in an individual TimeSeries
 	sum := &prompb.Sample{
 		Value:     pt.Sum(),
@@ -383,7 +381,7 @@ func addSingleSummaryDataPoint(pt pdata.SummaryDataPoint, resource pdata.Resourc
 	if pt.Flags().HasFlag(pdata.MetricDataPointFlagNoRecordedValue) {
 		sum.Value = math.Float64frombits(value.StaleNaN)
 	}
-	sumlabels := createAttributes(resource, pt.Attributes(), externalLabels, nameStr, baseName+sumStr)
+	sumlabels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, baseName+sumStr)
 	addSample(tsMap, sum, sumlabels, metric)
 
 	// treat count as a sample in an individual TimeSeries
@@ -394,7 +392,7 @@ func addSingleSummaryDataPoint(pt pdata.SummaryDataPoint, resource pdata.Resourc
 	if pt.Flags().HasFlag(pdata.MetricDataPointFlagNoRecordedValue) {
 		count.Value = math.Float64frombits(value.StaleNaN)
 	}
-	countlabels := createAttributes(resource, pt.Attributes(), externalLabels, nameStr, baseName+countStr)
+	countlabels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, baseName+countStr)
 	addSample(tsMap, count, countlabels, metric)
 
 	// process each percentile/quantile
@@ -408,7 +406,7 @@ func addSingleSummaryDataPoint(pt pdata.SummaryDataPoint, resource pdata.Resourc
 			quantile.Value = math.Float64frombits(value.StaleNaN)
 		}
 		percentileStr := strconv.FormatFloat(qt.Quantile(), 'f', -1, 64)
-		qtlabels := createAttributes(resource, pt.Attributes(), externalLabels, nameStr, baseName, quantileStr, percentileStr)
+		qtlabels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, baseName, quantileStr, percentileStr)
 		addSample(tsMap, quantile, qtlabels, metric)
 	}
 }

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -24,7 +24,22 @@ import (
 	"go.uber.org/multierr"
 )
 
-func MetricsToPRW(namespace string, externalLabels map[string]string, md pdata.Metrics) (tsMap map[string]*prompb.TimeSeries, dropped int, errs error) {
+// Deprecated: [0.45.0] use `prometheusremotewrite.FromMetrics`. It does not wrap the error as `NewPermanent`.
+func MetricsToPRW(namespace string, externalLabels map[string]string, md pdata.Metrics) (map[string]*prompb.TimeSeries, int, error) {
+	tsMap, err := FromMetrics(md, Settings{Namespace: namespace, ExternalLabels: externalLabels})
+	if err != nil {
+		err = consumererror.NewPermanent(err)
+	}
+	return tsMap, md.MetricCount() - len(tsMap), err
+}
+
+type Settings struct {
+	Namespace      string
+	ExternalLabels map[string]string
+}
+
+// FromMetrics converts pdata.Metrics to prometheus remote write format.
+func FromMetrics(md pdata.Metrics, settings Settings) (tsMap map[string]*prompb.TimeSeries, errs error) {
 	tsMap = make(map[string]*prompb.TimeSeries)
 
 	resourceMetricsSlice := md.ResourceMetrics()
@@ -43,8 +58,7 @@ func MetricsToPRW(namespace string, externalLabels map[string]string, md pdata.M
 
 				// check for valid type and temporality combination and for matching data field and type
 				if ok := validateMetrics(metric); !ok {
-					dropped++
-					errs = multierr.Append(errs, consumererror.NewPermanent(errors.New("invalid temporality and type combination")))
+					errs = multierr.Append(errs, errors.New("invalid temporality and type combination"))
 					continue
 				}
 
@@ -52,38 +66,33 @@ func MetricsToPRW(namespace string, externalLabels map[string]string, md pdata.M
 				switch metric.DataType() {
 				case pdata.MetricDataTypeGauge:
 					dataPoints := metric.Gauge().DataPoints()
-					if err := addNumberDataPointSlice(dataPoints, tsMap, namespace, externalLabels, resource, metric); err != nil {
-						dropped++
+					if err := addNumberDataPointSlice(dataPoints, resource, metric, settings, tsMap); err != nil {
 						errs = multierr.Append(errs, err)
 					}
 				case pdata.MetricDataTypeSum:
 					dataPoints := metric.Sum().DataPoints()
-					if err := addNumberDataPointSlice(dataPoints, tsMap, namespace, externalLabels, resource, metric); err != nil {
-						dropped++
+					if err := addNumberDataPointSlice(dataPoints, resource, metric, settings, tsMap); err != nil {
 						errs = multierr.Append(errs, err)
 					}
 
 				case pdata.MetricDataTypeHistogram:
 					dataPoints := metric.Histogram().DataPoints()
 					if dataPoints.Len() == 0 {
-						dropped++
-						errs = multierr.Append(errs, consumererror.NewPermanent(fmt.Errorf("empty data points. %s is dropped", metric.Name())))
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
 					}
 					for x := 0; x < dataPoints.Len(); x++ {
-						addSingleHistogramDataPoint(dataPoints.At(x), resource, metric, namespace, tsMap, externalLabels)
+						addSingleHistogramDataPoint(dataPoints.At(x), resource, metric, settings, tsMap)
 					}
 				case pdata.MetricDataTypeSummary:
 					dataPoints := metric.Summary().DataPoints()
 					if dataPoints.Len() == 0 {
-						dropped++
-						errs = multierr.Append(errs, consumererror.NewPermanent(fmt.Errorf("empty data points. %s is dropped", metric.Name())))
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
 					}
 					for x := 0; x < dataPoints.Len(); x++ {
-						addSingleSummaryDataPoint(dataPoints.At(x), resource, metric, namespace, tsMap, externalLabels)
+						addSingleSummaryDataPoint(dataPoints.At(x), resource, metric, settings, tsMap)
 					}
 				default:
-					dropped++
-					errs = multierr.Append(errs, consumererror.NewPermanent(errors.New("unsupported metric type")))
+					errs = multierr.Append(errs, errors.New("unsupported metric type"))
 				}
 			}
 		}
@@ -93,13 +102,13 @@ func MetricsToPRW(namespace string, externalLabels map[string]string, md pdata.M
 }
 
 func addNumberDataPointSlice(dataPoints pdata.NumberDataPointSlice,
-	tsMap map[string]*prompb.TimeSeries, namespace string, externalLabels map[string]string,
-	resource pdata.Resource, metric pdata.Metric) error {
+	resource pdata.Resource, metric pdata.Metric,
+	settings Settings, tsMap map[string]*prompb.TimeSeries) error {
 	if dataPoints.Len() == 0 {
-		return consumererror.NewPermanent(fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+		return fmt.Errorf("empty data points. %s is dropped", metric.Name())
 	}
 	for x := 0; x < dataPoints.Len(); x++ {
-		addSingleNumberDataPoint(dataPoints.At(x), resource, metric, namespace, tsMap, externalLabels)
+		addSingleNumberDataPoint(dataPoints.At(x), resource, metric, settings, tsMap)
 	}
 	return nil
 }


### PR DESCRIPTION
* Allow to add extra settings;
* Remove unnecessary dropped, can also be calculated as `md.MetricCount() - len(tsMap)`
* Remove dependency on the collector consumererror in the new API. When deprecated API is remove the dependency on the collector is removed.
* Change PRW exporter to the new API; Minor improvement on the errors handling;

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
