### PR TITLE
[receiver/prometheus] Validate that the largest prometheus bucket is the +Inf bucket

### DIFF
--- a/.chloggen/validate-prom-inf.yaml
+++ b/.chloggen/validate-prom-inf.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Validate that histograms include the inf bucket
+
+# One or more tracking issues related to the change
+issues: [9384]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -17,6 +17,7 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"encoding/hex"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 
@@ -113,6 +114,9 @@ func (mg *metricGroup) toDistributionPoint(dest pmetric.HistogramDataPointSlice)
 		if i != len(mg.complexValue)-1 {
 			// not need to add +inf as OTLP assumes it
 			bounds[i] = mg.complexValue[i].boundary
+		} else if mg.complexValue[i].boundary != math.Inf(1) {
+			// This histogram is missing the +Inf bucket, and isn't a complete prometheus histogram.
+			return
 		}
 		adjustedCount := mg.complexValue[i].value
 		// Buckets still need to be sent to know to set them as stale,

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -1129,19 +1129,6 @@ func TestMetricBuilderHistogram(t *testing.T) {
 			},
 			wants: func() []pmetric.Metrics {
 				md0 := pmetric.NewMetrics()
-				mL0 := md0.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
-				m0 := mL0.AppendEmpty()
-				m0.SetName("hist_test")
-				hist0 := m0.SetEmptyHistogram()
-				hist0.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
-				pt0 := hist0.DataPoints().AppendEmpty()
-				pt0.SetCount(3)
-				pt0.SetSum(100)
-				pt0.BucketCounts().FromRaw([]uint64{3})
-				pt0.SetTimestamp(tsNanos)
-				pt0.SetStartTimestamp(startTimestamp)
-				pt0.Attributes().PutStr("foo", "bar")
-
 				return []pmetric.Metrics{md0}
 			},
 		},


### PR DESCRIPTION
**Description:**

This is just a small additional piece of validation to make sure our interpretation of Prometheus histograms is correct.  Otherwise, our resulting histogram will place points that are in another bucket into the Inf bucket.

**Testing:**

Fixed some unit tests that were doing this.