### PR TITLE
Fix flaky test in jaegerremotesampling

### DIFF
--- a/extension/jaegerremotesampling/extension_test.go
+++ b/extension/jaegerremotesampling/extension_test.go
@@ -59,13 +59,14 @@ func TestStartAndShutdownRemote(t *testing.T) {
 
 	// create the mock server
 	server := grpc.NewServer()
+
+	// register the service
+	api_v2.RegisterSamplingManagerServer(server, &samplingServer{})
+
 	go func() {
 		err = server.Serve(lis)
 		require.NoError(t, err)
 	}()
-
-	// register the service
-	api_v2.RegisterSamplingManagerServer(server, &samplingServer{})
 
 	// create the config, pointing to the mock server
 	cfg := createDefaultConfig().(*Config)


### PR DESCRIPTION
Before this change, the test would intermittently fail with:

```
2022/04/11 13:42:07 FATAL: [core] grpc: Server.RegisterService after Server.Serve for "jaeger.api_v2.SamplingManager"
FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling        0.028s
```

I was able to consistently reproduce it with:

```
$ go test -race -v -timeout 300s -count 1000 --tags=""  -run "^TestStartAndShutdownRemote$" ./...
```

After this PR, I wasn't able to reproduce this anymore.

Fixes #9113

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>