### PR TITLE
[DO NOT MERGE] Demonstrate checklicense failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ gofmt:
 
 .PHONY: golint
 golint:
-	$(MAKE) for-all-target TARGET="lint"
+	$(MAKE) checklicense # in root module only
 
 .PHONY: goporto
 goporto:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -76,7 +76,8 @@ addlicense:
 
 .PHONY: checklicense
 checklicense:
-	@ADDLICENCESEOUT=`$(ADDLICENCESE) -check $(ALL_SRC) 2>&1`; \
+	echo "checking licenses for $(ALL_SRC) $(ALL_SRC) $(ALL_SRC)"
+	@ADDLICENCESEOUT=`$(ADDLICENCESE) -check $(ALL_SRC) $(ALL_SRC) $(ALL_SRC) 2>&1`; \
 		if [ "$$ADDLICENCESEOUT" ]; then \
 			echo "$(ADDLICENCESE) FAILED => add License errors:\n"; \
 			echo "$$ADDLICENCESEOUT\n"; \


### PR DESCRIPTION
The `checklicense` target will fail if we add many more files to this repo, unless changes are made.

A separate tracking issue is being drafted. This PR serves to illustrate the problem.