### PR TITLE
Update README.md

### DIFF
--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -155,7 +155,7 @@ Use the below commands to create a `ClusterRole` with required permissions and a
 
 ```bash
 <<EOF | kubectl apply -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: otelcontribcol
@@ -223,7 +223,7 @@ EOF
 
 ```bash
 <<EOF | kubectl apply -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: otelcontribcol


### PR DESCRIPTION
The example uses a deprecated API version, yielding warnings such as this one:

```
rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
```

removing "beta1" gets rid of the warnings.