### PR TITLE
[prometheusreceiver and prometheusremotewriteexporter] Update resource attributes used when translating to/from prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - `redisreceiver`: instrumentation name updated from `otelcol/redis` to `otelcol/redisreceiver` (#8255)
 - `apachereceiver`: Update instrumentation library name from `otelcol/apache` to `otelcol/apachereceiver` ()
 - `couchdbreceiver`: instrumentation name updated from `otelcol/couchdb` to `otelcol/couchdbreceiver` (#8366)
+- `prometheusreceiver` Produces different resource attributes when converting metrics to OTLP (#8266)
+- `prometheusremotewriteexporter` Relies on `service.*` attributes when adding job and instance to metrics (#8266)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@
 - `redisreceiver`: instrumentation name updated from `otelcol/redis` to `otelcol/redisreceiver` (#8255)
 - `apachereceiver`: Update instrumentation library name from `otelcol/apache` to `otelcol/apachereceiver` ()
 - `couchdbreceiver`: instrumentation name updated from `otelcol/couchdb` to `otelcol/couchdbreceiver` (#8366)
-- `prometheusreceiver` Produces different resource attributes when converting metrics to OTLP (#8266)
-- `prometheusremotewriteexporter` Relies on `service.*` attributes when adding job and instance to metrics (#8266)
+- `prometheusreceiver` Change resource attributes on metrics: `instance` -> `service.instance.id`, `host.name` -> `net.host.name`,  `port` -> `net.host.port`, `scheme` -> `http.scheme`, `job` removed (#8266)
+- `prometheusremotewriteexporter` Use `service.*` resource attributes instead of `job` and `instance` resource attributes when adding job and instance labels to metrics (#8266)
 
 ### 🧰 Bug fixes 🧰
 

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -15,6 +15,7 @@
 package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
 
 import (
+	"fmt"
 	"log"
 	"math"
 	"sort"
@@ -28,6 +29,7 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/prompb"
 	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 const (
@@ -149,16 +151,24 @@ func createAttributes(resource pdata.Resource, attributes pdata.AttributeMap, ex
 	// map ensures no duplicate label name
 	l := map[string]prompb.Label{}
 
-	resource.Attributes().Range(func(key string, value pdata.AttributeValue) bool {
-		if isUsefulResourceAttribute(key) {
-			l[key] = prompb.Label{
-				Name:  sanitize(key),
-				Value: value.AsString(),
-			}
+	// Map service.name + service.namespace to job
+	if serviceName, ok := resource.Attributes().Get(conventions.AttributeServiceName); ok {
+		val := serviceName.AsString()
+		if serviceNamespace, ok := resource.Attributes().Get(conventions.AttributeServiceNamespace); ok {
+			val = fmt.Sprintf("%s/%s", serviceNamespace.AsString(), val)
 		}
-
-		return true
-	})
+		l[model.JobLabel] = prompb.Label{
+			Name:  model.JobLabel,
+			Value: val,
+		}
+	}
+	// Map service.instance.id to instance
+	if instance, ok := resource.Attributes().Get(conventions.AttributeServiceInstanceID); ok {
+		l[model.InstanceLabel] = prompb.Label{
+			Name:  model.InstanceLabel,
+			Value: instance.AsString(),
+		}
+	}
 
 	// Ensure attributes are sorted by key for consistent merging of keys which
 	// collide when sanitized.
@@ -214,20 +224,6 @@ func createAttributes(resource pdata.Resource, attributes pdata.AttributeMap, ex
 	}
 
 	return s
-}
-
-func isUsefulResourceAttribute(key string) bool {
-	// TODO(jbd): Allow users to configure what other resource
-	// attributes to be included.
-	// Decide what to do with non-string attributes.
-	// We should always output "job" and "instance".
-	switch key {
-	case model.InstanceLabel:
-		return true
-	case model.JobLabel:
-		return true
-	}
-	return false
 }
 
 // getPromMetricName creates a Prometheus metric name by attaching namespace prefix for Monotonic metrics.

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -198,8 +198,8 @@ func Test_createLabelSet(t *testing.T) {
 		{
 			"labels_with_resource",
 			getResource(map[string]pdata.AttributeValue{
-				"job":      pdata.NewAttributeValueString("prometheus"),
-				"instance": pdata.NewAttributeValueString("127.0.0.1:8080"),
+				"service.name":        pdata.NewAttributeValueString("prometheus"),
+				"service.instance.id": pdata.NewAttributeValueString("127.0.0.1:8080"),
 			}),
 			lbs1,
 			map[string]string{},
@@ -209,8 +209,8 @@ func Test_createLabelSet(t *testing.T) {
 		{
 			"labels_with_nonstring_resource",
 			getResource(map[string]pdata.AttributeValue{
-				"job":      pdata.NewAttributeValueInt(12345),
-				"instance": pdata.NewAttributeValueBool(true),
+				"service.name":        pdata.NewAttributeValueInt(12345),
+				"service.instance.id": pdata.NewAttributeValueBool(true),
 			}),
 			lbs1,
 			map[string]string{},

--- a/receiver/prometheusreceiver/internal/prom_to_otlp.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp.go
@@ -50,12 +50,11 @@ func CreateNodeAndResourcePdata(job, instance, scheme string) *pdata.Resource {
 	attrs := resource.Attributes()
 	attrs.UpsertString(conventions.AttributeServiceName, job)
 	if isDiscernibleHost(host) {
-		attrs.UpsertString(conventions.AttributeHostName, host)
+		attrs.UpsertString(conventions.AttributeNetHostName, host)
 	}
-	attrs.UpsertString(jobAttr, job)
-	attrs.UpsertString(instanceAttr, instance)
-	attrs.UpsertString(portAttr, port)
-	attrs.UpsertString(schemeAttr, scheme)
+	attrs.UpsertString(conventions.AttributeServiceInstanceID, instance)
+	attrs.UpsertString(conventions.AttributeNetHostPort, port)
+	attrs.UpsertString(conventions.AttributeHTTPScheme, scheme)
 
 	return &resource
 }

--- a/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
@@ -32,12 +32,11 @@ func makeResourceWithJobInstanceScheme(def *jobInstanceDefinition, hasHost bool)
 	// when variables change, these tests will fail and we'll have reports.
 	attrs.UpsertString("service.name", def.job)
 	if hasHost {
-		attrs.UpsertString("host.name", def.host)
+		attrs.UpsertString("net.host.name", def.host)
 	}
-	attrs.UpsertString("job", def.job)
-	attrs.UpsertString("instance", def.instance)
-	attrs.UpsertString("port", def.port)
-	attrs.UpsertString("scheme", def.scheme)
+	attrs.UpsertString("service.instance.id", def.instance)
+	attrs.UpsertString("net.host.port", def.port)
+	attrs.UpsertString("http.scheme", def.scheme)
 	return &resource
 }
 

--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -30,11 +30,6 @@ const (
 	startTimeMetricName = "process_start_time_seconds"
 	scrapeUpMetricName  = "up"
 
-	portAttr     = "port"
-	schemeAttr   = "scheme"
-	jobAttr      = "job"
-	instanceAttr = "instance"
-
 	transport  = "http"
 	dataformat = "prometheus"
 )


### PR DESCRIPTION
**Description:** 

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8264.  
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7081.

This PR updates the resource attributes used when translating to and from prometheus to match the [prometheus conversion specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#prometheus-compatibility), which was updated in https://github.com/open-telemetry/opentelemetry-specification/pull/2381 with these attributes.

**Testing:** Unit tests were updated.  Prometheus compatibility tests still pass after this change.