### PR TITLE
Refresh expired credentials in awsprometheusremotewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🚩 Deprecations 🚩
 
 ### 🧰 Bug fixes 🧰
+- `awsprometheusremotewriteexporter`: refresh credentials before signing if expired (#7956)
 
 ### 🚀 New components 🚀
 
@@ -33,7 +34,6 @@
 - `loadbalancingexporter`: Allow non-exist hostname on startup (#7935)
 - `datadogexporter`: Use exact sum, count and average on Datadog distributions (#7830)
 - `storage/filestorage`: add optional compaction to filestorage (#7768)
-- `awsprometheusremotewriteexporter`: refresh credentials before signing if expired (#7956)
 
 ### 🛑 Breaking changes 🛑
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `loadbalancingexporter`: Allow non-exist hostname on startup (#7935)
 - `datadogexporter`: Use exact sum, count and average on Datadog distributions (#7830)
 - `storage/filestorage`: add optional compaction to filestorage (#7768)
+- `awsprometheusremotewriteexporter`: refresh credentials before signing if expired (#7956)
 
 ### 🛑 Breaking changes 🛑
 

--- a/exporter/awsprometheusremotewriteexporter/auth.go
+++ b/exporter/awsprometheusremotewriteexporter/auth.go
@@ -69,7 +69,10 @@ func (si *signingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	}
 	req2.Header.Set("User-Agent", ua)
 
-	expiration, _ := si.signer.Credentials.ExpiresAt()
+	expiration, err := si.signer.Credentials.ExpiresAt()
+	if err != nil {
+		expiration = time.Time{} // Avoid errors in the the if condition
+	}
 
 	if len(si.roleArn) != 0 && !expiration.IsZero() && si.signer.Credentials.IsExpired() {
 		// Under an assumed role, Credential expiration will be known so we update the credentials before requesting the Signature

--- a/exporter/awsprometheusremotewriteexporter/auth.go
+++ b/exporter/awsprometheusremotewriteexporter/auth.go
@@ -87,10 +87,13 @@ func (si *signingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 
 	// Sign the request
 	_, err = si.signer.Sign(req2, body, si.service, si.region, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("error signing the request: %v", err)
+	}
 
 	resp, err := si.transport.RoundTrip(req2)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error sending request: %v", err)
 	}
 
 	if resp != nil && resp.StatusCode == 403 {


### PR DESCRIPTION
**Description:** 

Added logic to validate if the current credentials are expired and force a refresh of them before signing the request to avoid dropping packages

Two cases are considered:

- role_arn is specified in the exporter configuration: In this case, the credential is aware of the expiration date and the logic can be applied.
- role_arn is **not** specified, then usually the credentials are considered long term (expiration date = time.Time{}) and the check cannot be performed. We can only infer the credentials are invalid based on the response from the server (403), and then refresh the credentials before failing the Roundtrip. If the file was properly updated, the next trip will be successful but packet loss will occur. A deeper change in the logic can be added to retry the package but the recommended approach in this case would be to pass a role_arn in the configuration.


**Link to tracking Issue:** Fix #7955

**Testing:** Both conditions were tested for over 1h and there was no errors in the transmission when `role_arn` was specified and a temporary packet loss when not specified as expected.

**Documentation:** N/A