### PR TITLE
[exporter/lokiexporter] Fix lokiexporter example config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - `hostmetricsreceiver`: Use cpu times for time delta in cpu.utilization calculation (#8856)
 - `dynatraceexporter`: Remove overly verbose stacktrace from certain logs (#8989)
+- `lokiexporter`: Fix lokiexporter example config (#9066)
 
 ### 🚩 Deprecations 🚩
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 
 - `hostmetricsreceiver`: Use cpu times for time delta in cpu.utilization calculation (#8856)
 - `dynatraceexporter`: Remove overly verbose stacktrace from certain logs (#8989)
-- `lokiexporter`: Fix lokiexporter example config (#9066)
 
 ### 🚩 Deprecations 🚩
 

--- a/exporter/lokiexporter/example/otel-collector-config.yml
+++ b/exporter/lokiexporter/example/otel-collector-config.yml
@@ -6,17 +6,7 @@ processors:
   batch:
     send_batch_size: 50
     timeout: 5s
-  # Enabling the memory_limiter is strongly recommended for every pipeline.
-  # Configuration is based on the amount of memory allocated to the collector.
-  # The configuration below assumes 2GB of memory. In general, the ballast
-  # should be set to 1/3 of the collector's memory, the limit should be 90% of
-  # the collector's memory up to 2GB, and the spike should be 25% of the
-  # collector's memory up to 2GB. In addition, the "--mem-ballast-size-mib" CLI
-  # flag must be set to the same value as the "ballast_size_mib". For more
-  # information, see
-  # https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md
   memory_limiter:
-    ballast_size_mib: 683
     check_interval: 2s
     limit_mib: 1800
     spike_limit_mib: 500
@@ -31,7 +21,7 @@ exporters:
       attributes:
         container_name: ""
         source: ""
-      resources:
+      resource:
         host.name: "hostname"
 
 extensions:


### PR DESCRIPTION
The base example otel-collector-config.yml file for the lokiexporter sets [resources](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/lokiexporter/example/otel-collector-config.yml#L34) (plural form) while the [mapstructure](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/3235bc0612cdb6fb8efda472c8e3f90ccb750c78/exporter/lokiexporter/config.go#L61) is resource (singular form).

This PR fixes the sample adjusting it to the actual resource format. Another option would be to make the mapstructure plural, but that would imply a contract (breaking) change.

<img width="1385" alt="Screen Shot 2022-04-04 at 10 57 16 PM" src="https://user-images.githubusercontent.com/611147/161631700-4243e28e-2fc9-45e5-81eb-6bf16a1cc285.png">
