### PR TITLE
[processor/transform]: add `join` function support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 - `datadogexporter`: Add `host_metadata` configuration section to configure host metadata export (#9100)
 - `cmd/mdatagen`: Update documentation generated for attributes to list enumerated values and show the "value" that will be visible on metrics when it is different from the attribute key in metadata.yaml (#8983)
 - `routingprocessor`: add option to drop resource attribute used for routing (#8990)
-- `transformprocessor`: add `join` function support (#) 
+- `transformprocessor`: add `join` function support (#9270) 
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - `datadogexporter`: Add `host_metadata` configuration section to configure host metadata export (#9100)
 - `cmd/mdatagen`: Update documentation generated for attributes to list enumerated values and show the "value" that will be visible on metrics when it is different from the attribute key in metadata.yaml (#8983)
 - `routingprocessor`: add option to drop resource attribute used for routing (#8990)
+- `transformprocessor`: add `join` function support (#) 
 
 ### 🧰 Bug fixes 🧰
 

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -22,6 +22,20 @@ it references an unset map value, there will be no action.
 - `keep_keys(target, string...)` - `target` is a path expression to a map type field. The map will be mutated to only contain
 the fields specified by the list of strings. e.g., `keep_keys(attributes, "http.method")`, `keep_keys(attributes, "http.method", "http.route")`
 
+- `join(delimiter, target, elems...)` - `target` is a path expression to a telemetry field to join elems and set `value` into
+e.g., `join("|", attributes["service.name"], attributes["service.name"], attributes["k8s.namespace.name"])`
+`input`:
+```bash
+attributes["service.name"]=demo
+attributes["k8s.namespace.name"]=default
+```
+
+`output`
+```bash
+attributes["service.name"]=demo|default
+attributes["k8s.namespace.name"]=default
+```
+
 Supported where operations:
 - `==` - matches telemetry where the values are equal to each other
 - `!=` - matches telemetry where the values are not equal to each other
@@ -43,6 +57,7 @@ processors:
         - set(status.code, 1) where attributes["http.path"] == "/health"
         - keep_keys(resource.attributes, "service.name", "service.namespace", "cloud.region")
         - set(name, attributes["http.route"])
+        - join("|", attributes["service.name"], attributes["service.name"], attributes["k8s.namespace.name"])
 service:
   pipelines:
     traces:
@@ -56,3 +71,4 @@ This processor will perform the operations in order for all spans
 1) Set status code to OK for all spans with a path `/health`
 2) Keep only `service.name`, `service.namespace`, `cloud.region` resource attributes
 3) Set `name` to the `http.route` attribute if it is set
+4) join the values of `attributes["service.name"]` and `attributes["k8s.namespace.name"]` with `|` delimiter, and set the value into `attributes["service.name"]`, like override.

--- a/processor/transformprocessor/config_test.go
+++ b/processor/transformprocessor/config_test.go
@@ -44,6 +44,7 @@ func TestLoadingConfig(t *testing.T) {
 			Queries: []string{
 				`set(name, "bear") where attributes["http.path"] == "/animal"`,
 				`keep_keys(attributes, "http.method", "http.path")`,
+				`join("|", attributes["service.name"], attributes["service.name"], attributes["k8s.namespace.name"])`,
 			},
 
 			functions: common.DefaultFunctions(),

--- a/processor/transformprocessor/testdata/config.yaml
+++ b/processor/transformprocessor/testdata/config.yaml
@@ -4,7 +4,7 @@ processors:
       queries:
         - set(name, "bear") where attributes["http.path"] == "/animal"
         - keep_keys(attributes, "http.method", "http.path")
-
+        - join("|", attributes["service.name"], attributes["service.name"], attributes["k8s.namespace.name"])
 receivers:
   nop:
 


### PR DESCRIPTION
Signed-off-by: jian.tan <jian.tan@daocloud.io>

**Description:** `transformprocessor`: add `join` function support

e.g,
```bash
join("|", attributes["service.name"], attributes["service.name"], attributes["k8s.namespace.name"])
```

`input`:
```bash
attributes["service.name"]=demo
attributes["k8s.namespace.name"]=default
```

`output`
```bash
attributes["service.name"]=demo|default # override with new value
attributes["k8s.namespace.name"]=default
```
