### PR TITLE
[tools] Bump dependency to regenerate cache

### DIFF
--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jstemmer/go-junit-report v1.0.0
 	github.com/pavius/impi v0.0.3
 	github.com/tcnksm/ghr v0.14.0
-	go.opentelemetry.io/build-tools/checkdoc v0.0.0-20220327151007-0b1d24fa04f4
+	go.opentelemetry.io/build-tools/checkdoc v0.0.0-20220502161954-e2bf744925c0
 	go.opentelemetry.io/build-tools/crosslink v0.0.0-20220323195613-c6fe4f9fe445
 	go.opentelemetry.io/build-tools/issuegenerator v0.0.0-20210920164323-2ceabab23375
 	go.opentelemetry.io/build-tools/multimod v0.0.0-20220110194441-2a9d5288bd70

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -902,6 +902,8 @@ go.opentelemetry.io/build-tools v0.0.0-20220321164008-b8e03aff061a h1:yLxbGYl9MX
 go.opentelemetry.io/build-tools v0.0.0-20220321164008-b8e03aff061a/go.mod h1:gkLviEngQuoeD670EP1KA/Oj4i5oNAzb+pjkk+4ecaQ=
 go.opentelemetry.io/build-tools/checkdoc v0.0.0-20220327151007-0b1d24fa04f4 h1:3G7sytU+iauFkcJW3rSms8Z1UuC0PKSqpmBQxV+1d18=
 go.opentelemetry.io/build-tools/checkdoc v0.0.0-20220327151007-0b1d24fa04f4/go.mod h1:Jh+M9G6ChbHDxFcWsct3eGdQ1fQ9er9GkdH3T6u3iVA=
+go.opentelemetry.io/build-tools/checkdoc v0.0.0-20220502161954-e2bf744925c0 h1:IfqOPSkl5yEnLyv8PfZk8SMXxcWCl0un/Ljvz9TG1uU=
+go.opentelemetry.io/build-tools/checkdoc v0.0.0-20220502161954-e2bf744925c0/go.mod h1:Jh+M9G6ChbHDxFcWsct3eGdQ1fQ9er9GkdH3T6u3iVA=
 go.opentelemetry.io/build-tools/crosslink v0.0.0-20220323195613-c6fe4f9fe445 h1:NP3HjBmEhvtuxZuq3HewWQGQqCt7ljor6PFNh8VVrA0=
 go.opentelemetry.io/build-tools/crosslink v0.0.0-20220323195613-c6fe4f9fe445/go.mod h1:OPvM7Yg5NywtBIqb8YGZOkROAI5z1lfFrwTmaonMyLA=
 go.opentelemetry.io/build-tools/issuegenerator v0.0.0-20210920164323-2ceabab23375 h1:EZpYcHXE+pO4Ogfawlb6uEFFpQ2soJVNXS8tYfuvxUw=


### PR DESCRIPTION
The problem described in #9280 has occurred again, resulting in new PRs failing CI due to missing tooling dependencies. This PR bumps a tooling dependency in order to trigger a regeneration of the tools cache. See #9281 