### PR TITLE
Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# DO NOT MERGE 
+## Testing whether GitHub bug was resolved, where non-maintainers can enable auto-merge via iOS app 
+
 # Changelog
 
 ## Unreleased


### PR DESCRIPTION
**Do Not Merge**

Just testing whether non-maintainters can enable auto-merge via the iOS. This was a GitHub bug that should have been recently resolved.