### PR TITLE
[exporter/tanzuobservability] Add internal SDK metric tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `sumologicexporter`: Move validation to Config (#7936)
 - `elasticsearchexporter`: Fix crash with batch processor (#7953).
 - `splunkhecexporter`: Batch metrics payloads (#7760)
+- `tanzuobservabilityexporter`: Add internal SDK metric tag (#7826)
 
 ### 🛑 Breaking changes 🛑
 

--- a/exporter/tanzuobservabilityexporter/exporter.go
+++ b/exporter/tanzuobservabilityexporter/exporter.go
@@ -80,7 +80,7 @@ func newTracesExporter(settings component.ExporterCreateSettings, c config.Expor
 		MetricsPort:          2878,
 		TracingPort:          tracingPort,
 		FlushIntervalSeconds: 1,
-		SDKMetricsTags:       map[string]string{"otel.collector_version": settings.BuildInfo.Version},
+		SDKMetricsTags:       map[string]string{"otel.traces.collector_version": settings.BuildInfo.Version},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy sender: %v", err)

--- a/exporter/tanzuobservabilityexporter/exporter.go
+++ b/exporter/tanzuobservabilityexporter/exporter.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/wavefronthq/wavefront-sdk-go/senders"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/multierr"
@@ -56,7 +57,7 @@ type tracesExporter struct {
 	logger *zap.Logger
 }
 
-func newTracesExporter(l *zap.Logger, c config.Exporter) (*tracesExporter, error) {
+func newTracesExporter(settings component.ExporterCreateSettings, c config.Exporter) (*tracesExporter, error) {
 	cfg, ok := c.(*Config)
 	if !ok {
 		return nil, fmt.Errorf("invalid config: %#v", c)
@@ -79,6 +80,7 @@ func newTracesExporter(l *zap.Logger, c config.Exporter) (*tracesExporter, error
 		MetricsPort:          2878,
 		TracingPort:          tracingPort,
 		FlushIntervalSeconds: 1,
+		SDKMetricsTags:       map[string]string{"otel.collector_version": settings.BuildInfo.Version},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy sender: %v", err)
@@ -87,7 +89,7 @@ func newTracesExporter(l *zap.Logger, c config.Exporter) (*tracesExporter, error
 	return &tracesExporter{
 		cfg:    cfg,
 		sender: s,
-		logger: l,
+		logger: settings.Logger,
 	}, nil
 }
 

--- a/exporter/tanzuobservabilityexporter/factory.go
+++ b/exporter/tanzuobservabilityexporter/factory.go
@@ -58,7 +58,7 @@ func createTracesExporter(
 	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.TracesExporter, error) {
-	exp, err := newTracesExporter(set.Logger, cfg)
+	exp, err := newTracesExporter(set, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func createMetricsExporter(
 	set component.ExporterCreateSettings,
 	cfg config.Exporter,
 ) (component.MetricsExporter, error) {
-	exp, err := newMetricsExporter(set.TelemetrySettings, cfg, createMetricsConsumer)
+	exp, err := newMetricsExporter(set, cfg, createMetricsConsumer)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/tanzuobservabilityexporter/metrics_exporter.go
+++ b/exporter/tanzuobservabilityexporter/metrics_exporter.go
@@ -35,7 +35,7 @@ func createMetricsConsumer(hostName string, port int, settings component.Telemet
 		Host:                 hostName,
 		MetricsPort:          port,
 		FlushIntervalSeconds: 1,
-		SDKMetricsTags:       map[string]string{"otel.collector_version": otelVersion},
+		SDKMetricsTags:       map[string]string{"otel.metrics.collector_version": otelVersion},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy sender: %v", err)

--- a/exporter/tanzuobservabilityexporter/metrics_exporter.go
+++ b/exporter/tanzuobservabilityexporter/metrics_exporter.go
@@ -30,12 +30,12 @@ type metricsExporter struct {
 	consumer *metricsConsumer
 }
 
-func createMetricsConsumer(
-	hostName string, port int, settings component.TelemetrySettings) (*metricsConsumer, error) {
+func createMetricsConsumer(hostName string, port int, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
 	s, err := senders.NewProxySender(&senders.ProxyConfiguration{
 		Host:                 hostName,
 		MetricsPort:          port,
 		FlushIntervalSeconds: 1,
+		SDKMetricsTags:       map[string]string{"otel.collector_version": otelVersion},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy sender: %v", err)
@@ -54,12 +54,10 @@ func createMetricsConsumer(
 		true), nil
 }
 
-type metricsConsumerCreator func(hostName string, port int, settings component.TelemetrySettings) (
+type metricsConsumerCreator func(hostName string, port int, settings component.TelemetrySettings, otelVersion string) (
 	*metricsConsumer, error)
 
-func newMetricsExporter(
-	settings component.TelemetrySettings, c config.Exporter, creator metricsConsumerCreator) (
-	*metricsExporter, error) {
+func newMetricsExporter(settings component.ExporterCreateSettings, c config.Exporter, creator metricsConsumerCreator) (*metricsExporter, error) {
 	cfg, ok := c.(*Config)
 	if !ok {
 		return nil, fmt.Errorf("invalid config: %#v", c)
@@ -73,7 +71,7 @@ func newMetricsExporter(
 		// The port is empty, otherwise url.Parse would have failed above
 		return nil, fmt.Errorf("metrics.endpoint requires a port")
 	}
-	consumer, err := creator(endpoint.Hostname(), metricsPort, settings)
+	consumer, err := creator(endpoint.Hostname(), metricsPort, settings.TelemetrySettings, settings.BuildInfo.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/tanzuobservabilityexporter/metrics_exporter_test.go
+++ b/exporter/tanzuobservabilityexporter/metrics_exporter_test.go
@@ -60,7 +60,7 @@ func createMockMetricsExporter(
 	sender *mockMetricSender) (component.MetricsExporter, error) {
 	cfg := createDefaultConfig()
 	creator := func(
-		hostName string, port int, settings component.TelemetrySettings) (*metricsConsumer, error) {
+		hostName string, port int, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
 		return newMetricsConsumer(
 			[]typedMetricConsumer{
 				newGaugeConsumer(sender, settings),
@@ -69,7 +69,8 @@ func createMockMetricsExporter(
 			false,
 		), nil
 	}
-	exp, err := newMetricsExporter(componenttest.NewNopTelemetrySettings(), cfg, creator)
+
+	exp, err := newMetricsExporter(componenttest.NewNopExporterCreateSettings(), cfg, creator)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/translator/signalfx/go.sum
+++ b/pkg/translator/signalfx/go.sum
@@ -38,8 +38,16 @@ go.opentelemetry.io/collector/model v0.44.0 h1:I+M6X2NANYChOGYrpbxCoEYJah3eHdMvu
 go.opentelemetry.io/collector/model v0.44.0/go.mod h1:4jo1R8uBDspLCxUGhQ0k3v/EFXFbW7s0AIy3LuGLbcU=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
+go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
+go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
+go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
+go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
+golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/pkg/translator/signalfx/go.sum
+++ b/pkg/translator/signalfx/go.sum
@@ -38,16 +38,8 @@ go.opentelemetry.io/collector/model v0.44.0 h1:I+M6X2NANYChOGYrpbxCoEYJah3eHdMvu
 go.opentelemetry.io/collector/model v0.44.0/go.mod h1:4jo1R8uBDspLCxUGhQ0k3v/EFXFbW7s0AIy3LuGLbcU=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
-go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
-go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
-go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
-go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
-golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
**Description:** Update TraceExporter and MetricExporter with a tag providing information
about the otel-collector version.

**Link to tracking Issue:** N/A

**Testing:** Manual Testing

**Documentation:** N/A