### PR TITLE
Update Makefile targets to improve process time.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -110,7 +110,9 @@ jobs:
       - name: CheckDoc
         run: make checkdoc
       - name: Porto
-        run: make -j2 goporto
+        run: |
+          make goporto
+          git diff --exit-code || (echo 'Porto links are out of date, please run "make goporto" and commit the changes in this PR.' && exit 1)
       - name: CodeGen
         run: |
           make generate

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
           key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Install dependencies
         if: steps.module-cache.outputs.hit != 'true'
-        run: make gomoddownload
+        run: make -j2 gomoddownload
       - name: Install Tools
         if: steps.tool-cache.outputs.cache-hit != 'true'
         run: make install-tools
@@ -110,7 +110,7 @@ jobs:
       - name: CheckDoc
         run: make checkdoc
       - name: Porto
-        run: make porto
+        run: make -j2 goporto
       - name: CodeGen
         run: |
           make generate

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -42,7 +42,7 @@ jobs:
           key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Install dependencies
         if: steps.module-cache.outputs.hit != 'true'
-        run: make gomoddownload
+        run: make -j2 gomoddownload
       - name: Install Tools
         if: steps.tool-cache.outputs.cache-hit != 'true'
         run: make install-tools

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -42,7 +42,7 @@ jobs:
           key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Install dependencies
         if: steps.module-cache.outputs.hit != 'true'
-        run: make gomoddownload
+        run: make -j2 gomoddownload
       - name: Install Tools
         if: steps.tool-cache.outputs.cache-hit != 'true'
         run: make install-tools

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ golint:
 
 .PHONY: goporto
 goporto:
-	$(MAKE) for-all-target TARGET="porto"
+	porto -w --include-internal --skip-dirs "^cmd$$" ./
 
 .PHONY: for-all
 for-all:

--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,11 @@ stability-tests: otelcontribcol
 
 .PHONY: gotidy
 gotidy:
-	$(MAKE) for-all CMD="rm -fr go.sum"
-	$(MAKE) for-all CMD="$(GOCMD) mod tidy -compat=1.17"
+	$(MAKE) for-all-target TARGET="tidy"
 
 .PHONY: gomoddownload
 gomoddownload:
-	@$(MAKE) for-all CMD="$(GOCMD) mod download"
+	$(MAKE) for-all-target TARGET="moddownload"
 
 .PHONY: gotest
 gotest:
@@ -235,7 +234,7 @@ otelcontribcol-windows_amd64:
 .PHONY: update-dep
 update-dep:
 	$(MAKE) for-all CMD="$(PWD)/internal/buildscripts/update-dep"
-	$(MAKE) gotidy
+	$(MAKE) -j2 gotidy
 	$(MAKE) otelcontribcol
 
 .PHONY: update-otel

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -95,6 +95,11 @@ fmt:
 lint: checklicense impi misspell
 	$(LINT) run --allow-parallel-runners
 
+.PHONY: tidy
+tidy:
+	rm -fr go.sum
+	$(GOCMD) mod tidy -compat=1.17
+
 .PHONY: porto
 porto:
 	porto -w --include-internal --skip-dirs "^cmd$$" ./
@@ -112,6 +117,6 @@ misspell-correction:
 impi:
 	@$(IMPI) --local github.com/open-telemetry/opentelemetry-collector-contrib --scheme stdThirdPartyLocal ./...
 
-.PHONY: dep
-dep:
+.PHONY: moddownload
+moddownload:
 	$(GOCMD) mod download

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -100,10 +100,6 @@ tidy:
 	rm -fr go.sum
 	$(GOCMD) mod tidy -compat=1.17
 
-.PHONY: porto
-porto:
-	porto -w --include-internal --skip-dirs "^cmd$$" ./
-
 .PHONY: misspell
 misspell:
 	@echo "running $(MISSPELL)"


### PR DESCRIPTION
* Change make gotidy target to use make target
* Change make gomoddownload target to use make target

Update GA to run in parallel some of the steps.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
