### PR TITLE
Fix to run trace correctness tests when using make run-correctness-traces-tests

### DIFF
--- a/testbed/Makefile
+++ b/testbed/Makefile
@@ -34,4 +34,4 @@ list-correctness-traces-tests:
 
 .PHONY: run-correctness-traces-tests
 run-correctness-traces-tests:
-	TESTS_DIR=correctnesstests/metrics ./runtests.sh
+	TESTS_DIR=correctnesstests/traces ./runtests.sh

--- a/testbed/correctnesstests/metrics/correctness_test_case.go
+++ b/testbed/correctnesstests/metrics/correctness_test_case.go
@@ -57,7 +57,6 @@ func (tc *correctnessTestCase) startCollector() {
 	err = tc.collector.Start(testbed.StartParams{
 		Name:        "Agent",
 		LogFilePath: fname,
-		CmdArgs:     []string{"--metrics-level=NONE"},
 	})
 	require.NoError(tc.t, err)
 }

--- a/testbed/testbed/components.go
+++ b/testbed/testbed/components.go
@@ -25,6 +25,13 @@ import (
 	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 	"go.uber.org/multierr"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opencensusexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
 )
 
 // Components returns the set of components for tests
@@ -41,14 +48,20 @@ func Components() (
 	errs = multierr.Append(errs, err)
 
 	receivers, err := component.MakeReceiverFactoryMap(
+		jaegerreceiver.NewFactory(),
+		opencensusreceiver.NewFactory(),
 		otlpreceiver.NewFactory(),
+		zipkinreceiver.NewFactory(),
 	)
 	errs = multierr.Append(errs, err)
 
 	exporters, err := component.MakeExporterFactoryMap(
+		jaegerexporter.NewFactory(),
 		loggingexporter.NewFactory(),
+		opencensusexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
+		zipkinexporter.NewFactory(),
 	)
 	errs = multierr.Append(errs, err)
 

--- a/testbed/testbed/in_process_collector.go
+++ b/testbed/testbed/in_process_collector.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/process"
@@ -32,9 +33,9 @@ type inProcessCollector struct {
 	factories  component.Factories
 	configStr  string
 	svc        *service.Collector
-	appDone    chan struct{}
 	stopped    bool
 	configFile string
+	wg         sync.WaitGroup
 }
 
 // NewInProcessCollector creates a new inProcessCollector using the supplied component factories.
@@ -77,22 +78,23 @@ func (ipp *inProcessCollector) Start(args StartParams) error {
 		return err
 	}
 
-	ipp.appDone = make(chan struct{})
+	ipp.wg.Add(1)
 	go func() {
-		defer close(ipp.appDone)
+		defer ipp.wg.Done()
 		if appErr := ipp.svc.Run(context.Background()); appErr != nil {
-			err = appErr
+			// TODO: Pass this to the error handler.
+			panic(appErr)
 		}
 	}()
 
 	for {
 		switch state := ipp.svc.GetState(); state {
 		case service.Starting:
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(time.Second)
 		case service.Running:
-			return err
+			return nil
 		default:
-			err = fmt.Errorf("unable to start, otelcol state is %d", state)
+			return fmt.Errorf("unable to start, otelcol state is %d", state)
 		}
 	}
 }
@@ -103,7 +105,7 @@ func (ipp *inProcessCollector) Stop() (stopped bool, err error) {
 		ipp.svc.Shutdown()
 		os.Remove(ipp.configFile)
 	}
-	<-ipp.appDone
+	ipp.wg.Wait()
 	stopped = ipp.stopped
 	return stopped, err
 }

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -139,22 +139,20 @@ func (tc *TestCase) composeTestResultFileName(fileName string) string {
 func (tc *TestCase) StartAgent(args ...string) {
 	logFileName := tc.composeTestResultFileName("agent.log")
 
-	err := tc.agentProc.Start(StartParams{
+	startParams := StartParams{
 		Name:         "Agent",
 		LogFilePath:  logFileName,
 		CmdArgs:      args,
 		resourceSpec: &tc.resourceSpec,
-	})
-
-	if err != nil {
+	}
+	if err := tc.agentProc.Start(startParams); err != nil {
 		tc.indicateError(err)
 		return
 	}
 
 	// Start watching resource consumption.
 	go func() {
-		err := tc.agentProc.WatchResourceConsumption()
-		if err != nil {
+		if err := tc.agentProc.WatchResourceConsumption(); err != nil {
 			tc.indicateError(err)
 		}
 	}()


### PR DESCRIPTION
This means that we never run/test trace correctness, let's see how we've done without that.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
