### PR TITLE
[exporter/prw]: Fix test flakes

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -656,11 +656,11 @@ func Test_PushMetrics(t *testing.T) {
 					prwe, nErr := newPRWExporter(cfg, set)
 					require.NoError(t, nErr)
 					ctx, cancel := context.WithCancel(context.Background())
-					t.Cleanup(cancel)
+					defer cancel()
 					require.NoError(t, prwe.Start(ctx, componenttest.NewNopHost()))
-					t.Cleanup(func() {
+					defer func() {
 						require.NoError(t, prwe.Shutdown(ctx))
-					})
+					}()
 					err := prwe.PushMetrics(ctx, *tt.md)
 					if tt.returnErr {
 						assert.Error(t, err)


### PR DESCRIPTION
**Description:** Changed some `t.Cleanup()` calls to `defer` to attempt to ensure that they are executed and finished prior to tmpdir removal.  Ensure that WAL reading stops when the exporter is shutdown.

**Link to tracking Issue:** #8342
