### PR TITLE
Fix featuregate for googlecloud exporter by not checking it during NewFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - `hostmetricsreceiver`: Use cpu times for time delta in cpu.utilization calculation (#8857)
 - `dynatraceexporter`: Remove overly verbose stacktrace from certain logs (#8989)
+- `googlecloudexporter`: fix the `exporter.googlecloud.OTLPDirect` fature-gate, which was not applied when the flag was provided (#9116)
 
 ### 🚩 Deprecations 🚩
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/4967.  While we debate how to address featuregates not working during NewFactory, make the featuregate in the googlecloud exporter work correctly.

**Description:** <Describe what has changed.>
Check the `exporter.googlecloud.OTLPDirect` featuregate during trace/metrics exporter creation, rather than factory creation.

**Testing:**

Manually tested with print statements to ensure feature gate flags are respected.