### PR TITLE
[exporter/prometheusremotewrite]: new context for WAL process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - `hostmetricsreceiver`: Use cpu times for time delta in cpu.utilization calculation (#8856)
 - `dynatraceexporter`: Remove overly verbose stacktrace from certain logs (#8989)
+- `prometheusremotewriteexporter`: Do not re-use Start() context for long-running processes. (#TBD)
 
 ### 🚩 Deprecations 🚩
 

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -99,7 +99,7 @@ func (prwe *prwExporter) Start(ctx context.Context, host component.Host) (err er
 	if err != nil {
 		return err
 	}
-	return prwe.turnOnWALIfEnabled(contextWithLogger(ctx, prwe.settings.Logger.Named("prw.wal")))
+	return prwe.turnOnWALIfEnabled(contextWithLogger(context.Background(), prwe.settings.Logger.Named("prw.wal")))
 }
 
 func (prwe *prwExporter) shutdownWALIfEnabled() error {


### PR DESCRIPTION
**Description:** Ensure that the WAL handling process has a distinct context as the context passed to `Start()` may be cancelled before the process should end.