### PR TITLE
 [receiver/hostmetrics] Add memory utilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `datadogexporter`: Add insecure_skip_verify flag to configuration (#7422)
 - `coralogixexporter`: Update readme (#7785)
 - `awscloudwatchlogsexporter`: Remove name from aws cloudwatch logs exporter (#7554)
+- `hostreceiver/memoryscraper`: Add memory.utilization (#6221)
 
 ## 🛑 Breaking changes 🛑
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/documentation.md
@@ -9,6 +9,7 @@ These are the metrics available for this scraper.
 | Name | Description | Unit | Type | Attributes |
 | ---- | ----------- | ---- | ---- | ---------- |
 | **system.memory.usage** | Bytes of memory in use. | By | Sum(Int) | <ul> <li>state</li> </ul> |
+| system.memory.utilization | Percentage of memory bytes in use. | 1 | Gauge(Double) | <ul> <li>state</li> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
 Any metric can be enabled or disabled with the following scraper configuration:

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_v2.go
@@ -15,13 +15,17 @@ type MetricSettings struct {
 
 // MetricsSettings provides settings for memory metrics.
 type MetricsSettings struct {
-	SystemMemoryUsage MetricSettings `mapstructure:"system.memory.usage"`
+	SystemMemoryUsage       MetricSettings `mapstructure:"system.memory.usage"`
+	SystemMemoryUtilization MetricSettings `mapstructure:"system.memory.utilization"`
 }
 
 func DefaultMetricsSettings() MetricsSettings {
 	return MetricsSettings{
 		SystemMemoryUsage: MetricSettings{
 			Enabled: true,
+		},
+		SystemMemoryUtilization: MetricSettings{
+			Enabled: false,
 		},
 	}
 }
@@ -79,11 +83,63 @@ func newMetricSystemMemoryUsage(settings MetricSettings) metricSystemMemoryUsage
 	return m
 }
 
+type metricSystemMemoryUtilization struct {
+	data     pdata.Metric   // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills system.memory.utilization metric with initial data.
+func (m *metricSystemMemoryUtilization) init() {
+	m.data.SetName("system.memory.utilization")
+	m.data.SetDescription("Percentage of memory bytes in use.")
+	m.data.SetUnit("1")
+	m.data.SetDataType(pdata.MetricDataTypeGauge)
+	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricSystemMemoryUtilization) recordDataPoint(start pdata.Timestamp, ts pdata.Timestamp, val float64, stateAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetDoubleVal(val)
+	dp.Attributes().Insert(A.State, pdata.NewAttributeValueString(stateAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSystemMemoryUtilization) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSystemMemoryUtilization) emit(metrics pdata.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSystemMemoryUtilization(settings MetricSettings) metricSystemMemoryUtilization {
+	m := metricSystemMemoryUtilization{settings: settings}
+	if settings.Enabled {
+		m.data = pdata.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime               pdata.Timestamp
-	metricSystemMemoryUsage metricSystemMemoryUsage
+	startTime                     pdata.Timestamp
+	metricSystemMemoryUsage       metricSystemMemoryUsage
+	metricSystemMemoryUtilization metricSystemMemoryUtilization
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -98,8 +154,9 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		startTime:               pdata.NewTimestampFromTime(time.Now()),
-		metricSystemMemoryUsage: newMetricSystemMemoryUsage(settings.SystemMemoryUsage),
+		startTime:                     pdata.NewTimestampFromTime(time.Now()),
+		metricSystemMemoryUsage:       newMetricSystemMemoryUsage(settings.SystemMemoryUsage),
+		metricSystemMemoryUtilization: newMetricSystemMemoryUtilization(settings.SystemMemoryUtilization),
 	}
 	for _, op := range options {
 		op(mb)
@@ -112,11 +169,17 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 // defined in metadata and user settings, e.g. delta/cumulative translation.
 func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
 	mb.metricSystemMemoryUsage.emit(metrics)
+	mb.metricSystemMemoryUtilization.emit(metrics)
 }
 
 // RecordSystemMemoryUsageDataPoint adds a data point to system.memory.usage metric.
 func (mb *MetricsBuilder) RecordSystemMemoryUsageDataPoint(ts pdata.Timestamp, val int64, stateAttributeValue string) {
 	mb.metricSystemMemoryUsage.recordDataPoint(mb.startTime, ts, val, stateAttributeValue)
+}
+
+// RecordSystemMemoryUtilizationDataPoint adds a data point to system.memory.utilization metric.
+func (mb *MetricsBuilder) RecordSystemMemoryUtilizationDataPoint(ts pdata.Timestamp, val float64, stateAttributeValue string) {
+	mb.metricSystemMemoryUtilization.recordDataPoint(mb.startTime, ts, val, stateAttributeValue)
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
@@ -32,3 +32,12 @@ func (s *scraper) recordMemoryUsageMetric(now pdata.Timestamp, memInfo *mem.Virt
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Sreclaimable), metadata.AttributeState.SlabReclaimable)
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Sunreclaim), metadata.AttributeState.SlabUnreclaimable)
 }
+
+func (s *scraper) recordMemoryUtilizationMetric(now pdata.Timestamp, memInfo *mem.VirtualMemoryStat) {
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Used)/float64(memInfo.Total), metadata.AttributeState.Used)
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Free)/float64(memInfo.Total), metadata.AttributeState.Free)
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Buffers)/float64(memInfo.Total), metadata.AttributeState.Buffered)
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Cached)/float64(memInfo.Total), metadata.AttributeState.Cached)
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Sreclaimable)/float64(memInfo.Total), metadata.AttributeState.SlabReclaimable)
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Sunreclaim)/float64(memInfo.Total), metadata.AttributeState.SlabUnreclaimable)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
@@ -29,3 +29,9 @@ func (s *scraper) recordMemoryUsageMetric(now pdata.Timestamp, memInfo *mem.Virt
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Free), metadata.AttributeState.Free)
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Inactive), metadata.AttributeState.Inactive)
 }
+
+func (s *scraper) recordMemoryUtilizationMetric(now pdata.Timestamp, memInfo *mem.VirtualMemoryStat) {
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Used)/float64(memInfo.Total), metadata.AttributeState.Used)
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Free)/float64(memInfo.Total), metadata.AttributeState.Free)
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Inactive)/float64(memInfo.Total), metadata.AttributeState.Inactive)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
@@ -28,3 +28,8 @@ func (s *scraper) recordMemoryUsageMetric(now pdata.Timestamp, memInfo *mem.Virt
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Used), metadata.AttributeState.Used)
 	s.mb.RecordSystemMemoryUsageDataPoint(now, int64(memInfo.Free), metadata.AttributeState.Free)
 }
+
+func (s *scraper) recordMemoryUtilizationMetric(now pdata.Timestamp, memInfo *mem.VirtualMemoryStat) {
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Used)/float64(memInfo.Total), metadata.AttributeState.Used)
+	s.mb.RecordSystemMemoryUtilizationDataPoint(now, float64(memInfo.Free)/float64(memInfo.Total), metadata.AttributeState.Free)
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -15,3 +15,11 @@ metrics:
       aggregation: cumulative
       monotonic: false
     attributes: [state]
+
+  system.memory.utilization:
+    enabled: false
+    description: Percentage of memory bytes in use.
+    unit: 1
+    gauge:
+      value_type: double
+    attributes: [state]

--- a/receiver/hostmetricsreceiver/internal/testutils.go
+++ b/receiver/hostmetricsreceiver/internal/testutils.go
@@ -52,6 +52,23 @@ func AssertSumMetricStartTimeEquals(t *testing.T, metric pdata.Metric, startTime
 	}
 }
 
+func AssertGaugeMetricHasAttributeValue(t *testing.T, metric pdata.Metric, index int, labelName string, expectedVal pdata.AttributeValue) {
+	val, ok := metric.Gauge().DataPoints().At(index).Attributes().Get(labelName)
+	assert.Truef(t, ok, "Missing attribute %q in metric %q", labelName, metric.Name())
+	assert.Equal(t, expectedVal, val)
+}
+
+func AssertGaugeMetricHasAttribute(t *testing.T, metric pdata.Metric, index int, labelName string) {
+	_, ok := metric.Gauge().DataPoints().At(index).Attributes().Get(labelName)
+	assert.Truef(t, ok, "Missing attribute %q in metric %q", labelName, metric.Name())
+}
+
+func AssertGaugeMetricStartTimeEquals(t *testing.T, metric pdata.Metric, startTime pdata.Timestamp) {
+	ddps := metric.Gauge().DataPoints()
+	for i := 0; i < ddps.Len(); i++ {
+		require.Equal(t, startTime, ddps.At(i).StartTimestamp())
+	}
+}
 func AssertSameTimeStampForAllMetrics(t *testing.T, metrics pdata.MetricSlice) {
 	AssertSameTimeStampForMetrics(t, metrics, 0, metrics.Len())
 }


### PR DESCRIPTION
**Description:**
This PR adds system.memory.utilization to hostmetricsreceiver

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6221

**Testing:** 
Tests added for the memory utilization scraper.

**Documentation:** 
New metrics added to [Documentation](https://github.com/rogercoll/opentelemetry-collector-contrib/blob/d8d14f71bca3545f83d3af198e0a0d5ede5f0341/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/documentation.md)