### PR TITLE
Deprecate k8s.cluster.name setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🚩 Deprecations 🚩
 
 - `exporter/azuremonitor`: Deprecate use of LogRecord.Name as the log envelope category name. There is no replacement.
+- `processor/k8sattributes`: Deprecate use of k8s.cluster.name metadata parameter (obsolete) (#9968) 
 
 ### 🚀 New components 🚀
 

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -60,7 +60,7 @@ type ExtractConfig struct {
 	// The field accepts a list of strings.
 	//
 	// Metadata fields supported right now are,
-	//   k8s.pod.name, k8s.pod.uid, k8s.deployment.name, k8s.cluster.name,
+	//   k8s.pod.name, k8s.pod.uid, k8s.deployment.name,
 	//   k8s.node.name, k8s.namespace.name and k8s.pod.start_time
 	//
 	// Specifying anything other than these values will result in an error.

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -59,7 +59,7 @@ func TestLoadConfig(t *testing.T) {
 			APIConfig:         k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeKubeConfig},
 			Passthrough:       false,
 			Extract: ExtractConfig{
-				Metadata: []string{"k8s.pod.name", "k8s.pod.uid", "k8s.deployment.name", "k8s.cluster.name", "k8s.namespace.name", "k8s.node.name", "k8s.pod.start_time"},
+				Metadata: []string{"k8s.pod.name", "k8s.pod.uid", "k8s.deployment.name", "k8s.namespace.name", "k8s.node.name", "k8s.pod.start_time"},
 				Annotations: []FieldExtractConfig{
 					{TagName: "a1", Key: "annotation-one", From: "pod"},
 					{TagName: "a2", Key: "annotation-two", Regex: "field=(?P<value>.+)", From: kube.MetadataFromPod},

--- a/processor/k8sattributesprocessor/doc.go
+++ b/processor/k8sattributesprocessor/doc.go
@@ -49,10 +49,8 @@
 //   - k8s.pod.uid
 //   - k8s.pod.start_time
 //   - k8s.deployment.name
-//   - k8s.cluster.name
 //   - k8s.node.name
-// Not all the attributes are guaranteed to be added. For example `k8s.cluster.name` usually is not provided by k8s API,
-// so likely it won't be set as an attribute.
+// Not all the attributes are guaranteed to be added.
 //
 // The following container level attributes require additional attributes to identify a particular container in a pod:
 //   1. Container spec attributes - will be set only if container identifying attribute `k8s.container.name` is set
@@ -135,7 +133,6 @@
 //            - k8s.pod.name
 //            - k8s.pod.uid
 //            - k8s.deployment.name
-//            - k8s.cluster.name
 //            - k8s.namespace.name
 //            - k8s.node.name
 //            - k8s.pod.start_time

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -226,17 +226,19 @@ func warnDeprecatedMetadataConfig(logger *zap.Logger, cfg config.Processor) {
 		case metadataDeployment:
 			oldName = metadataDeployment
 			newName = conventions.AttributeK8SDeploymentName
-		case metadataCluster:
-			oldName = metadataCluster
-			newName = conventions.AttributeK8SClusterName
 		case metadataNode:
 			oldName = metadataNode
 			newName = conventions.AttributeK8SNodeName
+		case deprecatedMetadataCluster:
+			logger.Warn("cluster metadata param has been deprecated and will be removed soon")
+		case conventions.AttributeK8SClusterName:
+			logger.Warn("k8s.cluster.name metadata param has been deprecated and will be removed soon")
 		}
 		if oldName != "" {
 			logger.Warn(fmt.Sprintf("%s has been deprecated in favor of %s for k8s-tagger processor", oldName, newName))
 		}
 	}
+
 }
 
 func errWrongKeyConfig(cfg config.Processor) error {

--- a/processor/k8sattributesprocessor/factory_test.go
+++ b/processor/k8sattributesprocessor/factory_test.go
@@ -70,3 +70,23 @@ func TestCreateProcessor(t *testing.T) {
 	// Switch it back so other tests run afterwards will not fail on unexpected state
 	kubeClientProvider = realClient
 }
+
+func TestCreateProcessorWithDeprecatedSettings(t *testing.T) {
+	factory := NewFactory()
+
+	cfg := factory.CreateDefaultConfig()
+	oCfg := cfg.(*Config)
+	oCfg.Extract.Metadata = []string{"k8s.cluster.name"}
+
+	params := componenttest.NewNopProcessorCreateSettings()
+
+	realClient := kubeClientProvider
+	kubeClientProvider = newFakeClient
+
+	tp, err := factory.CreateTracesProcessor(context.Background(), params, cfg, consumertest.NewNop())
+	assert.NotNil(t, tp)
+	assert.NoError(t, err)
+
+	// Switch it back so other tests run afterwards will not fail on unexpected state
+	kubeClientProvider = realClient
+}

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -449,7 +449,6 @@ func TestExtractionRules(t *testing.T) {
 			PodName:    true,
 			PodUID:     true,
 			Node:       true,
-			Cluster:    true,
 			StartTime:  true,
 		},
 		attributes: map[string]string{

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -141,7 +141,6 @@ type ExtractionRules struct {
 	PodName            bool
 	PodUID             bool
 	Node               bool
-	Cluster            bool
 	StartTime          bool
 	ContainerID        bool
 	ContainerImageName bool

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -37,10 +37,11 @@ const (
 	metadataPodUID     = "podUID"
 	metadataStartTime  = "startTime"
 	metadataDeployment = "deployment"
-	metadataCluster    = "cluster"
 	metadataNode       = "node"
 	// Will be removed when new fields get merged to https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go
 	metadataPodStartTime = "k8s.pod.start_time"
+	// This one was deprecated, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9886
+	deprecatedMetadataCluster = "cluster"
 )
 
 // option represents a configuration option that can be passes.
@@ -76,7 +77,6 @@ func withExtractMetadata(fields ...string) option {
 				conventions.AttributeK8SPodUID,
 				metadataPodStartTime,
 				conventions.AttributeK8SDeploymentName,
-				conventions.AttributeK8SClusterName,
 				conventions.AttributeK8SNodeName,
 				conventions.AttributeContainerID,
 				conventions.AttributeContainerImageName,
@@ -86,7 +86,7 @@ func withExtractMetadata(fields ...string) option {
 		for _, field := range fields {
 			switch field {
 			// Old conventions handled by the cases metdataNamespace, metadataPodName, metadataPodUID,
-			// metadataStartTime, metadataDeployment, metadataCluster, metadataNode are being supported for backward compatibility.
+			// metadataStartTime, metadataDeployment, deprecatedMetadataCluster, metadataNode are being supported for backward compatibility.
 			// These will be removed when new conventions get merged to https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go
 			case metdataNamespace, conventions.AttributeK8SNamespaceName:
 				p.rules.Namespace = true
@@ -98,8 +98,6 @@ func withExtractMetadata(fields ...string) option {
 				p.rules.StartTime = true
 			case metadataDeployment, conventions.AttributeK8SDeploymentName:
 				p.rules.Deployment = true
-			case metadataCluster, conventions.AttributeK8SClusterName:
-				p.rules.Cluster = true
 			case metadataNode, conventions.AttributeK8SNodeName:
 				p.rules.Node = true
 			case conventions.AttributeContainerID:
@@ -108,6 +106,8 @@ func withExtractMetadata(fields ...string) option {
 				p.rules.ContainerImageName = true
 			case conventions.AttributeContainerImageTag:
 				p.rules.ContainerImageTag = true
+			case deprecatedMetadataCluster, conventions.AttributeK8SClusterName:
+				// This one is deprecated, ignore it
 			default:
 				return fmt.Errorf("\"%s\" is not a supported metadata field", field)
 			}

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -319,7 +319,6 @@ func TestWithExtractMetadata(t *testing.T) {
 	assert.True(t, p.rules.PodUID)
 	assert.True(t, p.rules.StartTime)
 	assert.True(t, p.rules.Deployment)
-	assert.True(t, p.rules.Cluster)
 	assert.True(t, p.rules.Node)
 
 	p = &kubernetesprocessor{}
@@ -330,7 +329,6 @@ func TestWithExtractMetadata(t *testing.T) {
 	p = &kubernetesprocessor{}
 	assert.NoError(t, withExtractMetadata(conventions.AttributeK8SNamespaceName, conventions.AttributeK8SPodName, conventions.AttributeK8SPodUID)(p))
 	assert.True(t, p.rules.Namespace)
-	assert.False(t, p.rules.Cluster)
 	assert.True(t, p.rules.PodName)
 	assert.True(t, p.rules.PodUID)
 	assert.False(t, p.rules.StartTime)

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -12,7 +12,6 @@ processors:
         # - podName
         # - podUID
         # - deployment
-        # - cluster
         # - namespace
         # - node
         # - startTime
@@ -20,7 +19,6 @@ processors:
         - k8s.pod.name
         - k8s.pod.uid
         - k8s.deployment.name
-        - k8s.cluster.name
         - k8s.namespace.name
         - k8s.node.name
         - k8s.pod.start_time
@@ -86,6 +84,13 @@ processors:
       labels:
         - key_regex: opentel.* # extracts Keys & values of labels matching regex `opentel.*`
           from: pod
+
+  k8sattributes/4:
+    auth_type: "kubeConfig"
+    extract:
+      metadata:
+        # the following metadata field has been depracated
+        - k8s.cluster.name
 
 exporters:
   nop:


### PR DESCRIPTION
**Description:** 

Deprecates cluster name metadata usage

**Link to tracking Issue:** #9886

**Testing:** unit test added

**Documentation:** docs updated so they no longer refer cluster name