### PR TITLE
[receiver/podman] Change stats fetch logic

### DIFF
--- a/receiver/podmanreceiver/libpod_data.go
+++ b/receiver/podmanreceiver/libpod_data.go
@@ -1,0 +1,78 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package podmanreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"
+
+import "time"
+
+type Container struct {
+	AutoRemove bool
+	Command    []string
+	Created    string
+	CreatedAt  string
+	ExitCode   int
+	Exited     bool
+	Id         string
+	Image      string
+	ImageID    string
+	IsInfra    bool
+	Labels     map[string]string
+	Mounts     []string
+	Names      []string
+	Namespaces map[string]string
+	Networks   []string
+	Pid        int
+	Pod        string
+	PodName    string
+	Ports      []map[string]interface{}
+	Size       map[string]string
+	StartedAt  int
+	State      string
+	Status     string
+}
+
+type Event struct {
+	ID     string
+	Status string
+}
+
+type containerStats struct {
+	AvgCPU        float64
+	ContainerID   string
+	Name          string
+	PerCPU        []uint64
+	CPU           float64
+	CPUNano       uint64
+	CPUSystemNano uint64
+	DataPoints    int64
+	SystemNano    uint64
+	MemUsage      uint64
+	MemLimit      uint64
+	MemPerc       float64
+	NetInput      uint64
+	NetOutput     uint64
+	BlockInput    uint64
+	BlockOutput   uint64
+	PIDs          uint64
+	UpTime        time.Duration
+	Duration      uint64
+}
+
+type containerStatsReport struct {
+	Error string
+	Stats []containerStats
+}

--- a/receiver/podmanreceiver/podman.go
+++ b/receiver/podmanreceiver/podman.go
@@ -78,11 +78,6 @@ EVENT_LOOP:
 			case <-ctx.Done():
 				return
 			case event := <-eventCh:
-				pc.logger.Info(
-					"Podman container update:",
-					zap.String("id", event.ID),
-					zap.String("status", event.Status),
-				)
 				switch event.Status {
 				case "died":
 					pc.logger.Debug("Podman container died:", zap.String("id", event.ID))
@@ -149,9 +144,7 @@ func (pc *ContainerScraper) FetchContainerStats(ctx context.Context) ([]containe
 	params := url.Values{}
 	params.Add("stream", "false")
 
-	pc.logger.Info("Podman loaded containers", zap.Int("size", len(pc.containers)))
 	for cid, _ := range pc.containers {
-		pc.logger.Info("Podman fetching container", zap.String("id", cid))
 		params.Add("containers", cid)
 	}
 

--- a/receiver/podmanreceiver/podman.go
+++ b/receiver/podmanreceiver/podman.go
@@ -1,0 +1,175 @@
+package podmanreceiver
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type ContainerScraper struct {
+	client         PodmanClient
+	containers     map[string]Container
+	containersLock sync.Mutex
+	logger         *zap.Logger
+	config         *Config
+}
+
+func NewContainerScraper(engineClient PodmanClient, logger *zap.Logger, config *Config) *ContainerScraper {
+	return &ContainerScraper{
+		client:     engineClient,
+		containers: make(map[string]Container),
+		logger:     logger,
+		config:     config,
+	}
+}
+
+// LoadContainerList will load the initial running container maps for
+// inspection and establishing which containers warrant stat gathering calls
+// by the receiver.
+func (pc *ContainerScraper) LoadContainerList(ctx context.Context) error {
+	params := url.Values{}
+	runningFilter := map[string][]string{
+		"status": []string{"running"},
+	}
+	jsonFilter, err := json.Marshal(runningFilter)
+	if err != nil {
+		return nil
+	}
+	params.Add("filters", string(jsonFilter[:]))
+
+	listCtx, cancel := context.WithTimeout(ctx, pc.config.Timeout)
+	defer cancel()
+	containerList, err := pc.client.list(listCtx, params)
+	if err != nil {
+		return err
+	}
+
+	for _, c := range containerList {
+		pc.persistContainer(c)
+	}
+	return nil
+}
+
+func (pc *ContainerScraper) Events(ctx context.Context, options url.Values) (<-chan Event, <-chan error) {
+	return pc.client.events(ctx, options)
+}
+
+func (pc *ContainerScraper) ContainerEventLoop(ctx context.Context) {
+	filters := url.Values{}
+	cidFilter := map[string][]string{
+		"status": []string{"died", "start"},
+		"type":   []string{"container"},
+	}
+	jsonFilter, err := json.Marshal(cidFilter)
+	if err != nil {
+		return
+	}
+	filters.Add("filters", string(jsonFilter[:]))
+EVENT_LOOP:
+	for {
+		eventCh, errCh := pc.Events(ctx, filters)
+		for {
+
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventCh:
+				pc.logger.Info(
+					"Podman container update:",
+					zap.String("id", event.ID),
+					zap.String("status", event.Status),
+				)
+				switch event.Status {
+				case "died":
+					pc.logger.Debug("Podman container died:", zap.String("id", event.ID))
+					pc.removeContainer(event.ID)
+				case "start":
+					pc.logger.Debug(
+						"Podman container started:",
+						zap.String("id", event.ID),
+						zap.String("status", event.Status),
+					)
+					pc.InspectAndPersistContainer(ctx, event.ID)
+				}
+			case err := <-errCh:
+				// We are only interested when the context hasn't been canceled since requests made
+				// with a closed context are guaranteed to fail.
+				if ctx.Err() == nil {
+					pc.logger.Error("Error watching podman container events", zap.Error(err))
+					// Either decoding or connection error has occurred, so we should resume the event loop after
+					// waiting a moment.  In cases of extended daemon unavailability this will retry until
+					// collector teardown or background context is closed.
+					select {
+					case <-time.After(3 * time.Second):
+						continue EVENT_LOOP
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+
+		}
+	}
+}
+
+// InspectAndPersistContainer queries inspect api and returns *containerStats and true when container should be queried for stats,
+// nil and false otherwise. Persists the container in the cache if container is
+// running and not excluded.
+func (pc *ContainerScraper) InspectAndPersistContainer(ctx context.Context, cid string) (*Container, bool) {
+	params := url.Values{}
+	cidFilter := map[string][]string{
+		"id": []string{cid},
+	}
+	jsonFilter, err := json.Marshal(cidFilter)
+	if err != nil {
+		return nil, false
+	}
+	params.Add("filters", string(jsonFilter[:]))
+	listCtx, cancel := context.WithTimeout(ctx, pc.config.Timeout)
+	defer cancel()
+	cStats, err := pc.client.list(listCtx, params)
+	if len(cStats) == 1 && err == nil {
+		pc.persistContainer(cStats[0])
+		return &cStats[0], true
+	}
+	pc.logger.Error(
+		"Could not inspect updated container",
+		zap.String("id", cid),
+		zap.Error(err),
+	)
+	return nil, false
+}
+
+// FetchContainerStats will query the desired container stats
+func (pc *ContainerScraper) FetchContainerStats(ctx context.Context) ([]containerStats, error) {
+	params := url.Values{}
+	params.Add("stream", "false")
+
+	pc.logger.Info("Podman loaded containers", zap.Int("size", len(pc.containers)))
+	for cid, _ := range pc.containers {
+		pc.logger.Info("Podman fetching container", zap.String("id", cid))
+		params.Add("containers", cid)
+	}
+
+	statsCtx, cancel := context.WithTimeout(ctx, pc.config.Timeout)
+	defer cancel()
+	return pc.client.stats(statsCtx, params)
+}
+
+func (pc *ContainerScraper) persistContainer(c Container) {
+	pc.logger.Debug("Monitoring Podman container", zap.String("id", c.Id))
+	pc.containersLock.Lock()
+	defer pc.containersLock.Unlock()
+	pc.containers[c.Id] = c
+}
+
+func (pc *ContainerScraper) removeContainer(cid string) {
+	pc.containersLock.Lock()
+	defer pc.containersLock.Unlock()
+	delete(pc.containers, cid)
+	pc.logger.Debug("Removed container from stores.", zap.String("id", cid))
+}

--- a/receiver/podmanreceiver/podman_client.go
+++ b/receiver/podmanreceiver/podman_client.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -140,9 +139,6 @@ func (c *libpodClient) events(ctx context.Context, options url.Values) (<-chan E
 			default:
 				err := dec.Decode(&e)
 				if err != nil {
-					if err == io.EOF {
-						continue
-					}
 					errs <- err
 				} else {
 					events <- e

--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -54,18 +54,20 @@ func TestWatchingTimeouts(t *testing.T) {
 		Timeout:  50 * time.Millisecond,
 	}
 
-	cli, err := newPodmanClient(zap.NewNop(), config)
-	assert.NotNil(t, cli)
+	client, err := newLibpodClient(zap.NewNop(), config)
 	assert.Nil(t, err)
+
+	cli := NewContainerScraper(client, zap.NewNop(), config)
+	assert.NotNil(t, cli)
 
 	expectedError := "context deadline exceeded"
 
 	shouldHaveTaken := time.Now().Add(100 * time.Millisecond).UnixNano()
 
-	err = cli.ping(context.Background())
+	err = cli.LoadContainerList(context.Background())
 	require.Error(t, err)
 
-	containers, err := cli.stats(context.Background())
+	containers, err := cli.FetchContainerStats(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), expectedError)
 	assert.Nil(t, containers)


### PR DESCRIPTION
**Description:** Changes the logic to a one more similar to the Dockerstats receiver.

- With than structure we will be able to easily add container excluding/including options
- Will allow to add more metadata to the containers metrics (like the Pod, PodName, Labels, Pid, etc)

**Link to tracking Issue:** #9013 

**Testing:** Add tests and mocked libpod client

**Documentation:** No changes required