### PR TITLE
Retry unit tests upon failure

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -43,7 +43,10 @@ common: checklicense checkdoc impi lint misspell
 
 .PHONY: test
 test:
-	$(GOTEST) $(GOTEST_OPT) ./...
+	@# attempts to run the tests at most 5 times
+	for i in {1..5}; do \
+		$(GOTEST) $(GOTEST_OPT) ./... && break || echo "Tests failed (attempt #$$i)"; \
+	done
 
 .PHONY: do-unit-tests-with-cover
 do-unit-tests-with-cover:


### PR DESCRIPTION
This change attempts to reduce the build failures due to flaky tests by re-running the tests up to 5 times upon failure. This is not a real solution and it will increase build times for failures, but it automates in a smarter way what we are doing manually already anyway.

When the tests fail, this is the expected output:

```
$ make test
for i in {1..5}; do \
	go test -race -v -timeout 300s --tags="" ./... && break || echo "Tests failed (attempt #$i)"; \
done
go: updates to go.mod needed; to update it:
	go mod tidy
Tests failed (attempt #1)
go: updates to go.mod needed; to update it:
	go mod tidy
Tests failed (attempt #2)
go: updates to go.mod needed; to update it:
	go mod tidy
Tests failed (attempt #3)
go: updates to go.mod needed; to update it:
	go mod tidy
Tests failed (attempt #4)
go: updates to go.mod needed; to update it:
	go mod tidy
Tests failed (attempt #5)
```

When they work, this is the expected output (using the extension/jaegerremotesampling as example):

```
$ make test
for i in {1..5}; do \
	go test -race -v -timeout 300s --tags="" ./... && break || echo "Tests failed (attempt #$i)"; \
done
=== RUN   TestLoadConfig
--- PASS: TestLoadConfig (0.00s)
=== RUN   TestValidate
=== RUN   TestValidate/no_receiving_protocols
=== RUN   TestValidate/no_sources
=== RUN   TestValidate/too_many_sources
--- PASS: TestValidate (0.00s)
    --- PASS: TestValidate/no_receiving_protocols (0.00s)
    --- PASS: TestValidate/no_sources (0.00s)
    --- PASS: TestValidate/too_many_sources (0.00s)
=== RUN   TestNewExtension
--- PASS: TestNewExtension (0.00s)
=== RUN   TestStartAndShutdownLocalFile
--- PASS: TestStartAndShutdownLocalFile (0.00s)
=== RUN   TestStartAndShutdownRemote
--- PASS: TestStartAndShutdownRemote (0.00s)
=== RUN   TestCreateDefaultConfig
--- PASS: TestCreateDefaultConfig (0.00s)
=== RUN   TestCreateExtension
--- PASS: TestCreateExtension (0.00s)
=== RUN   TestNewFactory
--- PASS: TestNewFactory (0.00s)
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling	0.042s
=== RUN   TestMissingClientConfigManager
--- PASS: TestMissingClientConfigManager (0.00s)
=== RUN   TestStartAndStop
--- PASS: TestStartAndStop (0.00s)
=== RUN   TestEndpointsAreWired
=== RUN   TestEndpointsAreWired/legacy
=== RUN   TestEndpointsAreWired/new
--- PASS: TestEndpointsAreWired (0.01s)
    --- PASS: TestEndpointsAreWired/legacy (0.00s)
    --- PASS: TestEndpointsAreWired/new (0.00s)
=== RUN   TestServiceNameIsRequired
--- PASS: TestServiceNameIsRequired (0.00s)
=== RUN   TestErrorFromClientConfigManager
--- PASS: TestErrorFromClientConfigManager (0.00s)
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling/internal	0.041s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling/local	[no test files]
```

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
