### PR TITLE
[buildscripts/update-dep] Do not update indirect dependancies

### DIFF
--- a/internal/buildscripts/update-dep
+++ b/internal/buildscripts/update-dep
@@ -4,14 +4,14 @@
 
 set -e
 
-if grep -q "$MODULE " go.mod; then
+if grep "$MODULE " go.mod | grep -Fvq "// indirect"; then
   go get "$MODULE"@"$VERSION"
 fi
 
 # If MODULE is "go.opentelemetry.io/collector" need to update "go.opentelemetry.io/collector/model" as well.
 if [ "$MODULE" == "go.opentelemetry.io/collector" ]; then
   MODEL=$MODULE"/model"
-  if grep -q "$MODEL " go.mod; then
+  if grep "$MODEL " go.mod | grep -Fvq "// indirect"; then
     go get "$MODEL"@"$VERSION"
   fi
 fi


### PR DESCRIPTION
Do not forcefully update indirect dependancies since it can cause subtle issues in third-party libraries potentially

cc @codeboten 