### PR TITLE
[receiver/kafkametrics]: fix instrumentation scope name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `stackdriverexporter`: Remove the stackdriver exporter in favor of the identical googlecloud exporter (#9274)
 - `filelog`, `journald`, `syslog`, `tcplog`, `udplog`: Remove `preserve_to` field from sub-parsers (#9331)
+- `kafkametricsreceiver`: instrumentation name updated from `otelcol/kafkametrics` to `otelcol/kafkametricsreceiver` (#)
 
 ### 🚩 Deprecations 🚩
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `stackdriverexporter`: Remove the stackdriver exporter in favor of the identical googlecloud exporter (#9274)
 - `filelog`, `journald`, `syslog`, `tcplog`, `udplog`: Remove `preserve_to` field from sub-parsers (#9331)
-- `kafkametricsreceiver`: instrumentation name updated from `otelcol/kafkametrics` to `otelcol/kafkametricsreceiver` (#)
+- `kafkametricsreceiver`: instrumentation name updated from `otelcol/kafkametrics` to `otelcol/kafkametricsreceiver` (#9406)
 
 ### 🚩 Deprecations 🚩
 

--- a/receiver/kafkametricsreceiver/receiver.go
+++ b/receiver/kafkametricsreceiver/receiver.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	instrumentationLibName = "otelcol/kafkametrics"
+	instrumentationLibName = "otelcol/kafkametricsreceiver"
 	brokersScraperName     = "brokers"
 	topicsScraperName      = "topics"
 	consumersScraperName   = "consumers"


### PR DESCRIPTION
Signed-off-by: jian.tan <jian.tan@daocloud.io>

**Description:** fix https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9398.  update instrumentation scope name from `otelcol/kafkametrics` to `otelcol/kafkametricsreceiver` 
