### PR TITLE
[receiver/kafkametricsreceiver] do not crash collector on startup when kafka is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `fluentforwardreceiver`: Release port on shutdown (#9111)
 - `prometheusexporter`: Prometheus fails to generate logs when prometheus exporter produced a check exception occurs. (#8949)
 - `resourcedetectionprocessor`: Wire docker detector (#9372)
+- `kafkametricsreceiver`: Do not crash collector if Kafka is unavailable during startup (#8817)
 
 ## v0.49.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - `fluentforwardreceiver`: Release port on shutdown (#9111)
 - `prometheusexporter`: Prometheus fails to generate logs when prometheus exporter produced a check exception occurs. (#8949)
 - `resourcedetectionprocessor`: Wire docker detector (#9372)
-- `kafkametricsreceiver`: Do not crash collector if Kafka is unavailable during startup (#8817)
+- `kafkametricsreceiver`: The kafkametricsreceiver was changed to connect to kafka during scrape, rather than startup. If kafka is unavailable the receiver will attempt to connect during subsequent scrapes until succcessful (#8817).
 
 ## v0.49.0
 

--- a/receiver/kafkametricsreceiver/broker_scraper.go
+++ b/receiver/kafkametricsreceiver/broker_scraper.go
@@ -52,7 +52,7 @@ func (s *brokerScraper) setupClient() error {
 }
 
 func (s *brokerScraper) shutdown(context.Context) error {
-	if !s.client.Closed() {
+	if s.client != nil && !s.client.Closed() {
 		return s.client.Close()
 	}
 	return nil

--- a/receiver/kafkametricsreceiver/broker_scraper_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_test.go
@@ -88,6 +88,18 @@ func TestBrokerScraper_scrape_handles_client_error(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestBrokerScraper_shutdown_handles_nil_client(t *testing.T) {
+	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
+		return nil, fmt.Errorf("new client failed")
+	}
+	sc := sarama.NewConfig()
+	bs, err := createBrokerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NoError(t, err)
+	assert.NotNil(t, bs)
+	err = bs.Shutdown(context.Background())
+	assert.NoError(t, err)
+}
+
 func TestBrokerScraper_scrape(t *testing.T) {
 	client := newMockClient()
 	client.Mock.On("Brokers").Return(testBrokers)

--- a/receiver/kafkametricsreceiver/broker_scraper_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_test.go
@@ -76,7 +76,7 @@ func TestBrokerScraperStart(t *testing.T) {
 	assert.NoError(t, bs.Start(context.Background(), nil))
 }
 
-func TestBrokerScraper_startBrokerScraper_handles_client_error(t *testing.T) {
+func TestBrokerScraper_scrape_handles_client_error(t *testing.T) {
 	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
 		return nil, fmt.Errorf("new client failed")
 	}
@@ -84,7 +84,8 @@ func TestBrokerScraper_startBrokerScraper_handles_client_error(t *testing.T) {
 	bs, err := createBrokerScraper(context.Background(), Config{}, sc, zap.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, bs)
-	assert.Error(t, bs.Start(context.Background(), nil))
+	_, err = bs.Scrape(context.Background())
+	assert.Error(t, err)
 }
 
 func TestBrokerScraper_scrape(t *testing.T) {

--- a/receiver/kafkametricsreceiver/consumer_scraper.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper.go
@@ -65,7 +65,7 @@ func (s *consumerScraper) setupClient() error {
 }
 
 func (s *consumerScraper) shutdown(_ context.Context) error {
-	if !s.client.Closed() {
+	if s.client != nil && !s.client.Closed() {
 		return s.client.Close()
 	}
 	return nil

--- a/receiver/kafkametricsreceiver/consumer_scraper_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_test.go
@@ -65,7 +65,7 @@ func TestConsumerScraper_createConsumerScraper(t *testing.T) {
 	assert.NotNil(t, cs)
 }
 
-func TestConsumerScraper_startScraper_handles_client_error(t *testing.T) {
+func TestConsumerScraper_scrape_handles_client_error(t *testing.T) {
 	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
 		return nil, fmt.Errorf("new client failed")
 	}
@@ -73,11 +73,11 @@ func TestConsumerScraper_startScraper_handles_client_error(t *testing.T) {
 	cs, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, cs)
-	err = cs.Start(context.Background(), nil)
+	_, err = cs.Scrape(context.Background())
 	assert.Error(t, err)
 }
 
-func TestConsumerScraper_startScraper_handles_clusterAdmin_error(t *testing.T) {
+func TestConsumerScraper_scrape_handles_clusterAdmin_error(t *testing.T) {
 	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
 		client := newMockClient()
 		client.Mock.
@@ -91,7 +91,7 @@ func TestConsumerScraper_startScraper_handles_clusterAdmin_error(t *testing.T) {
 	cs, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
 	assert.NoError(t, err)
 	assert.NotNil(t, cs)
-	err = cs.Start(context.Background(), nil)
+	_, err = cs.Scrape(context.Background())
 	assert.Error(t, err)
 }
 

--- a/receiver/kafkametricsreceiver/consumer_scraper_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_test.go
@@ -77,6 +77,18 @@ func TestConsumerScraper_scrape_handles_client_error(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestConsumerScraper_scrape_handles_nil_client(t *testing.T) {
+	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
+		return nil, fmt.Errorf("new client failed")
+	}
+	sc := sarama.NewConfig()
+	cs, err := createConsumerScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NoError(t, err)
+	assert.NotNil(t, cs)
+	err = cs.Shutdown(context.Background())
+	assert.NoError(t, err)
+}
+
 func TestConsumerScraper_scrape_handles_clusterAdmin_error(t *testing.T) {
 	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
 		client := newMockClient()

--- a/receiver/kafkametricsreceiver/topic_scraper.go
+++ b/receiver/kafkametricsreceiver/topic_scraper.go
@@ -55,7 +55,7 @@ func (s *topicScraper) setupClient() error {
 }
 
 func (s *topicScraper) shutdown(context.Context) error {
-	if !s.client.Closed() {
+	if s.client != nil && !s.client.Closed() {
 		return s.client.Close()
 	}
 	return nil

--- a/receiver/kafkametricsreceiver/topic_scraper_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_test.go
@@ -71,7 +71,7 @@ func TestTopicScraper_createsScraper(t *testing.T) {
 	assert.NotNil(t, ms)
 }
 
-func TestTopicScraper_startScraperHandlesError(t *testing.T) {
+func TestTopicScraper_ScrapeHandlesError(t *testing.T) {
 	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
 		return nil, fmt.Errorf("no scraper here")
 	}
@@ -79,7 +79,7 @@ func TestTopicScraper_startScraperHandlesError(t *testing.T) {
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, zap.NewNop())
 	assert.NotNil(t, ms)
 	assert.Nil(t, err)
-	err = ms.Start(context.Background(), nil)
+	_, err = ms.Scrape(context.Background())
 	assert.Error(t, err)
 }
 

--- a/receiver/kafkametricsreceiver/topic_scraper_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_test.go
@@ -83,6 +83,18 @@ func TestTopicScraper_ScrapeHandlesError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestTopicScraper_ShutdownHandlesNilClient(t *testing.T) {
+	newSaramaClient = func(addrs []string, conf *sarama.Config) (sarama.Client, error) {
+		return nil, fmt.Errorf("no scraper here")
+	}
+	sc := sarama.NewConfig()
+	ms, err := createTopicsScraper(context.Background(), Config{}, sc, zap.NewNop())
+	assert.NotNil(t, ms)
+	assert.Nil(t, err)
+	err = ms.Shutdown(context.Background())
+	assert.NoError(t, err)
+}
+
 func TestTopicScraper_startScraperCreatesClient(t *testing.T) {
 	newSaramaClient = mockNewSaramaClient
 	sc := sarama.NewConfig()


### PR DESCRIPTION
**Description:** 
This PR updates the kafkametricsreceiver so that it will not crash the collector during start if kafka is not available. It pushes the sarama client setup into the `Scrape` method. If kafka is unavailable the `Scrape` will return an error and try to setup the client during subsequent scrapes until it is successful. This is part of a larger discussion (#8816) on how scrape based receivers should behave when the service they monitor is not available. I'm open to any and all suggestions how this should be handled, and hope to use this as a starting point to come up with best practices that can be applied to other scrape based receivers.

**Link to tracking Issue:** <Issue number if applicable>
#8816, #8349 

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests were updated for the changed behavior. I also did an end to test where I started the collector without a running kafka service. The collector starts and logs errors when the kafkametricsreceiver fails to scrape. I verified that when I start kafka, the receiver successfully connects and starts producing metrics. See the abbreviated log output below:

```
2022-03-23T11:27:09.410-0700	info	builder/receivers_builder.go:68	Receiver is starting...	{"kind": "receiver", "name": "kafkametrics"}
2022-03-23T11:27:09.410-0700	info	zapgrpc/zapgrpc.go:174	[core] Subchannel picks a new address "ingest.staging.lightstep.com:443" to connect	{"grpc_log": true}
2022-03-23T11:27:09.410-0700	info	builder/receivers_builder.go:73	Receiver started.	{"kind": "receiver", "name": "kafkametrics"}

...

2022-03-23T11:32:11.731-0700	error	scraperhelper/scrapercontroller.go:198	Error scraping metrics	{"kind": "receiver", "name": "kafkametrics", "error": "failed to create client in consumer scraper: kafka: client has run out of available brokers to talk to (Is your cluster reachable?)", "scraper": "consumers"}
go.opentelemetry.io/collector/receiver/scraperhelper.(*controller).scrapeMetricsAndReport
	go.opentelemetry.io/collector@v0.47.1-0.20220321233732-3cec6d3d98d9/receiver/scraperhelper/scrapercontroller.go:198
go.opentelemetry.io/collector/receiver/scraperhelper.(*controller).startScraping.func1
	go.opentelemetry.io/collector@v0.47.1-0.20220321233732-3cec6d3d98d9/receiver/scraperhelper/scrapercontroller.go:173

...

2022-03-23T11:33:09.617-0700	DEBUG	loggingexporter/logging_exporter.go:64	ResourceMetrics #0
Resource SchemaURL:
InstrumentationLibraryMetrics #0
InstrumentationLibraryMetrics SchemaURL:
InstrumentationLibrary otelcol/kafkametrics
Metric #0
Descriptor:
     -> Name: kafka.brokers
     -> Description:
     -> Unit:
     -> DataType: Gauge
NumberDataPoints #0
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2022-03-23 18:33:09.436189 +0000 UTC
Value: 1
ResourceMetrics #1
Resource SchemaURL:
InstrumentationLibraryMetrics #0
InstrumentationLibraryMetrics SchemaURL:
InstrumentationLibrary otelcol/kafkametrics
```
