### PR TITLE
[exporter/prometheusremotewriteexporter] Do not modify attributes Map in prometheusRW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `prometheusreceiver`: Fix the memory issue introduced in the 0.49.0 release (#9718)
 - `couchdbreceiver`: Fix issue where the receiver would not respect custom metric settings (#9598)
 - `nginxreceiver`: Include nginxreceiver in components (#9572)
+- `pkg/translator/prometheusremotewrite`: Fix data race when used with other exporters (#9736)
 
 ## v0.50.0
 

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -178,8 +178,12 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, externa
 
 	// Ensure attributes are sorted by key for consistent merging of keys which
 	// collide when sanitized.
-	attributes.Sort()
-	attributes.Range(func(key string, value pcommon.Value) bool {
+	// Sorting is done on a cloned map, as the original attributes map can read at
+	// the same time in different places.
+	cloneAttributes := pcommon.NewMap()
+	attributes.CopyTo(cloneAttributes)
+	cloneAttributes.Sort()
+	cloneAttributes.Range(func(key string, value pcommon.Value) bool {
 		var finalKey = sanitize(key)
 		if existingLabel, alreadyExists := l[finalKey]; alreadyExists {
 			existingLabel.Value = existingLabel.Value + ";" + value.AsString()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Modifying data in the prometheus remote write causes a race when more
than one exporters is accessing data.
To avoid this, all operations are done on cloned data.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9727

**Testing:**
I have executed the reproduction steps described in the bug report. With the fix the panic is not occurring anymore.

**Documentation:**
Added inline comment about the change as this is not self-explanatory.