### PR TITLE
[exporter/datadog] Modify deprecation messages to reflect new plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - `cmd/mdatagen`: Update generated functions to have simple parse function to handle string parsing consistently and limit code duplication across receivers (#7574)
 - `attributesprocessor`: Support filter by severity (#9132)
 - `processor/transform`: Add transformation of logs (#9368)
-- `datadogexporter`: update deprecation messages to reflect new deprecation plan (#9422)
+- `datadogexporter`: Update deprecation messages to reflect new deprecation plan (#9422)
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `cmd/mdatagen`: Update generated functions to have simple parse function to handle string parsing consistently and limit code duplication across receivers (#7574)
 - `attributesprocessor`: Support filter by severity (#9132)
 - `processor/transform`: Add transformation of logs (#9368)
+- `datadogexporter`: update deprecation messages to reflect new deprecation plan (#9422)
 
 ### 🧰 Bug fixes 🧰
 

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -469,7 +469,7 @@ func (c *Config) Unmarshal(configMap *config.Map) error {
 	// Add warnings about autodetected environment variables.
 	c.warnings = append(c.warnings, warnUseOfEnvVars(configMap, c)...)
 
-	deprecationTemplate := "%q has been deprecated and will be removed in %s. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/%d"
+	deprecationTemplate := "%q has been deprecated and will be removed in %s or later. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/%d"
 	if c.Service != "" {
 		c.warnings = append(c.warnings, fmt.Errorf(deprecationTemplate, "service", "v0.52.0", 8781))
 	}

--- a/exporter/datadogexporter/config/warn_envvars.go
+++ b/exporter/datadogexporter/config/warn_envvars.go
@@ -65,7 +65,7 @@ func futureDefaultConfig() *Config {
 // explicitly on configuration instead.
 func errUsedEnvVar(settingName, envVarName string) error {
 	return fmt.Errorf(
-		"%q will not default to %q's value starting on v0.50.0. Set %s: ${%s} to remove this warning",
+		"%q will not default to %q's value in a future minor version. Set %s: ${%s} to remove this warning",
 		settingName,
 		envVarName,
 		settingName,
@@ -142,7 +142,7 @@ func warnUseOfEnvVars(configMap *config.Map, cfg *Config) (warnings []error) {
 		warnings = append(warnings, errUsedEnvVar("traces.endpoint", "DD_APM_URL"))
 	}
 	if tagsDiffer(cfg.GetHostTags(), futureCfg.GetHostTags()) {
-		warnings = append(warnings, fmt.Errorf("\"tags\" will not default to \"DD_TAGS\"'s value starting on v0.50.0. Use 'env' configuration source instead to remove this warning"))
+		warnings = append(warnings, fmt.Errorf("\"tags\" will not default to \"DD_TAGS\"'s value in a future minor version. Use 'env' configuration source instead to remove this warning"))
 	}
 
 	if len(warnings) > 0 {

--- a/exporter/datadogexporter/config/warning_deprecated.go
+++ b/exporter/datadogexporter/config/warning_deprecated.go
@@ -92,7 +92,7 @@ var removedSettings = []renameError{}
 // Error implements the error interface.
 func (e renameError) Error() string {
 	return fmt.Sprintf(
-		"%q has been deprecated in favor of %q and will be removed in %s. See github.com/open-telemetry/opentelemetry-collector-contrib/issues/%d",
+		"%q has been deprecated in favor of %q and will be removed in %s or later. See github.com/open-telemetry/opentelemetry-collector-contrib/issues/%d",
 		e.oldName,
 		e.newName,
 		e.oldRemovedIn,

--- a/exporter/datadogexporter/config/warning_deprecated_test.go
+++ b/exporter/datadogexporter/config/warning_deprecated_test.go
@@ -50,7 +50,7 @@ func TestDeprecationSendMonotonic(t *testing.T) {
 			}),
 			expectedMode: CumulativeMonotonicSumModeToDelta,
 			warnings: []string{
-				"\"metrics::send_monotonic_counter\" has been deprecated in favor of \"metrics::sums::cumulative_monotonic_mode\" and will be removed in v0.50.0. See github.com/open-telemetry/opentelemetry-collector-contrib/issues/8489",
+				"\"metrics::send_monotonic_counter\" has been deprecated in favor of \"metrics::sums::cumulative_monotonic_mode\" and will be removed in v0.50.0 or later. See github.com/open-telemetry/opentelemetry-collector-contrib/issues/8489",
 			},
 		},
 		{
@@ -62,7 +62,7 @@ func TestDeprecationSendMonotonic(t *testing.T) {
 			}),
 			expectedMode: CumulativeMonotonicSumModeRawValue,
 			warnings: []string{
-				"\"metrics::send_monotonic_counter\" has been deprecated in favor of \"metrics::sums::cumulative_monotonic_mode\" and will be removed in v0.50.0. See github.com/open-telemetry/opentelemetry-collector-contrib/issues/8489",
+				"\"metrics::send_monotonic_counter\" has been deprecated in favor of \"metrics::sums::cumulative_monotonic_mode\" and will be removed in v0.50.0 or later. See github.com/open-telemetry/opentelemetry-collector-contrib/issues/8489",
 			},
 		},
 		{


### PR DESCRIPTION
**Description:** 

Modifies deprecation messages to be less specific. 

Originally, we intended to remove deprecated settings/functionality in a staggered fashion, but we have decided to do them all at once in a future minor version. Because of this, the logs need to be modified to be less specific and state that the features will be removed on a given version 'or later'. Mentioning a specific version is still useful for end-users to understand that the feature won't be removed at least until that point.

**Link to tracking Issue:** #8372
