### PR TITLE
[receiver/hostmetrics]: Enforce valid UTF-8 in process command lines.

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -90,6 +90,7 @@ process:
     names: [ <process name>, ... ]
     match_type: <strict|regexp>
   mute_process_name_error: <true|false>
+  ensure_utf8: <true|false>
 ```
 
 ## Advanced Configuration

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	// collector does not have permission for.
 	// See https://github.com/open-telemetry/opentelemetry-collector/issues/3004 for more information.
 	MuteProcessNameError bool `mapstructure:"mute_process_name_error,omitempty"`
+
+	// EnforceUTF8 is a flag that will sanitize invalid UTF-8 characters in the process command line.
+	EnforceUTF8 bool `mapstructure:"enforce_utf8,omitempty"`
 }
 
 type MatchConfig struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -17,6 +17,7 @@ package processscraper // import "github.com/open-telemetry/opentelemetry-collec
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/shirou/gopsutil/v3/host"
@@ -150,6 +151,14 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 		command, err := getProcessCommand(handle)
 		if err != nil {
 			errs.AddPartial(0, fmt.Errorf("error reading command for process %q (pid %v): %w", executable.name, pid, err))
+		}
+
+		if s.config.EnforceUTF8 {
+			command.command = strings.ToValidUTF8(command.command, "�")
+			command.commandLine = strings.ToValidUTF8(command.commandLine, "�")
+			for i, a := range command.commandLineSlice {
+				command.commandLineSlice[i] = strings.ToValidUTF8(a, "�")
+			}
 		}
 
 		username, err := handle.Username()

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -506,52 +506,52 @@ func TestScrapeMetrics_EnforceUTF8(t *testing.T) {
 		expectedCmdLines   []string
 	}
 
-	invalidUtf8_2octet := string([]byte{0xc3, 0x28}) // Invalid 2-octet sequence
+	invalidUtf8_2octet := string([]byte{0xc3, 0x28})     // Invalid 2-octet sequence
 	invalidUtf8_sequenceId := string([]byte{0xa0, 0xa1}) // Invalid sequence identifier
 
 	testCases := []testCase{
 		{
-			name:               "Valid UTF-8 Characters Unchanged",
-			enforceUtf8:        true,
+			name:        "Valid UTF-8 Characters Unchanged",
+			enforceUtf8: true,
 			inputCmdlineSlices: [][]string{
-				[]string{"a", "b", "c"},
+				{"a", "b", "c"},
 			},
-			expectedCmdLines:   []string{
+			expectedCmdLines: []string{
 				"a b c",
 			},
 		},
 		{
-			name:               "Invalid UTF-8 Characters Sanitized",
-			enforceUtf8:        true,
+			name:        "Invalid UTF-8 Characters Sanitized",
+			enforceUtf8: true,
 			inputCmdlineSlices: [][]string{
-				[]string{invalidUtf8_2octet, "b", "c"},
-				[]string{invalidUtf8_sequenceId, "b", "c"},
+				{invalidUtf8_2octet, "b", "c"},
+				{invalidUtf8_sequenceId, "b", "c"},
 			},
-			expectedCmdLines:   []string{
+			expectedCmdLines: []string{
 				"�( b c",
 				"� b c",
 			},
 		},
 		{
-			name:               "Invalid UTF-8 Characters Unchanged",
-			enforceUtf8:        false,
+			name:        "Invalid UTF-8 Characters Unchanged",
+			enforceUtf8: false,
 			inputCmdlineSlices: [][]string{
-				[]string{invalidUtf8_2octet, "b", "c"},
-				[]string{invalidUtf8_sequenceId, "b", "c"},
+				{invalidUtf8_2octet, "b", "c"},
+				{invalidUtf8_sequenceId, "b", "c"},
 			},
-			expectedCmdLines:   []string{
+			expectedCmdLines: []string{
 				invalidUtf8_2octet + " b c",
 				invalidUtf8_sequenceId + " b c",
 			},
 		},
 		{
-			name:               "Invalid UTF-8 Characters Default (Unchanged)",
-			omitConfigField:    true,
+			name:            "Invalid UTF-8 Characters Default (Unchanged)",
+			omitConfigField: true,
 			inputCmdlineSlices: [][]string{
-				[]string{invalidUtf8_2octet, "b", "c"},
-				[]string{invalidUtf8_sequenceId, "b", "c"},
+				{invalidUtf8_2octet, "b", "c"},
+				{invalidUtf8_sequenceId, "b", "c"},
 			},
-			expectedCmdLines:   []string{
+			expectedCmdLines: []string{
 				invalidUtf8_2octet + " b c",
 				invalidUtf8_sequenceId + " b c",
 			},

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -506,8 +506,8 @@ func TestScrapeMetrics_EnforceUTF8(t *testing.T) {
 		expectedCmdLines   []string
 	}
 
-	invalidUtf8_2octet := string([]byte{0xc3, 0x28})     // Invalid 2-octet sequence
-	invalidUtf8_sequenceId := string([]byte{0xa0, 0xa1}) // Invalid sequence identifier
+	invalidUtf8TwoOctet := string([]byte{0xc3, 0x28})     // Invalid 2-octet sequence
+	invalidUtf8SequenceId := string([]byte{0xa0, 0xa1}) // Invalid sequence identifier
 
 	testCases := []testCase{
 		{
@@ -524,8 +524,8 @@ func TestScrapeMetrics_EnforceUTF8(t *testing.T) {
 			name:        "Invalid UTF-8 Characters Sanitized",
 			enforceUtf8: true,
 			inputCmdlineSlices: [][]string{
-				{invalidUtf8_2octet, "b", "c"},
-				{invalidUtf8_sequenceId, "b", "c"},
+				{invalidUtf8TwoOctet, "b", "c"},
+				{invalidUtf8SequenceId, "b", "c"},
 			},
 			expectedCmdLines: []string{
 				"�( b c",
@@ -536,24 +536,24 @@ func TestScrapeMetrics_EnforceUTF8(t *testing.T) {
 			name:        "Invalid UTF-8 Characters Unchanged",
 			enforceUtf8: false,
 			inputCmdlineSlices: [][]string{
-				{invalidUtf8_2octet, "b", "c"},
-				{invalidUtf8_sequenceId, "b", "c"},
+				{invalidUtf8TwoOctet, "b", "c"},
+				{invalidUtf8SequenceId, "b", "c"},
 			},
 			expectedCmdLines: []string{
-				invalidUtf8_2octet + " b c",
-				invalidUtf8_sequenceId + " b c",
+				invalidUtf8TwoOctet + " b c",
+				invalidUtf8SequenceId + " b c",
 			},
 		},
 		{
 			name:            "Invalid UTF-8 Characters Default (Unchanged)",
 			omitConfigField: true,
 			inputCmdlineSlices: [][]string{
-				{invalidUtf8_2octet, "b", "c"},
-				{invalidUtf8_sequenceId, "b", "c"},
+				{invalidUtf8TwoOctet, "b", "c"},
+				{invalidUtf8SequenceId, "b", "c"},
 			},
 			expectedCmdLines: []string{
-				invalidUtf8_2octet + " b c",
-				invalidUtf8_sequenceId + " b c",
+				invalidUtf8TwoOctet + " b c",
+				invalidUtf8SequenceId + " b c",
 			},
 		},
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -507,7 +507,7 @@ func TestScrapeMetrics_EnforceUTF8(t *testing.T) {
 	}
 
 	invalidUtf8TwoOctet := string([]byte{0xc3, 0x28})     // Invalid 2-octet sequence
-	invalidUtf8SequenceId := string([]byte{0xa0, 0xa1}) // Invalid sequence identifier
+	invalidUtf8SequenceID := string([]byte{0xa0, 0xa1}) // Invalid sequence identifier
 
 	testCases := []testCase{
 		{
@@ -525,7 +525,7 @@ func TestScrapeMetrics_EnforceUTF8(t *testing.T) {
 			enforceUtf8: true,
 			inputCmdlineSlices: [][]string{
 				{invalidUtf8TwoOctet, "b", "c"},
-				{invalidUtf8SequenceId, "b", "c"},
+				{invalidUtf8SequenceID, "b", "c"},
 			},
 			expectedCmdLines: []string{
 				"�( b c",
@@ -537,11 +537,11 @@ func TestScrapeMetrics_EnforceUTF8(t *testing.T) {
 			enforceUtf8: false,
 			inputCmdlineSlices: [][]string{
 				{invalidUtf8TwoOctet, "b", "c"},
-				{invalidUtf8SequenceId, "b", "c"},
+				{invalidUtf8SequenceID, "b", "c"},
 			},
 			expectedCmdLines: []string{
 				invalidUtf8TwoOctet + " b c",
-				invalidUtf8SequenceId + " b c",
+				invalidUtf8SequenceID + " b c",
 			},
 		},
 		{
@@ -549,11 +549,11 @@ func TestScrapeMetrics_EnforceUTF8(t *testing.T) {
 			omitConfigField: true,
 			inputCmdlineSlices: [][]string{
 				{invalidUtf8TwoOctet, "b", "c"},
-				{invalidUtf8SequenceId, "b", "c"},
+				{invalidUtf8SequenceID, "b", "c"},
 			},
 			expectedCmdLines: []string{
 				invalidUtf8TwoOctet + " b c",
-				invalidUtf8SequenceId + " b c",
+				invalidUtf8SequenceID + " b c",
 			},
 		},
 	}


### PR DESCRIPTION
**Description:** Added a new `enforce_utf8` configuration option to the `hostmetrics` process scraper that ensures valid UTF-8 strings in process command lines.

**Testing:** New unit tests for UTF-8 sanitization with the option on, off, and unspecified.

**Documentation:** Added documentation for the new option in process scraper configuration.