### PR TITLE
Run unit tests on 1.18 in addition to 1.17

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -120,6 +120,9 @@ jobs:
       - name: MultimodVerify
         run: make multimod-verify
   unittest:
+    strategy:
+      matrix:
+        go-version: [1.18, 1.17]
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
@@ -128,7 +131,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ matrix.go-version }}
       - name: Setup Go Environment
         run: |
           echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV


### PR DESCRIPTION
**Description:**
Run unit tests on 1.18 in addition to 1.17.

Related to https://github.com/open-telemetry/opentelemetry-collector/issues/5032, but for contrib.

In order to merge this PR, an admin for the repo will need to change the branch protection rules for main to require the `build-and-test / unittest (1.18)` and `build-and-test / unittest (1.17)` checks instead of the `unittest` check.