### PR TITLE
Graduate the new googlecloud exporter to beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `kafkametricsreceiver`: instrumentation name updated from `otelcol/kafkametrics` to `otelcol/kafkametricsreceiver` (#9406)
 - `kubeletstatsreceiver`: instrumentation name updated from `kubeletstats` to `otelcol/kubeletstatsreceiver` (#9400)
 - `datadogexporter`: Remove `GetHostTags` method from `TagsConfig` struct (#9423)
+- `googlecloudexporter`: Graduate the `exporter.googlecloud.OTLPDirect` feature-gate to Beta.  This includes changes to the configuration structure, and many changes to default behavior. (#9471)
 
 ### 🚩 Deprecations 🚩
 

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -36,7 +36,7 @@ func init() {
 	featuregate.GetRegistry().MustRegister(featuregate.Gate{
 		ID:          pdataExporterFeatureGate,
 		Description: "When enabled, the googlecloud exporter translates pdata directly to google cloud monitoring's types, rather than first translating to opencensus.",
-		Enabled:     false,
+		Enabled:     true,
 	})
 }
 


### PR DESCRIPTION
**Description:**

The new exporter translates directly from pdata to google cloud monitoring's format, rather than translating to OpenCensus, and using the OpenCensus metrics exporter.

It includes many breaking changes, which are documented [here](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/main/exporter/collector/breaking-changes.md#breaking-changes-vs-old-googlecloud-exporter).

This updates the default for the feature-gate flag, and inverts the README documentation now that the default has changed (now it shows new config first, and then old config at the bottom).

**Testing:**

We have validated the alpha implementation with automated presubmit integration tests, and manual tests with a few receivers.