### PR TITLE
[receiver/hostmetrics] Remove redundant usages of metadata.Attribute

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -359,25 +359,25 @@ func assertCPUMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon
 		internal.AssertSumMetricStartTimeEquals(t, metric, startTime)
 	}
 	assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), 4*runtime.NumCPU())
-	internal.AssertSumMetricHasAttribute(t, metric, 0, metadata.Attributes.Cpu)
-	internal.AssertSumMetricHasAttributeValue(t, metric, 0, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttribute(t, metric, 0, "cpu")
+	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "state",
 		pcommon.NewValueString(metadata.AttributeStateUser.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 1, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "state",
 		pcommon.NewValueString(metadata.AttributeStateSystem.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 2, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 2, "state",
 		pcommon.NewValueString(metadata.AttributeStateIdle.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 3, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 3, "state",
 		pcommon.NewValueString(metadata.AttributeStateInterrupt.String()))
 }
 
 func assertCPUMetricHasLinuxSpecificStateLabels(t *testing.T, metric pmetric.Metric) {
-	internal.AssertSumMetricHasAttributeValue(t, metric, 4, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 4, "state",
 		pcommon.NewValueString(metadata.AttributeStateNice.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 5, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 5, "state",
 		pcommon.NewValueString(metadata.AttributeStateSoftirq.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 6, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 6, "state",
 		pcommon.NewValueString(metadata.AttributeStateSteal.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 7, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 7, "state",
 		pcommon.NewValueString(metadata.AttributeStateWait.String()))
 }
 
@@ -391,24 +391,24 @@ func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startT
 	if startTime != 0 {
 		internal.AssertGaugeMetricStartTimeEquals(t, metric, startTime)
 	}
-	internal.AssertGaugeMetricHasAttribute(t, metric, 0, metadata.Attributes.Cpu)
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 0, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttribute(t, metric, 0, "cpu")
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 0, "state",
 		pcommon.NewValueString(metadata.AttributeStateUser.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 1, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 1, "state",
 		pcommon.NewValueString(metadata.AttributeStateSystem.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 2, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 2, "state",
 		pcommon.NewValueString(metadata.AttributeStateIdle.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 3, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 3, "state",
 		pcommon.NewValueString(metadata.AttributeStateInterrupt.String()))
 }
 
 func assertCPUUtilizationMetricHasLinuxSpecificStateLabels(t *testing.T, metric pmetric.Metric) {
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 4, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 4, "state",
 		pcommon.NewValueString(metadata.AttributeStateNice.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 5, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 5, "state",
 		pcommon.NewValueString(metadata.AttributeStateSoftirq.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 6, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 6, "state",
 		pcommon.NewValueString(metadata.AttributeStateSteal.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 7, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 7, "state",
 		pcommon.NewValueString(metadata.AttributeStateWait.String()))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/config.go
@@ -77,34 +77,47 @@ func (cfg *Config) createFilter() (*fsFilter, error) {
 	var err error
 	filter := fsFilter{}
 
-	filter.includeDeviceFilter, err = newIncludeFilterHelper(cfg.IncludeDevices.Devices, &cfg.IncludeDevices.Config, metadata.Attributes.Device)
-	if err != nil {
-		return nil, err
+	if len(cfg.IncludeDevices.Devices) > 0 {
+		filter.includeDeviceFilter, err = filterset.CreateFilterSet(cfg.IncludeDevices.Devices, &cfg.IncludeDevices.Config)
+		if err != nil {
+			return nil, fmt.Errorf("error creating include_devices filter: %w", err)
+		}
 	}
 
-	filter.excludeDeviceFilter, err = newExcludeFilterHelper(cfg.ExcludeDevices.Devices, &cfg.ExcludeDevices.Config, metadata.Attributes.Device)
-	if err != nil {
-		return nil, err
+	if len(cfg.ExcludeDevices.Devices) > 0 {
+		filter.excludeDeviceFilter, err = filterset.CreateFilterSet(cfg.ExcludeDevices.Devices, &cfg.ExcludeDevices.Config)
+		if err != nil {
+			return nil, fmt.Errorf("error creating exclude_devices filter: %w", err)
+		}
 	}
 
-	filter.includeFSTypeFilter, err = newIncludeFilterHelper(cfg.IncludeFSTypes.FSTypes, &cfg.IncludeFSTypes.Config, metadata.Attributes.Type)
-	if err != nil {
-		return nil, err
+	if len(cfg.IncludeFSTypes.FSTypes) > 0 {
+		filter.includeFSTypeFilter, err = filterset.CreateFilterSet(cfg.IncludeFSTypes.FSTypes,
+			&cfg.IncludeFSTypes.Config)
+		if err != nil {
+			return nil, fmt.Errorf("error creating include_fs_types filter: %w", err)
+		}
 	}
 
-	filter.excludeFSTypeFilter, err = newExcludeFilterHelper(cfg.ExcludeFSTypes.FSTypes, &cfg.ExcludeFSTypes.Config, metadata.Attributes.Type)
-	if err != nil {
-		return nil, err
+	if len(cfg.ExcludeFSTypes.FSTypes) > 0 {
+		filter.excludeFSTypeFilter, err = filterset.CreateFilterSet(cfg.ExcludeFSTypes.FSTypes, &cfg.ExcludeFSTypes.Config)
+		if err != nil {
+			return nil, fmt.Errorf("error creating exclude_fs_types filter: %w", err)
+		}
 	}
 
-	filter.includeMountPointFilter, err = newIncludeFilterHelper(cfg.IncludeMountPoints.MountPoints, &cfg.IncludeMountPoints.Config, metadata.Attributes.Mountpoint)
-	if err != nil {
-		return nil, err
+	if len(cfg.IncludeMountPoints.MountPoints) > 0 {
+		filter.includeMountPointFilter, err = filterset.CreateFilterSet(cfg.IncludeMountPoints.MountPoints, &cfg.IncludeMountPoints.Config)
+		if err != nil {
+			return nil, fmt.Errorf("error creating include_mount_points filter: %w", err)
+		}
 	}
 
-	filter.excludeMountPointFilter, err = newExcludeFilterHelper(cfg.ExcludeMountPoints.MountPoints, &cfg.ExcludeMountPoints.Config, metadata.Attributes.Mountpoint)
-	if err != nil {
-		return nil, err
+	if len(cfg.ExcludeMountPoints.MountPoints) > 0 {
+		filter.excludeMountPointFilter, err = filterset.CreateFilterSet(cfg.ExcludeMountPoints.MountPoints, &cfg.ExcludeMountPoints.Config)
+		if err != nil {
+			return nil, fmt.Errorf("error creating exclude_mount_points filter: %w", err)
+		}
 	}
 
 	filter.setFiltersExist()
@@ -115,30 +128,4 @@ func (f *fsFilter) setFiltersExist() {
 	f.filtersExist = f.includeMountPointFilter != nil || f.excludeMountPointFilter != nil ||
 		f.includeFSTypeFilter != nil || f.excludeFSTypeFilter != nil ||
 		f.includeDeviceFilter != nil || f.excludeDeviceFilter != nil
-}
-
-const (
-	excludeKey = "exclude"
-	includeKey = "include"
-)
-
-func newIncludeFilterHelper(items []string, filterSet *filterset.Config, typ string) (filterset.FilterSet, error) {
-	return newFilterHelper(items, filterSet, includeKey, typ)
-}
-
-func newExcludeFilterHelper(items []string, filterSet *filterset.Config, typ string) (filterset.FilterSet, error) {
-	return newFilterHelper(items, filterSet, excludeKey, typ)
-}
-
-func newFilterHelper(items []string, filterSet *filterset.Config, typ string, filterType string) (filterset.FilterSet, error) {
-	var err error
-	var filter filterset.FilterSet
-
-	if len(items) > 0 {
-		filter, err = filterset.CreateFilterSet(items, filterSet)
-		if err != nil {
-			return nil, fmt.Errorf("error creating %s %s filters: %w", filterType, typ, err)
-		}
-	}
-	return filter, nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -153,7 +153,7 @@ func TestScrape(t *testing.T) {
 				Metrics:        metadata.DefaultMetricsSettings(),
 				IncludeDevices: DeviceMatchConfig{Devices: []string{"test"}},
 			},
-			newErrRegex: "^error creating device include filters:",
+			newErrRegex: "^error creating include_devices filter:",
 		},
 		{
 			name: "Invalid Exclude Device Filter",
@@ -161,7 +161,7 @@ func TestScrape(t *testing.T) {
 				Metrics:        metadata.DefaultMetricsSettings(),
 				ExcludeDevices: DeviceMatchConfig{Devices: []string{"test"}},
 			},
-			newErrRegex: "^error creating device exclude filters:",
+			newErrRegex: "^error creating exclude_devices filter:",
 		},
 		{
 			name: "Invalid Include Filesystems Filter",
@@ -169,7 +169,7 @@ func TestScrape(t *testing.T) {
 				Metrics:        metadata.DefaultMetricsSettings(),
 				IncludeFSTypes: FSTypeMatchConfig{FSTypes: []string{"test"}},
 			},
-			newErrRegex: "^error creating type include filters:",
+			newErrRegex: "^error creating include_fs_types filter:",
 		},
 		{
 			name: "Invalid Exclude Filesystems Filter",
@@ -177,7 +177,7 @@ func TestScrape(t *testing.T) {
 				Metrics:        metadata.DefaultMetricsSettings(),
 				ExcludeFSTypes: FSTypeMatchConfig{FSTypes: []string{"test"}},
 			},
-			newErrRegex: "^error creating type exclude filters:",
+			newErrRegex: "^error creating exclude_fs_types filter:",
 		},
 		{
 			name: "Invalid Include Moountpoints Filter",
@@ -185,7 +185,7 @@ func TestScrape(t *testing.T) {
 				Metrics:            metadata.DefaultMetricsSettings(),
 				IncludeMountPoints: MountPointMatchConfig{MountPoints: []string{"test"}},
 			},
-			newErrRegex: "^error creating mountpoint include filters:",
+			newErrRegex: "^error creating include_mount_points filter:",
 		},
 		{
 			name: "Invalid Exclude Moountpoints Filter",
@@ -193,7 +193,7 @@ func TestScrape(t *testing.T) {
 				Metrics:            metadata.DefaultMetricsSettings(),
 				ExcludeMountPoints: MountPointMatchConfig{MountPoints: []string{"test"}},
 			},
-			newErrRegex: "^error creating mountpoint exclude filters:",
+			newErrRegex: "^error creating exclude_mount_points filter:",
 		},
 		{
 			name:           "Partitions Error",

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -123,7 +123,7 @@ func TestScrape(t *testing.T) {
 			if runtime.GOOS == "linux" {
 				assertMemoryUsageMetricHasLinuxSpecificStateLabels(t, metrics.At(0))
 			} else if runtime.GOOS != "windows" {
-				internal.AssertSumMetricHasAttributeValue(t, metrics.At(0), 2, metadata.Attributes.State,
+				internal.AssertSumMetricHasAttributeValue(t, metrics.At(0), 2, "state",
 					pcommon.NewValueString(metadata.AttributeStateInactive.String()))
 			}
 
@@ -179,7 +179,7 @@ func TestScrape_MemoryUtilization(t *testing.T) {
 			if runtime.GOOS == "linux" {
 				assertMemoryUtilizationMetricHasLinuxSpecificStateLabels(t, metrics.At(0))
 			} else if runtime.GOOS != "windows" {
-				internal.AssertGaugeMetricHasAttributeValue(t, metrics.At(0), 2, metadata.Attributes.State,
+				internal.AssertGaugeMetricHasAttributeValue(t, metrics.At(0), 2, "state",
 					pcommon.NewValueString(metadata.AttributeStateInactive.String()))
 			}
 
@@ -191,39 +191,39 @@ func TestScrape_MemoryUtilization(t *testing.T) {
 func assertMemoryUsageMetricValid(t *testing.T, metric pmetric.Metric, expectedName string) {
 	assert.Equal(t, expectedName, metric.Name())
 	assert.GreaterOrEqual(t, metric.Sum().DataPoints().Len(), 2)
-	internal.AssertSumMetricHasAttributeValue(t, metric, 0, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 0, "state",
 		pcommon.NewValueString(metadata.AttributeStateUsed.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 1, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 1, "state",
 		pcommon.NewValueString(metadata.AttributeStateFree.String()))
 }
 
 func assertMemoryUtilizationMetricValid(t *testing.T, metric pmetric.Metric, expectedName string) {
 	assert.Equal(t, expectedName, metric.Name())
 	assert.GreaterOrEqual(t, metric.Gauge().DataPoints().Len(), 2)
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 0, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 0, "state",
 		pcommon.NewValueString(metadata.AttributeStateUsed.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 1, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 1, "state",
 		pcommon.NewValueString(metadata.AttributeStateFree.String()))
 }
 
 func assertMemoryUsageMetricHasLinuxSpecificStateLabels(t *testing.T, metric pmetric.Metric) {
-	internal.AssertSumMetricHasAttributeValue(t, metric, 2, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 2, "state",
 		pcommon.NewValueString(metadata.AttributeStateBuffered.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 3, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 3, "state",
 		pcommon.NewValueString(metadata.AttributeStateCached.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 4, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 4, "state",
 		pcommon.NewValueString(metadata.AttributeStateSlabReclaimable.String()))
-	internal.AssertSumMetricHasAttributeValue(t, metric, 5, metadata.Attributes.State,
+	internal.AssertSumMetricHasAttributeValue(t, metric, 5, "state",
 		pcommon.NewValueString(metadata.AttributeStateSlabUnreclaimable.String()))
 }
 
 func assertMemoryUtilizationMetricHasLinuxSpecificStateLabels(t *testing.T, metric pmetric.Metric) {
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 2, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 2, "state",
 		pcommon.NewValueString(metadata.AttributeStateBuffered.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 3, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 3, "state",
 		pcommon.NewValueString(metadata.AttributeStateCached.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 4, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 4, "state",
 		pcommon.NewValueString(metadata.AttributeStateSlabReclaimable.String()))
-	internal.AssertGaugeMetricHasAttributeValue(t, metric, 5, metadata.Attributes.State,
+	internal.AssertGaugeMetricHasAttributeValue(t, metric, 5, "state",
 		pcommon.NewValueString(metadata.AttributeStateSlabUnreclaimable.String()))
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
@@ -138,7 +138,7 @@ func validateRealData(t *testing.T, metrics pmetric.MetricSlice) {
 		assertContainsStatus := func(statusVal string) {
 			points := countMetric.Sum().DataPoints()
 			for i := 0; i < points.Len(); i++ {
-				v, ok := points.At(i).Attributes().Get(metadata.Attributes.Status)
+				v, ok := points.At(i).Attributes().Get("status")
 				if ok && v.StringVal() == statusVal {
 					return
 				}
@@ -207,7 +207,7 @@ func validateFakeData(t *testing.T, metrics pmetric.MetricSlice) {
 		attrs := map[string]int64{}
 		for i := 0; i < points.Len(); i++ {
 			point := points.At(i)
-			val, ok := point.Attributes().Get(metadata.A.Status)
+			val, ok := point.Attributes().Get("status")
 			assert.Truef(ok, "Missing status attribute in data point %d", i)
 			attrs[val.StringVal()] = point.IntVal()
 		}


### PR DESCRIPTION
metadata.Attributes is not needed in the new metrics builder to build metrics and can be removed.

This change removes redundant usages of that structure from hostmetrics receiver. 
- Usage in filesystemscraper/config.go is just incorrect.
- Usage of the metadata.Attributes in tests should be replaced with strings to make the tests more independent from metrics builder generator.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8842
