### PR TITLE
signalfxexporter: remove usage of sync/atomic

### DIFF
--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.50.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.50.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.50.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.50.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.50.0
@@ -14,13 +15,10 @@ require (
 	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201202163743-65b4fa925fc8
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/collector v0.50.1-0.20220429151328-041f39835df7
+	go.opentelemetry.io/collector/semconv v0.50.1-0.20220429151328-041f39835df7
+	go.uber.org/atomic v1.9.0
 	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.21.0
-)
-
-require (
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.50.0
-	go.opentelemetry.io/collector/semconv v0.50.1-0.20220429151328-041f39835df7
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -61,7 +59,6 @@ require (
 	go.opentelemetry.io/otel v1.7.0 // indirect
 	go.opentelemetry.io/otel/metric v0.30.0 // indirect
 	go.opentelemetry.io/otel/trace v1.7.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect

--- a/exporter/signalfxexporter/internal/dimensions/metadata.go
+++ b/exporter/signalfxexporter/internal/dimensions/metadata.go
@@ -17,7 +17,6 @@ package dimensions // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"fmt"
 	"strings"
-	"sync/atomic"
 
 	"go.uber.org/multierr"
 
@@ -111,7 +110,6 @@ func (dc *DimensionClient) PushMetadata(metadata []*metadata.MetadataUpdate) err
 		dimensionUpdate := getDimensionUpdateFromMetadata(*m, dc.metricsConverter)
 
 		if dimensionUpdate.Name == "" || dimensionUpdate.Value == "" {
-			atomic.AddInt64(&dc.TotalInvalidDimensions, int64(1))
 			return fmt.Errorf("dimensionUpdate %v is missing Name or value, cannot send", dimensionUpdate)
 		}
 


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9778

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
