### PR TITLE
pprofextension: use uber/atomic instead of sync/atomic

### DIFF
--- a/extension/pprofextension/go.mod
+++ b/extension/pprofextension/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.50.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/collector v0.50.1-0.20220429151328-041f39835df7
+	go.uber.org/atomic v1.9.0
 	go.uber.org/zap v1.21.0
 )
 
@@ -26,7 +27,6 @@ require (
 	go.opentelemetry.io/otel v1.7.0 // indirect
 	go.opentelemetry.io/otel/metric v0.30.0 // indirect
 	go.opentelemetry.io/otel/trace v1.7.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect

--- a/extension/pprofextension/pprofextension.go
+++ b/extension/pprofextension/pprofextension.go
@@ -23,19 +23,13 @@ import (
 	"os"
 	"runtime"
 	"runtime/pprof"
-	"sync/atomic"
-	"unsafe"
 
 	"go.opentelemetry.io/collector/component"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
 
-// Tracks that only a single instance is active per process.
-// See comment on Start method for the reasons for that.
-var activeInstance *pprofExtension
-
-// #nosec G103
-var activeInstancePtr = (*unsafe.Pointer)(unsafe.Pointer(&activeInstance))
+var running = atomic.NewBool(false)
 
 type pprofExtension struct {
 	config Config
@@ -52,7 +46,7 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 	// this issue we will allow the start of a single instance once per process
 	// Summary: only a single instance can be running in the same process.
 	// #nosec G103
-	if !atomic.CompareAndSwapPointer(activeInstancePtr, nil, unsafe.Pointer(p)) {
+	if !running.CAS(false, true) {
 		return errors.New("only a single pprof extension instance can be running per process")
 	}
 
@@ -60,7 +54,7 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 	var startErr error
 	defer func() {
 		if startErr != nil {
-			atomic.StorePointer(activeInstancePtr, nil)
+			running.Store(false)
 		}
 	}()
 
@@ -79,7 +73,7 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 	p.stopCh = make(chan struct{})
 	go func() {
 		defer func() {
-			atomic.StorePointer(activeInstancePtr, nil)
+			running.Store(false)
 			close(p.stopCh)
 		}()
 
@@ -103,7 +97,7 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 }
 
 func (p *pprofExtension) Shutdown(context.Context) error {
-	defer atomic.StorePointer(activeInstancePtr, nil)
+	defer running.Store(false)
 	if p.file != nil {
 		pprof.StopCPUProfile()
 		_ = p.file.Close() // ignore the error

--- a/extension/pprofextension/pprofextension.go
+++ b/extension/pprofextension/pprofextension.go
@@ -45,7 +45,6 @@ func (p *pprofExtension) Start(_ context.Context, host component.Host) error {
 	// the settings of the last started instance will prevail. In order to avoid
 	// this issue we will allow the start of a single instance once per process
 	// Summary: only a single instance can be running in the same process.
-	// #nosec G103
 	if !running.CAS(false, true) {
 		return errors.New("only a single pprof extension instance can be running per process")
 	}


### PR DESCRIPTION
Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9778

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>