### PR TITLE
internal/stanza: Avoid writing test/mock consumers when not necessary

### DIFF
--- a/internal/stanza/receiver_test.go
+++ b/internal/stanza/receiver_test.go
@@ -29,12 +29,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-log-collection/pipeline"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 )
 
 func TestStart(t *testing.T) {
-	mockConsumer := mockLogsConsumer{}
+	mockConsumer := &consumertest.LogsSink{}
 
 	factory := NewFactory(TestReceiverType{})
 
@@ -42,7 +43,7 @@ func TestStart(t *testing.T) {
 		context.Background(),
 		componenttest.NewNopReceiverCreateSettings(),
 		factory.CreateDefaultConfig(),
-		&mockConsumer,
+		mockConsumer,
 	)
 	require.NoError(t, err, "receiver should successfully build")
 
@@ -55,7 +56,7 @@ func TestStart(t *testing.T) {
 	// Eventually because of asynchronuous nature of the receiver.
 	require.Eventually(t,
 		func() bool {
-			return mockConsumer.Received() == 1
+			return mockConsumer.LogRecordCount() == 1
 		},
 		10*time.Second, 5*time.Millisecond, "one log entry expected",
 	)
@@ -63,14 +64,14 @@ func TestStart(t *testing.T) {
 }
 
 func TestHandleStartError(t *testing.T) {
-	mockConsumer := mockLogsConsumer{}
+	mockConsumer := &consumertest.LogsSink{}
 
 	factory := NewFactory(TestReceiverType{})
 
 	cfg := factory.CreateDefaultConfig().(*TestConfig)
 	cfg.Input = newUnstartableParams()
 
-	receiver, err := factory.CreateLogsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, &mockConsumer)
+	receiver, err := factory.CreateLogsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), cfg, mockConsumer)
 	require.NoError(t, err, "receiver should successfully build")
 
 	err = receiver.Start(context.Background(), componenttest.NewNopHost())
@@ -78,10 +79,10 @@ func TestHandleStartError(t *testing.T) {
 }
 
 func TestHandleConsumeError(t *testing.T) {
-	mockConsumer := mockLogsRejecter{}
+	mockConsumer := &mockLogsRejecter{}
 	factory := NewFactory(TestReceiverType{})
 
-	logsReceiver, err := factory.CreateLogsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), factory.CreateDefaultConfig(), &mockConsumer)
+	logsReceiver, err := factory.CreateLogsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), factory.CreateDefaultConfig(), mockConsumer)
 	require.NoError(t, err, "receiver should successfully build")
 
 	err = logsReceiver.Start(context.Background(), componenttest.NewNopHost())
@@ -93,11 +94,11 @@ func TestHandleConsumeError(t *testing.T) {
 	// Eventually because of asynchronuous nature of the receiver.
 	require.Eventually(t,
 		func() bool {
-			return mockConsumer.Rejected() == 1
+			return mockConsumer.LogRecordCount() == 1
 		},
 		10*time.Second, 5*time.Millisecond, "one log entry expected",
 	)
-	logsReceiver.Shutdown(context.Background())
+	require.NoError(t, logsReceiver.Shutdown(context.Background()))
 }
 
 func BenchmarkReadLine(b *testing.B) {

--- a/internal/stanza/storage_test.go
+++ b/internal/stanza/storage_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/otel/metric/nonrecording"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap/zaptest"
@@ -98,7 +99,6 @@ func createReceiver(t *testing.T) *receiver {
 			MetricsLevel:   configtelemetry.LevelNone,
 		},
 	}
-	mockConsumer := mockLogsConsumer{}
 
 	factory := NewFactory(TestReceiverType{})
 
@@ -106,7 +106,7 @@ func createReceiver(t *testing.T) *receiver {
 		context.Background(),
 		params,
 		factory.CreateDefaultConfig(),
-		&mockConsumer,
+		consumertest.NewNop(),
 	)
 	require.NoError(t, err, "receiver should successfully build")
 


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9778

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
