### PR TITLE
[receiver/kubeletstats] Refactor setting of volume labels

### DIFF
--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
 
 func TestValidateMetadataLabelsConfig(t *testing.T) {
@@ -165,7 +166,7 @@ func TestSetExtraLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fields := map[string]string{}
-			err := tt.metadata.setExtraLabels(fields, tt.args[0], MetadataLabel(tt.args[1]), tt.args[2])
+			err := tt.metadata.setExtraLabels(fields, stats.PodReference{UID: tt.args[0]}, MetadataLabel(tt.args[1]), tt.args[2])
 			if tt.wantError == "" {
 				require.NoError(t, err)
 				assert.EqualValues(t, tt.want, fields)
@@ -323,8 +324,10 @@ func TestSetExtraLabelsForVolumeTypes(t *testing.T) {
 						},
 					},
 				},
-			}, nil)
-			metadata.setExtraLabels(fields, tt.args[0], MetadataLabel(tt.args[1]), volName)
+			}, func(volCacheID, volumeClaim, namespace string, labels map[string]string) error {
+				return nil
+			})
+			metadata.setExtraLabels(fields, stats.PodReference{UID: tt.args[0]}, MetadataLabel(tt.args[1]), volName)
 			assert.Equal(t, tt.want, fields)
 		})
 	}

--- a/receiver/kubeletstatsreceiver/internal/kubelet/resource.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/resource.go
@@ -39,7 +39,7 @@ func fillContainerResource(dest pcommon.Resource, sPod stats.PodStats, sContaine
 		conventions.AttributeK8SNamespaceName: sPod.PodRef.Namespace,
 		conventions.AttributeK8SContainerName: sContainer.Name,
 	}
-	if err := metadata.setExtraLabels(labels, sPod.PodRef.UID, MetadataLabelContainerID, sContainer.Name); err != nil {
+	if err := metadata.setExtraLabels(labels, sPod.PodRef, MetadataLabelContainerID, sContainer.Name); err != nil {
 		return fmt.Errorf("failed to set extra labels from metadata: %w", err)
 	}
 	for k, v := range labels {
@@ -56,15 +56,8 @@ func fillVolumeResource(dest pcommon.Resource, sPod stats.PodStats, vs stats.Vol
 		labelVolumeName:                       vs.Name,
 	}
 
-	if err := metadata.setExtraLabels(labels, sPod.PodRef.UID, MetadataLabelVolumeType, vs.Name); err != nil {
+	if err := metadata.setExtraLabels(labels, sPod.PodRef, MetadataLabelVolumeType, vs.Name); err != nil {
 		return fmt.Errorf("failed to set extra labels from metadata: %w", err)
-	}
-
-	if labels[labelVolumeType] == labelValuePersistentVolumeClaim {
-		volCacheID := fmt.Sprintf("%s/%s", sPod.PodRef.UID, vs.Name)
-		if err := metadata.DetailedPVCLabelsSetter(volCacheID, labels[labelPersistentVolumeClaimName], sPod.PodRef.Namespace, labels); err != nil {
-			return fmt.Errorf("failed to set labels from volume claim: %w", err)
-		}
 	}
 
 	for k, v := range labels {


### PR DESCRIPTION
Move setting of PVC labels to the same function where labels for other volumes are set. This increases cohesion and unblocks a straight forward migration to the metrics builder v2.

All the obsolete "label" naming should go away with migration to the metrics builder