### PR TITLE
[exporter/loadbalancing] Allow non-exist hostname on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `awscloudwatchlogsexporter`: Remove name from aws cloudwatch logs exporter (#7554)
 - `hostreceiver/memoryscraper`: Add memory.utilization (#6221)
 - `elasticsearchexporter`: Remove usage of deprecated LogRecord.Name field (#7829).
+- `loadbalancingexporter`: Allow non-exist hostname on startup (#7935)
 
 ### 🛑 Breaking changes 🛑
 

--- a/exporter/loadbalancingexporter/consistent_hashing.go
+++ b/exporter/loadbalancingexporter/consistent_hashing.go
@@ -59,7 +59,7 @@ func (h *hashRing) endpointFor(traceID pdata.TraceID) string {
 	return h.findEndpoint(position(pos))
 }
 
-// findEndpoint returns the "next" endpoint starting from the given position
+// findEndpoint returns the "next" endpoint starting from the given position, or an empty string in case no endpoints are available
 func (h *hashRing) findEndpoint(pos position) string {
 	ringSize := len(h.items)
 	if ringSize == 0 {

--- a/exporter/loadbalancingexporter/consistent_hashing.go
+++ b/exporter/loadbalancingexporter/consistent_hashing.go
@@ -62,6 +62,9 @@ func (h *hashRing) endpointFor(traceID pdata.TraceID) string {
 // findEndpoint returns the "next" endpoint starting from the given position
 func (h *hashRing) findEndpoint(pos position) string {
 	ringSize := len(h.items)
+	if ringSize == 0 {
+		return ""
+	}
 	left, right := h.items[:ringSize/2], h.items[ringSize/2:]
 	found := bsearch(pos, left, right)
 	return found.endpoint

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -181,7 +181,7 @@ func (lb *loadBalancerImp) Endpoint(traceID pdata.TraceID) string {
 }
 
 func (lb *loadBalancerImp) Exporter(endpoint string) (component.Exporter, error) {
-	// NOTE: make rolling updates of next tier of collectors work. currently this may cause
+	// NOTE: make rolling updates of next tier of collectors work. currently, this may cause
 	// data loss because the latest batches sent to outdated backend will never find their way out.
 	// for details: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1690
 	lb.updateLock.RLock()

--- a/exporter/loadbalancingexporter/resolver_dns.go
+++ b/exporter/loadbalancingexporter/resolver_dns.go
@@ -77,7 +77,7 @@ func newDNSResolver(logger *zap.Logger, hostname string, port string) (*dnsResol
 
 func (r *dnsResolver) start(ctx context.Context) error {
 	if _, err := r.resolve(ctx); err != nil {
-		return err
+		r.logger.Warn("failed to resolve", zap.Error(err))
 	}
 
 	go r.periodicallyResolve()

--- a/exporter/loadbalancingexporter/resolver_dns_test.go
+++ b/exporter/loadbalancingexporter/resolver_dns_test.go
@@ -112,7 +112,7 @@ func TestCantResolve(t *testing.T) {
 	err = res.start(context.Background())
 
 	// verify
-	assert.Equal(t, expectedErr, err)
+	assert.NoError(t, err)
 }
 
 func TestOnChange(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
loadbalancing exporter will crash on startup if the hostname does not resolve, this add startup order requirements to the collectors pods.

This change allows the collector to start when:
- hostname do not exists
- SRV record (headless k8s service) in the hostname have no members


**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7051

**Testing:** <Describe what testing was performed and which tests were added.>
Unit test, running locally.

**Documentation:** <Describe the documentation added.>
None