### PR TITLE
[exporter/datadog] Replace HistogramMode defined as string with enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - `processor/transform`: Add transformation of logs (#9368)
 - `datadogexporter`: Add `metrics::summaries::mode` to specify export mode for summaries (#8846)
 - `prometheusreceiver`: Add resource attributes for kubernetes resource discovery labels (#9416)
+- `datadogexporter`: Replace HistogramMode defined as string with enum.
 
 ### 🧰 Bug fixes 🧰
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛑 Breaking changes 🛑
 
+- `datadogexporter`: Replace HistogramMode defined as string with enum.
+
 ### 🚩 Deprecations 🚩
 
 - `exporter/azuremonitor`: Deprecate use of LogRecord.Name as the log envelope category name. There is no replacement.
@@ -51,7 +53,6 @@
 - `processor/transform`: Add transformation of logs (#9368)
 - `datadogexporter`: Add `metrics::summaries::mode` to specify export mode for summaries (#8846)
 - `prometheusreceiver`: Add resource attributes for kubernetes resource discovery labels (#9416)
-- `datadogexporter`: Replace HistogramMode defined as string with enum.
 
 ### 🧰 Bug fixes 🧰
 

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -515,13 +515,6 @@ func (c *Config) Unmarshal(configMap *config.Map) error {
 	}
 	c.warnings = append(c.warnings, renamingWarnings...)
 
-	switch c.Metrics.HistConfig.Mode {
-	case HistogramModeCounters, HistogramModeNoBuckets, HistogramModeDistributions:
-		// Do nothing
-	default:
-		return fmt.Errorf("invalid `mode` %s", c.Metrics.HistConfig.Mode)
-	}
-
 	// Add warnings about autodetected environment variables.
 	c.warnings = append(c.warnings, warnUseOfEnvVars(configMap, c)...)
 

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -34,13 +34,6 @@ var (
 	errNoMetadata  = errors.New("only_metadata can't be enabled when host_metadata::enabled = false or host_metadata::hostname_source != first_resource")
 )
 
-// TODO: Import these from translator when we eliminate cyclic dependency.
-const (
-	histogramModeNoBuckets     = "nobuckets"
-	histogramModeCounters      = "counters"
-	histogramModeDistributions = "distributions"
-)
-
 const (
 	// DefaultSite is the default site of the Datadog intake to send data to
 	DefaultSite = "datadoghq.com"
@@ -93,6 +86,30 @@ type MetricsConfig struct {
 	SummaryConfig SummaryConfig `mapstructure:"summaries"`
 }
 
+type HistogramMode string
+
+const (
+	// HistogramModeNoBuckets reports no bucket histogram metrics. .sum and .count metrics will still be sent
+	// if `send_count_sum_metrics` is enabled.
+	HistogramModeNoBuckets HistogramMode = "nobuckets"
+	// HistogramModeCounters reports histograms as Datadog counts, one metric per bucket.
+	HistogramModeCounters HistogramMode = "counters"
+	// HistogramModeDistributions reports histograms as Datadog distributions (recommended).
+	HistogramModeDistributions HistogramMode = "distributions"
+)
+
+var _ encoding.TextUnmarshaler = (*HistogramMode)(nil)
+
+func (hm *HistogramMode) UnmarshalText(in []byte) error {
+	switch mode := HistogramMode(in); mode {
+	case HistogramModeCounters, HistogramModeDistributions, HistogramModeNoBuckets:
+		*hm = mode
+		return nil
+	default:
+		return fmt.Errorf("invalid histogram mode %q", mode)
+	}
+}
+
 // HistogramConfig customizes export of OTLP Histograms.
 type HistogramConfig struct {
 	// Mode for exporting histograms. Valid values are 'distributions', 'counters' or 'nobuckets'.
@@ -102,7 +119,7 @@ type HistogramConfig struct {
 	//    if `send_count_sum_metrics` is enabled.
 	//
 	// The current default is 'distributions'.
-	Mode string `mapstructure:"mode"`
+	Mode HistogramMode `mapstructure:"mode"`
 
 	// SendCountSum states if the export should send .sum and .count metrics for histograms.
 	// The current default is false.
@@ -110,7 +127,7 @@ type HistogramConfig struct {
 }
 
 func (c *HistogramConfig) validate() error {
-	if c.Mode == histogramModeNoBuckets && !c.SendCountSum {
+	if c.Mode == HistogramModeNoBuckets && !c.SendCountSum {
 		return fmt.Errorf("'nobuckets' mode and `send_count_sum_metrics` set to false will send no histogram metrics")
 	}
 	return nil
@@ -499,7 +516,7 @@ func (c *Config) Unmarshal(configMap *config.Map) error {
 	c.warnings = append(c.warnings, renamingWarnings...)
 
 	switch c.Metrics.HistConfig.Mode {
-	case histogramModeCounters, histogramModeNoBuckets, histogramModeDistributions:
+	case HistogramModeCounters, HistogramModeNoBuckets, HistogramModeDistributions:
 		// Do nothing
 	default:
 		return fmt.Errorf("invalid `mode` %s", c.Metrics.HistConfig.Mode)

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/metadata"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/translator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/testutils"
 )
 
@@ -44,7 +43,7 @@ func TestNewExporter(t *testing.T) {
 			},
 			DeltaTTL: 3600,
 			HistConfig: config.HistogramConfig{
-				Mode:         string(translator.HistogramModeDistributions),
+				Mode:         config.HistogramModeDistributions,
 				SendCountSum: false,
 			},
 			SumConfig: config.SumConfig{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Replace [HistogramConfig.Mode](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/033bc949bec36233c6c4a050a951f119dd00b16d/exporter/datadogexporter/config/config.go#L105) defined as string with [translator.HistogramMode](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/033bc949bec36233c6c4a050a951f119dd00b16d/exporter/datadogexporter/internal/model/translator/config.go#L89).

**Link to tracking Issue:** <Issue number if applicable> https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8373

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>