### PR TITLE
Bump RAM limit on MetricsFromFile test

### DIFF
--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -135,7 +135,7 @@ func TestMetricsFromFile(t *testing.T) {
 		agentProc,
 		&testbed.PerfTestValidator{},
 		performanceResultsSummary,
-		testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 120, ExpectedMaxRAM: 94}),
+		testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxCPU: 120, ExpectedMaxRAM: 110}),
 	)
 	defer tc.Stop()
 


### PR DESCRIPTION
Resolves #9020 

Proposed limit of `110` is derived from the +15% over observed max, as mentioned in #6134.