### PR TITLE
Added the remove stanza operator to registered operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `attributesprocessor`: Support filter by severity (#9132)
 - `processor/transform`: Add transformation of logs (#9368)
 - `datadogexporter`: Add `metrics::summaries::mode` to specify export mode for summaries (#8846)
+- `internal/stanza`: Add `remove` operator to registered operators ()
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - `attributesprocessor`: Support filter by severity (#9132)
 - `processor/transform`: Add transformation of logs (#9368)
 - `datadogexporter`: Add `metrics::summaries::mode` to specify export mode for summaries (#8846)
-- `internal/stanza`: Add `remove` operator to registered operators ()
+- `internal/stanza`: Add `remove` operator to registered operators (#9545)
 
 ### 🧰 Bug fixes 🧰
 

--- a/internal/stanza/register.go
+++ b/internal/stanza/register.go
@@ -29,6 +29,7 @@ import (
 	_ "github.com/open-telemetry/opentelemetry-log-collection/operator/transformer/flatten"
 	_ "github.com/open-telemetry/opentelemetry-log-collection/operator/transformer/move"
 	_ "github.com/open-telemetry/opentelemetry-log-collection/operator/transformer/recombine"
+	_ "github.com/open-telemetry/opentelemetry-log-collection/operator/transformer/remove"
 	_ "github.com/open-telemetry/opentelemetry-log-collection/operator/transformer/retain"
 	_ "github.com/open-telemetry/opentelemetry-log-collection/operator/transformer/router"
 )


### PR DESCRIPTION
**Description:** <Describe what has changed.>
It's in the list of supported operators in [opentelemetry-log-collection](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md) and there is no other way to currently remove something from a log entry without it.

