### PR TITLE
[exporter/datadog] sync model code

### DIFF
--- a/exporter/datadogexporter/internal/metrics/consumer.go
+++ b/exporter/datadogexporter/internal/metrics/consumer.go
@@ -88,32 +88,28 @@ func (c *Consumer) All(timestamp uint64, buildInfo component.BuildInfo) ([]datad
 // ConsumeTimeSeries implements the translator.Consumer interface.
 func (c *Consumer) ConsumeTimeSeries(
 	_ context.Context,
-	name string,
+	dims *translator.Dimensions,
 	typ translator.MetricDataType,
 	timestamp uint64,
 	value float64,
-	tags []string,
-	host string,
 ) {
 	dt := c.toDataType(typ)
-	met := NewMetric(name, dt, timestamp, value, tags)
-	met.SetHost(host)
+	met := NewMetric(dims.Name(), dt, timestamp, value, dims.Tags())
+	met.SetHost(dims.Host())
 	c.ms = append(c.ms, met)
 }
 
 // ConsumeSketch implements the translator.Consumer interface.
 func (c *Consumer) ConsumeSketch(
 	_ context.Context,
-	name string,
+	dims *translator.Dimensions,
 	timestamp uint64,
 	sketch *quantile.Sketch,
-	tags []string,
-	host string,
 ) {
 	c.sl = append(c.sl, sketches.SketchSeries{
-		Name:     name,
-		Tags:     tags,
-		Host:     host,
+		Name:     dims.Name(),
+		Tags:     dims.Tags(),
+		Host:     dims.Host(),
 		Interval: 1,
 		Points: []sketches.SketchPoint{{
 			Ts:     int64(timestamp / 1e9),

--- a/exporter/datadogexporter/internal/model/attributes/attributes.go
+++ b/exporter/datadogexporter/internal/model/attributes/attributes.go
@@ -163,6 +163,19 @@ func TagsFromAttributes(attrs pdata.AttributeMap) []string {
 	return tags
 }
 
+// OriginIDFromAttributes gets the origin IDs from resource attributes.
+// If not found, an empty string is returned for each of them.
+func OriginIDFromAttributes(attrs pdata.AttributeMap) (originID string) {
+	// originID is always empty. Container ID is preferred over Kubernetes pod UID.
+	// Prefixes come from pkg/util/kubernetes/kubelet and pkg/util/containers.
+	if containerID, ok := attrs.Get(conventions.AttributeContainerID); ok {
+		originID = "container_id://" + containerID.AsString()
+	} else if podUID, ok := attrs.Get(conventions.AttributeK8SPodUID); ok {
+		originID = "kubernetes_pod_uid://" + podUID.AsString()
+	}
+	return
+}
+
 // RunningTagsFromAttributes gets tags used for running metrics from attributes.
 func RunningTagsFromAttributes(attrs pdata.AttributeMap) []string {
 	tags := make([]string, 0, 1)

--- a/exporter/datadogexporter/internal/model/attributes/attributes_test.go
+++ b/exporter/datadogexporter/internal/model/attributes/attributes_test.go
@@ -81,3 +81,45 @@ func TestContainerTagFromAttributesEmpty(t *testing.T) {
 
 	assert.Equal(t, empty, ContainerTagFromAttributes(attributeMap))
 }
+
+func TestOriginIDFromAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		attrs    pdata.AttributeMap
+		originID string
+	}{
+		{
+			name: "pod UID and container ID",
+			attrs: pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{
+				conventions.AttributeContainerID: pdata.NewAttributeValueString("container_id_goes_here"),
+				conventions.AttributeK8SPodUID:   pdata.NewAttributeValueString("k8s_pod_uid_goes_here"),
+			}),
+			originID: "container_id://container_id_goes_here",
+		},
+		{
+			name: "only container ID",
+			attrs: pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{
+				conventions.AttributeContainerID: pdata.NewAttributeValueString("container_id_goes_here"),
+			}),
+			originID: "container_id://container_id_goes_here",
+		},
+		{
+			name: "only pod UID",
+			attrs: pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{
+				conventions.AttributeK8SPodUID: pdata.NewAttributeValueString("k8s_pod_uid_goes_here"),
+			}),
+			originID: "kubernetes_pod_uid://k8s_pod_uid_goes_here",
+		},
+		{
+			name:  "none",
+			attrs: pdata.NewAttributeMap(),
+		},
+	}
+
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			originID := OriginIDFromAttributes(testInstance.attrs)
+			assert.Equal(t, testInstance.originID, originID)
+		})
+	}
+}

--- a/exporter/datadogexporter/internal/model/attributes/azure/azure.go
+++ b/exporter/datadogexporter/internal/model/attributes/azure/azure.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package azure // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/attributes/azure"
 
 import (
@@ -54,8 +55,7 @@ func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
 
 // ClusterNameFromAttributes gets the Azure cluster name from attributes
 func ClusterNameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
-	// Get cluster name from resource group
-	// https://github.com/DataDog/datadog-agent/blob/aad29b8/pkg/util/azure/azure.go#L51
+	// Get cluster name from resource group from pkg/util/cloudprovider/azure:GetClusterName
 	if resourceGroup, ok := attrs.Get(AttributeResourceGroupName); ok {
 		splitAll := strings.Split(resourceGroup.StringVal(), "_")
 		if len(splitAll) < 4 || strings.ToLower(splitAll[0]) != "mc" {

--- a/exporter/datadogexporter/internal/model/attributes/ec2/ec2.go
+++ b/exporter/datadogexporter/internal/model/attributes/ec2/ec2.go
@@ -28,6 +28,7 @@ var (
 	clusterTagPrefix = ec2TagPrefix + "kubernetes.io/cluster/"
 )
 
+// HostInfo holds the EC2 host information.
 type HostInfo struct {
 	InstanceID  string
 	EC2Hostname string

--- a/exporter/datadogexporter/internal/model/attributes/gcp/gcp.go
+++ b/exporter/datadogexporter/internal/model/attributes/gcp/gcp.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package gcp // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/attributes/gcp"
 
 import (
@@ -20,6 +21,7 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
+// HostInfo holds the GCP host information.
 type HostInfo struct {
 	HostAliases []string
 	GCPTags     []string

--- a/exporter/datadogexporter/internal/model/internal/instrumentationlibrary/metadata.go
+++ b/exporter/datadogexporter/internal/model/internal/instrumentationlibrary/metadata.go
@@ -17,7 +17,7 @@ package instrumentationlibrary // import "github.com/open-telemetry/opentelemetr
 import (
 	"go.opentelemetry.io/collector/model/pdata"
 
-	translatorUtils "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/internal/utils"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/internal/utils"
 )
 
 const (
@@ -29,7 +29,7 @@ const (
 // the instrumentation library and converts them to Datadog tags.
 func TagsFromInstrumentationLibraryMetadata(il pdata.InstrumentationLibrary) []string {
 	return []string{
-		translatorUtils.FormatKeyValueTag(instrumentationLibraryTag, il.Name()),
-		translatorUtils.FormatKeyValueTag(instrumentationLibraryVersionTag, il.Version()),
+		utils.FormatKeyValueTag(instrumentationLibraryTag, il.Name()),
+		utils.FormatKeyValueTag(instrumentationLibraryVersionTag, il.Version()),
 	}
 }

--- a/exporter/datadogexporter/internal/model/internal/testutils/test_utils.go
+++ b/exporter/datadogexporter/internal/model/internal/testutils/test_utils.go
@@ -1,16 +1,7 @@
-// Copyright The OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
 
 package testutils // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/internal/testutils"
 

--- a/exporter/datadogexporter/internal/model/internal/testutils/test_utils.go
+++ b/exporter/datadogexporter/internal/model/internal/testutils/test_utils.go
@@ -1,7 +1,16 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package testutils // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/internal/testutils"
 

--- a/exporter/datadogexporter/internal/model/internal/utils/tags_test.go
+++ b/exporter/datadogexporter/internal/model/internal/utils/tags_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/internal/utils"
+package utils
 
 import (
 	"testing"

--- a/exporter/datadogexporter/internal/model/translator/consumer.go
+++ b/exporter/datadogexporter/internal/model/translator/consumer.go
@@ -35,12 +35,10 @@ type TimeSeriesConsumer interface {
 	// ConsumeTimeSeries consumes a timeseries-style metric.
 	ConsumeTimeSeries(
 		ctx context.Context,
-		name string,
+		dimensions *Dimensions,
 		typ MetricDataType,
 		timestamp uint64,
 		value float64,
-		tags []string,
-		host string,
 	)
 }
 
@@ -49,11 +47,9 @@ type SketchConsumer interface {
 	// ConsumeSketch consumes a pkg/quantile-style sketch.
 	ConsumeSketch(
 		ctx context.Context,
-		name string,
+		dimensions *Dimensions,
 		timestamp uint64,
 		sketch *quantile.Sketch,
-		tags []string,
-		host string,
 	)
 }
 

--- a/exporter/datadogexporter/internal/model/translator/dimensions.go
+++ b/exporter/datadogexporter/internal/model/translator/dimensions.go
@@ -28,10 +28,33 @@ const (
 	dimensionSeparator = string(byte(0))
 )
 
-type metricsDimensions struct {
-	name string
-	tags []string
-	host string
+// Dimensions of a metric that identify a timeseries uniquely.
+// This is similar to the concept of 'context' in DogStatsD/check metrics.
+type Dimensions struct {
+	name     string
+	tags     []string
+	host     string
+	originID string
+}
+
+// Name of the metric.
+func (d *Dimensions) Name() string {
+	return d.name
+}
+
+// Tags of the metric (read-only).
+func (d *Dimensions) Tags() []string {
+	return d.tags
+}
+
+// Host of the metric (may be empty).
+func (d *Dimensions) Host() string {
+	return d.host
+}
+
+// OriginID of the metric (may be empty).
+func (d *Dimensions) OriginID() string {
+	return d.originID
 }
 
 // getTags maps an attributeMap into a slice of Datadog tags
@@ -46,29 +69,31 @@ func getTags(labels pdata.AttributeMap) []string {
 }
 
 // AddTags to metrics dimensions.
-func (m *metricsDimensions) AddTags(tags ...string) metricsDimensions {
+func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 	// defensively copy the tags
-	newTags := make([]string, 0, len(tags)+len(m.tags))
+	newTags := make([]string, 0, len(tags)+len(d.tags))
 	newTags = append(newTags, tags...)
-	newTags = append(newTags, m.tags...)
-	return metricsDimensions{
-		name: m.name,
-		tags: newTags,
-		host: m.host,
+	newTags = append(newTags, d.tags...)
+	return &Dimensions{
+		name:     d.name,
+		tags:     newTags,
+		host:     d.host,
+		originID: d.originID,
 	}
 }
 
 // WithAttributeMap creates a new metricDimensions struct with additional tags from attributes.
-func (m *metricsDimensions) WithAttributeMap(labels pdata.AttributeMap) metricsDimensions {
-	return m.AddTags(getTags(labels)...)
+func (d *Dimensions) WithAttributeMap(labels pdata.AttributeMap) *Dimensions {
+	return d.AddTags(getTags(labels)...)
 }
 
 // WithSuffix creates a new dimensions struct with an extra name suffix.
-func (m *metricsDimensions) WithSuffix(suffix string) metricsDimensions {
-	return metricsDimensions{
-		name: fmt.Sprintf("%s.%s", m.name, suffix),
-		host: m.host,
-		tags: m.tags,
+func (d *Dimensions) WithSuffix(suffix string) *Dimensions {
+	return &Dimensions{
+		name:     fmt.Sprintf("%s.%s", d.name, suffix),
+		host:     d.host,
+		tags:     d.tags,
+		originID: d.originID,
 	}
 }
 
@@ -82,14 +107,15 @@ func concatDimensionValue(metricKeyBuilder *strings.Builder, value string) {
 
 // String maps dimensions to a string to use as an identifier.
 // The tags order does not matter.
-func (m *metricsDimensions) String() string {
+func (d *Dimensions) String() string {
 	var metricKeyBuilder strings.Builder
 
-	dimensions := make([]string, len(m.tags))
-	copy(dimensions, m.tags)
+	dimensions := make([]string, len(d.tags))
+	copy(dimensions, d.tags)
 
-	dimensions = append(dimensions, fmt.Sprintf("name:%s", m.name))
-	dimensions = append(dimensions, fmt.Sprintf("host:%s", m.host))
+	dimensions = append(dimensions, fmt.Sprintf("name:%s", d.name))
+	dimensions = append(dimensions, fmt.Sprintf("host:%s", d.host))
+	dimensions = append(dimensions, fmt.Sprintf("originID:%s", d.originID))
 	sort.Strings(dimensions)
 
 	for _, dim := range dimensions {

--- a/exporter/datadogexporter/internal/model/translator/dimensions_test.go
+++ b/exporter/datadogexporter/internal/model/translator/dimensions_test.go
@@ -28,7 +28,7 @@ func TestWithAttributeMap(t *testing.T) {
 		"key3": pdata.NewAttributeValueString(""),
 	})
 
-	dims := metricsDimensions{}
+	dims := Dimensions{}
 	assert.ElementsMatch(t,
 		dims.WithAttributeMap(attributes).tags,
 		[...]string{"key1:val1", "key2:val2", "key3:n/a"},
@@ -37,7 +37,7 @@ func TestWithAttributeMap(t *testing.T) {
 
 func TestMetricDimensionsString(t *testing.T) {
 	getKey := func(name string, tags []string, host string) string {
-		dims := metricsDimensions{name: name, tags: tags, host: host}
+		dims := Dimensions{name: name, tags: tags, host: host}
 		return dims.String()
 	}
 	metricName := "metric.name"
@@ -68,7 +68,7 @@ func TestMetricDimensionsStringNoTagsChange(t *testing.T) {
 	originalTags[0] = "key1:val1"
 	originalTags[1] = "key2:val2"
 
-	dims := metricsDimensions{
+	dims := Dimensions{
 		name: "a.metric.name",
 		tags: originalTags,
 	}
@@ -78,7 +78,7 @@ func TestMetricDimensionsStringNoTagsChange(t *testing.T) {
 
 }
 
-var testDims metricsDimensions = metricsDimensions{
+var testDims = Dimensions{
 	name: "test.metric",
 	tags: []string{"key:val"},
 	host: "host",
@@ -97,4 +97,25 @@ func TestAddTags(t *testing.T) {
 	dimsWithTags := testDims.AddTags("key1:val1", "key2:val2")
 	assert.ElementsMatch(t, []string{"key:val", "key1:val1", "key2:val2"}, dimsWithTags.tags)
 	assert.ElementsMatch(t, []string{"key:val"}, testDims.tags)
+}
+
+func TestAllFieldsAreCopied(t *testing.T) {
+	dims := &Dimensions{
+		name:     "example.name",
+		host:     "hostname",
+		tags:     []string{"tagOne:a", "tagTwo:b"},
+		originID: "origin_id",
+	}
+
+	newDims := dims.
+		AddTags("tagThree:c").
+		WithSuffix("suffix").
+		WithAttributeMap(pdata.NewAttributeMapFromMap(map[string]pdata.AttributeValue{
+			"tagFour": pdata.NewAttributeValueString("d"),
+		}))
+
+	assert.Equal(t, "example.name.suffix", newDims.Name())
+	assert.Equal(t, "hostname", newDims.Host())
+	assert.ElementsMatch(t, []string{"tagOne:a", "tagTwo:b", "tagThree:c", "tagFour:d"}, newDims.Tags())
+	assert.Equal(t, "origin_id", newDims.OriginID())
 }

--- a/exporter/datadogexporter/internal/model/translator/metrics_translator.go
+++ b/exporter/datadogexporter/internal/model/translator/metrics_translator.go
@@ -90,7 +90,7 @@ func (t *Translator) isSkippable(name string, v float64) bool {
 func (t *Translator) mapNumberMetrics(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	dims metricsDimensions,
+	dims *Dimensions,
 	dt MetricDataType,
 	slice pdata.NumberDataPointSlice,
 ) {
@@ -99,7 +99,7 @@ func (t *Translator) mapNumberMetrics(
 		p := slice.At(i)
 		pointDims := dims.WithAttributeMap(p.Attributes())
 		var val float64
-		switch p.ValueType() {
+		switch p.Type() {
 		case pdata.MetricValueTypeDouble:
 			val = p.DoubleVal()
 		case pdata.MetricValueTypeInt:
@@ -110,7 +110,7 @@ func (t *Translator) mapNumberMetrics(
 			continue
 		}
 
-		consumer.ConsumeTimeSeries(ctx, pointDims.name, dt, uint64(p.Timestamp()), val, pointDims.tags, pointDims.host)
+		consumer.ConsumeTimeSeries(ctx, pointDims, dt, uint64(p.Timestamp()), val)
 	}
 }
 
@@ -118,7 +118,7 @@ func (t *Translator) mapNumberMetrics(
 func (t *Translator) mapNumberMonotonicMetrics(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	dims metricsDimensions,
+	dims *Dimensions,
 	slice pdata.NumberDataPointSlice,
 ) {
 	for i := 0; i < slice.Len(); i++ {
@@ -128,7 +128,7 @@ func (t *Translator) mapNumberMonotonicMetrics(
 		pointDims := dims.WithAttributeMap(p.Attributes())
 
 		var val float64
-		switch p.ValueType() {
+		switch p.Type() {
 		case pdata.MetricValueTypeDouble:
 			val = p.DoubleVal()
 		case pdata.MetricValueTypeInt:
@@ -140,7 +140,7 @@ func (t *Translator) mapNumberMonotonicMetrics(
 		}
 
 		if dx, ok := t.prevPts.MonotonicDiff(pointDims, startTs, ts, val); ok {
-			consumer.ConsumeTimeSeries(ctx, pointDims.name, Count, ts, dx, pointDims.tags, pointDims.host)
+			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, dx)
 		}
 	}
 }
@@ -170,7 +170,7 @@ type histogramInfo struct {
 func (t *Translator) getSketchBuckets(
 	ctx context.Context,
 	consumer SketchConsumer,
-	pointDims metricsDimensions,
+	pointDims *Dimensions,
 	p pdata.HistogramDataPoint,
 	histInfo histogramInfo,
 	delta bool,
@@ -215,14 +215,14 @@ func (t *Translator) getSketchBuckets(
 			sketch.Basic.Sum = histInfo.sum
 			sketch.Basic.Avg = sketch.Basic.Sum / float64(sketch.Basic.Cnt)
 		}
-		consumer.ConsumeSketch(ctx, pointDims.name, ts, sketch, pointDims.tags, pointDims.host)
+		consumer.ConsumeSketch(ctx, pointDims, ts, sketch)
 	}
 }
 
 func (t *Translator) getLegacyBuckets(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	pointDims metricsDimensions,
+	pointDims *Dimensions,
 	p pdata.HistogramDataPoint,
 	delta bool,
 ) {
@@ -240,9 +240,9 @@ func (t *Translator) getLegacyBuckets(
 
 		count := float64(val)
 		if delta {
-			consumer.ConsumeTimeSeries(ctx, bucketDims.name, Count, ts, count, bucketDims.tags, bucketDims.host)
+			consumer.ConsumeTimeSeries(ctx, bucketDims, Count, ts, count)
 		} else if dx, ok := t.prevPts.Diff(bucketDims, startTs, ts, count); ok {
-			consumer.ConsumeTimeSeries(ctx, bucketDims.name, Count, ts, dx, bucketDims.tags, bucketDims.host)
+			consumer.ConsumeTimeSeries(ctx, bucketDims, Count, ts, dx)
 		}
 	}
 }
@@ -263,7 +263,7 @@ func (t *Translator) getLegacyBuckets(
 func (t *Translator) mapHistogramMetrics(
 	ctx context.Context,
 	consumer Consumer,
-	dims metricsDimensions,
+	dims *Dimensions,
 	slice pdata.HistogramDataPointSlice,
 	delta bool,
 ) {
@@ -299,8 +299,8 @@ func (t *Translator) mapHistogramMetrics(
 
 		if t.cfg.SendCountSum && histInfo.ok {
 			// We only send the sum and count if both values were ok.
-			consumer.ConsumeTimeSeries(ctx, countDims.name, Count, ts, float64(histInfo.count), countDims.tags, countDims.host)
-			consumer.ConsumeTimeSeries(ctx, sumDims.name, Count, ts, histInfo.sum, sumDims.tags, sumDims.host)
+			consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, float64(histInfo.count))
+			consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, histInfo.sum)
 		}
 
 		switch t.cfg.HistMode {
@@ -343,7 +343,7 @@ func getQuantileTag(quantile float64) string {
 func (t *Translator) mapSummaryMetrics(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	dims metricsDimensions,
+	dims *Dimensions,
 	slice pdata.SummaryDataPointSlice,
 ) {
 
@@ -357,7 +357,7 @@ func (t *Translator) mapSummaryMetrics(
 		{
 			countDims := pointDims.WithSuffix("count")
 			if dx, ok := t.prevPts.Diff(countDims, startTs, ts, float64(p.Count())); ok && !t.isSkippable(countDims.name, dx) {
-				consumer.ConsumeTimeSeries(ctx, countDims.name, Count, ts, dx, countDims.tags, countDims.host)
+				consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, dx)
 			}
 		}
 
@@ -365,7 +365,7 @@ func (t *Translator) mapSummaryMetrics(
 			sumDims := pointDims.WithSuffix("sum")
 			if !t.isSkippable(sumDims.name, p.Sum()) {
 				if dx, ok := t.prevPts.Diff(sumDims, startTs, ts, p.Sum()); ok {
-					consumer.ConsumeTimeSeries(ctx, sumDims.name, Count, ts, dx, sumDims.tags, sumDims.host)
+					consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, dx)
 				}
 			}
 		}
@@ -381,7 +381,7 @@ func (t *Translator) mapSummaryMetrics(
 				}
 
 				quantileDims := baseQuantileDims.AddTags(getQuantileTag(q.Quantile()))
-				consumer.ConsumeTimeSeries(ctx, quantileDims.name, Gauge, ts, q.Value(), quantileDims.tags, quantileDims.host)
+				consumer.ConsumeTimeSeries(ctx, quantileDims, Gauge, ts, q.Value())
 			}
 		}
 	}
@@ -434,10 +434,11 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 
 			for k := 0; k < metricsArray.Len(); k++ {
 				md := metricsArray.At(k)
-				baseDims := metricsDimensions{
-					name: md.Name(),
-					tags: additionalTags,
-					host: host,
+				baseDims := &Dimensions{
+					name:     md.Name(),
+					tags:     additionalTags,
+					host:     host,
+					originID: attributes.OriginIDFromAttributes(rm.Resource().Attributes()),
 				}
 				switch md.DataType() {
 				case pdata.MetricDataTypeGauge:

--- a/exporter/datadogexporter/internal/model/translator/metrics_translator.go
+++ b/exporter/datadogexporter/internal/model/translator/metrics_translator.go
@@ -99,7 +99,7 @@ func (t *Translator) mapNumberMetrics(
 		p := slice.At(i)
 		pointDims := dims.WithAttributeMap(p.Attributes())
 		var val float64
-		switch p.Type() {
+		switch p.ValueType() {
 		case pdata.MetricValueTypeDouble:
 			val = p.DoubleVal()
 		case pdata.MetricValueTypeInt:
@@ -128,7 +128,7 @@ func (t *Translator) mapNumberMonotonicMetrics(
 		pointDims := dims.WithAttributeMap(p.Attributes())
 
 		var val float64
-		switch p.Type() {
+		switch p.ValueType() {
 		case pdata.MetricValueTypeDouble:
 			val = p.DoubleVal()
 		case pdata.MetricValueTypeInt:

--- a/exporter/datadogexporter/internal/model/translator/metrics_translator_test.go
+++ b/exporter/datadogexporter/internal/model/translator/metrics_translator_test.go
@@ -136,38 +136,36 @@ type mockTimeSeriesConsumer struct {
 
 func (m *mockTimeSeriesConsumer) ConsumeTimeSeries(
 	_ context.Context,
-	name string,
+	dimensions *Dimensions,
 	typ MetricDataType,
 	ts uint64,
 	val float64,
-	tags []string,
-	host string,
 ) {
 	m.metrics = append(m.metrics,
 		metric{
-			name:      name,
+			name:      dimensions.Name(),
 			typ:       typ,
 			timestamp: ts,
 			value:     val,
-			tags:      tags,
-			host:      host,
+			tags:      dimensions.Tags(),
+			host:      dimensions.Host(),
 		},
 	)
 }
 
-func newDims(name string) metricsDimensions {
-	return metricsDimensions{name: name, tags: []string{}}
+func newDims(name string) *Dimensions {
+	return &Dimensions{name: name, tags: []string{}}
 }
 
-func newGauge(dims metricsDimensions, ts uint64, val float64) metric {
+func newGauge(dims *Dimensions, ts uint64, val float64) metric {
 	return metric{name: dims.name, typ: Gauge, timestamp: ts, value: val, tags: dims.tags}
 }
 
-func newCount(dims metricsDimensions, ts uint64, val float64) metric {
+func newCount(dims *Dimensions, ts uint64, val float64) metric {
 	return metric{name: dims.name, typ: Count, timestamp: ts, value: val, tags: dims.tags}
 }
 
-func newSketch(dims metricsDimensions, ts uint64, s summary.Summary) sketch {
+func newSketch(dims *Dimensions, ts uint64, s summary.Summary) sketch {
 	return sketch{name: dims.name, basic: s, timestamp: ts, tags: dims.tags}
 }
 
@@ -198,7 +196,7 @@ func TestMapIntMetrics(t *testing.T) {
 
 	// With attribute tags
 	consumer = &mockTimeSeriesConsumer{}
-	dims = metricsDimensions{name: "int64.test", tags: []string{"attribute_tag:attribute_value"}}
+	dims = &Dimensions{name: "int64.test", tags: []string{"attribute_tag:attribute_value"}}
 	tr.mapNumberMetrics(ctx, consumer, dims, Gauge, slice)
 	assert.ElementsMatch(t,
 		consumer.metrics,
@@ -233,7 +231,7 @@ func TestMapDoubleMetrics(t *testing.T) {
 
 	// With attribute tags
 	consumer = &mockTimeSeriesConsumer{}
-	dims = metricsDimensions{name: "float64.test", tags: []string{"attribute_tag:attribute_value"}}
+	dims = &Dimensions{name: "float64.test", tags: []string{"attribute_tag:attribute_value"}}
 	tr.mapNumberMetrics(ctx, consumer, dims, Gauge, slice)
 	assert.ElementsMatch(t,
 		consumer.metrics,
@@ -245,7 +243,7 @@ func seconds(i int) pdata.Timestamp {
 	return pdata.NewTimestampFromTime(time.Unix(int64(i), 0))
 }
 
-var exampleDims metricsDimensions = newDims("metric.example")
+var exampleDims = newDims("metric.example")
 
 func TestMapIntMonotonicMetrics(t *testing.T) {
 	// Create list of values
@@ -502,24 +500,26 @@ func TestMapDoubleMonotonicOutOfOrder(t *testing.T) {
 	)
 }
 
+var _ SketchConsumer = (*mockFullConsumer)(nil)
+
 type mockFullConsumer struct {
 	mockTimeSeriesConsumer
 	sketches []sketch
 }
 
-func (c *mockFullConsumer) ConsumeSketch(_ context.Context, name string, ts uint64, sk *quantile.Sketch, tags []string, host string) {
+func (c *mockFullConsumer) ConsumeSketch(_ context.Context, dimensions *Dimensions, ts uint64, sk *quantile.Sketch) {
 	c.sketches = append(c.sketches,
 		sketch{
-			name:      name,
+			name:      dimensions.Name(),
 			basic:     sk.Basic,
 			timestamp: ts,
-			tags:      tags,
-			host:      host,
+			tags:      dimensions.Tags(),
+			host:      dimensions.Host(),
 		},
 	)
 }
 
-func dimsWithBucket(dims metricsDimensions, lowerBound string, upperBound string) metricsDimensions {
+func dimsWithBucket(dims *Dimensions, lowerBound string, upperBound string) *Dimensions {
 	dims = dims.WithSuffix("bucket")
 	return dims.AddTags(
 		fmt.Sprintf("lower_bound:%s", lowerBound),
@@ -677,7 +677,7 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 			tr.cfg.HistMode = testInstance.histogramMode
 			tr.cfg.SendCountSum = testInstance.sendCountSum
 			consumer := &mockFullConsumer{}
-			dims := metricsDimensions{name: "doubleHist.test", tags: testInstance.tags}
+			dims := &Dimensions{name: "doubleHist.test", tags: testInstance.tags}
 			tr.mapHistogramMetrics(ctx, consumer, dims, slice, delta)
 			assert.ElementsMatch(t, consumer.metrics, testInstance.expectedMetrics)
 			assert.ElementsMatch(t, consumer.sketches, testInstance.expectedSketches)
@@ -795,7 +795,7 @@ func TestLegacyBucketsTags(t *testing.T) {
 	pointOne.SetExplicitBounds([]float64{0})
 	pointOne.SetTimestamp(seconds(0))
 	consumer := &mockTimeSeriesConsumer{}
-	dims := metricsDimensions{name: "test.histogram.one", tags: tags}
+	dims := &Dimensions{name: "test.histogram.one", tags: tags}
 	tr.getLegacyBuckets(ctx, consumer, dims, pointOne, true)
 	seriesOne := consumer.metrics
 
@@ -804,7 +804,7 @@ func TestLegacyBucketsTags(t *testing.T) {
 	pointTwo.SetExplicitBounds([]float64{1})
 	pointTwo.SetTimestamp(seconds(0))
 	consumer = &mockTimeSeriesConsumer{}
-	dims = metricsDimensions{name: "test.histogram.two", tags: tags}
+	dims = &Dimensions{name: "test.histogram.two", tags: tags}
 	tr.getLegacyBuckets(ctx, consumer, dims, pointTwo, true)
 	seriesTwo := consumer.metrics
 
@@ -868,8 +868,8 @@ func TestMapSummaryMetrics(t *testing.T) {
 
 	newTranslator := func(tags []string, quantiles bool) *Translator {
 		c := newTestCache()
-		c.cache.Set((&metricsDimensions{name: "summary.example.count", tags: tags}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
-		c.cache.Set((&metricsDimensions{name: "summary.example.sum", tags: tags}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
+		c.cache.Set((&Dimensions{name: "summary.example.count", tags: tags}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
+		c.cache.Set((&Dimensions{name: "summary.example.sum", tags: tags}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
 		options := []Option{WithFallbackHostnameProvider(testProvider("fallbackHostname"))}
 		if quantiles {
 			options = append(options, WithQuantiles())

--- a/exporter/datadogexporter/internal/model/translator/sketches_test.go
+++ b/exporter/datadogexporter/internal/model/translator/sketches_test.go
@@ -36,11 +36,9 @@ type sketchConsumer struct {
 // ConsumeSketch implements the translator.Consumer interface.
 func (c *sketchConsumer) ConsumeSketch(
 	_ context.Context,
-	_ string,
+	_ *Dimensions,
 	_ uint64,
 	sketch *quantile.Sketch,
-	_ []string,
-	_ string,
 ) {
 	c.sk = sketch
 }

--- a/exporter/datadogexporter/internal/model/translator/ttlcache.go
+++ b/exporter/datadogexporter/internal/model/translator/ttlcache.go
@@ -39,20 +39,20 @@ func newTTLCache(sweepInterval int64, deltaTTL int64) *ttlCache {
 
 // Diff submits a new value for a given non-monotonic metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
-func (t *ttlCache) Diff(dimensions metricsDimensions, startTs, ts uint64, val float64) (float64, bool) {
+func (t *ttlCache) Diff(dimensions *Dimensions, startTs, ts uint64, val float64) (float64, bool) {
 	return t.putAndGetDiff(dimensions, false, startTs, ts, val)
 }
 
 // MonotonicDiff submits a new value for a given monotonic metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
-func (t *ttlCache) MonotonicDiff(dimensions metricsDimensions, startTs, ts uint64, val float64) (float64, bool) {
+func (t *ttlCache) MonotonicDiff(dimensions *Dimensions, startTs, ts uint64, val float64) (float64, bool) {
 	return t.putAndGetDiff(dimensions, true, startTs, ts, val)
 }
 
 // putAndGetDiff submits a new value for a given metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
 func (t *ttlCache) putAndGetDiff(
-	dimensions metricsDimensions,
+	dimensions *Dimensions,
 	monotonic bool,
 	startTs, ts uint64,
 	val float64,

--- a/exporter/datadogexporter/internal/model/translator/ttlcache_test.go
+++ b/exporter/datadogexporter/internal/model/translator/ttlcache_test.go
@@ -25,7 +25,7 @@ func newTestCache() *ttlCache {
 	return cache
 }
 
-var dims metricsDimensions = metricsDimensions{name: "test"}
+var dims = &Dimensions{name: "test"}
 
 func TestMonotonicDiffUnknownStart(t *testing.T) {
 	startTs := uint64(0) // equivalent to start being unset


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Follow up to #7909, to make both codebases consistent. 
This does not have any user-visible changes on the Datadog exporter.

<details>

<summary>Script used for first commit</summary>

```sh
cp -r ~/Source/agent/datadog-agent/pkg/otlp/model/ exporter/datadogexporter/internal
rm exporter/datadogexporter/internal/model/{doc.go,go.mod,go.sum}
make goporto
fd -e go -X sd DataDog/datadog-agent/pkg/otlp/model open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model
```

</details>

Items needed to mark this as reviewable:

- [x] Merge DataDog/datadog-agent#10939
- [x] Merge DataDog/datadog-agent#10960
- [x] Update Collector's `*Consumer`s to conform to new interface
- [x] Update licensing header on test utils file
- [x] Wait for Agent changes to be QAed, just in case.
