### PR TITLE
Avoid using master when refer to the latest/main branch

### DIFF
--- a/.github/workflows/tracegen.yml
+++ b/.github/workflows/tracegen.yml
@@ -19,7 +19,7 @@ jobs:
           push: false
           tags: ghcr.io/open-telemetry/opentelemetry-collector-contrib/tracegen:dev
 
-  publish-master:
+  publish-latest:
     runs-on: ubuntu-latest
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     permissions:


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
