### PR TITLE
[exporter/azuremonitor] Drop reference to obsolete LogRecord.Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - `cumulativetodeltaprocessor`: Deprecated `metrics` configuration option in favor of `include` and `exclude` (#8952)
 - `datadogexporter`: Deprecate `metrics::report_quantiles` in favor of `metrics::summaries::mode` (#8846)
+- `exporter/azuremonitor`: Deprecate use of LogRecord.Name as the log envelope category name. There is no replacement.
 
 ### 🚀 New components 🚀
 

--- a/exporter/azuremonitorexporter/log_to_envelope.go
+++ b/exporter/azuremonitorexporter/log_to_envelope.go
@@ -24,9 +24,8 @@ import (
 )
 
 const (
-	traceIDTag      = "TraceId"
-	spanIDTag       = "SpanId"
-	categoryNameTag = "CategoryName"
+	traceIDTag = "TraceId"
+	spanIDTag  = "SpanId"
 )
 
 var severityLevelMap = map[string]contracts.SeverityLevel{
@@ -61,7 +60,6 @@ func (packer *logPacker) LogRecordToEnvelope(logRecord plog.LogRecord) *contract
 
 	messageData.Properties[spanIDTag] = logRecord.SpanID().HexString()
 
-	messageData.Properties[categoryNameTag] = logRecord.Name()
 	envelope.Name = messageData.EnvelopeName("")
 
 	data.BaseData = messageData

--- a/exporter/azuremonitorexporter/logexporter_test.go
+++ b/exporter/azuremonitorexporter/logexporter_test.go
@@ -88,7 +88,6 @@ func TestLogRecordToEnvelope(t *testing.T) {
 			assert.Equal(t, envelope.Tags[contracts.OperationId], hexTraceID)
 
 			assert.Equal(t, messageData.Properties[spanIDTag], logRecord.SpanID().HexString())
-			assert.Equal(t, messageData.Properties[categoryNameTag], logRecord.Name())
 		})
 	}
 }


### PR DESCRIPTION
LogRecord.Name is obsolete and uses of it must be removed from this repo.

Resolves
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9258

**Testing:**
unit testing only.
