### PR TITLE
[build] hide lengthy mispell command

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -100,7 +100,7 @@ porto:
 
 .PHONY: misspell
 misspell:
-	@echo "running $(MISSPELL) $(ALL_SRC_AND_DOC)" | awk 'length > 70{$$0=substr($$0,0,71)"..."}1'
+	@echo "running $(MISSPELL)"
 	@$(MISSPELL) $(ALL_SRC_AND_DOC)
 
 .PHONY: misspell-correction

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -100,7 +100,8 @@ porto:
 
 .PHONY: misspell
 misspell:
-	$(MISSPELL) $(ALL_SRC_AND_DOC)
+	@echo "running $(MISSPELL) $(ALL_SRC_AND_DOC)" | awk 'length > 70{$$0=substr($$0,0,71)"..."}1'
+	@$(MISSPELL) $(ALL_SRC_AND_DOC)
 
 .PHONY: misspell-correction
 misspell-correction:


### PR DESCRIPTION
Trim command output when running misspell to reduce clutter.

Fixes #7784

Instead of seeing this:
![Screen Shot 2022-02-10 at 1 07 06 PM](https://user-images.githubusercontent.com/223565/153496487-ea59af77-8b0c-4e1c-9d94-c1d002b456e0.png)


The caller sees:
```
Check License finished successfully
running misspell -error ./.github/ISSUE_TEMPLATE/bug_report.md ./.githu...
golangci-lint run --allow-parallel-runners
```