### PR TITLE
Promote @djaglowski to maintainer role

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs
 
 - [Anthony Mirabella](https://github.com/Aneurysm9), AWS
 - [Anuraag Agrawal](https://github.com/anuraaga), AWS
-- [Daniel Jaglowski](https://github.com/djaglowski), observIQ
 - [David Ashpole](https://github.com/dashpole), Google
 - [Dmitrii Anoshin](https://github.com/dmitryax), Splunk
 - [Pablo Baeyens](https://github.com/mx-psi), DataDog
@@ -76,6 +75,7 @@ Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs
 
 Maintainers ([@open-telemetry/collector-contrib-maintainer](https://github.com/orgs/open-telemetry/teams/collector-contrib-maintainer)):
 
+- [Daniel Jaglowski](https://github.com/djaglowski), observIQ
 - [Juraci Paixão Kröhling](https://github.com/jpkrohling), Grafana Labs
 - [Alex Boten](https://github.com/codeboten), Lightstep
 - [Bogdan Drutu](https://github.com/BogdanDrutu), Splunk


### PR DESCRIPTION
@djaglowski has been with the project for a long time, contributing to bunch of components. @djaglowski also owns a critical part of the logging pipeline which is the https://github.com/open-telemetry/opentelemetry-log-collection.

With the current proposal of moving the log collection into contrib https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8850 we would like to have him as maintainer to continue to maintain that library as well as helping the community to maintain the entire project.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
