### PR TITLE
[GHA] Bump cache number for tools

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Install dependencies
         if: steps.module-cache.outputs.hit != 'true'
         run: make -j2 gomoddownload
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Cache Build
         uses: actions/cache@v3
         with:
@@ -109,7 +109,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Cache Build
         uses: actions/cache@v3
         with:
@@ -156,7 +156,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Cache Build
         uses: actions/cache@v3
         with:
@@ -190,7 +190,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Run Integration Tests
         run: make integration-tests-with-cover
 
@@ -220,7 +220,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Correctness
         run: make -C testbed run-correctness-traces-tests
   correctness-metrics:
@@ -249,7 +249,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Correctness
         run: make -C testbed run-correctness-metrics-tests
 
@@ -417,7 +417,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Download Binaries
         uses: actions/download-artifact@v3
         with:
@@ -476,7 +476,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Set Release Tag
         id: github_tag
         run: ./.github/workflows/scripts/set_release_tag.sh

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -31,7 +31,7 @@ jobs:
           path: |
             /home/runner/go/pkg/mod
             /home/runner/.cache/go-build
-          key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          key: v2-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
       - name: Cache Tools
         id: tool-cache
         uses: actions/cache@v3
@@ -105,7 +105,7 @@ jobs:
           path: |
             /home/runner/go/pkg/mod
             /home/runner/.cache/go-build
-          key: v1-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          key: v2-go-pkg-mod-${{ runner.os }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
       - run: mkdir -p results && touch results/TESTRESULTS.md
       - name: Download Collector Binaries
         uses: actions/download-artifact@v3

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -39,7 +39,7 @@ jobs:
           cache-name: cache-tool-binaries
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Install dependencies
         if: steps.module-cache.outputs.hit != 'true'
         run: make -j2 gomoddownload
@@ -72,7 +72,7 @@ jobs:
           cache-name: cache-tool-binaries
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - run: sudo chmod 0777 -R /opt
       - name: Fluentbit Cache
         id: fluentbit-cache

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -19,7 +19,7 @@ jobs:
           cache-name: cache-tool-binaries
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Setup Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -39,7 +39,7 @@ jobs:
           cache-name: cache-tool-binaries
         with:
           path: /home/runner/go/bin
-          key: v1-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
+          key: v2-tools-${{ runner.os }}-${{ hashFiles('./internal/tools/go.mod') }}
       - name: Install dependencies
         if: steps.module-cache.outputs.hit != 'true'
         run: make -j2 gomoddownload


### PR DESCRIPTION
**Description:** 

Attempt to fix the lint job and others which are failing, pressumably because of a faulty cache.

**Link to tracking Issue:** 

Some examples:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/runs/6274699538?check_suite_focus=true
- https://github.com/open-telemetry/opentelemetry-collector-contrib/runs/6273969639?check_suite_focus=true
- https://github.com/open-telemetry/opentelemetry-collector-contrib/runs/6273463152?check_suite_focus=true