### PR TITLE
Add @pmm-sumo as an Approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs
 - [David Ashpole](https://github.com/dashpole), Google
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
 - [Pablo Baeyens](https://github.com/mx-psi), DataDog
+- [Przemek Maciolek](https://github.com/pmm-sumo), Sumo Logic
 
 Maintainers ([@open-telemetry/collector-contrib-maintainer](https://github.com/orgs/open-telemetry/teams/collector-contrib-maintainer)):
 


### PR DESCRIPTION
The current maintainers unanimously agreed that Przemek qualifies as an approver. Welcome, Przemek!
