### PR TITLE
[receiver/dockerstatsreceiver] Add container.runtime attribute to container metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `googlecloudexporter`: [Alpha] Translate metrics directly from OTLP to gcm using the `exporter.googlecloud.OTLPDirect` feature-gate (#7177)
 - `simpleprometheusreceiver`: Add support for static labels (#7908)
+- `dockerstatsreceiver`: Add container.runtime attribute to container metrics (#8261)
 
 ### 🛑 Breaking changes 🛑
 

--- a/receiver/dockerstatsreceiver/metrics.go
+++ b/receiver/dockerstatsreceiver/metrics.go
@@ -41,6 +41,7 @@ func ContainerStatsToMetrics(
 	rs := md.ResourceMetrics().AppendEmpty()
 	rs.SetSchemaUrl(conventions.SchemaURL)
 	resourceAttr := rs.Resource().Attributes()
+	resourceAttr.UpsertString(conventions.AttributeContainerRuntime, "docker")
 	resourceAttr.UpsertString(conventions.AttributeContainerID, container.ID)
 	resourceAttr.UpsertString(conventions.AttributeContainerImageName, container.Config.Image)
 	resourceAttr.UpsertString(conventions.AttributeContainerName, strings.TrimPrefix(container.Name, "/"))

--- a/receiver/dockerstatsreceiver/metrics_test.go
+++ b/receiver/dockerstatsreceiver/metrics_test.go
@@ -102,6 +102,7 @@ func metricsData(
 
 func defaultLabels() map[string]string {
 	return map[string]string{
+		"container.runtime":    "docker",
 		"container.hostname":   "abcdef012345",
 		"container.id":         "a2596076ca048f02bcd16a8acd12a7ea2d3bc430d1cde095357239dd3925a4c3",
 		"container.image.name": "myImage",


### PR DESCRIPTION
**Description:**
As per the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/container.md#container), container instances can be described with the `container.runtime` attribute.

In case of the dockerstatsreceiver, the runtime should always be `docker`.