### PR TITLE
[exporter/honeycomb] Update Honeycomb exporter to call QueueSettings Validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `sapmexporter`: Add validation for `sending_queue` setting (#8023)
 - `signalfxexporter`: Add validation for `sending_queue` setting (#8026)
 - `resourcedetectionprocessor`: Add confighttp.HTTPClientSettings To Resource Detection Config Fixes (#7397)
+- `honeycombexporter`: Add validation for `sending_queue` setting (#8113)
 
 ### 🛑 Breaking changes 🛑
 

--- a/exporter/honeycombexporter/config.go
+++ b/exporter/honeycombexporter/config.go
@@ -44,7 +44,7 @@ type Config struct {
 
 func (cfg *Config) Validate() error {
 	if err := cfg.QueueSettings.Validate(); err != nil {
-		return fmt.Errorf("queue settings has invalid configuration: %w", err)
+		return fmt.Errorf("`sending_queue` settings has invalid configuration: %w", err)
 	}
 	return nil
 }

--- a/exporter/honeycombexporter/config.go
+++ b/exporter/honeycombexporter/config.go
@@ -15,6 +15,8 @@
 package honeycombexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/honeycombexporter"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
@@ -41,5 +43,8 @@ type Config struct {
 }
 
 func (cfg *Config) Validate() error {
+	if err := cfg.QueueSettings.Validate(); err != nil {
+		return fmt.Errorf("queue settings has invalid configuration: %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

As requested in linked ticket, this PR ensures the QueueSetting.Valudate func is called as part of the HoneycombExporter Validate call.

**Link to tracking Issue:** <Issue number if applicable>
- Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7838

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>