### PR TITLE
[tooling/impi] Evaluate packages of current module only

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -117,7 +117,7 @@ misspell-correction:
 
 .PHONY: impi
 impi:
-	@$(IMPI) --local github.com/open-telemetry/opentelemetry-collector-contrib --scheme stdThirdPartyLocal ./...
+	@$(IMPI) --local github.com/open-telemetry/opentelemetry-collector-contrib --scheme stdThirdPartyLocal $(ALL_PKGS)
 
 .PHONY: moddownload
 moddownload:


### PR DESCRIPTION
Related to #9888

Currently causing issues with excluding a module on #9922 