### PR TITLE
[processor/k8sattributesprocessor] Add RBAC rules documentation

### DIFF
--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -90,14 +90,14 @@
 //
 // RBAC
 //
-//The k8sattributesprocessor needs `get`, `watch` and `list` permissions on both `pods` and `namespaces` resources, for all namespaces and pods included in the configured filters.
-//Here is an example of a `ClusterRole` to give a `ServiceAccount` the necessary permissions for all pods and namespaces in the cluster:
+// The k8sattributesprocessor needs `get`, `watch` and `list` permissions on both `pods` and `namespaces` resources, for all namespaces and pods included in the configured filters.
+// Here is an example of a `ClusterRole` to give a `ServiceAccount` the necessary permissions for all pods and namespaces in the cluster (replace `<OTEL_COL_NAMESPACE>` with a namespace where collector is deployed):
 //
 //      apiVersion: v1
 //      kind: ServiceAccount
 //      metadata:
 //        name: collector
-//        namespace: tracing
+//        namespace: <OTEL_COL_NAMESPACE>
 //      ---
 //      apiVersion: rbac.authorization.k8s.io/v1
 //      kind: ClusterRole
@@ -115,7 +115,7 @@
 //      subjects:
 //      - kind: ServiceAccount
 //        name: collector
-//        namespace: tracing
+//        namespace: <OTEL_COL_NAMESPACE>
 //      roleRef:
 //        kind: ClusterRole
 //        name: otel-collector

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -90,7 +90,36 @@
 //
 // RBAC
 //
-// TODO: mention the required RBAC rules.
+//The k8sattributesprocessor needs `get`, `watch` and `list` permissions on both `pods` and `namespaces` resources, across the entire cluster.
+//Here is an example of a `ClusterRole` to give a `ServiceAccount` the necessary permissions:
+//
+//      apiVersion: v1
+//      kind: ServiceAccount
+//      metadata:
+//        name: collector
+//        namespace: tracing
+//      ---
+//      apiVersion: rbac.authorization.k8s.io/v1
+//      kind: ClusterRole
+//      metadata:
+//        name: otel-collector
+//      rules:
+//      - apiGroups: [""]
+//        resources: ["pods", "namespaces"]
+//        verbs: ["get", "watch", "list"]
+//      ---
+//      apiVersion: rbac.authorization.k8s.io/v1
+//      kind: ClusterRoleBinding
+//      metadata:
+//        name: otel-collector
+//      subjects:
+//      - kind: ServiceAccount
+//        name: collector
+//        namespace: tracing
+//      roleRef:
+//        kind: ClusterRole
+//        name: otel-collector
+//        apiGroup: rbac.authorization.k8s.io
 //
 // Config
 //

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -90,7 +90,7 @@
 //
 // RBAC
 //
-//The k8sattributesprocessor needs `get`, `watch` and `list` permissions on both `pods` and `namespaces` resources, across the entire cluster.
+//The k8sattributesprocessor needs `get`, `watch` and `list` permissions on both `pods` and `namespaces` resources, for all namespaces and pods included in the configured filters.
 //Here is an example of a `ClusterRole` to give a `ServiceAccount` the necessary permissions:
 //
 //      apiVersion: v1

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -91,7 +91,7 @@
 // RBAC
 //
 //The k8sattributesprocessor needs `get`, `watch` and `list` permissions on both `pods` and `namespaces` resources, for all namespaces and pods included in the configured filters.
-//Here is an example of a `ClusterRole` to give a `ServiceAccount` the necessary permissions:
+//Here is an example of a `ClusterRole` to give a `ServiceAccount` the necessary permissions for all pods and namespaces in the cluster:
 //
 //      apiVersion: v1
 //      kind: ServiceAccount


### PR DESCRIPTION
**Description:** Add missing documentation on how to setup RBAC rules for the `k8sattributesprocessor`

**Link to tracking Issue:** N/A

**Testing:** I've tested the documented RBAC rules in my deployment of the collector.

**Documentation:** This adds an example of RBAC permissions to give to the collector in order to have the `k8sattributesprocessor` work.