### PR TITLE
[exporter/tanzuobservability]Instrumentation Library and Dropped Counts to Span Tags

### DIFF
--- a/exporter/tanzuobservabilityexporter/exporter_test.go
+++ b/exporter/tanzuobservabilityexporter/exporter_test.go
@@ -192,6 +192,35 @@ func validateTraces(t *testing.T, expected []*span, traces pdata.Traces) {
 	}
 }
 
+func TestExportTraceDataWithInstrumentationDetails(t *testing.T) {
+	minSpan := createSpan(
+		"root",
+		pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),
+		pdata.NewSpanID([8]byte{9, 9, 9, 9, 9, 9, 9, 9}),
+		pdata.SpanID{},
+	)
+	traces := constructTraces([]pdata.Span{minSpan})
+
+	traces.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).InstrumentationLibrary().
+		SetName("instrumentation_name")
+	traces.ResourceSpans().At(0).InstrumentationLibrarySpans().At(0).InstrumentationLibrary().
+		SetVersion("v0.0.1")
+
+	expected := []*span{{
+		Name:    "root",
+		TraceID: uuid.MustParse("01010101-0101-0101-0101-010101010101"),
+		SpanID:  uuid.MustParse("00000000-0000-0000-0909-090909090909"),
+		Tags: map[string]string{
+			labelApplication:     "defaultApp",
+			labelService:         "defaultService",
+			labelOtelSpanName:    "instrumentation_name",
+			labelOtelSpanVersion: "v0.0.1",
+		},
+	}}
+
+	validateTraces(t, expected, traces)
+}
+
 func TestExportTraceDataRespectsContext(t *testing.T) {
 	traces := constructTraces([]pdata.Span{createSpan(
 		"root",

--- a/exporter/tanzuobservabilityexporter/transformer.go
+++ b/exporter/tanzuobservabilityexporter/transformer.go
@@ -16,6 +16,7 @@ package tanzuobservabilityexporter // import "github.com/open-telemetry/opentele
 
 import (
 	"errors"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -72,6 +73,18 @@ func (t *traceTransformer) Span(orig pdata.Span) (span, error) {
 	t.setRequiredTags(tags)
 
 	tags[labelSpanKind] = spanKind(orig)
+
+	if droppedEventsCount := orig.DroppedEventsCount(); droppedEventsCount > 0 {
+		tags[labelDroppedEventsCount] = strconv.Itoa(int(droppedEventsCount))
+	}
+
+	if droppedLinksCount := orig.DroppedLinksCount(); droppedLinksCount > 0 {
+		tags[labelDroppedLinksCount] = strconv.Itoa(int(droppedLinksCount))
+	}
+
+	if droppedAttrsCount := orig.DroppedAttributesCount(); droppedAttrsCount > 0 {
+		tags[labelDroppedAttrsCount] = strconv.Itoa(int(droppedAttrsCount))
+	}
 
 	errorTags := errorTagsFromStatus(orig.Status())
 	for k, v := range errorTags {

--- a/exporter/tanzuobservabilityexporter/transformer_test.go
+++ b/exporter/tanzuobservabilityexporter/transformer_test.go
@@ -294,6 +294,75 @@ func TestSpanForSourceTag(t *testing.T) {
 	assert.Equal(t, "source_from_span_attribute", actual.Tags["_source"])
 }
 
+func TestSpanForDroppedEventsCount(t *testing.T) {
+	inNanos := int64(50000000)
+
+	//TestCase: 1 droppedEvents tag not set
+	resAttrs := pdata.NewAttributeMap()
+	transform := transformerFromAttributes(resAttrs)
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	span.SetStartTimestamp(pdata.Timestamp(inNanos))
+
+	actual, err := transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+	assert.NotContains(t, actual.Tags, "otel.dropped_events_count")
+
+	//TestCase2: droppedEvents set
+	span.SetDroppedEventsCount(123)
+
+	actual, err = transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+	assert.Equal(t, "123", actual.Tags["otel.dropped_events_count"])
+}
+
+func TestSpanForDroppedLinksCounts(t *testing.T) {
+	inNanos := int64(50000000)
+
+	//TestCase: 1 DroppedLinks tag not set
+	resAttrs := pdata.NewAttributeMap()
+	transform := transformerFromAttributes(resAttrs)
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	span.SetStartTimestamp(pdata.Timestamp(inNanos))
+
+	actual, err := transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+	assert.NotContains(t, actual.Tags, "otel.dropped_links_count")
+
+	//TestCase2: DroppedLinks set
+	span.SetDroppedLinksCount(123)
+
+	actual, err = transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+	assert.Equal(t, "123", actual.Tags["otel.dropped_links_count"])
+}
+
+func TestSpanForDroppedAttributesCounts(t *testing.T) {
+	inNanos := int64(50000000)
+
+	//TestCase: 1 DroppedAttributes tag not set
+	resAttrs := pdata.NewAttributeMap()
+	transform := transformerFromAttributes(resAttrs)
+	span := pdata.NewSpan()
+	span.SetSpanID(pdata.NewSpanID([8]byte{0, 0, 0, 0, 0, 0, 0, 1}))
+	span.SetTraceID(pdata.NewTraceID([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}))
+	span.SetStartTimestamp(pdata.Timestamp(inNanos))
+
+	actual, err := transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+	assert.NotContains(t, actual.Tags, "otel.dropped_attributes_count")
+
+	//TestCase2: DroppedAttributes set
+	span.SetDroppedAttributesCount(123)
+
+	actual, err = transform.Span(span)
+	require.NoError(t, err, "transforming span to wavefront format")
+	assert.Equal(t, "123", actual.Tags["otel.dropped_attributes_count"])
+}
+
 func TestGetSourceAndResourceTags(t *testing.T) {
 	resAttrs := pdata.NewAttributeMap()
 	resAttrs.InsertString(labelSource, "test_source")


### PR DESCRIPTION
**Description:** Add following span-tags:
otel.dropped_events_count
otel.dropped_links_count
otel.dropped_attributes_co
otel.span.name
otel.span.version

**Link to tracking Issue:** N/A

**Testing:** Unit and manual testing 

**Documentation:** N/A