### PR TITLE
[ci] Check contrib modules are using the correct core collector version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Install Tools
         if: steps.tool-cache.outputs.cache-hit != 'true'
         run: make install-tools
+  check-collector-module-version:
+    runs-on: ubuntu-latest
+    needs: [setup-environment]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Check Collector Module Version
+        run: ./.github/workflows/scripts/check-collector-module-version.sh
   lint:
     runs-on: ubuntu-latest
     needs: [setup-environment]

--- a/.github/workflows/scripts/check-collector-module-version.sh
+++ b/.github/workflows/scripts/check-collector-module-version.sh
@@ -1,0 +1,53 @@
+get_collector_version() {
+   collector_module="$1"
+   main_mod_file="$2"
+
+   if grep -q "$collector_module" "$main_mod_file"; then
+      grep "$collector_module" "$main_mod_file" | (read mod version;
+         echo $version)
+   else
+      echo "Error: failed to retrieve the \"$collector_module\" version from \"$main_mod_file\"."
+      exit 1
+   fi
+}
+
+check_collector_version_correct() {
+   collector_module="$1"
+   collector_mod_version="$2"
+   incorrect_version=0
+   mod_files=$(find . -type f -name "go.mod")
+
+   for mod_file in $mod_files; do
+      if grep -q "$collector_module" "$mod_file"; then
+         mod_line=$(grep "$collector_module" "$mod_file")
+         version=$(echo "$mod_line" | cut -d" " -f2)
+         
+         # To account for module is on its own require line
+         # version field is shifted right by 1
+         if [ "$version" == "$collector_module" ]; then
+            version=$(echo "$mod_line" | cut -d" " -f3)
+         fi
+
+         if [ "$version" != "$collector_mod_version" ]; then
+            incorrect_version=$((incorrect_version+1))
+            echo "Incorrect version \"$version\" of \"$collector_module\" is included in \"$mod_file\". It should be version \"$collector_mod_version\"."
+         fi
+      fi
+   done
+
+   echo "There are $incorrect_version incorrect \"$collector_module\" version(s) in the module files."
+   if [ "$incorrect_version" -gt 0 ]; then
+      exit 1
+   fi
+}
+
+COLLECTOR_MODULE="go.opentelemetry.io/collector "
+COLLECTOR_MODEL_MODULE="go.opentelemetry.io/collector/model"
+MAIN_MOD_FILE="./go.mod"
+COLLECTOR_MOD_VERSION=$(get_collector_version $COLLECTOR_MODULE $MAIN_MOD_FILE)
+
+# Check the collector module version in each of the module files
+check_collector_version_correct "$COLLECTOR_MODULE" "$COLLECTOR_MOD_VERSION"
+
+# Check the collector model module version in each of the module files
+check_collector_version_correct "$COLLECTOR_MODEL_MODULE" "$COLLECTOR_MOD_VERSION"

--- a/.github/workflows/scripts/check-collector-module-version.sh
+++ b/.github/workflows/scripts/check-collector-module-version.sh
@@ -34,9 +34,9 @@ get_collector_version() {
    fi
 }
 
-# Compare the collecor main core version against all the collector component
+# Compare the collector main core version against all the collector component
 # modules to verify that they are using this version as its dependency
-check_collector_version_correct() {
+check_collector_versions_correct() {
    collector_module="$1"
    collector_mod_version="$2"
    incorrect_version=0
@@ -76,7 +76,7 @@ MAIN_MOD_FILE="./go.mod"
 COLLECTOR_MOD_VERSION=$(get_collector_version "$COLLECTOR_MODULE" "$MAIN_MOD_FILE")
 
 # Check the collector module version in each of the module files
-check_collector_version_correct "$COLLECTOR_MODULE" "$COLLECTOR_MOD_VERSION"
+check_collector_versions_correct "$COLLECTOR_MODULE" "$COLLECTOR_MOD_VERSION"
 
 # Check the collector model module version in each of the module files
-check_collector_version_correct "$COLLECTOR_MODEL_MODULE" "$COLLECTOR_MOD_VERSION"
+check_collector_versions_correct "$COLLECTOR_MODEL_MODULE" "$COLLECTOR_MOD_VERSION"

--- a/.github/workflows/scripts/check-collector-module-version.sh
+++ b/.github/workflows/scripts/check-collector-module-version.sh
@@ -1,3 +1,26 @@
+#!/usr/bin/env bash
+
+#   Copyright The OpenTelemetry Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#
+# verifies if the collector components are using the main core collector version
+# as a dependency.
+#
+set -eu -o pipefail
+
+# Return the collector main core version
 get_collector_version() {
    collector_module="$1"
    main_mod_file="$2"
@@ -11,19 +34,22 @@ get_collector_version() {
    fi
 }
 
+# Compare the collecor main core version against all the collector component
+# modules to verify that they are using this version as its dependency
 check_collector_version_correct() {
    collector_module="$1"
    collector_mod_version="$2"
    incorrect_version=0
    mod_files=$(find . -type f -name "go.mod")
 
+   # Loop through all the module files, checking the collector version
    for mod_file in $mod_files; do
       if grep -q "$collector_module" "$mod_file"; then
          mod_line=$(grep "$collector_module" "$mod_file")
          version=$(echo "$mod_line" | cut -d" " -f2)
          
-         # To account for module is on its own require line
-         # version field is shifted right by 1
+         # To account for a module on its own 'require' line,
+         # the version field is shifted right by 1
          if [ "$version" == "$collector_module" ]; then
             version=$(echo "$mod_line" | cut -d" " -f3)
          fi
@@ -41,10 +67,13 @@ check_collector_version_correct() {
    fi
 }
 
+# Note space at end of string. This is so it filters for the exact string
+# only and does not return string which contains this string as a substring.
 COLLECTOR_MODULE="go.opentelemetry.io/collector "
+
 COLLECTOR_MODEL_MODULE="go.opentelemetry.io/collector/model"
 MAIN_MOD_FILE="./go.mod"
-COLLECTOR_MOD_VERSION=$(get_collector_version $COLLECTOR_MODULE $MAIN_MOD_FILE)
+COLLECTOR_MOD_VERSION=$(get_collector_version "$COLLECTOR_MODULE" "$MAIN_MOD_FILE")
 
 # Check the collector module version in each of the module files
 check_collector_version_correct "$COLLECTOR_MODULE" "$COLLECTOR_MOD_VERSION"


### PR DESCRIPTION
Description from @mx-psi in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8546#issuecomment-1084592613:

> My intention is to avoid the following situation:
> 1. Someone creates a PR adding a new examplemodule module, targeting Collector core vN module
> 2. Weeks pass, it gets reviewed and merged just before the vN+3 contrib release, still targeting vN
> 3. The release manager for vN+3 has then to manually update the examplemodule module code to be compatible with vN+3
>
> I want to avoid (3) and, instead, make the contributor adding examplemodule do that job before merging the PR, by comparing the Collector core version at the top-level go.mod file with the Collector core version at the examplemodule go.mod file.

**The result of check-collector-module-version (no incorrect versions):**

```console
There are 0 incorrect "go.opentelemetry.io/collector " version(s) in the module files.
There are 0 incorrect "go.opentelemetry.io/collector/model" version(s) in the module files.
```

**The result of check-collector-module-version (incorrect versions):**

```console
Incorrect version "v0.47.0" of "go.opentelemetry.io/collector " is included in "./receiver/couchbasereceiver/go.mod". It should be version "v0.48.0".
Incorrect version "v0.44.0" of "go.opentelemetry.io/collector " is included in "./exporter/awsemfexporter/go.mod". It should be version "v0.48.0".
There are 2 incorrect "go.opentelemetry.io/collector " version(s) in the module files.
```

**The result of check-collector-module-version (incorrect model versions):**

```console
There are 0 incorrect "go.opentelemetry.io/collector " version(s) in the module files.
Incorrect version "v0.43.0" of "go.opentelemetry.io/collector/model" is included in "./exporter/datadogexporter/go.mod". It should be version "v0.48.0".
There are 1 incorrect "go.opentelemetry.io/collector/model" version(s) in the module files.
```

Fixes #8546 

Signed-off-by: Martin Hickey <martin.hickey@ie.ibm.com>