### PR TITLE
[receiver/hostmetrics] Wrap scraping errors

### DIFF
--- a/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper.go
@@ -73,7 +73,7 @@ func (p *PerfLibScraper) Initialize(objects ...string) error {
 func (p *PerfLibScraper) Scrape() (PerfDataCollection, error) {
 	objects, err := perflib.QueryPerformanceData(p.objectIndices)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to query performance data: %w", err)
 	}
 
 	indexed := make(map[string]*perflib.PerfObject)

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -16,6 +16,7 @@ package filesystemscraper // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/disk"
@@ -90,7 +91,7 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 		}
 		usage, usageErr := s.usage(partition.Mountpoint)
 		if usageErr != nil {
-			errors.AddPartial(0, usageErr)
+			errors.AddPartial(0, fmt.Errorf("failed to read usage at %s: %w", partition.Mountpoint, usageErr))
 			continue
 		}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper.go
@@ -106,7 +106,7 @@ func (s *scraper) recordNetworkCounterMetrics(metrics pdata.MetricSlice) error {
 	// get total stats only
 	ioCounters, err := s.ioCounters( /*perNetworkInterfaceController=*/ true)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read network IO stats: %w", err)
 	}
 
 	// filter network interfaces by name
@@ -158,7 +158,7 @@ func (s *scraper) recordNetworkConnectionsMetrics(metrics pdata.MetricSlice) err
 
 	connections, err := s.connections("tcp")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read TCP connections: %w", err)
 	}
 
 	tcpConnectionStatusCounts := getTCPConnectionStatusCounts(connections)

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -95,13 +95,13 @@ func TestScrape(t *testing.T) {
 		{
 			name:             "IOCounters Error",
 			ioCountersFunc:   func(bool) ([]net.IOCountersStat, error) { return nil, errors.New("err2") },
-			expectedErr:      "err2",
+			expectedErr:      "failed to read network IO stats: err2",
 			expectedErrCount: networkMetricsLen,
 		},
 		{
 			name:             "Connections Error",
 			connectionsFunc:  func(string) ([]net.ConnectionStat, error) { return nil, errors.New("err3") },
-			expectedErr:      "err3",
+			expectedErr:      "failed to read TCP connections: err3",
 			expectedErrCount: connectionsMetricsLen,
 		},
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
@@ -19,6 +19,7 @@ package pagingscraper // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/host"
@@ -85,7 +86,7 @@ func (s *scraper) scrapePagingUsageMetric() error {
 	now := pdata.NewTimestampFromTime(time.Now())
 	pageFileStats, err := s.getPageFileStats()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read page file stats: %w", err)
 	}
 
 	s.recordPagingUsageDataPoints(now, pageFileStats)
@@ -117,7 +118,7 @@ func (s *scraper) scrapePagingMetrics() error {
 	now := pdata.NewTimestampFromTime(time.Now())
 	swap, err := s.swapMemory()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read swap info: %w", err)
 	}
 
 	s.recordPagingOperationsDataPoints(now, swap)

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
@@ -42,20 +42,20 @@ func TestScrape_Errors(t *testing.T) {
 		{
 			name:              "virtualMemoryError",
 			virtualMemoryFunc: func() ([]*pageFileStats, error) { return nil, errors.New("err1") },
-			expectedError:     "err1",
+			expectedError:     "failed to read page file stats: err1",
 			expectedErrCount:  pagingUsageMetricsLen,
 		},
 		{
 			name:             "swapMemoryError",
 			swapMemoryFunc:   func() (*mem.SwapMemoryStat, error) { return nil, errors.New("err2") },
-			expectedError:    "err2",
+			expectedError:    "failed to read swap info: err2",
 			expectedErrCount: pagingMetricsLen,
 		},
 		{
 			name:              "multipleErrors",
 			virtualMemoryFunc: func() ([]*pageFileStats, error) { return nil, errors.New("err1") },
 			swapMemoryFunc:    func() (*mem.SwapMemoryStat, error) { return nil, errors.New("err2") },
-			expectedError:     "err1; err2",
+			expectedError:     "failed to read page file stats: err1; failed to read swap info: err2",
 			expectedErrCount:  pagingUsageMetricsLen + pagingMetricsLen,
 		},
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
@@ -19,6 +19,7 @@ package pagingscraper // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/host"
@@ -92,7 +93,7 @@ func (s *scraper) scrapePagingUsageMetric() error {
 	now := pdata.NewTimestampFromTime(time.Now())
 	pageFiles, err := s.pageFileStats()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read page file stats: %w", err)
 	}
 
 	s.recordPagingUsageDataPoints(now, pageFiles)


### PR DESCRIPTION
Errors returned by gopsutil are missing the context, it makes it hard to find out where they were raised.

Example: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5879