### PR TITLE
Bump opentelemetry-log-collection library to v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### 🧰 Bug fixes 🧰
 
 - `prometheusreceiver`: Fix segfault that can occur after receiving stale metrics (#8056)
+- `filelogreceiver`: Fix issue where logs could occasionally be duplicated (#8123)
 
 ### 🚀 New components 🚀
 

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -348,7 +348,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.45.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.45.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.45.1 // indirect
-	github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 // indirect
+	github.com/open-telemetry/opentelemetry-log-collection v0.26.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -1635,8 +1635,8 @@ github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je4
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 h1:iPBQJZAD5Nt0z2vWGT2UDJMImKi4DF105VX8Dz3p3RY=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0 h1:wYUzXU5Fc7YES9JvPww1j+QbxgiAiVSBseZSKQp0O2M=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/go.mod
+++ b/go.mod
@@ -347,7 +347,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.45.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx v0.45.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.45.1 // indirect
-	github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 // indirect
+	github.com/open-telemetry/opentelemetry-log-collection v0.26.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1633,8 +1633,8 @@ github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je4
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 h1:iPBQJZAD5Nt0z2vWGT2UDJMImKi4DF105VX8Dz3p3RY=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0 h1:wYUzXU5Fc7YES9JvPww1j+QbxgiAiVSBseZSKQp0O2M=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/internal/stanza/go.mod
+++ b/internal/stanza/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.45.1
-	github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372
+	github.com/open-telemetry/opentelemetry-log-collection v0.26.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.45.1-0.20220223001941-c9c253193a75
 	go.opentelemetry.io/collector/model v0.45.1-0.20220222185228-27f7607ca13a

--- a/internal/stanza/go.sum
+++ b/internal/stanza/go.sum
@@ -158,8 +158,8 @@ github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnu
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 h1:iPBQJZAD5Nt0z2vWGT2UDJMImKi4DF105VX8Dz3p3RY=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0 h1:wYUzXU5Fc7YES9JvPww1j+QbxgiAiVSBseZSKQp0O2M=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.45.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza v0.45.1
-	github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372
+	github.com/open-telemetry/opentelemetry-log-collection v0.26.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.45.1-0.20220223001941-c9c253193a75
 	go.opentelemetry.io/collector/model v0.45.1-0.20220222185228-27f7607ca13a

--- a/receiver/filelogreceiver/go.sum
+++ b/receiver/filelogreceiver/go.sum
@@ -168,8 +168,8 @@ github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYhe
 github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc h1:49ewVBwLcy+eYqI4R0ICilCI4dPjddpFXWv3liXzUxM=
 github.com/observiq/nanojack v0.0.0-20201106172433-343928847ebc/go.mod h1:WXIHwGy+c7/IK2PiJ4oxuTHkpnkSut7TNFpKnI5llPU=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 h1:iPBQJZAD5Nt0z2vWGT2UDJMImKi4DF105VX8Dz3p3RY=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0 h1:wYUzXU5Fc7YES9JvPww1j+QbxgiAiVSBseZSKQp0O2M=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/receiver/journaldreceiver/go.mod
+++ b/receiver/journaldreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza v0.45.1
-	github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372
+	github.com/open-telemetry/opentelemetry-log-collection v0.26.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.45.1-0.20220223001941-c9c253193a75
 	gopkg.in/yaml.v2 v2.4.0

--- a/receiver/journaldreceiver/go.sum
+++ b/receiver/journaldreceiver/go.sum
@@ -163,8 +163,8 @@ github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnu
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 h1:iPBQJZAD5Nt0z2vWGT2UDJMImKi4DF105VX8Dz3p3RY=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0 h1:wYUzXU5Fc7YES9JvPww1j+QbxgiAiVSBseZSKQp0O2M=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza v0.45.1
-	github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372
+	github.com/open-telemetry/opentelemetry-log-collection v0.26.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.45.1-0.20220223001941-c9c253193a75
 	go.opentelemetry.io/collector/model v0.45.1-0.20220222185228-27f7607ca13a

--- a/receiver/syslogreceiver/go.sum
+++ b/receiver/syslogreceiver/go.sum
@@ -168,8 +168,8 @@ github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYhe
 github.com/observiq/go-syslog/v3 v3.0.2 h1:vaeINFErM/E3cKE2Ot1FAhhGq5mv7uGBOzjnGL3qhbY=
 github.com/observiq/go-syslog/v3 v3.0.2/go.mod h1:9abcumkQwDUY0VgWdH6CaaJ3Ks39A7NvIelMlavPru0=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 h1:iPBQJZAD5Nt0z2vWGT2UDJMImKi4DF105VX8Dz3p3RY=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0 h1:wYUzXU5Fc7YES9JvPww1j+QbxgiAiVSBseZSKQp0O2M=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/receiver/tcplogreceiver/go.mod
+++ b/receiver/tcplogreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza v0.45.1
-	github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372
+	github.com/open-telemetry/opentelemetry-log-collection v0.26.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.45.1-0.20220223001941-c9c253193a75
 	gopkg.in/yaml.v2 v2.4.0

--- a/receiver/tcplogreceiver/go.sum
+++ b/receiver/tcplogreceiver/go.sum
@@ -165,8 +165,8 @@ github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnu
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 h1:iPBQJZAD5Nt0z2vWGT2UDJMImKi4DF105VX8Dz3p3RY=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0 h1:wYUzXU5Fc7YES9JvPww1j+QbxgiAiVSBseZSKQp0O2M=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/receiver/udplogreceiver/go.mod
+++ b/receiver/udplogreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/stanza v0.45.1
-	github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372
+	github.com/open-telemetry/opentelemetry-log-collection v0.26.0
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector v0.45.1-0.20220223001941-c9c253193a75
 	gopkg.in/yaml.v2 v2.4.0

--- a/receiver/udplogreceiver/go.sum
+++ b/receiver/udplogreceiver/go.sum
@@ -163,8 +163,8 @@ github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnu
 github.com/observiq/ctimefmt v1.0.0 h1:r7vTJ+Slkrt9fZ67mkf+mA6zAdR5nGIJRMTzkUyvilk=
 github.com/observiq/ctimefmt v1.0.0/go.mod h1:mxi62//WbSpG/roCO1c6MqZ7zQTvjVtYheqHN3eOjvc=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372 h1:iPBQJZAD5Nt0z2vWGT2UDJMImKi4DF105VX8Dz3p3RY=
-github.com/open-telemetry/opentelemetry-log-collection v0.25.1-0.20220223175442-26aeee9f1372/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0 h1:wYUzXU5Fc7YES9JvPww1j+QbxgiAiVSBseZSKQp0O2M=
+github.com/open-telemetry/opentelemetry-log-collection v0.26.0/go.mod h1:fhbLWuhofaFWHsYK6p5zfeBflPHM/uF2Xa2FxaQCQuI=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=


### PR DESCRIPTION
[Release notes](https://github.com/open-telemetry/opentelemetry-log-collection/releases/tag/v0.26.0)

Most of these changes were already merged to main in #8081. 

This additionally includes a bug fix for an occasional log duplication issue.