### PR TITLE
[pkg/translator/prometheusremotewrite] Support non-string resource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - `prometheusreceiver`: Fix segfault that can occur after receiving stale metrics (#8056)
 - `filelogreceiver`: Fix issue where logs could occasionally be duplicated (#8123)
+- `prometheusremotewriteexporter`: Fix empty non-string resource attributes (#8116)
 
 ### 🚀 New components 🚀
 

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -161,7 +161,7 @@ func createAttributes(resource pdata.Resource, attributes pdata.AttributeMap, ex
 		if isUsefulResourceAttribute(key) {
 			l[key] = prompb.Label{
 				Name:  sanitize(key),
-				Value: value.StringVal(), // TODO(jbd): Decide what to do with non-string attributes.
+				Value: value.AsString(),
 			}
 		}
 

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -189,7 +189,7 @@ func Test_createLabelSet(t *testing.T) {
 	}{
 		{
 			"labels_clean",
-			getResource(),
+			getResource(map[string]pdata.AttributeValue{}),
 			lbs1,
 			map[string]string{},
 			[]string{label31, value31, label32, value32},
@@ -197,15 +197,29 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"labels_with_resource",
-			getResource("job", "prometheus", "instance", "127.0.0.1:8080"),
+			getResource(map[string]pdata.AttributeValue{
+				"job":      pdata.NewAttributeValueString("prometheus"),
+				"instance": pdata.NewAttributeValueString("127.0.0.1:8080"),
+			}),
 			lbs1,
 			map[string]string{},
 			[]string{label31, value31, label32, value32},
 			getPromLabels(label11, value11, label12, value12, label31, value31, label32, value32, "job", "prometheus", "instance", "127.0.0.1:8080"),
 		},
 		{
+			"labels_with_nonstring_resource",
+			getResource(map[string]pdata.AttributeValue{
+				"job":      pdata.NewAttributeValueInt(12345),
+				"instance": pdata.NewAttributeValueBool(true),
+			}),
+			lbs1,
+			map[string]string{},
+			[]string{label31, value31, label32, value32},
+			getPromLabels(label11, value11, label12, value12, label31, value31, label32, value32, "job", "12345", "instance", "true"),
+		},
+		{
 			"labels_duplicate_in_extras",
-			getResource(),
+			getResource(map[string]pdata.AttributeValue{}),
 			lbs1,
 			map[string]string{},
 			[]string{label11, value31},
@@ -213,7 +227,7 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"labels_dirty",
-			getResource(),
+			getResource(map[string]pdata.AttributeValue{}),
 			lbs1Dirty,
 			map[string]string{},
 			[]string{label31 + dirty1, value31, label32, value32},
@@ -221,7 +235,7 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"no_original_case",
-			getResource(),
+			getResource(map[string]pdata.AttributeValue{}),
 			pdata.NewAttributeMap(),
 			nil,
 			[]string{label31, value31, label32, value32},
@@ -229,7 +243,7 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"empty_extra_case",
-			getResource(),
+			getResource(map[string]pdata.AttributeValue{}),
 			lbs1,
 			map[string]string{},
 			[]string{"", ""},
@@ -237,7 +251,7 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"single_left_over_case",
-			getResource(),
+			getResource(map[string]pdata.AttributeValue{}),
 			lbs1,
 			map[string]string{},
 			[]string{label31, value31, label32},
@@ -245,7 +259,7 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"valid_external_labels",
-			getResource(),
+			getResource(map[string]pdata.AttributeValue{}),
 			lbs1,
 			exlbs1,
 			[]string{label31, value31, label32, value32},
@@ -253,7 +267,7 @@ func Test_createLabelSet(t *testing.T) {
 		},
 		{
 			"overwritten_external_labels",
-			getResource(),
+			getResource(map[string]pdata.AttributeValue{}),
 			lbs1,
 			exlbs2,
 			[]string{label31, value31, label32, value32},

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -396,11 +396,11 @@ func getSummaryMetric(name string, attributes pdata.AttributeMap, ts uint64, sum
 	return metric
 }
 
-func getResource(resources ...string) pdata.Resource {
+func getResource(resources map[string]pdata.AttributeValue) pdata.Resource {
 	resource := pdata.NewResource()
 
-	for i := 0; i < len(resources); i += 2 {
-		resource.Attributes().Upsert(resources[i], pdata.NewAttributeValueString(resources[i+1]))
+	for k, v := range resources {
+		resource.Attributes().Upsert(k, v)
 	}
 
 	return resource


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7878

It isn't really a big deal, since job and instance shouldn't ever be non-string, but may be more important if https://github.com/open-telemetry/opentelemetry-specification/pull/2381 is adopted.

**Description:** <Describe what has changed.>
For non-string resource attributes, use the `AsString` method to convert them to prometheus labels.

Related: https://github.com/open-telemetry/opentelemetry-specification/pull/2343

cc @Aneurysm9 