### PR TITLE
[exporter/datadog] The command should be `/otelcol-contrib` in the example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `prometheusexporter`: Prometheus fails to generate logs when prometheus exporter produced a check exception occurs. (#8949)
 - `resourcedetectionprocessor`: Wire docker detector (#9372)
 - `kafkametricsreceiver`: The kafkametricsreceiver was changed to connect to kafka during scrape, rather than startup. If kafka is unavailable the receiver will attempt to connect during subsequent scrapes until succcessful (#8817).
+- `datadogexporter`: The command in the `exporter/datadogexporter/example/example_k8s_manifest.yaml` should be `/otelcol-contrib`. (#9425).
 
 ## v0.49.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - `prometheusexporter`: Prometheus fails to generate logs when prometheus exporter produced a check exception occurs. (#8949)
 - `resourcedetectionprocessor`: Wire docker detector (#9372)
 - `kafkametricsreceiver`: The kafkametricsreceiver was changed to connect to kafka during scrape, rather than startup. If kafka is unavailable the receiver will attempt to connect during subsequent scrapes until succcessful (#8817).
-- `datadogexporter`: The command in the `exporter/datadogexporter/example/example_k8s_manifest.yaml` should be `/otelcol-contrib`. (#9425).
+- `datadogexporter`: Update Kubernetes example manifest to new executable name. (#9425).
 
 ## v0.49.0
 

--- a/exporter/datadogexporter/example/example_k8s_manifest.yaml
+++ b/exporter/datadogexporter/example/example_k8s_manifest.yaml
@@ -236,7 +236,7 @@ spec:
       - command:
           - "/otelcol-contrib"
           - "--config=/conf/otel-collector-config.yaml"
-        image: otel/opentelemetry-collector-contrib:latest
+        image: otel/opentelemetry-collector-contrib:0.49.0
         name: otel-collector
         resources:
           limits:

--- a/exporter/datadogexporter/example/example_k8s_manifest.yaml
+++ b/exporter/datadogexporter/example/example_k8s_manifest.yaml
@@ -102,9 +102,9 @@ spec:
     spec:
       containers:
       - command:
-          - "/otelcontribcol"
+          - "/otelcol-contrib"
           - "--config=/conf/otel-agent-config.yaml"
-        image: otel/opentelemetry-collector-contrib:0.39.0
+        image: otel/opentelemetry-collector-contrib:0.49.0
         name: otel-agent
         resources:
           limits:
@@ -234,7 +234,7 @@ spec:
     spec:
       containers:
       - command:
-          - "/otelcontribcol"
+          - "/otelcol-contrib"
           - "--config=/conf/otel-collector-config.yaml"
         image: otel/opentelemetry-collector-contrib:latest
         name: otel-collector


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The command in `exporter/datadogexporter/example/example_k8s_manifest.yaml` should be `/otelcol-contrib` according to the [Dockerfile](https://hub.docker.com/layers/otel/opentelemetry-collector-contrib/0.49.0-amd64/images/sha256-98cedffda4eb76cbb6eeb9d9f1d7ccf78db39b0434ce1e3b60ddf6e1ffa531f3?context=explore).

Facing the error when applying the existing example.

```
failed to create containerd task: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "/otelcontribcol": stat /otelcontribcol: no such file or directory: stat --config=/conf/otel-agent-config.yaml: no such file or directory: unknown: RunContainerError
```

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>