### PR TITLE
exporters/datadogexporter: deprecate SampleRate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 
 - `cumulativetodeltaprocessor`: Deprecated `metrics` configuration option in favor of `include` and `exclude` (#8952)
 - `datadogexporter`: Deprecate `metrics::report_quantiles` in favor of `metrics::summaries::mode` (#8846)
+- `datadogexporter`: Deprecate `traces.sample_rate` setting. It was never used anywhere. (#9771)
 
 ### 🚀 New components 🚀
 

--- a/exporter/datadogexporter/config/config.go
+++ b/exporter/datadogexporter/config/config.go
@@ -235,6 +235,7 @@ type TracesConfig struct {
 	// SampleRate is the rate at which to sample this event. Default is 1,
 	// meaning no sampling. If you want to send one event out of every 250
 	// times Send() is called, you would specify 250 here.
+	// Deprecated: [v0.50.0] Not used anywhere.
 	SampleRate uint `mapstructure:"sample_rate"`
 
 	// ignored resources
@@ -532,6 +533,8 @@ func (c *Config) Unmarshal(configMap *config.Map) error {
 	if c.Env != "" {
 		c.warnings = append(c.warnings, fmt.Errorf(deprecationTemplate, "env", "v0.52.0", 9016))
 	}
-
+	if c.Traces.SampleRate != 0 {
+		c.warnings = append(c.warnings, fmt.Errorf(deprecationTemplate, "traces.sample_rate", "v0.52.0", 9771))
+	}
 	return nil
 }

--- a/exporter/datadogexporter/config/warn_envvars.go
+++ b/exporter/datadogexporter/config/warn_envvars.go
@@ -51,7 +51,6 @@ func futureDefaultConfig() *Config {
 			},
 		},
 		Traces: TracesConfig{
-			SampleRate:      1,
 			IgnoreResources: []string{},
 		},
 		HostMetadata: HostMetadataConfig{

--- a/exporter/datadogexporter/example/config.yaml
+++ b/exporter/datadogexporter/example/config.yaml
@@ -177,13 +177,6 @@ exporters:
     ## Trace exporter specific configuration.
     #
     # traces:
-      ## @param sample_rate - integer - optional - default: 1
-      #  The rate at which to sample traces. Default is 1 (Always Sample),
-      #  meaning no sampling. If you want to send one event out of every 250
-      #  you would specify 250.
-      #
-      # sample_rate: 1
-
       ## @param endpoint - string - optional
       ## The host of the Datadog intake server to send traces to.
       ## If unset it will be determined from the `DD_APM_URL` environment variable (Deprecated: [v0.47.0] set environment variable explicitly on configuration instead).

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -106,7 +106,6 @@ func (*factory) createDefaultConfig() config.Exporter {
 		},
 
 		Traces: ddconfig.TracesConfig{
-			SampleRate: 1,
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: os.Getenv("DD_APM_URL"), // If not provided, set during config sanitization
 			},

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -96,7 +96,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 		},
 
 		Traces: ddconfig.TracesConfig{
-			SampleRate: 1,
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: "APM_URL",
 			},
@@ -176,7 +175,6 @@ func TestLoadConfig(t *testing.T) {
 		},
 	}, apiConfig.Metrics)
 	assert.Equal(t, ddconfig.TracesConfig{
-		SampleRate: 1,
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: "https://trace.agent.datadoghq.eu",
 		},
@@ -230,7 +228,6 @@ func TestLoadConfig(t *testing.T) {
 		},
 
 		Traces: ddconfig.TracesConfig{
-			SampleRate: 1,
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: "https://trace.agent.datadoghq.com",
 			},
@@ -332,7 +329,6 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 		}, apiConfig.Metrics)
 	assert.Equal(t,
 		ddconfig.TracesConfig{
-			SampleRate: 1,
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: "https://trace.agent.datadoghq.test",
 			},
@@ -385,7 +381,6 @@ func TestLoadConfigEnvVariables(t *testing.T) {
 		},
 	}, defaultConfig.Metrics)
 	assert.Equal(t, ddconfig.TracesConfig{
-		SampleRate: 1,
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: "https://trace.agent.datadoghq.com",
 		},

--- a/exporter/datadogexporter/testdata/config.yaml
+++ b/exporter/datadogexporter/testdata/config.yaml
@@ -23,9 +23,6 @@ exporters:
       site: datadoghq.eu
       fail_on_invalid_key: true
 
-    traces:
-      sample_rate: 1
-
   datadog/api2:
     hostname: customhostname
 
@@ -42,7 +39,6 @@ exporters:
       report_quantiles: false
 
     traces:
-      sample_rate: 1
       endpoint: https://trace.agent.datadoghq.test
 
   datadog/default:

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -78,7 +78,6 @@ func testTracesExporterHelper(td ptrace.Traces, t *testing.T) []string {
 			},
 		},
 		Traces: config.TracesConfig{
-			SampleRate: 1,
 			TCPAddr: confignet.TCPAddr{
 				Endpoint: server.URL,
 			},
@@ -187,8 +186,7 @@ func TestPushTraceData(t *testing.T) {
 			TCPAddr: confignet.TCPAddr{Endpoint: server.URL},
 		},
 		Traces: config.TracesConfig{
-			SampleRate: 1,
-			TCPAddr:    confignet.TCPAddr{Endpoint: server.URL},
+			TCPAddr: confignet.TCPAddr{Endpoint: server.URL},
 		},
 
 		HostMetadata: config.HostMetadataConfig{


### PR DESCRIPTION
It seems that this config setting was not used anywhere and appeared
only in config.