### PR TITLE
Fixes (#6734) CPU Reserved Should Be 1024 Per VCPU ECS Container Insi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
  - `prometheusreceiver`: Correctly map description and units when converting
   Prometheus metadata directly to pdata. (#7748)
  - `sumologicexporter`: fix exporter panics on malformed histogram (#7548)
+- `awsecscontainermetrics`: CPU Reserved is now 1024/vCPU for ECS Container Insights (#6734)
 
 ## 🚀 New components 🚀
 

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator.go
@@ -97,11 +97,9 @@ func overrideWithTaskLevelLimit(taskMetrics *ECSMetrics, metadata ecsutil.TaskMe
 		taskMetrics.MemoryReserved = *metadata.Limits.Memory
 	}
 
-	taskMetrics.CPUReserved = taskMetrics.CPUReserved / cpusInVCpu
-
 	// Overwrite CPU limit with task level limit
 	if metadata.Limits.CPU != nil {
-		taskMetrics.CPUReserved = *metadata.Limits.CPU
+		taskMetrics.CPUReserved = *metadata.Limits.CPU * cpusInVCpu
 	}
 
 	// taskMetrics.CPUReserved cannot be zero. In ECS, user needs to set CPU limit
@@ -109,7 +107,7 @@ func overrideWithTaskLevelLimit(taskMetrics *ECSMetrics, metadata ecsutil.TaskMe
 	// task level CPULimit is not present, we calculate it from the summation of
 	// all container CPU limits.
 	if taskMetrics.CPUReserved > 0 {
-		taskMetrics.CPUUtilized = ((taskMetrics.CPUUsageInVCPU / taskMetrics.CPUReserved) * 100)
+		taskMetrics.CPUUtilized = taskMetrics.CPUUsageInVCPU * cpusInVCpu
 	}
 }
 

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/constant.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/constant.go
@@ -77,6 +77,6 @@ const (
 	unitBytesPerSec = "Bytes/Second"
 	unitCount       = "Count"
 	unitVCpu        = "vCPU"
-	unitPercent     = "Percent"
 	unitSecond      = "Seconds"
+	unitNone        = "None"
 )

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
@@ -39,8 +39,8 @@ func convertToOTLPMetrics(prefix string, m ECSMetrics, r pdata.Resource, timesta
 	appendIntGauge(prefix+attributeCPUCores, unitCount, int64(m.NumOfCPUCores), timestamp, ilms.AppendEmpty())
 	appendIntGauge(prefix+attributeCPUOnlines, unitCount, int64(m.CPUOnlineCpus), timestamp, ilms.AppendEmpty())
 	appendIntSum(prefix+attributeCPUSystemUsage, unitNanoSecond, int64(m.SystemCPUUsage), timestamp, ilms.AppendEmpty())
-	appendDoubleGauge(prefix+attributeCPUUtilized, unitPercent, m.CPUUtilized, timestamp, ilms.AppendEmpty())
-	appendDoubleGauge(prefix+attributeCPUReserved, unitVCpu, m.CPUReserved, timestamp, ilms.AppendEmpty())
+	appendDoubleGauge(prefix+attributeCPUUtilized, unitNone, m.CPUUtilized, timestamp, ilms.AppendEmpty())
+	appendDoubleGauge(prefix+attributeCPUReserved, unitNone, m.CPUReserved, timestamp, ilms.AppendEmpty())
 	appendDoubleGauge(prefix+attributeCPUUsageInVCPU, unitVCpu, m.CPUUsageInVCPU, timestamp, ilms.AppendEmpty())
 
 	appendDoubleGauge(prefix+attributeNetworkRateRx, unitBytesPerSec, m.NetworkRateRxBytesPerSecond, timestamp, ilms.AppendEmpty())


### PR DESCRIPTION
…ghts

**Description:** 
Container Insights unit mismatch for cpu reserved and utilized 

**Link to tracking Issue:** Fixes #6734

**Testing:** 
<img width="1792" alt="Screen Shot 2022-02-09 at 2 22 31 PM" src="https://user-images.githubusercontent.com/81644108/153275587-fa08d1ba-aaf4-4807-999e-3fb3445c3331.png">

Container insights via cluster 
```
{
    "Version": "0",
    "Type": "Container",
    "ContainerName": "spark-sample-app",
    "TaskId": "08bb35d7bf9a4ea081ef0223daa91b17",
    "TaskDefinitionFamily": "spark-app-only",
    "TaskDefinitionRevision": "1",
    "ClusterName": "seth-fargate-testing",
    "Image": "public.ecr.aws/aws-otel-test/aws-otel-java-test-spark:v0.11.0",
    "ContainerKnownStatus": "PENDING",
    "Timestamp": 1644434400000,
    "CpuUtilized": 19.45041259765625,
    "CpuReserved": 0,
    "MemoryUtilized": 159,
    "StorageReadBytes": 0,
    "StorageWriteBytes": 163840,
    "NetworkRxBytes": 2698,
    "NetworkRxDropped": 0,
    "NetworkRxErrors": 0,
    "NetworkRxPackets": 184940,
    "NetworkTxBytes": 941,
    "NetworkTxDropped": 0,
    "NetworkTxErrors": 0,
    "NetworkTxPackets": 8095
}
```

Container insights via collector 
```
{
    "AccountId": "504799192994",
    "ClusterName": "seth-test-fargate-no-container-insights",
    "CpuReserved": 1024,
    "CpuUtilized": 22.902693919573416,
    "LaunchType": "FARGATE",
    "MemoryReserved": 2048,
    "MemoryUtilized": 199,
    "NetworkRxBytes": 7198.608101324631,
    "NetworkTxBytes": 2743.6030876551354,
    "PullStartedAt": "2022-02-09T19:07:52.02527745Z",
    "PullStoppedAt": "2022-02-09T19:08:36.600744097Z",
    "Region": "us-west-2",
    "ServiceName": "undefined",
    "StorageReadBytes": 0,
    "StorageWriteBytes": 163840,
    "TaskARN": "arn:aws:ecs:us-west-2:504799192994:task/seth-test-fargate-no-container-insights/3fe83a945ab94af9b97a816d1e34a247",
    "TaskDefinitionFamily": "spark-with-container-insights",
    "TaskDefinitionRevision": "4",
    "TaskId": "3fe83a945ab94af9b97a816d1e34a247",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Namespace": "ECS/ContainerInsights",
                "Dimensions": [
                    [
                        "ClusterName"
                    ],
                    [
                        "ClusterName",
                        "TaskDefinitionFamily"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "NetworkRxBytes",
                        "Unit": "Bytes/Second"
                    },
                    {
                        "Name": "NetworkTxBytes",
                        "Unit": "Bytes/Second"
                    },
                    {
                        "Name": "StorageReadBytes",
                        "Unit": "Bytes"
                    },
                    {
                        "Name": "StorageWriteBytes",
                        "Unit": "Bytes"
                    },
                    {
                        "Name": "MemoryUtilized",
                        "Unit": "Megabytes"
                    },
                    {
                        "Name": "MemoryReserved",
                        "Unit": "Megabytes"
                    },
                    {
                        "Name": "CpuUtilized",
                        "Unit": "None"
                    },
                    {
                        "Name": "CpuReserved",
                        "Unit": "None"
                    }
                ]
            }
        ],
        "Timestamp": 1644434899996
    },
    "aws.ecs.task.known_status": "RUNNING",
    "cloud.availability_zone": "us-west-2a"
}
```

config otel-task-metrics-config in aws collector

```
extensions:
  health_check:

receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317
      http:
        endpoint: 0.0.0.0:55681
  awsxray:
    endpoint: 0.0.0.0:2000
    transport: udp
  statsd:
    endpoint: 0.0.0.0:8125
    aggregation_interval: 60s
  awsecscontainermetrics:

processors:
  batch/traces:
    timeout: 1s
    send_batch_size: 50
  batch/metrics:
    timeout: 60s
  filter:
    metrics:
      include:
        match_type: strict
        metric_names:
          - ecs.task.memory.reserved
          - ecs.task.memory.utilized
          - ecs.task.cpu.reserved
          - ecs.task.cpu.utilized
          - ecs.task.network.rate.rx
          - ecs.task.network.rate.tx
          - ecs.task.storage.read_bytes
          - ecs.task.storage.write_bytes
          - container.duration
  metricstransform:
    transforms:
      - metric_name: ecs.task.memory.utilized
        action: update
        new_name: MemoryUtilized
      - metric_name: ecs.task.memory.reserved
        action: update
        new_name: MemoryReserved
      - metric_name: ecs.task.cpu.utilized
        action: update
        new_name: CpuUtilized
      - metric_name: ecs.task.cpu.reserved
        action: update
        new_name: CpuReserved
      - metric_name: ecs.task.network.rate.rx
        action: update
        new_name: NetworkRxBytes
      - metric_name: ecs.task.network.rate.tx
        action: update
        new_name: NetworkTxBytes
      - metric_name: ecs.task.storage.read_bytes
        action: update
        new_name: StorageReadBytes
      - metric_name: ecs.task.storage.write_bytes
        action: update
        new_name: StorageWriteBytes

  resource:
    attributes:
      - key: ClusterName
        from_attribute: aws.ecs.cluster.name
        action: insert
      - key: aws.ecs.cluster.name
        action: delete
      - key: ServiceName
        from_attribute: aws.ecs.service.name
        action: insert
      - key: aws.ecs.service.name
        action: delete
      - key: TaskId
        from_attribute: aws.ecs.task.id
        action: insert
      - key: aws.ecs.task.id
        action: delete
      - key: TaskDefinitionFamily
        from_attribute: aws.ecs.task.family
        action: insert
      - key: aws.ecs.task.family
        action: delete
      - key: TaskARN
        from_attribute: aws.ecs.task.arn
        action: insert
      - key: aws.ecs.task.arn
        action: delete
      - key: DockerName
        from_attribute: aws.ecs.docker.name
        action: insert
      - key: aws.ecs.docker.name
        action: delete
      - key: TaskDefinitionRevision
        from_attribute: aws.ecs.task.version
        action: insert
      - key: aws.ecs.task.version
        action: delete
      - key: PullStartedAt
        from_attribute: aws.ecs.task.pull_started_at
        action: insert
      - key: aws.ecs.task.pull_started_at
        action: delete
      - key: PullStoppedAt
        from_attribute: aws.ecs.task.pull_stopped_at
        action: insert
      - key: aws.ecs.task.pull_stopped_at
        action: delete
      - key: AvailabilityZone
        from_attribute: cloud.zone
        action: insert
      - key: cloud.zone
        action: delete
      - key: LaunchType
        from_attribute: aws.ecs.task.launch_type
        action: insert
      - key: aws.ecs.task.launch_type
        action: delete
      - key: Region
        from_attribute: cloud.region
        action: insert
      - key: cloud.region
        action: delete
      - key: AccountId
        from_attribute: cloud.account.id
        action: insert
      - key: cloud.account.id
        action: delete
      - key: DockerId
        from_attribute: container.id
        action: insert
      - key: container.id
        action: delete
      - key: ContainerName
        from_attribute: container.name
        action: insert
      - key: container.name
        action: delete
      - key: Image
        from_attribute: container.image.name
        action: insert
      - key: container.image.name
        action: delete
      - key: ImageId
        from_attribute: aws.ecs.container.image.id
        action: insert
      - key: aws.ecs.container.image.id
        action: delete
      - key: ExitCode
        from_attribute: aws.ecs.container.exit_code
        action: insert
      - key: aws.ecs.container.exit_code
        action: delete
      - key: CreatedAt
        from_attribute: aws.ecs.container.created_at
        action: insert
      - key: aws.ecs.container.created_at
        action: delete
      - key: StartedAt
        from_attribute: aws.ecs.container.started_at
        action: insert
      - key: aws.ecs.container.started_at
        action: delete
      - key: FinishedAt
        from_attribute: aws.ecs.container.finished_at
        action: insert
      - key: aws.ecs.container.finished_at
        action: delete
      - key: ImageTag
        from_attribute: container.image.tag
        action: insert
      - key: container.image.tag
        action: delete

exporters:
  awsxray:
  awsemf/application:
    namespace: ECS/AWSOTel/Application
    log_group_name: '/aws/ecs/application/metrics'
  awsemf/performance:
    namespace: ECS/ContainerInsights
    log_group_name: '/aws/ecs/containerinsights/{ClusterName}/performance'
    log_stream_name: '{TaskId}'
    resource_to_telemetry_conversion:
      enabled: true
    dimension_rollup_option: NoDimensionRollup
    metric_declarations:
      - dimensions: [ [ ClusterName ], [ ClusterName, TaskDefinitionFamily ] ]
        metric_name_selectors:
          - MemoryUtilized
          - MemoryReserved
          - CpuUtilized
          - CpuReserved
          - NetworkRxBytes
          - NetworkTxBytes
          - StorageReadBytes
          - StorageWriteBytes
      - metric_name_selectors: [container.*]

service:
  pipelines:
    traces:
      receivers: [otlp,awsxray]
      processors: [batch/traces]
      exporters: [awsxray]
    metrics/application:
      receivers: [otlp, statsd]
      processors: [batch/metrics]
      exporters: [awsemf/application]
    metrics/performance:
      receivers: [awsecscontainermetrics ]
      processors: [filter, metricstransform, resource]
      exporters: [ awsemf/performance ]

  extensions: [health_check]
```
