### PR TITLE
short meter with metric v0.29.0

### DIFF
--- a/examples/demo/client/main.go
+++ b/examples/demo/client/main.go
@@ -128,7 +128,7 @@ func main() {
 	defer shutdown()
 
 	tracer := otel.Tracer("demo-client-tracer")
-	meter := global.MeterProvider().Meter("demo-client-meter")
+	meter := global.Meter("demo-client-meter")
 
 	method, _ := baggage.NewMember("method", "repl")
 	client, _ := baggage.NewMember("client", "cli")

--- a/examples/demo/server/main.go
+++ b/examples/demo/server/main.go
@@ -127,7 +127,7 @@ func main() {
 	shutdown := initProvider()
 	defer shutdown()
 
-	meter := global.MeterProvider().Meter("demo-server-meter")
+	meter := global.Meter("demo-server-meter")
 	serverAttribute := attribute.String("server-attribute", "foo")
 	commonLabels := []attribute.KeyValue{serverAttribute}
 	requestCount, _ := meter.SyncInt64().Counter(


### PR DESCRIPTION
with otel v0.29.0 released.
I followed the pr https://github.com/open-telemetry/opentelemetry-go/pull/2750 to short the meter definition.