### PR TITLE
Remove tigrannajaryan as Maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Maintainers ([@open-telemetry/collector-contrib-maintainer](https://github.com/o
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs
 - [Alex Boten](https://github.com/codeboten), Lightstep
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk
+
+Emeritus Maintainers
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 
 Learn more about roles in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md).


### PR DESCRIPTION
I am no longer able to allocate time to be a maintainer of the Collector contrib
due to focusing on other parts of OpenTelemetry.

I will continue fulfilling a maintainer responsibility of the Collector core.

Thank you all, it was a pleasure working with you! And who knows, I may be able to
return sometime in the future.

I am moving myself to the Emeritus section according to the rules introduced in
https://github.com/open-telemetry/community/pull/961

P.S. We should add other previous approvers/maintainers in the Emeritus section.
