### PR TITLE
Add seed list for the sponsor rotation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,21 @@ and the rest of contributors.
   the folder. If a component can not be properly tested within the existing framework, it must increase the non testable
   components number with a comment within the PR explaining as to why it can not be tested.
 
+### Rotating sponsors
+
+The following GitHub users are the currently available sponsors, either by being an approver or a maintainer of the contrib repository. The list is ordered based on a random sort of the list of sponsors done live at the Collector SIG meeting on 27-Apr-2022 and serves as the seed for the round-robin selection of sponsors, as described in the section above.
+
+* [@dashpole](https://github.com/dashpole)
+* [@djaglowski](https://github.com/djaglowski)
+* [@codeboten](https://github.com/codeboten)
+* [@Aneurysm9](https://github.com/Aneurysm9)
+* [@mx-psi](https://github.com/mx-psi)
+* [@pmm-sumo](https://github.com/pmm-sumo)
+* [@jpkrohling](https://github.com/jpkrohling)
+* [@dmitryax](https://github.com/dmitryax)
+* [@bogdandrutu](https://github.com/bogdandrutu)
+
+Whenever a sponsor is picked from the top of this list, please move them to the bottom.
 ## General Recommendations
 Below are some recommendations that apply to typical components. These are not rigid rules and there are exceptions but
 in general try to follow them.


### PR DESCRIPTION
As discussed during today's SIG call, this PR records the seed list for the sponsor round-robin rotation.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
