### PR TITLE
Add k8s service discovery resource attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `attributesprocessor`: Support filter by severity (#9132)
 - `processor/transform`: Add transformation of logs (#9368)
 - `datadogexporter`: Add `metrics::summaries::mode` to specify export mode for summaries (#8846)
+- `prometheusreceiver`: Add resource attributes for kubernetes resource discovery labels (#9416)
 
 ### 🧰 Bug fixes 🧰
 

--- a/receiver/prometheusreceiver/internal/otlp_transaction.go
+++ b/receiver/prometheusreceiver/internal/otlp_transaction.go
@@ -116,7 +116,7 @@ func (t *transactionPdata) initTransaction(labels labels.Labels) error {
 		t.job = job
 		t.instance = instance
 	}
-	t.nodeResource = CreateNodeAndResourcePdata(job, instance, metadataCache.SharedLabels().Get(model.SchemeLabel))
+	t.nodeResource = CreateNodeAndResourcePdata(job, instance, metadataCache.SharedLabels())
 	t.metricBuilder = newMetricBuilderPdata(metadataCache, t.useStartTimeMetric, t.startTimeMetricRegex, t.logger, t.startTimeMs)
 	t.isNew = false
 	return nil

--- a/receiver/prometheusreceiver/internal/otlp_transaction_test.go
+++ b/receiver/prometheusreceiver/internal/otlp_transaction_test.go
@@ -108,7 +108,8 @@ func Test_transaction_pdata(t *testing.T) {
 		if got := tr.Commit(); got != nil {
 			t.Errorf("expecting nil from Commit() but got err %v", got)
 		}
-		expectedNodeResource := CreateNodeAndResourcePdata("test", "localhost:8080", "http")
+		l := []labels.Label{{Name: "__scheme__", Value: "http"}}
+		expectedNodeResource := CreateNodeAndResourcePdata("test", "localhost:8080", l)
 		mds := sink.AllMetrics()
 		if len(mds) != 1 {
 			t.Fatalf("wanted one batch, got %v\n", sink.AllMetrics())

--- a/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
@@ -17,12 +17,54 @@ package internal
 import (
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 )
 
 type jobInstanceDefinition struct {
 	job, instance, host, scheme, port string
+}
+
+type k8sResourceDefinition struct {
+	podName, podUID, container, node, rs, ds, ss, job, cronjob, ns string
+}
+
+func makeK8sResource(jobInstance *jobInstanceDefinition, def *k8sResourceDefinition) *pcommon.Resource {
+	resource := makeResourceWithJobInstanceScheme(jobInstance, true)
+	attrs := resource.Attributes()
+	if def.podName != "" {
+		attrs.UpsertString(conventions.AttributeK8SPodName, def.podName)
+	}
+	if def.podUID != "" {
+		attrs.UpsertString(conventions.AttributeK8SPodUID, def.podUID)
+	}
+	if def.container != "" {
+		attrs.UpsertString(conventions.AttributeK8SContainerName, def.container)
+	}
+	if def.node != "" {
+		attrs.UpsertString(conventions.AttributeK8SNodeName, def.node)
+	}
+	if def.rs != "" {
+		attrs.UpsertString(conventions.AttributeK8SReplicaSetName, def.rs)
+	}
+	if def.ds != "" {
+		attrs.UpsertString(conventions.AttributeK8SDaemonSetName, def.ds)
+	}
+	if def.ss != "" {
+		attrs.UpsertString(conventions.AttributeK8SStatefulSetName, def.ss)
+	}
+	if def.job != "" {
+		attrs.UpsertString(conventions.AttributeK8SJobName, def.job)
+	}
+	if def.cronjob != "" {
+		attrs.UpsertString(conventions.AttributeK8SCronJobName, def.cronjob)
+	}
+	if def.ns != "" {
+		attrs.UpsertString(conventions.AttributeK8SNamespaceName, def.ns)
+	}
+	return resource
 }
 
 func makeResourceWithJobInstanceScheme(def *jobInstanceDefinition, hasHost bool) *pcommon.Resource {
@@ -44,64 +86,203 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 	tests := []struct {
 		name, job string
 		instance  string
-		scheme    string
+		sdLabels  labels.Labels
 		want      *pcommon.Resource
 	}{
 		{
 			name: "all attributes proper",
-			job:  "job", instance: "hostname:8888", scheme: "http",
+			job:  "job", instance: "hostname:8888", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "hostname:8888", "hostname", "http", "8888",
 			}, true),
 		},
 		{
 			name: "missing port",
-			job:  "job", instance: "myinstance", scheme: "https",
+			job:  "job", instance: "myinstance", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "https"}),
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "myinstance", "myinstance", "https", "",
 			}, true),
 		},
 		{
 			name: "blank scheme",
-			job:  "job", instance: "myinstance:443", scheme: "",
+			job:  "job", instance: "myinstance:443", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: ""}),
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "myinstance:443", "myinstance", "", "443",
 			}, true),
 		},
 		{
 			name: "blank instance, blank scheme",
-			job:  "job", instance: "", scheme: "",
+			job:  "job", instance: "", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: ""}),
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "", "", "", "",
 			}, true),
 		},
 		{
 			name: "blank instance, non-blank scheme",
-			job:  "job", instance: "", scheme: "http",
+			job:  "job", instance: "", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "", "", "http", "",
 			}, true),
 		},
 		{
 			name: "0.0.0.0 address",
-			job:  "job", instance: "0.0.0.0:8888", scheme: "http",
+			job:  "job", instance: "0.0.0.0:8888", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "0.0.0.0:8888", "", "http", "8888",
 			}, false),
 		},
 		{
 			name: "localhost",
-			job:  "job", instance: "localhost:8888", scheme: "http",
+			job:  "job", instance: "localhost:8888", sdLabels: labels.New(labels.Label{Name: "__scheme__", Value: "http"}),
 			want: makeResourceWithJobInstanceScheme(&jobInstanceDefinition{
 				"job", "localhost:8888", "", "http", "8888",
 			}, false),
+		},
+		{
+			name: "kubernetes daemonset pod",
+			job:  "job", instance: "hostname:8888", sdLabels: labels.New(
+				labels.Label{Name: "__scheme__", Value: "http"},
+				labels.Label{Name: "__meta_kubernetes_pod_name", Value: "my-pod-23491"},
+				labels.Label{Name: "__meta_kubernetes_pod_uid", Value: "84279wretgu89dg489q2"},
+				labels.Label{Name: "__meta_kubernetes_pod_container_name", Value: "my-container"},
+				labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "k8s-node-123"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_name", Value: "my-pod"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "DaemonSet"},
+				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
+			),
+			want: makeK8sResource(&jobInstanceDefinition{
+				"job", "hostname:8888", "hostname", "http", "8888",
+			}, &k8sResourceDefinition{
+				podName:   "my-pod-23491",
+				podUID:    "84279wretgu89dg489q2",
+				container: "my-container",
+				node:      "k8s-node-123",
+				ds:        "my-pod",
+				ns:        "kube-system",
+			}),
+		},
+		{
+			name: "kubernetes replicaset pod",
+			job:  "job", instance: "hostname:8888", sdLabels: labels.New(
+				labels.Label{Name: "__scheme__", Value: "http"},
+				labels.Label{Name: "__meta_kubernetes_pod_name", Value: "my-pod-23491"},
+				labels.Label{Name: "__meta_kubernetes_pod_uid", Value: "84279wretgu89dg489q2"},
+				labels.Label{Name: "__meta_kubernetes_pod_container_name", Value: "my-container"},
+				labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "k8s-node-123"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_name", Value: "my-pod"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "ReplicaSet"},
+				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
+			),
+			want: makeK8sResource(&jobInstanceDefinition{
+				"job", "hostname:8888", "hostname", "http", "8888",
+			}, &k8sResourceDefinition{
+				podName:   "my-pod-23491",
+				podUID:    "84279wretgu89dg489q2",
+				container: "my-container",
+				node:      "k8s-node-123",
+				rs:        "my-pod",
+				ns:        "kube-system",
+			}),
+		},
+		{
+			name: "kubernetes statefulset pod",
+			job:  "job", instance: "hostname:8888", sdLabels: labels.New(
+				labels.Label{Name: "__scheme__", Value: "http"},
+				labels.Label{Name: "__meta_kubernetes_pod_name", Value: "my-pod-23491"},
+				labels.Label{Name: "__meta_kubernetes_pod_uid", Value: "84279wretgu89dg489q2"},
+				labels.Label{Name: "__meta_kubernetes_pod_container_name", Value: "my-container"},
+				labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "k8s-node-123"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_name", Value: "my-pod"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "StatefulSet"},
+				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
+			),
+			want: makeK8sResource(&jobInstanceDefinition{
+				"job", "hostname:8888", "hostname", "http", "8888",
+			}, &k8sResourceDefinition{
+				podName:   "my-pod-23491",
+				podUID:    "84279wretgu89dg489q2",
+				container: "my-container",
+				node:      "k8s-node-123",
+				ss:        "my-pod",
+				ns:        "kube-system",
+			}),
+		},
+		{
+			name: "kubernetes job pod",
+			job:  "job", instance: "hostname:8888", sdLabels: labels.New(
+				labels.Label{Name: "__scheme__", Value: "http"},
+				labels.Label{Name: "__meta_kubernetes_pod_name", Value: "my-pod-23491"},
+				labels.Label{Name: "__meta_kubernetes_pod_uid", Value: "84279wretgu89dg489q2"},
+				labels.Label{Name: "__meta_kubernetes_pod_container_name", Value: "my-container"},
+				labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "k8s-node-123"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_name", Value: "my-pod"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "Job"},
+				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
+			),
+			want: makeK8sResource(&jobInstanceDefinition{
+				"job", "hostname:8888", "hostname", "http", "8888",
+			}, &k8sResourceDefinition{
+				podName:   "my-pod-23491",
+				podUID:    "84279wretgu89dg489q2",
+				container: "my-container",
+				node:      "k8s-node-123",
+				job:       "my-pod",
+				ns:        "kube-system",
+			}),
+		},
+		{
+			name: "kubernetes cronjob pod",
+			job:  "job", instance: "hostname:8888", sdLabels: labels.New(
+				labels.Label{Name: "__scheme__", Value: "http"},
+				labels.Label{Name: "__meta_kubernetes_pod_name", Value: "my-pod-23491"},
+				labels.Label{Name: "__meta_kubernetes_pod_uid", Value: "84279wretgu89dg489q2"},
+				labels.Label{Name: "__meta_kubernetes_pod_container_name", Value: "my-container"},
+				labels.Label{Name: "__meta_kubernetes_pod_node_name", Value: "k8s-node-123"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_name", Value: "my-pod"},
+				labels.Label{Name: "__meta_kubernetes_pod_controller_kind", Value: "CronJob"},
+				labels.Label{Name: "__meta_kubernetes_namespace", Value: "kube-system"},
+			),
+			want: makeK8sResource(&jobInstanceDefinition{
+				"job", "hostname:8888", "hostname", "http", "8888",
+			}, &k8sResourceDefinition{
+				podName:   "my-pod-23491",
+				podUID:    "84279wretgu89dg489q2",
+				container: "my-container",
+				node:      "k8s-node-123",
+				cronjob:   "my-pod",
+				ns:        "kube-system",
+			}),
+		},
+		{
+			name: "kubernetes node (e.g. kubelet)",
+			job:  "job", instance: "hostname:8888", sdLabels: labels.New(
+				labels.Label{Name: "__scheme__", Value: "http"},
+				labels.Label{Name: "__meta_kubernetes_node_name", Value: "k8s-node-123"},
+			),
+			want: makeK8sResource(&jobInstanceDefinition{
+				"job", "hostname:8888", "hostname", "http", "8888",
+			}, &k8sResourceDefinition{
+				node: "k8s-node-123",
+			}),
+		},
+		{
+			name: "kubernetes service endpoint",
+			job:  "job", instance: "hostname:8888", sdLabels: labels.New(
+				labels.Label{Name: "__scheme__", Value: "http"},
+				labels.Label{Name: "__meta_kubernetes_endpoint_node_name", Value: "k8s-node-123"},
+			),
+			want: makeK8sResource(&jobInstanceDefinition{
+				"job", "hostname:8888", "hostname", "http", "8888",
+			}, &k8sResourceDefinition{
+				node: "k8s-node-123",
+			}),
 		},
 	}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := CreateNodeAndResourcePdata(tt.job, tt.instance, tt.scheme)
+			got := CreateNodeAndResourcePdata(tt.job, tt.instance, tt.sdLabels)
 			require.Equal(t, got, tt.want)
 		})
 	}

--- a/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
+++ b/receiver/prometheusreceiver/internal/prom_to_otlp_test.go
@@ -283,6 +283,8 @@ func TestCreateNodeAndResourcePromToOTLP(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got := CreateNodeAndResourcePdata(tt.job, tt.instance, tt.sdLabels)
+			got.Attributes().Sort()
+			tt.want.Attributes().Sort()
 			require.Equal(t, got, tt.want)
 		})
 	}

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -28,6 +28,7 @@ import (
 
 	gokitlog "github.com/go-kit/log"
 	promcfg "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/scrape"
 	"github.com/stretchr/testify/assert"
@@ -152,8 +153,9 @@ func setupMockPrometheus(tds ...*testData) (*mockPrometheus, *promcfg.Config, er
 		return mp, nil, err
 	}
 	// update attributes value (will use for validation)
+	l := []labels.Label{{Name: "__scheme__", Value: "http"}}
 	for _, t := range tds {
-		t.attributes = internal.CreateNodeAndResourcePdata(t.name, u.Host, "http").Attributes()
+		t.attributes = internal.CreateNodeAndResourcePdata(t.name, u.Host, l).Attributes()
 	}
 	pCfg, err := promcfg.Load(string(cfg), false, gokitlog.NewNopLogger())
 	return mp, pCfg, err


### PR DESCRIPTION
**Description:**

I've found myself writing relabel rules to take labels from prometheus service discovery and then wondering how to convert from metric labels to resource labels.  In GKE, we even wrote a custom processor to do this for us.  I realized the other day that we actually have all of these labels available to us in the prometheus receiver.

This PR converts some of the service discovery `__meta` labels from prometheus' kubernetes service discovery into otel semantic conventions.  This could be extended to include other service discovery implementations (e.g. gce, aws, azure, docker swarm, etc.), or we could even add configuration to allow users to define their own map for prom service discovery labels to prometheus resource attributes.

This is most useful when specifying `- role: pod` (Used by the PodMonitor [prom-operator](https://github.com/prometheus-operator/prometheus-operator) resource) or `- role: node` in `kubernetes_sd_configs`, as OpenTelemetry k8s attributes map well to the set of prometheus service discovery labels.  In particular, `- role: endpoints` (used by ServiceMonitor resource) and `-role: service` (used by Probe resource) doesn't add any particularly useful attributes.

**Example**

With this collector config:

```yaml
receivers:
  prometheus:
    config:
      scrape_configs:
      - job_name: 'kubernetes-pods'
        kubernetes_sd_configs:
        - role: pod
        relabel_configs:
        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
          action: keep
          regex: true
        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
          action: replace
          target_label: __metrics_path__
          regex: (.+)
        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
          action: replace
          regex: (.+):(?:\d+);(\d+)
          replacement: $$1:$$2
          target_label: __address__
exporters:
  logging:
    logLevel: debug
service:
  pipelines:
    metrics:
      receivers: [prometheus]
      exporters: [logging]
```

You get the following resource labels in the output:
```
DEBUG	loggingexporter/logging_exporter.go:66	ResourceMetrics #0
Resource SchemaURL:
Resource labels:
     -> service.name: STRING(kubernetes-pods)
     -> net.host.name: STRING(xx.xx.x.x)
     -> service.instance.id: STRING(xx.xx.x.x:80)
     -> net.host.port: STRING(80)
     -> http.scheme: STRING(http)
     -> k8s.pod.name: STRING(kube-dns-697dc8fc8b-zl95s)
     -> k8s.pod.uid: STRING(adc8575a-2d85-49bb-907b-16626182ec3d)
     -> k8s.container.name: STRING(prometheus-to-sd)
     -> k8s.node.name: STRING(gke-dashpole-test-default-pool-61f071a2-1re0)
     -> k8s.replicaset.name: STRING(kube-dns-697dc8fc8b)
ScopeMetrics #0
ScopeMetrics SchemaURL:
InstrumentationScope
Metric #0
Descriptor:
     -> Name: up
     -> Description: The scraping was successful
     -> Unit:
     -> DataType: Gauge
```