### PR TITLE
[receiver/filelog] Use ObservedTimestamp in case event Timestamp is empty

### DIFF
--- a/internal/stanza/converter.go
+++ b/internal/stanza/converter.go
@@ -332,7 +332,12 @@ func Convert(ent *entry.Entry) pdata.Logs {
 
 // convertInto converts entry.Entry into provided pdata.LogRecord.
 func convertInto(ent *entry.Entry, dest pdata.LogRecord) {
-	dest.SetTimestamp(pdata.NewTimestampFromTime(ent.Timestamp))
+	entTimestamp := ent.Timestamp
+	if entTimestamp.IsZero() {
+		entTimestamp = ent.ObservedTimestamp
+	}
+
+	dest.SetTimestamp(pdata.NewTimestampFromTime(entTimestamp))
 	dest.SetSeverityNumber(sevMap[ent.Severity])
 	dest.SetSeverityText(sevTextMap[ent.Severity])
 

--- a/internal/stanza/converter_test.go
+++ b/internal/stanza/converter_test.go
@@ -790,6 +790,38 @@ func TestConvertSeverity(t *testing.T) {
 	}
 }
 
+func TestConvertTimestamp(t *testing.T) {
+	timeNow := time.Now()
+	cases := []struct {
+		name string
+		timestamp time.Time
+		expectedTimestamp pdata.Timestamp
+	}{
+		{
+			name: "Entry timestamp is not empty",
+			timestamp: timeNow.Add(-24 * 3 * time.Hour),
+			expectedTimestamp: pdata.Timestamp(timeNow.Add(-24 * 3 * time.Hour).UnixNano()),
+		},
+		{
+			name: "Entry timestamp is empty",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := entry.New()
+			entry.Timestamp = tc.timestamp
+			log := convertAndDrill(entry)
+
+			if entry.Timestamp.IsZero() {
+				require.Equal(t, pdata.Timestamp(entry.ObservedTimestamp.UnixNano()), log.Timestamp())
+			} else {
+				require.Equal(t, tc.expectedTimestamp, log.Timestamp())
+			}
+		})
+	}
+}
+
 func TestConvertTrace(t *testing.T) {
 	record := convertAndDrill(&entry.Entry{
 		TraceId: []byte{


### PR DESCRIPTION
**Description:** Implemented [specification related to ObservedTimestamp](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-observedtimestamp) 

In case of receiving text logs (for example system.log) via filelog receiver, timestamp is not defined. Collector converts empty timestamp to Timestamp: 1754-08-30 22:43:41.128654848 +0000 UTC.
Because of this behaviour it was not possible to tail system logs (timestamp is not correct)

This fix uses ObservedTimestamp if Timestamp is empty. And allows to tail text logs

Before fix:
event `Thu Apr 7 22:39:24 UTC 2022 DEBUG Something routine` was converted to:
```
...
Timestamp: 1754-08-30 22:43:41.128654848 +0000 UTC
Body: Thu Apr 7 22:39:24 UTC 2022 DEBUG Something routine
Attributes:
     -> log.file.name: STRING(example.log)
...
```

After fix:
event `Thu Apr 7 22:39:24 UTC 2022 DEBUG Something routine` is converted to:
```
...
Timestamp: 2022-04-07 15:49:35.805863 +0000 UTC
Body: Thu Apr 7 22:39:24 UTC 2022 DEBUG Something routine
Attributes:
     -> log.file.name: STRING(example.log)
...
```
**Testing:** Test TestConvertTimestamp was added

P.S
There is one moment which bothers me. If we configure the receiver to make it read logs from the beginning::
```
receivers:
  filelog:
    include: [ example.log ]
    start_at: beginning
```
collector will set timestamp equal to the time it observed event, not the time this event was actually happened.
But I think that's ok. If we want to read logs from the beginning and keep proper timestamp we should use parser to properly parse data from event body, like
```
receivers:
  filelog:
    include: [ example.log ]
    start_at: beginning
    operators:
       - type: regex_parser
         parse_from: body
         regex: ...
```
