### PR TITLE
[exporter/kafka] Add OTLP traces partition key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `clickhouseexporter`: Implement consume log logic. (#9705)
 - `influxdbexporter`: Add support for cumulative, non-monotonic metrics. (#8348)
 - `oauth2clientauthextension`: Add support for EndpointParams (#7307)
+- `kafkaexporter`: Set partition key for OTLP traces (#8272)
 - Add `NewMetricData` function to `MetricsBuilder` to consistently set instrumentation library name (#8255)
 - `coralogixexporter` Allow exporter timeout to be configured (#7957)
 

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -11,8 +11,8 @@ The following settings can be optionally configured:
 - `brokers` (default = localhost:9092): The list of kafka brokers
 - `topic` (default = otlp_spans for traces, otlp_metrics for metrics, otlp_logs for logs): The name of the kafka topic to export to.
 - `encoding` (default = otlp_proto): The encoding of the traces sent to kafka. All available encodings:
-  - `otlp_proto`: payload is Protobuf serialized from `ExportTraceServiceRequest` if set as a traces exporter or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs.
-  - `otlp_json`:  ** EXPERIMENTAL ** payload is JSON serialized from `ExportTraceServiceRequest` if set as a traces exporter or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs. 
+  - `otlp_proto`: payload is Protobuf serialized from `ExportTraceServiceRequest` if set as a traces exporter, keyed by TraceID, or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs.
+  - `otlp_json`:  ** EXPERIMENTAL ** payload is JSON serialized from `ExportTraceServiceRequest` if set as a traces exporter, keyed by TraceID, or `ExportMetricsServiceRequest` for metrics or `ExportLogsServiceRequest` for logs.
   - The following encodings are valid *only* for **traces**.
     - `jaeger_proto`: the payload is serialized to a single Jaeger proto `Span`, and keyed by TraceID.
     - `jaeger_json`: the payload is serialized to a single Jaeger JSON Span using `jsonpb`, and keyed by TraceID.

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/jaegertracing/jaeger v1.32.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.46.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.46.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.46.0
 	github.com/stretchr/testify v1.7.0
 	github.com/xdg-go/scram v1.1.1
@@ -60,5 +61,7 @@ require (
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal => ../../pkg/batchpersignal
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger => ../../pkg/translator/jaeger

--- a/exporter/kafkaexporter/pdata_marshaler_test.go
+++ b/exporter/kafkaexporter/pdata_marshaler_test.go
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkaexporter
+
+import (
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/otlp"
+	"go.opentelemetry.io/collector/model/pdata"
+)
+
+func TestPdataTracesMarshaler(t *testing.T) {
+	traceID := pdata.NewTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	expectedKey := traceID.Bytes()
+
+	td := pdata.NewTraces()
+	span := td.ResourceSpans().AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("foo")
+	span.SetStartTimestamp(pdata.Timestamp(10))
+	span.SetEndTimestamp(pdata.Timestamp(20))
+	span.SetTraceID(traceID)
+	span.SetSpanID(pdata.NewSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+
+	protoMarshaler := otlp.NewProtobufTracesMarshaler()
+	protoBytes, err := protoMarshaler.MarshalTraces(td)
+	require.NoError(t, err)
+
+	jsonMarshaler := otlp.NewJSONTracesMarshaler()
+	jsonBytes, err := jsonMarshaler.MarshalTraces(td)
+	require.NoError(t, err)
+
+	tests := []struct {
+		marshaler TracesMarshaler
+		encoding  string
+		messages  []*sarama.ProducerMessage
+	}{
+		{
+			marshaler: newPdataTracesMarshaler(protoMarshaler, "otlp_proto"),
+			encoding:  "otlp_proto",
+			messages: []*sarama.ProducerMessage{
+				{
+					Topic: "topic",
+					Value: sarama.ByteEncoder(protoBytes),
+					Key:   sarama.ByteEncoder(expectedKey[:]),
+				},
+			},
+		},
+		{
+			marshaler: newPdataTracesMarshaler(jsonMarshaler, "otlp_json"),
+			encoding:  "otlp_json",
+			messages: []*sarama.ProducerMessage{
+				{
+					Topic: "topic",
+					Value: sarama.ByteEncoder(jsonBytes),
+					Key:   sarama.ByteEncoder(expectedKey[:]),
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.encoding, func(t *testing.T) {
+			messages, err := test.marshaler.Marshal(td, "topic")
+			require.NoError(t, err)
+			assert.Equal(t, test.messages, messages)
+			assert.Equal(t, test.encoding, test.marshaler.Encoding())
+		})
+	}
+}

--- a/receiver/kafkametricsreceiver/go.mod
+++ b/receiver/kafkametricsreceiver/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.46.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.46.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.46.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
@@ -84,6 +85,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafka
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/containertest => ../../internal/containertest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal => ./../../pkg/batchpersignal
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger => ./../../pkg/translator/jaeger
 

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.46.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.46.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
@@ -70,6 +71,8 @@ require (
 replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter => ../../exporter/kafkaexporter
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal => ../../pkg/batchpersignal
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger => ../../pkg/translator/jaeger
 


### PR DESCRIPTION
**Description:**
Set the partition key when writing OTLP traces to Kafka, bringing into line with [Jaeger marshalling](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/579334c559a687b6c41341b62e55a60732a2329c/exporter/kafkaexporter/jaeger_marshaler.go#L52).

This PR intends to land a consistency fix before expanding in the future with follow up PRs to allow configuration of `keyBy`.

**Link to tracking Issue:** 
#5847

**Testing:**

**Documentation:**