### PR TITLE
[receiver/awsxrayreceiver] Bugfix - Add defaults for optional stack frame parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
     cpu metrics as a double values.
 - `tanzuobservabilityexporter`: Fix a typo in Instrumentation Library name and version tags (#8384)
 - `logreceivers`: Fix an issue where receiver would sometimes fail to build using Go 1.18 (#8521)
+- `awsxrayreceiver`: Add defaults for optional stack frame parameters (#8790)
 
 ### 🚩 Deprecations 🚩
 

--- a/internal/aws/xray/util.go
+++ b/internal/aws/xray/util.go
@@ -21,3 +21,11 @@ func String(v string) *string {
 	}
 	return &v
 }
+
+// StringOrEmpty returns empty string if the input is nil, otherwise returns the string itself.
+func StringOrEmpty(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}

--- a/internal/aws/xray/util_test.go
+++ b/internal/aws/xray/util_test.go
@@ -36,3 +36,15 @@ func TestUtilWithEmptyString(t *testing.T) {
 
 	assert.Nil(t, res)
 }
+
+func TestStringOrEmptyWithNormalString(t *testing.T) {
+	res := StringOrEmpty(&testString)
+
+	assert.Equal(t, testString, res)
+}
+
+func TestStringOrEmptyWithNil(t *testing.T) {
+	res := StringOrEmpty(nil)
+
+	assert.Equal(t, emptyString, res)
+}

--- a/receiver/awsxrayreceiver/internal/translator/cause.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause.go
@@ -97,14 +97,19 @@ func convertStackFramesToStackTraceStr(excp awsxray.Exception) string {
 	b.WriteString(*excp.Message)
 	b.WriteString("\n")
 	for _, frame := range excp.Stack {
-		line := strconv.Itoa(*frame.Line)
+		label := awsxray.StringOrEmpty(frame.Label)
+		path := awsxray.StringOrEmpty(frame.Path)
+		line := ""
+		if frame.Line != nil {
+			line = strconv.Itoa(*frame.Line)
+		}
 		// the string representation of a frame looks like:
 		// <*frame.Label>(<*frame.Path>):line\n
-		b.Grow(4 + len(*frame.Label) + 2 + len(*frame.Path) + len(": ") + len(line) + len("\n"))
+		b.Grow(4 + len(label) + 2 + len(path) + len(": ") + len(line) + len("\n"))
 		b.WriteString("\tat ")
-		b.WriteString(*frame.Label)
+		b.WriteString(label)
 		b.WriteString("(")
-		b.WriteString(*frame.Path)
+		b.WriteString(path)
 		b.WriteString(": ")
 		b.WriteString(line)
 		b.WriteString(")")

--- a/receiver/awsxrayreceiver/internal/translator/cause.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause.go
@@ -99,7 +99,7 @@ func convertStackFramesToStackTraceStr(excp awsxray.Exception) string {
 	for _, frame := range excp.Stack {
 		label := awsxray.StringOrEmpty(frame.Label)
 		path := awsxray.StringOrEmpty(frame.Path)
-		line := ""
+		line := "<unknown>"
 		if frame.Line != nil {
 			line = strconv.Itoa(*frame.Line)
 		}

--- a/receiver/awsxrayreceiver/internal/translator/cause_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause_test.go
@@ -81,7 +81,7 @@ func TestConvertStackFramesToStackTraceStrNoLine(t *testing.T) {
 		},
 	}
 	actual := convertStackFramesToStackTraceStr(excp)
-	assert.Equal(t, actual, "exceptionType: exceptionMessage\n\tat label0(path0: 10)\n\tat label1(path1: )\n")
+	assert.Equal(t, actual, "exceptionType: exceptionMessage\n\tat label0(path0: 10)\n\tat label1(path1: <unknown>)\n")
 }
 
 func TestConvertStackFramesToStackTraceStrNoLabel(t *testing.T) {

--- a/receiver/awsxrayreceiver/internal/translator/cause_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause_test.go
@@ -43,3 +43,63 @@ func TestConvertStackFramesToStackTraceStr(t *testing.T) {
 	actual := convertStackFramesToStackTraceStr(excp)
 	assert.Equal(t, actual, "exceptionType: exceptionMessage\n\tat label0(path0: 10)\n\tat label1(path1: 11)\n")
 }
+
+func TestConvertStackFramesToStackTraceStrNoPath(t *testing.T) {
+	excp := awsxray.Exception{
+		Type:    awsxray.String("exceptionType"),
+		Message: awsxray.String("exceptionMessage"),
+		Stack: []awsxray.StackFrame{
+			{
+				Path:  awsxray.String("path0"),
+				Line:  aws.Int(10),
+				Label: awsxray.String("label0"),
+			},
+			{
+				Line:  aws.Int(11),
+				Label: awsxray.String("label1"),
+			},
+		},
+	}
+	actual := convertStackFramesToStackTraceStr(excp)
+	assert.Equal(t, actual, "exceptionType: exceptionMessage\n\tat label0(path0: 10)\n\tat label1(: 11)\n")
+}
+
+func TestConvertStackFramesToStackTraceStrNoLine(t *testing.T) {
+	excp := awsxray.Exception{
+		Type:    awsxray.String("exceptionType"),
+		Message: awsxray.String("exceptionMessage"),
+		Stack: []awsxray.StackFrame{
+			{
+				Path:  awsxray.String("path0"),
+				Line:  aws.Int(10),
+				Label: awsxray.String("label0"),
+			},
+			{
+				Path:  awsxray.String("path1"),
+				Label: awsxray.String("label1"),
+			},
+		},
+	}
+	actual := convertStackFramesToStackTraceStr(excp)
+	assert.Equal(t, actual, "exceptionType: exceptionMessage\n\tat label0(path0: 10)\n\tat label1(path1: )\n")
+}
+
+func TestConvertStackFramesToStackTraceStrNoLabel(t *testing.T) {
+	excp := awsxray.Exception{
+		Type:    awsxray.String("exceptionType"),
+		Message: awsxray.String("exceptionMessage"),
+		Stack: []awsxray.StackFrame{
+			{
+				Path:  awsxray.String("path0"),
+				Line:  aws.Int(10),
+				Label: awsxray.String("label0"),
+			},
+			{
+				Path: awsxray.String("path1"),
+				Line: aws.Int(11),
+			},
+		},
+	}
+	actual := convertStackFramesToStackTraceStr(excp)
+	assert.Equal(t, actual, "exceptionType: exceptionMessage\n\tat label0(path0: 10)\n\tat (path1: 11)\n")
+}


### PR DESCRIPTION
**Description:** 
This PR fixes the issue where the receiver would panic while parsing the stackframe if any of the optional parameters are missing. Now before accessing these optional parameter values, they are checked and defaulted to `""` if they are `nil`.
Added a small utility function for this check.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8271

**Testing:** 
Added new unit tests where the optional parameters were omitted. Also added unit tests for the utility function.

**Documentation:** 
NA