### PR TITLE
remove LogRecord.name references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@
 ### 🛑 Breaking changes 🛑
 
 - `windowsperfcountersreceiver`: Added metrics configuration (#8376)
+- `lokiexporter`: Remove deprecated LogRecord.name field ()
+- `splunkhecexporter`: Remove deprecated LogRecord.name field ()
 
 ### 🚩 Deprecations 🚩
 
 - `datadogexporter`: Deprecate `OnlyMetadata` method from `Config` struct (#8359)
 - `datadogexporter`: Deprecate `GetCensoredKey` method from `APIConfig` struct (#8830)
-
 - `resourcedetectionprocessor`: Add attribute allowlist (#8547)
 
 ### 💡 Enhancements 💡

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 ### 🛑 Breaking changes 🛑
 
 - `windowsperfcountersreceiver`: Added metrics configuration (#8376)
-- `lokiexporter`: Remove deprecated LogRecord.name field ()
-- `splunkhecexporter`: Remove deprecated LogRecord.name field ()
+- `lokiexporter`: Remove deprecated LogRecord.name field (#8951)
+- `splunkhecexporter`: Remove deprecated LogRecord.name field (#8951)
 
 ### 🚩 Deprecations 🚩
 

--- a/exporter/lokiexporter/encode_json.go
+++ b/exporter/lokiexporter/encode_json.go
@@ -78,7 +78,6 @@ func encodeJSON(lr pdata.LogRecord, res pdata.Resource) (string, error) {
 		return "", err
 	}
 	logRecord = lokiEntry{
-		Name:       lr.Name(),
 		Body:       body,
 		TraceID:    lr.TraceID().HexString(),
 		SpanID:     lr.SpanID().HexString(),

--- a/exporter/splunkhecexporter/logdata_to_splunk.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk.go
@@ -41,12 +41,8 @@ func mapLogRecordToSplunkEvent(res pdata.Resource, lr pdata.LogRecord, config *C
 	sourceTypeKey := config.HecToOtelAttrs.SourceType
 	indexKey := config.HecToOtelAttrs.Index
 	hostKey := config.HecToOtelAttrs.Host
-	nameKey := config.HecFields.Name
 	severityTextKey := config.HecFields.SeverityText
 	severityNumberKey := config.HecFields.SeverityNumber
-	if lr.Name() != "" {
-		fields[nameKey] = lr.Name()
-	}
 	if spanID := lr.SpanID().HexString(); spanID != "" {
 		fields[spanIDFieldKey] = spanID
 	}

--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -64,7 +64,6 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 			name: "with_name",
 			logRecordFn: func() pdata.LogRecord {
 				logRecord := pdata.NewLogRecord()
-				logRecord.SetName("my very own name")
 				logRecord.Body().SetStringVal("mylog")
 				logRecord.Attributes().InsertString(splunk.DefaultSourceLabel, "myapp")
 				logRecord.Attributes().InsertString(splunk.DefaultSourceTypeLabel, "myapp-type")
@@ -81,7 +80,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				return config
 			},
 			wantSplunkEvents: []*splunk.Event{
-				commonLogSplunkEvent("mylog", ts, map[string]interface{}{"custom": "custom", "otel.log.name": "my very own name"},
+				commonLogSplunkEvent("mylog", ts, map[string]interface{}{"custom": "custom"},
 					"myhost", "myapp", "myapp-type"),
 			},
 		},

--- a/internal/coreinternal/processor/filterlog/filterlog.go
+++ b/internal/coreinternal/processor/filterlog/filterlog.go
@@ -77,9 +77,5 @@ func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 // supported to have more than one of these specified, and all specified must
 // evaluate to true for a match to occur.
 func (mp *propertiesMatcher) MatchLogRecord(lr pdata.LogRecord, resource pdata.Resource, library pdata.InstrumentationLibrary) bool {
-	if mp.nameFilters != nil && !mp.nameFilters.Matches(lr.Name()) {
-		return false
-	}
-
 	return mp.PropertiesMatcher.Match(lr.Attributes(), resource, library)
 }

--- a/testbed/datasenders/syslog.go
+++ b/testbed/datasenders/syslog.go
@@ -108,7 +108,7 @@ func (f *SyslogWriter) Send(lr pdata.LogRecord) error {
 		sdid.WriteString(fmt.Sprintf("%s=\"%s\" ", k, v.StringVal()))
 		return true
 	})
-	msg := fmt.Sprintf("<166> %s localhost %s - - [%s] %s\n", ts, lr.Name(), sdid.String(), lr.Body().StringVal())
+	msg := fmt.Sprintf("<166> %s localhost - - - [%s] %s\n", ts, sdid.String(), lr.Body().StringVal())
 
 	f.buf = append(f.buf, msg)
 	return f.SendCheck()

--- a/testbed/datasenders/tcpudp.go
+++ b/testbed/datasenders/tcpudp.go
@@ -106,7 +106,7 @@ func (f *TCPUDPWriter) Send(lr pdata.LogRecord) error {
 		sdid.WriteString(fmt.Sprintf("%s=\"%s\" ", k, v.StringVal()))
 		return true
 	})
-	msg := fmt.Sprintf("<166> %s localhost %s - - [%s] %s\n", ts, lr.Name(), sdid.String(), lr.Body().StringVal())
+	msg := fmt.Sprintf("<166> %s localhost - - - [%s] %s\n", ts, sdid.String(), lr.Body().StringVal())
 
 	f.buf = append(f.buf, msg)
 	return f.SendCheck()


### PR DESCRIPTION
The name field is deprecated. Removing references to it.