### PR TITLE
[exporter/splunkhec] Add an option to disable log or profiling data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `prometheusremotewriteexporter`: Translate resource attributes to the target info metric (#8493)
 - `podmanreceiver`: Add API timeout configuration option (#9014)
 - `cmd/mdatagen`: Add `sem_conv_version` field to metadata.yaml that is used to set metrics SchemaURL (#9010)
+- `splunkheceporter`: Add an option to disable log or profiling data (#9065)
 
 ### 🛑 Breaking changes 🛑
 

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -28,7 +28,11 @@ The following configuration options can also be configured:
 - `max_content_length_logs` (default: 2097152): Maximum log data size in bytes per HTTP post limited to 2097152 bytes (2 MiB).
 - `max_content_length_metrics` (default: 2097152): Maximum metric data size in bytes per HTTP post limited to 2097152 bytes (2 MiB).
 - `splunk_app_name` (default: "OpenTelemetry Collector Contrib") App name is used to track telemetry information for Splunk App's using HEC by App name.
-- `splunk_app_version` (default: Current OpenTelemetry Collector Contrib Build Version): App version is used to track telemetry information for Splunk App's using HEC by App version.
+- `splunk_app_version` (default: Current OpenTelemetry Collector Contrib Build Version): App version is used to track telemetry information for Splunk App's using HEC by App version. 
+- `log_data_enabled` (default: true): Specifies whether the log data is exported. Set it to `false` if you want the log 
+  data to be dropped instead. Applicable in the `logs` pipeline only.
+- `profiling_data_enabled` (default: true): Specifies whether the profiling data is exported. Set it to `false` if 
+  you want the profiling data to be dropped instead. Applicable in the `logs` pipeline only.
 - `hec_metadata_to_otel_attrs/source` (default = 'com.splunk.source'): Specifies the mapping of a specific unified model attribute value to the standard source field of a HEC event.
 - `hec_metadata_to_otel_attrs/sourcetype` (default = 'com.splunk.sourcetype'): Specifies the mapping of a specific unified model attribute value to the standard sourcetype field of a HEC event.
 - `hec_metadata_to_otel_attrs/index` (default = 'com.splunk.index'):  Specifies the mapping of a specific unified model attribute value to the standard index field of a HEC event.

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -52,6 +52,12 @@ type Config struct {
 	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
 
+	// LogDataEnabled can be used to disable sending logs by the exporter.
+	LogDataEnabled bool `mapstructure:"log_data_enabled"`
+
+	// ProfilingDataEnabled can be used to disable sending profiling data by the exporter.
+	ProfilingDataEnabled bool `mapstructure:"profiling_data_enabled"`
+
 	// HEC Token is the authentication token provided by Splunk: https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector.
 	Token string `mapstructure:"token"`
 
@@ -154,6 +160,9 @@ func (cfg *Config) getURL() (out *url.URL, err error) {
 func (cfg *Config) Validate() error {
 	if err := cfg.QueueSettings.Validate(); err != nil {
 		return fmt.Errorf("sending_queue settings has invalid configuration: %w", err)
+	}
+	if !cfg.LogDataEnabled && !cfg.ProfilingDataEnabled {
+		return errors.New(`either "log_data_enabled" or "profiling_data_enabled" has to be true`)
 	}
 	return nil
 }

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -61,6 +61,8 @@ func TestLoadConfig(t *testing.T) {
 		Index:                   "metrics",
 		SplunkAppName:           "OpenTelemetry-Collector Splunk Exporter",
 		SplunkAppVersion:        "v0.0.1",
+		LogDataEnabled:          true,
+		ProfilingDataEnabled:    true,
 		MaxConnections:          100,
 		MaxContentLengthLogs:    2 * 1024 * 1024,
 		MaxContentLengthMetrics: 2 * 1024 * 1024,

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -60,7 +60,9 @@ func NewFactory() component.ExporterFactory {
 
 func createDefaultConfig() config.Exporter {
 	return &Config{
-		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
+		LogDataEnabled:       true,
+		ProfilingDataEnabled: true,
+		ExporterSettings:     config.NewExporterSettings(config.NewComponentID(typeStr)),
 		TimeoutSettings: exporterhelper.TimeoutSettings{
 			Timeout: defaultHTTPTimeout,
 		},

--- a/exporter/splunkhecexporter/testdata/config.yaml
+++ b/exporter/splunkhecexporter/testdata/config.yaml
@@ -14,6 +14,8 @@ exporters:
     source: "otel"
     sourcetype: "otel"
     index: "metrics"
+    log_data_enabled: true
+    profiling_data_enabled: true
     tls:
       insecure_skip_verify: false
       ca_file: ""


### PR DESCRIPTION
Since profiling data is currently reusing logs pipeline, we need an option to disable either logs or profiling data type at the Splunk HEC exporter.