### PR TITLE
[receiver/podmanstatsreceiver] Add container.runtime attribute to container metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `googlecloudexporter`: [Alpha] Translate metrics directly from OTLP to gcm using the `exporter.googlecloud.OTLPDirect` feature-gate (#7177)
 - `simpleprometheusreceiver`: Add support for static labels (#7908)
+- `podmanreceiver`: Add container.runtime attribute to container metrics (#8262)
 
 ### 🛑 Breaking changes 🛑
 

--- a/receiver/podmanreceiver/metrics.go
+++ b/receiver/podmanreceiver/metrics.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 type point struct {
@@ -34,6 +35,7 @@ func translateStatsToMetrics(stats *containerStats, ts time.Time, rm pdata.Resou
 	pbts := pdata.NewTimestampFromTime(ts)
 
 	resource := rm.Resource()
+	resource.Attributes().InsertString(conventions.AttributeContainerRuntime, "podman")
 	resource.Attributes().InsertString("container.name", stats.Name)
 	resource.Attributes().InsertString("container.id", stats.ContainerID)
 

--- a/receiver/podmanreceiver/metrics_test.go
+++ b/receiver/podmanreceiver/metrics_test.go
@@ -39,8 +39,9 @@ func assertStatsEqualToMetrics(t *testing.T, podmanStats *containerStats, md pda
 	rsm := md.ResourceMetrics().At(0)
 
 	resourceAttrs := map[string]string{
-		"container.id":   "abcd1234",
-		"container.name": "cntrA",
+		"container.runtime": "podman",
+		"container.id":      "abcd1234",
+		"container.name":    "cntrA",
 	}
 	for k, v := range resourceAttrs {
 		attr, exists := rsm.Resource().Attributes().Get(k)


### PR DESCRIPTION
**Description:**
As per the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/container.md#container), container instances can be described with the `container.runtime` attribute.

In case of the podmanstatsreceiver, the runtime should always be `podman`.