### PR TITLE
Fix key TTL to fix flaky test

### DIFF
--- a/extension/asapauthextension/extension_test.go
+++ b/extension/asapauthextension/extension_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"bitbucket.org/atlassian/go-asap/v2"
 	"github.com/stretchr/testify/assert"
@@ -49,7 +50,7 @@ var _ asap.KeyFetcher = (*mockKeyFetcher)(nil)
 func TestRoundTripper(t *testing.T) {
 	cfg := &Config{
 		PrivateKey: privateKey,
-		TTL:        60,
+		TTL:        60 * time.Second,
 		Audience:   []string{"test"},
 		Issuer:     "test_issuer",
 		KeyID:      "test_issuer/test_kid",
@@ -76,7 +77,7 @@ func TestRoundTripper(t *testing.T) {
 func TestRPCAuth(t *testing.T) {
 	cfg := &Config{
 		PrivateKey: privateKey,
-		TTL:        60,
+		TTL:        60 * time.Second,
 		Audience:   []string{"test"},
 		Issuer:     "test_issuer",
 		KeyID:      "test_issuer/test_kid",


### PR DESCRIPTION
**Description:**

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9259

There was a typo in the test where I forgot to add a `* time.Second` after the TTL value, so the key's TTL was 60 nanoseconds instead of 60 seconds. The build environment must be slow enough, but not the local environments. Produced locally by running it through the debugger which slowed down the execution time enough to see what was going on. 