### PR TITLE
[exporter/datadog] Add empty `removedSettings` list

### DIFF
--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -377,6 +377,10 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) Unmarshal(configMap *config.Map) error {
+	if err := handleRemovedSettings(configMap); err != nil {
+		return err
+	}
+
 	err := configMap.UnmarshalExact(c)
 	if err != nil {
 		return err

--- a/exporter/datadogexporter/config/warning_deprecated.go
+++ b/exporter/datadogexporter/config/warning_deprecated.go
@@ -38,7 +38,7 @@ type renameError struct {
 	issueNumber uint
 }
 
-// List of settings that are deprecated.
+// List of settings that are deprecated but not yet removed.
 var renamedSettings = []renameError{
 	{
 		oldName:      "metrics::send_monotonic_counter",
@@ -55,6 +55,9 @@ var renamedSettings = []renameError{
 	},
 }
 
+// List of settings that have been removed, but for which we keep a custom error.
+var removedSettings = []renameError{}
+
 // Error implements the error interface.
 func (e renameError) Error() string {
 	return fmt.Sprintf(
@@ -64,6 +67,19 @@ func (e renameError) Error() string {
 		e.oldRemovedIn,
 		e.issueNumber,
 	)
+}
+
+// RemovedErr returns an error describing that the old name was removed in favor of the new name.
+func (e renameError) RemovedErr(configMap *config.Map) error {
+	if configMap.IsSet(e.oldName) {
+		return fmt.Errorf(
+			"%q was removed in favor of %q. See github.com/open-telemetry/opentelemetry-collector-contrib/issues/%d",
+			e.oldName,
+			e.newName,
+			e.issueNumber,
+		)
+	}
+	return nil
 }
 
 // Check if the deprecated option is being used.
@@ -92,6 +108,13 @@ func handleRenamedSettings(configMap *config.Map, cfg *Config) (warnings []error
 			// only update config if old name is in use
 			renaming.UpdateCfg(cfg)
 		}
+	}
+	return
+}
+
+func handleRemovedSettings(configMap *config.Map) (err error) {
+	for _, removed := range removedSettings {
+		err = multierr.Append(err, removed.RemovedErr(configMap))
 	}
 	return
 }


### PR DESCRIPTION
**Description:** 

This is a noop PR in preparation for future removal of settings like `metrics::send_monotonic_counter`.
The intention is to make future PRs as simple as possible so that we can ensure merging them in the right release.

**Link to tracking Issue:** Relates to #8372
