### PR TITLE
[exporter/datadog] Remove `GetHostTags` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `filelog`, `journald`, `syslog`, `tcplog`, `udplog`: Remove `preserve_to` field from sub-parsers (#9331)
 - `kafkametricsreceiver`: instrumentation name updated from `otelcol/kafkametrics` to `otelcol/kafkametricsreceiver` (#9406)
 - `kubeletstatsreceiver`: instrumentation name updated from `kubeletstats` to `otelcol/kubeletstatsreceiver` (#9400)
+- `datadogexporter`: Remove `GetHotsTags` method from `TagsConfig` struct (#TODO)
 
 ### 🚩 Deprecations 🚩
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `filelog`, `journald`, `syslog`, `tcplog`, `udplog`: Remove `preserve_to` field from sub-parsers (#9331)
 - `kafkametricsreceiver`: instrumentation name updated from `otelcol/kafkametrics` to `otelcol/kafkametricsreceiver` (#9406)
 - `kubeletstatsreceiver`: instrumentation name updated from `kubeletstats` to `otelcol/kubeletstatsreceiver` (#9400)
-- `datadogexporter`: Remove `GetHotsTags` method from `TagsConfig` struct (#9423)
+- `datadogexporter`: Remove `GetHostTags` method from `TagsConfig` struct (#9423)
 
 ### 🚩 Deprecations 🚩
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `filelog`, `journald`, `syslog`, `tcplog`, `udplog`: Remove `preserve_to` field from sub-parsers (#9331)
 - `kafkametricsreceiver`: instrumentation name updated from `otelcol/kafkametrics` to `otelcol/kafkametricsreceiver` (#9406)
 - `kubeletstatsreceiver`: instrumentation name updated from `kubeletstats` to `otelcol/kubeletstatsreceiver` (#9400)
-- `datadogexporter`: Remove `GetHotsTags` method from `TagsConfig` struct (#TODO)
+- `datadogexporter`: Remove `GetHotsTags` method from `TagsConfig` struct (#9423)
 
 ### 🚩 Deprecations 🚩
 

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -236,9 +236,8 @@ type TagsConfig struct {
 	Tags []string `mapstructure:"tags"`
 }
 
-// GetHostTags gets the host tags extracted from the configuration
-// Deprecated: [v0.49.0] Access fields explicitly instead.
-func (t *TagsConfig) GetHostTags() []string {
+// getHostTags gets the host tags extracted from the configuration
+func (t *TagsConfig) getHostTags() []string {
 	tags := t.Tags
 
 	if len(tags) == 0 {

--- a/exporter/datadogexporter/config/config_test.go
+++ b/exporter/datadogexporter/config/config_test.go
@@ -40,7 +40,7 @@ func TestHostTags(t *testing.T) {
 			"key1:val1",
 			"key2:val2",
 		},
-		tc.GetHostTags(),
+		tc.getHostTags(),
 	)
 
 	tc = TagsConfig{
@@ -59,7 +59,7 @@ func TestHostTags(t *testing.T) {
 			"key1:val1",
 			"key2:val2",
 		},
-		tc.GetHostTags(),
+		tc.getHostTags(),
 	)
 
 	tc = TagsConfig{
@@ -77,7 +77,7 @@ func TestHostTags(t *testing.T) {
 			"key3:val3",
 			"key4:val4",
 		},
-		tc.GetHostTags(),
+		tc.getHostTags(),
 	)
 }
 

--- a/exporter/datadogexporter/config/warn_envvars.go
+++ b/exporter/datadogexporter/config/warn_envvars.go
@@ -141,7 +141,7 @@ func warnUseOfEnvVars(configMap *config.Map, cfg *Config) (warnings []error) {
 	if cfg.Traces.Endpoint != futureCfg.Traces.Endpoint {
 		warnings = append(warnings, errUsedEnvVar("traces.endpoint", "DD_APM_URL"))
 	}
-	if tagsDiffer(cfg.GetHostTags(), futureCfg.GetHostTags()) {
+	if tagsDiffer(cfg.getHostTags(), futureCfg.getHostTags()) {
 		warnings = append(warnings, fmt.Errorf("\"tags\" will not default to \"DD_TAGS\"'s value starting on v0.50.0. Use 'env' configuration source instead to remove this warning"))
 	}
 


### PR DESCRIPTION
**Description:** 

Remove deprecated `GetHostTags` method. This is a breaking change, but does not affect end-users since it is a Go API only change.

This change is split off from #9249, since we have decided to do all end-user breaking changes in a single future release.

**Link to tracking Issue:** #8373
