### PR TITLE
[extension/fluentbit] mark extension as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - `datadogexporter`: Deprecate `service` setting in favor of `service.name` semantic convention (#8784)
 - `datadogexporter`: Deprecate `version` setting in favor of `service.version` semantic convention (#8784)
 - `datadogexporter`: Deprecate `GetHostTags` method from `TagsConfig` struct (#8975)
-- `fluentbitextension`: Deprecate Fluentbit extension ()
+- `fluentbitextension`: Deprecate Fluentbit extension (#9062)
 
 ### 🚀 New components 🚀
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `datadogexporter`: Deprecate `service` setting in favor of `service.name` semantic convention (#8784)
 - `datadogexporter`: Deprecate `version` setting in favor of `service.version` semantic convention (#8784)
 - `datadogexporter`: Deprecate `GetHostTags` method from `TagsConfig` struct (#8975)
+- `fluentbitextension`: Deprecate Fluentbit extension ()
 
 ### 🚀 New components 🚀
 

--- a/extension/fluentbitextension/README.md
+++ b/extension/fluentbitextension/README.md
@@ -1,4 +1,7 @@
-# FluentBit Subprocess Extension
+# Deprecated FluentBit Subprocess Extension
+
+This extension has been deprecated due to security concerns around the ability to specify the execution of
+any arbitrary processes via its configuration. See [#6721](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6721) for additional details.
 
 **This extension is experimental and may receive breaking changes or be removed
 at any time.**

--- a/extension/fluentbitextension/factory.go
+++ b/extension/fluentbitextension/factory.go
@@ -16,15 +16,19 @@ package fluentbitextension // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"context"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.uber.org/zap"
 )
 
 const (
 	// The value of extension "type" in configuration.
 	typeStr = "fluentbit"
 )
+
+var once sync.Once
 
 // NewFactory creates a factory for FluentBit extension.
 func NewFactory() component.ExtensionFactory {
@@ -40,7 +44,14 @@ func createDefaultConfig() config.Extension {
 	}
 }
 
+func logDeprecation(logger *zap.Logger) {
+	once.Do(func() {
+		logger.Warn("fluentbit extension is deprecated and will be removed in future versions.")
+	})
+}
+
 func createExtension(_ context.Context, params component.ExtensionCreateSettings, cfg config.Extension) (component.Extension, error) {
+	logDeprecation(params.Logger)
 	config := cfg.(*Config)
 	return newProcessManager(config, params.Logger), nil
 }


### PR DESCRIPTION
After many discussions it seems the community is leaning towards removing the components that execute subprocesses. As such, marking the fluentbit exception as deprecated.

Related https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6721

If folks are ok with this path moving forward, I can follow this up with a PR to remove the component from the manifest in the releases repository in the next version.