### PR TITLE
[receiver/jmx] mark receiver as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - `datadogexporter`: Deprecate `service` setting in favor of `service.name` semantic convention (#8784)
 - `datadogexporter`: Deprecate `version` setting in favor of `service.version` semantic convention (#8784)
 - `datadogexporter`: Deprecate `GetHostTags` method from `TagsConfig` struct (#8975)
-- `jmxreceiver`: Deprecate JMX receiver ()
+- `jmxreceiver`: Deprecate JMX receiver (#9063)
 
 ### 🚀 New components 🚀
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `datadogexporter`: Deprecate `service` setting in favor of `service.name` semantic convention (#8784)
 - `datadogexporter`: Deprecate `version` setting in favor of `service.version` semantic convention (#8784)
 - `datadogexporter`: Deprecate `GetHostTags` method from `TagsConfig` struct (#8975)
+- `jmxreceiver`: Deprecate JMX receiver ()
 
 ### 🚀 New components 🚀
 

--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -1,5 +1,8 @@
 # Deprecated JMX Receiver
 
+This receiver has been deprecated due to security concerns around the ability to specify the execution of
+any arbitrary processes via its configuration. See [#6750](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6750) for additional details.
+
 ### Overview
 
 The JMX Receiver will work in conjunction with the [OpenTelemetry JMX Metric Gatherer](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/README.md)

--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -1,4 +1,4 @@
-# JMX Receiver
+# Deprecated JMX Receiver
 
 ### Overview
 

--- a/receiver/jmxreceiver/factory.go
+++ b/receiver/jmxreceiver/factory.go
@@ -16,18 +16,22 @@ package jmxreceiver // import "github.com/open-telemetry/opentelemetry-collector
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.uber.org/zap"
 )
 
 const (
 	typeStr      = "jmx"
 	otlpEndpoint = "0.0.0.0:0"
 )
+
+var once sync.Once
 
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
@@ -51,12 +55,19 @@ func createDefaultConfig() config.Receiver {
 	}
 }
 
+func logDeprecation(logger *zap.Logger) {
+	once.Do(func() {
+		logger.Warn("jmx receiver is deprecated and will be removed in future versions.")
+	})
+}
+
 func createReceiver(
 	_ context.Context,
 	params component.ReceiverCreateSettings,
 	cfg config.Receiver,
 	consumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
+	logDeprecation(params.Logger)
 	jmxConfig := cfg.(*Config)
 	if err := jmxConfig.validate(); err != nil {
 		return nil, err


### PR DESCRIPTION
After many discussions it seems the community is leaning towards removing the components that execute subprocesses. As such, marking the JMX receiver as deprecated.

Related: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6750

If folks are ok with this path moving forward, I can follow this up with a PR to remove the component from the manifest in the releases repository in the next version.