### PR TITLE
docs: fix spanmetricsprocessor to prometheus example

### DIFF
--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -96,7 +96,7 @@ processors:
         default: GET
       - name: http.status_code
     dimensions_cache_size: 1000
-    aggregation_temporality: "AGGREGATION_TEMPORALITY_DELTA"     
+    aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"     
 
 exporters:
   jaeger:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`prometheusexporter` expects `AggregationTemporality` to be `MetricAggregationTemporalityCumulative`, the existing example produces a config that does not produce any metrics output.

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/814c3a9e4a3d4d4f8bbba140fed0156616dfa765/exporter/prometheusexporter/accumulator.go#L176-L178

Update `AggregationTemporality` from delta to cumulative.

**Link to tracking Issue:** <Issue number if applicable>
N/A
**Testing:** <Describe what testing was performed and which tests were added.>
N/A
**Documentation:** <Describe the documentation added.>
N/A