### PR TITLE
[exporter/datadog] Deprecate `GetCensoredKey` method, unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🚩 Deprecations 🚩
 
 - `datadogexporter`: Deprecate `OnlyMetadata` method from `Config` struct (#8359)
+- `datadogexporter`: Deprecate `GetCensoredKey` method from `APIConfig` struct (#8830)
 
 ## v0.47.0
 

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -60,7 +60,8 @@ type APIConfig struct {
 	Site string `mapstructure:"site"`
 }
 
-// GetCensoredKey returns the API key censored for logging purposes
+// GetCensoredKey returns the API key censored for logging purposes.
+// Deprecated: [v0.48.0] Will be removed in v0.49.0.
 func (api *APIConfig) GetCensoredKey() string {
 	if len(api.Key) <= 5 {
 		return api.Key


### PR DESCRIPTION
**Description:** 

Deprecate `GetCensoredKey` method, unused.

**Link to tracking Issue:** #8373
