### PR TITLE
[receiver/hostmetrics] Skip a failing test on unsupported systems

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -499,6 +499,8 @@ func getExpectedScrapeFailures(nameError, exeError, timeError, memError, diskErr
 }
 
 func TestScrapeMetrics_MuteProcessNameError(t *testing.T) {
+	skipTestOnUnsupportedOS(t)
+
 	processNameError := errors.New("err1")
 
 	type testCase struct {


### PR DESCRIPTION
Process scraper is only available on Windows and Linux. Most of the tests are skipped on other systems while `TestScrapeMetrics_MuteProcessNameError` is still enabled and failing.