### PR TITLE
[processor/transform] Added parameter validation for truncate_all and limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `datadogexporter`: Replace HistogramMode defined as string with enum.
 - `pkg/translator/signalfx`: Change signalfx translator to expose To/From translator structs. (#9740)
+- `transformprocessor`: Add parameter validation to `truncate_all` and `limit` functions.  The `limit` parameter can no longer be negative. (#9783)
 
 ### 🚩 Deprecations 🚩
 

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -22,9 +22,9 @@ it references an unset map value, there will be no action.
 - `keep_keys(target, string...)` - `target` is a path expression to a map type field. The map will be mutated to only contain
 the fields specified by the list of strings. e.g., `keep_keys(attributes, "http.method")`, `keep_keys(attributes, "http.method", "http.route")`
 
-- `truncate_all(target, limit)` - `target` is a path expression to a map type field. `limit` is an integer.  The map will be mutated such that all string values are truncated to the limit. e.g., `truncate_all(attributes, 100)` will truncate all string values in `attributes` such that all string values have less than or equal to 100 characters.  Non-string values are ignored.
+- `truncate_all(target, limit)` - `target` is a path expression to a map type field. `limit` is a non-negative integer.  The map will be mutated such that all string values are truncated to the limit. e.g., `truncate_all(attributes, 100)` will truncate all string values in `attributes` such that all string values have less than or equal to 100 characters.  Non-string values are ignored.
 
-- `limit(target, limit)` - `target` is a path expression to a map type field. `limit` is an integer.  The map will be mutated such that the number of items does not exceed the limit. e.g., `limit(attributes, 100)` will limit `attributes` to no more than 100 items. Which items are dropped is random.
+- `limit(target, limit)` - `target` is a path expression to a map type field. `limit` is a non-negative integer.  The map will be mutated such that the number of items does not exceed the limit. e.g., `limit(attributes, 100)` will limit `attributes` to no more than 100 items. Which items are dropped is random.
 
 Supported where operations:
 - `==` - matches telemetry where the values are equal to each other

--- a/processor/transformprocessor/internal/common/functions.go
+++ b/processor/transformprocessor/internal/common/functions.go
@@ -73,6 +73,9 @@ func keepKeys(target GetSetter, keys []string) (ExprFunc, error) {
 }
 
 func truncateAll(target GetSetter, limit int64) (ExprFunc, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("invalid limit for truncate_all function, %d cannot be negative", limit)
+	}
 	return func(ctx TransformContext) interface{} {
 		if limit < 0 {
 			return nil
@@ -104,6 +107,9 @@ func truncateAll(target GetSetter, limit int64) (ExprFunc, error) {
 }
 
 func limit(target GetSetter, limit int64) (ExprFunc, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("invalid limit for limit function, %d cannot be negative", limit)
+	}
 	return func(ctx TransformContext) interface{} {
 		val := target.Get(ctx)
 		if val == nil {

--- a/processor/transformprocessor/internal/common/functions_test.go
+++ b/processor/transformprocessor/internal/common/functions_test.go
@@ -94,7 +94,7 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 			},
 		},
 		{
-			name: "not matching slice type",
+			name: "keep_keys not matching slice type",
 			inv: Invocation{
 				Function: "keep_keys",
 				Arguments: []Value{
@@ -114,7 +114,7 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 			},
 		},
 		{
-			name: "not int",
+			name: "truncate_all not int",
 			inv: Invocation{
 				Function: "truncate_all",
 				Arguments: []Value{
@@ -134,7 +134,27 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 			},
 		},
 		{
-			name: "not int",
+			name: "truncate_all negative limit",
+			inv: Invocation{
+				Function: "truncate_all",
+				Arguments: []Value{
+					{
+						Path: &Path{
+							Fields: []Field{
+								{
+									Name: "name",
+								},
+							},
+						},
+					},
+					{
+						Int: intp(-1),
+					},
+				},
+			},
+		},
+		{
+			name: "limit not int",
 			inv: Invocation{
 				Function: "limit",
 				Arguments: []Value{
@@ -149,6 +169,26 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 					},
 					{
 						String: strp("not an int"),
+					},
+				},
+			},
+		},
+		{
+			name: "limit negative limit",
+			inv: Invocation{
+				Function: "limit",
+				Arguments: []Value{
+					{
+						Path: &Path{
+							Fields: []Field{
+								{
+									Name: "name",
+								},
+							},
+						},
+					},
+					{
+						Int: intp(-1),
 					},
 				},
 			},

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -317,38 +317,6 @@ func Test_newFunctionCall(t *testing.T) {
 			},
 		},
 		{
-			name: "truncate resource negative",
-			inv: common.Invocation{
-				Function: "truncate_all",
-				Arguments: []common.Value{
-					{
-						Path: &common.Path{
-							Fields: []common.Field{
-								{
-									Name: "resource",
-								},
-								{
-									Name: "attributes",
-								},
-							},
-						},
-					},
-					{
-						Int: intp(-1),
-					},
-				},
-			},
-			want: func(span ptrace.Span) {
-				input.CopyTo(span)
-				span.Attributes().Clear()
-				attrs := pcommon.NewMap()
-				attrs.InsertString("test", "hello world")
-				attrs.InsertInt("test2", 3)
-				attrs.InsertBool("test3", true)
-				attrs.CopyTo(span.Attributes())
-			},
-		},
-		{
 			name: "limit attributes",
 			inv: common.Invocation{
 				Function: "limit",


### PR DESCRIPTION
**Description:**
Adds validation for the `limit` parameter for both the `truncate_all` and `limit` functions.  [Errors returned will fail the processor's validate function.](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/1ff279a2edbbff8825d2f1ab97a8197b9a13affc/processor/transformprocessor/config.go#L49)

**Link to tracking Issue:**
Resolves #9555 

**Testing:**
Updated unit tests

**Documentation:** 
Updated README