### PR TITLE
[receiver\sqlserver] Fix SQL Server metrics from gauge to monotonic sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `resourcedetectionprocessor`: Wire docker detector (#9372)
 - `kafkametricsreceiver`: The kafkametricsreceiver was changed to connect to kafka during scrape, rather than startup. If kafka is unavailable the receiver will attempt to connect during subsequent scrapes until succcessful (#8817).
 - `datadogexporter`: Update Kubernetes example manifest to new executable name. (#9425).
+- `sqlserverreceiver`: Update `sqlserver.transaction_log.growth.count` and `sqlserver.transaction_log.shrink.count` to be monotonic sums. (#9522)
 
 ## v0.49.0
 

--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -24,8 +24,8 @@ These are the metrics available for this scraper.
 | **sqlserver.transaction_log.flush.data.rate** | Total number of log bytes flushed. | By/s | Gauge(Double) | <ul> </ul> |
 | **sqlserver.transaction_log.flush.rate** | Number of log flushes. | {flushes}/s | Gauge(Double) | <ul> </ul> |
 | **sqlserver.transaction_log.flush.wait.rate** | Number of commits waiting for a transaction log flush. | {commits}/s | Gauge(Double) | <ul> </ul> |
-| **sqlserver.transaction_log.growth.count** | Total number of transaction log expansions for a database. | {growths} | Gauge(Double) | <ul> </ul> |
-| **sqlserver.transaction_log.shrink.count** | Total number of transaction log shrinks for a database. | {shrinks} | Gauge(Double) | <ul> </ul> |
+| **sqlserver.transaction_log.growth.count** | Total number of transaction log expansions for a database. | {growths} | Sum(Double) | <ul> </ul> |
+| **sqlserver.transaction_log.shrink.count** | Total number of transaction log shrinks for a database. | {shrinks} | Sum(Double) | <ul> </ul> |
 | **sqlserver.transaction_log.usage** | Percent of transaction log space used. | % | Gauge(Double) | <ul> </ul> |
 | **sqlserver.user.connection.count** | Number of users connected to the SQL Server. | {connections} | Gauge(Double) | <ul> </ul> |
 

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_v2.go
@@ -900,14 +900,16 @@ func (m *metricSqlserverTransactionLogGrowthCount) init() {
 	m.data.SetName("sqlserver.transaction_log.growth.count")
 	m.data.SetDescription("Total number of transaction log expansions for a database.")
 	m.data.SetUnit("{growths}")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricSqlserverTransactionLogGrowthCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
@@ -915,14 +917,14 @@ func (m *metricSqlserverTransactionLogGrowthCount) recordDataPoint(start pcommon
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricSqlserverTransactionLogGrowthCount) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionLogGrowthCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
@@ -949,14 +951,16 @@ func (m *metricSqlserverTransactionLogShrinkCount) init() {
 	m.data.SetName("sqlserver.transaction_log.shrink.count")
 	m.data.SetDescription("Total number of transaction log shrinks for a database.")
 	m.data.SetUnit("{shrinks}")
-	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
 func (m *metricSqlserverTransactionLogShrinkCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
 	if !m.settings.Enabled {
 		return
 	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
@@ -964,14 +968,14 @@ func (m *metricSqlserverTransactionLogShrinkCount) recordDataPoint(start pcommon
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
 func (m *metricSqlserverTransactionLogShrinkCount) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
 	}
 }
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionLogShrinkCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -89,13 +89,17 @@ metrics:
     enabled: true
     description: Total number of transaction log expansions for a database.
     unit: "{growths}"
-    gauge:
+    sum:
+      monotonic: true
+      aggregation: cumulative
       value_type: double
   sqlserver.transaction_log.shrink.count:
     enabled: true
     description: Total number of transaction log shrinks for a database.
     unit: "{shrinks}"
-    gauge:
+    sum:
+      monotonic: true
+      aggregation: cumulative
       value_type: double
   sqlserver.transaction_log.usage:
     enabled: true


### PR DESCRIPTION
**Description:** 
Fix bug where transaction log shrinks and growths were improperly marked as gauges when they are in fact monotonic sums.

**Issue:** #9522 

**Testing:** Manually ran and verified that changed metrics came back as monotonic sums instead of gauges.

**Documentation:** Updated documentation to reflect metric changes