### PR TITLE
Bump load test memory limits

### DIFF
--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -73,7 +73,7 @@ func TestBallastMemory(t *testing.T) {
 		maxRSS      uint32
 	}{
 		{100, 80},
-		{500, 100},
+		{500, 110},
 		{1000, 120},
 	}
 

--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -67,7 +67,7 @@ func TestLog10kDPS(t *testing.T) {
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
 				ExpectedMaxCPU: 30,
-				ExpectedMaxRAM: 100,
+				ExpectedMaxRAM: 105,
 			},
 			extensions: datasenders.NewLocalFileStorageExtension(),
 		},

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -61,7 +61,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 50,
-				ExpectedMaxRAM: 98,
+				ExpectedMaxRAM: 105,
 			},
 		},
 		{

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -70,7 +70,7 @@ func TestMetric10kDPS(t *testing.T) {
 			testbed.NewOTLPHTTPDataReceiver(testbed.GetAvailablePort(t)),
 			testbed.ResourceSpec{
 				ExpectedMaxCPU: 55,
-				ExpectedMaxRAM: 92,
+				ExpectedMaxRAM: 100,
 			},
 		},
 		{


### PR DESCRIPTION
**Description:** Increase memory limits on load tests to accommodate growth, including for #6495

maxRss was last changed in #6691 to fix #6535

ExpectedMaxRAM for OTLP and for filelog checkpoints was last changed in #6134

ExpectedMaxRAM for OTLP-HTTP was last changed in #7925 to resolve #7916

**Link to tracking Issue:** n/a

**Testing:** The changes apply to the load tests invokeable with `make -C testbed run-tests`

**Documentation:** n/a