### PR TITLE
[chore] remove SetName usage for log records

### DIFF
--- a/exporter/awskinesisexporter/internal/batch/encoder_test.go
+++ b/exporter/awskinesisexporter/internal/batch/encoder_test.go
@@ -55,7 +55,6 @@ func NewTestLogs(logCount int) plog.Logs {
 
 	for i := 0; i < logCount; i++ {
 		log := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-		log.SetName("foo")
 		log.SetSeverityText("bar")
 	}
 

--- a/exporter/azuremonitorexporter/logexporter_test.go
+++ b/exporter/azuremonitorexporter/logexporter_test.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	testLogs = []byte(`{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"dotnet"}}]},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1643240673066096200","severityText":"Information","name":"FilterModule.Program","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"},{"timeUnixNano":"0","observedTimeUnixNano":"1643240673066096200","severityText":"Information","name":"FilterModule.Program","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"},{"timeUnixNano":"0","observedTimeUnixNano":"0","severityText":"Information","name":"FilterModule.Program","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"}]}]}]}`)
+	testLogs = []byte(`{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"dotnet"}}]},"scopeLogs":[{"scope":{},"logRecords":[{"timeUnixNano":"1643240673066096200","severityText":"Information","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"},{"timeUnixNano":"0","observedTimeUnixNano":"1643240673066096200","severityText":"Information","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"},{"timeUnixNano":"0","observedTimeUnixNano":"0","severityText":"Information","body":{"stringValue":"Message Body"},"flags":1,"traceId":"7b20d1349ef9b6d6f9d4d1d4a3ac2e82","spanId":"0c2ad924e1771630"}]}]}]}`)
 )
 
 // Tests proper wrapping of a log record to an envelope

--- a/internal/coreinternal/testdata/log.go
+++ b/internal/coreinternal/testdata/log.go
@@ -79,7 +79,6 @@ func GenerateLogsTwoLogRecordsSameResourceOneDifferent() plog.Logs {
 	return ld
 }
 func fillLogOne(log plog.LogRecord) {
-	log.SetName("logA")
 	log.SetTimestamp(TestLogTimestamp)
 	log.SetDroppedAttributesCount(1)
 	log.SetSeverityNumber(plog.SeverityNumberINFO)
@@ -95,7 +94,6 @@ func fillLogOne(log plog.LogRecord) {
 }
 
 func fillLogTwo(log plog.LogRecord) {
-	log.SetName("logB")
 	log.SetTimestamp(TestLogTimestamp)
 	log.SetDroppedAttributesCount(1)
 	log.SetSeverityNumber(plog.SeverityNumberINFO)
@@ -109,7 +107,6 @@ func fillLogTwo(log plog.LogRecord) {
 }
 
 func fillLogThree(log plog.LogRecord) {
-	log.SetName("logC")
 	log.SetTimestamp(TestLogTimestamp)
 	log.SetDroppedAttributesCount(1)
 	log.SetSeverityNumber(plog.SeverityNumberWARN)

--- a/pkg/batchperresourceattr/batchperresourceattr_test.go
+++ b/pkg/batchperresourceattr/batchperresourceattr_test.go
@@ -312,10 +312,8 @@ func fillResourceLogs(rs plog.ResourceLogs, key string, val pcommon.Value) {
 	rs.Resource().Attributes().Upsert("__other_key__", pcommon.NewValueInt(123))
 	ils := rs.ScopeLogs().AppendEmpty()
 	firstLogRecord := ils.LogRecords().AppendEmpty()
-	firstLogRecord.SetName("first-log-record")
 	firstLogRecord.SetFlags(rand.Uint32())
 	secondLogRecord := ils.LogRecords().AppendEmpty()
-	secondLogRecord.SetName("second-log-record")
 	secondLogRecord.SetFlags(rand.Uint32())
 }
 

--- a/processor/filterprocessor/filter_processor_logs_test.go
+++ b/processor/filterprocessor/filter_processor_logs_test.go
@@ -375,7 +375,11 @@ func TestFilterLogProcessor(t *testing.T) {
 				gotLogs := rLogs.At(i).ScopeLogs().At(0).LogRecords()
 				assert.Equal(t, len(wantOut), gotLogs.Len())
 				for idx := range wantOut {
-					assert.Equal(t, wantOut[idx], gotLogs.At(idx).Name())
+					val, ok := gotLogs.At(idx).Attributes().Get("name")
+					if !ok {
+						continue
+					}
+					assert.Equal(t, wantOut[idx], val.AsString())
 				}
 			}
 			assert.NoError(t, flp.Shutdown(ctx))
@@ -394,8 +398,7 @@ func testResourceLogs(lwrs []logWithResource) plog.Logs {
 		ls := rl.ScopeLogs().AppendEmpty().LogRecords()
 		for _, name := range lwr.logNames {
 			l := ls.AppendEmpty()
-			l.SetName(name)
-
+			l.Attributes().InsertString("name", name)
 			// Add record level attribtues
 			for k := 0; k < ls.Len(); k++ {
 				pcommon.NewMapFromRaw(lwrs[i].recordAttributes).CopyTo(ls.At(k).Attributes())

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -83,7 +83,6 @@ func someComplexLogs(withResourceAttrIndex bool, rlCount int, illCount int) plog
 
 		for j := 0; j < illCount; j++ {
 			log := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-			log.SetName(fmt.Sprintf("foo-%d-%d", i, j))
 			log.Attributes().InsertString("commonGroupedAttr", "abc")
 			log.Attributes().InsertString("commonNonGroupedAttr", "xyz")
 		}
@@ -488,7 +487,6 @@ func someLogs(attrs pcommon.Map, instrumentationLibraryCount int, logCount int) 
 			sl := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty()
 			sl.Scope().SetName(ilName)
 			log := sl.LogRecords().AppendEmpty()
-			log.SetName(fmt.Sprint("foo-", j))
 			attrs.CopyTo(log.Attributes())
 		}
 	}

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -264,8 +264,7 @@ func generateLogs(resourceFunc ...generateResourceFunc) plog.Logs {
 		res := ls.Resource()
 		resFun(res)
 	}
-	log := ls.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-	log.SetName("foobar")
+	ls.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
 	return l
 }
 

--- a/processor/routingprocessor/processor_test.go
+++ b/processor/routingprocessor/processor_test.go
@@ -855,18 +855,15 @@ func TestLogs_AreCorrectlySplitPerResourceAttributeRouting(t *testing.T) {
 
 	rl := l.ResourceLogs().AppendEmpty()
 	rl.Resource().Attributes().InsertString("X-Tenant", "acme")
-	log := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-	log.SetName("mylog")
+	rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
 
 	rl = l.ResourceLogs().AppendEmpty()
 	rl.Resource().Attributes().InsertString("X-Tenant", "acme")
-	log = rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-	log.SetName("mylog1")
+	rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
 
 	rl = l.ResourceLogs().AppendEmpty()
 	rl.Resource().Attributes().InsertString("X-Tenant", "something-else")
-	log = rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
-	log.SetName("mylog2")
+	rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
 
 	ctx := context.Background()
 	require.NoError(t, exp.Start(ctx, host))

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -26,7 +26,6 @@ import (
 
 func Test_newFunctionCall(t *testing.T) {
 	input := plog.NewLogRecord()
-	input.SetName("bear")
 	attrs := pcommon.NewMap()
 	attrs.InsertString("test", "1")
 	attrs.InsertInt("test2", 3)

--- a/receiver/googlecloudpubsubreceiver/testdata/data.go
+++ b/receiver/googlecloudpubsubreceiver/testdata/data.go
@@ -53,8 +53,7 @@ func CreateLogExport() []byte {
 	resource := resources.AppendEmpty()
 	libs := resource.ScopeLogs()
 	logs := libs.AppendEmpty()
-	log := logs.LogRecords().AppendEmpty()
-	log.SetName("test")
+	logs.LogRecords().AppendEmpty()
 	data, _ := plog.NewProtoMarshaler().MarshalLogs(out)
 	return data
 }

--- a/testbed/testbed/data_providers.go
+++ b/testbed/testbed/data_providers.go
@@ -117,7 +117,6 @@ func (dp *perfTestDataProvider) GenerateMetrics() (pmetric.Metrics, bool) {
 
 	for i := 0; i < dp.options.ItemsPerBatch; i++ {
 		metric := metrics.AppendEmpty()
-		metric.SetName("load_generator_" + strconv.Itoa(i))
 		metric.SetDescription("Load Generator Counter #" + strconv.Itoa(i))
 		metric.SetUnit("1")
 		metric.SetDataType(pmetric.MetricDataTypeGauge)
@@ -161,7 +160,6 @@ func (dp *perfTestDataProvider) GenerateLogs() (plog.Logs, bool) {
 		record := logRecords.AppendEmpty()
 		record.SetSeverityNumber(plog.SeverityNumberINFO3)
 		record.SetSeverityText("INFO3")
-		record.SetName("load_generator_" + strconv.Itoa(i))
 		record.Body().SetStringVal("Load Generator Counter #" + strconv.Itoa(i))
 		record.SetFlags(uint32(2))
 		record.SetTimestamp(now)


### PR DESCRIPTION
As per the change in the proto, the name field is no longer valid for log records. This change removes all calls to `SetName`