### PR TITLE
[receiver/apache] update instrumentation name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `nginxreceiver`: instrumentation name updated from `otelcol/nginx` to `otelcol/nginxreceiver` (#8255)
 - `postgresqlreceiver`: instrumentation name updated from `otelcol/postgresql` to `otelcol/postgresqlreceiver` (#8255)
 - `redisreceiver`: instrumentation name updated from `otelcol/redis` to `otelcol/redisreceiver` (#8255)
+- `apachereceiver`: Update instrumentation library name from `otelcol/apache` to `otelcol/apachereceiver` ()
 
 ### 🧰 Bug fixes 🧰
 

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -103,10 +103,8 @@ func (r *apacheScraper) scrape(context.Context) (pdata.Metrics, error) {
 		}
 	}
 
-	md := pdata.NewMetrics()
-	ilm := md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/apache")
-	r.mb.Emit(ilm.Metrics())
+	md := r.mb.NewMetricData()
+	r.mb.Emit(md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics())
 	return md, nil
 }
 

--- a/receiver/apachereceiver/testdata/integration/expected.json
+++ b/receiver/apachereceiver/testdata/integration/expected.json
@@ -4,7 +4,7 @@
          "instrumentationLibraryMetrics": [
             {
                "instrumentationLibrary": {
-                  "name": "otelcol/apache"
+                  "name": "otelcol/apachereceiver"
                },
                "metrics": [
                   {

--- a/receiver/apachereceiver/testdata/scraper/expected.json
+++ b/receiver/apachereceiver/testdata/scraper/expected.json
@@ -5,7 +5,7 @@
       "instrumentationLibraryMetrics": [
         {
           "instrumentationLibrary": {
-            "name": "otelcol/apache"
+            "name": "otelcol/apachereceiver"
           },
           "metrics": [
             {


### PR DESCRIPTION
This uses the metric builder method NewMetricData for consistency.

Fixes #8363