### PR TITLE
[lint] Fix / ignore some lint issues resulting from deprecations in 1.18

### DIFF
--- a/cmd/mdatagen/lint.go
+++ b/cmd/mdatagen/lint.go
@@ -19,9 +19,6 @@ import (
 	"strings"
 	"unicode"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen/third_party/golint"
 )
 
@@ -33,7 +30,7 @@ func formatIdentifier(s string, exported bool) (string, error) {
 	// Convert various characters to . for strings.Title to operate on.
 	replace := strings.NewReplacer("_", ".", "-", ".", "<", ".", ">", ".", "/", ".", ":", ".")
 	str := replace.Replace(s)
-	str = cases.Title(language.English).String(str)
+	str = strings.Title(str) // nolint SA1019
 	str = strings.ReplaceAll(str, ".", "")
 
 	var word string

--- a/cmd/mdatagen/lint.go
+++ b/cmd/mdatagen/lint.go
@@ -19,6 +19,9 @@ import (
 	"strings"
 	"unicode"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen/third_party/golint"
 )
 
@@ -30,7 +33,7 @@ func formatIdentifier(s string, exported bool) (string, error) {
 	// Convert various characters to . for strings.Title to operate on.
 	replace := strings.NewReplacer("_", ".", "-", ".", "<", ".", ">", ".", "/", ".", ":", ".")
 	str := replace.Replace(s)
-	str = strings.Title(str)
+	str = cases.Title(language.English).String(str)
 	str = strings.ReplaceAll(str, ".", "")
 
 	var word string

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -27,6 +27,8 @@ import (
 	en_translations "github.com/go-playground/validator/v10/translations/en"
 	"go.opentelemetry.io/collector/config/mapprovider/filemapprovider"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type metricName string
@@ -78,7 +80,9 @@ func (mvt *ValueType) UnmarshalText(text []byte) error {
 
 // String returns capitalized name of the ValueType.
 func (mvt ValueType) String() string {
-	return strings.Title(strings.ToLower(mvt.ValueType.String()))
+	return cases.Title(language.English).String(
+		cases.Title(language.English).String(mvt.ValueType.String()),
+	)
 }
 
 // Primitive returns name of primitive type for the ValueType.

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -27,8 +27,6 @@ import (
 	en_translations "github.com/go-playground/validator/v10/translations/en"
 	"go.opentelemetry.io/collector/config/mapprovider/filemapprovider"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 type metricName string
@@ -80,9 +78,7 @@ func (mvt *ValueType) UnmarshalText(text []byte) error {
 
 // String returns capitalized name of the ValueType.
 func (mvt ValueType) String() string {
-	return cases.Title(language.English).String(
-		cases.Title(language.English).String(mvt.ValueType.String()),
-	)
+	return strings.Title(strings.ToLower(mvt.ValueType.String())) // nolint SA1019
 }
 
 // Primitive returns name of primitive type for the ValueType.

--- a/receiver/awsxrayreceiver/internal/udppoller/poller.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller.go
@@ -155,7 +155,7 @@ func (p *poller) read(buf *[]byte) (int, error) {
 	}
 	switch err := err.(type) {
 	case net.Error:
-		if !err.Temporary() {
+		if !err.Temporary() { // nolint SA1019
 			return -1, fmt.Errorf("read from UDP socket: %w", &recvErr.ErrIrrecoverable{Err: err})
 		}
 	default:

--- a/receiver/carbonreceiver/transport/tcp_server.go
+++ b/receiver/carbonreceiver/transport/tcp_server.go
@@ -106,9 +106,9 @@ func (t *tcpServer) ListenAndServe(
 			t.reporter.OnDebugf(
 				"TCP Transport (%s) - Accept (temporary=%v) net.Error: %v",
 				t.ln.Addr().String(),
-				netErr.Temporary(),
+				netErr.Temporary(), // nolint SA1019
 				netErr)
-			if netErr.Temporary() {
+			if netErr.Temporary() { // nolint SA1019
 				continue
 			}
 		}

--- a/receiver/carbonreceiver/transport/udp_server.go
+++ b/receiver/carbonreceiver/transport/udp_server.go
@@ -79,7 +79,7 @@ func (u *udpServer) ListenAndServe(
 				u.packetConn.LocalAddr(),
 				err)
 			if netErr, ok := err.(net.Error); ok {
-				if netErr.Temporary() {
+				if netErr.Temporary() { // nolint SA1019
 					continue
 				}
 			}

--- a/receiver/statsdreceiver/transport/udp_server.go
+++ b/receiver/statsdreceiver/transport/udp_server.go
@@ -70,7 +70,7 @@ func (u *udpServer) ListenAndServe(
 				u.packetConn.LocalAddr(),
 				err)
 			if netErr, ok := err.(net.Error); ok {
-				if netErr.Temporary() {
+				if netErr.Temporary() { // nolint SA1019
 					continue
 				}
 			}


### PR DESCRIPTION
`strings.Title()` and `net.Error.Temporary()` are deprecated in 1.18. Neither appears to be an urgent concern, so just ignoring them.