### PR TITLE
[receiver/mysql] Fix readme setup script link

### DIFF
--- a/receiver/mysqlreceiver/README.md
+++ b/receiver/mysqlreceiver/README.md
@@ -10,7 +10,7 @@ Supported pipeline types: `metrics`
 
 This receiver supports MySQL version 8.0
 
-Collecting most metrics requires the ability to execute `SHOW GLOBAL STATUS`. The `buffer_pool_size` metric requires access to the `information_schema.innodb_metrics` table. Please refer to [setup.sh](./testdata/scripts/setup.sh) for an example of how to configure these permissions. 
+Collecting most metrics requires the ability to execute `SHOW GLOBAL STATUS`. The `buffer_pool_size` metric requires access to the `information_schema.innodb_metrics` table. Please refer to [setup.sh](./testdata/integration/scripts/setup.sh) for an example of how to configure these permissions. 
 
 ## Configuration
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->


The link is incorrect, missing the `integration` directory in the path.

**Documentation:** <Describe the documentation added.>

Fixed the link.