### PR TITLE
[attributesprocessor] remove log names from filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `datadogexporter`: Remove `GetCensoredKey` method from `APIConfig` struct (#8980)
 - `mongodbatlasreceiver`: Updated to uses newer metric builder which changed some metric and resource attributes (#9093)
 - `dynatraceexporter`: Make `serialization` package `/internal` (#9097)
+- `attributesprocessor`: Remove log names from filters (#9131)
 
 ### 🧰 Bug fixes 🧰
 

--- a/internal/coreinternal/processor/filterconfig/config.go
+++ b/internal/coreinternal/processor/filterconfig/config.go
@@ -90,11 +90,6 @@ type MatchProperties struct {
 	// This is an optional field.
 	SpanNames []string `mapstructure:"span_names"`
 
-	// LogNames is a list of strings that the LogRecord's name field must match
-	// against.
-	// Deprecated: the Name field is removed from the log data model.
-	LogNames []string `mapstructure:"log_names"`
-
 	// LogBodies is a list of strings that the LogRecord's body field must match
 	// against.
 	LogBodies []string `mapstructure:"log_bodies"`
@@ -123,10 +118,6 @@ type MatchProperties struct {
 
 // ValidateForSpans validates properties for spans.
 func (mp *MatchProperties) ValidateForSpans() error {
-	if len(mp.LogNames) > 0 {
-		return errors.New("log_names should not be specified for trace spans")
-	}
-
 	if len(mp.LogBodies) > 0 {
 		return errors.New("log_bodies should not be specified for trace spans")
 	}

--- a/internal/coreinternal/processor/filterlog/filterlog.go
+++ b/internal/coreinternal/processor/filterlog/filterlog.go
@@ -36,9 +36,6 @@ type Matcher interface {
 type propertiesMatcher struct {
 	filtermatcher.PropertiesMatcher
 
-	// log names to compare to.
-	nameFilters filterset.FilterSet
-
 	// log bodies to compare to.
 	bodyFilters filterset.FilterSet
 }
@@ -58,13 +55,6 @@ func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 		return nil, err
 	}
 
-	var nameFS filterset.FilterSet
-	if len(mp.LogNames) > 0 {
-		nameFS, err = filterset.CreateFilterSet(mp.LogNames, &mp.Config)
-		if err != nil {
-			return nil, fmt.Errorf("error creating log record name filters: %v", err)
-		}
-	}
 	var bodyFS filterset.FilterSet
 	if len(mp.LogBodies) > 0 {
 		bodyFS, err = filterset.CreateFilterSet(mp.LogBodies, &mp.Config)
@@ -75,7 +65,6 @@ func NewMatcher(mp *filterconfig.MatchProperties) (Matcher, error) {
 
 	return &propertiesMatcher{
 		PropertiesMatcher: rm,
-		nameFilters:       nameFS,
 		bodyFilters:       bodyFS,
 	}, nil
 }

--- a/internal/coreinternal/processor/filterlog/filterlog_test.go
+++ b/internal/coreinternal/processor/filterlog/filterlog_test.go
@@ -43,9 +43,8 @@ func TestLogRecord_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 			errorString: `at least one of "attributes", "libraries", "resources" or "log_bodies" field must be specified`,
 		},
 		{
-			name: "empty_log_names_and_attributes",
+			name: "empty_log_bodies_and_attributes",
 			property: filterconfig.MatchProperties{
-				LogNames:  []string{},
 				LogBodies: []string{},
 			},
 			errorString: `at least one of "attributes", "libraries", "resources" or "log_bodies" field must be specified`,

--- a/internal/coreinternal/processor/filterspan/filterspan_test.go
+++ b/internal/coreinternal/processor/filterspan/filterspan_test.go
@@ -54,9 +54,9 @@ func TestSpan_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 		{
 			name: "log_properties",
 			property: filterconfig.MatchProperties{
-				LogNames: []string{"log"},
+				LogBodies: []string{"log"},
 			},
-			errorString: "log_names should not be specified for trace spans",
+			errorString: "log_bodies should not be specified for trace spans",
 		},
 		{
 			name: "invalid_match_type",

--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -166,13 +166,13 @@ if the input data should be included or excluded from the processor. To configur
 this option, under `include` and/or `exclude` at least `match_type` and one of the following
 is required:
 - For spans, one of `services`, `span_names`, `attributes`, `resources`, or `libraries` must be specified
-with a non-empty value for a valid configuration. The `log_names`, `log_bodies`, `expressions`, `resource_attributes` and
+with a non-empty value for a valid configuration. The `log_bodies`, `expressions`, `resource_attributes` and
 `metric_names` fields are invalid.
-- For logs, one of `log_names`, `log_bodies`, `attributes`, `resources`, or `libraries` must be specified with a
+- For logs, one of `log_bodies`, `attributes`, `resources`, or `libraries` must be specified with a
 non-empty value for a valid configuration. The `span_names`, `metric_names`, `expressions`, `resource_attributes`,
 and `services` fields are invalid.
 - For metrics, one of `metric_names`, `resources` must be specified
-with a valid non-empty value for a valid configuration. The `span_names`, `log_names`, `log_bodies` and
+with a valid non-empty value for a valid configuration. The `span_names`, `log_bodies` and
 `services` fields are invalid.
 
 
@@ -213,10 +213,6 @@ attributes:
       # The span name must match at least one of the items.
       # This is an optional field.
       span_names: [<item1>, ..., <itemN>]
-
-      # The log name must match at least one of the items.
-      # This is an optional field.
-      log_names: [<item1>, ..., <itemN>]
 
       # The log body must match at least one of the items.
       # Currently only string body types are supported.

--- a/processor/attributesprocessor/factory.go
+++ b/processor/attributesprocessor/factory.go
@@ -98,10 +98,6 @@ func createLogProcessor(
 		return nil, fmt.Errorf("error creating \"attributes\" processor: %w of processor %v", err, cfg.ID())
 	}
 
-	if (oCfg.Include != nil && len(oCfg.Include.LogNames) > 0) || (oCfg.Exclude != nil && len(oCfg.Exclude.LogNames) > 0) {
-		set.Logger.Warn("log_names setting is deprecated and will be removed soon")
-	}
-
 	include, err := filterlog.NewMatcher(oCfg.Include)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description:**
Remove the log_names property matcher for logs, as log names are now obsolete.
Also, the log_names property is not used in actually filtering records, and therefore already not in use.

**Link to tracking Issue:**
No issue.

**Testing:**
No new tests. Deleting code only.

**Documentation:**
None - removed.