### PR TITLE
[receiver/windowsperfcountersreceiver] Emit double values instead of integer values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `dynatraceexporter`: Remove overly verbose stacktrace from certain logs (#8989)
 - `googlecloudexporter`: fix the `exporter.googlecloud.OTLPDirect` fature-gate, which was not applied when the flag was provided (#9116)
 - `windowsperfcountersreceiver`: fix exported values being integers instead of doubles (#9138)
+
 ### 🚩 Deprecations 🚩
 
 - `datadogexporter`: Deprecate `service` setting in favor of `service.name` semantic convention (#8784)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - `hostmetricsreceiver`: Use cpu times for time delta in cpu.utilization calculation (#8857)
 - `dynatraceexporter`: Remove overly verbose stacktrace from certain logs (#8989)
 - `googlecloudexporter`: fix the `exporter.googlecloud.OTLPDirect` fature-gate, which was not applied when the flag was provided (#9116)
-
+- `windowsperfcountersreceiver`: fix exported values being integers instead of doubles (#9138)
 ### 🚩 Deprecations 🚩
 
 - `datadogexporter`: Deprecate `service` setting in favor of `service.name` semantic convention (#8784)

--- a/receiver/windowsperfcountersreceiver/testdata/scraper/sum_metric.json
+++ b/receiver/windowsperfcountersreceiver/testdata/scraper/sum_metric.json
@@ -12,7 +12,7 @@
                         "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
                         "dataPoints": [
                            {
-                              "asInt": "19446169600",
+                              "asDouble": "19446169600",
                               "timeUnixNano": "1646862225775600200"
                            }
                         ]

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
@@ -165,15 +165,6 @@ func (s *scraper) scrape(context.Context) (pdata.Metrics, error) {
 	return md, errs
 }
 
-func initializeNumberDataPointAsDouble(dataPoint pdata.NumberDataPoint, now pdata.Timestamp, instanceLabel string, value float64) {
-	if instanceLabel != "" {
-		dataPoint.Attributes().InsertString(instanceLabelName, instanceLabel)
-	}
-
-	dataPoint.SetTimestamp(now)
-	dataPoint.SetDoubleVal(value)
-}
-
 func initializeMetricDps(metric pdata.Metric, now pdata.Timestamp, counterValues []win_perf_counters.CounterValue, attributes map[string]string) {
 	var dps pdata.NumberDataPointSlice
 
@@ -197,6 +188,6 @@ func initializeMetricDps(metric pdata.Metric, now pdata.Timestamp, counterValues
 		}
 
 		dp.SetTimestamp(now)
-		dp.SetIntVal(int64(counterValue.Value))
+		dp.SetDoubleVal(counterValue.Value)
 	}
 }


### PR DESCRIPTION
**Description:**
- Emit the scraped float64 values instead of truncating to int64
- Removed now unused function for initializing the datapoint as double

**Link to tracking Issue:** #9136 

**Testing:** 
Updated unit test to expect double value
Manually tested with this config:
```yaml
receivers:
  windowsperfcounters:
    collection_interval: 10s
    metrics:
      processor.time:
        description: active and idle time of the processor
        unit: "%"
        gauge:
    perfcounters:
    - object: "Processor Information"
      instances: "*"
      counters:
        - name: "% Processor Time"
          metric: processor.time

exporters:
  logging:
    loglevel: debug

service:
  pipelines:
    metrics:
      receivers: [windowsperfcounters]
      exporters: [logging]
```

I see datapoints with double values:
```
NumberDataPoints #4
Data point attributes:
     -> instance: STRING(0,_Total)
StartTimestamp: 1970-01-01 00:00:00 +0000 UTC
Timestamp: 2022-04-11 16:41:18.6038037 +0000 UTC
Value: 0.866840
```