### PR TITLE
[processor/routing] Expand error handling on failure to build exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `signalfxexporter`: Add validation for `sending_queue` setting (#8026)
 - `resourcedetectionprocessor`: Add confighttp.HTTPClientSettings To Resource Detection Config Fixes (#7397)
 - `honeycombexporter`: Add validation for `sending_queue` setting (#8113)
+- `routingprocessor`: Expand error handling on failure to build exporters (#8125)
 
 ### 🛑 Breaking changes 🛑
 

--- a/processor/routingprocessor/factory_test.go
+++ b/processor/routingprocessor/factory_test.go
@@ -16,14 +16,16 @@ package routingprocessor
 
 import (
 	"context"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.uber.org/zap"
 
-	"go.opentelemetry.io/collector/service/servicetest"
 	"path/filepath"
 	"testing"
+
+	"go.opentelemetry.io/collector/service/servicetest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -172,10 +174,10 @@ func TestProcessorDoesNotFailToBuildExportersWithMultiplePipelines(t *testing.T)
 		GetExportersFunc: func() map[config.DataType]map[config.ComponentID]component.Exporter {
 			return map[config.DataType]map[config.ComponentID]component.Exporter{
 				config.TracesDataType: {
-					config.NewComponentID("otlp/traces"):   otlpTracesExporter,
+					config.NewComponentID("otlp/traces"): otlpTracesExporter,
 				},
 				config.MetricsDataType: {
-					config.NewComponentID("otlp/metrics"):   otlpMetricsExporter,
+					config.NewComponentID("otlp/metrics"): otlpMetricsExporter,
 				},
 			}
 		},
@@ -189,6 +191,7 @@ func TestProcessorDoesNotFailToBuildExportersWithMultiplePipelines(t *testing.T)
 		err = exp.Start(context.Background(), host)
 		// assert that no error is thrown due to multiple pipelines and exporters not using the routing processor
 		assert.NoError(t, err)
+		assert.NoError(t, exp.Shutdown(context.Background()))
 	}
 }
 

--- a/processor/routingprocessor/factory_test.go
+++ b/processor/routingprocessor/factory_test.go
@@ -16,24 +16,21 @@ package routingprocessor
 
 import (
 	"context"
-
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configgrpc"
-	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	"go.uber.org/zap"
-
 	"path/filepath"
 	"testing"
 
-	"go.opentelemetry.io/collector/service/servicetest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+	"go.opentelemetry.io/collector/service/servicetest"
+	"go.uber.org/zap"
 )
 
 func TestProcessorGetsCreatedWithValidConfiguration(t *testing.T) {

--- a/processor/routingprocessor/router.go
+++ b/processor/routingprocessor/router.go
@@ -334,8 +334,8 @@ func (r *router) registerExporters(hostExporters map[config.DataType]map[config.
 		},
 	} {
 		if err := reg.registerFunc(hostExporters[reg.typ]); err != nil {
-			if errors.Is(err, errDefaultExporterNotFound) {
-				r.logger.Warn("can't find the default exporter for the routing processor for this pipeline type. This is OK if you did not specify this processor for that pipeline type",
+			if errors.Is(err, errDefaultExporterNotFound) || errors.Is(err, errExporterNotFound) {
+				r.logger.Warn("can't find the exporter for the routing processor for this pipeline type. This is OK if you did not specify this processor for that pipeline type",
 					zap.Any("pipeline_type", reg.typ),
 					zap.Error(err),
 				)

--- a/processor/routingprocessor/testdata/config_multipipelines.yaml
+++ b/processor/routingprocessor/testdata/config_multipipelines.yaml
@@ -1,0 +1,31 @@
+receivers:
+  nop:
+
+processors:
+  routing:
+    attribute_source: resource
+    from_attribute: X-Tenant
+    table:
+      - value: acme
+        exporters:
+          - otlp/traces
+
+exporters:
+  otlp/metrics:
+  otlp/traces:
+
+service:
+  pipelines:
+    traces:
+      receivers:
+        - nop
+      processors:
+        - routing
+      exporters:
+        - otlp/traces
+    metrics:
+      receivers:
+        - nop
+      processors: []
+      exporters:
+        - otlp/metrics


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This pr is expanding the error handling introduced in PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7423, since the error is also occurring for all exporters defined in the routing processor, not just the default ones.

If multiple pipelines are defined and the routing processor is only added to one of them, a false error is thrown saying the exporter can not be found. The PR above fixed it for the default exporters, so the goal of this PR is to also fix it for the non-default exporters defined in the routing processor.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6920

**Testing:** <Describe what testing was performed and which tests were added.>
I tested this change in my own local distribution and the error was no longer occurring with a configuration like this [example](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6920#issuecomment-1042899023)
