### PR TITLE
Remove Name From AWS Cloudwatch Logs Exporter Fixes (#7554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `datadogexporter`: Don't send host metadata if hostname is empty (#7426)
 - `datadogexporter`: Add insecure_skip_verify flag to configuration (#7422)
 - `coralogixexporter`: Update readme (#7785)
+- `awscloudwatchlogsexporter`: Remove name from aws cloudwatch logs exporter (#7554)
 
 ## 🛑 Breaking changes 🛑
 

--- a/exporter/awscloudwatchlogsexporter/exporter.go
+++ b/exporter/awscloudwatchlogsexporter/exporter.go
@@ -171,7 +171,6 @@ func logsToCWLogs(logger *zap.Logger, ld pdata.Logs) ([]*cloudwatchlogs.InputLog
 }
 
 type cwLogBody struct {
-	Name                   string                 `json:"name,omitempty"`
 	Body                   interface{}            `json:"body,omitempty"`
 	SeverityNumber         int32                  `json:"severity_number,omitempty"`
 	SeverityText           string                 `json:"severity_text,omitempty"`
@@ -187,7 +186,6 @@ func logToCWLog(resourceAttrs map[string]interface{}, log pdata.LogRecord) (*clo
 	// TODO(jbd): Benchmark and improve the allocations.
 	// Evaluate go.elastic.co/fastjson as a replacement for encoding/json.
 	body := cwLogBody{
-		Name:                   log.Name(),
 		Body:                   attrValue(log.Body()),
 		SeverityNumber:         int32(log.SeverityNumber()),
 		SeverityText:           log.SeverityText(),

--- a/exporter/awscloudwatchlogsexporter/exporter_test.go
+++ b/exporter/awscloudwatchlogsexporter/exporter_test.go
@@ -66,7 +66,7 @@ func TestLogToCWLog(t *testing.T) {
 			log:      testLogRecord(),
 			want: &cloudwatchlogs.InputLogEvent{
 				Timestamp: aws.Int64(1609719139),
-				Message:   aws.String(`{"name":"test","body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"flags":255,"trace_id":"0102030405060708090a0b0c0d0e0f10","span_id":"0102030405060708","attributes":{"key1":1,"key2":"attr2"},"resource":{"host":"abc123","node":5}}`),
+				Message:   aws.String(`{"body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"flags":255,"trace_id":"0102030405060708090a0b0c0d0e0f10","span_id":"0102030405060708","attributes":{"key1":1,"key2":"attr2"},"resource":{"host":"abc123","node":5}}`),
 			},
 		},
 		{
@@ -75,7 +75,7 @@ func TestLogToCWLog(t *testing.T) {
 			log:      testLogRecord(),
 			want: &cloudwatchlogs.InputLogEvent{
 				Timestamp: aws.Int64(1609719139),
-				Message:   aws.String(`{"name":"test","body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"flags":255,"trace_id":"0102030405060708090a0b0c0d0e0f10","span_id":"0102030405060708","attributes":{"key1":1,"key2":"attr2"}}`),
+				Message:   aws.String(`{"body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"flags":255,"trace_id":"0102030405060708090a0b0c0d0e0f10","span_id":"0102030405060708","attributes":{"key1":1,"key2":"attr2"}}`),
 			},
 		},
 		{
@@ -84,7 +84,7 @@ func TestLogToCWLog(t *testing.T) {
 			log:      testLogRecordWithoutTrace(),
 			want: &cloudwatchlogs.InputLogEvent{
 				Timestamp: aws.Int64(1609719139),
-				Message:   aws.String(`{"name":"test","body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"attributes":{"key1":1,"key2":"attr2"},"resource":{"host":"abc123","node":5}}`),
+				Message:   aws.String(`{"body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"attributes":{"key1":1,"key2":"attr2"},"resource":{"host":"abc123","node":5}}`),
 			},
 		},
 	}
@@ -121,7 +121,6 @@ func testResource() pdata.Resource {
 
 func testLogRecord() pdata.LogRecord {
 	record := pdata.NewLogRecord()
-	record.SetName("test")
 	record.SetSeverityNumber(5)
 	record.SetSeverityText("debug")
 	record.SetDroppedAttributesCount(4)
@@ -137,7 +136,6 @@ func testLogRecord() pdata.LogRecord {
 
 func testLogRecordWithoutTrace() pdata.LogRecord {
 	record := pdata.NewLogRecord()
-	record.SetName("test")
 	record.SetSeverityNumber(5)
 	record.SetSeverityText("debug")
 	record.SetDroppedAttributesCount(4)
@@ -247,7 +245,7 @@ func TestConsumeLogs(t *testing.T) {
 	r.Resource().Attributes().UpsertString("hello", "test")
 	logRecords := r.InstrumentationLibraryLogs().AppendEmpty().LogRecords()
 	logRecords.EnsureCapacity(5)
-	logRecords.AppendEmpty().SetName("test")
+	logRecords.AppendEmpty()
 	assert.Equal(t, 1, ld.LogRecordCount())
 
 	logPusher := new(mockPusher)


### PR DESCRIPTION
**Description:** 
Remove name from log struct

**Link to tracking Issue:** 
(#7554)

**Testing:** 
<img width="1792" alt="Screen Shot 2022-02-10 at 10 37 42 AM" src="https://user-images.githubusercontent.com/81644108/153443072-4e04e331-86b4-44b3-a059-f0a0c6d0ed08.png">

