### PR TITLE
[Metrics builder] Move resource creation to the generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 - `resourcedetectionprocessor`: Add attribute allowlist (#8547)
 
+### 💡 Enhancements 💡
+
+- `cmd/mdatagen`: Add resource attributes definition to metadata.yaml and move `pdata.Metrics` creation to the
+  generated code (#5270) 
+
 ## v0.47.0
 
 ### 💡 Enhancements 💡

--- a/cmd/mdatagen/documentation.tmpl
+++ b/cmd/mdatagen/documentation.tmpl
@@ -25,7 +25,18 @@ metrics:
 ```
 {{- end }}
 
-## Attributes
+{{- if .ResourceAttributes }}
+
+## Resource attributes
+
+| Name | Description | Type |
+| ---- | ----------- | ---- |
+{{- range $attributeName, $attributeInfo := .ResourceAttributes }}
+| {{ $attributeName }} | {{ $attributeInfo.Description }} | {{ $attributeInfo.Type }} |
+{{- end }}
+{{- end }}
+
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-playground/validator/v10/non-standard/validators"
 	en_translations "github.com/go-playground/validator/v10/translations/en"
 	"go.opentelemetry.io/collector/config/mapprovider/filemapprovider"
+	"go.opentelemetry.io/collector/model/pdata"
 )
 
 type metricName string
@@ -46,6 +47,56 @@ func (mn attributeName) Render() (string, error) {
 
 func (mn attributeName) RenderUnexported() (string, error) {
 	return formatIdentifier(string(mn), false)
+}
+
+// ValueType defines an attribute value type.
+type ValueType struct {
+	// ValueType is type of the metric number, options are "double", "int".
+	ValueType pdata.ValueType
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (mvt *ValueType) UnmarshalText(text []byte) error {
+	switch vtStr := string(text); vtStr {
+	case "":
+		mvt.ValueType = pdata.ValueTypeEmpty
+	case "string":
+		mvt.ValueType = pdata.ValueTypeString
+	case "int":
+		mvt.ValueType = pdata.ValueTypeInt
+	case "double":
+		mvt.ValueType = pdata.ValueTypeDouble
+	case "bool":
+		mvt.ValueType = pdata.ValueTypeDouble
+	case "bytes":
+		mvt.ValueType = pdata.ValueTypeDouble
+	default:
+		return fmt.Errorf("invalid type: %q", vtStr)
+	}
+	return nil
+}
+
+// String returns capitalized name of the ValueType.
+func (mvt ValueType) String() string {
+	return strings.Title(strings.ToLower(mvt.ValueType.String()))
+}
+
+// Primitive returns name of primitive type for the ValueType.
+func (mvt ValueType) Primitive() string {
+	switch mvt.ValueType {
+	case pdata.ValueTypeString:
+		return "string"
+	case pdata.ValueTypeInt:
+		return "int64"
+	case pdata.ValueTypeDouble:
+		return "float64"
+	case pdata.ValueTypeBool:
+		return "bool"
+	case pdata.ValueTypeBytes:
+		return "[]byte"
+	default:
+		return ""
+	}
 }
 
 type metric struct {
@@ -99,11 +150,15 @@ type attribute struct {
 	Value string
 	// Enum can optionally describe the set of values to which the attribute can belong.
 	Enum []string
+	// Type is an attribute type.
+	Type ValueType `mapstructure:"type"`
 }
 
 type metadata struct {
 	// Name of the component.
 	Name string `validate:"notblank"`
+	// ResourceAttributes that can be emitted by the component.
+	ResourceAttributes map[attributeName]attribute `mapstructure:"resource_attributes" validate:"dive"`
 	// Attributes emitted by one or more metrics.
 	Attributes map[attributeName]attribute `validate:"dive"`
 	// Metrics that can be emitted by the component.

--- a/cmd/mdatagen/metric-metadata.yaml
+++ b/cmd/mdatagen/metric-metadata.yaml
@@ -1,6 +1,14 @@
 # Required: name of the receiver.
 name:
 
+# Optional: map of resource attribute definitions with the key being the attribute name.
+resource_attributes:
+  <attribute.name>:
+    # Required: description of the attribute.
+    description:
+    # Required: attribute type.
+    type: <string|int|double|bool|bytes>
+
 # Optional: map of attribute definitions with the key being the attribute name and value
 # being described below.
 attributes:

--- a/cmd/mdatagen/metrics_v2.tmpl
+++ b/cmd/mdatagen/metrics_v2.tmpl
@@ -101,7 +101,10 @@ func newMetric{{ $name.Render }}(settings MetricSettings) metric{{ $name.Render 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                pdata.Timestamp
+	startTime                pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity          int             // maximum observed number of metrics per resource.
+	resourceCapacity         int             // maximum observed number of resource attributes.
+	metricsBuffer            pdata.Metrics   // accumulates metrics data before emitting.
 	{{- range $name, $metric := .Metrics }}
 	metric{{ $name.Render }} metric{{ $name.Render }}
 	{{- end }}
@@ -120,6 +123,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:            pdata.NewMetrics(),
 		{{- range $name, $metric := .Metrics }}
 		metric{{ $name.Render }}: newMetric{{ $name.Render }}(settings.{{ $name.Render }}),
 		{{- end }}
@@ -130,13 +134,58 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+{{- range $name, $attr := .ResourceAttributes }}
+// With{{ $name.Render }} sets provided value as "{{ $name }}" attribute for current resource.
+func With{{ $name.Render }}(val {{ $attr.Type.Primitive }}) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().Upsert{{ $attr.Type }}("{{ $name }}", val)
+	}
+}
+{{ end }}
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/{{ .Name }}")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	{{- range $name, $metric := .Metrics }}
-	mb.metric{{- $name.Render }}.emit(metrics)
+	mb.metric{{- $name.Render }}.emit(ils.Metrics())
 	{{- end }}
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 {{ range $name, $metric := .Metrics -}}
@@ -157,16 +206,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/{{ .Name }}")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -24,7 +24,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/apachereceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics_v2.go
@@ -369,7 +369,10 @@ func newMetricApacheWorkers(settings MetricSettings) metricApacheWorkers {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                      pdata.Timestamp
+	startTime                      pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                int             // maximum observed number of metrics per resource.
+	resourceCapacity               int             // maximum observed number of resource attributes.
+	metricsBuffer                  pdata.Metrics   // accumulates metrics data before emitting.
 	metricApacheCurrentConnections metricApacheCurrentConnections
 	metricApacheRequests           metricApacheRequests
 	metricApacheScoreboard         metricApacheScoreboard
@@ -391,6 +394,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                      pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                  pdata.NewMetrics(),
 		metricApacheCurrentConnections: newMetricApacheCurrentConnections(settings.ApacheCurrentConnections),
 		metricApacheRequests:           newMetricApacheRequests(settings.ApacheRequests),
 		metricApacheScoreboard:         newMetricApacheScoreboard(settings.ApacheScoreboard),
@@ -404,16 +408,52 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricApacheCurrentConnections.emit(metrics)
-	mb.metricApacheRequests.emit(metrics)
-	mb.metricApacheScoreboard.emit(metrics)
-	mb.metricApacheTraffic.emit(metrics)
-	mb.metricApacheUptime.emit(metrics)
-	mb.metricApacheWorkers.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/apachereceiver")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricApacheCurrentConnections.emit(ils.Metrics())
+	mb.metricApacheRequests.emit(ils.Metrics())
+	mb.metricApacheScoreboard.emit(ils.Metrics())
+	mb.metricApacheTraffic.emit(ils.Metrics())
+	mb.metricApacheUptime.emit(ils.Metrics())
+	mb.metricApacheWorkers.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordApacheCurrentConnectionsDataPoint adds a data point to apache.current_connections metric.
@@ -453,16 +493,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/apachereceiver")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/apachereceiver/scraper.go
+++ b/receiver/apachereceiver/scraper.go
@@ -103,9 +103,7 @@ func (r *apacheScraper) scrape(context.Context) (pdata.Metrics, error) {
 		}
 	}
 
-	md := r.mb.NewMetricData()
-	r.mb.Emit(md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics())
-	return md, nil
+	return r.mb.Emit(), nil
 }
 
 // GetStats collects metric stats by making a get request at an endpoint.

--- a/receiver/couchbasereceiver/documentation.md
+++ b/receiver/couchbasereceiver/documentation.md
@@ -18,7 +18,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/couchbasereceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/couchbasereceiver/internal/metadata/generated_metrics_v2.go
@@ -24,7 +24,10 @@ func DefaultMetricsSettings() MetricsSettings {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime pdata.Timestamp
+	startTime        pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity  int             // maximum observed number of metrics per resource.
+	resourceCapacity int             // maximum observed number of resource attributes.
+	metricsBuffer    pdata.Metrics   // accumulates metrics data before emitting.
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -39,7 +42,8 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		startTime: pdata.NewTimestampFromTime(time.Now()),
+		startTime:     pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer: pdata.NewMetrics(),
 	}
 	for _, op := range options {
 		op(mb)
@@ -47,10 +51,46 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/couchbasereceiver")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // Reset resets metrics builder to its initial state. It should be used when external metrics source is restarted,
@@ -60,16 +100,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/couchbasereceiver")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/couchdbreceiver/documentation.md
+++ b/receiver/couchdbreceiver/documentation.md
@@ -26,11 +26,16 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Resource attributes
+
+| Name | Description | Type |
+| ---- | ----------- | ---- |
+| couchdb.node.name | The name of the node. | String |
+
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |
-| couchdb.node.name | The name of the node. |
 | http.method | An HTTP request method. |
 | http.status_code | An HTTP status code. |
 | operation | The operation type. |

--- a/receiver/couchdbreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_metrics_v2.go
@@ -471,7 +471,10 @@ func newMetricCouchdbHttpdViews(settings MetricSettings) metricCouchdbHttpdViews
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                       pdata.Timestamp
+	startTime                       pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                 int             // maximum observed number of metrics per resource.
+	resourceCapacity                int             // maximum observed number of resource attributes.
+	metricsBuffer                   pdata.Metrics   // accumulates metrics data before emitting.
 	metricCouchdbAverageRequestTime metricCouchdbAverageRequestTime
 	metricCouchdbDatabaseOpen       metricCouchdbDatabaseOpen
 	metricCouchdbDatabaseOperations metricCouchdbDatabaseOperations
@@ -495,6 +498,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                       pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                   pdata.NewMetrics(),
 		metricCouchdbAverageRequestTime: newMetricCouchdbAverageRequestTime(settings.CouchdbAverageRequestTime),
 		metricCouchdbDatabaseOpen:       newMetricCouchdbDatabaseOpen(settings.CouchdbDatabaseOpen),
 		metricCouchdbDatabaseOperations: newMetricCouchdbDatabaseOperations(settings.CouchdbDatabaseOperations),
@@ -510,18 +514,61 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricCouchdbAverageRequestTime.emit(metrics)
-	mb.metricCouchdbDatabaseOpen.emit(metrics)
-	mb.metricCouchdbDatabaseOperations.emit(metrics)
-	mb.metricCouchdbFileDescriptorOpen.emit(metrics)
-	mb.metricCouchdbHttpdBulkRequests.emit(metrics)
-	mb.metricCouchdbHttpdRequests.emit(metrics)
-	mb.metricCouchdbHttpdResponses.emit(metrics)
-	mb.metricCouchdbHttpdViews.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// WithCouchdbNodeName sets provided value as "couchdb.node.name" attribute for current resource.
+func WithCouchdbNodeName(val string) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertString("couchdb.node.name", val)
+	}
+}
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/couchdbreceiver")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricCouchdbAverageRequestTime.emit(ils.Metrics())
+	mb.metricCouchdbDatabaseOpen.emit(ils.Metrics())
+	mb.metricCouchdbDatabaseOperations.emit(ils.Metrics())
+	mb.metricCouchdbFileDescriptorOpen.emit(ils.Metrics())
+	mb.metricCouchdbHttpdBulkRequests.emit(ils.Metrics())
+	mb.metricCouchdbHttpdRequests.emit(ils.Metrics())
+	mb.metricCouchdbHttpdResponses.emit(ils.Metrics())
+	mb.metricCouchdbHttpdViews.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordCouchdbAverageRequestTimeDataPoint adds a data point to couchdb.average_request_time metric.
@@ -573,20 +620,8 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	}
 }
 
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/couchdbreceiver")
-	return md
-}
-
 // Attributes contains the possible metric attributes that can be used.
 var Attributes = struct {
-	// CouchdbNodeName (The name of the node.)
-	CouchdbNodeName string
 	// HTTPMethod (An HTTP request method.)
 	HTTPMethod string
 	// HTTPStatusCode (An HTTP status code.)
@@ -596,7 +631,6 @@ var Attributes = struct {
 	// View (The view type.)
 	View string
 }{
-	"couchdb.node.name",
 	"http.method",
 	"http.status_code",
 	"operation",

--- a/receiver/couchdbreceiver/metadata.yaml
+++ b/receiver/couchdbreceiver/metadata.yaml
@@ -1,8 +1,11 @@
 name: couchdbreceiver
 
-attributes:
+resource_attributes:
   couchdb.node.name:
     description: The name of the node.
+    type: string
+
+attributes:
   http.method:
     description: An HTTP request method.
     enum: [ COPY, DELETE, GET, HEAD, OPTIONS, POST, PUT ]

--- a/receiver/couchdbreceiver/scraper.go
+++ b/receiver/couchdbreceiver/scraper.go
@@ -57,10 +57,6 @@ func (c *couchdbScraper) scrape(context.Context) (pdata.Metrics, error) {
 		return pdata.NewMetrics(), errors.New("no client available")
 	}
 
-	return c.getResourceMetrics()
-}
-
-func (c *couchdbScraper) getResourceMetrics() (pdata.Metrics, error) {
 	localNode := "_local"
 	stats, err := c.client.GetStats(localNode)
 	if err != nil {
@@ -71,16 +67,7 @@ func (c *couchdbScraper) getResourceMetrics() (pdata.Metrics, error) {
 		return pdata.NewMetrics(), err
 	}
 
-	md := pdata.NewMetrics()
-	err = c.appendMetrics(stats, md.ResourceMetrics())
-	return md, err
-}
-
-func (c *couchdbScraper) appendMetrics(stats map[string]interface{}, rms pdata.ResourceMetricsSlice) error {
 	now := pdata.NewTimestampFromTime(time.Now())
-	md := c.mb.NewMetricData()
-
-	md.ResourceMetrics().At(0).Resource().Attributes().UpsertString(metadata.A.CouchdbNodeName, c.config.Endpoint)
 
 	var errors scrapererror.ScrapeErrors
 	c.recordCouchdbAverageRequestTimeDataPoint(now, stats, errors)
@@ -92,10 +79,5 @@ func (c *couchdbScraper) appendMetrics(stats map[string]interface{}, rms pdata.R
 	c.recordCouchdbFileDescriptorOpenDataPoint(now, stats, errors)
 	c.recordCouchdbDatabaseOperationsDataPoint(now, stats, errors)
 
-	c.mb.Emit(md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics())
-	if md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Len() > 0 {
-		md.ResourceMetrics().At(0).CopyTo(rms.AppendEmpty())
-	}
-
-	return errors.Combine()
+	return c.mb.Emit(metadata.WithCouchdbNodeName(c.config.Endpoint)), errors.Combine()
 }

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -47,7 +47,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_v2.go
@@ -1634,7 +1634,10 @@ func newMetricJvmThreadsCount(settings MetricSettings) metricJvmThreadsCount {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                                      pdata.Timestamp
+	startTime                                      pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                                int             // maximum observed number of metrics per resource.
+	resourceCapacity                               int             // maximum observed number of resource attributes.
+	metricsBuffer                                  pdata.Metrics   // accumulates metrics data before emitting.
 	metricElasticsearchClusterDataNodes            metricElasticsearchClusterDataNodes
 	metricElasticsearchClusterHealth               metricElasticsearchClusterHealth
 	metricElasticsearchClusterNodes                metricElasticsearchClusterNodes
@@ -1679,6 +1682,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                                      pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                                  pdata.NewMetrics(),
 		metricElasticsearchClusterDataNodes:            newMetricElasticsearchClusterDataNodes(settings.ElasticsearchClusterDataNodes),
 		metricElasticsearchClusterHealth:               newMetricElasticsearchClusterHealth(settings.ElasticsearchClusterHealth),
 		metricElasticsearchClusterNodes:                newMetricElasticsearchClusterNodes(settings.ElasticsearchClusterNodes),
@@ -1715,39 +1719,75 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricElasticsearchClusterDataNodes.emit(metrics)
-	mb.metricElasticsearchClusterHealth.emit(metrics)
-	mb.metricElasticsearchClusterNodes.emit(metrics)
-	mb.metricElasticsearchClusterShards.emit(metrics)
-	mb.metricElasticsearchNodeCacheEvictions.emit(metrics)
-	mb.metricElasticsearchNodeCacheMemoryUsage.emit(metrics)
-	mb.metricElasticsearchNodeClusterConnections.emit(metrics)
-	mb.metricElasticsearchNodeClusterIo.emit(metrics)
-	mb.metricElasticsearchNodeDocuments.emit(metrics)
-	mb.metricElasticsearchNodeFsDiskAvailable.emit(metrics)
-	mb.metricElasticsearchNodeHTTPConnections.emit(metrics)
-	mb.metricElasticsearchNodeOpenFiles.emit(metrics)
-	mb.metricElasticsearchNodeOperationsCompleted.emit(metrics)
-	mb.metricElasticsearchNodeOperationsTime.emit(metrics)
-	mb.metricElasticsearchNodeShardsSize.emit(metrics)
-	mb.metricElasticsearchNodeThreadPoolTasksFinished.emit(metrics)
-	mb.metricElasticsearchNodeThreadPoolTasksQueued.emit(metrics)
-	mb.metricElasticsearchNodeThreadPoolThreads.emit(metrics)
-	mb.metricJvmClassesLoaded.emit(metrics)
-	mb.metricJvmGcCollectionsCount.emit(metrics)
-	mb.metricJvmGcCollectionsElapsed.emit(metrics)
-	mb.metricJvmMemoryHeapCommitted.emit(metrics)
-	mb.metricJvmMemoryHeapMax.emit(metrics)
-	mb.metricJvmMemoryHeapUsed.emit(metrics)
-	mb.metricJvmMemoryNonheapCommitted.emit(metrics)
-	mb.metricJvmMemoryNonheapUsed.emit(metrics)
-	mb.metricJvmMemoryPoolMax.emit(metrics)
-	mb.metricJvmMemoryPoolUsed.emit(metrics)
-	mb.metricJvmThreadsCount.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/elasticsearchreceiver")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricElasticsearchClusterDataNodes.emit(ils.Metrics())
+	mb.metricElasticsearchClusterHealth.emit(ils.Metrics())
+	mb.metricElasticsearchClusterNodes.emit(ils.Metrics())
+	mb.metricElasticsearchClusterShards.emit(ils.Metrics())
+	mb.metricElasticsearchNodeCacheEvictions.emit(ils.Metrics())
+	mb.metricElasticsearchNodeCacheMemoryUsage.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterConnections.emit(ils.Metrics())
+	mb.metricElasticsearchNodeClusterIo.emit(ils.Metrics())
+	mb.metricElasticsearchNodeDocuments.emit(ils.Metrics())
+	mb.metricElasticsearchNodeFsDiskAvailable.emit(ils.Metrics())
+	mb.metricElasticsearchNodeHTTPConnections.emit(ils.Metrics())
+	mb.metricElasticsearchNodeOpenFiles.emit(ils.Metrics())
+	mb.metricElasticsearchNodeOperationsCompleted.emit(ils.Metrics())
+	mb.metricElasticsearchNodeOperationsTime.emit(ils.Metrics())
+	mb.metricElasticsearchNodeShardsSize.emit(ils.Metrics())
+	mb.metricElasticsearchNodeThreadPoolTasksFinished.emit(ils.Metrics())
+	mb.metricElasticsearchNodeThreadPoolTasksQueued.emit(ils.Metrics())
+	mb.metricElasticsearchNodeThreadPoolThreads.emit(ils.Metrics())
+	mb.metricJvmClassesLoaded.emit(ils.Metrics())
+	mb.metricJvmGcCollectionsCount.emit(ils.Metrics())
+	mb.metricJvmGcCollectionsElapsed.emit(ils.Metrics())
+	mb.metricJvmMemoryHeapCommitted.emit(ils.Metrics())
+	mb.metricJvmMemoryHeapMax.emit(ils.Metrics())
+	mb.metricJvmMemoryHeapUsed.emit(ils.Metrics())
+	mb.metricJvmMemoryNonheapCommitted.emit(ils.Metrics())
+	mb.metricJvmMemoryNonheapUsed.emit(ils.Metrics())
+	mb.metricJvmMemoryPoolMax.emit(ils.Metrics())
+	mb.metricJvmMemoryPoolUsed.emit(ils.Metrics())
+	mb.metricJvmThreadsCount.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordElasticsearchClusterDataNodesDataPoint adds a data point to elasticsearch.cluster.data_nodes metric.
@@ -1902,16 +1942,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/elasticsearchreceiver")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -57,13 +57,10 @@ func (s *scraper) start(context.Context, component.Host) error {
 }
 
 func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
-	md := pdata.NewMetrics()
-	metrics := md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics()
-
 	now := pdata.NewTimestampFromTime(s.now())
 	cpuTimes, err := s.times( /*percpu=*/ true)
 	if err != nil {
-		return md, scrapererror.NewPartialScrapeError(err, metricsLen)
+		return pdata.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 
 	for _, cpuTime := range cpuTimes {
@@ -72,9 +69,8 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 
 	err = s.ucal.CalculateAndRecord(now, cpuTimes, s.recordCPUUtilization)
 	if err != nil {
-		return md, scrapererror.NewPartialScrapeError(err, metricsLen)
+		return pdata.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 
-	s.mb.Emit(metrics)
-	return md, nil
+	return s.mb.Emit(), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -197,6 +197,10 @@ func TestScrape_CpuUtilization(t *testing.T) {
 			require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
 			assert.Equal(t, test.expectedMetricCount, md.MetricCount())
+			if md.ResourceMetrics().Len() == 0 {
+				return
+			}
+
 			metrics := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 			internal.AssertSameTimeStampForAllMetrics(t, metrics)
 			if test.times {
@@ -303,7 +307,7 @@ func TestScrape_CpuUtilizationStandard(t *testing.T) {
 		require.NoError(t, err)
 		//no metrics in the first scrape
 		if len(scrapeData.expectedDps) == 0 {
-			assert.Equal(t, 0, md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().Len())
+			assert.Equal(t, 0, md.ResourceMetrics().Len())
 			continue
 		}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
@@ -20,7 +20,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
@@ -139,7 +139,10 @@ func newMetricSystemCPUUtilization(settings MetricSettings) metricSystemCPUUtili
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                  pdata.Timestamp
+	startTime                  pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity            int             // maximum observed number of metrics per resource.
+	resourceCapacity           int             // maximum observed number of resource attributes.
+	metricsBuffer              pdata.Metrics   // accumulates metrics data before emitting.
 	metricSystemCPUTime        metricSystemCPUTime
 	metricSystemCPUUtilization metricSystemCPUUtilization
 }
@@ -157,6 +160,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                  pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:              pdata.NewMetrics(),
 		metricSystemCPUTime:        newMetricSystemCPUTime(settings.SystemCPUTime),
 		metricSystemCPUUtilization: newMetricSystemCPUUtilization(settings.SystemCPUUtilization),
 	}
@@ -166,12 +170,48 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricSystemCPUTime.emit(metrics)
-	mb.metricSystemCPUUtilization.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/cpu")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemCPUTime.emit(ils.Metrics())
+	mb.metricSystemCPUUtilization.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordSystemCPUTimeDataPoint adds a data point to system.cpu.time metric.
@@ -191,16 +231,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/cpu")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_test.go
@@ -120,6 +120,10 @@ func TestScrape(t *testing.T) {
 			require.NoError(t, err, "Failed to scrape metrics: %v", err)
 
 			assert.Equal(t, test.expectMetrics, md.MetricCount())
+			if md.ResourceMetrics().Len() == 0 {
+				return
+			}
+
 			metrics := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics()
 			assert.Equal(t, test.expectMetrics, metrics.Len())
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/documentation.md
@@ -25,7 +25,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics_v2.go
@@ -428,7 +428,10 @@ func newMetricSystemDiskWeightedIoTime(settings MetricSettings) metricSystemDisk
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                         pdata.Timestamp
+	startTime                         pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                   int             // maximum observed number of metrics per resource.
+	resourceCapacity                  int             // maximum observed number of resource attributes.
+	metricsBuffer                     pdata.Metrics   // accumulates metrics data before emitting.
 	metricSystemDiskIo                metricSystemDiskIo
 	metricSystemDiskIoTime            metricSystemDiskIoTime
 	metricSystemDiskMerged            metricSystemDiskMerged
@@ -451,6 +454,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                         pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                     pdata.NewMetrics(),
 		metricSystemDiskIo:                newMetricSystemDiskIo(settings.SystemDiskIo),
 		metricSystemDiskIoTime:            newMetricSystemDiskIoTime(settings.SystemDiskIoTime),
 		metricSystemDiskMerged:            newMetricSystemDiskMerged(settings.SystemDiskMerged),
@@ -465,17 +469,53 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricSystemDiskIo.emit(metrics)
-	mb.metricSystemDiskIoTime.emit(metrics)
-	mb.metricSystemDiskMerged.emit(metrics)
-	mb.metricSystemDiskOperationTime.emit(metrics)
-	mb.metricSystemDiskOperations.emit(metrics)
-	mb.metricSystemDiskPendingOperations.emit(metrics)
-	mb.metricSystemDiskWeightedIoTime.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/disk")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemDiskIo.emit(ils.Metrics())
+	mb.metricSystemDiskIoTime.emit(ils.Metrics())
+	mb.metricSystemDiskMerged.emit(ils.Metrics())
+	mb.metricSystemDiskOperationTime.emit(ils.Metrics())
+	mb.metricSystemDiskOperations.emit(ils.Metrics())
+	mb.metricSystemDiskPendingOperations.emit(ils.Metrics())
+	mb.metricSystemDiskWeightedIoTime.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordSystemDiskIoDataPoint adds a data point to system.disk.io metric.
@@ -520,16 +560,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/disk")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/documentation.md
@@ -21,7 +21,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper.go
@@ -72,15 +72,12 @@ func (s *scraper) start(context.Context, component.Host) error {
 }
 
 func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
-	md := pdata.NewMetrics()
-	metrics := md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics()
-
 	now := pdata.NewTimestampFromTime(time.Now())
 
 	// omit logical (virtual) filesystems (not relevant for windows)
 	partitions, err := s.partitions( /*all=*/ false)
 	if err != nil {
-		return md, scrapererror.NewPartialScrapeError(err, metricsLen)
+		return pdata.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 
 	var errors scrapererror.ScrapeErrors
@@ -99,10 +96,8 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 	}
 
 	if len(usages) > 0 {
-		metrics.EnsureCapacity(metricsLen)
 		s.recordFileSystemUsageMetric(now, usages)
 		s.recordSystemSpecificMetrics(now, usages)
-		s.mb.Emit(metrics)
 	}
 
 	err = errors.Combine()
@@ -110,7 +105,7 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 		err = scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 
-	return md, err
+	return s.mb.Emit(), err
 }
 
 func getMountMode(opts []string) string {

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_v2.go
@@ -205,7 +205,10 @@ func newMetricSystemFilesystemUtilization(settings MetricSettings) metricSystemF
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                         pdata.Timestamp
+	startTime                         pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                   int             // maximum observed number of metrics per resource.
+	resourceCapacity                  int             // maximum observed number of resource attributes.
+	metricsBuffer                     pdata.Metrics   // accumulates metrics data before emitting.
 	metricSystemFilesystemInodesUsage metricSystemFilesystemInodesUsage
 	metricSystemFilesystemUsage       metricSystemFilesystemUsage
 	metricSystemFilesystemUtilization metricSystemFilesystemUtilization
@@ -224,6 +227,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                         pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                     pdata.NewMetrics(),
 		metricSystemFilesystemInodesUsage: newMetricSystemFilesystemInodesUsage(settings.SystemFilesystemInodesUsage),
 		metricSystemFilesystemUsage:       newMetricSystemFilesystemUsage(settings.SystemFilesystemUsage),
 		metricSystemFilesystemUtilization: newMetricSystemFilesystemUtilization(settings.SystemFilesystemUtilization),
@@ -234,13 +238,49 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricSystemFilesystemInodesUsage.emit(metrics)
-	mb.metricSystemFilesystemUsage.emit(metrics)
-	mb.metricSystemFilesystemUtilization.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/filesystem")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemFilesystemInodesUsage.emit(ils.Metrics())
+	mb.metricSystemFilesystemUsage.emit(ils.Metrics())
+	mb.metricSystemFilesystemUtilization.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordSystemFilesystemInodesUsageDataPoint adds a data point to system.filesystem.inodes.usage metric.
@@ -265,16 +305,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/filesystem")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/documentation.md
@@ -21,7 +21,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics_v2.go
@@ -184,7 +184,10 @@ func newMetricSystemCPULoadAverage5m(settings MetricSettings) metricSystemCPULoa
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                     pdata.Timestamp
+	startTime                     pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity               int             // maximum observed number of metrics per resource.
+	resourceCapacity              int             // maximum observed number of resource attributes.
+	metricsBuffer                 pdata.Metrics   // accumulates metrics data before emitting.
 	metricSystemCPULoadAverage15m metricSystemCPULoadAverage15m
 	metricSystemCPULoadAverage1m  metricSystemCPULoadAverage1m
 	metricSystemCPULoadAverage5m  metricSystemCPULoadAverage5m
@@ -203,6 +206,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                     pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                 pdata.NewMetrics(),
 		metricSystemCPULoadAverage15m: newMetricSystemCPULoadAverage15m(settings.SystemCPULoadAverage15m),
 		metricSystemCPULoadAverage1m:  newMetricSystemCPULoadAverage1m(settings.SystemCPULoadAverage1m),
 		metricSystemCPULoadAverage5m:  newMetricSystemCPULoadAverage5m(settings.SystemCPULoadAverage5m),
@@ -213,13 +217,49 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricSystemCPULoadAverage15m.emit(metrics)
-	mb.metricSystemCPULoadAverage1m.emit(metrics)
-	mb.metricSystemCPULoadAverage5m.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/load")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemCPULoadAverage15m.emit(ils.Metrics())
+	mb.metricSystemCPULoadAverage1m.emit(ils.Metrics())
+	mb.metricSystemCPULoadAverage5m.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordSystemCPULoadAverage15mDataPoint adds a data point to system.cpu.load_average.15m metric.
@@ -244,16 +284,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/load")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper.go
@@ -65,13 +65,10 @@ func (s *scraper) shutdown(ctx context.Context) error {
 
 // scrape
 func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
-	md := pdata.NewMetrics()
-	metrics := md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics()
-
 	now := pdata.NewTimestampFromTime(time.Now())
 	avgLoadValues, err := s.load()
 	if err != nil {
-		return md, scrapererror.NewPartialScrapeError(err, metricsLen)
+		return pdata.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 
 	if s.config.CPUAverage {
@@ -81,11 +78,9 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 		avgLoadValues.Load15 = avgLoadValues.Load1 / divisor
 	}
 
-	metrics.EnsureCapacity(metricsLen)
-
 	s.mb.RecordSystemCPULoadAverage1mDataPoint(now, avgLoadValues.Load1)
 	s.mb.RecordSystemCPULoadAverage5mDataPoint(now, avgLoadValues.Load5)
 	s.mb.RecordSystemCPULoadAverage15mDataPoint(now, avgLoadValues.Load15)
-	s.mb.Emit(metrics)
-	return md, nil
+
+	return s.mb.Emit(), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/documentation.md
@@ -20,7 +20,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_v2.go
@@ -137,7 +137,10 @@ func newMetricSystemMemoryUtilization(settings MetricSettings) metricSystemMemor
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                     pdata.Timestamp
+	startTime                     pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity               int             // maximum observed number of metrics per resource.
+	resourceCapacity              int             // maximum observed number of resource attributes.
+	metricsBuffer                 pdata.Metrics   // accumulates metrics data before emitting.
 	metricSystemMemoryUsage       metricSystemMemoryUsage
 	metricSystemMemoryUtilization metricSystemMemoryUtilization
 }
@@ -155,6 +158,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                     pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                 pdata.NewMetrics(),
 		metricSystemMemoryUsage:       newMetricSystemMemoryUsage(settings.SystemMemoryUsage),
 		metricSystemMemoryUtilization: newMetricSystemMemoryUtilization(settings.SystemMemoryUtilization),
 	}
@@ -164,12 +168,48 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricSystemMemoryUsage.emit(metrics)
-	mb.metricSystemMemoryUtilization.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/memory")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemMemoryUsage.emit(ils.Metrics())
+	mb.metricSystemMemoryUtilization.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordSystemMemoryUsageDataPoint adds a data point to system.memory.usage metric.
@@ -189,16 +229,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/memory")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
@@ -59,23 +59,20 @@ func (s *scraper) start(context.Context, component.Host) error {
 }
 
 func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
-	md := pdata.NewMetrics()
-	metrics := md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics()
-
 	now := pdata.NewTimestampFromTime(time.Now())
 	memInfo, err := s.virtualMemory()
 	if err != nil {
-		return md, scrapererror.NewPartialScrapeError(err, metricsLen)
+		return pdata.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 
 	if memInfo != nil {
-		metrics.EnsureCapacity(metricsLen)
 		s.recordMemoryUsageMetric(now, memInfo)
 		if memInfo.Total <= 0 {
-			return md, scrapererror.NewPartialScrapeError(fmt.Errorf("%w: %d", ErrInvalidTotalMem, memInfo.Total), metricsLen)
+			return pdata.NewMetrics(), scrapererror.NewPartialScrapeError(fmt.Errorf("%w: %d", ErrInvalidTotalMem,
+				memInfo.Total), metricsLen)
 		}
 		s.recordMemoryUtilizationMetric(now, memInfo)
 	}
-	s.mb.Emit(metrics)
-	return md, nil
+
+	return s.mb.Emit(), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
@@ -23,7 +23,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_v2.go
@@ -315,7 +315,10 @@ func newMetricSystemNetworkPackets(settings MetricSettings) metricSystemNetworkP
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                      pdata.Timestamp
+	startTime                      pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                int             // maximum observed number of metrics per resource.
+	resourceCapacity               int             // maximum observed number of resource attributes.
+	metricsBuffer                  pdata.Metrics   // accumulates metrics data before emitting.
 	metricSystemNetworkConnections metricSystemNetworkConnections
 	metricSystemNetworkDropped     metricSystemNetworkDropped
 	metricSystemNetworkErrors      metricSystemNetworkErrors
@@ -336,6 +339,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                      pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                  pdata.NewMetrics(),
 		metricSystemNetworkConnections: newMetricSystemNetworkConnections(settings.SystemNetworkConnections),
 		metricSystemNetworkDropped:     newMetricSystemNetworkDropped(settings.SystemNetworkDropped),
 		metricSystemNetworkErrors:      newMetricSystemNetworkErrors(settings.SystemNetworkErrors),
@@ -348,15 +352,51 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricSystemNetworkConnections.emit(metrics)
-	mb.metricSystemNetworkDropped.emit(metrics)
-	mb.metricSystemNetworkErrors.emit(metrics)
-	mb.metricSystemNetworkIo.emit(metrics)
-	mb.metricSystemNetworkPackets.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/network")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemNetworkConnections.emit(ils.Metrics())
+	mb.metricSystemNetworkDropped.emit(ils.Metrics())
+	mb.metricSystemNetworkErrors.emit(ils.Metrics())
+	mb.metricSystemNetworkIo.emit(ils.Metrics())
+	mb.metricSystemNetworkPackets.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordSystemNetworkConnectionsDataPoint adds a data point to system.network.connections metric.
@@ -391,16 +431,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/network")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/documentation.md
@@ -22,7 +22,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics_v2.go
@@ -254,7 +254,10 @@ func newMetricSystemPagingUtilization(settings MetricSettings) metricSystemPagin
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                     pdata.Timestamp
+	startTime                     pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity               int             // maximum observed number of metrics per resource.
+	resourceCapacity              int             // maximum observed number of resource attributes.
+	metricsBuffer                 pdata.Metrics   // accumulates metrics data before emitting.
 	metricSystemPagingFaults      metricSystemPagingFaults
 	metricSystemPagingOperations  metricSystemPagingOperations
 	metricSystemPagingUsage       metricSystemPagingUsage
@@ -274,6 +277,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                     pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                 pdata.NewMetrics(),
 		metricSystemPagingFaults:      newMetricSystemPagingFaults(settings.SystemPagingFaults),
 		metricSystemPagingOperations:  newMetricSystemPagingOperations(settings.SystemPagingOperations),
 		metricSystemPagingUsage:       newMetricSystemPagingUsage(settings.SystemPagingUsage),
@@ -285,14 +289,50 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricSystemPagingFaults.emit(metrics)
-	mb.metricSystemPagingOperations.emit(metrics)
-	mb.metricSystemPagingUsage.emit(metrics)
-	mb.metricSystemPagingUtilization.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/paging")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemPagingFaults.emit(ils.Metrics())
+	mb.metricSystemPagingOperations.emit(ils.Metrics())
+	mb.metricSystemPagingUsage.emit(ils.Metrics())
+	mb.metricSystemPagingUtilization.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordSystemPagingFaultsDataPoint adds a data point to system.paging.faults metric.
@@ -322,16 +362,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/paging")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
@@ -63,9 +63,6 @@ func (s *scraper) start(context.Context, component.Host) error {
 }
 
 func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
-	md := pdata.NewMetrics()
-	metrics := md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics()
-
 	var errors scrapererror.ScrapeErrors
 
 	err := s.scrapePagingUsageMetric()
@@ -78,8 +75,7 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 		errors.AddPartial(pagingMetricsLen, err)
 	}
 
-	s.mb.Emit(metrics)
-	return md, errors.Combine()
+	return s.mb.Emit(), errors.Combine()
 }
 
 func (s *scraper) scrapePagingUsageMetric() error {

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
@@ -70,9 +70,6 @@ func (s *scraper) start(context.Context, component.Host) error {
 }
 
 func (s *scraper) scrape(context.Context) (pdata.Metrics, error) {
-	md := pdata.NewMetrics()
-	metrics := md.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics()
-
 	var errors scrapererror.ScrapeErrors
 
 	err := s.scrapePagingUsageMetric()
@@ -85,8 +82,7 @@ func (s *scraper) scrape(context.Context) (pdata.Metrics, error) {
 		errors.AddPartial(pagingMetricsLen, err)
 	}
 
-	s.mb.Emit(metrics)
-	return md, errors.Combine()
+	return s.mb.Emit(), errors.Combine()
 }
 
 func (s *scraper) scrapePagingUsageMetric() error {

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/documentation.md
@@ -13,7 +13,7 @@ These are the metrics available for this scraper.
 
 **Highlighted metrics** are emitted by default.
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/documentation.md
@@ -22,7 +22,18 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Resource attributes
+
+| Name | Description | Type |
+| ---- | ----------- | ---- |
+| process.command | The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in proc/[pid]/cmdline. On Windows, can be set to the first parameter extracted from GetCommandLineW. | String |
+| process.command_line | The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of GetCommandLineW. Do not set this if you have to assemble it just for monitoring; use process.command_args instead. | String |
+| process.executable.name | The name of the process executable. On Linux based systems, can be set to the Name in proc/[pid]/status. On Windows, can be set to the base name of GetProcessImageFileNameW. | String |
+| process.executable.path | The full path to the process executable. On Linux based systems, can be set to the target of proc/[pid]/exe. On Windows, can be set to the result of GetProcessImageFileNameW. | String |
+| process.owner | The username of the user that owns the process. | String |
+| process.pid | Process identifier (PID). | Int |
+
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_v2.go
@@ -249,7 +249,10 @@ func newMetricProcessMemoryVirtualUsage(settings MetricSettings) metricProcessMe
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                        pdata.Timestamp
+	startTime                        pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                  int             // maximum observed number of metrics per resource.
+	resourceCapacity                 int             // maximum observed number of resource attributes.
+	metricsBuffer                    pdata.Metrics   // accumulates metrics data before emitting.
 	metricProcessCPUTime             metricProcessCPUTime
 	metricProcessDiskIo              metricProcessDiskIo
 	metricProcessMemoryPhysicalUsage metricProcessMemoryPhysicalUsage
@@ -269,6 +272,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                        pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                    pdata.NewMetrics(),
 		metricProcessCPUTime:             newMetricProcessCPUTime(settings.ProcessCPUTime),
 		metricProcessDiskIo:              newMetricProcessDiskIo(settings.ProcessDiskIo),
 		metricProcessMemoryPhysicalUsage: newMetricProcessMemoryPhysicalUsage(settings.ProcessMemoryPhysicalUsage),
@@ -280,14 +284,92 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricProcessCPUTime.emit(metrics)
-	mb.metricProcessDiskIo.emit(metrics)
-	mb.metricProcessMemoryPhysicalUsage.emit(metrics)
-	mb.metricProcessMemoryVirtualUsage.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// WithProcessCommand sets provided value as "process.command" attribute for current resource.
+func WithProcessCommand(val string) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertString("process.command", val)
+	}
+}
+
+// WithProcessCommandLine sets provided value as "process.command_line" attribute for current resource.
+func WithProcessCommandLine(val string) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertString("process.command_line", val)
+	}
+}
+
+// WithProcessExecutableName sets provided value as "process.executable.name" attribute for current resource.
+func WithProcessExecutableName(val string) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertString("process.executable.name", val)
+	}
+}
+
+// WithProcessExecutablePath sets provided value as "process.executable.path" attribute for current resource.
+func WithProcessExecutablePath(val string) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertString("process.executable.path", val)
+	}
+}
+
+// WithProcessOwner sets provided value as "process.owner" attribute for current resource.
+func WithProcessOwner(val string) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertString("process.owner", val)
+	}
+}
+
+// WithProcessPid sets provided value as "process.pid" attribute for current resource.
+func WithProcessPid(val int64) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertInt("process.pid", val)
+	}
+}
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/process")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricProcessCPUTime.emit(ils.Metrics())
+	mb.metricProcessDiskIo.emit(ils.Metrics())
+	mb.metricProcessMemoryPhysicalUsage.emit(ils.Metrics())
+	mb.metricProcessMemoryVirtualUsage.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordProcessCPUTimeDataPoint adds a data point to process.cpu.time metric.
@@ -317,16 +399,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/hostmetricsreceiver/process")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -1,5 +1,38 @@
 name: hostmetricsreceiver/process
 
+resource_attributes:
+  process.pid:
+    description: Process identifier (PID).
+    type: int
+  process.executable.name:
+    description: >-
+      The name of the process executable. On Linux based systems, can be set to the
+      Name in proc/[pid]/status. On Windows, can be set to the base name of
+      GetProcessImageFileNameW.
+    type: string
+  process.executable.path:
+    description: >-
+      The full path to the process executable. On Linux based systems, can be set to
+      the target of proc/[pid]/exe. On Windows, can be set to the result of
+      GetProcessImageFileNameW.
+    type: string
+  process.command:
+    description: >-
+      The command used to launch the process (i.e. the command name). On Linux based
+      systems, can be set to the zeroth string in proc/[pid]/cmdline. On Windows, can
+      be set to the first parameter extracted from GetCommandLineW.
+    type: string
+  process.command_line:
+    description: >-
+      The full command used to launch the process as a single string representing the
+      full command. On Windows, can be set to the result of GetCommandLineW. Do not
+      set this if you have to assemble it just for monitoring; use
+      process.command_args instead.
+    type: string
+  process.owner:
+    description: The username of the user that owns the process.
+    type: string
+
 attributes:
   direction:
     description: Direction of flow of bytes (read or write).

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -22,7 +22,6 @@ import (
 	"github.com/shirou/gopsutil/v3/host"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/model/pdata"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
@@ -83,28 +82,19 @@ func (s *scraper) start(context.Context, component.Host) error {
 }
 
 func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
-	md := pdata.NewMetrics()
-	rms := md.ResourceMetrics()
-
 	var errs scrapererror.ScrapeErrors
 
 	metadata, err := s.getProcessMetadata()
 	if err != nil {
 		partialErr, isPartial := err.(scrapererror.PartialScrapeError)
 		if !isPartial {
-			return md, err
+			return pdata.NewMetrics(), err
 		}
 
 		errs.AddPartial(partialErr.Failed, partialErr)
 	}
 
-	rms.EnsureCapacity(len(metadata))
 	for _, md := range metadata {
-		rm := rms.AppendEmpty()
-		rm.SetSchemaUrl(conventions.SchemaURL)
-		md.initializeResource(rm.Resource())
-		metrics := rm.InstrumentationLibraryMetrics().AppendEmpty().Metrics()
-
 		now := pdata.NewTimestampFromTime(time.Now())
 
 		if err = s.scrapeAndAppendCPUTimeMetric(now, md.handle); err != nil {
@@ -118,10 +108,11 @@ func (s *scraper) scrape(_ context.Context) (pdata.Metrics, error) {
 		if err = s.scrapeAndAppendDiskIOMetric(now, md.handle); err != nil {
 			errs.AddPartial(diskMetricsLen, fmt.Errorf("error reading disk usage for process %q (pid %v): %w", md.executable.name, md.pid, err))
 		}
-		s.mb.Emit(metrics)
+
+		s.mb.EmitForResource(md.resourceOptions()...)
 	}
 
-	return md, errs.Combine()
+	return s.mb.Emit(), errs.Combine()
 }
 
 // getProcessMetadata returns a slice of processMetadata, including handles,

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -70,19 +70,11 @@ func TestScrape(t *testing.T) {
 	}
 
 	require.Greater(t, md.ResourceMetrics().Len(), 1)
-	assertSchemaIsSet(t, md.ResourceMetrics())
 	assertProcessResourceAttributesExist(t, md.ResourceMetrics())
 	assertCPUTimeMetricValid(t, md.ResourceMetrics(), expectedStartTime)
 	assertMemoryUsageMetricValid(t, md.ResourceMetrics(), expectedStartTime)
 	assertDiskIOMetricValid(t, md.ResourceMetrics(), expectedStartTime)
 	assertSameTimeStampForAllMetricsWithinResource(t, md.ResourceMetrics())
-}
-
-func assertSchemaIsSet(t *testing.T, resourceMetrics pdata.ResourceMetricsSlice) {
-	for i := 0; i < resourceMetrics.Len(); i++ {
-		rm := resourceMetrics.At(0)
-		assert.EqualValues(t, conventions.SchemaURL, rm.SchemaUrl())
-	}
 }
 
 func assertProcessResourceAttributesExist(t *testing.T, resourceMetrics pdata.ResourceMetricsSlice) {
@@ -486,15 +478,18 @@ func getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError
 	if diskError == nil {
 		expectedLen += diskMetricsLen
 	}
+
+	if expectedLen == 0 {
+		return 0, 0
+	}
 	return 1, expectedLen
 }
 
 func getExpectedScrapeFailures(nameError, exeError, timeError, memError, diskError error) int {
-	expectedResourceMetricsLen, expectedMetricsLen := getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError, diskError)
-	if expectedResourceMetricsLen == 0 {
+	if nameError != nil || exeError != nil {
 		return 1
 	}
-
+	_, expectedMetricsLen := getExpectedLengthOfReturnedMetrics(nameError, exeError, timeError, memError, diskError)
 	return metricsLen - expectedMetricsLen
 }
 
@@ -535,6 +530,8 @@ func TestScrapeMetrics_MuteProcessNameError(t *testing.T) {
 			}
 			scraper, err := newProcessScraper(config)
 			require.NoError(t, err, "Failed to create process scraper: %v", err)
+			err = scraper.start(context.Background(), componenttest.NewNopHost())
+			require.NoError(t, err, "Failed to initialize process scraper: %v", err)
 
 			handleMock := &processHandleMock{}
 			handleMock.On("Name").Return("test", processNameError)

--- a/receiver/kafkametricsreceiver/documentation.md
+++ b/receiver/kafkametricsreceiver/documentation.md
@@ -22,7 +22,7 @@ These are the metrics available for this scraper.
 
 **Highlighted metrics** are emitted by default.
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/kubeletstatsreceiver/documentation.md
+++ b/receiver/kubeletstatsreceiver/documentation.md
@@ -29,7 +29,7 @@ These are the metrics available for this scraper.
 
 **Highlighted metrics** are emitted by default.
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/memcachedreceiver/documentation.md
+++ b/receiver/memcachedreceiver/documentation.md
@@ -22,7 +22,7 @@ These are the metrics available for this scraper.
 
 **Highlighted metrics** are emitted by default.
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/mongodbatlasreceiver/documentation.md
+++ b/receiver/mongodbatlasreceiver/documentation.md
@@ -74,7 +74,7 @@ These are the metrics available for this scraper.
 
 **Highlighted metrics** are emitted by default.
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -30,7 +30,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
@@ -709,7 +709,10 @@ func newMetricMongodbStorageSize(settings MetricSettings) metricMongodbStorageSi
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                    pdata.Timestamp
+	startTime                    pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity              int             // maximum observed number of metrics per resource.
+	resourceCapacity             int             // maximum observed number of resource attributes.
+	metricsBuffer                pdata.Metrics   // accumulates metrics data before emitting.
 	metricMongodbCacheOperations metricMongodbCacheOperations
 	metricMongodbCollectionCount metricMongodbCollectionCount
 	metricMongodbConnectionCount metricMongodbConnectionCount
@@ -737,6 +740,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                    pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                pdata.NewMetrics(),
 		metricMongodbCacheOperations: newMetricMongodbCacheOperations(settings.MongodbCacheOperations),
 		metricMongodbCollectionCount: newMetricMongodbCollectionCount(settings.MongodbCollectionCount),
 		metricMongodbConnectionCount: newMetricMongodbConnectionCount(settings.MongodbConnectionCount),
@@ -756,22 +760,58 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricMongodbCacheOperations.emit(metrics)
-	mb.metricMongodbCollectionCount.emit(metrics)
-	mb.metricMongodbConnectionCount.emit(metrics)
-	mb.metricMongodbDataSize.emit(metrics)
-	mb.metricMongodbExtentCount.emit(metrics)
-	mb.metricMongodbGlobalLockTime.emit(metrics)
-	mb.metricMongodbIndexCount.emit(metrics)
-	mb.metricMongodbIndexSize.emit(metrics)
-	mb.metricMongodbMemoryUsage.emit(metrics)
-	mb.metricMongodbObjectCount.emit(metrics)
-	mb.metricMongodbOperationCount.emit(metrics)
-	mb.metricMongodbStorageSize.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/mongodbreceiver")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricMongodbCacheOperations.emit(ils.Metrics())
+	mb.metricMongodbCollectionCount.emit(ils.Metrics())
+	mb.metricMongodbConnectionCount.emit(ils.Metrics())
+	mb.metricMongodbDataSize.emit(ils.Metrics())
+	mb.metricMongodbExtentCount.emit(ils.Metrics())
+	mb.metricMongodbGlobalLockTime.emit(ils.Metrics())
+	mb.metricMongodbIndexCount.emit(ils.Metrics())
+	mb.metricMongodbIndexSize.emit(ils.Metrics())
+	mb.metricMongodbMemoryUsage.emit(ils.Metrics())
+	mb.metricMongodbObjectCount.emit(ils.Metrics())
+	mb.metricMongodbOperationCount.emit(ils.Metrics())
+	mb.metricMongodbStorageSize.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordMongodbCacheOperationsDataPoint adds a data point to mongodb.cache.operations metric.
@@ -841,16 +881,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/mongodbreceiver")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -35,7 +35,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -73,8 +73,6 @@ func (m *mySQLScraper) scrape(context.Context) (pdata.Metrics, error) {
 		return pdata.Metrics{}, errors.New("failed to connect to http client")
 	}
 
-	// metric initialization
-	md := m.mb.NewMetricData()
 	now := pdata.NewTimestampFromTime(time.Now())
 
 	// collect innodb metrics.
@@ -510,8 +508,7 @@ func (m *mySQLScraper) scrape(context.Context) (pdata.Metrics, error) {
 		}
 	}
 
-	m.mb.Emit(md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics())
-	return md, errors.Combine()
+	return m.mb.Emit(), errors.Combine()
 }
 
 func (m *mySQLScraper) recordDataPages(now pdata.Timestamp, globalStats map[string]string, errors scrapererror.ScrapeErrors) {

--- a/receiver/nginxreceiver/documentation.md
+++ b/receiver/nginxreceiver/documentation.md
@@ -22,7 +22,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/nginxreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_metrics_v2.go
@@ -245,7 +245,10 @@ func newMetricNginxRequests(settings MetricSettings) metricNginxRequests {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                      pdata.Timestamp
+	startTime                      pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                int             // maximum observed number of metrics per resource.
+	resourceCapacity               int             // maximum observed number of resource attributes.
+	metricsBuffer                  pdata.Metrics   // accumulates metrics data before emitting.
 	metricNginxConnectionsAccepted metricNginxConnectionsAccepted
 	metricNginxConnectionsCurrent  metricNginxConnectionsCurrent
 	metricNginxConnectionsHandled  metricNginxConnectionsHandled
@@ -265,6 +268,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                      pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                  pdata.NewMetrics(),
 		metricNginxConnectionsAccepted: newMetricNginxConnectionsAccepted(settings.NginxConnectionsAccepted),
 		metricNginxConnectionsCurrent:  newMetricNginxConnectionsCurrent(settings.NginxConnectionsCurrent),
 		metricNginxConnectionsHandled:  newMetricNginxConnectionsHandled(settings.NginxConnectionsHandled),
@@ -276,14 +280,50 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricNginxConnectionsAccepted.emit(metrics)
-	mb.metricNginxConnectionsCurrent.emit(metrics)
-	mb.metricNginxConnectionsHandled.emit(metrics)
-	mb.metricNginxRequests.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/nginxreceiver")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricNginxConnectionsAccepted.emit(ils.Metrics())
+	mb.metricNginxConnectionsCurrent.emit(ils.Metrics())
+	mb.metricNginxConnectionsHandled.emit(ils.Metrics())
+	mb.metricNginxRequests.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordNginxConnectionsAcceptedDataPoint adds a data point to nginx.connections_accepted metric.
@@ -313,16 +353,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/nginxreceiver")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/nginxreceiver/scraper.go
+++ b/receiver/nginxreceiver/scraper.go
@@ -75,7 +75,6 @@ func (r *nginxScraper) scrape(context.Context) (pdata.Metrics, error) {
 	}
 
 	now := pdata.NewTimestampFromTime(time.Now())
-	md := r.mb.NewMetricData()
 
 	r.mb.RecordNginxRequestsDataPoint(now, stats.Requests)
 	r.mb.RecordNginxConnectionsAcceptedDataPoint(now, stats.Connections.Accepted)
@@ -85,6 +84,5 @@ func (r *nginxScraper) scrape(context.Context) (pdata.Metrics, error) {
 	r.mb.RecordNginxConnectionsCurrentDataPoint(now, stats.Connections.Writing, metadata.AttributeState.Writing)
 	r.mb.RecordNginxConnectionsCurrentDataPoint(now, stats.Connections.Waiting, metadata.AttributeState.Waiting)
 
-	r.mb.Emit(md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics())
-	return md, nil
+	return r.mb.Emit(), nil
 }

--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -25,7 +25,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
@@ -430,7 +430,10 @@ func newMetricPostgresqlRows(settings MetricSettings) metricPostgresqlRows {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                  pdata.Timestamp
+	startTime                  pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity            int             // maximum observed number of metrics per resource.
+	resourceCapacity           int             // maximum observed number of resource attributes.
+	metricsBuffer              pdata.Metrics   // accumulates metrics data before emitting.
 	metricPostgresqlBackends   metricPostgresqlBackends
 	metricPostgresqlBlocksRead metricPostgresqlBlocksRead
 	metricPostgresqlCommits    metricPostgresqlCommits
@@ -453,6 +456,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                  pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:              pdata.NewMetrics(),
 		metricPostgresqlBackends:   newMetricPostgresqlBackends(settings.PostgresqlBackends),
 		metricPostgresqlBlocksRead: newMetricPostgresqlBlocksRead(settings.PostgresqlBlocksRead),
 		metricPostgresqlCommits:    newMetricPostgresqlCommits(settings.PostgresqlCommits),
@@ -467,17 +471,53 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricPostgresqlBackends.emit(metrics)
-	mb.metricPostgresqlBlocksRead.emit(metrics)
-	mb.metricPostgresqlCommits.emit(metrics)
-	mb.metricPostgresqlDbSize.emit(metrics)
-	mb.metricPostgresqlOperations.emit(metrics)
-	mb.metricPostgresqlRollbacks.emit(metrics)
-	mb.metricPostgresqlRows.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/postgresqlreceiver")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricPostgresqlBackends.emit(ils.Metrics())
+	mb.metricPostgresqlBlocksRead.emit(ils.Metrics())
+	mb.metricPostgresqlCommits.emit(ils.Metrics())
+	mb.metricPostgresqlDbSize.emit(ils.Metrics())
+	mb.metricPostgresqlOperations.emit(ils.Metrics())
+	mb.metricPostgresqlRollbacks.emit(ils.Metrics())
+	mb.metricPostgresqlRows.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordPostgresqlBackendsDataPoint adds a data point to postgresql.backends metric.
@@ -522,16 +562,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/postgresqlreceiver")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -81,8 +81,6 @@ func (p *postgreSQLScraper) scrape(ctx context.Context) (pdata.Metrics, error) {
 		databases = dbList
 	}
 
-	// metric initialization
-	md := p.mb.NewMetricData()
 	now := pdata.NewTimestampFromTime(time.Now())
 
 	var errors scrapererror.ScrapeErrors
@@ -104,8 +102,7 @@ func (p *postgreSQLScraper) scrape(ctx context.Context) (pdata.Metrics, error) {
 		p.collectDatabaseTableMetrics(ctx, now, dbClient, errors)
 	}
 
-	p.mb.Emit(md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics())
-	return md, errors.Combine()
+	return p.mb.Emit(), errors.Combine()
 }
 
 func (p *postgreSQLScraper) collectBlockReads(

--- a/receiver/rabbitmqreceiver/documentation.md
+++ b/receiver/rabbitmqreceiver/documentation.md
@@ -24,11 +24,16 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Resource attributes
+
+| Name | Description | Type |
+| ---- | ----------- | ---- |
+| rabbitmq.node.name | The name of the RabbitMQ node. | String |
+| rabbitmq.queue.name | The name of the RabbitMQ queue. | String |
+| rabbitmq.vhost.name | The name of the RabbitMQ vHost. | String |
+
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |
 | message.state | The state of messages in a queue. |
-| rabbitmq.node.name | The name of the RabbitMQ node. |
-| rabbitmq.queue.name | The name of the RabbitMQ queue. |
-| rabbitmq.vhost.name | The name of the RabbitMQ vHost. |

--- a/receiver/rabbitmqreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/rabbitmqreceiver/internal/metadata/generated_metrics_v2.go
@@ -357,7 +357,10 @@ func newMetricRabbitmqMessagePublished(settings MetricSettings) metricRabbitmqMe
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                         pdata.Timestamp
+	startTime                         pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                   int             // maximum observed number of metrics per resource.
+	resourceCapacity                  int             // maximum observed number of resource attributes.
+	metricsBuffer                     pdata.Metrics   // accumulates metrics data before emitting.
 	metricRabbitmqConsumerCount       metricRabbitmqConsumerCount
 	metricRabbitmqMessageAcknowledged metricRabbitmqMessageAcknowledged
 	metricRabbitmqMessageCurrent      metricRabbitmqMessageCurrent
@@ -379,6 +382,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                         pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                     pdata.NewMetrics(),
 		metricRabbitmqConsumerCount:       newMetricRabbitmqConsumerCount(settings.RabbitmqConsumerCount),
 		metricRabbitmqMessageAcknowledged: newMetricRabbitmqMessageAcknowledged(settings.RabbitmqMessageAcknowledged),
 		metricRabbitmqMessageCurrent:      newMetricRabbitmqMessageCurrent(settings.RabbitmqMessageCurrent),
@@ -392,16 +396,73 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricRabbitmqConsumerCount.emit(metrics)
-	mb.metricRabbitmqMessageAcknowledged.emit(metrics)
-	mb.metricRabbitmqMessageCurrent.emit(metrics)
-	mb.metricRabbitmqMessageDelivered.emit(metrics)
-	mb.metricRabbitmqMessageDropped.emit(metrics)
-	mb.metricRabbitmqMessagePublished.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// WithRabbitmqNodeName sets provided value as "rabbitmq.node.name" attribute for current resource.
+func WithRabbitmqNodeName(val string) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertString("rabbitmq.node.name", val)
+	}
+}
+
+// WithRabbitmqQueueName sets provided value as "rabbitmq.queue.name" attribute for current resource.
+func WithRabbitmqQueueName(val string) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertString("rabbitmq.queue.name", val)
+	}
+}
+
+// WithRabbitmqVhostName sets provided value as "rabbitmq.vhost.name" attribute for current resource.
+func WithRabbitmqVhostName(val string) ResourceOption {
+	return func(r pdata.Resource) {
+		r.Attributes().UpsertString("rabbitmq.vhost.name", val)
+	}
+}
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/rabbitmqreceiver")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricRabbitmqConsumerCount.emit(ils.Metrics())
+	mb.metricRabbitmqMessageAcknowledged.emit(ils.Metrics())
+	mb.metricRabbitmqMessageCurrent.emit(ils.Metrics())
+	mb.metricRabbitmqMessageDelivered.emit(ils.Metrics())
+	mb.metricRabbitmqMessageDropped.emit(ils.Metrics())
+	mb.metricRabbitmqMessagePublished.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordRabbitmqConsumerCountDataPoint adds a data point to rabbitmq.consumer.count metric.
@@ -443,31 +504,12 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	}
 }
 
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/rabbitmqreceiver")
-	return md
-}
-
 // Attributes contains the possible metric attributes that can be used.
 var Attributes = struct {
 	// MessageState (The state of messages in a queue.)
 	MessageState string
-	// RabbitmqNodeName (The name of the RabbitMQ node.)
-	RabbitmqNodeName string
-	// RabbitmqQueueName (The name of the RabbitMQ queue.)
-	RabbitmqQueueName string
-	// RabbitmqVhostName (The name of the RabbitMQ vHost.)
-	RabbitmqVhostName string
 }{
 	"state",
-	"rabbitmq.node.name",
-	"rabbitmq.queue.name",
-	"rabbitmq.vhost.name",
 }
 
 // A is an alias for Attributes.

--- a/receiver/rabbitmqreceiver/metadata.yaml
+++ b/receiver/rabbitmqreceiver/metadata.yaml
@@ -1,12 +1,17 @@
 name: rabbitmqreceiver
 
-attributes:
+resource_attributes:
   rabbitmq.queue.name:
     description: The name of the RabbitMQ queue.
+    type: string
   rabbitmq.node.name:
     description: The name of the RabbitMQ node.
+    type: string
   rabbitmq.vhost.name:
     description: The name of the RabbitMQ vHost.
+    type: string
+
+attributes:
   message.state:
     value: state
     description: The state of messages in a queue.

--- a/receiver/rabbitmqreceiver/scraper.go
+++ b/receiver/rabbitmqreceiver/scraper.go
@@ -27,8 +27,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver/internal/models"
 )
 
-const instrumentationLibraryName = "otelcol/rabbitmqreceiver"
-
 var errClientNotInit = errors.New("client not initialized")
 
 // Names of metrics in message_stats
@@ -74,41 +72,30 @@ func (r *rabbitmqScraper) start(ctx context.Context, host component.Host) (err e
 
 // scrape collects metrics from the RabbitMQ API
 func (r *rabbitmqScraper) scrape(ctx context.Context) (pdata.Metrics, error) {
-	metrics := pdata.NewMetrics()
 	now := pdata.NewTimestampFromTime(time.Now())
-	rms := metrics.ResourceMetrics()
 
 	// Validate we don't attempt to scrape without initializing the client
 	if r.client == nil {
-		return metrics, errClientNotInit
+		return pdata.NewMetrics(), errClientNotInit
 	}
 
 	// Get queues for processing
 	queues, err := r.client.GetQueues(ctx)
 	if err != nil {
-		return metrics, err
+		return pdata.NewMetrics(), err
 	}
 
 	// Collect metrics for each queue
 	for _, queue := range queues {
 
-		r.collectQueue(queue, now, rms)
+		r.collectQueue(queue, now)
 	}
 
-	return metrics, nil
+	return r.mb.Emit(), nil
 }
 
 // collectQueue collects metrics
-func (r *rabbitmqScraper) collectQueue(queue *models.Queue, now pdata.Timestamp, rms pdata.ResourceMetricsSlice) {
-	resourceMetric := rms.AppendEmpty()
-	resourceAttrs := resourceMetric.Resource().Attributes()
-	resourceAttrs.InsertString(metadata.A.RabbitmqQueueName, queue.Name)
-	resourceAttrs.InsertString(metadata.A.RabbitmqNodeName, queue.Node)
-	resourceAttrs.InsertString(metadata.A.RabbitmqVhostName, queue.VHost)
-
-	ilms := resourceMetric.InstrumentationLibraryMetrics().AppendEmpty()
-	ilms.InstrumentationLibrary().SetName(instrumentationLibraryName)
-
+func (r *rabbitmqScraper) collectQueue(queue *models.Queue, now pdata.Timestamp) {
 	r.mb.RecordRabbitmqConsumerCountDataPoint(now, queue.Consumers)
 	r.mb.RecordRabbitmqMessageCurrentDataPoint(now, queue.UnacknowledgedMessages, metadata.AttributeMessageState.Unacknowledged)
 	r.mb.RecordRabbitmqMessageCurrentDataPoint(now, queue.ReadyMessages, metadata.AttributeMessageState.Ready)
@@ -139,10 +126,13 @@ func (r *rabbitmqScraper) collectQueue(queue *models.Queue, now pdata.Timestamp,
 			r.mb.RecordRabbitmqMessageAcknowledgedDataPoint(now, val64)
 		case dropUnroutableStat:
 			r.mb.RecordRabbitmqMessageDroppedDataPoint(now, val64)
-
 		}
 	}
-	r.mb.Emit(ilms.Metrics())
+	r.mb.EmitForResource(
+		metadata.WithRabbitmqQueueName(queue.Name),
+		metadata.WithRabbitmqNodeName(queue.Node),
+		metadata.WithRabbitmqVhostName(queue.VHost),
+	)
 }
 
 // convertValToInt64 values from message state unmarshal as float64s but should be int64.

--- a/receiver/redisreceiver/documentation.md
+++ b/receiver/redisreceiver/documentation.md
@@ -47,7 +47,7 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |

--- a/receiver/redisreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics_v2.go
@@ -1600,7 +1600,10 @@ func newMetricRedisUptime(settings MetricSettings) metricRedisUptime {
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user settings.
 type MetricsBuilder struct {
-	startTime                                    pdata.Timestamp
+	startTime                                    pdata.Timestamp // start time that will be applied to all recorded data points.
+	metricsCapacity                              int             // maximum observed number of metrics per resource.
+	resourceCapacity                             int             // maximum observed number of resource attributes.
+	metricsBuffer                                pdata.Metrics   // accumulates metrics data before emitting.
 	metricRedisClientsBlocked                    metricRedisClientsBlocked
 	metricRedisClientsConnected                  metricRedisClientsConnected
 	metricRedisClientsMaxInputBuffer             metricRedisClientsMaxInputBuffer
@@ -1645,6 +1648,7 @@ func WithStartTime(startTime pdata.Timestamp) metricBuilderOption {
 func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
 		startTime:                                    pdata.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                                pdata.NewMetrics(),
 		metricRedisClientsBlocked:                    newMetricRedisClientsBlocked(settings.RedisClientsBlocked),
 		metricRedisClientsConnected:                  newMetricRedisClientsConnected(settings.RedisClientsConnected),
 		metricRedisClientsMaxInputBuffer:             newMetricRedisClientsMaxInputBuffer(settings.RedisClientsMaxInputBuffer),
@@ -1681,39 +1685,75 @@ func NewMetricsBuilder(settings MetricsSettings, options ...metricBuilderOption)
 	return mb
 }
 
-// Emit appends generated metrics to a pdata.MetricsSlice and updates the internal state to be ready for recording
-// another set of data points. This function will be doing all transformations required to produce metric representation
-// defined in metadata and user settings, e.g. delta/cumulative translation.
-func (mb *MetricsBuilder) Emit(metrics pdata.MetricSlice) {
-	mb.metricRedisClientsBlocked.emit(metrics)
-	mb.metricRedisClientsConnected.emit(metrics)
-	mb.metricRedisClientsMaxInputBuffer.emit(metrics)
-	mb.metricRedisClientsMaxOutputBuffer.emit(metrics)
-	mb.metricRedisCommands.emit(metrics)
-	mb.metricRedisCommandsProcessed.emit(metrics)
-	mb.metricRedisConnectionsReceived.emit(metrics)
-	mb.metricRedisConnectionsRejected.emit(metrics)
-	mb.metricRedisCPUTime.emit(metrics)
-	mb.metricRedisDbAvgTTL.emit(metrics)
-	mb.metricRedisDbExpires.emit(metrics)
-	mb.metricRedisDbKeys.emit(metrics)
-	mb.metricRedisKeysEvicted.emit(metrics)
-	mb.metricRedisKeysExpired.emit(metrics)
-	mb.metricRedisKeyspaceHits.emit(metrics)
-	mb.metricRedisKeyspaceMisses.emit(metrics)
-	mb.metricRedisLatestFork.emit(metrics)
-	mb.metricRedisMemoryFragmentationRatio.emit(metrics)
-	mb.metricRedisMemoryLua.emit(metrics)
-	mb.metricRedisMemoryPeak.emit(metrics)
-	mb.metricRedisMemoryRss.emit(metrics)
-	mb.metricRedisMemoryUsed.emit(metrics)
-	mb.metricRedisNetInput.emit(metrics)
-	mb.metricRedisNetOutput.emit(metrics)
-	mb.metricRedisRdbChangesSinceLastSave.emit(metrics)
-	mb.metricRedisReplicationBacklogFirstByteOffset.emit(metrics)
-	mb.metricRedisReplicationOffset.emit(metrics)
-	mb.metricRedisSlavesConnected.emit(metrics)
-	mb.metricRedisUptime.emit(metrics)
+// updateCapacity updates max length of metrics and resource attributes that will be used for the slice capacity.
+func (mb *MetricsBuilder) updateCapacity(rm pdata.ResourceMetrics) {
+	if mb.metricsCapacity < rm.InstrumentationLibraryMetrics().At(0).Metrics().Len() {
+		mb.metricsCapacity = rm.InstrumentationLibraryMetrics().At(0).Metrics().Len()
+	}
+	if mb.resourceCapacity < rm.Resource().Attributes().Len() {
+		mb.resourceCapacity = rm.Resource().Attributes().Len()
+	}
+}
+
+// ResourceOption applies changes to provided resource.
+type ResourceOption func(pdata.Resource)
+
+// EmitForResource saves all the generated metrics under a new resource and updates the internal state to be ready for
+// recording another set of data points as part of another resource. This function can be helpful when one scraper
+// needs to emit metrics from several resources. Otherwise calling this function is not required,
+// just `Emit` function can be called instead. Resource attributes should be provided as ResourceOption arguments.
+func (mb *MetricsBuilder) EmitForResource(ro ...ResourceOption) {
+	rm := pdata.NewResourceMetrics()
+	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
+	for _, op := range ro {
+		op(rm.Resource())
+	}
+	ils := rm.InstrumentationLibraryMetrics().AppendEmpty()
+	ils.InstrumentationLibrary().SetName("otelcol/redisreceiver")
+	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricRedisClientsBlocked.emit(ils.Metrics())
+	mb.metricRedisClientsConnected.emit(ils.Metrics())
+	mb.metricRedisClientsMaxInputBuffer.emit(ils.Metrics())
+	mb.metricRedisClientsMaxOutputBuffer.emit(ils.Metrics())
+	mb.metricRedisCommands.emit(ils.Metrics())
+	mb.metricRedisCommandsProcessed.emit(ils.Metrics())
+	mb.metricRedisConnectionsReceived.emit(ils.Metrics())
+	mb.metricRedisConnectionsRejected.emit(ils.Metrics())
+	mb.metricRedisCPUTime.emit(ils.Metrics())
+	mb.metricRedisDbAvgTTL.emit(ils.Metrics())
+	mb.metricRedisDbExpires.emit(ils.Metrics())
+	mb.metricRedisDbKeys.emit(ils.Metrics())
+	mb.metricRedisKeysEvicted.emit(ils.Metrics())
+	mb.metricRedisKeysExpired.emit(ils.Metrics())
+	mb.metricRedisKeyspaceHits.emit(ils.Metrics())
+	mb.metricRedisKeyspaceMisses.emit(ils.Metrics())
+	mb.metricRedisLatestFork.emit(ils.Metrics())
+	mb.metricRedisMemoryFragmentationRatio.emit(ils.Metrics())
+	mb.metricRedisMemoryLua.emit(ils.Metrics())
+	mb.metricRedisMemoryPeak.emit(ils.Metrics())
+	mb.metricRedisMemoryRss.emit(ils.Metrics())
+	mb.metricRedisMemoryUsed.emit(ils.Metrics())
+	mb.metricRedisNetInput.emit(ils.Metrics())
+	mb.metricRedisNetOutput.emit(ils.Metrics())
+	mb.metricRedisRdbChangesSinceLastSave.emit(ils.Metrics())
+	mb.metricRedisReplicationBacklogFirstByteOffset.emit(ils.Metrics())
+	mb.metricRedisReplicationOffset.emit(ils.Metrics())
+	mb.metricRedisSlavesConnected.emit(ils.Metrics())
+	mb.metricRedisUptime.emit(ils.Metrics())
+	if ils.Metrics().Len() > 0 {
+		mb.updateCapacity(rm)
+		rm.MoveTo(mb.metricsBuffer.ResourceMetrics().AppendEmpty())
+	}
+}
+
+// Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
+// recording another set of metrics. This function will be responsible for applying all the transformations required to
+// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+func (mb *MetricsBuilder) Emit(ro ...ResourceOption) pdata.Metrics {
+	mb.EmitForResource(ro...)
+	metrics := pdata.NewMetrics()
+	mb.metricsBuffer.MoveTo(metrics)
+	return metrics
 }
 
 // RecordRedisClientsBlockedDataPoint adds a data point to redis.clients.blocked metric.
@@ -1868,16 +1908,6 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 	for _, op := range options {
 		op(mb)
 	}
-}
-
-// NewMetricData creates new pdata.Metrics and sets the InstrumentationLibrary
-// name on the ResourceMetrics.
-func (mb *MetricsBuilder) NewMetricData() pdata.Metrics {
-	md := pdata.NewMetrics()
-	rm := md.ResourceMetrics().AppendEmpty()
-	ilm := rm.InstrumentationLibraryMetrics().AppendEmpty()
-	ilm.InstrumentationLibrary().SetName("otelcol/redisreceiver")
-	return md
 }
 
 // Attributes contains the possible metric attributes that can be used.

--- a/receiver/redisreceiver/redis_scraper.go
+++ b/receiver/redisreceiver/redis_scraper.go
@@ -84,14 +84,10 @@ func (rs *redisScraper) Scrape(context.Context) (pdata.Metrics, error) {
 	}
 	rs.uptime = currentUptime
 
-	md := rs.mb.NewMetricData()
-
 	rs.recordCommonMetrics(now, inf)
 	rs.recordKeyspaceMetrics(now, inf)
 
-	rs.mb.Emit(md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics())
-
-	return md, nil
+	return rs.mb.Emit(), nil
 }
 
 // recordCommonMetrics records metrics from Redis info key-value pairs.

--- a/receiver/zookeeperreceiver/documentation.md
+++ b/receiver/zookeeperreceiver/documentation.md
@@ -33,11 +33,16 @@ metrics:
     enabled: <true|false>
 ```
 
-## Attributes
+## Resource attributes
+
+| Name | Description | Type |
+| ---- | ----------- | ---- |
+| server.state | State of the Zookeeper server (leader, standalone or follower). | String |
+| zk.version | Zookeeper version of the instance. | String |
+
+## Metric attributes
 
 | Name | Description |
 | ---- | ----------- |
 | direction | State of a packet based on io direction. |
-| server.state | State of the Zookeeper server (leader, standalone or follower). |
 | state | State of followers |
-| zk.version | Zookeeper version of the instance. |

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -1,10 +1,14 @@
 name: zookeeperreceiver
 
-attributes:
+resource_attributes:
   server.state:
     description: State of the Zookeeper server (leader, standalone or follower).
+    type: string
   zk.version:
     description: Zookeeper version of the instance.
+    type: string
+
+attributes:
   state:
     description: State of followers
     enum:


### PR DESCRIPTION
This change updates metrics builder to fully control creation of the `pdata.Metrics` object, scraper author don't need to create and pass it to `MetricsBuiler.Emit` function anymore.

This change also moves definition of resource attributes to metadata.yaml which is used to generate attribute helper that can be used in the scraper.

Closes: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8358

Also this is the first PR towards https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7301.

The following items will be resolved as follow-up PRs:
- Add sem ver support in metadata.yaml
- Define resource schema in metadata.yaml and automatically set it up instead of using `wrapBySchemaURLSetterConsumer`