### PR TITLE
[prometheus components] For histograms without sums, leave the sum unset

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -389,6 +389,8 @@ func Test_PushMetrics(t *testing.T) {
 
 	emptyDataPointHistogramBatch := getMetricsFromMetricList(validMetrics1[validEmptyHistogram], validMetrics2[validEmptyHistogram])
 
+	histogramNoSumBatch := getMetricsFromMetricList(validMetrics1[validHistogramNoSum], validMetrics2[validHistogramNoSum])
+
 	summaryBatch := getMetricsFromMetricList(validMetrics1[validSummary], validMetrics2[validSummary])
 
 	// len(BucketCount) > len(ExplicitBounds)
@@ -494,7 +496,14 @@ func Test_PushMetrics(t *testing.T) {
 			name:               "valid_empty_histogram_case",
 			metrics:            &emptyDataPointHistogramBatch,
 			reqTestFunc:        checkFunc,
-			expectedTimeSeries: 6,
+			expectedTimeSeries: 4,
+			httpResponseCode:   http.StatusAccepted,
+		},
+		{
+			name:               "histogram_no_sum_case",
+			metrics:            &histogramNoSumBatch,
+			reqTestFunc:        checkFunc,
+			expectedTimeSeries: 10,
 			httpResponseCode:   http.StatusAccepted,
 		},
 		{

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -47,7 +47,7 @@ type metricGroup struct {
 	ls           labels.Labels
 	count        float64
 	hasCount     bool
-	sum          float64
+	sum          *float64
 	hasSum       bool
 	value        float64
 	complexValue []*dataPoint
@@ -105,7 +105,7 @@ func (mg *metricGroup) toDistributionPoint(dest pmetric.HistogramDataPointSlice)
 	bounds := make([]float64, len(mg.complexValue)-1)
 	bucketCounts := make([]uint64, len(mg.complexValue))
 
-	pointIsStale := value.IsStaleNaN(mg.sum) || value.IsStaleNaN(mg.count)
+	pointIsStale := (mg.sum != nil && value.IsStaleNaN(*mg.sum)) || value.IsStaleNaN(mg.count)
 
 	for i := 0; i < len(mg.complexValue); i++ {
 		if i != len(mg.complexValue)-1 {
@@ -130,7 +130,9 @@ func (mg *metricGroup) toDistributionPoint(dest pmetric.HistogramDataPointSlice)
 		point.SetFlagsImmutable(pmetric.DefaultMetricDataPointFlags.WithNoRecordedValue(true))
 	} else {
 		point.SetCount(uint64(mg.count))
-		point.SetSum(mg.sum)
+		if mg.sum != nil {
+			point.SetSum(*mg.sum)
+		}
 	}
 
 	point.SetExplicitBounds(pcommon.NewImmutableFloat64Slice(bounds))
@@ -167,11 +169,13 @@ func (mg *metricGroup) toSummaryPoint(dest pmetric.SummaryDataPointSlice) {
 	mg.sortPoints()
 
 	point := dest.AppendEmpty()
-	pointIsStale := value.IsStaleNaN(mg.sum) || value.IsStaleNaN(mg.count)
+	pointIsStale := (mg.sum != nil && value.IsStaleNaN(*mg.sum)) || value.IsStaleNaN(mg.count)
 	if pointIsStale {
 		point.SetFlagsImmutable(pmetric.DefaultMetricDataPointFlags.WithNoRecordedValue(true))
 	} else {
-		point.SetSum(mg.sum)
+		if mg.sum != nil {
+			point.SetSum(*mg.sum)
+		}
 		point.SetCount(uint64(mg.count))
 	}
 
@@ -260,7 +264,7 @@ func (mf *metricFamily) Add(metricName string, ls labels.Labels, t int64, v floa
 	case pmetric.MetricDataTypeHistogram, pmetric.MetricDataTypeSummary:
 		switch {
 		case strings.HasSuffix(metricName, metricsSuffixSum):
-			mg.sum = v
+			mg.sum = &v
 			mg.hasSum = true
 		case strings.HasSuffix(metricName, metricsSuffixCount):
 			// always use the timestamp from count, because is the only required field for histograms and summaries.

--- a/receiver/prometheusreceiver/internal/metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/metricsbuilder_test.go
@@ -915,7 +915,6 @@ func Test_OTLPMetricBuilder_histogram(t *testing.T) {
 				hist0.SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 				pt0 := hist0.DataPoints().AppendEmpty()
 				pt0.SetCount(3)
-				pt0.SetSum(0)
 				pt0.SetExplicitBounds(pcommon.NewImmutableFloat64Slice([]float64{10, 20}))
 				pt0.SetBucketCounts(pcommon.NewImmutableUInt64Slice([]uint64{1, 1, 1}))
 				pt0.SetTimestamp(startTsNanos)

--- a/unreleased/prom-unset-sum.yaml
+++ b/unreleased/prom-unset-sum.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver/prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Leave the sum unset in histograms without sums, and don't produce _sum metric points for histograms without sums
+
+# One or more tracking issues related to the change
+issues: [7546]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:**

Prometheus histograms don't have a sum if the histogram includes negative observations.  Now that the protocol supports a notion of "unset" sums, use this in prometheus components to correctly handle setting the sum.

I tried to do this for the prometheus exporter as well, but [NewConstHistogram](https://github.com/prometheus/client_golang/blob/2e1c4818ccfdcf953ce399cadad615ff2bed968c/prometheus/histogram.go#L620) requires a sum (i.e. doesn't support an unset sum).  https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/prometheusexporter/collector.go#L200

**Link to tracking Issue:**

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7546

**Testing:**

Added unit tests.