### PR TITLE
Kafka Exporter/Receiver fix docs to auth.tls.insecure_skip_verify

### DIFF
--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -32,7 +32,7 @@ The following settings can be optionally configured:
     - `key_file`: path to the TLS key to use for TLS required connections. Should
       only be used if `insecure` is set to true.
     - `insecure` (default = false): Disable verifying the server's certificate chain and host 
-      name (`InsecureSkipVerify` in the tls config)
+      name (`insecure_skip_verify` in the tls config)
     - `server_name_override`: ServerName indicates the name of the server requested by the client
       in order to support virtual hosting.
   - `kerberos`


### PR DESCRIPTION
 **Description:**  Fixing the Kafka Exporter docs where  `auth.tls.insecure` maps to ` tls.insecure_skip_verify`

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8045

**Testing:** None

**Documentation:** None