### PR TITLE
[processor/groupbyattrsprocessor] allow empty keys for compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `honeycombexporter`: Add validation for `sending_queue` setting (#8113)
 - `routingprocessor`: Expand error handling on failure to build exporters (#8125)
 - `skywalkingreceiver`: Add new skywalking receiver component folder and structure (#8107)
+- `groupbyattrsprocesor`: Allow empty keys, which allows to use the processor for compaction (#7793)
 
 ### 🛑 Breaking changes 🛑
 
@@ -43,7 +44,6 @@
 - `splunkhecexporter`: Batch metrics payloads (#7760)
 - `tanzuobservabilityexporter`: Add internal SDK metric tag (#7826)
 - `hostreceiver/processscraper`: Migrate the scraper to the mdatagen metrics builder (#7287)
-- `groupbyattrsprocesor`: Allow empty keys, which allows to use the processor for compaction (#7793)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - `splunkhecexporter`: Batch metrics payloads (#7760)
 - `tanzuobservabilityexporter`: Add internal SDK metric tag (#7826)
 - `hostreceiver/processscraper`: Migrate the scraper to the mdatagen metrics builder (#7287)
+- `groupbyattrsprocesor`: Allow empty keys, which allows to use the processor for compaction (#7793)
 
 ### 🧰 Bug fixes 🧰
 

--- a/processor/groupbyattrsprocessor/README.md
+++ b/processor/groupbyattrsprocessor/README.md
@@ -92,29 +92,29 @@ In some cases, the data might come in single requests to the collector and even 
 
 For example, consider the following input:
 
-```
+```go
 Resource {host.name="localhost"}
   InstumentationLibrary {name="MyLibrary"}
   Spans
-    Span {"span_id"=1, ...}
+    Span {span_id=1, ...}
   InstumentationLibrary {name="OtherLibrary"}
   Spans
-    Span {"span_id"=2, ...}
+    Span {span_id=2, ...}
     
 Resource {host.name="localhost"}
   InstumentationLibrary {name="MyLibrary"}
   Spans
-    Span {"span_id"=3, ...}
+    Span {span_id=3, ...}
     
 Resource {host.name="localhost"}
   InstumentationLibrary {name="MyLibrary"}
   Spans
-    Span {"span_id"=4, ...}
+    Span {span_id=4, ...}
     
 Resource {host.name="otherhost"}
   InstumentationLibrary {name="MyLibrary"}
   Spans
-    Span {"span_id"=5, ...}
+    Span {span_id=5, ...}
 ```
 
 With the below configuration, the **groupbyattrs** will re-associate the spans with matching Resource and InstrumentationLibrary
@@ -126,21 +126,21 @@ processors:
 
 The output of the processor will therefore be:
 
-```
+```go
 Resource {host.name="localhost"}
   InstumentationLibrary {name="MyLibrary"}
   Spans
-    Span {"span_id"=1, ...}
-    Span {"span_id"=3, ...}
-    Span {"span_id"=4, ...}
+    Span {span_id=1, ...}
+    Span {span_id=3, ...}
+    Span {span_id=4, ...}
   InstumentationLibrary {name="OtherLibrary"}
   Spans
-    Span {"span_id"=2, ...}
+    Span {span_id=2, ...}
 
 Resource {host.name="otherhost"}
   InstumentationLibrary {name="MyLibrary"}
   Spans
-    Span {"span_id"=5, ...}
+    Span {span_id=5, ...}
 ```
 
 

--- a/processor/groupbyattrsprocessor/README.md
+++ b/processor/groupbyattrsprocessor/README.md
@@ -11,6 +11,7 @@ Typical use cases:
 * extract resources from "flat" data formats, such as Fluentbit logs or Prometheus metrics
 * associate Prometheus metrics to a *Resource* that describes the relevant host, based on label present on all metrics
 * optimize data packaging by extracting common attributes
+* compacting multiple records that share the same Resource attributes but are under multiple ResourceSpans/ResourceMetrics/ResourceLogs into single ResourceSpans/ResourceMetrics/ResourceLogs (when empty list of keys is being provided) 
 
 ## Example
 

--- a/processor/groupbyattrsprocessor/config.go
+++ b/processor/groupbyattrsprocessor/config.go
@@ -23,6 +23,6 @@ type Config struct {
 	config.ProcessorSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
 	// GroupByKeys describes the attribute names that are going to be used for grouping.
-	// Must include at least one attribute name.
+	// Empty value is allowed, since processor in such case can compact data
 	GroupByKeys []string `mapstructure:"keys"`
 }

--- a/processor/groupbyattrsprocessor/config_test.go
+++ b/processor/groupbyattrsprocessor/config_test.go
@@ -41,10 +41,17 @@ func TestLoadConfig(t *testing.T) {
 	require.Nil(t, err)
 	require.NotNil(t, cfg)
 
-	conf := cfg.Processors[config.NewComponentIDWithName(typeStr, "custom")]
-	assert.Equal(t, conf,
+	groupingConf := cfg.Processors[config.NewComponentIDWithName(typeStr, "grouping")]
+	assert.Equal(t, groupingConf,
 		&Config{
-			ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "custom")),
+			ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "grouping")),
 			GroupByKeys:       []string{"key1", "key2"},
+		})
+
+	compactionConf := cfg.Processors[config.NewComponentIDWithName(typeStr, "compaction")]
+	assert.Equal(t, compactionConf,
+		&Config{
+			ProcessorSettings: config.NewProcessorSettings(config.NewComponentIDWithName(typeStr, "compaction")),
+			GroupByKeys:       []string{},
 		})
 }

--- a/processor/groupbyattrsprocessor/config_test.go
+++ b/processor/groupbyattrsprocessor/config_test.go
@@ -23,7 +23,10 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configtest"
+	"go.opentelemetry.io/collector/processor/batchprocessor"
 	"go.opentelemetry.io/collector/service/servicetest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -31,6 +34,10 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	factories.Processors[typeStr] = factory
+
+	factories.Processors["batch"] = batchprocessor.NewFactory()
+	factories.Processors["groupbytrace"] = groupbytraceprocessor.NewFactory()
+
 	require.NoError(t, err)
 
 	err = configtest.CheckConfigStruct(factory.CreateDefaultConfig())

--- a/processor/groupbyattrsprocessor/factory.go
+++ b/processor/groupbyattrsprocessor/factory.go
@@ -16,7 +16,6 @@ package groupbyattrsprocessor // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"go.opencensus.io/stats/view"
@@ -33,8 +32,7 @@ const (
 )
 
 var (
-	errAtLeastOneAttributeNeeded = fmt.Errorf("option 'groupByKeys' must include at least one non-empty attribute name")
-	consumerCapabilities         = consumer.Capabilities{MutatesData: true}
+	consumerCapabilities = consumer.Capabilities{MutatesData: true}
 )
 
 var once sync.Once
@@ -62,7 +60,7 @@ func createDefaultConfig() config.Processor {
 	}
 }
 
-func createGroupByAttrsProcessor(logger *zap.Logger, attributes []string) (*groupByAttrsProcessor, error) {
+func createGroupByAttrsProcessor(logger *zap.Logger, attributes []string) *groupByAttrsProcessor {
 	var nonEmptyAttributes []string
 	presentAttributes := make(map[string]struct{})
 
@@ -78,11 +76,7 @@ func createGroupByAttrsProcessor(logger *zap.Logger, attributes []string) (*grou
 		}
 	}
 
-	if len(nonEmptyAttributes) == 0 {
-		return nil, errAtLeastOneAttributeNeeded
-	}
-
-	return &groupByAttrsProcessor{logger: logger, groupByKeys: nonEmptyAttributes}, nil
+	return &groupByAttrsProcessor{logger: logger, groupByKeys: nonEmptyAttributes}
 }
 
 // createTracesProcessor creates a trace processor based on this config.
@@ -93,10 +87,7 @@ func createTracesProcessor(
 	nextConsumer consumer.Traces) (component.TracesProcessor, error) {
 
 	oCfg := cfg.(*Config)
-	gap, err := createGroupByAttrsProcessor(params.Logger, oCfg.GroupByKeys)
-	if err != nil {
-		return nil, err
-	}
+	gap := createGroupByAttrsProcessor(params.Logger, oCfg.GroupByKeys)
 
 	return processorhelper.NewTracesProcessor(
 		cfg,
@@ -113,10 +104,7 @@ func createLogsProcessor(
 	nextConsumer consumer.Logs) (component.LogsProcessor, error) {
 
 	oCfg := cfg.(*Config)
-	gap, err := createGroupByAttrsProcessor(params.Logger, oCfg.GroupByKeys)
-	if err != nil {
-		return nil, err
-	}
+	gap := createGroupByAttrsProcessor(params.Logger, oCfg.GroupByKeys)
 
 	return processorhelper.NewLogsProcessor(
 		cfg,
@@ -133,10 +121,7 @@ func createMetricsProcessor(
 	nextConsumer consumer.Metrics) (component.MetricsProcessor, error) {
 
 	oCfg := cfg.(*Config)
-	gap, err := createGroupByAttrsProcessor(params.Logger, oCfg.GroupByKeys)
-	if err != nil {
-		return nil, err
-	}
+	gap := createGroupByAttrsProcessor(params.Logger, oCfg.GroupByKeys)
 
 	return processorhelper.NewMetricsProcessor(
 		cfg,

--- a/processor/groupbyattrsprocessor/factory_test.go
+++ b/processor/groupbyattrsprocessor/factory_test.go
@@ -53,14 +53,13 @@ func TestCreateTestProcessor(t *testing.T) {
 }
 
 func TestNoKeys(t *testing.T) {
-	gbap, err := createGroupByAttrsProcessor(zap.NewNop(), []string{})
-	assert.Error(t, err)
-	assert.Nil(t, gbap)
+	// This is allowed since can be used for compacting data
+	gap := createGroupByAttrsProcessor(zap.NewNop(), []string{})
+	assert.NotNil(t, gap)
 }
 
 func TestDuplicateKeys(t *testing.T) {
-	gbap, err := createGroupByAttrsProcessor(zap.NewNop(), []string{"foo", "foo", ""})
-	assert.NoError(t, err)
+	gbap := createGroupByAttrsProcessor(zap.NewNop(), []string{"foo", "foo", ""})
 	assert.NotNil(t, gbap)
 	assert.EqualValues(t, []string{"foo"}, gbap.groupByKeys)
 }

--- a/processor/groupbyattrsprocessor/go.mod
+++ b/processor/groupbyattrsprocessor/go.mod
@@ -3,27 +3,26 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/group
 go 1.17
 
 require (
+	github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor v0.45.1
 	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/collector v0.45.1-0.20220225200547-7bdb684e27bf
 	go.opentelemetry.io/collector/model v0.45.1-0.20220225200547-7bdb684e27bf
 	go.uber.org/zap v1.21.0
-
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/knadh/koanf v1.4.0 // indirect
-	github.com/kr/pretty v0.3.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.45.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	go.opentelemetry.io/otel v1.4.1 // indirect
 	go.opentelemetry.io/otel/metric v0.27.0 // indirect
@@ -34,3 +33,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor => ../../processor/groupbytraceprocessor

--- a/processor/groupbyattrsprocessor/go.sum
+++ b/processor/groupbyattrsprocessor/go.sum
@@ -131,6 +131,8 @@ github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mostynb/go-grpc-compression v1.1.16 h1:D9tGUINmcII049pxOj9dl32Fzhp26TrDVQXECoKJqQg=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.45.1 h1:/pIlXQuVkI7UB2H8//HBkM5Wph9PRQUgdiAlDNN7hXI=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.45.1/go.mod h1:pPxKBz6HxHRQPuBs9V0drizpxZzm8oDCSf/qnnXL7tY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -136,6 +136,15 @@ func someComplexMetrics(withResourceAttrIndex bool, rmCount int, ilmCount int, d
 	return metrics
 }
 
+func assertResourceContainsAttributes(t *testing.T, resource pdata.Resource, attributeMap pdata.AttributeMap) {
+	attributeMap.Range(func(k string, v pdata.AttributeValue) bool {
+		rv, found := resource.Attributes().Get(k)
+		assert.True(t, found)
+		assert.Equal(t, v, rv)
+		return true
+	})
+}
+
 // The "complex" use case has following input data:
 //  * Resource[Spans|Logs|Metrics] #1
 //    Attributes: resourceAttrIndex => <resource_no> (when `withResourceAttrIndex` set to true)
@@ -152,13 +161,11 @@ func someComplexMetrics(withResourceAttrIndex bool, rmCount int, ilmCount int, d
 //   * Resource[Spans|Logs|Metrics] #N
 //      ...
 func TestComplexAttributeGrouping(t *testing.T) {
-	// Following are record-level attributes that should be preserved after processing
-	outputRecordAttrs := pdata.NewAttributeMap()
-	outputRecordAttrs.InsertString("commonNonGroupedAttr", "xyz")
-
 	tests := []struct {
 		name                              string
+		groupByKeys                       []string
 		withResourceAttrIndex             bool
+		shouldMoveCommonGroupedAttr       bool
 		inputResourceCount                int
 		inputInstrumentationLibraryCount  int
 		outputResourceCount               int
@@ -167,7 +174,9 @@ func TestComplexAttributeGrouping(t *testing.T) {
 	}{
 		{
 			name:                             "With not unique Resource-level attributes",
+			groupByKeys:                      []string{"commonGroupedAttr"},
 			withResourceAttrIndex:            false,
+			shouldMoveCommonGroupedAttr:      true,
 			inputResourceCount:               4,
 			inputInstrumentationLibraryCount: 4,
 			// All resources and instrumentation libraries are matching and can be joined together
@@ -177,10 +186,36 @@ func TestComplexAttributeGrouping(t *testing.T) {
 		},
 		{
 			name:                             "With unique Resource-level attributes",
+			groupByKeys:                      []string{"commonGroupedAttr"},
 			withResourceAttrIndex:            true,
+			shouldMoveCommonGroupedAttr:      true,
 			inputResourceCount:               4,
 			inputInstrumentationLibraryCount: 4,
 			// Since each resource has a unique attribute value, so they cannot be joined together into one
+			outputResourceCount:               4,
+			outputInstrumentationLibraryCount: 1,
+			outputTotalRecordsCount:           16,
+		},
+		{
+			name:                             "Compaction by using empty group by keys",
+			groupByKeys:                      []string{},
+			withResourceAttrIndex:            false,
+			shouldMoveCommonGroupedAttr:      false,
+			inputResourceCount:               4,
+			inputInstrumentationLibraryCount: 4,
+			// This compacts all resources into one actually
+			outputResourceCount:               1,
+			outputInstrumentationLibraryCount: 1,
+			outputTotalRecordsCount:           16,
+		},
+		{
+			name:                             "Compaction by using empty group by keys and grouping resources",
+			groupByKeys:                      []string{},
+			withResourceAttrIndex:            true,
+			shouldMoveCommonGroupedAttr:      false,
+			inputResourceCount:               4,
+			inputInstrumentationLibraryCount: 4,
+			// This does not change the number of resources since they have unique attribute sets
 			outputResourceCount:               4,
 			outputInstrumentationLibraryCount: 1,
 			outputTotalRecordsCount:           16,
@@ -193,7 +228,7 @@ func TestComplexAttributeGrouping(t *testing.T) {
 			inputTraces := someComplexTraces(tt.withResourceAttrIndex, tt.inputResourceCount, tt.inputInstrumentationLibraryCount)
 			inputMetrics := someComplexMetrics(tt.withResourceAttrIndex, tt.inputResourceCount, tt.inputInstrumentationLibraryCount, 2)
 
-			gap := createGroupByAttrsProcessor(zap.NewNop(), []string{"commonGroupedAttr"})
+			gap := createGroupByAttrsProcessor(zap.NewNop(), tt.groupByKeys)
 
 			processedLogs, err := gap.processLogs(context.Background(), inputLogs)
 			assert.NoError(t, err)
@@ -204,6 +239,17 @@ func TestComplexAttributeGrouping(t *testing.T) {
 			processedMetrics, err := gap.processMetrics(context.Background(), inputMetrics)
 			assert.NoError(t, err)
 
+			// Following are record-level attributes that should be preserved after processing
+			outputRecordAttrs := pdata.NewAttributeMap()
+			outputResourceAttrs := pdata.NewAttributeMap()
+			if tt.shouldMoveCommonGroupedAttr {
+				// This was present at record level and should be found on Resource level after the processor
+				outputResourceAttrs.InsertString("commonGroupedAttr", "abc")
+			} else {
+				outputRecordAttrs.InsertString("commonGroupedAttr", "abc")
+			}
+			outputRecordAttrs.InsertString("commonNonGroupedAttr", "xyz")
+
 			rls := processedLogs.ResourceLogs()
 			assert.Equal(t, tt.outputResourceCount, rls.Len())
 			assert.Equal(t, tt.outputTotalRecordsCount, processedLogs.LogRecordCount())
@@ -211,9 +257,7 @@ func TestComplexAttributeGrouping(t *testing.T) {
 				rl := rls.At(i)
 				assert.Equal(t, tt.outputInstrumentationLibraryCount, rl.InstrumentationLibraryLogs().Len())
 
-				// This was present at record level and should be found on Resource level after the processor
-				commonAttrValue, _ := rl.Resource().Attributes().Get("commonGroupedAttr")
-				assert.Equal(t, pdata.NewAttributeValueString("abc"), commonAttrValue)
+				assertResourceContainsAttributes(t, rl.Resource(), outputResourceAttrs)
 
 				for j := 0; j < rl.InstrumentationLibraryLogs().Len(); j++ {
 					logs := rl.InstrumentationLibraryLogs().At(j).LogRecords()
@@ -230,9 +274,7 @@ func TestComplexAttributeGrouping(t *testing.T) {
 				rs := rss.At(i)
 				assert.Equal(t, tt.outputInstrumentationLibraryCount, rs.InstrumentationLibrarySpans().Len())
 
-				// This was present at record level and should be found on Resource level after the processor
-				commonAttrValue, _ := rs.Resource().Attributes().Get("commonGroupedAttr")
-				assert.Equal(t, pdata.NewAttributeValueString("abc"), commonAttrValue)
+				assertResourceContainsAttributes(t, rs.Resource(), outputResourceAttrs)
 
 				for j := 0; j < rs.InstrumentationLibrarySpans().Len(); j++ {
 					spans := rs.InstrumentationLibrarySpans().At(j).Spans()
@@ -249,9 +291,7 @@ func TestComplexAttributeGrouping(t *testing.T) {
 				rm := rms.At(i)
 				assert.Equal(t, tt.outputInstrumentationLibraryCount, rm.InstrumentationLibraryMetrics().Len())
 
-				// This was present at record level and should be found on Resource level after the processor
-				commonAttrValue, _ := rm.Resource().Attributes().Get("commonGroupedAttr")
-				assert.Equal(t, pdata.NewAttributeValueString("abc"), commonAttrValue)
+				assertResourceContainsAttributes(t, rm.Resource(), outputResourceAttrs)
 
 				for j := 0; j < rm.InstrumentationLibraryMetrics().Len(); j++ {
 					metrics := rm.InstrumentationLibraryMetrics().At(j).Metrics()
@@ -282,14 +322,20 @@ func TestAttributeGrouping(t *testing.T) {
 			count:          4,
 		},
 		{
-			name:           "One attribute",
+			name:           "One groupByKey",
 			groupByKeys:    []string{"xx"},
 			nonGroupedKeys: []string{"yy"},
 			count:          4,
 		},
 		{
-			name:           "No groupByKeys",
+			name:           "Not matching groupByKeys",
 			groupByKeys:    []string{"zz"},
+			nonGroupedKeys: []string{"xx", "yy"},
+			count:          4,
+		},
+		{
+			name:           "Empty groupByKeys",
+			groupByKeys:    []string{},
 			nonGroupedKeys: []string{"xx", "yy"},
 			count:          4,
 		},
@@ -297,13 +343,13 @@ func TestAttributeGrouping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logs := someLogs(attrMap, tt.count)
-			spans := someSpans(attrMap, tt.count)
-			gaugeMetrics := someGaugeMetrics(attrMap, tt.count)
-			sumMetrics := someSumMetrics(attrMap, tt.count)
-			summaryMetrics := someSummaryMetrics(attrMap, tt.count)
-			histogramMetrics := someHistogramMetrics(attrMap, tt.count)
-			exponentialHistogramMetrics := someExponentialHistogramMetrics(attrMap, tt.count)
+			logs := someLogs(attrMap, 1, tt.count)
+			spans := someSpans(attrMap, 1, tt.count)
+			gaugeMetrics := someGaugeMetrics(attrMap, 1, tt.count)
+			sumMetrics := someSumMetrics(attrMap, 1, tt.count)
+			summaryMetrics := someSummaryMetrics(attrMap, 1, tt.count)
+			histogramMetrics := someHistogramMetrics(attrMap, 1, tt.count)
+			exponentialHistogramMetrics := someExponentialHistogramMetrics(attrMap, 1, tt.count)
 
 			gap := createGroupByAttrsProcessor(zap.NewNop(), tt.groupByKeys)
 
@@ -414,104 +460,125 @@ func TestAttributeGrouping(t *testing.T) {
 	}
 }
 
-func someSpans(attrs pdata.AttributeMap, count int) pdata.Traces {
+func someSpans(attrs pdata.AttributeMap, instrumentationLibraryCount int, spanCount int) pdata.Traces {
 	traces := pdata.NewTraces()
-	ils := traces.ResourceSpans().AppendEmpty().InstrumentationLibrarySpans().AppendEmpty()
+	for i := 0; i < instrumentationLibraryCount; i++ {
+		ilName := fmt.Sprint("ils-", i)
 
-	for i := 0; i < count; i++ {
-		span := ils.Spans().AppendEmpty()
-		span.SetName(fmt.Sprint("foo-", i))
-		attrs.CopyTo(span.Attributes())
+		for j := 0; j < spanCount; j++ {
+			ils := traces.ResourceSpans().AppendEmpty().InstrumentationLibrarySpans().AppendEmpty()
+			ils.InstrumentationLibrary().SetName(ilName)
+			span := ils.Spans().AppendEmpty()
+			span.SetName(fmt.Sprint("foo-", j))
+			attrs.CopyTo(span.Attributes())
+		}
 	}
-
 	return traces
 }
 
-func someLogs(attrs pdata.AttributeMap, count int) pdata.Logs {
+func someLogs(attrs pdata.AttributeMap, instrumentationLibraryCount int, logCount int) pdata.Logs {
 	logs := pdata.NewLogs()
-	ill := logs.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty()
+	for i := 0; i < instrumentationLibraryCount; i++ {
+		ilName := fmt.Sprint("ils-", i)
 
-	for i := 0; i < count; i++ {
-		log := ill.LogRecords().AppendEmpty()
-		log.SetName(fmt.Sprint("foo-", i))
-		attrs.CopyTo(log.Attributes())
+		for j := 0; j < logCount; j++ {
+			ill := logs.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty()
+			ill.InstrumentationLibrary().SetName(ilName)
+			log := ill.LogRecords().AppendEmpty()
+			log.SetName(fmt.Sprint("foo-", j))
+			attrs.CopyTo(log.Attributes())
+		}
 	}
-
 	return logs
 }
 
-func someGaugeMetrics(attrs pdata.AttributeMap, count int) pdata.Metrics {
+func someGaugeMetrics(attrs pdata.AttributeMap, instrumentationLibraryCount int, metricCount int) pdata.Metrics {
 	metrics := pdata.NewMetrics()
-	ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+	for i := 0; i < instrumentationLibraryCount; i++ {
+		ilName := fmt.Sprint("ils-", i)
 
-	for i := 0; i < count; i++ {
-		metric := ilm.Metrics().AppendEmpty()
-		metric.SetName(fmt.Sprint("gauge-", i))
-		metric.SetDataType(pdata.MetricDataTypeGauge)
-		dataPoint := metric.Gauge().DataPoints().AppendEmpty()
-		attrs.CopyTo(dataPoint.Attributes())
+		for j := 0; j < metricCount; j++ {
+			ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+			ilm.InstrumentationLibrary().SetName(ilName)
+			metric := ilm.Metrics().AppendEmpty()
+			metric.SetName(fmt.Sprint("gauge-", j))
+			metric.SetDataType(pdata.MetricDataTypeGauge)
+			dataPoint := metric.Gauge().DataPoints().AppendEmpty()
+			attrs.CopyTo(dataPoint.Attributes())
+		}
 	}
-
 	return metrics
 }
 
-func someSumMetrics(attrs pdata.AttributeMap, count int) pdata.Metrics {
+func someSumMetrics(attrs pdata.AttributeMap, instrumentationLibraryCount int, metricCount int) pdata.Metrics {
 	metrics := pdata.NewMetrics()
-	ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+	for i := 0; i < instrumentationLibraryCount; i++ {
+		ilName := fmt.Sprint("ils-", i)
 
-	for i := 0; i < count; i++ {
-		metric := ilm.Metrics().AppendEmpty()
-		metric.SetName(fmt.Sprint("sum-", i))
-		metric.SetDataType(pdata.MetricDataTypeSum)
-		dataPoint := metric.Sum().DataPoints().AppendEmpty()
-		attrs.CopyTo(dataPoint.Attributes())
+		for j := 0; j < metricCount; j++ {
+			ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+			ilm.InstrumentationLibrary().SetName(ilName)
+			metric := ilm.Metrics().AppendEmpty()
+			metric.SetName(fmt.Sprint("sum-", j))
+			metric.SetDataType(pdata.MetricDataTypeSum)
+			dataPoint := metric.Sum().DataPoints().AppendEmpty()
+			attrs.CopyTo(dataPoint.Attributes())
+		}
 	}
-
 	return metrics
 }
 
-func someSummaryMetrics(attrs pdata.AttributeMap, count int) pdata.Metrics {
+func someSummaryMetrics(attrs pdata.AttributeMap, instrumentationLibraryCount int, metricCount int) pdata.Metrics {
 	metrics := pdata.NewMetrics()
-	ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+	for i := 0; i < instrumentationLibraryCount; i++ {
+		ilName := fmt.Sprint("ils-", i)
 
-	for i := 0; i < count; i++ {
-		metric := ilm.Metrics().AppendEmpty()
-		metric.SetName(fmt.Sprint("summary-", i))
-		metric.SetDataType(pdata.MetricDataTypeSummary)
-		dataPoint := metric.Summary().DataPoints().AppendEmpty()
-		attrs.CopyTo(dataPoint.Attributes())
+		for j := 0; j < metricCount; j++ {
+			ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+			ilm.InstrumentationLibrary().SetName(ilName)
+			metric := ilm.Metrics().AppendEmpty()
+			metric.SetName(fmt.Sprint("summary-", j))
+			metric.SetDataType(pdata.MetricDataTypeSummary)
+			dataPoint := metric.Summary().DataPoints().AppendEmpty()
+			attrs.CopyTo(dataPoint.Attributes())
+		}
 	}
-
 	return metrics
 }
 
-func someHistogramMetrics(attrs pdata.AttributeMap, count int) pdata.Metrics {
+func someHistogramMetrics(attrs pdata.AttributeMap, instrumentationLibraryCount int, metricCount int) pdata.Metrics {
 	metrics := pdata.NewMetrics()
-	ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+	for i := 0; i < instrumentationLibraryCount; i++ {
+		ilName := fmt.Sprint("ils-", i)
 
-	for i := 0; i < count; i++ {
-		metric := ilm.Metrics().AppendEmpty()
-		metric.SetName(fmt.Sprint("histogram-", i))
-		metric.SetDataType(pdata.MetricDataTypeHistogram)
-		dataPoint := metric.Histogram().DataPoints().AppendEmpty()
-		attrs.CopyTo(dataPoint.Attributes())
+		for j := 0; j < metricCount; j++ {
+			ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+			ilm.InstrumentationLibrary().SetName(ilName)
+			metric := ilm.Metrics().AppendEmpty()
+			metric.SetName(fmt.Sprint("histogram-", j))
+			metric.SetDataType(pdata.MetricDataTypeHistogram)
+			dataPoint := metric.Histogram().DataPoints().AppendEmpty()
+			attrs.CopyTo(dataPoint.Attributes())
+		}
 	}
-
 	return metrics
 }
 
-func someExponentialHistogramMetrics(attrs pdata.AttributeMap, count int) pdata.Metrics {
+func someExponentialHistogramMetrics(attrs pdata.AttributeMap, instrumentationLibraryCount int, metricCount int) pdata.Metrics {
 	metrics := pdata.NewMetrics()
-	ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+	for i := 0; i < instrumentationLibraryCount; i++ {
+		ilName := fmt.Sprint("ils-", i)
 
-	for i := 0; i < count; i++ {
-		metric := ilm.Metrics().AppendEmpty()
-		metric.SetName(fmt.Sprint("exponential-histogram-", i))
-		metric.SetDataType(pdata.MetricDataTypeExponentialHistogram)
-		dataPoint := metric.ExponentialHistogram().DataPoints().AppendEmpty()
-		attrs.CopyTo(dataPoint.Attributes())
+		for j := 0; j < metricCount; j++ {
+			ilm := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
+			ilm.InstrumentationLibrary().SetName(ilName)
+			metric := ilm.Metrics().AppendEmpty()
+			metric.SetName(fmt.Sprint("exponential-histogram-", j))
+			metric.SetDataType(pdata.MetricDataTypeExponentialHistogram)
+			dataPoint := metric.ExponentialHistogram().DataPoints().AppendEmpty()
+			attrs.CopyTo(dataPoint.Attributes())
+		}
 	}
-
 	return metrics
 }
 
@@ -688,29 +755,47 @@ func retrieveMetric(metrics pdata.MetricSlice, name string, metricType pdata.Met
 	return pdata.Metric{}, false
 }
 
-func someResourceSpans(attrs pdata.AttributeMap, count int) pdata.Traces {
-	traces := pdata.NewTraces()
-	for i := 0; i < count; i++ {
-		ils := traces.ResourceSpans().AppendEmpty().InstrumentationLibrarySpans().AppendEmpty()
-		span := ils.Spans().AppendEmpty()
-		span.SetName(fmt.Sprint("foo-", i))
-		attrs.CopyTo(span.Attributes())
-	}
-	return traces
-}
+func TestCompacting(t *testing.T) {
+	spans := someSpans(attrMap, 10, 10)
+	logs := someLogs(attrMap, 10, 10)
+	metrics := someGaugeMetrics(attrMap, 10, 10)
 
-func TestCompactingTraces(t *testing.T) {
-	spans := someResourceSpans(attrMap, 100)
+	assert.Equal(t, 100, spans.ResourceSpans().Len())
+	assert.Equal(t, 100, logs.ResourceLogs().Len())
+	assert.Equal(t, 100, metrics.ResourceMetrics().Len())
 
 	gap := createGroupByAttrsProcessor(zap.NewNop(), []string{})
 
 	processedSpans, err := gap.processTraces(context.Background(), spans)
 	assert.NoError(t, err)
+	processedLogs, err := gap.processLogs(context.Background(), logs)
+	assert.NoError(t, err)
+	processedMetrics, err := gap.processMetrics(context.Background(), metrics)
+	assert.NoError(t, err)
 
-	assert.Equal(t, 100, spans.ResourceSpans().Len())
 	assert.Equal(t, 1, processedSpans.ResourceSpans().Len())
+	assert.Equal(t, 1, processedLogs.ResourceLogs().Len())
+	assert.Equal(t, 1, processedMetrics.ResourceMetrics().Len())
+
 	rss := processedSpans.ResourceSpans().At(0)
+	rls := processedLogs.ResourceLogs().At(0)
+	rlm := processedMetrics.ResourceMetrics().At(0)
+
 	assert.Equal(t, 0, rss.Resource().Attributes().Len())
-	// All spans are now under same resourcespans
-	assert.Equal(t, 100, rss.InstrumentationLibrarySpans().At(0).Spans().Len())
+	assert.Equal(t, 0, rls.Resource().Attributes().Len())
+	assert.Equal(t, 0, rlm.Resource().Attributes().Len())
+
+	assert.Equal(t, 10, rss.InstrumentationLibrarySpans().Len())
+	assert.Equal(t, 10, rls.InstrumentationLibraryLogs().Len())
+	assert.Equal(t, 10, rlm.InstrumentationLibraryMetrics().Len())
+
+	for i := 0; i < 10; i++ {
+		ils := rss.InstrumentationLibrarySpans().At(i)
+		ill := rls.InstrumentationLibraryLogs().At(i)
+		ilm := rlm.InstrumentationLibraryMetrics().At(i)
+
+		assert.Equal(t, 10, ils.Spans().Len())
+		assert.Equal(t, 10, ill.LogRecords().Len())
+		assert.Equal(t, 10, ilm.Metrics().Len())
+	}
 }

--- a/processor/groupbyattrsprocessor/testdata/config.yaml
+++ b/processor/groupbyattrsprocessor/testdata/config.yaml
@@ -2,11 +2,13 @@ receivers:
   nop:
 
 processors:
+  batch:
   groupbyattrs/grouping:
     keys:
       - key1
       - key2
   groupbyattrs/compaction:
+  groupbytrace:
 
 exporters:
   nop:
@@ -19,5 +21,5 @@ service:
       exporters: [nop]
     traces/compaction:
       receivers: [nop]
-      processors: [groupbyattrs/compaction]
+      processors: [groupbytrace, batch, groupbyattrs/compaction]
       exporters: [nop]

--- a/processor/groupbyattrsprocessor/testdata/config.yaml
+++ b/processor/groupbyattrsprocessor/testdata/config.yaml
@@ -2,10 +2,11 @@ receivers:
   nop:
 
 processors:
-  groupbyattrs/custom:
+  groupbyattrs/grouping:
     keys:
       - key1
       - key2
+  groupbyattrs/compaction:
 
 exporters:
   nop:
@@ -14,5 +15,9 @@ service:
   pipelines:
     traces:
       receivers: [nop]
-      processors: [groupbyattrs/custom]
+      processors: [groupbyattrs/grouping]
+      exporters: [nop]
+    traces/compaction:
+      receivers: [nop]
+      processors: [groupbyattrs/compaction]
       exporters: [nop]


### PR DESCRIPTION
**Description:** 

Extension of `groupbyattrsprocessor` for compacting data when spread across multiple ResourceSpans/ResourceMetrics/ResourceLogs with matching Resource and InstrumentationLibrary

**Link to tracking Issue:** [#2265 in core](https://github.com/open-telemetry/opentelemetry-collector/issues/2265)

**Testing:** Several unit tests added

**Documentation:** Docs clarified on usage of empty keys. Provided example on compaction

Benchmark results (compacting 100 spans in different layouts):

```
BenchmarkCompacting
BenchmarkCompacting/instrumentation_library_count=1,_spans_per_library_count=100
BenchmarkCompacting/instrumentation_library_count=1,_spans_per_library_count=100-16         	   27966	     42352 ns/op
BenchmarkCompacting/instrumentation_library_count=10,_spans_per_library_count=10
BenchmarkCompacting/instrumentation_library_count=10,_spans_per_library_count=10-16         	   23912	     50266 ns/op
BenchmarkCompacting/instrumentation_library_count=100,_spans_per_library_count=1
BenchmarkCompacting/instrumentation_library_count=100,_spans_per_library_count=1-16         	   16819	     71327 ns/op
```