### PR TITLE
Add examples/nomad folder

### DIFF
--- a/examples/nomad/README.md
+++ b/examples/nomad/README.md
@@ -1,0 +1,12 @@
+# OpenTelemetry Collector Demo
+
+This demo provides you with all you need to run the OpenTelemetry Collector on a local installation of HashiCorp [Nomad](https://nomadproject.io) using [Traefik](https://traefik.io) as your load balancer. It configures both both HTTP and gRPC endpoints on Traefik.
+
+For a detailed, step-by-step tutorial on how to run the files included in this directory, check out [Just-in-Time Nomad: Running the OpenTelemetry Collector on HashiCorp Nomad with HashiQube](https://storiesfromtheherd.com/just-in-time-nomad-running-the-opentelemetry-collector-on-hashicorp-nomad-with-hashiqube-4eaf009b8382).
+
+The tutorial includes instructions on how to set up a local Nomad environment using [HashiQube](https://github.com/avillela/hashiqube) (a fork of [servian/hashiqube](https://github.com/servian/hashiqube)). It spins up a Vagrant VM running [Nomad](https://nomadproject.io), [Consul](https://www.consul.io),  [Vault](https://www.vaultproject.io) and [Traefik](https://traefik.io). Detailed instructions can be found in the project [readme](https://github.com/avillela/hashiqube#readme).
+
+
+## Additional Resources
+
+Check out the [OpenTelemetry Collector Nomad Pack](https://github.com/hashicorp/nomad-pack-community-registry/tree/main/packs/opentelemetry_collector) in the [Nomad Pack Community Registry](https://github.com/hashicorp/nomad-pack-community-registry).

--- a/examples/nomad/otel-collector.nomad
+++ b/examples/nomad/otel-collector.nomad
@@ -43,13 +43,6 @@ job "otel-collector" {
     }
 
     
-    vault {
-      policies      = [
-  "otel"
-]
-    }
-    
-
     task "otel-collector" {
       driver = "docker"
 
@@ -77,9 +70,6 @@ job "otel-collector" {
       }
 
       env {
-        DATADOG_SERVICE_NAME = "my-dd-service"
-        DATADOG_TAG_NAME = "env:local_dev_env"
-        HONEYCOMB_DATASET = "my-hny-dataset"
         HOST_DEV = "/hostfs/dev"
         HOST_ETC = "/hostfs/etc"
         HOST_PROC = "/hostfs/proc"
@@ -109,29 +99,11 @@ exporters:
   logging:
     logLevel: debug
 
-  otlp/hc:
-    endpoint: "api.honeycomb.io:443"
-    headers: 
-      "x-honeycomb-team": "{{ with secret "kv/data/otel/o11y/honeycomb" }}{{ .Data.data.api_key }}{{ end }}"
-      "x-honeycomb-dataset": "$HONEYCOMB_DATASET"
-  otlp/ls:
-    endpoint: ingest.lightstep.com:443
-    headers: 
-      "lightstep-access-token": "{{ with secret "kv/data/otel/o11y/lightstep" }}{{ .Data.data.api_key }}{{ end }}"
-
-  datadog:
-    service: $DATADOG_SERVICE_NAME
-    tags:
-      - $DATADOG_TAG_NAME
-    api:
-      key: "{{ with secret "kv/data/otel/o11y/datadog" }}{{ .Data.data.api_key }}{{ end }}"
-      site: datadoghq.com
-
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging, otlp/ls, otlp/hc, datadog]
+      exporters: [logging]
 
 EOH
 

--- a/examples/nomad/otel-collector.nomad
+++ b/examples/nomad/otel-collector.nomad
@@ -1,0 +1,208 @@
+job "otel-collector" {
+  region = "global"
+
+  datacenters = ["dc1"]
+  namespace   = "default"
+
+  type = "service"
+
+  
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "otel-collector" {
+    count = 1
+    network {
+      mode = "bridge"
+      port "healthcheck" {
+        to = 13133
+      }
+      port "jaeger-grpc" {
+        to = 14250
+      }
+      port "jaeger-thrift-http" {
+        to = 14268
+      }
+      port "metrics" {
+        to = 8888
+      }
+      port "otlp" {
+        to = 4317
+      }
+      port "otlphttp" {
+        to = 4318
+      }
+      port "zipkin" {
+        to = 9411
+      }
+      port "zpages" {
+        to = 55679
+      }
+    }
+
+    
+    vault {
+      policies      = [
+  "otel"
+]
+    }
+    
+
+    task "otel-collector" {
+      driver = "docker"
+
+      config {
+        image = "otel/opentelemetry-collector-contrib:0.50.0"
+        force_pull = true
+        entrypoint = [
+          "/otelcol-contrib",
+          "--config=local/otel/config.yaml",
+        ]
+
+        ports = [
+  "otlphttp",
+  "zipkin",
+  "zpages",
+  "healthcheck",
+  "jaeger-grpc",
+  "jaeger-thrift-http",
+  "metrics",
+  "otlp"
+]
+
+        
+
+      }
+
+      env {
+        DATADOG_SERVICE_NAME = "my-dd-service"
+        DATADOG_TAG_NAME = "env:local_dev_env"
+        HONEYCOMB_DATASET = "my-hny-dataset"
+        HOST_DEV = "/hostfs/dev"
+        HOST_ETC = "/hostfs/etc"
+        HOST_PROC = "/hostfs/proc"
+        HOST_RUN = "/hostfs/run"
+        HOST_SYS = "/hostfs/sys"
+        HOST_VAR = "/hostfs/var"
+    }
+
+      template {
+        data = <<EOH
+---
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+    timeout: 10s
+  memory_limiter:
+    limit_mib: 1536
+    spike_limit_mib: 512
+    check_interval: 5s
+
+exporters:
+  logging:
+    logLevel: debug
+
+  otlp/hc:
+    endpoint: "api.honeycomb.io:443"
+    headers: 
+      "x-honeycomb-team": "{{ with secret "kv/data/otel/o11y/honeycomb" }}{{ .Data.data.api_key }}{{ end }}"
+      "x-honeycomb-dataset": "$HONEYCOMB_DATASET"
+  otlp/ls:
+    endpoint: ingest.lightstep.com:443
+    headers: 
+      "lightstep-access-token": "{{ with secret "kv/data/otel/o11y/lightstep" }}{{ .Data.data.api_key }}{{ end }}"
+
+  datadog:
+    service: $DATADOG_SERVICE_NAME
+    tags:
+      - $DATADOG_TAG_NAME
+    api:
+      key: "{{ with secret "kv/data/otel/o11y/datadog" }}{{ .Data.data.api_key }}{{ end }}"
+      site: datadoghq.com
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging, otlp/ls, otlp/hc, datadog]
+
+EOH
+
+        change_mode   = "restart"
+        destination   = "local/otel/config.yaml"
+      }
+
+      
+
+      resources {
+        cpu    = 256
+        memory = 512
+      }
+      service {
+        name = "opentelemetry-collector"
+        port = "metrics"
+        tags = ["prometheus"]
+      }
+      service {
+        name = "opentelemetry-collector"
+        port = "zipkin"
+        tags = ["zipkin"]
+      }
+      service {
+        name = "opentelemetry-collector"
+        port = "healthcheck"
+        tags = ["health"]
+        check {
+          type     = "http"
+          path     = "/"
+          interval = "15s"
+          timeout  = "3s"
+        }
+      }
+      service {
+        name = "opentelemetry-collector"
+        port = "jaeger-grpc"
+        tags = ["jaeger-grpc"]
+      }
+      service {
+        name = "opentelemetry-collector"
+        port = "jaeger-thrift-http"
+        tags = ["jaeger-thrift-http"]
+      }
+      service {
+        name = "opentelemetry-collector"
+        port = "zpages"
+        tags = ["zpages"]
+      }
+
+      
+      service {
+        tags = [
+          "traefik.tcp.routers.otel-collector-grpc.rule=HostSNI(`*`)",
+          "traefik.tcp.routers.otel-collector-grpc.entrypoints=grpc",
+          "traefik.enable=true",
+        ]        
+        port = "otlp"
+      }
+
+      service {
+        tags = [
+          "traefik.http.routers.otel-collector-http.rule=Host(`otel-collector-http.localhost`)",
+          "traefik.http.routers.otel-collector-http.entrypoints=web",
+          "traefik.http.routers.otel-collector-http.tls=false",
+          "traefik.enable=true",
+        ]
+        port = "otlphttp"
+      }
+
+    }
+  }
+}
+

--- a/examples/nomad/traefik.nomad
+++ b/examples/nomad/traefik.nomad
@@ -1,0 +1,108 @@
+job "traefik" {
+  region      = "global"
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "svc" {
+    count = 1
+
+    network {
+      mode = "host"
+
+      port "http" {
+        static = 80
+      }
+
+      port "api" {
+        static = 8080
+      }
+
+      port "metrics" {
+        static = 8082
+      }
+
+      port "grpc" {
+        static = 7233
+      }
+
+    }
+
+    service {
+      name = "traefik-entrypoint-grpc"
+      port = "grpc"
+
+      check {
+        type     = "tcp"
+        interval = "10s"
+        timeout  = "5s"
+      }
+    }
+
+    service {
+      name = "traefik-dashboard"
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.dashboard.rule=Host(`traefik.localhost`)",
+        "traefik.http.routers.dashboard.service=api@internal",
+        "traefik.http.routers.dashboard.entrypoints=web",
+      ]
+
+      port = "http"
+
+      check {
+        type     = "tcp"
+        interval = "10s"
+        timeout  = "5s"
+      }
+    }
+
+    task "loadbalancer" {
+      driver = "docker"
+
+      config {
+        network_mode = "host"
+        image        = "traefik:v2.6.1"
+        ports        = ["http", "api", "metrics", "grpc"]
+
+        volumes = [
+          "local/traefik.toml:/etc/traefik/traefik.toml",
+        ]
+      }
+
+      template {
+        data = <<EOF
+[entryPoints]
+    [entryPoints.web]
+    address = ":80"
+    [entryPoints.metrics]
+    address = ":8082"
+    [entryPoints.grpc]
+    address = ":7233"
+
+
+[api]
+    dashboard = true
+    insecure  = true
+
+[log]
+    level = "DEBUG"
+# Enable Consul Catalog configuration backend.
+[providers.consulCatalog]
+    prefix           = "traefik"
+    exposedByDefault = false
+
+    [providers.consulCatalog.endpoint]
+      address = "http://localhost:8500"
+      scheme  = "http"
+EOF
+
+        destination = "local/traefik.toml"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Description:**
For those wishing to run the OTel Collector on HashiCorp Nomad. Add examples/nomad folder with instructions on how to run the OTel Collector on Nomad using Traefik as the load balancer.

Added `otel-collector.nomad` jobspec and `traefik.nomad` jobspec.

**Link to tracking Issue:** n/a

**Testing:** Tested as per following [this tutorial](https://storiesfromtheherd.com/just-in-time-nomad-running-the-opentelemetry-collector-on-hashicorp-nomad-with-hashiqube-4eaf009b8382).

**Documentation:** Added readme linking to comprehensive tutorial explaining how to run this locally in Nomad.
