### PR TITLE
[receiver/rabbitmq] updating receiver name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `zookeeperreceiver`: instrumentation name updated from `otelcol/zookeeper` to `otelcol/zookeeperreceiver` (#8389)
 - `coralogixexporter`: Create dynamic subsystem name (#7957)
   - Deprecate configuration changed. Dynamic subsystem name from traces service name property.
+- `rabbitmqreceiver`: instrumentation name updated from `otelcol/rabbitmq` to `otelcol/rabbitmqreceiver` (#8400)
 
 ### 🧰 Bug fixes 🧰
 

--- a/receiver/rabbitmqreceiver/scraper.go
+++ b/receiver/rabbitmqreceiver/scraper.go
@@ -27,7 +27,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver/internal/models"
 )
 
-const instrumentationLibraryName = "otelcol/rabbitmq"
+const instrumentationLibraryName = "otelcol/rabbitmqreceiver"
 
 var errClientNotInit = errors.New("client not initialized")
 

--- a/receiver/rabbitmqreceiver/testdata/expected_metrics/metrics_golden.json
+++ b/receiver/rabbitmqreceiver/testdata/expected_metrics/metrics_golden.json
@@ -4,7 +4,7 @@
          "instrumentationLibraryMetrics": [
             {
                "instrumentationLibrary": {
-                  "name": "otelcol/rabbitmq"
+                  "name": "otelcol/rabbitmqreceiver"
                },
                "metrics": [
                   {
@@ -88,7 +88,7 @@
          "instrumentationLibraryMetrics": [
             {
                "instrumentationLibrary": {
-                  "name": "otelcol/rabbitmq"
+                  "name": "otelcol/rabbitmqreceiver"
                },
                "metrics": [
                   {


### PR DESCRIPTION
For consistency, updating the rabbitmq receiver to follow the same pattern as the other receivers. In a follow up PR, the code in scraper.go will be refactored, but I wanted to separate the name change from that refactor.

Fix #8399
