### PR TITLE
[exporter/signalfx] Fix correlation timeout bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `hostmetricsreceiver`: Use cpu times for time delta in cpu.utilization calculation (#8857)
 - `dynatraceexporter`: Remove overly verbose stacktrace from certain logs (#8989)
 - `googlecloudexporter`: fix the `exporter.googlecloud.OTLPDirect` fature-gate, which was not applied when the flag was provided (#9116)
+- `signalfxexporter`: Fix bug to enable timeouts for correlating traces and metrics (#9101)
 
 ### 🚩 Deprecations 🚩
 

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -20,7 +20,10 @@ require (
 	go.uber.org/zap v1.21.0
 )
 
-require gopkg.in/yaml.v2 v2.4.0
+require (
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.48.0
+	gopkg.in/yaml.v2 v2.4.0
+)
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect

--- a/internal/coreinternal/timeutils/doc.go
+++ b/internal/coreinternal/timeutils/doc.go
@@ -1,0 +1,1 @@
+package timeutils

--- a/internal/coreinternal/timeutils/doc.go
+++ b/internal/coreinternal/timeutils/doc.go
@@ -1,1 +1,19 @@
-package timeutils
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package idutils provides a set of helper functions to convert ids.
+//
+// Functions in big_endian_converter.go help converting uint64 ids to TraceID
+// and SpanID using big endian, and vice versa.
+package timeutils // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"

--- a/internal/coreinternal/timeutils/ticker_helper.go
+++ b/internal/coreinternal/timeutils/ticker_helper.go
@@ -26,11 +26,16 @@ type TTicker interface {
 	Stop()
 }
 
+// Implements TTicker and abstracts underlying time ticker's functionality to make usage
+// simpler.
 type PolicyTicker struct {
 	Ticker     *time.Ticker
 	OnTickFunc func()
 	StopCh     chan struct{}
 }
+
+// Ensure PolicyTicker implements TTicker interface
+var _ TTicker = (*PolicyTicker)(nil)
 
 func (pt *PolicyTicker) Start(d time.Duration) {
 	pt.Ticker = time.NewTicker(d)
@@ -46,13 +51,12 @@ func (pt *PolicyTicker) Start(d time.Duration) {
 		}
 	}()
 }
+
 func (pt *PolicyTicker) OnTick() {
 	pt.OnTickFunc()
 }
+
 func (pt *PolicyTicker) Stop() {
 	close(pt.StopCh)
 	pt.Ticker.Stop()
 }
-
-// Ensure PolicyTicker implements TTicker interface
-var _ TTicker = (*PolicyTicker)(nil)

--- a/internal/coreinternal/timeutils/ticker_helper.go
+++ b/internal/coreinternal/timeutils/ticker_helper.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeutils // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
+
+import "time"
+
+// TTicker interface allows easier testing of Ticker related functionality
+type TTicker interface {
+	// start sets the frequency of the Ticker and starts the periodic calls to OnTick.
+	Start(d time.Duration)
+	// OnTick is called when the Ticker fires.
+	OnTick()
+	// Stop firing the Ticker.
+	Stop()
+}
+
+type PolicyTicker struct {
+	Ticker     *time.Ticker
+	OnTickFunc func()
+	StopCh     chan struct{}
+}
+
+func (pt *PolicyTicker) Start(d time.Duration) {
+	pt.Ticker = time.NewTicker(d)
+	pt.StopCh = make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-pt.Ticker.C:
+				pt.OnTick()
+			case <-pt.StopCh:
+				return
+			}
+		}
+	}()
+}
+func (pt *PolicyTicker) OnTick() {
+	pt.OnTickFunc()
+}
+func (pt *PolicyTicker) Stop() {
+	close(pt.StopCh)
+	pt.Ticker.Stop()
+}
+
+// Ensure PolicyTicker implements TTicker interface
+var _ TTicker = (*PolicyTicker)(nil)

--- a/internal/coreinternal/timeutils/ticker_test.go
+++ b/internal/coreinternal/timeutils/ticker_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 type testObj struct {
-	mu       sync.Mutex
+	mu  sync.Mutex
 	foo int
 }
 
@@ -66,11 +66,11 @@ func TestPolicyTickerSucceeds(t *testing.T) {
 	to := &testObj{foo: 0}
 	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
 
-	// Ticker is first called after required duration, not at start. This means
-	// expected count will be 1 less than how many durations have passed.
 	expectedTicks := 4
 	defaultDuration := 500 * time.Millisecond
-	testSleepDuration := time.Duration(expectedTicks + 1) * defaultDuration
+	// Extra padding reduces the chance of a race happening here
+	padDuration := 200 * time.Millisecond
+	testSleepDuration := time.Duration(expectedTicks)*defaultDuration + padDuration
 
 	pTicker.Start(defaultDuration)
 	time.Sleep(testSleepDuration)

--- a/internal/coreinternal/timeutils/ticker_test.go
+++ b/internal/coreinternal/timeutils/ticker_test.go
@@ -15,6 +15,7 @@
 package timeutils
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -22,15 +23,24 @@ import (
 )
 
 type testObj struct {
+	mu       sync.Mutex
 	foo int
 }
 
 func (to *testObj) IncrementFoo() {
+	to.mu.Lock()
+	defer to.mu.Unlock()
 	to.foo += 1
 }
 
+func checkFooValue(to *testObj, expectedValue int) bool {
+	to.mu.Lock()
+	defer to.mu.Unlock()
+	return to.foo == expectedValue
+}
+
 func TestPolicyTickerFails(t *testing.T) {
-	to := testObj{foo: 0}
+	to := &testObj{foo: 0}
 	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
 
 	// Tickers with a duration <= 0 should panic
@@ -39,38 +49,40 @@ func TestPolicyTickerFails(t *testing.T) {
 }
 
 func TestPolicyTickerStart(t *testing.T) {
-	to := testObj{foo: 0}
+	to := &testObj{foo: 0}
 	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
 
 	// Make sure no ticks occur when we immediately stop the ticker
 	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 0, to.foo)
+	assert.True(t, checkFooValue(to, 0), "Expected value: %d, actual: %d", 0, to.foo)
 	pTicker.Start(1 * time.Second)
 	pTicker.Stop()
-	assert.Equal(t, 0, to.foo)
+	assert.True(t, checkFooValue(to, 0), "Expected value: %d, actual: %d", 0, to.foo)
 }
 
 func TestPolicyTickerSucceeds(t *testing.T) {
 	// Start the ticker, make sure variable is incremented properly,
 	// also make sure stop works as expected.
-	to := testObj{foo: 0}
+	to := &testObj{foo: 0}
 	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
 
-	expectedTicks := 5
-	defaultDuration := 500 * time.Millisecond
-	// Fuzz is used to try to make sure we're not racing here.
-	fuzzDuration := 100 * time.Millisecond
-	testSleepDuration := time.Duration(expectedTicks) * defaultDuration + fuzzDuration
+	// Ticker is first called after required duration, not at start. This means
+	// expected count will be 1 less than how many durations have passed.
+	expectedTicks := 4
+	defaultDuration := 200 * time.Millisecond
+	testSleepDuration := time.Duration(expectedTicks + 1) * defaultDuration
 
 	pTicker.Start(defaultDuration)
 	time.Sleep(testSleepDuration)
-	assert.Equal(t, expectedTicks, to.foo)
+	assert.True(t, checkFooValue(to, expectedTicks), "Expected value: %d, actual: %d", expectedTicks, to.foo)
 
 	pTicker.Stop()
 	// Since these tests are time sensitive they can be flaky. By getting the count
 	// after stopping, we can still test to make sure it's no longer being incremented,
 	// without requiring there by no OnTick calls between the sleep call and stopping.
+	time.Sleep(defaultDuration)
 	expectedTicks = to.foo
+
 	time.Sleep(testSleepDuration)
-	assert.Equal(t, expectedTicks, to.foo)
+	assert.True(t, checkFooValue(to, expectedTicks), "Expected value: %d, actual: %d", expectedTicks, to.foo)
 }

--- a/internal/coreinternal/timeutils/ticker_test.go
+++ b/internal/coreinternal/timeutils/ticker_test.go
@@ -30,7 +30,7 @@ type testObj struct {
 func (to *testObj) IncrementFoo() {
 	to.mu.Lock()
 	defer to.mu.Unlock()
-	to.foo += 1
+	to.foo++
 }
 
 func checkFooValue(to *testObj, expectedValue int) bool {
@@ -69,7 +69,7 @@ func TestPolicyTickerSucceeds(t *testing.T) {
 	// Ticker is first called after required duration, not at start. This means
 	// expected count will be 1 less than how many durations have passed.
 	expectedTicks := 4
-	defaultDuration := 200 * time.Millisecond
+	defaultDuration := 500 * time.Millisecond
 	testSleepDuration := time.Duration(expectedTicks + 1) * defaultDuration
 
 	pTicker.Start(defaultDuration)

--- a/internal/coreinternal/timeutils/ticker_test.go
+++ b/internal/coreinternal/timeutils/ticker_test.go
@@ -1,0 +1,62 @@
+package timeutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testObj struct {
+	foo int
+}
+
+func (to *testObj) IncrementFoo() {
+	to.foo += 1
+}
+
+func TestPolicyTickerFails(t *testing.T) {
+	to := testObj{foo: 0}
+	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
+
+	// Tickers with a duration <= 0 should panic
+	assert.Panics(t, func() { pTicker.Start(time.Duration(0)) })
+	assert.Panics(t, func() { pTicker.Start(time.Duration(-1)) })
+}
+
+func TestPolicyTickerStart(t *testing.T) {
+	to := testObj{foo: 0}
+	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
+
+	// Make sure no ticks occur when we immediately stop the ticker
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 0, to.foo)
+	pTicker.Start(1 * time.Second)
+	pTicker.Stop()
+	assert.Equal(t, 0, to.foo)
+}
+
+func TestPolicyTickerSucceeds(t *testing.T) {
+	// Start the ticker, make sure variable is incremented properly,
+	// also make sure stop works as expected.
+	to := testObj{foo: 0}
+	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
+
+	// Ticker is first called after required duration, not at start. This means
+	// expected count will be 1 less than how many durations have passed.
+	expectedTicks := 4
+	defaultDuration := 200 * time.Millisecond
+	testSleepDuration := time.Duration(expectedTicks+1) * defaultDuration
+
+	pTicker.Start(defaultDuration)
+	time.Sleep(testSleepDuration)
+	assert.Equal(t, expectedTicks, to.foo)
+
+	pTicker.Stop()
+	// Since these tests are time sensitive they can be flaky. By getting the count
+	// after stopping, we can still test to make sure it's no longer being incremented,
+	// without requiring there by no OnTick calls between the sleep call and stopping.
+	expectedTicks = to.foo
+	time.Sleep(testSleepDuration)
+	assert.Equal(t, expectedTicks, to.foo)
+}

--- a/internal/coreinternal/timeutils/ticker_test.go
+++ b/internal/coreinternal/timeutils/ticker_test.go
@@ -56,11 +56,11 @@ func TestPolicyTickerSucceeds(t *testing.T) {
 	to := testObj{foo: 0}
 	pTicker := &PolicyTicker{OnTickFunc: to.IncrementFoo}
 
-	// Ticker is first called after required duration, not at start. This means
-	// expected count will be 1 less than how many durations have passed.
-	expectedTicks := 4
+	expectedTicks := 5
 	defaultDuration := 500 * time.Millisecond
-	testSleepDuration := time.Duration(expectedTicks+1) * defaultDuration
+	// Fuzz is used to try to make sure we're not racing here.
+	fuzzDuration := 100 * time.Millisecond
+	testSleepDuration := time.Duration(expectedTicks) * defaultDuration + fuzzDuration
 
 	pTicker.Start(defaultDuration)
 	time.Sleep(testSleepDuration)

--- a/internal/coreinternal/timeutils/ticker_test.go
+++ b/internal/coreinternal/timeutils/ticker_test.go
@@ -1,3 +1,17 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package timeutils
 
 import (
@@ -45,7 +59,7 @@ func TestPolicyTickerSucceeds(t *testing.T) {
 	// Ticker is first called after required duration, not at start. This means
 	// expected count will be 1 less than how many durations have passed.
 	expectedTicks := 4
-	defaultDuration := 200 * time.Millisecond
+	defaultDuration := 500 * time.Millisecond
 	testSleepDuration := time.Duration(expectedTicks+1) * defaultDuration
 
 	pTicker.Start(defaultDuration)

--- a/processor/tailsamplingprocessor/go.mod
+++ b/processor/tailsamplingprocessor/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/uuid v1.3.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.48.0
 	github.com/stretchr/testify v1.7.1
 	go.opencensus.io v0.23.0
 	go.opentelemetry.io/collector v0.48.0
@@ -15,23 +16,22 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/knadh/koanf v1.4.0 // indirect
-	github.com/kr/pretty v0.3.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	go.opentelemetry.io/otel v1.6.1 // indirect
 	go.opentelemetry.io/otel/metric v0.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.6.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal

--- a/processor/tailsamplingprocessor/go.sum
+++ b/processor/tailsamplingprocessor/go.sum
@@ -32,7 +32,6 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
-github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
@@ -106,9 +105,7 @@ github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583
 github.com/knadh/koanf v1.4.0 h1:/k0Bh49SqLyLNfte9r6cvuZWrApOQhglOmhIU3L/zDw=
 github.com/knadh/koanf v1.4.0/go.mod h1:1cfH5223ZeZUOs8FU2UdTmaNfHpqgtjV0+NHjRO43gs=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
-github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -136,11 +133,9 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
-github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -235,7 +230,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -286,7 +280,6 @@ gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUy
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
@@ -54,7 +55,7 @@ type tailSamplingSpanProcessor struct {
 	policies        []*policy
 	logger          *zap.Logger
 	idToTrace       sync.Map
-	policyTicker    tTicker
+	policyTicker    timeutils.TTicker
 	tickerFrequency time.Duration
 	decisionBatcher idbatcher.Batcher
 	deleteChan      chan pdata.TraceID
@@ -108,7 +109,7 @@ func newTracesProcessor(logger *zap.Logger, nextConsumer consumer.Traces, cfg Co
 		tickerFrequency: time.Second,
 	}
 
-	tsp.policyTicker = &policyTicker{onTickFunc: tsp.samplingPolicyOnTick}
+	tsp.policyTicker = &timeutils.PolicyTicker{OnTickFunc: tsp.samplingPolicyOnTick}
 	tsp.deleteChan = make(chan pdata.TraceID, cfg.NumTraces)
 
 	return tsp, nil
@@ -400,14 +401,14 @@ func (tsp *tailSamplingSpanProcessor) Capabilities() consumer.Capabilities {
 
 // Start is invoked during service startup.
 func (tsp *tailSamplingSpanProcessor) Start(context.Context, component.Host) error {
-	tsp.policyTicker.start(tsp.tickerFrequency)
+	tsp.policyTicker.Start(tsp.tickerFrequency)
 	return nil
 }
 
 // Shutdown is invoked during service shutdown.
 func (tsp *tailSamplingSpanProcessor) Shutdown(context.Context) error {
 	tsp.decisionBatcher.Stop()
-	tsp.policyTicker.stop()
+	tsp.policyTicker.Stop()
 	return nil
 }
 
@@ -438,43 +439,3 @@ func prepareTraceBatch(rss pdata.ResourceSpans, spans []*pdata.Span) pdata.Trace
 	}
 	return traceTd
 }
-
-// tTicker interface allows easier testing of ticker related functionality used by tailSamplingProcessor
-type tTicker interface {
-	// start sets the frequency of the ticker and starts the periodic calls to OnTick.
-	start(d time.Duration)
-	// onTick is called when the ticker fires.
-	onTick()
-	// stop firing the ticker.
-	stop()
-}
-
-type policyTicker struct {
-	ticker     *time.Ticker
-	onTickFunc func()
-	stopCh     chan struct{}
-}
-
-func (pt *policyTicker) start(d time.Duration) {
-	pt.ticker = time.NewTicker(d)
-	pt.stopCh = make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-pt.ticker.C:
-				pt.onTick()
-			case <-pt.stopCh:
-				return
-			}
-		}
-	}()
-}
-func (pt *policyTicker) onTick() {
-	pt.onTickFunc()
-}
-func (pt *policyTicker) stop() {
-	close(pt.stopCh)
-	pt.ticker.Stop()
-}
-
-var _ tTicker = (*policyTicker)(nil)

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/collector/model/pdata"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/idbatcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )
@@ -636,16 +637,16 @@ type manualTTicker struct {
 	Started bool
 }
 
-var _ tTicker = (*manualTTicker)(nil)
+var _ timeutils.TTicker = (*manualTTicker)(nil)
 
-func (t *manualTTicker) start(time.Duration) {
+func (t *manualTTicker) Start(time.Duration) {
 	t.Started = true
 }
 
-func (t *manualTTicker) onTick() {
+func (t *manualTTicker) OnTick() {
 }
 
-func (t *manualTTicker) stop() {
+func (t *manualTTicker) Stop() {
 }
 
 type syncIDBatcher struct {

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.48.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.48.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.48.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
@@ -84,3 +85,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experiment
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr => ../../pkg/batchperresourceattr
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx => ../../pkg/translator/signalfx
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The SignalFx Exporter supports correlations between metrics and traces. This means that when a trace occurs from a given host, with dimensions like service and environment, these dimensions can be used to query metrics for these traces. These correlations are supposed to timeout after the stale_service_timeout amount of time passes, but they weren't. This fix makes sure correlations timeout so that metrics aren't linked with stale trace data.

**Testing:**
Manual testing is working as expected, but it's currently impossible (from my understanding) to write tests for this functionality. The problem is that the tests would need to create both metrics and traces to send to the signalfx backend, but at that high of a level the correlation values couldn't be properly checked, as they're not available outside the local package.