### PR TITLE
[receiver\sqlserver] Fix SQL Server metrics to have int type where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `azuremonitorexporter`: Fix log exporter bug related to incorrectly mapping SpanId (#9579)
 - `mysqlreceiver`: Fix attribute values mismatch with its definition (#9688)
 - `opencensusreceiver`: Do not report fatal error if err is server closed (#9559).
+- `sqlserverreceiver`: Fix the receiver to have integer types on metrics where applicable (#9601)
 
 ## v0.50.0
 

--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -16,7 +16,7 @@ These are the metrics available for this scraper.
 | **sqlserver.page.buffer_cache.hit_ratio** | Pages found in the buffer pool without having to read from disk. | % | Gauge(Double) | <ul> </ul> |
 | **sqlserver.page.checkpoint.flush.rate** | Number of pages flushed by operations requiring dirty pages to be flushed. | {pages}/s | Gauge(Double) | <ul> </ul> |
 | **sqlserver.page.lazy_write.rate** | Number of lazy writes moving dirty pages to disk. | {writes}/s | Gauge(Double) | <ul> </ul> |
-| **sqlserver.page.life_expectancy** | Time a page will stay in the buffer pool. | s | Gauge(Double) | <ul> </ul> |
+| **sqlserver.page.life_expectancy** | Time a page will stay in the buffer pool. | s | Gauge(Int) | <ul> </ul> |
 | **sqlserver.page.operation.rate** | Number of physical database page operations issued. | {operations}/s | Gauge(Double) | <ul> <li>page.operations</li> </ul> |
 | **sqlserver.page.split.rate** | Number of pages split as a result of overflowing index pages. | {pages}/s | Gauge(Double) | <ul> </ul> |
 | **sqlserver.transaction.rate** | Number of transactions started for the database (not including XTP-only transactions). | {transactions}/s | Gauge(Double) | <ul> </ul> |
@@ -24,10 +24,10 @@ These are the metrics available for this scraper.
 | **sqlserver.transaction_log.flush.data.rate** | Total number of log bytes flushed. | By/s | Gauge(Double) | <ul> </ul> |
 | **sqlserver.transaction_log.flush.rate** | Number of log flushes. | {flushes}/s | Gauge(Double) | <ul> </ul> |
 | **sqlserver.transaction_log.flush.wait.rate** | Number of commits waiting for a transaction log flush. | {commits}/s | Gauge(Double) | <ul> </ul> |
-| **sqlserver.transaction_log.growth.count** | Total number of transaction log expansions for a database. | {growths} | Sum(Double) | <ul> </ul> |
-| **sqlserver.transaction_log.shrink.count** | Total number of transaction log shrinks for a database. | {shrinks} | Sum(Double) | <ul> </ul> |
-| **sqlserver.transaction_log.usage** | Percent of transaction log space used. | % | Gauge(Double) | <ul> </ul> |
-| **sqlserver.user.connection.count** | Number of users connected to the SQL Server. | {connections} | Gauge(Double) | <ul> </ul> |
+| **sqlserver.transaction_log.growth.count** | Total number of transaction log expansions for a database. | {growths} | Sum(Int) | <ul> </ul> |
+| **sqlserver.transaction_log.shrink.count** | Total number of transaction log shrinks for a database. | {shrinks} | Sum(Int) | <ul> </ul> |
+| **sqlserver.transaction_log.usage** | Percent of transaction log space used. | % | Gauge(Int) | <ul> </ul> |
+| **sqlserver.user.connection.count** | Number of users connected to the SQL Server. | {connections} | Gauge(Int) | <ul> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
 Any metric can be enabled or disabled with the following scraper configuration:

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_v2.go
@@ -509,14 +509,14 @@ func (m *metricSqlserverPageLifeExpectancy) init() {
 	m.data.SetDataType(pmetric.MetricDataTypeGauge)
 }
 
-func (m *metricSqlserverPageLifeExpectancy) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+func (m *metricSqlserverPageLifeExpectancy) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetDoubleVal(val)
+	dp.SetIntVal(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -905,14 +905,14 @@ func (m *metricSqlserverTransactionLogGrowthCount) init() {
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricSqlserverTransactionLogGrowthCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+func (m *metricSqlserverTransactionLogGrowthCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetDoubleVal(val)
+	dp.SetIntVal(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -956,14 +956,14 @@ func (m *metricSqlserverTransactionLogShrinkCount) init() {
 	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
 }
 
-func (m *metricSqlserverTransactionLogShrinkCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+func (m *metricSqlserverTransactionLogShrinkCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetDoubleVal(val)
+	dp.SetIntVal(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1005,14 +1005,14 @@ func (m *metricSqlserverTransactionLogUsage) init() {
 	m.data.SetDataType(pmetric.MetricDataTypeGauge)
 }
 
-func (m *metricSqlserverTransactionLogUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+func (m *metricSqlserverTransactionLogUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetDoubleVal(val)
+	dp.SetIntVal(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1054,14 +1054,14 @@ func (m *metricSqlserverUserConnectionCount) init() {
 	m.data.SetDataType(pmetric.MetricDataTypeGauge)
 }
 
-func (m *metricSqlserverUserConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
+func (m *metricSqlserverUserConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
 	if !m.settings.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	dp.SetDoubleVal(val)
+	dp.SetIntVal(val)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1269,7 +1269,7 @@ func (mb *MetricsBuilder) RecordSqlserverPageLazyWriteRateDataPoint(ts pcommon.T
 }
 
 // RecordSqlserverPageLifeExpectancyDataPoint adds a data point to sqlserver.page.life_expectancy metric.
-func (mb *MetricsBuilder) RecordSqlserverPageLifeExpectancyDataPoint(ts pcommon.Timestamp, val float64) {
+func (mb *MetricsBuilder) RecordSqlserverPageLifeExpectancyDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricSqlserverPageLifeExpectancy.recordDataPoint(mb.startTime, ts, val)
 }
 
@@ -1309,22 +1309,22 @@ func (mb *MetricsBuilder) RecordSqlserverTransactionLogFlushWaitRateDataPoint(ts
 }
 
 // RecordSqlserverTransactionLogGrowthCountDataPoint adds a data point to sqlserver.transaction_log.growth.count metric.
-func (mb *MetricsBuilder) RecordSqlserverTransactionLogGrowthCountDataPoint(ts pcommon.Timestamp, val float64) {
+func (mb *MetricsBuilder) RecordSqlserverTransactionLogGrowthCountDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricSqlserverTransactionLogGrowthCount.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverTransactionLogShrinkCountDataPoint adds a data point to sqlserver.transaction_log.shrink.count metric.
-func (mb *MetricsBuilder) RecordSqlserverTransactionLogShrinkCountDataPoint(ts pcommon.Timestamp, val float64) {
+func (mb *MetricsBuilder) RecordSqlserverTransactionLogShrinkCountDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricSqlserverTransactionLogShrinkCount.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverTransactionLogUsageDataPoint adds a data point to sqlserver.transaction_log.usage metric.
-func (mb *MetricsBuilder) RecordSqlserverTransactionLogUsageDataPoint(ts pcommon.Timestamp, val float64) {
+func (mb *MetricsBuilder) RecordSqlserverTransactionLogUsageDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricSqlserverTransactionLogUsage.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSqlserverUserConnectionCountDataPoint adds a data point to sqlserver.user.connection.count metric.
-func (mb *MetricsBuilder) RecordSqlserverUserConnectionCountDataPoint(ts pcommon.Timestamp, val float64) {
+func (mb *MetricsBuilder) RecordSqlserverUserConnectionCountDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricSqlserverUserConnectionCount.recordDataPoint(mb.startTime, ts, val)
 }
 

--- a/receiver/sqlserverreceiver/internal/metadata/metrics_builder_ext.go
+++ b/receiver/sqlserverreceiver/internal/metadata/metrics_builder_ext.go
@@ -21,7 +21,7 @@ import (
 func (mb *MetricsBuilder) RecordAnyDataPoint(ts pcommon.Timestamp, val float64, name string, attributes map[string]string) {
 	switch name {
 	case "sqlserver.user.connection.count":
-		mb.RecordSqlserverUserConnectionCountDataPoint(ts, val)
+		mb.RecordSqlserverUserConnectionCountDataPoint(ts, int64(val))
 	case "sqlserver.batch.request.rate":
 		mb.RecordSqlserverBatchRequestRateDataPoint(ts, val)
 	case "sqlserver.batch.sql_compilation.rate":
@@ -39,7 +39,7 @@ func (mb *MetricsBuilder) RecordAnyDataPoint(ts pcommon.Timestamp, val float64, 
 	case "sqlserver.page.lazy_write.rate":
 		mb.RecordSqlserverPageLazyWriteRateDataPoint(ts, val)
 	case "sqlserver.page.life_expectancy":
-		mb.RecordSqlserverPageLifeExpectancyDataPoint(ts, val)
+		mb.RecordSqlserverPageLifeExpectancyDataPoint(ts, int64(val))
 	case "sqlserver.page.operation.rate":
 		mb.RecordSqlserverPageOperationRateDataPoint(ts, val, attributes["type"])
 	case "sqlserver.page.split.rate":
@@ -51,11 +51,11 @@ func (mb *MetricsBuilder) RecordAnyDataPoint(ts pcommon.Timestamp, val float64, 
 	case "sqlserver.transaction_log.flush.wait.rate":
 		mb.RecordSqlserverTransactionLogFlushWaitRateDataPoint(ts, val)
 	case "sqlserver.transaction_log.growth.count":
-		mb.RecordSqlserverTransactionLogGrowthCountDataPoint(ts, val)
+		mb.RecordSqlserverTransactionLogGrowthCountDataPoint(ts, int64(val))
 	case "sqlserver.transaction_log.shrink.count":
-		mb.RecordSqlserverTransactionLogShrinkCountDataPoint(ts, val)
+		mb.RecordSqlserverTransactionLogShrinkCountDataPoint(ts, int64(val))
 	case "sqlserver.transaction_log.usage":
-		mb.RecordSqlserverTransactionLogUsageDataPoint(ts, val)
+		mb.RecordSqlserverTransactionLogUsageDataPoint(ts, int64(val))
 	case "sqlserver.transaction.rate":
 		mb.RecordSqlserverTransactionRateDataPoint(ts, val)
 	case "sqlserver.transaction.write.rate":

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -17,7 +17,7 @@ metrics:
     description: Number of users connected to the SQL Server.
     unit: "{connections}"
     gauge:
-      value_type: double
+      value_type: int
   sqlserver.lock.wait_time.avg:
     enabled: true
     description: Average wait time for all lock requests that had to wait.
@@ -59,7 +59,7 @@ metrics:
     description: Time a page will stay in the buffer pool.
     unit: s
     gauge:
-      value_type: double
+      value_type: int
   sqlserver.page.split.rate:
     enabled: true
     description: Number of pages split as a result of overflowing index pages.
@@ -92,7 +92,7 @@ metrics:
     sum:
       monotonic: true
       aggregation: cumulative
-      value_type: double
+      value_type: int
   sqlserver.transaction_log.shrink.count:
     enabled: true
     description: Total number of transaction log shrinks for a database.
@@ -100,13 +100,13 @@ metrics:
     sum:
       monotonic: true
       aggregation: cumulative
-      value_type: double
+      value_type: int
   sqlserver.transaction_log.usage:
     enabled: true
     description: Percent of transaction log space used.
     unit: "%"
     gauge:
-      value_type: double
+      value_type: int
   sqlserver.transaction_log.flush.wait.rate:
     enabled: true
     description: Number of commits waiting for a transaction log flush.


### PR DESCRIPTION
**Description:**
Some of the metrics that this receiver collects are only ever integers even though they are currently marked as doubles.

This PR changes the following metrics from double type to int:
sqlserver.transaction_log.usage
sqlserver.transaction_log.shrink.count
sqlserver.transaction_log.growth.count
sqlserver.page.life_expectancy
sqlserver.user.connection.count

**Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9601

**Testing:** Manually ran and verified that changed metrics came back as integers instead of doubles.

**Documentation:** Updated documentation to reflect metric changes