### PR TITLE
[exporter/datadog] Fix canceling on `createTracesExporter`

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -197,7 +197,6 @@ func (f *factory) createTracesExporter(
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	var pushTracesFn consumer.ConsumeTracesFunc
 
 	if cfg.OnlyMetadata {
@@ -216,6 +215,7 @@ func (f *factory) createTracesExporter(
 	} else {
 		exporter, err := newTracesExporter(ctx, set, cfg, &f.onceMetadata)
 		if err != nil {
+			cancel()
 			return nil, err
 		}
 		pushTracesFn = exporter.pushTraceDataScrubbed


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Fixes a bug introduced in #9426 where a context is incorrectly canceled via `defer` instead of being canceled only when the function errors out.

It was spotted by @gbbr on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9426#discussion_r866521743.

Since this has not been out on any release, no changelog note is needed.