### PR TITLE
[prometheusremotewriteexporter] Support sending trace id and span id for exemplars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `googlecloudpubsubreceiver` Added implementation of Google Cloud Pubsub receiver. (#8391)
 - `googlecloudpubsubexporter` Added implementation of Google Cloud Pubsub exporter. (#8391)
 - `coralogixexporter` Allow exporter timeout to be configured (#7957)
+- `prometheusremotewriteexporter` support adding trace id and span id attached to exemplars (#8380)
 
 ### 🛑 Breaking changes 🛑
 

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -424,18 +424,29 @@ func Test_getPromExemplars(t *testing.T) {
 	}{
 		{
 			"with_exemplars",
-			getHistogramDataPointWithExemplars(tnow, floatVal1, traceIDKey, traceIDValue1),
+			getHistogramDataPointWithExemplars(t, tnow, floatVal1, traceIDValue1, spanIDValue1, label11, value11),
 			[]prompb.Exemplar{
 				{
 					Value:     floatVal1,
 					Timestamp: timestamp.FromTime(tnow),
-					Labels:    []prompb.Label{getLabel(traceIDKey, traceIDValue1)},
+					Labels:    []prompb.Label{getLabel(traceIDKey, traceIDValue1), getLabel(spanIDKey, spanIDValue1), getLabel(label11, value11)},
+				},
+			},
+		},
+		{
+			"with_exemplars_without_trace_or_span",
+			getHistogramDataPointWithExemplars(t, tnow, floatVal1, "", "", label11, value11),
+			[]prompb.Exemplar{
+				{
+					Value:     floatVal1,
+					Timestamp: timestamp.FromTime(tnow),
+					Labels:    []prompb.Label{getLabel(label11, value11)},
 				},
 			},
 		},
 		{
 			"too_many_runes_drops_labels",
-			getHistogramDataPointWithExemplars(tnow, floatVal1, keyWith129Runes, ""),
+			getHistogramDataPointWithExemplars(t, tnow, floatVal1, "", "", keyWith129Runes, ""),
 			[]prompb.Exemplar{
 				{
 					Value:     floatVal1,
@@ -445,12 +456,23 @@ func Test_getPromExemplars(t *testing.T) {
 		},
 		{
 			"runes_at_limit_bytes_over_keeps_labels",
-			getHistogramDataPointWithExemplars(tnow, floatVal1, keyWith128Runes, ""),
+			getHistogramDataPointWithExemplars(t, tnow, floatVal1, "", "", keyWith128Runes, ""),
 			[]prompb.Exemplar{
 				{
 					Value:     floatVal1,
 					Timestamp: timestamp.FromTime(tnow),
 					Labels:    []prompb.Label{getLabel(keyWith128Runes, "")},
+				},
+			},
+		},
+		{
+			"too_many_runes_with_exemplar_drops_attrs_keeps_exemplar",
+			getHistogramDataPointWithExemplars(t, tnow, floatVal1, traceIDValue1, spanIDValue1, keyWith64Runes, ""),
+			[]prompb.Exemplar{
+				{
+					Value:     floatVal1,
+					Timestamp: timestamp.FromTime(tnow),
+					Labels:    []prompb.Label{getLabel(traceIDKey, traceIDValue1), getLabel(spanIDKey, spanIDValue1)},
 				},
 			},
 		},

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
 )
 
@@ -236,18 +237,14 @@ func getHistogramDataPointWithExemplars(t *testing.T, time time.Time, value floa
 	if traceID != "" {
 		var traceIDBytes [16]byte
 		traceIDBytesSlice, err := hex.DecodeString(traceID)
-		if err != nil {
-			t.Fatalf("error decoding trace id: %v", err)
-		}
+		require.NoErrorf(t, err, "error decoding trace id: %v", err)
 		copy(traceIDBytes[:], traceIDBytesSlice)
 		e.SetTraceID(pdata.NewTraceID(traceIDBytes))
 	}
 	if spanID != "" {
 		var spanIDBytes [8]byte
 		spanIDBytesSlice, err := hex.DecodeString(spanID)
-		if err != nil {
-			t.Fatalf("error decoding span id: %v", err)
-		}
+		require.NoErrorf(t, err, "error decoding span id: %v", err)
 		copy(spanIDBytes[:], spanIDBytesSlice)
 		e.SetSpanID(pdata.NewSpanID(spanIDBytes))
 	}

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -15,8 +15,10 @@
 package prometheusremotewrite
 
 import (
+	"encoding/hex"
 	"math"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/prometheus/prometheus/prompb"
@@ -45,14 +47,16 @@ var (
 	value41            = "test_value41"
 	dirty1             = "%"
 	dirty2             = "?"
-	traceIDValue1      = "traceID-value1"
-	traceIDKey         = "trace_id"
+	traceIDValue1      = "4303853f086f4f8c86cf198b6551df84"
+	spanIDValue1       = "e5513c32795c41b9"
 	colliding1         = "test.colliding"
 	colliding2         = "test/colliding"
 	collidingSanitized = "test_colliding"
 	keyWith129Runes    = "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
 	// because of the special characters, this has 132 bytes and 128 runes
 	keyWith128Runes = "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii世界"
+	// 64 + trace id + span id = 129 characters
+	keyWith64Runes = "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
 
 	intVal1   int64 = 1
 	intVal2   int64 = 2
@@ -221,13 +225,32 @@ func getTimeSeriesWithSamplesAndExemplars(labels []prompb.Label, samples []promp
 	}
 }
 
-func getHistogramDataPointWithExemplars(time time.Time, value float64, attributeKey string, attributeValue string) *pdata.HistogramDataPoint {
+func getHistogramDataPointWithExemplars(t *testing.T, time time.Time, value float64, traceID string, spanID string, attributeKey string, attributeValue string) *pdata.HistogramDataPoint {
 	h := pdata.NewHistogramDataPoint()
 
 	e := h.Exemplars().AppendEmpty()
 	e.SetDoubleVal(value)
 	e.SetTimestamp(pdata.NewTimestampFromTime(time))
 	e.FilteredAttributes().Insert(attributeKey, pdata.NewAttributeValueString(attributeValue))
+
+	if traceID != "" {
+		var traceIDBytes [16]byte
+		traceIDBytesSlice, err := hex.DecodeString(traceID)
+		if err != nil {
+			t.Fatalf("error decoding trace id: %v", err)
+		}
+		copy(traceIDBytes[:], traceIDBytesSlice)
+		e.SetTraceID(pdata.NewTraceID(traceIDBytes))
+	}
+	if spanID != "" {
+		var spanIDBytes [8]byte
+		spanIDBytesSlice, err := hex.DecodeString(spanID)
+		if err != nil {
+			t.Fatalf("error decoding span id: %v", err)
+		}
+		copy(spanIDBytes[:], spanIDBytesSlice)
+		e.SetSpanID(pdata.NewSpanID(spanIDBytes))
+	}
 
 	return &h
 }


### PR DESCRIPTION
**Description:**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8351.  This is aligned with the [specification for OTLP -> prometheus](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification%2Fmetrics%2Fdatamodel.md#exemplars-2).

The specification does not say how to handle collisions between attributes named `trace_id` and `span_id` and the trace id or span id of the exemplar itself.  This PR has attributes take precedence over trace id and span id from the exemplar itself.

**Testing:**

Unit test checks that trace id and span id are added as labels on prometheus exemplars.