### PR TITLE
[receiver/mysql] Fix attribute values mismatch with its definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 ### 🧰 Bug fixes 🧰
 
 - `k8sclusterreceiver`: Fix the receiver to work with 1.19 and 1.20 k8s API versions (#9523)
-- `azuremonitorexporter` : Fix log exporter bug related to incorrectly mapping SpanId (#9579)
+- `azuremonitorexporter`: Fix log exporter bug related to incorrectly mapping SpanId (#9579)
+- `mysqlreceiver`: Fix attribute values mismatch with its definition (#9688)
 
 ## v0.50.0
 

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -153,7 +153,7 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 		case "Handler_discover":
 			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, "discover"))
 		case "Handler_external_lock":
-			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, "lock"))
+			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, "external_lock"))
 		case "Handler_mrr_init":
 			addPartialIfError(errors, m.mb.RecordMysqlHandlersDataPoint(now, v, "mrr_init"))
 		case "Handler_prepare":
@@ -185,7 +185,7 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 
 		// double_writes
 		case "Innodb_dblwr_pages_written":
-			addPartialIfError(errors, m.mb.RecordMysqlDoubleWritesDataPoint(now, v, "written"))
+			addPartialIfError(errors, m.mb.RecordMysqlDoubleWritesDataPoint(now, v, "pages_written"))
 		case "Innodb_dblwr_writes":
 			addPartialIfError(errors, m.mb.RecordMysqlDoubleWritesDataPoint(now, v, "writes"))
 
@@ -193,7 +193,7 @@ func (m *mySQLScraper) scrape(context.Context) (pmetric.Metrics, error) {
 		case "Innodb_log_waits":
 			addPartialIfError(errors, m.mb.RecordMysqlLogOperationsDataPoint(now, v, "waits"))
 		case "Innodb_log_write_requests":
-			addPartialIfError(errors, m.mb.RecordMysqlLogOperationsDataPoint(now, v, "requests"))
+			addPartialIfError(errors, m.mb.RecordMysqlLogOperationsDataPoint(now, v, "write_requests"))
 		case "Innodb_log_writes":
 			addPartialIfError(errors, m.mb.RecordMysqlLogOperationsDataPoint(now, v, "writes"))
 

--- a/receiver/mysqlreceiver/testdata/integration/expected.5_7.json
+++ b/receiver/mysqlreceiver/testdata/integration/expected.5_7.json
@@ -362,7 +362,7 @@
                                  {
                                     "key": "kind",
                                     "value": {
-                                       "stringValue": "written"
+                                       "stringValue": "pages_written"
                                     }
                                  }
                               ],
@@ -412,7 +412,7 @@
                                  {
                                     "key": "kind",
                                     "value": {
-                                       "stringValue": "lock"
+                                       "stringValue": "external_lock"
                                     }
                                  }
                               ],
@@ -694,7 +694,7 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "requests"
+                                       "stringValue": "write_requests"
                                     }
                                  }
                               ],

--- a/receiver/mysqlreceiver/testdata/integration/expected.8_0.json
+++ b/receiver/mysqlreceiver/testdata/integration/expected.8_0.json
@@ -362,7 +362,7 @@
                                  {
                                     "key": "kind",
                                     "value": {
-                                       "stringValue": "written"
+                                       "stringValue": "pages_written"
                                     }
                                  }
                               ],
@@ -412,7 +412,7 @@
                                  {
                                     "key": "kind",
                                     "value": {
-                                       "stringValue": "lock"
+                                       "stringValue": "external_lock"
                                     }
                                  }
                               ],
@@ -694,7 +694,7 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "requests"
+                                       "stringValue": "write_requests"
                                     }
                                  }
                               ],

--- a/receiver/mysqlreceiver/testdata/scraper/expected.json
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.json
@@ -362,7 +362,7 @@
                                  {
                                     "key": "kind",
                                     "value": {
-                                       "stringValue": "written"
+                                       "stringValue": "pages_written"
                                     }
                                  }
                               ],
@@ -412,7 +412,7 @@
                                  {
                                     "key": "kind",
                                     "value": {
-                                       "stringValue": "lock"
+                                       "stringValue": "external_lock"
                                     }
                                  }
                               ],
@@ -694,7 +694,7 @@
                                  {
                                     "key": "operation",
                                     "value": {
-                                       "stringValue": "requests"
+                                       "stringValue": "write_requests"
                                     }
                                  }
                               ],


### PR DESCRIPTION
Some attribute are emitted with values different from what's defined in metadata.yaml. This fix takes metadata.yaml definition as a source of truth and updates the emitted data
