### PR TITLE
[exporter/dynatrace] Downgrade error logs to warn to remove stacktrace in prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🧰 Bug fixes 🧰
 
 - `hostmetricsreceiver`: Use cpu times for time delta in cpu.utilization calculation (#8856)
+- `dynatraceexporter`: Remove overly verbose stacktrace from certain logs (#8989)
 
 ### 🚩 Deprecations 🚩
 

--- a/exporter/dynatraceexporter/metrics_exporter.go
+++ b/exporter/dynatraceexporter/metrics_exporter.go
@@ -135,11 +135,10 @@ func (e *exporter) serializeMetrics(md pdata.Metrics) []string {
 				metricLines, err := serialization.SerializeMetric(e.settings.Logger, e.cfg.Prefix, metric, e.defaultDimensions, e.staticDimensions, e.prevPts)
 
 				if err != nil {
-					e.settings.Logger.Sugar().Errorw(
-						"failed to serialize",
+					e.settings.Logger.Sugar().Warnw("failed to serialize",
 						"datatype", metric.DataType().String(),
 						"name", metric.Name(),
-						zap.Error(err),
+						"error", err,
 					)
 				}
 
@@ -232,7 +231,7 @@ func (e *exporter) sendBatch(ctx context.Context, lines []string) error {
 			return nil
 		}
 
-		e.settings.Logger.Sugar().Errorw("Response from Dynatrace",
+		e.settings.Logger.Sugar().Warnw("Response from Dynatrace",
 			"accepted-lines", responseBody.Ok,
 			"rejected-lines", responseBody.Invalid,
 			"error-message", responseBody.Error.Message,


### PR DESCRIPTION
Using zap `SugaredLogger.Errorw` automatically includes stacktrace data which was overly verbose and unhelpful.