### PR TITLE
[exporters/datadog] Adding rbac manifest into the example_k8s_manifest.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `routingprocessor`: Expand error handling on failure to build exporters (#8125)
 - `skywalkingreceiver`: Add new skywalking receiver component folder and structure (#8107)
 - `groupbyattrsprocesor`: Allow empty keys, which allows to use the processor for compaction (#7793)
+- `datadogexporter`: Add rbac to example k8s manifest file (#8186)
 
 ### 🛑 Breaking changes 🛑
 

--- a/exporter/datadogexporter/example/example_k8s_manifest.yaml
+++ b/exporter/datadogexporter/example/example_k8s_manifest.yaml
@@ -7,9 +7,15 @@
 # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/12dbcfc3faf80ec532d832fc7e6650222be33ff9/processor/k8sattributesprocessor/doc.go#L26-L28
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: open-telemetry
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: otel-agent-conf
+  namespace: open-telemetry
   labels:
     app: opentelemetry
     component: otel-agent-conf
@@ -32,7 +38,7 @@ data:
       zipkin:
     exporters:
       otlp:
-        endpoint: "otel-collector.default:4317"
+        endpoint: "otel-collector.open-telemetry:4317"
         tls:
           insecure: true
     processors:
@@ -79,6 +85,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: otel-agent
+  namespace: open-telemetry
   labels:
     app: opentelemetry
     component: otel-agent
@@ -147,6 +154,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: otel-collector-conf
+  namespace: open-telemetry
   labels:
     app: opentelemetry
     component: otel-collector-conf
@@ -187,6 +195,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: otel-collector
+  namespace: open-telemetry
   labels:
     app: opentelemetry
     component: otel-collector
@@ -205,6 +214,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: otel-collector
+  namespace: open-telemetry
   labels:
     app: opentelemetry
     component: otel-collector
@@ -257,3 +267,32 @@ spec:
               - key: otel-collector-config
                 path: otel-collector-config.yaml
           name: otel-collector-config-vol
+      serviceAccountName: opentelemetry-collector
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opentelemetry-collector
+  namespace: open-telemetry
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector-role-binding
+subjects:
+- kind: ServiceAccount
+  name: opentelemetry-collector
+  namespace: open-telemetry
+roleRef:
+  kind: ClusterRole
+  name: otel-collector-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
**Description:** 
Namespace, ServiceAccount, ClusterRole and ClusterRoleBinding have been added to example_k8s_manifest.yaml to fix rbac errors in otel-collector pod.

Errors:
```
W0301 08:39:49.359379       1 reflector.go:324] k8s.io/client-go@v0.23.1/tools/cache/reflector.go:167: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:open-telemetry:default" cannot list resource "pods" in API group "" at the cluster scope
E0301 08:39:49.359460       1 reflector.go:138] k8s.io/client-go@v0.23.1/tools/cache/reflector.go:167: Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:open-telemetry:default" cannot list resource "pods" in API group "" at the cluster scope
```

**Link to tracking Issue:**
n/a

**Testing:** 
Tested in local kind k8s cluster

**Documentation:**
n/a