### PR TITLE
[extension/fluentbit][receiver/promexec] add deprecation notice

### DIFF
--- a/extension/fluentbitextension/go.mod
+++ b/extension/fluentbitextension/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: fluentbit extension is deprecated and will be removed in future versions.
 module github.com/open-telemetry/opentelemetry-collector-contrib/extension/fluentbitextension
 
 go 1.17

--- a/receiver/prometheusexecreceiver/go.mod
+++ b/receiver/prometheusexecreceiver/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: prometheus_exec receiver is deprecated and will be removed in future versions.
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusexecreceiver
 
 go 1.17


### PR DESCRIPTION
Adding deprecation notice to both promexec receiver and fluentbit extension.

Followup to: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9058 https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9062