### PR TITLE
[OIDC Extension] Rename default value for `Attribute` to Authorization from authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🧰 Bug fixes 🧰
 
 - `hostmetricsreceiver`: Use cpu times for time delta in cpu.utilization calculation (#8856)
-
+- `oidcauthextension`: Renamed default value of `Attribute` configuration parameter to `Authorization` from `authorization` (#8994)
 ### 🚩 Deprecations 🚩
 
 - `datadogexporter`: Deprecate `service` setting in favor of `service.name` semantic convention (#8784)

--- a/extension/oidcauthextension/config.go
+++ b/extension/oidcauthextension/config.go
@@ -20,7 +20,7 @@ import "go.opentelemetry.io/collector/config"
 type Config struct {
 	config.ExtensionSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 
-	// The attribute (header name) to look for auth data. Optional, default value: "authorization".
+	// The attribute (header name) to look for auth data. Optional, default value: "Authorization".
 	Attribute string `mapstructure:"attribute"`
 
 	// IssuerURL is the base URL for the OIDC provider.

--- a/extension/oidcauthextension/extension_test.go
+++ b/extension/oidcauthextension/extension_test.go
@@ -66,7 +66,7 @@ func TestOIDCAuthenticationSucceeded(t *testing.T) {
 	require.NoError(t, err)
 
 	// test
-	ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
+	ctx, err := p.Authenticate(context.Background(), map[string][]string{"Authorization": {fmt.Sprintf("Bearer %s", token)}})
 
 	// verify
 	assert.NoError(t, err)
@@ -207,7 +207,7 @@ func TestOIDCInvalidAuthHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	// test
-	ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {"some-value"}})
+	ctx, err := p.Authenticate(context.Background(), map[string][]string{"Authorization": {"some-value"}})
 
 	// verify
 	assert.Equal(t, errInvalidAuthenticationHeaderFormat, err)
@@ -262,7 +262,7 @@ func TestFailedToVerifyToken(t *testing.T) {
 	require.NoError(t, err)
 
 	// test
-	ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {"Bearer some-token"}})
+	ctx, err := p.Authenticate(context.Background(), map[string][]string{"Authorization": {"Bearer some-token"}})
 
 	// verify
 	assert.Error(t, err)
@@ -326,7 +326,7 @@ func TestFailedToGetGroupsClaimFromToken(t *testing.T) {
 			require.NoError(t, err)
 
 			// test
-			ctx, err := p.Authenticate(context.Background(), map[string][]string{"authorization": {fmt.Sprintf("Bearer %s", token)}})
+			ctx, err := p.Authenticate(context.Background(), map[string][]string{"Authorization": {fmt.Sprintf("Bearer %s", token)}})
 
 			// verify
 			assert.ErrorIs(t, err, tt.expectedError)

--- a/extension/oidcauthextension/factory.go
+++ b/extension/oidcauthextension/factory.go
@@ -25,7 +25,7 @@ const (
 	// The value of extension "type" in configuration.
 	typeStr = "oidc"
 
-	defaultAttribute = "authorization"
+	defaultAttribute = "Authorization"
 )
 
 // NewFactory creates a factory for the OIDC Authenticator extension.


### PR DESCRIPTION
**Description:** 

The client libraries (OAuth2) usually set the authorization tokens as "Authorization: <>".  Currently, by default OIDC extension looks for "authorization" header key. 

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector/issues/4982 and #8994 

**Testing:** Unit tests and [E2E test as described here ](https://github.com/open-telemetry/opentelemetry-collector/issues/4982#issuecomment-1084098240)

**Documentation:** Changed the comments 

cc: @jpkrohling 