### PR TITLE
[extension/filestorage] Change bbolt DB settings for improved performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `cmd/mdatagen`: Add resource attributes definition to metadata.yaml and move `pdata.Metrics` creation to the
   generated code (#5270) 
 - Add `make crosslink` target to ensure replace statements are included in `go.mod` for all transitive dependencies within repository (#8822)
+- `filestorageextension`: Change bbolt DB settings for better performance (#9004)
 
 ### 🛑 Breaking changes 🛑
 

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -33,8 +33,10 @@ type fileStorageClient struct {
 
 func newClient(filePath string, timeout time.Duration) (*fileStorageClient, error) {
 	options := &bbolt.Options{
-		Timeout: timeout,
-		NoSync:  true,
+		Timeout:        timeout,
+		NoSync:         true,
+		NoFreelistSync: true,
+		FreelistType:   bbolt.FreelistMapType,
 	}
 	db, err := bbolt.Open(filePath, 0600, options)
 	if err != nil {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Disable freelist syncing and switch to a freelist type that's more performant on larger DBs. See issue for a more detailed description.

**Link to tracking Issue:** Closes #9003 

**Testing:**
Added two additional benchmarks for larger DBs. I've also manually verified that the changes are backwards-compatible.