### PR TITLE
[internal/k8sconfig] Configure k8s library to not crash

### DIFF
--- a/internal/k8sconfig/config.go
+++ b/internal/k8sconfig/config.go
@@ -21,10 +21,16 @@ import (
 	"os"
 
 	quotaclientset "github.com/openshift/client-go/quota/clientset/versioned"
+	k8sruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
+
+func init() {
+	k8sruntime.ReallyCrash = false
+	k8sruntime.PanicHandlers = []func(interface{}){}
+}
 
 // AuthType describes the type of authentication to use for the K8s API
 type AuthType string

--- a/internal/k8sconfig/go.mod
+++ b/internal/k8sconfig/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
+	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
 )
 
@@ -34,7 +35,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.23.5 // indirect
-	k8s.io/apimachinery v0.23.5 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect


### PR DESCRIPTION
This is not necessarily a root cause fix, but it may be sufficient to address crashes observed in test cases.

Resolves #6986
Resolves #9002
Resolves #9326

---

## Explanation of changes

1. The same error is presenting in various tests across both `k8sclusterreceiver` and `k8seventreceiver`.
2. Both of these packages rely on `internal/k8sconfig`, which provides the client used by both receivers.
3. The client creates a `Controller` which, when run, creates a `Reflector` that ultimately runs a very complicated and fragile looking function called [ListAndWatch](https://github.com/kubernetes/client-go/blob/28ccde769fc5519dd84e5512ebf303ac86ef9d7c/tools/cache/reflector.go#L254), which I believe is throwing panics in recoverable situations.
4. The `Controller` defers a [`HandleCrash`](https://github.com/kubernetes/apimachinery/blob/080c0c77fab5f76acfa0c31e9e59411ecc861973/pkg/util/runtime/runtime.go#L46) function, which is configurable using global settings. One is a `ReallyCrash` boolean which determines whether or not to crash or continue. The other is a slice of `PanicHandlers`, which by default contains one function that logs the panic stack trace.
5. The changes in this PR tell the library not to not crash and not to log panics. These are not ideal settings, but I think they may be a starting point for more robust handling in these components. Perhaps a future PR will implement a `PanicHandler` that manages component status and if necessary resolves internal component state.

Also of interest, is that the stop channel provided to `Controller.Run` [apparently does not work as intended](https://github.com/kubernetes/client-go/blob/master/tools/cache/controller.go#L178-L181).

---

The error is reproducible locally but does not occur frequently. On my machine, I see it less than 1/1000 test runs, but almost always within 5000, so the following reproduces the issue consistently for me: `(cd receiver/k8seventsreceiver && go test -race -v -timeout 300s -count 5000 --tags="" ./...)`
