### PR TITLE
[k8sclusterreceiver]: Update the `receiver.k8sclusterreceiver.reportCpuMetricsAsDouble` feature gate 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 - `mongodbatlasreceiver`: Updated to uses newer metric builder which changed some metric and resource attributes (#9093)
 - `dynatraceexporter`: Make `serialization` package `/internal` (#9097)
 - `attributesprocessor`: Remove log names from filters (#9131)
+- `k8sclusterreceiver`: The `receiver.k8sclusterreceiver.reportCpuMetricsAsDouble` feature gate is now enabled by default (#9367)
+  - Users may have to update monitoring for a few Kubernetes cpu metrics, for 
+    more details see [feature-gate-configurations](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8sclusterreceiver#feature-gate-configurations).
 
 ### 🚩 Deprecations 🚩
 

--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -67,17 +67,19 @@ with detailed sample configurations [here](./testdata/config.yaml).
     - k8s.node.allocatable_cpu
   - Stages and Timeline
     - Alpha
-      - In this stage the feature is disabled by default and must be enabled by the user.
-      - Target version
-        - v0.47.0
-    - Beta
-      - In this stage the feature enabled by default but can be disabled by the user.
-      - Target version
-        - v0.50.0
+      - In this stage the feature gate is disabled by default and must be enabled by the user. This allows users to preemptively opt in and start using the bug fix by enabling the feature gate.
+      - Collector version: v0.47.0
+      - Release Date: Late March 2022
+    - Beta (current stage)
+      - In this stage the feature gate is enabled by default and can be disabled by the user.
+      - Users could experience some friction in this stage, they may need to update monitoring for the affected metrics or opt out of using the bug fix by disabling the feature gate.
+      - Target Collector version: v0.50.0
+      - Target Release Date: Early May 2022
     - Generally Available
-      - In this stage the feature is permanently enabled and the feature gate is no longer available.
-      - Target version
-        - v0.53.0
+      - In this stage the feature gate is permanently enabled and the feature gate is no longer available for anyone.
+      - Users could experience some friction in this stage, they may have to update monitoring for the affected metrics or be blocked from upgrading the collector to versions v0.53.0 and newer.
+      - Target Collector version: v0.53.0
+      - Target Release Date: Mid June 2022
   - Usage
     - Feature gate identifiers prefixed with - will disable the gate and prefixing with + or with no prefix will enable the gate.
     - Start the otelcol with the feature gate enabled:

--- a/receiver/k8sclusterreceiver/internal/collection/collector.go
+++ b/receiver/k8sclusterreceiver/internal/collection/collector.go
@@ -84,7 +84,7 @@ type DataCollector struct {
 
 var reportCPUMetricsAsDoubleFeatureGate = featuregate.Gate{
 	ID:      reportCPUMetricsAsDoubleFeatureGateID,
-	Enabled: false,
+	Enabled: true,
 	Description: "The k8s container and node cpu metrics being reported by the k8sclusterreceiver are transitioning " +
 		"from being reported as integer millicpu units to being reported as double cpu units to adhere to " +
 		"opentelemetry cpu metric specifications. You can control whether the k8sclusterreceiver reports container " +


### PR DESCRIPTION
**Description:**
Moving the receiver.k8sclusterreceiver.reportCpuMetricsAsDouble feature gate from its Alpha stage to its Beta stage for release v0.50.0.  The feature gate will now be enabled by default.

**Link to tracking Issue:**
This is small PR, so I did not create a new issue. 
Here is the original related issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/8245

**Testing:** <Describe what testing was performed and which tests were added.>
All the functionality was tested in the original related issue.

**Documentation:**
Updated the README notes to include more information.