### PR TITLE
Cleanup usage of occonventions in the translators

### DIFF
--- a/pkg/translator/jaeger/jaegerproto_to_traces.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces.go
@@ -26,7 +26,6 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/idutils"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
 )
 
@@ -97,7 +96,6 @@ func jProcessToInternalResource(process *model.Process, dest pdata.Resource) {
 
 	// Handle special keys translations.
 	translateHostnameAttr(attrs)
-	translateJaegerVersionAttr(attrs)
 }
 
 // translateHostnameAttr translates "hostname" atttribute
@@ -107,16 +105,6 @@ func translateHostnameAttr(attrs pdata.Map) {
 	if hostnameFound && !convHostNameFound {
 		attrs.Insert(conventions.AttributeHostName, hostname)
 		attrs.Delete("hostname")
-	}
-}
-
-// translateHostnameAttr translates "jaeger.version" atttribute
-func translateJaegerVersionAttr(attrs pdata.Map) {
-	jaegerVersion, jaegerVersionFound := attrs.Get("jaeger.version")
-	_, exporterVersionFound := attrs.Get(occonventions.AttributeExporterVersion)
-	if jaegerVersionFound && !exporterVersionFound {
-		attrs.InsertString(occonventions.AttributeExporterVersion, "Jaeger-"+jaegerVersion.StringVal())
-		attrs.Delete("jaeger.version")
 	}
 }
 

--- a/pkg/translator/jaeger/jaegerthrift_to_traces.go
+++ b/pkg/translator/jaeger/jaegerthrift_to_traces.go
@@ -74,7 +74,6 @@ func jThriftProcessToInternalResource(process *jaeger.Process, dest pdata.Resour
 
 	// Handle special keys translations.
 	translateHostnameAttr(attrs)
-	translateJaegerVersionAttr(attrs)
 }
 
 func jThriftSpansToInternal(spans []*jaeger.Span, dest pdata.SpanSlice) {

--- a/pkg/translator/opencensus/conventions.go
+++ b/pkg/translator/opencensus/conventions.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package occonventions // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
+package opencensus // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 
 // OTLP attributes to map certain OpenCensus proto fields. These fields don't have
 // corresponding fields in OTLP, nor are defined in OTLP semantic conventions.
 const (
-	AttributeProcessStartTime        = "opencensus.starttime"
-	AttributeExporterVersion         = "opencensus.exporterversion"
-	AttributeResourceType            = "opencensus.resourcetype"
-	AttributeSameProcessAsParentSpan = "opencensus.same_process_as_parent_span"
+	attributeProcessStartTime        = "opencensus.starttime"
+	attributeExporterVersion         = "opencensus.exporterversion"
+	attributeResourceType            = "opencensus.resourcetype"
+	attributeSameProcessAsParentSpan = "opencensus.same_process_as_parent_span"
 )

--- a/pkg/translator/opencensus/metrics_to_oc_test.go
+++ b/pkg/translator/opencensus/metrics_to_oc_test.go
@@ -27,7 +27,6 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 )
 
@@ -36,10 +35,10 @@ func TestMetricsToOC(t *testing.T) {
 	attrs := sampleMetricData.ResourceMetrics().At(0).Resource().Attributes()
 	attrs.Upsert(conventions.AttributeHostName, pdata.NewValueString("host1"))
 	attrs.Upsert(conventions.AttributeProcessPID, pdata.NewValueInt(123))
-	attrs.Upsert(occonventions.AttributeProcessStartTime, pdata.NewValueString("2020-02-11T20:26:00Z"))
+	attrs.Upsert(attributeProcessStartTime, pdata.NewValueString("2020-02-11T20:26:00Z"))
 	attrs.Upsert(conventions.AttributeTelemetrySDKLanguage, pdata.NewValueString("cpp"))
 	attrs.Upsert(conventions.AttributeTelemetrySDKVersion, pdata.NewValueString("v2.0.1"))
-	attrs.Upsert(occonventions.AttributeExporterVersion, pdata.NewValueString("v1.2.0"))
+	attrs.Upsert(attributeExporterVersion, pdata.NewValueString("v1.2.0"))
 
 	tests := []struct {
 		name     string

--- a/pkg/translator/opencensus/oc_testdata_test.go
+++ b/pkg/translator/opencensus/oc_testdata_test.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 )
 
@@ -615,13 +614,13 @@ func generateOCTestMetricDoubleSummary() *ocmetrics.Metric {
 
 func generateResourceWithOcNodeAndResource() pdata.Resource {
 	resource := pdata.NewResource()
-	resource.Attributes().InsertString(occonventions.AttributeProcessStartTime, "2020-02-11T20:26:00Z")
+	resource.Attributes().InsertString(attributeProcessStartTime, "2020-02-11T20:26:00Z")
 	resource.Attributes().InsertString(conventions.AttributeHostName, "host1")
 	resource.Attributes().InsertInt(conventions.AttributeProcessPID, 123)
 	resource.Attributes().InsertString(conventions.AttributeTelemetrySDKVersion, "v2.0.1")
-	resource.Attributes().InsertString(occonventions.AttributeExporterVersion, "v1.2.0")
+	resource.Attributes().InsertString(attributeExporterVersion, "v1.2.0")
 	resource.Attributes().InsertString(conventions.AttributeTelemetrySDKLanguage, "cpp")
-	resource.Attributes().InsertString(occonventions.AttributeResourceType, "good-resource")
+	resource.Attributes().InsertString(attributeResourceType, "good-resource")
 	resource.Attributes().InsertString("node-str-attr", "node-str-attr-val")
 	resource.Attributes().InsertString("resource-str-attr", "resource-str-attr-val")
 	resource.Attributes().InsertInt("resource-int-attr", 123)

--- a/pkg/translator/opencensus/oc_to_resource.go
+++ b/pkg/translator/opencensus/oc_to_resource.go
@@ -22,8 +22,6 @@ import (
 	"go.opencensus.io/resource/resourcekeys"
 	"go.opentelemetry.io/collector/model/pdata"
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 )
 
 var ocLangCodeToLangMap = getOCLangCodeToLangMap()
@@ -98,7 +96,7 @@ func ocNodeResourceToInternal(ocNode *occommon.Node, ocResource *ocresource.Reso
 		}
 		if ocNode.Identifier != nil {
 			if ocNode.Identifier.StartTimestamp != nil {
-				attrs.UpsertString(occonventions.AttributeProcessStartTime, ocNode.Identifier.StartTimestamp.AsTime().Format(time.RFC3339Nano))
+				attrs.UpsertString(attributeProcessStartTime, ocNode.Identifier.StartTimestamp.AsTime().Format(time.RFC3339Nano))
 			}
 			if ocNode.Identifier.HostName != "" {
 				attrs.UpsertString(conventions.AttributeHostName, ocNode.Identifier.HostName)
@@ -112,7 +110,7 @@ func ocNodeResourceToInternal(ocNode *occommon.Node, ocResource *ocresource.Reso
 				attrs.UpsertString(conventions.AttributeTelemetrySDKVersion, ocNode.LibraryInfo.CoreLibraryVersion)
 			}
 			if ocNode.LibraryInfo.ExporterVersion != "" {
-				attrs.UpsertString(occonventions.AttributeExporterVersion, ocNode.LibraryInfo.ExporterVersion)
+				attrs.UpsertString(attributeExporterVersion, ocNode.LibraryInfo.ExporterVersion)
 			}
 			if ocNode.LibraryInfo.Language != occommon.LibraryInfo_LANGUAGE_UNSPECIFIED {
 				if str, ok := ocLangCodeToLangMap[ocNode.LibraryInfo.Language]; ok {
@@ -134,7 +132,7 @@ func ocNodeResourceToInternal(ocNode *occommon.Node, ocResource *ocresource.Reso
 		}
 		// Add special fields.
 		if ocResource.Type != "" {
-			attrs.UpsertString(occonventions.AttributeResourceType, ocResource.Type)
+			attrs.UpsertString(attributeResourceType, ocResource.Type)
 		}
 	}
 }

--- a/pkg/translator/opencensus/oc_to_resource_test.go
+++ b/pkg/translator/opencensus/oc_to_resource_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/model/pdata"
 	"google.golang.org/protobuf/proto"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 )
 
 func TestOcNodeResourceToInternal(t *testing.T) {
@@ -55,7 +53,7 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 		}
 		return true
 	})
-	ocResource.Labels[occonventions.AttributeResourceType] = "this will be overridden 2"
+	ocResource.Labels[attributeResourceType] = "this will be overridden 2"
 
 	// Convert again.
 	resource = pdata.NewResource()

--- a/pkg/translator/opencensus/oc_to_traces.go
+++ b/pkg/translator/opencensus/oc_to_traces.go
@@ -25,7 +25,6 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
 )
 
@@ -362,5 +361,5 @@ func ocSameProcessAsParentSpanToInternal(spaps *wrapperspb.BoolValue, dest pdata
 	if spaps == nil {
 		return
 	}
-	dest.Attributes().UpsertBool(occonventions.AttributeSameProcessAsParentSpan, spaps.Value)
+	dest.Attributes().UpsertBool(attributeSameProcessAsParentSpan, spaps.Value)
 }

--- a/pkg/translator/opencensus/oc_to_traces_test.go
+++ b/pkg/translator/opencensus/oc_to_traces_test.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 )
 
@@ -396,14 +395,14 @@ func TestOcSameProcessAsParentSpanToInternal(t *testing.T) {
 
 	ocSameProcessAsParentSpanToInternal(wrapperspb.Bool(false), span)
 	assert.Equal(t, 1, span.Attributes().Len())
-	v, ok := span.Attributes().Get(occonventions.AttributeSameProcessAsParentSpan)
+	v, ok := span.Attributes().Get(attributeSameProcessAsParentSpan)
 	assert.True(t, ok)
 	assert.EqualValues(t, pdata.ValueTypeBool, v.Type())
 	assert.False(t, v.BoolVal())
 
 	ocSameProcessAsParentSpanToInternal(wrapperspb.Bool(true), span)
 	assert.Equal(t, 1, span.Attributes().Len())
-	v, ok = span.Attributes().Get(occonventions.AttributeSameProcessAsParentSpan)
+	v, ok = span.Attributes().Get(attributeSameProcessAsParentSpan)
 	assert.True(t, ok)
 	assert.EqualValues(t, pdata.ValueTypeBool, v.Type())
 	assert.True(t, v.BoolVal())

--- a/pkg/translator/opencensus/resource_to_oc.go
+++ b/pkg/translator/opencensus/resource_to_oc.go
@@ -24,8 +24,6 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 )
 
 type ocInferredResourceType struct {
@@ -93,11 +91,11 @@ func internalResourceToOC(resource pdata.Resource) (*occommon.Node, *ocresource.
 		switch k {
 		case conventions.AttributeCloudAvailabilityZone:
 			labels[resourcekeys.CloudKeyZone] = val
-		case occonventions.AttributeResourceType:
+		case attributeResourceType:
 			ocResource.Type = val
 		case conventions.AttributeServiceName:
 			getServiceInfo(ocNode).Name = val
-		case occonventions.AttributeProcessStartTime:
+		case attributeProcessStartTime:
 			t, err := time.Parse(time.RFC3339Nano, val)
 			if err != nil {
 				return true
@@ -113,7 +111,7 @@ func internalResourceToOC(resource pdata.Resource) (*occommon.Node, *ocresource.
 			}
 		case conventions.AttributeTelemetrySDKVersion:
 			getLibraryInfo(ocNode).CoreLibraryVersion = val
-		case occonventions.AttributeExporterVersion:
+		case attributeExporterVersion:
 			getLibraryInfo(ocNode).ExporterVersion = val
 		case conventions.AttributeTelemetrySDKLanguage:
 			if code, ok := langToOCLangCodeMap[val]; ok {

--- a/pkg/translator/opencensus/resource_to_oc_test.go
+++ b/pkg/translator/opencensus/resource_to_oc_test.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/goldendataset"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 )
 
 func TestResourceToOC(t *testing.T) {
@@ -107,7 +106,7 @@ func TestContainerResourceToOC(t *testing.T) {
 	}
 
 	// Also test that the explicit resource type is preserved if present
-	resource.Attributes().InsertString(occonventions.AttributeResourceType, "other-type")
+	resource.Attributes().InsertString(attributeResourceType, "other-type")
 	want.Type = "other-type"
 
 	_, ocResource = internalResourceToOC(resource)
@@ -207,7 +206,7 @@ func TestResourceToOCAndBack(t *testing.T) {
 			actual := pdata.NewResource()
 			ocNodeResourceToInternal(ocNode, ocResource, actual)
 			// Remove opencensus resource type from actual. This will be added during translation.
-			actual.Attributes().Delete(occonventions.AttributeResourceType)
+			actual.Attributes().Delete(attributeResourceType)
 			assert.Equal(t, expected.Attributes().Len(), actual.Attributes().Len())
 			expected.Attributes().Range(func(k string, v pdata.Value) bool {
 				a, ok := actual.Attributes().Get(k)

--- a/pkg/translator/opencensus/traces_to_oc.go
+++ b/pkg/translator/opencensus/traces_to_oc.go
@@ -26,7 +26,6 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
 )
 
@@ -189,7 +188,7 @@ func stringAttributeValue(val string) *octrace.AttributeValue {
 }
 
 func attributesMapToOCSameProcessAsParentSpan(attr pdata.Map) *wrapperspb.BoolValue {
-	val, ok := attr.Get(occonventions.AttributeSameProcessAsParentSpan)
+	val, ok := attr.Get(attributeSameProcessAsParentSpan)
 	if !ok || val.Type() != pdata.ValueTypeBool {
 		return nil
 	}

--- a/pkg/translator/opencensus/traces_to_oc_test.go
+++ b/pkg/translator/opencensus/traces_to_oc_test.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/goldendataset"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
 )
@@ -139,13 +138,13 @@ func TestAttributesMapTOOcSameProcessAsParentSpan(t *testing.T) {
 	attr := pdata.NewMap()
 	assert.Nil(t, attributesMapToOCSameProcessAsParentSpan(attr))
 
-	attr.UpsertBool(occonventions.AttributeSameProcessAsParentSpan, true)
+	attr.UpsertBool(attributeSameProcessAsParentSpan, true)
 	assert.True(t, proto.Equal(wrapperspb.Bool(true), attributesMapToOCSameProcessAsParentSpan(attr)))
 
-	attr.UpsertBool(occonventions.AttributeSameProcessAsParentSpan, false)
+	attr.UpsertBool(attributeSameProcessAsParentSpan, false)
 	assert.True(t, proto.Equal(wrapperspb.Bool(false), attributesMapToOCSameProcessAsParentSpan(attr)))
 
-	attr.UpdateInt(occonventions.AttributeSameProcessAsParentSpan, 13)
+	attr.UpdateInt(attributeSameProcessAsParentSpan, 13)
 	assert.Nil(t, attributesMapToOCSameProcessAsParentSpan(attr))
 }
 

--- a/pkg/translator/zipkin/zipkinv2/to_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/to_translator.go
@@ -30,7 +30,6 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/idutils"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/occonventions"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/internal/zipkin"
 )
@@ -95,10 +94,7 @@ var nonSpanAttributes = func() map[string]struct{} {
 	attrs[zipkin.TagServiceNameSource] = struct{}{}
 	attrs[conventions.OtelLibraryName] = struct{}{}
 	attrs[conventions.OtelLibraryVersion] = struct{}{}
-	attrs[occonventions.AttributeProcessStartTime] = struct{}{}
-	attrs[occonventions.AttributeExporterVersion] = struct{}{}
 	attrs[conventions.AttributeProcessPID] = struct{}{}
-	attrs[occonventions.AttributeResourceType] = struct{}{}
 	return attrs
 }()
 


### PR DESCRIPTION
Jaeger usage of the occonventions was needed for when the pipeline's data were OC based, and is a legacy from that moment.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7791
