### PR TITLE
Add workflow for make gotidy CI check

### DIFF
--- a/.github/workflows/gotidy.yml
+++ b/.github/workflows/gotidy.yml
@@ -1,0 +1,27 @@
+# This action requires that PRs run `make gotidy` to ensure
+# dependencies are up to date in reaction to any changes
+
+name: gotidy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+jobs:
+  gotidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for go mod dependency changes
+        run: |
+          make gotidy
+          if [[ $(git diff --name-only | grep go\.mod) || $(git diff --name-only | grep go\.sum) ]]
+          then
+            echo "go.mod/go.sum deps changes detected."
+            echo "Please run `make gotidy`"
+            false
+          else
+            echo "No go module changes detected."
+          fi


### PR DESCRIPTION
**Description:** This adds a workflow check to make sure `make gotidy` has been run on a PR. Right now this command produces a diff on `main` which is confusing as other PRs that run it will pull in unrelated changes (see https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9679#discussion_r863900260). This hurts the effectiveness of this command as a way to conveniently update all related deps

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Tested in https://github.com/damemi/opentelemetry-collector-contrib/pull/457

**Documentation:** <Describe the documentation added.>