### PR TITLE
[receiver/prometheus] Support OpenMetrics Info and Stateset metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - `transformprocessor`: Add transformation of logs (#9368)
 - `datadogexporter`: Add `metrics::summaries::mode` to specify export mode for summaries (#8846)
 - `prometheusreceiver`: Add resource attributes for kubernetes resource discovery labels (#9416)
+- `prometheusreceiver`: Support OpenMetrics Info and Stateset metrics (#9378)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `transformprocessor`: Add new `limit` function to allow limiting the number of items in a map, such as the number of attributes in `attributes` or `resource.attributes` (#9552)
 - `processor/attributes`: Support attributes set by server authenticator (#9420)
 - `datadogexporter`: Experimental support for Exponential Histograms with delta aggregation temporality (#8350)
+- `prometheusreceiver`: Support OpenMetrics Info and Stateset metrics (#9378)
 
 ### 🧰 Bug fixes 🧰
 
@@ -84,7 +85,6 @@
 - `transformprocessor`: Add transformation of logs (#9368)
 - `datadogexporter`: Add `metrics::summaries::mode` to specify export mode for summaries (#8846)
 - `prometheusreceiver`: Add resource attributes for kubernetes resource discovery labels (#9416)
-- `prometheusreceiver`: Support OpenMetrics Info and Stateset metrics (#9378)
 
 ### 🧰 Bug fixes 🧰
 

--- a/receiver/prometheusreceiver/internal/otlp_metricfamily.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricfamily.go
@@ -29,7 +29,9 @@ import (
 )
 
 type metricFamily struct {
-	mtype             pmetric.MetricDataType
+	mtype pmetric.MetricDataType
+	// isMonotonic only applies to sums
+	isMonotonic       bool
 	groups            map[string]*metricGroup
 	name              string
 	mc                MetadataCache
@@ -59,13 +61,14 @@ var pdataStaleFlags = pmetric.NewMetricDataPointFlags(pmetric.MetricDataPointFla
 
 func newMetricFamily(metricName string, mc MetadataCache, logger *zap.Logger) *metricFamily {
 	metadata, familyName := metadataForMetric(metricName, mc)
-	mtype := convToMetricType(metadata.Type)
+	mtype, isMonotonic := convToMetricType(metadata.Type)
 	if mtype == pmetric.MetricDataTypeNone {
 		logger.Debug(fmt.Sprintf("Unknown-typed metric : %s %+v", metricName, metadata))
 	}
 
 	return &metricFamily{
 		mtype:             mtype,
+		isMonotonic:       isMonotonic,
 		groups:            make(map[string]*metricGroup),
 		name:              familyName,
 		mc:                mc,
@@ -354,7 +357,7 @@ func (mf *metricFamily) ToMetric(metrics *pmetric.MetricSlice) (int, int) {
 	case pmetric.MetricDataTypeSum:
 		sum := metric.Sum()
 		sum.SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
-		sum.SetIsMonotonic(true)
+		sum.SetIsMonotonic(mf.isMonotonic)
 		sdpL := sum.DataPoints()
 		for _, mg := range mf.getGroups() {
 			if !mg.toNumberDataPoint(mf.labelKeysOrdered, &sdpL) {

--- a/receiver/prometheusreceiver/internal/otlp_metricsbuilder.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricsbuilder.go
@@ -59,7 +59,7 @@ func getBoundary(metricType pmetric.MetricDataType, labels labels.Labels) (float
 	return strconv.ParseFloat(v, 64)
 }
 
-// convToPdataMetricType returns the data type and if it is monotonic
+// convToMetricType returns the data type and if it is monotonic
 func convToMetricType(metricType textparse.MetricType) (pmetric.MetricDataType, bool) {
 	switch metricType {
 	case textparse.MetricTypeCounter:

--- a/receiver/prometheusreceiver/internal/otlp_metricsbuilder_test.go
+++ b/receiver/prometheusreceiver/internal/otlp_metricsbuilder_test.go
@@ -181,52 +181,67 @@ func TestGetBoundary(t *testing.T) {
 
 func TestConvToMetricType(t *testing.T) {
 	tests := []struct {
-		name  string
-		mtype textparse.MetricType
-		want  pmetric.MetricDataType
+		name          string
+		mtype         textparse.MetricType
+		want          pmetric.MetricDataType
+		wantMonotonic bool
 	}{
 		{
-			name:  "textparse.counter",
-			mtype: textparse.MetricTypeCounter,
-			want:  pmetric.MetricDataTypeSum,
+			name:          "textparse.counter",
+			mtype:         textparse.MetricTypeCounter,
+			want:          pmetric.MetricDataTypeSum,
+			wantMonotonic: true,
 		},
 		{
-			name:  "textparse.gauge",
-			mtype: textparse.MetricTypeGauge,
-			want:  pmetric.MetricDataTypeGauge,
+			name:          "textparse.gauge",
+			mtype:         textparse.MetricTypeGauge,
+			want:          pmetric.MetricDataTypeGauge,
+			wantMonotonic: false,
 		},
 		{
-			name:  "textparse.unknown",
-			mtype: textparse.MetricTypeUnknown,
-			want:  pmetric.MetricDataTypeGauge,
+			name:          "textparse.unknown",
+			mtype:         textparse.MetricTypeUnknown,
+			want:          pmetric.MetricDataTypeGauge,
+			wantMonotonic: false,
 		},
 		{
-			name:  "textparse.histogram",
-			mtype: textparse.MetricTypeHistogram,
-			want:  pmetric.MetricDataTypeHistogram,
+			name:          "textparse.histogram",
+			mtype:         textparse.MetricTypeHistogram,
+			want:          pmetric.MetricDataTypeHistogram,
+			wantMonotonic: true,
 		},
 		{
-			name:  "textparse.summary",
-			mtype: textparse.MetricTypeSummary,
-			want:  pmetric.MetricDataTypeSummary,
+			name:          "textparse.summary",
+			mtype:         textparse.MetricTypeSummary,
+			want:          pmetric.MetricDataTypeSummary,
+			wantMonotonic: true,
 		},
 		{
-			name:  "textparse.metric_type_info",
-			mtype: textparse.MetricTypeInfo,
-			want:  pmetric.MetricDataTypeNone,
+			name:          "textparse.metric_type_info",
+			mtype:         textparse.MetricTypeInfo,
+			want:          pmetric.MetricDataTypeSum,
+			wantMonotonic: false,
 		},
 		{
-			name:  "textparse.metric_state_set",
-			mtype: textparse.MetricTypeStateset,
-			want:  pmetric.MetricDataTypeNone,
+			name:          "textparse.metric_state_set",
+			mtype:         textparse.MetricTypeStateset,
+			want:          pmetric.MetricDataTypeSum,
+			wantMonotonic: false,
+		},
+		{
+			name:          "textparse.metric_gauge_hostogram",
+			mtype:         textparse.MetricTypeGaugeHistogram,
+			want:          pmetric.MetricDataTypeNone,
+			wantMonotonic: false,
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := convToMetricType(tt.mtype)
+			got, monotonic := convToMetricType(tt.mtype)
 			require.Equal(t, got.String(), tt.want.String())
+			require.Equal(t, monotonic, tt.wantMonotonic)
 		})
 	}
 }

--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -27,6 +27,7 @@ const (
 	metricsSuffixBucket = "_bucket"
 	metricsSuffixSum    = "_sum"
 	metricSuffixTotal   = "_total"
+	metricSuffixInfo    = "_info"
 	startTimeMetricName = "process_start_time_seconds"
 	scrapeUpMetricName  = "up"
 
@@ -35,7 +36,7 @@ const (
 )
 
 var (
-	trimmableSuffixes     = []string{metricsSuffixBucket, metricsSuffixCount, metricsSuffixSum, metricSuffixTotal}
+	trimmableSuffixes     = []string{metricsSuffixBucket, metricsSuffixCount, metricsSuffixSum, metricSuffixTotal, metricSuffixInfo}
 	errNoDataToBuild      = errors.New("there's no data to build")
 	errNoBoundaryLabel    = errors.New("given metricType has no BucketLabel or QuantileLabel")
 	errEmptyBoundaryLabel = errors.New("BucketLabel or QuantileLabel is empty")

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -396,6 +396,13 @@ func compareMetricType(typ pmetric.MetricDataType) metricTypeComparator {
 	}
 }
 
+func compareMetricIsMonotonic(isMonotonic bool) metricTypeComparator {
+	return func(t *testing.T, metric *pmetric.Metric) {
+		assert.Equal(t, pmetric.MetricDataTypeSum.String(), metric.DataType().String(), "IsMonotonic only exists for sums")
+		assert.Equal(t, isMonotonic, metric.Sum().IsMonotonic(), "IsMonotonic does not match")
+	}
+}
+
 func compareAttributes(attributes map[string]string) numberPointComparator {
 	return func(t *testing.T, numberDataPoint *pmetric.NumberDataPoint) {
 		req := assert.Equal(t, len(attributes), numberDataPoint.Attributes().Len(), "Attributes length do not match")


### PR DESCRIPTION
**Description:**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8516 by converting OpenMetrics info and stateset metrics to non-monotonic sums, as described in the specification.

**Testing:**

Unit tests added.