### PR TITLE
[Makefile] Fix issues with common targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,11 @@ all-modules:
 	@echo $(ALL_MODULES) | tr ' ' '\n' | sort
 
 .PHONY: all
-all: common gotest otelcontribcol otelcontribcol-unstable
+all: all-common gotest otelcontribcol otelcontribcol-unstable
+
+.PHONY: all-common
+all-common:
+	@$(MAKE) for-all-target TARGET="common"
 
 .PHONY: e2e-test
 e2e-test: otelcontribcol otelcontribcol-unstable otelcontribcol-testbed

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -1,17 +1,6 @@
 # SRC_ROOT is the top of the source tree.
 SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 
-ALL_SRC := $(shell find . -name '*.go' \
-                                -not -path '*/third_party/*' \
-                                -type f | sort)
-
-# All source code and documents. Used in spell check.
-ALL_SRC_AND_DOC := $(shell find . \( -name "*.md" -o -name "*.go" -o -name "*.yaml" \) \
-                                -type f | sort)
-
-# ALL_PKGS is used with 'go cover'
-ALL_PKGS := $(shell $(GOCMD) list $(sort $(dir $(ALL_SRC))) 2>/dev/null)
-
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
@@ -30,16 +19,33 @@ IMPI=impi
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
 
+ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | sort)
+
+ALL_SRC := $(shell find $(ALL_PKG_DIRS) -name '*.go' \
+                                -not -path '*/third_party/*' \
+                                -type f | sort)
+
+# All source code and documents. Used in spell check.
+ALL_SRC_AND_DOC := $(shell find $(ALL_PKG_DIRS) -name "*.md" -o -name "*.go" -o -name "*.yaml" \
+                                -not -path '*/third_party/*' \
+                                -type f | sort)
+
+# ALL_PKGS is used with 'go cover'
+ALL_PKGS := $(shell $(GOCMD) list $(sort $(dir $(ALL_SRC))))
+
 all-pkgs:
 	@echo $(ALL_PKGS) | tr ' ' '\n' | sort
 
 all-srcs:
 	@echo $(ALL_SRC) | tr ' ' '\n' | sort
 
+all-pkg-dirs:
+	@echo $(ALL_PKG_DIRS) | tr ' ' '\n' | sort
+
 .DEFAULT_GOAL := common
 
 .PHONY: common
-common: checklicense checkdoc impi lint misspell
+common: checklicense impi lint misspell
 
 .PHONY: test
 test:


### PR DESCRIPTION
Resolves #9763

Summary of changes, including a few minor related issues:
- New `ALL_PKG_DIRS` uses `go list` to find the directories corresponding to packages _of the current module only_.
- `ALL_SRC` changed to find `.go` files _of the current module only_.
- Fixed `ALL_PKGS`, which was erroring out silently because it depended on `GOCMD` too early.
-  Fixed root module's default make target, which only ran `common` for the root module. Now runs `common` for all modules.
- Removed `checkdoc` from per-module make file, as this only needs to run at the root.