### PR TITLE
Change signalfx translator to expose To/From translator structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛑 Breaking changes 🛑
 
 - `datadogexporter`: Replace HistogramMode defined as string with enum.
+- `pkg/translator/signalfx`: Change signalfx translator to expose To/From translator structs. (#9740)
 
 ### 🚩 Deprecations 🚩
 

--- a/exporter/signalfxexporter/internal/translation/converter.go
+++ b/exporter/signalfxexporter/internal/translation/converter.go
@@ -39,6 +39,8 @@ var (
 	sfxMetricTypeGauge             = sfxpb.MetricType_GAUGE
 	sfxMetricTypeCumulativeCounter = sfxpb.MetricType_CUMULATIVE_COUNTER
 	sfxMetricTypeCounter           = sfxpb.MetricType_COUNTER
+
+	translator = &signalfx.FromTranslator{}
 )
 
 // MetricsConverter converts MetricsData to sfxpb DataPoints. It holds an optional
@@ -85,7 +87,7 @@ func (c *MetricsConverter) MetricsToSignalFxV2(md pmetric.Metrics) []*sfxpb.Data
 		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
 			ilm := rm.ScopeMetrics().At(j)
 			for k := 0; k < ilm.Metrics().Len(); k++ {
-				dps := signalfx.FromMetric(ilm.Metrics().At(k), extraDimensions)
+				dps := translator.FromMetric(ilm.Metrics().At(k), extraDimensions)
 				dps = c.translateAndFilter(dps)
 				sfxDataPoints = append(sfxDataPoints, dps...)
 			}

--- a/pkg/translator/signalfx/from_metrics.go
+++ b/pkg/translator/signalfx/from_metrics.go
@@ -43,8 +43,11 @@ const (
 	quantileDimensionKey = "quantile"
 )
 
+// FromTranslator converts from pdata to SignalFx proto data model.
+type FromTranslator struct{}
+
 // FromMetrics converts pmetric.Metrics to SignalFx proto data points.
-func FromMetrics(md pmetric.Metrics) ([]*sfxpb.DataPoint, error) {
+func (ft *FromTranslator) FromMetrics(md pmetric.Metrics) ([]*sfxpb.DataPoint, error) {
 	var sfxDataPoints []*sfxpb.DataPoint
 
 	rms := md.ResourceMetrics()
@@ -55,7 +58,7 @@ func FromMetrics(md pmetric.Metrics) ([]*sfxpb.DataPoint, error) {
 		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
 			ilm := rm.ScopeMetrics().At(j)
 			for k := 0; k < ilm.Metrics().Len(); k++ {
-				sfxDataPoints = append(sfxDataPoints, FromMetric(ilm.Metrics().At(k), extraDimensions)...)
+				sfxDataPoints = append(sfxDataPoints, ft.FromMetric(ilm.Metrics().At(k), extraDimensions)...)
 			}
 		}
 	}
@@ -65,7 +68,7 @@ func FromMetrics(md pmetric.Metrics) ([]*sfxpb.DataPoint, error) {
 
 // FromMetric converts pmetric.Metric to SignalFx proto data points.
 // TODO: Remove this and change signalfxexporter to us FromMetrics.
-func FromMetric(m pmetric.Metric, extraDimensions []*sfxpb.Dimension) []*sfxpb.DataPoint {
+func (ft *FromTranslator) FromMetric(m pmetric.Metric, extraDimensions []*sfxpb.Dimension) []*sfxpb.DataPoint {
 	var dps []*sfxpb.DataPoint
 
 	mt := fromMetricTypeToMetricType(m)

--- a/pkg/translator/signalfx/from_metrics_test.go
+++ b/pkg/translator/signalfx/from_metrics_test.go
@@ -380,8 +380,8 @@ func Test_FromMetrics(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md := tt.metricsFn()
-			gotSfxDataPoints, err := FromMetrics(md)
+			from := &FromTranslator{}
+			gotSfxDataPoints, err := from.FromMetrics(tt.metricsFn())
 			require.NoError(t, err)
 			// Sort SFx dimensions since they are built from maps and the order
 			// of those is not deterministic.

--- a/pkg/translator/signalfx/to_metrics.go
+++ b/pkg/translator/signalfx/to_metrics.go
@@ -23,8 +23,11 @@ import (
 	"go.uber.org/multierr"
 )
 
+// ToTranslator converts from SignalFx proto data model to pdata.
+type ToTranslator struct{}
+
 // ToMetrics converts SignalFx proto data points to pmetric.Metrics.
-func ToMetrics(sfxDataPoints []*model.DataPoint) (pmetric.Metrics, error) {
+func (tt *ToTranslator) ToMetrics(sfxDataPoints []*model.DataPoint) (pmetric.Metrics, error) {
 	// TODO: not optimized at all, basically regenerating everything for each
 	// 	data point.
 	md := pmetric.NewMetrics()

--- a/pkg/translator/signalfx/to_metrics_test.go
+++ b/pkg/translator/signalfx/to_metrics_test.go
@@ -206,7 +206,8 @@ func Test_ToMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md, err := ToMetrics(tt.sfxDataPoints)
+			to := &ToTranslator{}
+			md, err := to.ToMetrics(tt.sfxDataPoints)
 			if tt.wantError {
 				assert.Error(t, err)
 			} else {

--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -76,6 +76,8 @@ var (
 	errNextConsumerRespBody  = initJSONResponse(responseErrNextConsumer)
 	errLogsNotConfigured     = initJSONResponse(responseErrLogsNotConfigured)
 	errMetricsNotConfigured  = initJSONResponse(responseErrMetricsNotConfigured)
+
+	translator = &signalfx.ToTranslator{}
 )
 
 // sfxReceiver implements the component.MetricsReceiver for SignalFx metric protocol.
@@ -237,7 +239,7 @@ func (r *sfxReceiver) handleDatapointReq(resp http.ResponseWriter, req *http.Req
 		return
 	}
 
-	md, err := signalfx.ToMetrics(msg.Datapoints)
+	md, err := translator.ToMetrics(msg.Datapoints)
 	if err != nil {
 		r.settings.Logger.Debug("SignalFx conversion error", zap.Error(err))
 	}


### PR DESCRIPTION
This change allows in the future to add custom configuration for the translation.

Another use-case is to use feature gates, but since this package tries to depend only on pdata, cannot use that, so will pass as settings to the translator structs.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
