### PR TITLE
[processor/attributesprocessor] Support regex patterns on DELETE action

### DIFF
--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -295,7 +295,15 @@ func (ap *AttrProc) Process(ctx context.Context, logger *zap.Logger, attrs pdata
 		// and could impact performance.
 		switch action.Action {
 		case DELETE:
-			attrs.Remove(action.Key)
+			if action.Regex != nil {
+				attrs.RemoveIf(
+					func(s string, v pdata.Value) bool {
+						return action.Regex.MatchString(s)
+					},
+				)
+			} else {
+				attrs.Remove(action.Key)
+			}
 		case INSERT:
 			av, found := getSourceAttributeValue(ctx, action, attrs)
 			if !found {

--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -227,6 +227,13 @@ func NewAttrProc(settings *Settings) (*AttrProc, error) {
 			if valueSourceCount > 0 {
 				return nil, fmt.Errorf("error creating AttrProc. Action \"%s\" does not use value sources. This must not be specified for %d-th action", a.Action, i)
 			}
+			if a.RegexPattern != "" {
+				re, err := regexp.Compile(a.RegexPattern)
+				if err != nil {
+					return nil, fmt.Errorf("error creating AttrProc. Field \"pattern\" has invalid pattern: \"%s\" to be set at the %d-th actions", a.RegexPattern, i)
+				}
+				action.Regex = re
+			}
 			if a.ConvertedType != "" {
 				return nil, fmt.Errorf("error creating AttrProc. Action \"%s\" does not use the \"converted_type\" field. This must not be specified for %d-th action", a.Action, i)
 			}

--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -281,7 +281,7 @@ func (ap *AttrProc) Process(ctx context.Context, logger *zap.Logger, attrs pdata
 		// and could impact performance.
 		switch action.Action {
 		case DELETE:
-			attrs.Delete(action.Key)
+			attrs.Remove(action.Key)
 		case INSERT:
 			av, found := getSourceAttributeValue(ctx, action, attrs)
 			if !found {

--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -216,9 +216,16 @@ func NewAttrProc(settings *Settings) (*AttrProc, error) {
 				action.FromAttribute = a.FromAttribute
 				action.FromContext = a.FromContext
 			}
-		case HASH, DELETE:
+		case HASH:
 			if valueSourceCount > 0 || a.RegexPattern != "" {
 				return nil, fmt.Errorf("error creating AttrProc. Action \"%s\" does not use value sources or \"pattern\" field. These must not be specified for %d-th action", a.Action, i)
+			}
+			if a.ConvertedType != "" {
+				return nil, fmt.Errorf("error creating AttrProc. Action \"%s\" does not use the \"converted_type\" field. This must not be specified for %d-th action", a.Action, i)
+			}
+		case DELETE:
+			if valueSourceCount > 0 {
+				return nil, fmt.Errorf("error creating AttrProc. Action \"%s\" does not use value sources. This must not be specified for %d-th action", a.Action, i)
 			}
 			if a.ConvertedType != "" {
 				return nil, fmt.Errorf("error creating AttrProc. Action \"%s\" does not use the \"converted_type\" field. This must not be specified for %d-th action", a.Action, i)


### PR DESCRIPTION
**Description:**
As of now, the DELETE action enables users to delete a singular attribute with a well-known name.  The current behavior does not help users that need to delete attributes with dynamically named keys (imagine an application that included epoch timestamps in an attribute's name).

This change allows users to specify a `pattern` on a DELETE action which will be compiled into a regex and used to remove all attributes that match the pattern, via `AttributeMap.RemoveIf()`.

**Link to tracking Issue:** #8551 #5853

**Testing:** Tested manually in my local dev environment, still working on adding tests.

**Documentation:** Will update the relevant docs and example configs once config schema is agreed upon.