### PR TITLE
[ci] Check component code owners

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -1,0 +1,47 @@
+#####################################################
+#
+# List of components in OpenTelemetry Collector Contrib
+# waiting on owners to be assigned
+#
+#####################################################
+#
+# Learn about membership in OpenTelemetry community:
+#  https://github.com/open-telemetry/community/blob/main/community-membership.md
+#
+#
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+cmd/configschema
+examples/demo/client
+examples/demo/server
+exporter/opencensusexporter
+exporter/parquetexporter
+extension/fluentbitextension
+extension/httpforwarder
+extension/sigv4authextension
+extension/storage
+internal/common
+internal/containertest
+internal/coreinternal
+internal/sharedcomponent
+internal/tools
+pkg/batchperresourceattr
+pkg/experimentalmetricmetadata
+pkg/stanza
+pkg/stanza/internal/tools
+pkg/translator/jaeger
+pkg/translator/opencensus
+pkg/translator/prometheusremotewrite
+pkg/translator/signalfx
+pkg/translator/zipkin
+pkg/winperfcounters
+processor/deltatorateprocessor
+processor/metricsgenerationprocessor
+receiver/opencensusreceiver
+receiver/podmanreceiver
+receiver/simpleprometheusreceiver
+receiver/simpleprometheusreceiver/examples/federation/prom-counter
+testbed
+testbed/mockdatareceivers/mockawsxrayreceiver

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,16 @@ jobs:
         uses: actions/checkout@v2
       - name: Check Collector Module Version
         run: ./.github/workflows/scripts/check-collector-module-version.sh
+  check-codeowners:
+    runs-on: ubuntu-latest
+    needs: [setup-environment]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Check Code Owner Existence
+        run: ./.github/workflows/scripts/check-codeowners.sh check_code_owner_existence
+      - name: Check Component Existence
+        run: ./.github/workflows/scripts/check-codeowners.sh check_component_existence
   lint-matrix:
     strategy:
       matrix:

--- a/.github/workflows/scripts/check-codeowners.sh
+++ b/.github/workflows/scripts/check-codeowners.sh
@@ -36,7 +36,7 @@ check_code_owner_existence() {
       # sub folders e.g. 'internal/aws' is listed in $CODEOWNERS
       # which accounts for internal/aws/awsutil, internal/aws/k8s etc.
       PREFIX_MODULE_PATH=$(echo $module | cut -d/ -f 1-2)
-      if ! grep -q "^$PREFIX_MODULE_PATH" "$CODEOWNERS"; then
+      if ! grep -wq "^$PREFIX_MODULE_PATH/ " "$CODEOWNERS"; then
         ((MISSING_COMPONENTS=MISSING_COMPONENTS+1))
         echo "\"$module\" not included in CODEOWNERS"
       fi

--- a/.github/workflows/scripts/check-codeowners.sh
+++ b/.github/workflows/scripts/check-codeowners.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+#   Copyright The OpenTelemetry Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#
+# verifies:
+# 1. That vendor components are assigned to owner(s)
+# 2. That list of vendor components (in $CODEOWNERS) still exists
+# in the project
+#
+set -eu -o pipefail
+
+CODEOWNERS=".github/CODEOWNERS"
+
+# Get component folders from the project and checks that they have 
+# an owner in $CODEOWNERS 
+check_code_owner_existence() {
+  MODULES=$(find . -type f -name "go.mod" -exec dirname {} \; | sort | grep -E '^./' | cut -c 3-)
+  MISSING_COMPONENTS=0
+  for module in ${MODULES}
+  do
+    if ! grep -q "^$module" "$CODEOWNERS"; then
+      # Account for parent folders which implicitly include 
+      # sub folders e.g. 'internal/aws' is listed in $CODEOWNERS
+      # which accounts for internal/aws/awsutil, internal/aws/k8s etc.
+      PREFIX_MODULE_PATH=$(echo $module | cut -d/ -f 1-2)
+      if ! grep -q "^$PREFIX_MODULE_PATH" "$CODEOWNERS"; then
+        ((MISSING_COMPONENTS=MISSING_COMPONENTS+1))
+        echo "\"$module\" not included in CODEOWNERS"
+      fi
+    fi
+  done
+  echo "there are $MISSING_COMPONENTS components not included in CODEOWNERS"
+  if [ "$MISSING_COMPONENTS" -gt 0 ]; then
+    exit 1
+  fi
+}
+
+# Checks that components specified in $CODEOWNERS still exist in the project
+check_component_existence() {
+  NOT_EXIST_COMPONENTS=0
+  while IFS= read -r line
+  do
+    if [[ $line =~ ^[^#\*] ]]; then
+      COMPONENT_PATH=$(echo "$line" | cut -d" " -f1)
+      if [ ! -d "$COMPONENT_PATH" ]; then
+        echo "\"$COMPONENT_PATH\" does not exist as specified in CODEOWNERS"
+        ((NOT_EXIST_COMPONENTS=NOT_EXIST_COMPONENTS+1))
+      fi
+    fi
+  done <"$CODEOWNERS"
+  echo "there are $NOT_EXIST_COMPONENTS component(s) that do not exist as specified in CODEOWNERS"
+  if [ "$NOT_EXIST_COMPONENTS" -gt 0 ]; then
+    exit 1
+  fi
+}
+
+if [[ "$1" == "check_code_owner_existence" ]];  then
+  check_code_owner_existence
+elif [[ "$1" == "check_component_existence" ]]; then
+  check_component_existence
+fi

--- a/.github/workflows/scripts/check-codeowners.sh
+++ b/.github/workflows/scripts/check-codeowners.sh
@@ -31,7 +31,7 @@ check_code_owner_existence() {
   MISSING_COMPONENTS=0
   for module in ${MODULES}
   do
-    if ! grep -q "^$module" "$CODEOWNERS"; then
+    if ! grep -q "^$module " "$CODEOWNERS"; then
       # Account for parent folders which implicitly include 
       # sub folders e.g. 'internal/aws' is listed in $CODEOWNERS
       # which accounts for internal/aws/awsutil, internal/aws/k8s etc.

--- a/.github/workflows/scripts/check-codeowners.sh
+++ b/.github/workflows/scripts/check-codeowners.sh
@@ -23,12 +23,14 @@
 set -eu -o pipefail
 
 CODEOWNERS=".github/CODEOWNERS"
+ALLOWLIST=".github/ALLOWLIST"
 
 # Get component folders from the project and checks that they have 
 # an owner in $CODEOWNERS 
 check_code_owner_existence() {
   MODULES=$(find . -type f -name "go.mod" -exec dirname {} \; | sort | grep -E '^./' | cut -c 3-)
   MISSING_COMPONENTS=0
+  ALLOW_LIST_COMPONENTS=0
   for module in ${MODULES}
   do
     if ! grep -q "^$module " "$CODEOWNERS"; then
@@ -37,12 +39,19 @@ check_code_owner_existence() {
       # which accounts for internal/aws/awsutil, internal/aws/k8s etc.
       PREFIX_MODULE_PATH=$(echo $module | cut -d/ -f 1-2)
       if ! grep -wq "^$PREFIX_MODULE_PATH/ " "$CODEOWNERS"; then
-        ((MISSING_COMPONENTS=MISSING_COMPONENTS+1))
-        echo "\"$module\" not included in CODEOWNERS"
+        # Check if it is a known component that is waiting on an owner
+        if grep -wq "$module" "$ALLOWLIST"; then
+          ((ALLOW_LIST_COMPONENTS=ALLOW_LIST_COMPONENTS+1))
+          echo "\"$module\" not included in CODEOWNERS but in the ALLOWLIST"
+        else
+          ((MISSING_COMPONENTS=MISSING_COMPONENTS+1))
+          echo "\"$module\" not included in CODEOWNERS"
+        fi
       fi
     fi
   done
-  echo "there are $MISSING_COMPONENTS components not included in CODEOWNERS"
+  echo "there are $ALLOW_LIST_COMPONENTS components not included in CODEOWNERS but known in the ALLOWLIST"
+  echo "there are $MISSING_COMPONENTS components not included in CODEOWNERS and not known in the ALLOWLIST"
   if [ "$MISSING_COMPONENTS" -gt 0 ]; then
     exit 1
   fi


### PR DESCRIPTION
This PR checks that components have owners (as listed in CODEOWNERS) and that each listed component still exists in the project.

Implementation:

- Check every component has a CODEOWNERS line
- Check every component listed on CODEOWNERS actually exists in the project
- Call through CI job

Fixes #3871

Supersedes #4137

Signed-off-by: Martin Hickey <martin.hickey@ie.ibm.com>
Co-authored-by: Eundoo Song [eundoo.song@gmail.com](mailto:eundoo.song@gmail.com)