### PR TITLE
[prometheusremotewriteexporter] Drop prometheus exemplar labels when the max length is exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 - `zipkinexporter`: Set "error" tag value when status is set to error (#8187)
 - `prometheusremotewriteexporter`: Correctly handle metric labels which collide after sanitization (#8378)
+- `prometheusremotewriteexporter`: Drop labels when exemplar attributes exceed the max number of characters (#8379)
 
 ### 🚀 New components 🚀
 

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -434,12 +434,23 @@ func Test_getPromExemplars(t *testing.T) {
 			},
 		},
 		{
-			"too_many_characters_drops_labels",
-			getHistogramDataPointWithExemplars(tnow, floatVal1, keyWith129Chars, traceIDValue1),
+			"too_many_runes_drops_labels",
+			getHistogramDataPointWithExemplars(tnow, floatVal1, keyWith129Runes, ""),
 			[]prompb.Exemplar{
 				{
 					Value:     floatVal1,
 					Timestamp: timestamp.FromTime(tnow),
+				},
+			},
+		},
+		{
+			"runes_at_limit_bytes_over_keeps_labels",
+			getHistogramDataPointWithExemplars(tnow, floatVal1, keyWith128Runes, ""),
+			[]prompb.Exemplar{
+				{
+					Value:     floatVal1,
+					Timestamp: timestamp.FromTime(tnow),
+					Labels:    []prompb.Label{getLabel(keyWith128Runes, "")},
 				},
 			},
 		},

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -434,6 +434,16 @@ func Test_getPromExemplars(t *testing.T) {
 			},
 		},
 		{
+			"too_many_characters_drops_labels",
+			getHistogramDataPointWithExemplars(tnow, floatVal1, keyWith129Chars, traceIDValue1),
+			[]prompb.Exemplar{
+				{
+					Value:     floatVal1,
+					Timestamp: timestamp.FromTime(tnow),
+				},
+			},
+		},
+		{
 			"without_exemplar",
 			getHistogramDataPoint(),
 			nil,

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -50,6 +50,7 @@ var (
 	colliding1         = "test.colliding"
 	colliding2         = "test/colliding"
 	collidingSanitized = "test_colliding"
+	keyWith129Chars    = "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
 
 	intVal1   int64 = 1
 	intVal2   int64 = 2

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -50,7 +50,9 @@ var (
 	colliding1         = "test.colliding"
 	colliding2         = "test/colliding"
 	collidingSanitized = "test_colliding"
-	keyWith129Chars    = "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
+	keyWith129Runes    = "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
+	// because of the special characters, this has 132 bytes and 128 runes
+	keyWith128Runes = "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii世界"
 
 	intVal1   int64 = 1
 	intVal2   int64 = 2


### PR DESCRIPTION
**Description:**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8352.  This follows the OTLP -> Prometheus specification for [handling exemplar labels](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification%2Fmetrics%2Fdatamodel.md#exemplars-2).

**Testing:**

Added a unit test