### PR TITLE
refactor(routingprocessor): use MoveTo instead of CopyTo

### DIFF
--- a/processor/routingprocessor/router.go
+++ b/processor/routingprocessor/router.go
@@ -95,10 +95,10 @@ func (r *router) routeMetricsForResource(_ context.Context, tm pdata.Metrics) []
 		}
 
 		if rEntry, ok := routingMap[attrValue]; ok {
-			resMetrics.CopyTo(rEntry.resMetrics.AppendEmpty())
+			resMetrics.MoveTo(rEntry.resMetrics.AppendEmpty())
 		} else {
 			new := pdata.NewResourceMetricsSlice()
-			resMetrics.CopyTo(new.AppendEmpty())
+			resMetrics.MoveTo(new.AppendEmpty())
 
 			routingMap[attrValue] = routingEntry{
 				exporters:  exp,
@@ -181,10 +181,10 @@ func (r *router) routeTracesForResource(_ context.Context, tr pdata.Traces) []ro
 		}
 
 		if rEntry, ok := routingMap[attrValue]; ok {
-			resSpans.CopyTo(rEntry.resSpans.AppendEmpty())
+			resSpans.MoveTo(rEntry.resSpans.AppendEmpty())
 		} else {
 			new := pdata.NewResourceSpansSlice()
-			resSpans.CopyTo(new.AppendEmpty())
+			resSpans.MoveTo(new.AppendEmpty())
 
 			routingMap[attrValue] = routingEntry{
 				exporters: exp,
@@ -267,10 +267,10 @@ func (r *router) routeLogsForResource(_ context.Context, tl pdata.Logs) []routed
 		}
 
 		if rEntry, ok := routingMap[attrValue]; ok {
-			resLogs.CopyTo(rEntry.resLogs.AppendEmpty())
+			resLogs.MoveTo(rEntry.resLogs.AppendEmpty())
 		} else {
 			new := pdata.NewResourceLogsSlice()
-			resLogs.CopyTo(new.AppendEmpty())
+			resLogs.MoveTo(new.AppendEmpty())
 
 			routingMap[attrValue] = routingEntry{
 				exporters: exp,


### PR DESCRIPTION
**Description:** use MoveTo instead of CopyTo

**Link to tracking Issue:** N/A

**Testing:** existing UTs

**Documentation:** 

```
$ go test -v -count 1 -run ^$ -bench Benchmark -benchmem -count 1 .
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark_MetricsRouting_ResourceAttribute
Benchmark_MetricsRouting_ResourceAttribute-16            1463461               813.2 ns/op           688 B/op         16 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor    2.432s
$ go test -v -count 1 -run ^$ -bench Benchmark -benchmem -count 1 .
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
Benchmark_MetricsRouting_ResourceAttribute
Benchmark_MetricsRouting_ResourceAttribute-16            1694242               702.0 ns/op           592 B/op         15 allocs/op
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor    2.328s
```