### PR TITLE
[exporter/dynatrace] Validate QueueSettings and perform config validation in Validate() instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 💡 Enhancements 💡
 
+- `dynatraceexporter`: Validate QueueSettings and perform config validation in Validate() instead (#8020)
+
 ### 🛑 Breaking changes 🛑
 
 ### 🚩 Deprecations 🚩

--- a/exporter/dynatraceexporter/config/config.go
+++ b/exporter/dynatraceexporter/config/config.go
@@ -50,8 +50,11 @@ type Config struct {
 	Tags []string `mapstructure:"tags"`
 }
 
-// ValidateAndConfigureHTTPClientSettings validates the configuration and sets default values
-func (c *Config) ValidateAndConfigureHTTPClientSettings() error {
+func (c *Config) Validate() error {
+	if err := c.QueueSettings.Validate(); err != nil {
+		return fmt.Errorf("queue settings has invalid configuration: %w", err)
+	}
+
 	if c.HTTPClientSettings.Headers == nil {
 		c.HTTPClientSettings.Headers = make(map[string]string)
 	}
@@ -74,9 +77,5 @@ func (c *Config) ValidateAndConfigureHTTPClientSettings() error {
 	c.HTTPClientSettings.Headers["Content-Type"] = "text/plain; charset=UTF-8"
 	c.HTTPClientSettings.Headers["User-Agent"] = "opentelemetry-collector"
 
-	return nil
-}
-
-func (c *Config) Validate() error {
 	return nil
 }

--- a/exporter/dynatraceexporter/config/config_test.go
+++ b/exporter/dynatraceexporter/config/config_test.go
@@ -15,12 +15,12 @@
 package config
 
 import (
-	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"testing"
 
 	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/apiconstants"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestConfig_Validate(t *testing.T) {

--- a/exporter/dynatraceexporter/config/config_test.go
+++ b/exporter/dynatraceexporter/config/config_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"testing"
 
 	"github.com/dynatrace-oss/dynatrace-metric-utils-go/metric/apiconstants"
@@ -22,10 +23,10 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 )
 
-func TestConfig_ValidateAndConfigureHTTPClientSettings(t *testing.T) {
+func TestConfig_Validate(t *testing.T) {
 	t.Run("Empty configuration", func(t *testing.T) {
 		c := &Config{}
-		err := c.ValidateAndConfigureHTTPClientSettings()
+		err := c.Validate()
 		assert.NoError(t, err)
 
 		assert.Equal(t, apiconstants.GetDefaultOneAgentEndpoint(), c.Endpoint, "Should use default OneAgent endpoint")
@@ -33,7 +34,7 @@ func TestConfig_ValidateAndConfigureHTTPClientSettings(t *testing.T) {
 
 	t.Run("Valid configuration", func(t *testing.T) {
 		c := &Config{HTTPClientSettings: confighttp.HTTPClientSettings{Endpoint: "http://example.com/"}, APIToken: "token"}
-		err := c.ValidateAndConfigureHTTPClientSettings()
+		err := c.Validate()
 		assert.NoError(t, err)
 
 		assert.Equal(t, "http://example.com/", c.Endpoint, "Should use provided endpoint")
@@ -41,7 +42,13 @@ func TestConfig_ValidateAndConfigureHTTPClientSettings(t *testing.T) {
 
 	t.Run("Invalid Endpoint", func(t *testing.T) {
 		c := &Config{HTTPClientSettings: confighttp.HTTPClientSettings{Endpoint: "example.com"}}
-		err := c.ValidateAndConfigureHTTPClientSettings()
+		err := c.Validate()
+		assert.Error(t, err)
+	})
+
+	t.Run("Invalid QueueSettings", func(t *testing.T) {
+		c := &Config{QueueSettings: exporterhelper.QueueSettings{QueueSize: -1, Enabled: true}}
+		err := c.Validate()
 		assert.Error(t, err)
 	})
 }

--- a/exporter/dynatraceexporter/factory.go
+++ b/exporter/dynatraceexporter/factory.go
@@ -67,10 +67,6 @@ func createMetricsExporter(
 
 	cfg := c.(*dtconfig.Config)
 
-	if err := cfg.ValidateAndConfigureHTTPClientSettings(); err != nil {
-		return nil, err
-	}
-
 	exp := newMetricsExporter(set, cfg)
 
 	exporter, err := exporterhelper.NewMetricsExporter(

--- a/exporter/dynatraceexporter/factory_test.go
+++ b/exporter/dynatraceexporter/factory_test.go
@@ -59,14 +59,14 @@ func TestLoadConfig(t *testing.T) {
 
 	factory := NewFactory()
 	factories.Exporters[typeStr] = factory
-	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "config.yml"), factories)
+	cfg, err := servicetest.LoadConfig(filepath.Join("testdata", "config.yml"), factories)
 
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
 	t.Run("defaults", func(t *testing.T) {
 		defaultConfig := cfg.Exporters[config.NewComponentIDWithName(typeStr, "defaults")].(*dtconfig.Config)
-		err = defaultConfig.ValidateAndConfigureHTTPClientSettings()
+		err = defaultConfig.Validate()
 		require.NoError(t, err)
 		assert.Equal(t, &dtconfig.Config{
 			ExporterSettings: config.NewExporterSettings(config.NewComponentIDWithName(typeStr, "defaults")),
@@ -85,7 +85,7 @@ func TestLoadConfig(t *testing.T) {
 	})
 	t.Run("valid config", func(t *testing.T) {
 		validConfig := cfg.Exporters[config.NewComponentIDWithName(typeStr, "valid")].(*dtconfig.Config)
-		err = validConfig.ValidateAndConfigureHTTPClientSettings()
+		err = validConfig.Validate()
 
 		require.NoError(t, err)
 		assert.Equal(t, &dtconfig.Config{
@@ -112,7 +112,7 @@ func TestLoadConfig(t *testing.T) {
 	})
 	t.Run("valid config with tags", func(t *testing.T) {
 		validConfig := cfg.Exporters[config.NewComponentIDWithName(typeStr, "valid_tags")].(*dtconfig.Config)
-		err = validConfig.ValidateAndConfigureHTTPClientSettings()
+		err = validConfig.Validate()
 
 		require.NoError(t, err)
 		assert.Equal(t, &dtconfig.Config{
@@ -137,13 +137,13 @@ func TestLoadConfig(t *testing.T) {
 	})
 	t.Run("bad endpoint", func(t *testing.T) {
 		badEndpointConfig := cfg.Exporters[config.NewComponentIDWithName(typeStr, "bad_endpoint")].(*dtconfig.Config)
-		err = badEndpointConfig.ValidateAndConfigureHTTPClientSettings()
+		err = badEndpointConfig.Validate()
 		require.Error(t, err)
 	})
 
 	t.Run("missing api token", func(t *testing.T) {
 		missingTokenConfig := cfg.Exporters[config.NewComponentIDWithName(typeStr, "missing_token")].(*dtconfig.Config)
-		err = missingTokenConfig.ValidateAndConfigureHTTPClientSettings()
+		err = missingTokenConfig.Validate()
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
**Description:**
Due to a change in the collector core (https://github.com/open-telemetry/opentelemetry-collector/pull/4799) @codeboten added a `Validate` method to the Dynatrace Exporter's config in #7779. 

This PR makes the exporter config use this `Validate` method for validation instead of the previously used `ValidateAndConfigureHTTPClientSettings` method. This `Validate` method is automatically called on startup, and therefore does not need to be called by the factory anymore. It also adds validation of `QueueSettings`.

**Link to tracking Issue:** Fixes #7836 

**Testing:** 
- Unit test added
- Manual testing

**Documentation:** no documentation added/changed