### PR TITLE
[exporter/datadog] Deprecate `env` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - `datadogexporter`: Deprecate `service` setting in favor of `service.name` semantic convention (#8784)
 - `datadogexporter`: Deprecate `version` setting in favor of `service.version` semantic convention (#8784)
+- `datadogexporter`: Deprecate `env` setting in favor of `deployment.environment` semantic convention (#9017)
 - `datadogexporter`: Deprecate `GetHostTags` method from `TagsConfig` struct (#8975)
 
 ### 🚀 New components 🚀

--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -68,7 +68,6 @@ processors:
 exporters:
   datadog/api:
     hostname: customhostname
-    env: prod
 
     tags:
       - example:tag

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -207,7 +207,7 @@ type TagsConfig struct {
 	Hostname string `mapstructure:"hostname"`
 
 	// Env is the environment for unified service tagging.
-	// Deprecated: [v0.49.0] Set `deployment.environment` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8783 for details.
+	// Deprecated: [v0.49.0] Set `deployment.environment` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9016 for details.
 	// This option will be removed in v0.52.0.
 	// It can also be set through the `DD_ENV` environment variable (Deprecated: [v0.47.0] set environment variable explicitly on configuration instead).
 	Env string `mapstructure:"env"`

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -207,6 +207,8 @@ type TagsConfig struct {
 	Hostname string `mapstructure:"hostname"`
 
 	// Env is the environment for unified service tagging.
+	// Deprecated: [v0.49.0] Set `deployment.environment` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/TODO for details.
+	// This option will be removed in v0.52.0.
 	// It can also be set through the `DD_ENV` environment variable (Deprecated: [v0.47.0] set environment variable explicitly on configuration instead).
 	Env string `mapstructure:"env"`
 
@@ -405,6 +407,9 @@ func (c *Config) Unmarshal(configMap *config.Map) error {
 	}
 	if c.Version != "" {
 		c.warnings = append(c.warnings, fmt.Errorf(deprecationTemplate, "version", "v0.52.0", 8783))
+	}
+	if c.Env != "" {
+		c.warnings = append(c.warnings, fmt.Errorf(deprecationTemplate, "env", "v0.52.0", 9016))
 	}
 
 	return nil

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -207,7 +207,7 @@ type TagsConfig struct {
 	Hostname string `mapstructure:"hostname"`
 
 	// Env is the environment for unified service tagging.
-	// Deprecated: [v0.49.0] Set `deployment.environment` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/TODO for details.
+	// Deprecated: [v0.49.0] Set `deployment.environment` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8783 for details.
 	// This option will be removed in v0.52.0.
 	// It can also be set through the `DD_ENV` environment variable (Deprecated: [v0.47.0] set environment variable explicitly on configuration instead).
 	Env string `mapstructure:"env"`

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -15,22 +15,24 @@ exporters:
 
     ## @param env - string - optional
     ## The environment for unified service tagging.
+    ## Deprecated: [v0.49.0] Set `deployment.environment` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8783 for details.
+    ## This option will be removed in v0.52.0.
     ## If unset it will be determined from the `DD_ENV` environment variable (Deprecated: [v0.47.0] set environment variable explicitly on configuration instead).
     #
     # env: prod
 
     ## @param service - string - optional
     ## The service for unified service tagging.
-    ## Deprecated: [v0.48.0] Set `service.name` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8781 for details.
-    ## This option will be removed in v0.51.0.
+    ## Deprecated: [v0.49.0] Set `service.name` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8781 for details.
+    ## This option will be removed in v0.52.0.
     ## If unset it will be determined from the `DD_SERVICE` environment variable (Deprecated: [v0.47.0] set environment variable explicitly on configuration instead).
     #
     # service: myservice
 
     ## @param version - string - optional
     ## The version for unified service tagging.
-    ## Deprecated: [v0.48.0] Set `service.version` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8783 for details.
-    ## This option will be removed in v0.51.0.
+    ## Deprecated: [v0.49.0] Set `service.version` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8783 for details.
+    ## This option will be removed in v0.52.0.
     ## If unset it will be determined from the `DD_VERSION` environment variable (Deprecated: [v0.47.0] set environment variable explicitly on configuration instead).
     #
     # version: myversion

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -15,7 +15,7 @@ exporters:
 
     ## @param env - string - optional
     ## The environment for unified service tagging.
-    ## Deprecated: [v0.49.0] Set `deployment.environment` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8783 for details.
+    ## Deprecated: [v0.49.0] Set `deployment.environment` semconv instead, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9016 for details.
     ## This option will be removed in v0.52.0.
     ## If unset it will be determined from the `DD_ENV` environment variable (Deprecated: [v0.47.0] set environment variable explicitly on configuration instead).
     #

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -233,7 +233,6 @@ func TestLoadConfig(t *testing.T) {
 func TestLoadConfigEnvVariables(t *testing.T) {
 	assert.NoError(t, os.Setenv("DD_API_KEY", "replacedapikey"))
 	assert.NoError(t, os.Setenv("DD_HOST", "testhost"))
-	assert.NoError(t, os.Setenv("DD_ENV", "testenv"))
 	assert.NoError(t, os.Setenv("DD_SITE", "datadoghq.test"))
 	assert.NoError(t, os.Setenv("DD_TAGS", "envexample:tag envexample2:tag"))
 	assert.NoError(t, os.Setenv("DD_URL", "https://api.datadoghq.com"))
@@ -242,7 +241,6 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.Unsetenv("DD_API_KEY"))
 		assert.NoError(t, os.Unsetenv("DD_HOST"))
-		assert.NoError(t, os.Unsetenv("DD_ENV"))
 		assert.NoError(t, os.Unsetenv("DD_SITE"))
 		assert.NoError(t, os.Unsetenv("DD_TAGS"))
 		assert.NoError(t, os.Unsetenv("DD_URL"))
@@ -270,7 +268,7 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 	assert.Equal(t, exporterhelper.NewDefaultQueueSettings(), apiConfig.QueueSettings)
 	assert.Equal(t, ddconfig.TagsConfig{
 		Hostname:   "customhostname",
-		Env:        "prod",
+		Env:        "none",
 		EnvVarTags: "envexample:tag envexample2:tag",
 		Tags:       []string{"example:tag"},
 	}, apiConfig.TagsConfig)
@@ -317,7 +315,7 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 	assert.Equal(t, exporterhelper.NewDefaultQueueSettings(), defaultConfig.QueueSettings)
 	assert.Equal(t, ddconfig.TagsConfig{
 		Hostname:   "testhost",
-		Env:        "testenv",
+		Env:        "none",
 		EnvVarTags: "envexample:tag envexample2:tag",
 	}, defaultConfig.TagsConfig)
 	assert.Equal(t, ddconfig.APIConfig{

--- a/exporter/datadogexporter/testdata/config.yaml
+++ b/exporter/datadogexporter/testdata/config.yaml
@@ -7,6 +7,7 @@ processors:
 exporters:
   datadog/api:
     hostname: customhostname
+    # Deprecated; kept here to avoid regressions.
     env: prod
     # Deprecated; kept here to avoid regressions.
     service: myservice
@@ -25,8 +26,6 @@ exporters:
 
   datadog/api2:
     hostname: customhostname
-    env: prod
-
     tags:
       - example:tag
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Deprecate `env` setting in favor of `deployment.environment`.

**Link to tracking Issue:** #9016

**Testing:** Tested that a deprecation warning is logged when using this setting.

**Documentation:** Removed usage of `env` from examples.