### PR TITLE
[extension/filestorage] use correct bbolt options for compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### 🧰 Bug fixes 🧰
 
+- `filestorageextension`: use correct bbolt options for compaction (#9134)
 - `hostmetricsreceiver`: Use cpu times for time delta in cpu.utilization calculation (#8857)
 - `dynatraceexporter`: Remove overly verbose stacktrace from certain logs (#8989)
 - `googlecloudexporter`: fix the `exporter.googlecloud.OTLPDirect` fature-gate, which was not applied when the flag was provided (#9116)

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -31,13 +31,17 @@ type fileStorageClient struct {
 	db *bbolt.DB
 }
 
-func newClient(filePath string, timeout time.Duration) (*fileStorageClient, error) {
-	options := &bbolt.Options{
+func bboltOptions(timeout time.Duration) *bbolt.Options {
+	return &bbolt.Options{
 		Timeout:        timeout,
 		NoSync:         true,
 		NoFreelistSync: true,
 		FreelistType:   bbolt.FreelistMapType,
 	}
+}
+
+func newClient(filePath string, timeout time.Duration) (*fileStorageClient, error) {
+	options := bboltOptions(timeout)
 	db, err := bbolt.Open(filePath, 0600, options)
 	if err != nil {
 		return nil, err
@@ -121,10 +125,7 @@ func (c *fileStorageClient) Compact(ctx context.Context, compactionDirectory str
 	}
 
 	// use temporary file as compaction target
-	options := &bbolt.Options{
-		Timeout: timeout,
-		NoSync:  true,
-	}
+	options := bboltOptions(timeout)
 
 	// cannot reuse newClient as db shouldn't contain any bucket
 	db, err := bbolt.Open(file.Name(), 0600, options)


### PR DESCRIPTION
**Description:** We changed the bbolt options for opening the db on client creation in #9004 but forgot to change them for compaction as well. 

**Link to tracking Issue:** N/A

**Testing:** Existing tests are good enough. This change only affects performance in particular circumstances. See #9004 and the linked issue for a more detailed discussion.

**Documentation:** N/A