### PR TITLE
feat(processors/k8sattributesprocessor): support metadata enrichment based on multiple attributes

### DIFF
--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -230,7 +230,7 @@ type PodAssociationConfig struct {
 	// Deprecated: Sources should be used to provide From and Name.
 	// If this is set, From and Name are going to be used as Sources' ones
 	// From represents the source of the association.
-	// Allowed values are "connection" and "labels".
+	// Allowed values are "connection" and "resource_attribute".
 	From string `mapstructure:"from"`
 
 	// Deprecated: Sources should be used to provide From and Name.

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -223,6 +223,12 @@ type PodAssociationConfig struct {
 	// by using Name
 	Delimiter string `mapstructure:"delimiter"`
 
+	// This is deprecated. Sources should be used to provide From and Name
+	// If this is set, From and Name are going to be used as Sources' ones
+	// From represents the source of the association.
+	// Allowed values are "connection" and "labels".
+	From string `mapstructure:"from"`
+
 	// Name where result of association should be put
 	// e.g. ip, pod_uid, k8s.pod.ip
 	Name string `mapstructure:"name"`

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -218,9 +218,18 @@ type PodAssociationConfig struct {
 	// Allowed values are "connection" and "resource_attribute".
 	From string `mapstructure:"from"`
 
-	// Name represents extracted key name.
+	// Delimiter defines how the sources should be concatenated.
+	// Result of concatenation can be stored in attribute
+	// by using Name
+	Delimiter string `mapstructure:"delimiter"`
+
+	// Name where result of association should be put
 	// e.g. ip, pod_uid, k8s.pod.ip
 	Name string `mapstructure:"name"`
+
+	// List of pod association sources which should be taken
+	// to identify pod
+	Sources []PodAssociationSourceConfig `mapstructure:"sources"`
 }
 
 // ExcludeConfig represent a list of Pods to exclude
@@ -230,5 +239,15 @@ type ExcludeConfig struct {
 
 // ExcludePodConfig represent a Pod name to ignore
 type ExcludePodConfig struct {
+	Name string `mapstructure:"name"`
+}
+
+type PodAssociationSourceConfig struct {
+	// From represents the source of the association.
+	// Allowed values are "connection" and "labels".
+	From string `mapstructure:"from"`
+
+	// Name represents extracted key name.
+	// e.g. ip, pod_uid, k8s.pod.ip
 	Name string `mapstructure:"name"`
 }

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -218,18 +218,15 @@ type PodAssociationConfig struct {
 	// Allowed values are "connection" and "resource_attribute".
 	From string `mapstructure:"from"`
 
-	// Delimiter defines how the sources should be concatenated.
-	// Result of concatenation can be stored in attribute
-	// by using Name
-	Delimiter string `mapstructure:"delimiter"`
-
 	// Deprecated: Sources should be used to provide From and Name.
 	// If this is set, From and Name are going to be used as Sources' ones
 	// From represents the source of the association.
 	// Allowed values are "connection" and "labels".
 	From string `mapstructure:"from"`
 
-	// Name where result of association should be put
+	// Deprecated: Sources should be used to provide From and Name.
+	// If this is set, From and Name are going to be used as Sources' ones
+	// Name represents extracted key name.
 	// e.g. ip, pod_uid, k8s.pod.ip
 	Name string `mapstructure:"name"`
 

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -73,7 +73,7 @@ type ExtractConfig struct {
 	// documentation for more details.
 	Annotations []FieldExtractConfig `mapstructure:"annotations"`
 
-	// Annotations allows extracting data from pod labels and record it
+	// Labels allows extracting data from pod labels and record it
 	// as resource attributes.
 	// It is a list of FieldExtractConfig type. See FieldExtractConfig
 	// documentation for more details.
@@ -244,7 +244,7 @@ type ExcludePodConfig struct {
 
 type PodAssociationSourceConfig struct {
 	// From represents the source of the association.
-	// Allowed values are "connection" and "labels".
+	// Allowed values are "connection" and "resource_attribute".
 	From string `mapstructure:"from"`
 
 	// Name represents extracted key name.

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -223,7 +223,7 @@ type PodAssociationConfig struct {
 	// by using Name
 	Delimiter string `mapstructure:"delimiter"`
 
-	// This is deprecated. Sources should be used to provide From and Name
+	// Deprecated: Sources should be used to provide From and Name.
 	// If this is set, From and Name are going to be used as Sources' ones
 	// From represents the source of the association.
 	// Allowed values are "connection" and "labels".

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -15,9 +15,12 @@
 package k8sattributesprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/config"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/kube"
 )
 
 // Config defines configuration for k8s attributes processor.
@@ -50,7 +53,17 @@ type Config struct {
 }
 
 func (cfg *Config) Validate() error {
-	return cfg.APIConfig.Validate()
+	if err := cfg.APIConfig.Validate(); err != nil {
+		return err
+	}
+
+	for _, assoc := range cfg.Association {
+		if len(assoc.Sources) > kube.PodIdentifierMaxLength {
+			return fmt.Errorf("too many association sources. limit is %v", kube.PodIdentifierMaxLength)
+		}
+	}
+
+	return nil
 }
 
 // ExtractConfig section allows specifying extraction rules to extract
@@ -214,10 +227,6 @@ type FieldFilterConfig struct {
 // PodAssociationConfig contain single rule how to associate Pod metadata
 // with logs, spans and metrics
 type PodAssociationConfig struct {
-	// From represents the source of the association.
-	// Allowed values are "connection" and "resource_attribute".
-	From string `mapstructure:"from"`
-
 	// Deprecated: Sources should be used to provide From and Name.
 	// If this is set, From and Name are going to be used as Sources' ones
 	// From represents the source of the association.

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -73,7 +73,7 @@ type ExtractConfig struct {
 	// documentation for more details.
 	Annotations []FieldExtractConfig `mapstructure:"annotations"`
 
-	// Labels allows extracting data from pod labels and record it
+	// Annotations allows extracting data from pod labels and record it
 	// as resource attributes.
 	// It is a list of FieldExtractConfig type. See FieldExtractConfig
 	// documentation for more details.

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -115,13 +115,10 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 				},
+				// Deprecated way
 				{
-					Sources: []PodAssociationSourceConfig{
-						{
-							From: "resource_attribute",
-							Name: "k8s.pod.uid",
-						},
-					},
+					From: "resource_attribute",
+					Name: "k8s.pod.uid",
 				},
 			},
 			Exclude: ExcludeConfig{

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -84,24 +84,44 @@ func TestLoadConfig(t *testing.T) {
 			},
 			Association: []PodAssociationConfig{
 				{
-					From: "resource_attribute",
-					Name: "ip",
+					Sources: []PodAssociationSourceConfig{
+						{
+							From: "resource_attribute",
+							Name: "ip",
+						},
+					},
 				},
 				{
-					From: "resource_attribute",
-					Name: "k8s.pod.ip",
+					Sources: []PodAssociationSourceConfig{
+						{
+							From: "resource_attribute",
+							Name: "k8s.pod.ip",
+						},
+					},
 				},
 				{
-					From: "resource_attribute",
-					Name: "host.name",
+					Sources: []PodAssociationSourceConfig{
+						{
+							From: "resource_attribute",
+							Name: "host.name",
+						},
+					},
 				},
 				{
-					From: "connection",
-					Name: "ip",
+					Sources: []PodAssociationSourceConfig{
+						{
+							From: "connection",
+							Name: "ip",
+						},
+					},
 				},
 				{
-					From: "resource_attribute",
-					Name: "k8s.pod.uid",
+					Sources: []PodAssociationSourceConfig{
+						{
+							From: "resource_attribute",
+							Name: "k8s.pod.uid",
+						},
+					},
 				},
 			},
 			Exclude: ExcludeConfig{

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -24,7 +24,7 @@
 //  - name - name of the association. Result of association is going to be saved as resource attribute with this name.
 //  - sources - sources of association. It represents list of rules. All rules are going to be executed and concatenated using delimiter.
 //              Metadata are going to be saved in the cache using created key
-//  - delimiter - string wchich is going to be used for sources concatenation
+//  - delimiter - string which is going to be used for sources concatenation
 //
 // Each sources rule is specified as a pair of from (representing the rule type) and name (representing the attribute name if from is set to resource_attribute).
 // Following rule types are available:

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -22,6 +22,7 @@
 //
 // Each association is specified as a list of sources of association.
 // Sources represents list of rules. All rules are going to be executed and combination of result is going to be a pod metadata cache key.
+// In order to get an association applied, all the data defined in each source has to be successfully fetched from a log, trace or metric.
 //
 // Each sources rule is specified as a pair of `from` (representing the rule type) and `name` (representing the attribute name if `From` is set to `resource_attribute`).
 // Following rule types are available:
@@ -54,7 +55,6 @@
 //   - k8s.deployment.name
 //   - k8s.node.name
 // Not all the attributes are guaranteed to be added.
-//
 //
 // Only attribute names from `metadata` should be used for pod_association's `resource_attribute`,
 // because empty or non-existing values will be ignored.

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -20,13 +20,10 @@
 // The rules for associating the data passing through the processor (spans, metrics and logs) with specific Pod Metadata are configured via "pod_association" key.
 // It represents a list of associations that are executed in the specified order until the first one is able to do the match.
 //
-// Each association is specified as a object containing three fields:
-//  - name - name of the association. Result of association is going to be saved as resource attribute with this name.
-//  - sources - sources of association. It represents list of rules. All rules are going to be executed and concatenated using delimiter.
-//              Metadata are going to be saved in the cache using created key
-//  - delimiter - string which is going to be used for sources concatenation
+// Each association is specified as a list of sources of association.
+// Sources represents list of rules. All rules are going to be executed and combination of result is going to be a pod metadata cache key.
 //
-// Each sources rule is specified as a pair of from (representing the rule type) and name (representing the attribute name if from is set to resource_attribute).
+// Each sources rule is specified as a pair of `from` (representing the rule type) and `name` (representing the attribute name if `From` is set to `resource_attribute`).
 // Following rule types are available:
 //   from: "connection" - takes the IP attribute from connection context (if available)
 //   from: "resource_attribute" - allows to specify the attribute name to lookup up in the list of attributes of the received Resource.
@@ -34,18 +31,11 @@
 //
 // Pod association configuration.
 // pod_association:
-//  - delimiter: ''
-//    sources:
+//  - sources:
 //     - from: resource_attribute
 //       name: k8s.pod.ip
-//  - delimiter: ''
-//    sources:
-//    - from: resource_attribute
-//      name: k8s.pod.ip
-//  # below association are going to be saved as `pod_name_namespace` with value of `<k8s.pod.name>.<k8s.namespace.name>` if executed
-//  - delimiter: '.'
-//    name: pod_name_namespace
-//    sources:
+//  # below association matches for pair `k8s.pod.name` and `k8s.namespace.name`
+//  - sources:
 //    - from: resource_attribute
 //      name: k8s.pod.name
 //    - from: resource_attribute

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -56,7 +56,8 @@
 // Not all the attributes are guaranteed to be added.
 //
 //
-// Only attribute names from `metadata` should be used for pod_association's `resource_attribute`
+// Only attribute names from `metadata` should be used for pod_association's `resource_attribute`,
+// because empty or non-existing values will be ignored.
 //
 // The following container level attributes require additional attributes to identify a particular container in a pod:
 //   1. Container spec attributes - will be set only if container identifying attribute `k8s.container.name` is set

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -277,6 +277,8 @@ pod_association:%s
 
 with
 
-pod_association:%s`, deprecated, actual))
+pod_association:%s
+
+`, deprecated, actual))
 	}
 }

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -256,14 +256,22 @@ func errWrongKeyConfig(cfg config.Processor) error {
 
 func warnDeprecatedPodAssociationConfig(logger *zap.Logger, cfg config.Processor) {
 	oCfg := cfg.(*Config)
-	warn := false
+	warnFrom := false
+	warnName := false
 	for _, assoc := range oCfg.Association {
 		if assoc.From != "" {
-			warn = true
+			warnFrom = true
+		}
+		if assoc.Name != "" {
+			warnName = true
 		}
 	}
 
-	if warn {
+	if warnFrom {
 		logger.Warn("pod_association.From has been deprecated in favor of pod_association.sources.From for k8sattributes processor")
+	}
+
+	if warnName {
+		logger.Warn("pod_association.Name has been deprecated in favor of pod_association.sources.Name for k8sattributes processor")
 	}
 }

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -256,22 +256,27 @@ func errWrongKeyConfig(cfg config.Processor) error {
 
 func warnDeprecatedPodAssociationConfig(logger *zap.Logger, cfg config.Processor) {
 	oCfg := cfg.(*Config)
-	warnFrom := false
-	warnName := false
+	deprecated := ""
+	actual := ""
 	for _, assoc := range oCfg.Association {
-		if assoc.From != "" {
-			warnFrom = true
-		}
-		if assoc.Name != "" {
-			warnName = true
+		if assoc.From != "" || assoc.Name != "" {
+			deprecated += fmt.Sprintf(`
+- from: %s
+  name: %s`, assoc.From, assoc.Name)
+			actual += fmt.Sprintf(`
+- sources:
+  - from: %s
+  - name: %s`, assoc.From, assoc.Name)
 		}
 	}
 
-	if warnFrom {
-		logger.Warn("pod_association.From has been deprecated in favor of pod_association.sources.From for k8sattributes processor")
-	}
+	if deprecated != "" {
+		logger.Warn(fmt.Sprintf(`Deprecated pod_association configuration detected. Please replace:
 
-	if warnName {
-		logger.Warn("pod_association.Name has been deprecated in favor of pod_association.sources.Name for k8sattributes processor")
+pod_association:%s
+
+with
+
+pod_association:%s`, deprecated, actual))
 	}
 }

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -236,7 +236,7 @@ func warnDeprecatedMetadataConfig(logger *zap.Logger, cfg config.Processor) {
 			logger.Warn("k8s.cluster.name metadata param has been deprecated and will be removed soon")
 		}
 		if oldName != "" {
-			logger.Warn(fmt.Sprintf("%s has been deprecated in favor of %s for k8sattributes processor", oldName, newName))
+			logger.Warn(fmt.Sprintf("%s has been deprecated in favor of %s for k8s-tagger processor", oldName, newName))
 		}
 	}
 

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -155,6 +155,7 @@ func createKubernetesProcessor(
 	kp := &kubernetesprocessor{logger: params.Logger}
 
 	warnDeprecatedMetadataConfig(kp.logger, cfg)
+	warnDeprecatedPodAssociationConfig(kp.logger, cfg)
 
 	err := errWrongKeyConfig(cfg)
 	if err != nil {
@@ -235,7 +236,7 @@ func warnDeprecatedMetadataConfig(logger *zap.Logger, cfg config.Processor) {
 			logger.Warn("k8s.cluster.name metadata param has been deprecated and will be removed soon")
 		}
 		if oldName != "" {
-			logger.Warn(fmt.Sprintf("%s has been deprecated in favor of %s for k8s-tagger processor", oldName, newName))
+			logger.Warn(fmt.Sprintf("%s has been deprecated in favor of %s for k8sattributes processor", oldName, newName))
 		}
 	}
 
@@ -251,4 +252,18 @@ func errWrongKeyConfig(cfg config.Processor) error {
 	}
 
 	return nil
+}
+
+func warnDeprecatedPodAssociationConfig(logger *zap.Logger, cfg config.Processor) {
+	oCfg := cfg.(*Config)
+	warn := false
+	for _, assoc := range oCfg.Association {
+		if assoc.From != "" {
+			warn = true
+		}
+	}
+
+	if warn {
+		logger.Warn("pod_association.From has been deprecated in favor of pod_association.sources.From for k8sattributes processor")
+	}
 }

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -266,7 +266,7 @@ func warnDeprecatedPodAssociationConfig(logger *zap.Logger, cfg config.Processor
 			actual += fmt.Sprintf(`
 - sources:
   - from: %s
-  - name: %s`, assoc.From, assoc.Name)
+    name: %s`, assoc.From, assoc.Name)
 		}
 	}
 

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -259,14 +259,24 @@ func warnDeprecatedPodAssociationConfig(logger *zap.Logger, cfg config.Processor
 	deprecated := ""
 	actual := ""
 	for _, assoc := range oCfg.Association {
-		if assoc.From != "" || assoc.Name != "" {
-			deprecated += fmt.Sprintf(`
-- from: %s
-  name: %s`, assoc.From, assoc.Name)
-			actual += fmt.Sprintf(`
+		if assoc.From == "" && assoc.Name == "" {
+			continue
+		}
+
+		deprecated += fmt.Sprintf(`
+- from: %s`, assoc.From)
+		actual += fmt.Sprintf(`
 - sources:
-  - from: %s
-    name: %s`, assoc.From, assoc.Name)
+  - from: %s`, assoc.From)
+
+		if assoc.Name != "" {
+			deprecated += fmt.Sprintf(`
+  name: %s`, assoc.Name)
+		}
+
+		if assoc.From != kube.ConnectionSource {
+			actual += fmt.Sprintf(`
+    name: %s`, assoc.Name)
 		}
 	}
 

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -406,13 +406,13 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 		for i, source := range assoc.Sources {
 			// If association configured to take IP address from connection
 			switch {
-			case source.From == "connection":
+			case source.From == ConnectionSource:
 				if pod.Address == "" {
 					skip = true
 				} else {
 					ret[i] = PodIdentifierAttributeFromSource(source, pod.Address)
 				}
-			case source.From == "resource_attribute":
+			case source.From == ResourceSource:
 				attr := ""
 				switch source.Name {
 				case conventions.AttributeK8SNamespaceName:

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -443,15 +443,15 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 	}
 
 	// Ensure backward compatibility
-	if newPod.PodUID != "" {
+	if pod.PodUID != "" {
 		ids = append(ids, PodIdentifier{
-			BuildPodIdentifierAttribute("resource_attribute", conventions.AttributeK8SPodUID, newPod.PodUID),
+			BuildPodIdentifierAttribute("resource_attribute", conventions.AttributeK8SPodUID, pod.PodUID),
 		})
 	}
 
-	if newPod.Address != "" {
+	if pod.Address != "" {
 		ids = append(ids, PodIdentifier{
-			BuildPodIdentifierAttribute("connection", "k8s.pod.ip", newPod.Address),
+			BuildPodIdentifierAttribute("connection", "k8s.pod.ip", pod.Address),
 		})
 	}
 

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -59,6 +59,9 @@ type WatchClient struct {
 	Namespaces map[string]*Namespace
 }
 
+// PodIdentifierDelimiter is used to create kubePodIdentifier from list of sources
+const PodIdentifierDelimiter = "."
+
 // Extract deployment name from the pod name. Pod name is created using
 // format: [deployment-name]-[Random-String-For-ReplicaSet]-[Random-String-For-Pod]
 var dRegex = regexp.MustCompile(`^(.*)-[0-9a-zA-Z]*-[0-9a-zA-Z]*$`)
@@ -425,7 +428,7 @@ func (c *WatchClient) getIdentifiersFromAssoc(newPod *Pod) []PodIdentifier {
 		}
 
 		if len(ret) == len(assoc.Sources) {
-			ids = append(ids, PodIdentifier(strings.Join(ret, assoc.Delimiter)))
+			ids = append(ids, PodIdentifier(strings.Join(ret, PodIdentifierDelimiter)))
 		}
 	}
 

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -59,9 +59,6 @@ type WatchClient struct {
 	Namespaces map[string]*Namespace
 }
 
-// PodIdentifierDelimiter is used to create kubePodIdentifier from list of sources
-const PodIdentifierDelimiter = "."
-
 // Extract deployment name from the pod name. Pod name is created using
 // format: [deployment-name]-[Random-String-For-ReplicaSet]-[Random-String-For-Pod]
 var dRegex = regexp.MustCompile(`^(.*)-[0-9a-zA-Z]*-[0-9a-zA-Z]*$`)

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -445,13 +445,13 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 	// Ensure backward compatibility
 	if pod.PodUID != "" {
 		ids = append(ids, PodIdentifier{
-			BuildPodIdentifierAttribute("resource_attribute", conventions.AttributeK8SPodUID, pod.PodUID),
+			PodIdentifierAttributeFromResourceAttribute(conventions.AttributeK8SPodUID, pod.PodUID),
 		})
 	}
 
 	if pod.Address != "" {
 		ids = append(ids, PodIdentifier{
-			BuildPodIdentifierAttribute("connection", "k8s.pod.ip", pod.Address),
+			PodIdentifierAttributeFromConnection(pod.Address),
 		})
 	}
 

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -410,7 +410,7 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 				if pod.Address == "" {
 					skip = true
 				} else {
-					ret[i] = GetPodIdentifierAttribute(source, pod.Address)
+					ret[i] = PodIdentifierAttributeFromSource(source, pod.Address)
 				}
 			case source.From == "resource_attribute":
 				attr := ""
@@ -432,7 +432,7 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 				if attr == "" {
 					skip = true
 				} else {
-					ret[i] = GetPodIdentifierAttribute(source, attr)
+					ret[i] = PodIdentifierAttributeFromSource(source, attr)
 				}
 			}
 		}

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -429,6 +429,15 @@ func (c *WatchClient) getIdentifiersFromAssoc(newPod *Pod) []PodIdentifier {
 		}
 	}
 
+	// Ensure backward compatibility
+	if newPod.PodUID != "" {
+		ids = append(ids, PodIdentifier(newPod.PodUID))
+	}
+
+	if newPod.Address != "" {
+		ids = append(ids, PodIdentifier(newPod.Address))
+	}
+
 	return ids
 }
 

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -393,9 +393,10 @@ func (c *WatchClient) getPodFromAPI(pod *api_v1.Pod) *Pod {
 	return newPod
 }
 
-func (c *WatchClient) getIdentifiersFromAssoc(newPod *Pod) []PodIdentifier {
-	if newPod.Attributes == nil {
-		newPod.Attributes = map[string]string{}
+// getIdentifiersFromAssoc returns list of PodIdentifiers for given pod
+func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
+	if pod.Attributes == nil {
+		pod.Attributes = map[string]string{}
 	}
 
 	ids := []PodIdentifier{}
@@ -406,27 +407,24 @@ func (c *WatchClient) getIdentifiersFromAssoc(newPod *Pod) []PodIdentifier {
 			// If association configured to take IP address from connection
 			switch {
 			case source.From == "connection":
-				if newPod.Address == "" {
+				if pod.Address == "" {
 					skip = true
 				} else {
-					ret[i] = GetPodIdentifierAttribute(source, newPod.Address)
-					if source.Name != "" {
-						newPod.Attributes[source.Name] = newPod.Address
-					}
+					ret[i] = GetPodIdentifierAttribute(source, pod.Address)
 				}
 			case source.From == "resource_attribute":
 				attr := ""
 				switch source.Name {
 				case conventions.AttributeK8SNamespaceName:
-					attr = newPod.Namespace
+					attr = pod.Namespace
 				case conventions.AttributeK8SPodName:
-					attr = newPod.Name
+					attr = pod.Name
 				case conventions.AttributeK8SPodUID:
-					attr = newPod.PodUID
+					attr = pod.PodUID
 				case conventions.AttributeHostName:
-					attr = newPod.Address
+					attr = pod.Address
 				default:
-					if v, ok := newPod.Attributes[source.Name]; ok {
+					if v, ok := pod.Attributes[source.Name]; ok {
 						attr = v
 					}
 				}

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -369,7 +369,7 @@ func (c *WatchClient) extractNamespaceAttributes(namespace *api_v1.Namespace) ma
 	return tags
 }
 
-func (c *WatchClient) getPodFromAPI(pod *api_v1.Pod) *Pod {
+func (c *WatchClient) podFromAPI(pod *api_v1.Pod) *Pod {
 	newPod := &Pod{
 		Name:      pod.Name,
 		Namespace: pod.GetNamespace(),
@@ -452,7 +452,7 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 }
 
 func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
-	newPod := c.getPodFromAPI(pod)
+	newPod := c.podFromAPI(pod)
 
 	c.m.Lock()
 	defer c.m.Unlock()
@@ -472,8 +472,8 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 }
 
 func (c *WatchClient) forgetPod(pod *api_v1.Pod) {
-	newPod := c.getPodFromAPI(pod)
-	for _, id := range c.getIdentifiersFromAssoc(newPod) {
+	podToRemove := c.podFromAPI(pod)
+	for _, id := range c.getIdentifiersFromAssoc(podToRemove) {
 		p, ok := c.GetPod(id)
 
 		if ok && p.Name == pod.Name {

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -392,10 +392,6 @@ func (c *WatchClient) getPodFromAPI(pod *api_v1.Pod) *Pod {
 
 // getIdentifiersFromAssoc returns list of PodIdentifiers for given pod
 func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
-	if pod.Attributes == nil {
-		pod.Attributes = map[string]string{}
-	}
-
 	ids := []PodIdentifier{}
 	for _, assoc := range c.Associations {
 		ret := PodIdentifier{}
@@ -406,9 +402,9 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 			case source.From == ConnectionSource:
 				if pod.Address == "" {
 					skip = true
-				} else {
-					ret[i] = PodIdentifierAttributeFromSource(source, pod.Address)
+					break
 				}
+				ret[i] = PodIdentifierAttributeFromSource(source, pod.Address)
 			case source.From == ResourceSource:
 				attr := ""
 				switch source.Name {
@@ -428,9 +424,9 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 
 				if attr == "" {
 					skip = true
-				} else {
-					ret[i] = PodIdentifierAttributeFromSource(source, attr)
+					break
 				}
+				ret[i] = PodIdentifierAttributeFromSource(source, attr)
 			}
 		}
 
@@ -478,9 +474,7 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 func (c *WatchClient) forgetPod(pod *api_v1.Pod) {
 	newPod := c.getPodFromAPI(pod)
 	for _, id := range c.getIdentifiersFromAssoc(newPod) {
-		c.m.RLock()
 		p, ok := c.GetPod(id)
-		c.m.RUnlock()
 
 		if ok && p.Name == pod.Name {
 			c.appendDeleteQueue(id, pod.Name)

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -390,22 +390,6 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	if pod.UID != "" {
-		c.Pods[PodIdentifier(pod.UID)] = newPod
-	}
-	if pod.Status.PodIP != "" {
-		// compare initial scheduled timestamp for existing pod and new pod with same IP
-		// and only replace old pod if scheduled time of new pod is newer? This should fix
-		// the case where scheduler has assigned the same IP to a new pod but update event for
-		// the old pod came in later.
-		if p, ok := c.Pods[PodIdentifier(pod.Status.PodIP)]; ok {
-			if p.StartTime != nil && pod.Status.StartTime.Before(p.StartTime) {
-				return
-			}
-		}
-		c.Pods[PodIdentifier(pod.Status.PodIP)] = newPod
-	}
-
 	for _, assoc := range c.Associations {
 		ret := []string{}
 		for _, source := range assoc.Sources {
@@ -431,9 +415,13 @@ func (c *WatchClient) addOrUpdatePod(pod *api_v1.Pod) {
 			}
 		}
 
+		// compare initial scheduled timestamp for existing pod and new pod with same identifier
+		// and only replace old pod if scheduled time of new pod is newer or equal.
+		// This should fix the case where scheduler has assigned the same attribtues (like IP address)
+		// to a new pod but update event for the old pod came in later.
 		id := PodIdentifier(strings.Join(ret, assoc.Delimiter))
 		if p, ok := c.Pods[id]; ok {
-			if p.StartTime != nil && pod.Status.StartTime.Before(p.StartTime) {
+			if p.StartTime != nil && !p.StartTime.Before(pod.Status.StartTime) {
 				return
 			}
 		}

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1143,7 +1143,24 @@ func newTestClientWithRulesAndFilters(t *testing.T, e ExtractionRules, f Filters
 			{Name: regexp.MustCompile(`jaeger-collector`)},
 		},
 	}
-	c, err := New(logger, k8sconfig.APIConfig{}, e, f, []Association{}, exclude, newFakeAPIClientset, NewFakeInformer, NewFakeNamespaceInformer)
+	associations := []Association{
+		{
+			Sources: []AssociationSource{
+				{
+					From: "connection",
+				},
+			},
+		},
+		{
+			Sources: []AssociationSource{
+				{
+					From: "resource_attribute",
+					Name: "k8s.pod.uid",
+				},
+			},
+		},
+	}
+	c, err := New(logger, k8sconfig.APIConfig{}, e, f, associations, exclude, newFakeAPIClientset, NewFakeInformer, NewFakeNamespaceInformer)
 	require.NoError(t, err)
 	return c.(*WatchClient), logs
 }

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -42,6 +42,10 @@ func newFakeAPIClientset(_ k8sconfig.APIConfig) (kubernetes.Interface, error) {
 }
 
 func newPodIdentifier(from string, name string, value string) PodIdentifier {
+	if from == "connection" {
+		name = ""
+	}
+
 	return PodIdentifier{
 		{
 			Source: AssociationSource{
@@ -1166,7 +1170,6 @@ func newTestClientWithRulesAndFilters(t *testing.T, e ExtractionRules, f Filters
 			Sources: []AssociationSource{
 				{
 					From: "connection",
-					Name: "k8s.pod.ip",
 				},
 			},
 		},

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -48,17 +48,17 @@ type PodIdentifierAttribute struct {
 // PodIdentifier is a custom type to represent Pod identification
 type PodIdentifier [PodIdentifierMaxLength]PodIdentifierAttribute
 
-// GetPodIdentifierAttribute builds PodIdentifierAttribute using AssociationSource and value
-func GetPodIdentifierAttribute(source AssociationSource, value string) PodIdentifierAttribute {
+// PodIdentifierAttributeFromSource builds PodIdentifierAttribute using AssociationSource and value
+func PodIdentifierAttributeFromSource(source AssociationSource, value string) PodIdentifierAttribute {
 	return PodIdentifierAttribute{
 		Source: source,
 		Value:  value,
 	}
 }
 
-// GetPodIdentifierAttribute builds PodIdentifierAttribute using from, name (in order to build AssociationSource) and value
+// PodIdentifierAttributeFromSource builds PodIdentifierAttribute using from, name (in order to build AssociationSource) and value
 func BuildPodIdentifierAttribute(from string, name string, value string) PodIdentifierAttribute {
-	return GetPodIdentifierAttribute(
+	return PodIdentifierAttributeFromSource(
 		AssociationSource{
 			From: from,
 			Name: name,

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -37,6 +37,9 @@ const (
 	// MetadataFromNamespace is used to specify to extract metadata/labels/annotations from namespace
 	MetadataFromNamespace  = "namespace"
 	PodIdentifierMaxLength = 4
+
+	ResourceSource   = "resource_attribute"
+	ConnectionSource = "connection"
 )
 
 // PodIdentifierAttribute represents AssociationSource with matching value for pod

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -35,11 +35,37 @@ const (
 	// MetadataFromPod is used to specify to extract metadata/labels/annotations from pod
 	MetadataFromPod = "pod"
 	// MetadataFromNamespace is used to specify to extract metadata/labels/annotations from namespace
-	MetadataFromNamespace = "namespace"
+	MetadataFromNamespace  = "namespace"
+	PodIdentifierMaxLength = 16
 )
 
-// PodIdentifier is a custom type to represent IP Address or Pod UID
-type PodIdentifier string
+// PodIdentifierAttribute represents AssociationSource with matching value for pod
+type PodIdentifierAttribute struct {
+	Source AssociationSource
+	Value  string
+}
+
+// PodIdentifier is a custom type to represent Pod identification
+type PodIdentifier [PodIdentifierMaxLength]PodIdentifierAttribute
+
+// GetPodIdentifierAttribute builds PodIdentifierAttribute using AssociationSource and value
+func GetPodIdentifierAttribute(source AssociationSource, value string) PodIdentifierAttribute {
+	return PodIdentifierAttribute{
+		Source: source,
+		Value:  value,
+	}
+}
+
+// GetPodIdentifierAttribute builds PodIdentifierAttribute using from, name (in order to build AssociationSource) and value
+func BuildPodIdentifierAttribute(from string, name string, value string) PodIdentifierAttribute {
+	return GetPodIdentifierAttribute(
+		AssociationSource{
+			From: from,
+			Name: name,
+		},
+		value,
+	)
+}
 
 var (
 	// TODO: move these to config with default values

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -140,7 +140,6 @@ type ExtractionRules struct {
 	Namespace          bool
 	PodName            bool
 	PodUID             bool
-	PodIP              bool
 	Node               bool
 	StartTime          bool
 	ContainerID        bool

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -36,7 +36,7 @@ const (
 	MetadataFromPod = "pod"
 	// MetadataFromNamespace is used to specify to extract metadata/labels/annotations from namespace
 	MetadataFromNamespace  = "namespace"
-	PodIdentifierMaxLength = 16
+	PodIdentifierMaxLength = 4
 )
 
 // PodIdentifierAttribute represents AssociationSource with matching value for pod

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -51,6 +51,11 @@ type PodIdentifierAttribute struct {
 // PodIdentifier is a custom type to represent Pod identification
 type PodIdentifier [PodIdentifierMaxLength]PodIdentifierAttribute
 
+// IsNotEmpty checks if PodIdentifier is empty or not
+func (p *PodIdentifier) IsNotEmpty() bool {
+	return p[0].Source.From != ""
+}
+
 // PodIdentifierAttributeFromSource builds PodIdentifierAttribute using AssociationSource and value
 func PodIdentifierAttributeFromSource(source AssociationSource, value string) PodIdentifierAttribute {
 	return PodIdentifierAttribute{

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -223,8 +223,9 @@ type Associations struct {
 
 // Association represents one association rule
 type Association struct {
-	From string
-	Name string
+	Delimiter string
+	Name      string
+	Sources   []AssociationSource
 }
 
 // Excludes represent a list of Pods to ignore
@@ -235,4 +236,9 @@ type Excludes struct {
 // ExcludePods represent a Pod name to ignore
 type ExcludePods struct {
 	Name *regexp.Regexp
+}
+
+type AssociationSource struct {
+	From string
+	Name string
 }

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -59,12 +59,23 @@ func PodIdentifierAttributeFromSource(source AssociationSource, value string) Po
 	}
 }
 
-// PodIdentifierAttributeFromSource builds PodIdentifierAttribute using from, name (in order to build AssociationSource) and value
-func BuildPodIdentifierAttribute(from string, name string, value string) PodIdentifierAttribute {
+// PodIdentifierAttributeFromSource builds PodIdentifierAttribute for connection with given value
+func PodIdentifierAttributeFromConnection(value string) PodIdentifierAttribute {
 	return PodIdentifierAttributeFromSource(
 		AssociationSource{
-			From: from,
-			Name: name,
+			From: ConnectionSource,
+			Name: "",
+		},
+		value,
+	)
+}
+
+// PodIdentifierAttributeFromSource builds PodIdentifierAttribute for given resource_attribute name and value
+func PodIdentifierAttributeFromResourceAttribute(key string, value string) PodIdentifierAttribute {
+	return PodIdentifierAttributeFromSource(
+		AssociationSource{
+			From: ResourceSource,
+			Name: key,
 		},
 		value,
 	)

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -223,9 +223,8 @@ type Associations struct {
 
 // Association represents one association rule
 type Association struct {
-	Delimiter string
-	Name      string
-	Sources   []AssociationSource
+	Name    string
+	Sources []AssociationSource
 }
 
 // Excludes represent a list of Pods to ignore

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -140,6 +140,7 @@ type ExtractionRules struct {
 	Namespace          bool
 	PodName            bool
 	PodUID             bool
+	PodIP              bool
 	Node               bool
 	StartTime          bool
 	ContainerID        bool

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -287,20 +287,31 @@ func withExtractPodAssociations(podAssociations ...PodAssociationConfig) option 
 		var assoc kube.Association
 		for _, association := range podAssociations {
 			assoc = kube.Association{
-				Name:    association.Name,
 				Sources: []kube.AssociationSource{},
 			}
 
+			var name string
+
 			if association.From != "" {
+				if association.From == kube.ConnectionSource {
+					name = ""
+				} else {
+					name = association.Name
+				}
 				assoc.Sources = append(assoc.Sources, kube.AssociationSource{
 					From: association.From,
-					Name: association.Name,
+					Name: name,
 				})
 			} else {
 				for _, associationSource := range association.Sources {
+					if associationSource.From == kube.ConnectionSource {
+						name = ""
+					} else {
+						name = associationSource.Name
+					}
 					assoc.Sources = append(assoc.Sources, kube.AssociationSource{
 						From: associationSource.From,
-						Name: associationSource.Name,
+						Name: name,
 					})
 				}
 			}

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -284,11 +284,20 @@ func withFilterFields(filters ...FieldFilterConfig) option {
 func withExtractPodAssociations(podAssociations ...PodAssociationConfig) option {
 	return func(p *kubernetesprocessor) error {
 		associations := make([]kube.Association, 0, len(podAssociations))
+		var assoc kube.Association
 		for _, association := range podAssociations {
-			associations = append(associations, kube.Association{
-				From: association.From,
-				Name: association.Name,
-			})
+			assoc = kube.Association{
+				Delimiter: association.Delimiter,
+				Name:      association.Name,
+				Sources:   []kube.AssociationSource{},
+			}
+			for _, associationSource := range association.Sources {
+				assoc.Sources = append(assoc.Sources, kube.AssociationSource{
+					From: associationSource.From,
+					Name: associationSource.Name,
+				})
+			}
+			associations = append(associations, assoc)
 		}
 		p.podAssociations = associations
 		return nil

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -287,8 +287,8 @@ func withExtractPodAssociations(podAssociations ...PodAssociationConfig) option 
 		var assoc kube.Association
 		for _, association := range podAssociations {
 			assoc = kube.Association{
-				Name:      association.Name,
-				Sources:   []kube.AssociationSource{},
+				Name:    association.Name,
+				Sources: []kube.AssociationSource{},
 			}
 
 			if association.From != "" {

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -291,11 +291,19 @@ func withExtractPodAssociations(podAssociations ...PodAssociationConfig) option 
 				Name:      association.Name,
 				Sources:   []kube.AssociationSource{},
 			}
-			for _, associationSource := range association.Sources {
+
+			if association.From != "" {
 				assoc.Sources = append(assoc.Sources, kube.AssociationSource{
-					From: associationSource.From,
-					Name: associationSource.Name,
+					From: association.From,
+					Name: association.Name,
 				})
+			} else {
+				for _, associationSource := range association.Sources {
+					assoc.Sources = append(assoc.Sources, kube.AssociationSource{
+						From: associationSource.From,
+						Name: associationSource.Name,
+					})
+				}
 			}
 			associations = append(associations, assoc)
 		}

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -287,7 +287,6 @@ func withExtractPodAssociations(podAssociations ...PodAssociationConfig) option 
 		var assoc kube.Association
 		for _, association := range podAssociations {
 			assoc = kube.Association{
-				Delimiter: association.Delimiter,
 				Name:      association.Name,
 				Sources:   []kube.AssociationSource{},
 			}

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -735,6 +735,26 @@ func TestWithExtractPodAssociation(t *testing.T) {
 				},
 			},
 		},
+		{
+			"deprecated",
+			[]PodAssociationConfig{
+				{
+					From: "label",
+					Name: "ip",
+				},
+			},
+			[]kube.Association{
+				{
+					Name: "ip",
+					Sources: []kube.AssociationSource{
+						{
+							From: "label",
+							Name: "ip",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -745,11 +745,50 @@ func TestWithExtractPodAssociation(t *testing.T) {
 			},
 			[]kube.Association{
 				{
-					Name: "ip",
 					Sources: []kube.AssociationSource{
 						{
 							From: "label",
 							Name: "ip",
+						},
+					},
+				},
+			},
+		},
+		{
+			"connection deprecated",
+			[]PodAssociationConfig{
+				{
+					From: "connection",
+					Name: "ip",
+				},
+			},
+			[]kube.Association{
+				{
+					Sources: []kube.AssociationSource{
+						{
+							From: "connection",
+						},
+					},
+				},
+			},
+		},
+		{
+			"connection",
+			[]PodAssociationConfig{
+				{
+					Sources: []PodAssociationSourceConfig{
+						{
+							From: "connection",
+							Name: "ip",
+						},
+					},
+				},
+			},
+			[]kube.Association{
+				{
+					Sources: []kube.AssociationSource{
+						{
+							From: "connection",
 						},
 					},
 				},

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -716,14 +716,22 @@ func TestWithExtractPodAssociation(t *testing.T) {
 			"basic",
 			[]PodAssociationConfig{
 				{
-					From: "label",
-					Name: "ip",
+					Sources: []PodAssociationSourceConfig{
+						{
+							From: "label",
+							Name: "ip",
+						},
+					},
 				},
 			},
 			[]kube.Association{
 				{
-					From: "label",
-					Name: "ip",
+					Sources: []kube.AssociationSource{
+						{
+							From: "label",
+							Name: "ip",
+						},
+					},
 				},
 			},
 		},

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -54,7 +54,7 @@ func extractPodID(ctx context.Context, attrs pcommon.Map, associations []kube.As
 
 		// If all association sources has been resolved, return result
 		if len(ret) == len(asso.Sources) {
-			return asso.Name, kube.PodIdentifier(strings.Join(ret, asso.Delimiter))
+			return asso.Name, kube.PodIdentifier(strings.Join(ret, kube.PodIdentifierDelimiter))
 		}
 	}
 	return "", ""

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -36,7 +36,6 @@ func extractPodID(ctx context.Context, attrs pcommon.Map, associations []kube.As
 	}
 
 	connectionIP := getConnectionIP(ctx)
-	hostname := stringAttributeFromMap(attrs, conventions.AttributeHostName)
 	for _, asso := range associations {
 		ret := []string{}
 		for _, source := range asso.Sources {
@@ -45,19 +44,10 @@ func extractPodID(ctx context.Context, attrs pcommon.Map, associations []kube.As
 			case source.From == "connection" && connectionIP != "":
 				ret = append(ret, string(connectionIP))
 			case source.From == "resource_attribute":
-				// If association configured by resource_attribute
-				// In k8s environment, host.name label set to a pod IP address.
-				// If the value doesn't represent an IP address, we skip it.
-				if source.Name == conventions.AttributeHostName {
-					if net.ParseIP(hostname) != nil {
-						ret = append(ret, hostname)
-					}
-				} else {
-					// Extract values based on configured resource_attribute.
-					attributeValue := stringAttributeFromMap(attrs, source.Name)
-					if attributeValue != "" {
-						ret = append(ret, attributeValue)
-					}
+				// Extract values based on configured resource_attribute.
+				attributeValue := stringAttributeFromMap(attrs, source.Name)
+				if attributeValue != "" {
+					ret = append(ret, attributeValue)
 				}
 			}
 		}

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -52,7 +52,7 @@ func extractPodID(ctx context.Context, attrs pcommon.Map, associations []kube.As
 			}
 		}
 
-		// If all addociation sources has been resolved, return result
+		// If all association sources has been resolved, return result
 		if len(ret) == len(asso.Sources) {
 			return asso.Name, kube.PodIdentifier(strings.Join(ret, asso.Delimiter))
 		}

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -46,12 +46,12 @@ func extractPodID(ctx context.Context, attrs pcommon.Map, associations []kube.As
 		for i, source := range asso.Sources {
 			// If association configured to take IP address from connection
 			switch {
-			case source.From == "connection":
+			case source.From == kube.ConnectionSource:
 				if connectionIP == "" {
 					skip = true
 				}
 				ret[i] = kube.PodIdentifierAttributeFromSource(source, connectionIP)
-			case source.From == "resource_attribute":
+			case source.From == kube.ResourceSource:
 				// Extract values based on configured resource_attribute.
 				attributeValue := stringAttributeFromMap(attrs, source.Name)
 				if attributeValue == "" {

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -32,9 +32,9 @@ import (
 func extractPodID(ctx context.Context, attrs pcommon.Map, associations []kube.Association) (string, kube.PodIdentifier) {
 	// If pod association is not set
 	if len(associations) == 0 {
-		label, id := extractPodIDNoAssociations(ctx, attrs)
+		_, id := extractPodIDNoAssociations(ctx, attrs)
 		return "", kube.PodIdentifier{
-			kube.BuildPodIdentifierAttribute("connection", label, id),
+			kube.PodIdentifierAttributeFromConnection(id),
 		}
 	}
 

--- a/processor/k8sattributesprocessor/pod_association.go
+++ b/processor/k8sattributesprocessor/pod_association.go
@@ -50,7 +50,7 @@ func extractPodID(ctx context.Context, attrs pcommon.Map, associations []kube.As
 				if connectionIP == "" {
 					skip = true
 				}
-				ret[i] = kube.GetPodIdentifierAttribute(source, connectionIP)
+				ret[i] = kube.PodIdentifierAttributeFromSource(source, connectionIP)
 			case source.From == "resource_attribute":
 				// Extract values based on configured resource_attribute.
 				attributeValue := stringAttributeFromMap(attrs, source.Name)
@@ -58,7 +58,7 @@ func extractPodID(ctx context.Context, attrs pcommon.Map, associations []kube.As
 					skip = true
 				}
 
-				ret[i] = kube.GetPodIdentifierAttribute(source, attributeValue)
+				ret[i] = kube.PodIdentifierAttributeFromSource(source, attributeValue)
 			}
 		}
 

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -110,7 +110,7 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 	_, podIdentifierValue := extractPodID(ctx, resource.Attributes(), kp.podAssociations)
 	kp.logger.Debug("evaluating pod identifier", zap.Any("value", podIdentifierValue))
 	for i := range podIdentifierValue {
-		if podIdentifierValue[i].Source.From == "connection" && podIdentifierValue[i].Value != "" {
+		if podIdentifierValue[i].Source.From == kube.ConnectionSource && podIdentifierValue[i].Value != "" {
 			resource.Attributes().InsertString(k8sIPLabelName, podIdentifierValue[i].Value)
 		}
 	}

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -110,8 +110,8 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 	_, podIdentifierValue := extractPodID(ctx, resource.Attributes(), kp.podAssociations)
 	kp.logger.Debug("evaluating pod identifier", zap.Any("value", podIdentifierValue))
 	for i := range podIdentifierValue {
-		if podIdentifierValue[i].Source.From == "connection" && podIdentifierValue[i].Source.Name != "" {
-			resource.Attributes().InsertString(podIdentifierValue[i].Source.Name, podIdentifierValue[i].Value)
+		if podIdentifierValue[i].Source.From == "connection" && podIdentifierValue[i].Value != "" {
+			resource.Attributes().InsertString(k8sIPLabelName, podIdentifierValue[i].Value)
 		}
 	}
 	if kp.passthroughMode {

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -120,7 +120,7 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 		return
 	}
 
-	if len(podIdentifierValue) > 0 {
+	if podIdentifierValue.IsNotEmpty() {
 		if pod, ok := kp.kc.GetPod(podIdentifierValue); ok {
 			kp.logger.Debug("getting the pod", zap.Any("pod", pod))
 

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -107,8 +107,9 @@ func (kp *kubernetesprocessor) processLogs(ctx context.Context, ld plog.Logs) (p
 
 // processResource adds Pod metadata tags to resource based on pod association configuration
 func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pcommon.Resource) {
-	_, podIdentifierValue := extractPodID(ctx, resource.Attributes(), kp.podAssociations)
+	podIdentifierValue := extractPodID(ctx, resource.Attributes(), kp.podAssociations)
 	kp.logger.Debug("evaluating pod identifier", zap.Any("value", podIdentifierValue))
+
 	for i := range podIdentifierValue {
 		if podIdentifierValue[i].Source.From == kube.ConnectionSource && podIdentifierValue[i].Value != "" {
 			resource.Attributes().InsertString(k8sIPLabelName, podIdentifierValue[i].Value)

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -113,19 +113,22 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 	for i := range podIdentifierValue {
 		if podIdentifierValue[i].Source.From == kube.ConnectionSource && podIdentifierValue[i].Value != "" {
 			resource.Attributes().InsertString(k8sIPLabelName, podIdentifierValue[i].Value)
+			break
 		}
 	}
 	if kp.passthroughMode {
 		return
 	}
 
-	if pod, ok := kp.kc.GetPod(podIdentifierValue); ok {
-		kp.logger.Debug("getting the pod", zap.Any("pod", pod))
+	if len(podIdentifierValue) > 0 {
+		if pod, ok := kp.kc.GetPod(podIdentifierValue); ok {
+			kp.logger.Debug("getting the pod", zap.Any("pod", pod))
 
-		for key, val := range pod.Attributes {
-			resource.Attributes().InsertString(key, val)
+			for key, val := range pod.Attributes {
+				resource.Attributes().InsertString(key, val)
+			}
+			kp.addContainerAttributes(resource.Attributes(), pod)
 		}
-		kp.addContainerAttributes(resource.Attributes(), pod)
 	}
 
 	namespace := stringAttributeFromMap(resource.Attributes(), conventions.AttributeK8SNamespaceName)

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -1015,7 +1015,6 @@ func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
 		},
 	}
 
-	// invalid ip should not be used to lookup k8s pod
 	kc.Pods["invalid-ip"] = &kube.Pod{
 		Name: "PodA",
 		Attributes: map[string]string{
@@ -1042,6 +1041,10 @@ func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
 			hostname: "invalid-ip",
 			expectedAttrs: map[string]string{
 				conventions.AttributeHostName: "invalid-ip",
+				"k":                           "v",
+				"1":                           "2",
+				"aa":                          "b",
+				"k8s.pod.ip":                  "invalid-ip",
 			},
 		},
 		{

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -565,16 +565,31 @@ func TestIPSourceWithPodAssociation(t *testing.T) {
 	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
 		kp.podAssociations = []kube.Association{
 			{
-				From: "resource_attribute",
 				Name: "k8s.pod.ip",
+				Sources: []kube.AssociationSource{
+					{
+						From: "resource_attribute",
+						Name: "k8s.pod.ip",
+					},
+				},
 			},
 			{
-				From: "resource_attribute",
-				Name: "ip",
+				Name: "k8s.pod.ip",
+				Sources: []kube.AssociationSource{
+					{
+						From: "resource_attribute",
+						Name: "ip",
+					},
+				},
 			},
 			{
-				From: "resource_attribute",
-				Name: "host.name",
+				Name: "k8s.pod.ip",
+				Sources: []kube.AssociationSource{
+					{
+						From: "resource_attribute",
+						Name: "host.name",
+					},
+				},
 			},
 		}
 	})
@@ -615,8 +630,12 @@ func TestPodUID(t *testing.T) {
 	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
 		kp.podAssociations = []kube.Association{
 			{
-				From: "resource_attribute",
-				Name: "k8s.pod.uid",
+				Sources: []kube.AssociationSource{
+					{
+						From: "resource_attribute",
+						Name: "k8s.pod.uid",
+					},
+				},
 			},
 		}
 		kp.kc.(*fakeClient).Pods["ef10d10b-2da5-4030-812e-5f45c1531227"] = &kube.Pod{
@@ -663,8 +682,13 @@ func TestProcessorAddLabels(t *testing.T) {
 	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
 		kp.podAssociations = []kube.Association{
 			{
-				From: "connection",
-				Name: "ip",
+				Name: "k8s.pod.ip",
+				Sources: []kube.AssociationSource{
+					{
+						From: "connection",
+						Name: "ip",
+					},
+				},
 			},
 		}
 	})
@@ -717,8 +741,13 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 			op: func(kp *kubernetesprocessor) {
 				kp.podAssociations = []kube.Association{
 					{
-						From: "resource_attribute",
 						Name: "k8s.pod.uid",
+						Sources: []kube.AssociationSource{
+							{
+								From: "resource_attribute",
+								Name: "k8s.pod.uid",
+							},
+						},
 					},
 				}
 				kp.kc.(*fakeClient).Pods[kube.PodIdentifier("19f651bc-73e4-410f-b3e9-f0241679d3b8")] = &kube.Pod{
@@ -855,8 +884,13 @@ func TestProcessorPicksUpPassthoughPodIp(t *testing.T) {
 	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
 		kp.podAssociations = []kube.Association{
 			{
-				From: "resource_attribute",
 				Name: "k8s.pod.ip",
+				Sources: []kube.AssociationSource{
+					{
+						From: "resource_attribute",
+						Name: "k8s.pod.ip",
+					},
+				},
 			},
 		}
 		kp.kc.(*fakeClient).Pods["2.2.2.2"] = &kube.Pod{
@@ -971,8 +1005,13 @@ func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
 	kc := kp.kc.(*fakeClient)
 	kp.podAssociations = []kube.Association{
 		{
-			From: "resource_attribute",
-			Name: "host.name",
+			Name: "k8s.pod.ip",
+			Sources: []kube.AssociationSource{
+				{
+					From: "resource_attribute",
+					Name: "host.name",
+				},
+			},
 		},
 	}
 

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -41,8 +41,14 @@ import (
 )
 
 func newPodIdentifier(from string, name string, value string) kube.PodIdentifier {
+	if from == kube.ConnectionSource {
+		return kube.PodIdentifier{
+			kube.PodIdentifierAttributeFromConnection(value),
+		}
+	}
+
 	return kube.PodIdentifier{
-		kube.BuildPodIdentifierAttribute(from, name, value),
+		kube.PodIdentifierAttributeFromResourceAttribute(name, value),
 	}
 }
 
@@ -388,7 +394,7 @@ func TestProcessorNoAttrs(t *testing.T) {
 	// pod doesn't have attrs to add
 	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
 		pi := kube.PodIdentifier{
-			kube.BuildPodIdentifierAttribute("connection", "k8s.pod.ip", "1.1.1.1"),
+			kube.PodIdentifierAttributeFromConnection("1.1.1.1"),
 		}
 		kp.kc.(*fakeClient).Pods[pi] = &kube.Pod{Name: "PodA"}
 	})
@@ -409,7 +415,7 @@ func TestProcessorNoAttrs(t *testing.T) {
 	// attrs should be added now
 	m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
 		pi := kube.PodIdentifier{
-			kube.BuildPodIdentifierAttribute("connection", "k8s.pod.ip", "1.1.1.1"),
+			kube.PodIdentifierAttributeFromConnection("1.1.1.1"),
 		}
 
 		kp.kc.(*fakeClient).Pods[pi] = &kube.Pod{
@@ -691,7 +697,6 @@ func TestProcessorAddLabels(t *testing.T) {
 				Sources: []kube.AssociationSource{
 					{
 						From: "connection",
-						Name: "k8s.pod.ip",
 					},
 				},
 			},
@@ -701,7 +706,7 @@ func TestProcessorAddLabels(t *testing.T) {
 	for ip, attrs := range tests {
 		m.kubernetesProcessorOperation(func(kp *kubernetesprocessor) {
 			pi := kube.PodIdentifier{
-				kube.BuildPodIdentifierAttribute("connection", "k8s.pod.ip", ip),
+				kube.PodIdentifierAttributeFromConnection(ip),
 			}
 			kp.kc.(*fakeClient).Pods[pi] = &kube.Pod{Attributes: attrs}
 		})

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -70,9 +70,9 @@ processors:
       - sources:
         - from: connection
           name: ip
-      - sources:
-        - from: resource_attribute
-          name: k8s.pod.uid
+      # deprecated way
+      - from: resource_attribute
+        name: k8s.pod.uid
     
     exclude:
       pods:

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -58,16 +58,21 @@ processors:
           op: not-equals
 
     pod_association:
-      - from: resource_attribute
-        name: ip
-      - from: resource_attribute
-        name: k8s.pod.ip
-      - from: resource_attribute
-        name: host.name
-      - from: connection
-        name: ip
-      - from: resource_attribute
-        name: k8s.pod.uid
+      - sources:
+        - from: resource_attribute
+          name: ip
+      - sources:
+        - from: resource_attribute
+          name: k8s.pod.ip
+      - sources:
+        - from: resource_attribute
+          name: host.name
+      - sources:
+        - from: connection
+          name: ip
+      - sources:
+        - from: resource_attribute
+          name: k8s.pod.uid
     
     exclude:
       pods:

--- a/unreleased/drosiek-k8sprocessor.yaml
+++ b/unreleased/drosiek-k8sprocessor.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change
+note: Support metadata enrichment based on multiple attributes
+
+# One or more tracking issues related to the change
+issues: [4309]

--- a/unreleased/drosiek-k8sprocessor.yaml
+++ b/unreleased/drosiek-k8sprocessor.yaml
@@ -1,11 +1,11 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: k8sattributesprocessor
 
 # A brief description of the change
-note: Support metadata enrichment based on multiple attributes
+note: Announcing `pod_association` rules will be deprecated. Use `pod_associations.sources` rules instead. This is in order to support metadata enrichment based on multiple attributes.
 
 # One or more tracking issues related to the change
 issues: [4309]

--- a/unreleased/drosiek-k8sprocessor.yaml
+++ b/unreleased/drosiek-k8sprocessor.yaml
@@ -5,7 +5,7 @@ change_type: deprecation
 component: k8sattributesprocessor
 
 # A brief description of the change
-note: Announcing `pod_association` rules will be deprecated. Use `pod_associations.sources` rules instead. This is in order to support metadata enrichment based on multiple attributes.
+note: Announcing `pod_association` rules will be deprecated. Use `pod_association.sources` rules instead. This is in order to support metadata enrichment based on multiple attributes.
 
 # One or more tracking issues related to the change
 issues: [4309]


### PR DESCRIPTION
**Description:**

This PR is continuation of #4310 as I cannot reopen it.

It deprecates current pod association structure and instead it proposes another one, which is able to handle multiple source attributes. The direct justification is to support metadata enrichment for pair (`k8s.pod.name`, `k8s.namespace.name`).

**Link to tracking Issue:** #4309

**Testing:** unit tests

**Documentation:** `doc.go`