### PR TITLE
[build] fix issue generator github action

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -45,7 +45,7 @@ jobs:
           go test --tags containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper ./...        
         working-directory: ./receiver/activedirectorydsreceiver
       - name: GitHub Issue Generator
-        if: ${{ failure() && github.ref == 'ref/head/main' }}
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         run: |
-          cd internal/tools && go install go.opentelemetry.io/collector/cmd/issuegenerator
+          cd internal/tools && go install go.opentelemetry.io/build-tools/issuegenerator
           issuegenerator $TEST_RESULTS

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -131,5 +131,5 @@ jobs:
         with:
           path: ./*.tar
       - name: GitHub Issue Generator
-        if: ${{ failure() && github.ref == 'ref/head/main' }}
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         run: issuegenerator $TEST_RESULTS


### PR DESCRIPTION
The github action for auto-generating issues when load tests are failing in main has been broken for some time. The check for branch was looking at the wrong branch name. Additionally the install command in the windows version was using an old go path.
