### PR TITLE
[Metrics builder] Remove Attributes struct

### DIFF
--- a/cmd/mdatagen/main.go
+++ b/cmd/mdatagen/main.go
@@ -89,6 +89,12 @@ func generateMetrics(ymlDir string, thisDir string, md metadata, useExpGen bool)
 				"attributeInfo": func(an attributeName) attribute {
 					return md.Attributes[an]
 				},
+				"attributeKey": func(an attributeName) string {
+					if md.Attributes[an].Value != "" {
+						return md.Attributes[an].Value
+					}
+					return string(an)
+				},
 				"parseImportsRequired": func(metrics map[metricName]metric) bool {
 					for _, m := range metrics {
 						if m.Data().HasMetricInputType() {

--- a/cmd/mdatagen/metrics_v2.tmpl
+++ b/cmd/mdatagen/metrics_v2.tmpl
@@ -108,7 +108,7 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.Set{{ $metric.Data.MetricValueType }}Val(val)
 	{{- end }}
 	{{- range $metric.Attributes }}
-	dp.Attributes().Insert(A.{{ .Render }}, pcommon.NewValueString({{ .RenderUnexported }}AttributeValue))
+	dp.Attributes().Insert("{{ attributeKey .}}", pcommon.NewValueString({{ .RenderUnexported }}AttributeValue))
 	{{- end }}
 }
 
@@ -285,22 +285,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-{{- range $name, $info := .Attributes }}
-	// {{ $name.Render }} ({{ $info.Description }})
-	{{ $name.Render }} string
-{{- end }}
-}{
-{{- range $name, $info := .Attributes }}
-	{{- if $info.Value }}
-	"{{ $info.Value }}",
-	{{- else }}
-	"{{ $name }}",
-	{{- end }}
-{{- end }}
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/activedirectorydsreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/activedirectorydsreceiver/internal/metadata/generated_metrics_v2.go
@@ -310,7 +310,7 @@ func (m *metricActiveDirectoryDsBindRate) recordDataPoint(start pcommon.Timestam
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.BindType, pcommon.NewValueString(bindTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(bindTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -665,7 +665,7 @@ func (m *metricActiveDirectoryDsOperationRate) recordDataPoint(start pcommon.Tim
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.OperationType, pcommon.NewValueString(operationTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(operationTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -718,8 +718,8 @@ func (m *metricActiveDirectoryDsReplicationNetworkIo) recordDataPoint(start pcom
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
-	dp.Attributes().Insert(A.NetworkDataType, pcommon.NewValueString(networkDataTypeAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(networkDataTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -772,7 +772,7 @@ func (m *metricActiveDirectoryDsReplicationObjectRate) recordDataPoint(start pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -876,7 +876,7 @@ func (m *metricActiveDirectoryDsReplicationPropertyRate) recordDataPoint(start p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -980,7 +980,7 @@ func (m *metricActiveDirectoryDsReplicationSyncRequestCount) recordDataPoint(sta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.SyncResult, pcommon.NewValueString(syncResultAttributeValue))
+	dp.Attributes().Insert("result", pcommon.NewValueString(syncResultAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1033,8 +1033,8 @@ func (m *metricActiveDirectoryDsReplicationValueRate) recordDataPoint(start pcom
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
-	dp.Attributes().Insert(A.ValueType, pcommon.NewValueString(valueTypeAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(valueTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1138,7 +1138,7 @@ func (m *metricActiveDirectoryDsSuboperationRate) recordDataPoint(start pcommon.
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.SuboperationType, pcommon.NewValueString(suboperationTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(suboperationTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1441,32 +1441,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// BindType (The type of bind to the domain server.)
-	BindType string
-	// Direction (The direction of data flow.)
-	Direction string
-	// NetworkDataType (The type of network data sent.)
-	NetworkDataType string
-	// OperationType (The type of operation.)
-	OperationType string
-	// SuboperationType (The type of suboperation.)
-	SuboperationType string
-	// SyncResult (The result status of the sync request.)
-	SyncResult string
-	// ValueType (The type of value sent.)
-	ValueType string
-}{
-	"type",
-	"direction",
-	"type",
-	"type",
-	"type",
-	"result",
-	"type",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/apachereceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics_v2.go
@@ -166,7 +166,7 @@ func (m *metricApacheCurrentConnections) recordDataPoint(start pcommon.Timestamp
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ServerName, pcommon.NewValueString(serverNameAttributeValue))
+	dp.Attributes().Insert("server_name", pcommon.NewValueString(serverNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -219,7 +219,7 @@ func (m *metricApacheRequests) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ServerName, pcommon.NewValueString(serverNameAttributeValue))
+	dp.Attributes().Insert("server_name", pcommon.NewValueString(serverNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -272,8 +272,8 @@ func (m *metricApacheScoreboard) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ServerName, pcommon.NewValueString(serverNameAttributeValue))
-	dp.Attributes().Insert(A.ScoreboardState, pcommon.NewValueString(scoreboardStateAttributeValue))
+	dp.Attributes().Insert("server_name", pcommon.NewValueString(serverNameAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(scoreboardStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -326,7 +326,7 @@ func (m *metricApacheTraffic) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ServerName, pcommon.NewValueString(serverNameAttributeValue))
+	dp.Attributes().Insert("server_name", pcommon.NewValueString(serverNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -379,7 +379,7 @@ func (m *metricApacheUptime) recordDataPoint(start pcommon.Timestamp, ts pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ServerName, pcommon.NewValueString(serverNameAttributeValue))
+	dp.Attributes().Insert("server_name", pcommon.NewValueString(serverNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -432,8 +432,8 @@ func (m *metricApacheWorkers) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ServerName, pcommon.NewValueString(serverNameAttributeValue))
-	dp.Attributes().Insert(A.WorkersState, pcommon.NewValueString(workersStateAttributeValue))
+	dp.Attributes().Insert("server_name", pcommon.NewValueString(serverNameAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(workersStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -609,20 +609,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// ScoreboardState (The state of a connection.)
-	ScoreboardState string
-	// ServerName (The name of the Apache HTTP server.)
-	ServerName string
-	// WorkersState (The state of workers.)
-	WorkersState string
-}{
-	"state",
-	"server_name",
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/couchbasereceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/couchbasereceiver/internal/metadata/generated_metrics_v2.go
@@ -102,10 +102,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-}{}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/couchdbreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_metrics_v2.go
@@ -278,7 +278,7 @@ func (m *metricCouchdbDatabaseOperations) recordDataPoint(start pcommon.Timestam
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Operation, pcommon.NewValueString(operationAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -433,7 +433,7 @@ func (m *metricCouchdbHttpdRequests) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.HTTPMethod, pcommon.NewValueString(httpMethodAttributeValue))
+	dp.Attributes().Insert("http.method", pcommon.NewValueString(httpMethodAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -486,7 +486,7 @@ func (m *metricCouchdbHttpdResponses) recordDataPoint(start pcommon.Timestamp, t
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.HTTPStatusCode, pcommon.NewValueString(httpStatusCodeAttributeValue))
+	dp.Attributes().Insert("http.status_code", pcommon.NewValueString(httpStatusCodeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -539,7 +539,7 @@ func (m *metricCouchdbHttpdViews) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.View, pcommon.NewValueString(viewAttributeValue))
+	dp.Attributes().Insert("view", pcommon.NewValueString(viewAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -718,23 +718,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// HTTPMethod (An HTTP request method.)
-	HTTPMethod string
-	// HTTPStatusCode (An HTTP status code.)
-	HTTPStatusCode string
-	// Operation (The operation type.)
-	Operation string
-	// View (The view type.)
-	View string
-}{
-	"http.method",
-	"http.status_code",
-	"operation",
-	"view",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_v2.go
@@ -523,7 +523,7 @@ func (m *metricElasticsearchClusterHealth) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.HealthStatus, pcommon.NewValueString(healthStatusAttributeValue))
+	dp.Attributes().Insert("status", pcommon.NewValueString(healthStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -627,7 +627,7 @@ func (m *metricElasticsearchClusterShards) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ShardState, pcommon.NewValueString(shardStateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(shardStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -680,7 +680,7 @@ func (m *metricElasticsearchNodeCacheEvictions) recordDataPoint(start pcommon.Ti
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.CacheName, pcommon.NewValueString(cacheNameAttributeValue))
+	dp.Attributes().Insert("cache_name", pcommon.NewValueString(cacheNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -733,7 +733,7 @@ func (m *metricElasticsearchNodeCacheMemoryUsage) recordDataPoint(start pcommon.
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.CacheName, pcommon.NewValueString(cacheNameAttributeValue))
+	dp.Attributes().Insert("cache_name", pcommon.NewValueString(cacheNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -837,7 +837,7 @@ func (m *metricElasticsearchNodeClusterIo) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -890,7 +890,7 @@ func (m *metricElasticsearchNodeDocuments) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.DocumentState, pcommon.NewValueString(documentStateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(documentStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1096,7 +1096,7 @@ func (m *metricElasticsearchNodeOperationsCompleted) recordDataPoint(start pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Operation, pcommon.NewValueString(operationAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1149,7 +1149,7 @@ func (m *metricElasticsearchNodeOperationsTime) recordDataPoint(start pcommon.Ti
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Operation, pcommon.NewValueString(operationAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1253,8 +1253,8 @@ func (m *metricElasticsearchNodeThreadPoolTasksFinished) recordDataPoint(start p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ThreadPoolName, pcommon.NewValueString(threadPoolNameAttributeValue))
-	dp.Attributes().Insert(A.TaskState, pcommon.NewValueString(taskStateAttributeValue))
+	dp.Attributes().Insert("thread_pool_name", pcommon.NewValueString(threadPoolNameAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(taskStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1307,7 +1307,7 @@ func (m *metricElasticsearchNodeThreadPoolTasksQueued) recordDataPoint(start pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ThreadPoolName, pcommon.NewValueString(threadPoolNameAttributeValue))
+	dp.Attributes().Insert("thread_pool_name", pcommon.NewValueString(threadPoolNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1360,8 +1360,8 @@ func (m *metricElasticsearchNodeThreadPoolThreads) recordDataPoint(start pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ThreadPoolName, pcommon.NewValueString(threadPoolNameAttributeValue))
-	dp.Attributes().Insert(A.ThreadState, pcommon.NewValueString(threadStateAttributeValue))
+	dp.Attributes().Insert("thread_pool_name", pcommon.NewValueString(threadPoolNameAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(threadStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1463,7 +1463,7 @@ func (m *metricJvmGcCollectionsCount) recordDataPoint(start pcommon.Timestamp, t
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.CollectorName, pcommon.NewValueString(collectorNameAttributeValue))
+	dp.Attributes().Insert("name", pcommon.NewValueString(collectorNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1516,7 +1516,7 @@ func (m *metricJvmGcCollectionsElapsed) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.CollectorName, pcommon.NewValueString(collectorNameAttributeValue))
+	dp.Attributes().Insert("name", pcommon.NewValueString(collectorNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1812,7 +1812,7 @@ func (m *metricJvmMemoryPoolMax) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.MemoryPoolName, pcommon.NewValueString(memoryPoolNameAttributeValue))
+	dp.Attributes().Insert("name", pcommon.NewValueString(memoryPoolNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1863,7 +1863,7 @@ func (m *metricJvmMemoryPoolUsed) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.MemoryPoolName, pcommon.NewValueString(memoryPoolNameAttributeValue))
+	dp.Attributes().Insert("name", pcommon.NewValueString(memoryPoolNameAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2266,50 +2266,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// CacheName (The name of cache.)
-	CacheName string
-	// CollectorName (The name of the garbage collector.)
-	CollectorName string
-	// Direction (The direction of network data.)
-	Direction string
-	// DiskUsageState (The state of a section of space on disk.)
-	DiskUsageState string
-	// DocumentState (The state of the document.)
-	DocumentState string
-	// FsDirection (The direction of filesystem IO.)
-	FsDirection string
-	// HealthStatus (The health status of the cluster.)
-	HealthStatus string
-	// MemoryPoolName (The name of the JVM memory pool.)
-	MemoryPoolName string
-	// Operation (The type of operation.)
-	Operation string
-	// ShardState (The state of the shard.)
-	ShardState string
-	// TaskState (The state of the task.)
-	TaskState string
-	// ThreadPoolName (The name of the thread pool.)
-	ThreadPoolName string
-	// ThreadState (The state of the thread.)
-	ThreadState string
-}{
-	"cache_name",
-	"name",
-	"direction",
-	"state",
-	"state",
-	"direction",
-	"status",
-	"name",
-	"operation",
-	"state",
-	"state",
-	"thread_pool_name",
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
@@ -107,8 +107,8 @@ func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Cpu, pcommon.NewValueString(cpuAttributeValue))
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("cpu", pcommon.NewValueString(cpuAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -159,8 +159,8 @@ func (m *metricSystemCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Cpu, pcommon.NewValueString(cpuAttributeValue))
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("cpu", pcommon.NewValueString(cpuAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -285,17 +285,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Cpu (CPU number starting at 0.)
-	Cpu string
-	// State (Breakdown of CPU usage by type.)
-	State string
-}{
-	"cpu",
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics_v2.go
@@ -103,8 +103,8 @@ func (m *metricSystemDiskIo) recordDataPoint(start pcommon.Timestamp, ts pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -157,7 +157,7 @@ func (m *metricSystemDiskIoTime) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -210,8 +210,8 @@ func (m *metricSystemDiskMerged) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -264,8 +264,8 @@ func (m *metricSystemDiskOperationTime) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -318,8 +318,8 @@ func (m *metricSystemDiskOperations) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -372,7 +372,7 @@ func (m *metricSystemDiskPendingOperations) recordDataPoint(start pcommon.Timest
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -425,7 +425,7 @@ func (m *metricSystemDiskWeightedIoTime) recordDataPoint(start pcommon.Timestamp
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -590,17 +590,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Device (Name of the disk.)
-	Device string
-	// Direction (Direction of flow of bytes/operations (read or write).)
-	Direction string
-}{
-	"device",
-	"direction",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_v2.go
@@ -91,11 +91,11 @@ func (m *metricSystemFilesystemInodesUsage) recordDataPoint(start pcommon.Timest
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Mode, pcommon.NewValueString(modeAttributeValue))
-	dp.Attributes().Insert(A.Mountpoint, pcommon.NewValueString(mountpointAttributeValue))
-	dp.Attributes().Insert(A.Type, pcommon.NewValueString(typeAttributeValue))
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("mode", pcommon.NewValueString(modeAttributeValue))
+	dp.Attributes().Insert("mountpoint", pcommon.NewValueString(mountpointAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(typeAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -148,11 +148,11 @@ func (m *metricSystemFilesystemUsage) recordDataPoint(start pcommon.Timestamp, t
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Mode, pcommon.NewValueString(modeAttributeValue))
-	dp.Attributes().Insert(A.Mountpoint, pcommon.NewValueString(mountpointAttributeValue))
-	dp.Attributes().Insert(A.Type, pcommon.NewValueString(typeAttributeValue))
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("mode", pcommon.NewValueString(modeAttributeValue))
+	dp.Attributes().Insert("mountpoint", pcommon.NewValueString(mountpointAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(typeAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -203,10 +203,10 @@ func (m *metricSystemFilesystemUtilization) recordDataPoint(start pcommon.Timest
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Mode, pcommon.NewValueString(modeAttributeValue))
-	dp.Attributes().Insert(A.Mountpoint, pcommon.NewValueString(mountpointAttributeValue))
-	dp.Attributes().Insert(A.Type, pcommon.NewValueString(typeAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("mode", pcommon.NewValueString(modeAttributeValue))
+	dp.Attributes().Insert("mountpoint", pcommon.NewValueString(mountpointAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(typeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -339,26 +339,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Device (Identifier of the filesystem.)
-	Device string
-	// Mode (Mountpoint mode such "ro", "rw", etc.)
-	Mode string
-	// Mountpoint (Mountpoint path.)
-	Mountpoint string
-	// State (Breakdown of filesystem usage by type.)
-	State string
-	// Type (Filesystem type, such as, "ext4", "tmpfs", etc.)
-	Type string
-}{
-	"device",
-	"mode",
-	"mountpoint",
-	"state",
-	"type",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics_v2.go
@@ -288,10 +288,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-}{}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_v2.go
@@ -103,7 +103,7 @@ func (m *metricSystemMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -154,7 +154,7 @@ func (m *metricSystemMemoryUtilization) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -279,14 +279,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// State (Breakdown of memory usage by type.)
-	State string
-}{
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_v2.go
@@ -117,8 +117,8 @@ func (m *metricSystemNetworkConnections) recordDataPoint(start pcommon.Timestamp
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Protocol, pcommon.NewValueString(protocolAttributeValue))
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("protocol", pcommon.NewValueString(protocolAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -171,8 +171,8 @@ func (m *metricSystemNetworkDropped) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -225,8 +225,8 @@ func (m *metricSystemNetworkErrors) recordDataPoint(start pcommon.Timestamp, ts 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -279,8 +279,8 @@ func (m *metricSystemNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcom
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -333,8 +333,8 @@ func (m *metricSystemNetworkPackets) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -483,23 +483,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Device (Name of the network interface.)
-	Device string
-	// Direction (Direction of flow of bytes/operations (receive or transmit).)
-	Direction string
-	// Protocol (Network protocol, e.g. TCP or UDP.)
-	Protocol string
-	// State (State of the network connection.)
-	State string
-}{
-	"device",
-	"direction",
-	"protocol",
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics_v2.go
@@ -147,7 +147,7 @@ func (m *metricSystemPagingFaults) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Type, pcommon.NewValueString(typeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(typeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -200,8 +200,8 @@ func (m *metricSystemPagingOperations) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
-	dp.Attributes().Insert(A.Type, pcommon.NewValueString(typeAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(typeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -254,8 +254,8 @@ func (m *metricSystemPagingUsage) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -306,8 +306,8 @@ func (m *metricSystemPagingUtilization) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Device, pcommon.NewValueString(deviceAttributeValue))
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("device", pcommon.NewValueString(deviceAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -448,23 +448,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Device (Name of the page file.)
-	Device string
-	// Direction (Page In or Page Out.)
-	Direction string
-	// State (Breakdown of paging usage by type.)
-	State string
-	// Type (Type of fault.)
-	Type string
-}{
-	"device",
-	"direction",
-	"state",
-	"type",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics_v2.go
@@ -127,7 +127,7 @@ func (m *metricSystemProcessesCount) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Status, pcommon.NewValueString(statusAttributeValue))
+	dp.Attributes().Insert("status", pcommon.NewValueString(statusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -303,14 +303,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Status (Breakdown status of the processes.)
-	Status string
-}{
-	"status",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_v2.go
@@ -121,7 +121,7 @@ func (m *metricProcessCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -174,7 +174,7 @@ func (m *metricProcessDiskIo) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -459,17 +459,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Direction (Direction of flow of bytes (read or write).)
-	Direction string
-	// State (Breakdown of CPU usage by type.)
-	State string
-}{
-	"direction",
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/iisreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/iisreceiver/internal/metadata/generated_metrics_v2.go
@@ -372,7 +372,7 @@ func (m *metricIisNetworkFileCount) recordDataPoint(start pcommon.Timestamp, ts 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -425,7 +425,7 @@ func (m *metricIisNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -478,7 +478,7 @@ func (m *metricIisRequestCount) recordDataPoint(start pcommon.Timestamp, ts pcom
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Request, pcommon.NewValueString(requestAttributeValue))
+	dp.Attributes().Insert("request", pcommon.NewValueString(requestAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -933,17 +933,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Direction (The direction data is moving.)
-	Direction string
-	// Request (The type of request sent by a client.)
-	Request string
-}{
-	"direction",
-	"request",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/memcachedreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_metrics_v2.go
@@ -283,7 +283,7 @@ func (m *metricMemcachedCommands) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Command, pcommon.NewValueString(commandAttributeValue))
+	dp.Attributes().Insert("command", pcommon.NewValueString(commandAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -438,7 +438,7 @@ func (m *metricMemcachedCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -593,7 +593,7 @@ func (m *metricMemcachedNetwork) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -644,7 +644,7 @@ func (m *metricMemcachedOperationHitRatio) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Operation, pcommon.NewValueString(operationAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -697,8 +697,8 @@ func (m *metricMemcachedOperations) recordDataPoint(start pcommon.Timestamp, ts 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Type, pcommon.NewValueString(typeAttributeValue))
-	dp.Attributes().Insert(A.Operation, pcommon.NewValueString(operationAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(typeAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -945,26 +945,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Command (The type of command.)
-	Command string
-	// Direction (Direction of data flow.)
-	Direction string
-	// Operation (The type of operation.)
-	Operation string
-	// State (The type of CPU usage.)
-	State string
-	// Type (Result of cache request.)
-	Type string
-}{
-	"command",
-	"direction",
-	"operation",
-	"state",
-	"type",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_v2.go
@@ -1018,7 +1018,7 @@ func (m *metricMongodbatlasDbCounts) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.ObjectType, pcommon.NewValueString(objectTypeAttributeValue))
+	dp.Attributes().Insert("object_type", pcommon.NewValueString(objectTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1069,7 +1069,7 @@ func (m *metricMongodbatlasDbSize) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.ObjectType, pcommon.NewValueString(objectTypeAttributeValue))
+	dp.Attributes().Insert("object_type", pcommon.NewValueString(objectTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1120,7 +1120,7 @@ func (m *metricMongodbatlasDiskPartitionIopsAverage) recordDataPoint(start pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskDirection, pcommon.NewValueString(diskDirectionAttributeValue))
+	dp.Attributes().Insert("disk_direction", pcommon.NewValueString(diskDirectionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1171,7 +1171,7 @@ func (m *metricMongodbatlasDiskPartitionIopsMax) recordDataPoint(start pcommon.T
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskDirection, pcommon.NewValueString(diskDirectionAttributeValue))
+	dp.Attributes().Insert("disk_direction", pcommon.NewValueString(diskDirectionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1222,7 +1222,7 @@ func (m *metricMongodbatlasDiskPartitionLatencyAverage) recordDataPoint(start pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskDirection, pcommon.NewValueString(diskDirectionAttributeValue))
+	dp.Attributes().Insert("disk_direction", pcommon.NewValueString(diskDirectionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1273,7 +1273,7 @@ func (m *metricMongodbatlasDiskPartitionLatencyMax) recordDataPoint(start pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskDirection, pcommon.NewValueString(diskDirectionAttributeValue))
+	dp.Attributes().Insert("disk_direction", pcommon.NewValueString(diskDirectionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1324,7 +1324,7 @@ func (m *metricMongodbatlasDiskPartitionSpaceAverage) recordDataPoint(start pcom
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskStatus, pcommon.NewValueString(diskStatusAttributeValue))
+	dp.Attributes().Insert("disk_status", pcommon.NewValueString(diskStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1375,7 +1375,7 @@ func (m *metricMongodbatlasDiskPartitionSpaceMax) recordDataPoint(start pcommon.
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskStatus, pcommon.NewValueString(diskStatusAttributeValue))
+	dp.Attributes().Insert("disk_status", pcommon.NewValueString(diskStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1426,7 +1426,7 @@ func (m *metricMongodbatlasDiskPartitionUsageAverage) recordDataPoint(start pcom
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskStatus, pcommon.NewValueString(diskStatusAttributeValue))
+	dp.Attributes().Insert("disk_status", pcommon.NewValueString(diskStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1477,7 +1477,7 @@ func (m *metricMongodbatlasDiskPartitionUsageMax) recordDataPoint(start pcommon.
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskStatus, pcommon.NewValueString(diskStatusAttributeValue))
+	dp.Attributes().Insert("disk_status", pcommon.NewValueString(diskStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1528,7 +1528,7 @@ func (m *metricMongodbatlasDiskPartitionUtilizationAverage) recordDataPoint(star
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskStatus, pcommon.NewValueString(diskStatusAttributeValue))
+	dp.Attributes().Insert("disk_status", pcommon.NewValueString(diskStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1579,7 +1579,7 @@ func (m *metricMongodbatlasDiskPartitionUtilizationMax) recordDataPoint(start pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DiskStatus, pcommon.NewValueString(diskStatusAttributeValue))
+	dp.Attributes().Insert("disk_status", pcommon.NewValueString(diskStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1630,7 +1630,7 @@ func (m *metricMongodbatlasProcessAsserts) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.AssertType, pcommon.NewValueString(assertTypeAttributeValue))
+	dp.Attributes().Insert("assert_type", pcommon.NewValueString(assertTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1730,7 +1730,7 @@ func (m *metricMongodbatlasProcessCacheIo) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CacheDirection, pcommon.NewValueString(cacheDirectionAttributeValue))
+	dp.Attributes().Insert("cache_direction", pcommon.NewValueString(cacheDirectionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1783,7 +1783,7 @@ func (m *metricMongodbatlasProcessCacheSize) recordDataPoint(start pcommon.Times
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CacheStatus, pcommon.NewValueString(cacheStatusAttributeValue))
+	dp.Attributes().Insert("cache_status", pcommon.NewValueString(cacheStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1885,7 +1885,7 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage) recordDataP
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1936,7 +1936,7 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageMax) recordDataPoint
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1987,7 +1987,7 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageAverage) recordDataPoint(start
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2038,7 +2038,7 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageMax) recordDataPoint(start pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2089,7 +2089,7 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageAverage) recordDataPoint(sta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2140,7 +2140,7 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageMax) recordDataPoint(start p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2191,7 +2191,7 @@ func (m *metricMongodbatlasProcessCPUUsageAverage) recordDataPoint(start pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2242,7 +2242,7 @@ func (m *metricMongodbatlasProcessCPUUsageMax) recordDataPoint(start pcommon.Tim
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2293,7 +2293,7 @@ func (m *metricMongodbatlasProcessCursors) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CursorState, pcommon.NewValueString(cursorStateAttributeValue))
+	dp.Attributes().Insert("cursor_state", pcommon.NewValueString(cursorStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2344,7 +2344,7 @@ func (m *metricMongodbatlasProcessDbDocumentRate) recordDataPoint(start pcommon.
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.DocumentStatus, pcommon.NewValueString(documentStatusAttributeValue))
+	dp.Attributes().Insert("document_status", pcommon.NewValueString(documentStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2395,8 +2395,8 @@ func (m *metricMongodbatlasProcessDbOperationsRate) recordDataPoint(start pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Operation, pcommon.NewValueString(operationAttributeValue))
-	dp.Attributes().Insert(A.ClusterRole, pcommon.NewValueString(clusterRoleAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
+	dp.Attributes().Insert("cluster_role", pcommon.NewValueString(clusterRoleAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2449,7 +2449,7 @@ func (m *metricMongodbatlasProcessDbOperationsTime) recordDataPoint(start pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.ExecutionType, pcommon.NewValueString(executionTypeAttributeValue))
+	dp.Attributes().Insert("execution_type", pcommon.NewValueString(executionTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2500,7 +2500,7 @@ func (m *metricMongodbatlasProcessDbQueryExecutorScanned) recordDataPoint(start 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.ScannedType, pcommon.NewValueString(scannedTypeAttributeValue))
+	dp.Attributes().Insert("scanned_type", pcommon.NewValueString(scannedTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2551,7 +2551,7 @@ func (m *metricMongodbatlasProcessDbQueryTargetingScannedPerReturned) recordData
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.ScannedType, pcommon.NewValueString(scannedTypeAttributeValue))
+	dp.Attributes().Insert("scanned_type", pcommon.NewValueString(scannedTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2602,7 +2602,7 @@ func (m *metricMongodbatlasProcessDbStorage) recordDataPoint(start pcommon.Times
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.StorageStatus, pcommon.NewValueString(storageStatusAttributeValue))
+	dp.Attributes().Insert("storage_status", pcommon.NewValueString(storageStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2653,7 +2653,7 @@ func (m *metricMongodbatlasProcessFtsCPUUsage) recordDataPoint(start pcommon.Tim
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2704,7 +2704,7 @@ func (m *metricMongodbatlasProcessGlobalLock) recordDataPoint(start pcommon.Time
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.GlobalLockState, pcommon.NewValueString(globalLockStateAttributeValue))
+	dp.Attributes().Insert("global_lock_state", pcommon.NewValueString(globalLockStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2804,7 +2804,7 @@ func (m *metricMongodbatlasProcessIndexCounters) recordDataPoint(start pcommon.T
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.BtreeCounterType, pcommon.NewValueString(btreeCounterTypeAttributeValue))
+	dp.Attributes().Insert("btree_counter_type", pcommon.NewValueString(btreeCounterTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3002,7 +3002,7 @@ func (m *metricMongodbatlasProcessMemoryUsage) recordDataPoint(start pcommon.Tim
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.MemoryState, pcommon.NewValueString(memoryStateAttributeValue))
+	dp.Attributes().Insert("memory_state", pcommon.NewValueString(memoryStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3053,7 +3053,7 @@ func (m *metricMongodbatlasProcessNetworkIo) recordDataPoint(start pcommon.Times
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3204,7 +3204,7 @@ func (m *metricMongodbatlasProcessOplogTime) recordDataPoint(start pcommon.Times
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.OplogType, pcommon.NewValueString(oplogTypeAttributeValue))
+	dp.Attributes().Insert("oplog_type", pcommon.NewValueString(oplogTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3255,7 +3255,7 @@ func (m *metricMongodbatlasProcessPageFaults) recordDataPoint(start pcommon.Time
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.MemoryIssueType, pcommon.NewValueString(memoryIssueTypeAttributeValue))
+	dp.Attributes().Insert("memory_issue_type", pcommon.NewValueString(memoryIssueTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3355,7 +3355,7 @@ func (m *metricMongodbatlasProcessTickets) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.TicketType, pcommon.NewValueString(ticketTypeAttributeValue))
+	dp.Attributes().Insert("ticket_type", pcommon.NewValueString(ticketTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3406,7 +3406,7 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageAverage) recordDataPoint(star
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3457,7 +3457,7 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageMax) recordDataPoint(start pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3508,7 +3508,7 @@ func (m *metricMongodbatlasSystemCPUUsageAverage) recordDataPoint(start pcommon.
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3559,7 +3559,7 @@ func (m *metricMongodbatlasSystemCPUUsageMax) recordDataPoint(start pcommon.Time
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3610,7 +3610,7 @@ func (m *metricMongodbatlasSystemFtsCPUNormalizedUsage) recordDataPoint(start pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3661,7 +3661,7 @@ func (m *metricMongodbatlasSystemFtsCPUUsage) recordDataPoint(start pcommon.Time
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.CPUState, pcommon.NewValueString(cpuStateAttributeValue))
+	dp.Attributes().Insert("cpu_state", pcommon.NewValueString(cpuStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3763,7 +3763,7 @@ func (m *metricMongodbatlasSystemFtsMemoryUsage) recordDataPoint(start pcommon.T
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.MemoryState, pcommon.NewValueString(memoryStateAttributeValue))
+	dp.Attributes().Insert("memory_state", pcommon.NewValueString(memoryStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3814,7 +3814,7 @@ func (m *metricMongodbatlasSystemMemoryUsageAverage) recordDataPoint(start pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.MemoryStatus, pcommon.NewValueString(memoryStatusAttributeValue))
+	dp.Attributes().Insert("memory_status", pcommon.NewValueString(memoryStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3865,7 +3865,7 @@ func (m *metricMongodbatlasSystemMemoryUsageMax) recordDataPoint(start pcommon.T
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.MemoryStatus, pcommon.NewValueString(memoryStatusAttributeValue))
+	dp.Attributes().Insert("memory_status", pcommon.NewValueString(memoryStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3916,7 +3916,7 @@ func (m *metricMongodbatlasSystemNetworkIoAverage) recordDataPoint(start pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3967,7 +3967,7 @@ func (m *metricMongodbatlasSystemNetworkIoMax) recordDataPoint(start pcommon.Tim
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4018,7 +4018,7 @@ func (m *metricMongodbatlasSystemPagingIoAverage) recordDataPoint(start pcommon.
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4069,7 +4069,7 @@ func (m *metricMongodbatlasSystemPagingIoMax) recordDataPoint(start pcommon.Time
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4120,7 +4120,7 @@ func (m *metricMongodbatlasSystemPagingUsageAverage) recordDataPoint(start pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.MemoryState, pcommon.NewValueString(memoryStateAttributeValue))
+	dp.Attributes().Insert("memory_state", pcommon.NewValueString(memoryStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4171,7 +4171,7 @@ func (m *metricMongodbatlasSystemPagingUsageMax) recordDataPoint(start pcommon.T
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.MemoryState, pcommon.NewValueString(memoryStateAttributeValue))
+	dp.Attributes().Insert("memory_state", pcommon.NewValueString(memoryStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -4846,77 +4846,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// AssertType (MongoDB assertion type)
-	AssertType string
-	// BtreeCounterType (Database index effectiveness)
-	BtreeCounterType string
-	// CacheDirection (Whether read into or written from)
-	CacheDirection string
-	// CacheStatus (Cache status)
-	CacheStatus string
-	// ClusterRole (Whether process is acting as replica or primary)
-	ClusterRole string
-	// CPUState (CPU state)
-	CPUState string
-	// CursorState (Whether cursor is open or timed out)
-	CursorState string
-	// Direction (Network traffic direction)
-	Direction string
-	// DiskDirection (Measurement type for disk operation)
-	DiskDirection string
-	// DiskStatus (Disk measurement type)
-	DiskStatus string
-	// DocumentStatus (Status of documents in the database)
-	DocumentStatus string
-	// ExecutionType (Type of command)
-	ExecutionType string
-	// GlobalLockState (Which queue is locked)
-	GlobalLockState string
-	// MemoryIssueType (Type of memory issue encountered)
-	MemoryIssueType string
-	// MemoryState (Memory usage type)
-	MemoryState string
-	// MemoryStatus (Memory measurement type)
-	MemoryStatus string
-	// ObjectType (MongoDB object type)
-	ObjectType string
-	// Operation (Type of database operation)
-	Operation string
-	// OplogType (Oplog type)
-	OplogType string
-	// ScannedType (Objects or indexes scanned during query)
-	ScannedType string
-	// StorageStatus (Views on database size)
-	StorageStatus string
-	// TicketType (Type of ticket available)
-	TicketType string
-}{
-	"assert_type",
-	"btree_counter_type",
-	"cache_direction",
-	"cache_status",
-	"cluster_role",
-	"cpu_state",
-	"cursor_state",
-	"direction",
-	"disk_direction",
-	"disk_status",
-	"document_status",
-	"execution_type",
-	"global_lock_state",
-	"memory_issue_type",
-	"memory_state",
-	"memory_status",
-	"object_type",
-	"operation",
-	"oplog_type",
-	"scanned_type",
-	"storage_status",
-	"ticket_type",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
@@ -220,7 +220,7 @@ func (m *metricMongodbCacheOperations) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Type, pcommon.NewValueString(typeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(typeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -273,7 +273,7 @@ func (m *metricMongodbCollectionCount) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -326,8 +326,8 @@ func (m *metricMongodbConnectionCount) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
-	dp.Attributes().Insert(A.ConnectionType, pcommon.NewValueString(connectionTypeAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(connectionTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -380,7 +380,7 @@ func (m *metricMongodbDataSize) recordDataPoint(start pcommon.Timestamp, ts pcom
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -433,7 +433,7 @@ func (m *metricMongodbExtentCount) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -537,7 +537,7 @@ func (m *metricMongodbIndexCount) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -590,7 +590,7 @@ func (m *metricMongodbIndexSize) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -643,8 +643,8 @@ func (m *metricMongodbMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
-	dp.Attributes().Insert(A.MemoryType, pcommon.NewValueString(memoryTypeAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(memoryTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -697,7 +697,7 @@ func (m *metricMongodbObjectCount) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -750,7 +750,7 @@ func (m *metricMongodbOperationCount) recordDataPoint(start pcommon.Timestamp, t
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Operation, pcommon.NewValueString(operationAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -803,7 +803,7 @@ func (m *metricMongodbStorageSize) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1014,26 +1014,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// ConnectionType (The status of the connection.)
-	ConnectionType string
-	// Database (The name of a database.)
-	Database string
-	// MemoryType (The type of memory used.)
-	MemoryType string
-	// Operation (The MongoDB operation being counted.)
-	Operation string
-	// Type (The result of a cache request.)
-	Type string
-}{
-	"type",
-	"database",
-	"type",
-	"operation",
-	"type",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_v2.go
@@ -622,7 +622,7 @@ func (m *metricMysqlBufferPoolDataPages) recordDataPoint(start pcommon.Timestamp
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.BufferPoolData, pcommon.NewValueString(bufferPoolDataAttributeValue))
+	dp.Attributes().Insert("status", pcommon.NewValueString(bufferPoolDataAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -726,7 +726,7 @@ func (m *metricMysqlBufferPoolOperations) recordDataPoint(start pcommon.Timestam
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.BufferPoolOperations, pcommon.NewValueString(bufferPoolOperationsAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(bufferPoolOperationsAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -830,7 +830,7 @@ func (m *metricMysqlBufferPoolPages) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.BufferPoolPages, pcommon.NewValueString(bufferPoolPagesAttributeValue))
+	dp.Attributes().Insert("kind", pcommon.NewValueString(bufferPoolPagesAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -883,7 +883,7 @@ func (m *metricMysqlBufferPoolUsage) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.BufferPoolData, pcommon.NewValueString(bufferPoolDataAttributeValue))
+	dp.Attributes().Insert("status", pcommon.NewValueString(bufferPoolDataAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -936,7 +936,7 @@ func (m *metricMysqlCommands) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Command, pcommon.NewValueString(commandAttributeValue))
+	dp.Attributes().Insert("command", pcommon.NewValueString(commandAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -989,7 +989,7 @@ func (m *metricMysqlDoubleWrites) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.DoubleWrites, pcommon.NewValueString(doubleWritesAttributeValue))
+	dp.Attributes().Insert("kind", pcommon.NewValueString(doubleWritesAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1042,7 +1042,7 @@ func (m *metricMysqlHandlers) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Handler, pcommon.NewValueString(handlerAttributeValue))
+	dp.Attributes().Insert("kind", pcommon.NewValueString(handlerAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1095,7 +1095,7 @@ func (m *metricMysqlLocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.T
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Locks, pcommon.NewValueString(locksAttributeValue))
+	dp.Attributes().Insert("kind", pcommon.NewValueString(locksAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1148,7 +1148,7 @@ func (m *metricMysqlLogOperations) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.LogOperations, pcommon.NewValueString(logOperationsAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(logOperationsAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1201,7 +1201,7 @@ func (m *metricMysqlOperations) recordDataPoint(start pcommon.Timestamp, ts pcom
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Operations, pcommon.NewValueString(operationsAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationsAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1254,7 +1254,7 @@ func (m *metricMysqlPageOperations) recordDataPoint(start pcommon.Timestamp, ts 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.PageOperations, pcommon.NewValueString(pageOperationsAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(pageOperationsAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1307,7 +1307,7 @@ func (m *metricMysqlRowLocks) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.RowLocks, pcommon.NewValueString(rowLocksAttributeValue))
+	dp.Attributes().Insert("kind", pcommon.NewValueString(rowLocksAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1360,7 +1360,7 @@ func (m *metricMysqlRowOperations) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.RowOperations, pcommon.NewValueString(rowOperationsAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(rowOperationsAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1413,7 +1413,7 @@ func (m *metricMysqlSorts) recordDataPoint(start pcommon.Timestamp, ts pcommon.T
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Sorts, pcommon.NewValueString(sortsAttributeValue))
+	dp.Attributes().Insert("kind", pcommon.NewValueString(sortsAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1466,7 +1466,7 @@ func (m *metricMysqlThreads) recordDataPoint(start pcommon.Timestamp, ts pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Threads, pcommon.NewValueString(threadsAttributeValue))
+	dp.Attributes().Insert("kind", pcommon.NewValueString(threadsAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1785,53 +1785,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// BufferPoolData (The status of buffer pool data.)
-	BufferPoolData string
-	// BufferPoolOperations (The buffer pool operations types.)
-	BufferPoolOperations string
-	// BufferPoolPages (The buffer pool pages types.)
-	BufferPoolPages string
-	// Command (The command types.)
-	Command string
-	// DoubleWrites (The doublewrite types.)
-	DoubleWrites string
-	// Handler (The handler types.)
-	Handler string
-	// Locks (The table locks type.)
-	Locks string
-	// LogOperations (The log operation types.)
-	LogOperations string
-	// Operations (The operation types.)
-	Operations string
-	// PageOperations (The page operation types.)
-	PageOperations string
-	// RowLocks (The row lock type.)
-	RowLocks string
-	// RowOperations (The row operation type.)
-	RowOperations string
-	// Sorts (The sort count type.)
-	Sorts string
-	// Threads (The thread count type.)
-	Threads string
-}{
-	"status",
-	"operation",
-	"kind",
-	"command",
-	"kind",
-	"kind",
-	"kind",
-	"operation",
-	"operation",
-	"operation",
-	"kind",
-	"operation",
-	"kind",
-	"kind",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/nginxreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_metrics_v2.go
@@ -147,7 +147,7 @@ func (m *metricNginxConnectionsCurrent) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -389,14 +389,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// State (The state of a connection)
-	State string
-}{
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
@@ -186,7 +186,7 @@ func (m *metricPostgresqlBackends) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -239,9 +239,9 @@ func (m *metricPostgresqlBlocksRead) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
-	dp.Attributes().Insert(A.Table, pcommon.NewValueString(tableAttributeValue))
-	dp.Attributes().Insert(A.Source, pcommon.NewValueString(sourceAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("table", pcommon.NewValueString(tableAttributeValue))
+	dp.Attributes().Insert("source", pcommon.NewValueString(sourceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -294,7 +294,7 @@ func (m *metricPostgresqlCommits) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -347,7 +347,7 @@ func (m *metricPostgresqlDbSize) recordDataPoint(start pcommon.Timestamp, ts pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -400,9 +400,9 @@ func (m *metricPostgresqlOperations) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
-	dp.Attributes().Insert(A.Table, pcommon.NewValueString(tableAttributeValue))
-	dp.Attributes().Insert(A.Operation, pcommon.NewValueString(operationAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("table", pcommon.NewValueString(tableAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -455,7 +455,7 @@ func (m *metricPostgresqlRollbacks) recordDataPoint(start pcommon.Timestamp, ts 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -508,9 +508,9 @@ func (m *metricPostgresqlRows) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
-	dp.Attributes().Insert(A.Table, pcommon.NewValueString(tableAttributeValue))
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("table", pcommon.NewValueString(tableAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -674,26 +674,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Database (The name of the database.)
-	Database string
-	// Operation (The database operation.)
-	Operation string
-	// Source (The block read source type.)
-	Source string
-	// State (The tuple (row) state.)
-	State string
-	// Table (The schema name followed by the table name.)
-	Table string
-}{
-	"database",
-	"operation",
-	"source",
-	"state",
-	"table",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/rabbitmqreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/rabbitmqreceiver/internal/metadata/generated_metrics_v2.go
@@ -200,7 +200,7 @@ func (m *metricRabbitmqMessageCurrent) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.MessageState, pcommon.NewValueString(messageStateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(messageStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -530,14 +530,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// MessageState (The state of messages in a queue.)
-	MessageState string
-}{
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/redisreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics_v2.go
@@ -566,7 +566,7 @@ func (m *metricRedisCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -617,7 +617,7 @@ func (m *metricRedisDbAvgTTL) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Db, pcommon.NewValueString(dbAttributeValue))
+	dp.Attributes().Insert("db", pcommon.NewValueString(dbAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -668,7 +668,7 @@ func (m *metricRedisDbExpires) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Db, pcommon.NewValueString(dbAttributeValue))
+	dp.Attributes().Insert("db", pcommon.NewValueString(dbAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -719,7 +719,7 @@ func (m *metricRedisDbKeys) recordDataPoint(start pcommon.Timestamp, ts pcommon.
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Db, pcommon.NewValueString(dbAttributeValue))
+	dp.Attributes().Insert("db", pcommon.NewValueString(dbAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1910,17 +1910,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Db (Redis database identifier)
-	Db string
-	// State (Redis CPU usage state)
-	State string
-}{
-	"db",
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/riakreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/riakreceiver/internal/metadata/generated_metrics_v2.go
@@ -179,7 +179,7 @@ func (m *metricRiakNodeOperationCount) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Request, pcommon.NewValueString(requestAttributeValue))
+	dp.Attributes().Insert("request", pcommon.NewValueString(requestAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -230,7 +230,7 @@ func (m *metricRiakNodeOperationTimeMean) recordDataPoint(start pcommon.Timestam
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Request, pcommon.NewValueString(requestAttributeValue))
+	dp.Attributes().Insert("request", pcommon.NewValueString(requestAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -334,7 +334,7 @@ func (m *metricRiakVnodeIndexOperationCount) recordDataPoint(start pcommon.Times
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Operation, pcommon.NewValueString(operationAttributeValue))
+	dp.Attributes().Insert("operation", pcommon.NewValueString(operationAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -387,7 +387,7 @@ func (m *metricRiakVnodeOperationCount) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Request, pcommon.NewValueString(requestAttributeValue))
+	dp.Attributes().Insert("request", pcommon.NewValueString(requestAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -550,17 +550,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Operation (The operation type for index operations.)
-	Operation string
-	// Request (The request operation type.)
-	Request string
-}{
-	"operation",
-	"request",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/saphanareceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/saphanareceiver/internal/metadata/generated_metrics_v2.go
@@ -742,7 +742,7 @@ func (m *metricSaphanaAlertCount) recordDataPoint(start pcommon.Timestamp, ts pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.AlertRating, pcommon.NewValueString(alertRatingAttributeValue))
+	dp.Attributes().Insert("rating", pcommon.NewValueString(alertRatingAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -844,8 +844,8 @@ func (m *metricSaphanaColumnMemoryUsed) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ColumnMemoryType, pcommon.NewValueString(columnMemoryTypeAttributeValue))
-	dp.Attributes().Insert(A.ColumnMemorySubtype, pcommon.NewValueString(columnMemorySubtypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(columnMemoryTypeAttributeValue))
+	dp.Attributes().Insert("subtype", pcommon.NewValueString(columnMemorySubtypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -898,7 +898,7 @@ func (m *metricSaphanaComponentMemoryUsed) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Component, pcommon.NewValueString(componentAttributeValue))
+	dp.Attributes().Insert("component", pcommon.NewValueString(componentAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -951,7 +951,7 @@ func (m *metricSaphanaConnectionCount) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ConnectionStatus, pcommon.NewValueString(connectionStatusAttributeValue))
+	dp.Attributes().Insert("status", pcommon.NewValueString(connectionStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1004,7 +1004,7 @@ func (m *metricSaphanaCPUUsed) recordDataPoint(start pcommon.Timestamp, ts pcomm
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.CPUType, pcommon.NewValueString(cpuTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(cpuTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1057,9 +1057,9 @@ func (m *metricSaphanaDiskSizeCurrent) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Path, pcommon.NewValueString(pathAttributeValue))
-	dp.Attributes().Insert(A.DiskUsageType, pcommon.NewValueString(diskUsageTypeAttributeValue))
-	dp.Attributes().Insert(A.DiskStateUsedFree, pcommon.NewValueString(diskStateUsedFreeAttributeValue))
+	dp.Attributes().Insert("path", pcommon.NewValueString(pathAttributeValue))
+	dp.Attributes().Insert("usage_type", pcommon.NewValueString(diskUsageTypeAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(diskStateUsedFreeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1112,7 +1112,7 @@ func (m *metricSaphanaHostMemoryCurrent) recordDataPoint(start pcommon.Timestamp
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.MemoryStateUsedFree, pcommon.NewValueString(memoryStateUsedFreeAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(memoryStateUsedFreeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1165,7 +1165,7 @@ func (m *metricSaphanaHostSwapCurrent) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.HostSwapState, pcommon.NewValueString(hostSwapStateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(hostSwapStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1269,7 +1269,7 @@ func (m *metricSaphanaInstanceMemoryCurrent) recordDataPoint(start pcommon.Times
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.MemoryStateUsedFree, pcommon.NewValueString(memoryStateUsedFreeAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(memoryStateUsedFreeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1422,8 +1422,8 @@ func (m *metricSaphanaLicenseExpirationTime) recordDataPoint(start pcommon.Times
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.System, pcommon.NewValueString(systemAttributeValue))
-	dp.Attributes().Insert(A.Product, pcommon.NewValueString(productAttributeValue))
+	dp.Attributes().Insert("system", pcommon.NewValueString(systemAttributeValue))
+	dp.Attributes().Insert("product", pcommon.NewValueString(productAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1476,8 +1476,8 @@ func (m *metricSaphanaLicenseLimit) recordDataPoint(start pcommon.Timestamp, ts 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.System, pcommon.NewValueString(systemAttributeValue))
-	dp.Attributes().Insert(A.Product, pcommon.NewValueString(productAttributeValue))
+	dp.Attributes().Insert("system", pcommon.NewValueString(systemAttributeValue))
+	dp.Attributes().Insert("product", pcommon.NewValueString(productAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1530,8 +1530,8 @@ func (m *metricSaphanaLicensePeak) recordDataPoint(start pcommon.Timestamp, ts p
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.System, pcommon.NewValueString(systemAttributeValue))
-	dp.Attributes().Insert(A.Product, pcommon.NewValueString(productAttributeValue))
+	dp.Attributes().Insert("system", pcommon.NewValueString(systemAttributeValue))
+	dp.Attributes().Insert("product", pcommon.NewValueString(productAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1633,7 +1633,7 @@ func (m *metricSaphanaNetworkRequestCount) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ActivePendingRequestState, pcommon.NewValueString(activePendingRequestStateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(activePendingRequestStateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1686,7 +1686,7 @@ func (m *metricSaphanaNetworkRequestFinishedCount) recordDataPoint(start pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.InternalExternalRequestType, pcommon.NewValueString(internalExternalRequestTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(internalExternalRequestTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1737,10 +1737,10 @@ func (m *metricSaphanaReplicationAverageTime) recordDataPoint(start pcommon.Time
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.PrimaryHost, pcommon.NewValueString(primaryHostAttributeValue))
-	dp.Attributes().Insert(A.SecondaryHost, pcommon.NewValueString(secondaryHostAttributeValue))
-	dp.Attributes().Insert(A.Port, pcommon.NewValueString(portAttributeValue))
-	dp.Attributes().Insert(A.ReplicationMode, pcommon.NewValueString(replicationModeAttributeValue))
+	dp.Attributes().Insert("primary", pcommon.NewValueString(primaryHostAttributeValue))
+	dp.Attributes().Insert("secondary", pcommon.NewValueString(secondaryHostAttributeValue))
+	dp.Attributes().Insert("port", pcommon.NewValueString(portAttributeValue))
+	dp.Attributes().Insert("mode", pcommon.NewValueString(replicationModeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1793,10 +1793,10 @@ func (m *metricSaphanaReplicationBacklogSize) recordDataPoint(start pcommon.Time
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.PrimaryHost, pcommon.NewValueString(primaryHostAttributeValue))
-	dp.Attributes().Insert(A.SecondaryHost, pcommon.NewValueString(secondaryHostAttributeValue))
-	dp.Attributes().Insert(A.Port, pcommon.NewValueString(portAttributeValue))
-	dp.Attributes().Insert(A.ReplicationMode, pcommon.NewValueString(replicationModeAttributeValue))
+	dp.Attributes().Insert("primary", pcommon.NewValueString(primaryHostAttributeValue))
+	dp.Attributes().Insert("secondary", pcommon.NewValueString(secondaryHostAttributeValue))
+	dp.Attributes().Insert("port", pcommon.NewValueString(portAttributeValue))
+	dp.Attributes().Insert("mode", pcommon.NewValueString(replicationModeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1849,10 +1849,10 @@ func (m *metricSaphanaReplicationBacklogTime) recordDataPoint(start pcommon.Time
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.PrimaryHost, pcommon.NewValueString(primaryHostAttributeValue))
-	dp.Attributes().Insert(A.SecondaryHost, pcommon.NewValueString(secondaryHostAttributeValue))
-	dp.Attributes().Insert(A.Port, pcommon.NewValueString(portAttributeValue))
-	dp.Attributes().Insert(A.ReplicationMode, pcommon.NewValueString(replicationModeAttributeValue))
+	dp.Attributes().Insert("primary", pcommon.NewValueString(primaryHostAttributeValue))
+	dp.Attributes().Insert("secondary", pcommon.NewValueString(secondaryHostAttributeValue))
+	dp.Attributes().Insert("port", pcommon.NewValueString(portAttributeValue))
+	dp.Attributes().Insert("mode", pcommon.NewValueString(replicationModeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1905,7 +1905,7 @@ func (m *metricSaphanaRowStoreMemoryUsed) recordDataPoint(start pcommon.Timestam
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.RowMemoryType, pcommon.NewValueString(rowMemoryTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(rowMemoryTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1958,8 +1958,8 @@ func (m *metricSaphanaSchemaMemoryUsedCurrent) recordDataPoint(start pcommon.Tim
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Schema, pcommon.NewValueString(schemaAttributeValue))
-	dp.Attributes().Insert(A.SchemaMemoryType, pcommon.NewValueString(schemaMemoryTypeAttributeValue))
+	dp.Attributes().Insert("schema", pcommon.NewValueString(schemaAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(schemaMemoryTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2012,7 +2012,7 @@ func (m *metricSaphanaSchemaMemoryUsedMax) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Schema, pcommon.NewValueString(schemaAttributeValue))
+	dp.Attributes().Insert("schema", pcommon.NewValueString(schemaAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2065,8 +2065,8 @@ func (m *metricSaphanaSchemaOperationCount) recordDataPoint(start pcommon.Timest
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Schema, pcommon.NewValueString(schemaAttributeValue))
-	dp.Attributes().Insert(A.SchemaOperationType, pcommon.NewValueString(schemaOperationTypeAttributeValue))
+	dp.Attributes().Insert("schema", pcommon.NewValueString(schemaAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(schemaOperationTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2119,7 +2119,7 @@ func (m *metricSaphanaSchemaRecordCompressedCount) recordDataPoint(start pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Schema, pcommon.NewValueString(schemaAttributeValue))
+	dp.Attributes().Insert("schema", pcommon.NewValueString(schemaAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2172,8 +2172,8 @@ func (m *metricSaphanaSchemaRecordCount) recordDataPoint(start pcommon.Timestamp
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Schema, pcommon.NewValueString(schemaAttributeValue))
-	dp.Attributes().Insert(A.SchemaRecordType, pcommon.NewValueString(schemaRecordTypeAttributeValue))
+	dp.Attributes().Insert("schema", pcommon.NewValueString(schemaAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(schemaRecordTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2226,7 +2226,7 @@ func (m *metricSaphanaServiceCodeSize) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Service, pcommon.NewValueString(serviceAttributeValue))
+	dp.Attributes().Insert("service", pcommon.NewValueString(serviceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2279,7 +2279,7 @@ func (m *metricSaphanaServiceCount) recordDataPoint(start pcommon.Timestamp, ts 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ServiceStatus, pcommon.NewValueString(serviceStatusAttributeValue))
+	dp.Attributes().Insert("status", pcommon.NewValueString(serviceStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2332,7 +2332,7 @@ func (m *metricSaphanaServiceMemoryCompactorsAllocated) recordDataPoint(start pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Service, pcommon.NewValueString(serviceAttributeValue))
+	dp.Attributes().Insert("service", pcommon.NewValueString(serviceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2385,7 +2385,7 @@ func (m *metricSaphanaServiceMemoryCompactorsFreeable) recordDataPoint(start pco
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Service, pcommon.NewValueString(serviceAttributeValue))
+	dp.Attributes().Insert("service", pcommon.NewValueString(serviceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2438,7 +2438,7 @@ func (m *metricSaphanaServiceMemoryEffectiveLimit) recordDataPoint(start pcommon
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Service, pcommon.NewValueString(serviceAttributeValue))
+	dp.Attributes().Insert("service", pcommon.NewValueString(serviceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2491,8 +2491,8 @@ func (m *metricSaphanaServiceMemoryHeapCurrent) recordDataPoint(start pcommon.Ti
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Service, pcommon.NewValueString(serviceAttributeValue))
-	dp.Attributes().Insert(A.MemoryStateUsedFree, pcommon.NewValueString(memoryStateUsedFreeAttributeValue))
+	dp.Attributes().Insert("service", pcommon.NewValueString(serviceAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(memoryStateUsedFreeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2545,7 +2545,7 @@ func (m *metricSaphanaServiceMemoryLimit) recordDataPoint(start pcommon.Timestam
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Service, pcommon.NewValueString(serviceAttributeValue))
+	dp.Attributes().Insert("service", pcommon.NewValueString(serviceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2598,8 +2598,8 @@ func (m *metricSaphanaServiceMemorySharedCurrent) recordDataPoint(start pcommon.
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Service, pcommon.NewValueString(serviceAttributeValue))
-	dp.Attributes().Insert(A.MemoryStateUsedFree, pcommon.NewValueString(memoryStateUsedFreeAttributeValue))
+	dp.Attributes().Insert("service", pcommon.NewValueString(serviceAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(memoryStateUsedFreeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2652,8 +2652,8 @@ func (m *metricSaphanaServiceMemoryUsed) recordDataPoint(start pcommon.Timestamp
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Service, pcommon.NewValueString(serviceAttributeValue))
-	dp.Attributes().Insert(A.ServiceMemoryUsedType, pcommon.NewValueString(serviceMemoryUsedTypeAttributeValue))
+	dp.Attributes().Insert("service", pcommon.NewValueString(serviceAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(serviceMemoryUsedTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2706,7 +2706,7 @@ func (m *metricSaphanaServiceStackSize) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Service, pcommon.NewValueString(serviceAttributeValue))
+	dp.Attributes().Insert("service", pcommon.NewValueString(serviceAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2759,7 +2759,7 @@ func (m *metricSaphanaServiceThreadCount) recordDataPoint(start pcommon.Timestam
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.ThreadStatus, pcommon.NewValueString(threadStatusAttributeValue))
+	dp.Attributes().Insert("status", pcommon.NewValueString(threadStatusAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2863,7 +2863,7 @@ func (m *metricSaphanaTransactionCount) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.TransactionType, pcommon.NewValueString(transactionTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(transactionTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2916,8 +2916,8 @@ func (m *metricSaphanaUptime) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.System, pcommon.NewValueString(systemAttributeValue))
-	dp.Attributes().Insert(A.Database, pcommon.NewValueString(databaseAttributeValue))
+	dp.Attributes().Insert("system", pcommon.NewValueString(systemAttributeValue))
+	dp.Attributes().Insert("database", pcommon.NewValueString(databaseAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2970,9 +2970,9 @@ func (m *metricSaphanaVolumeOperationCount) recordDataPoint(start pcommon.Timest
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Path, pcommon.NewValueString(pathAttributeValue))
-	dp.Attributes().Insert(A.DiskUsageType, pcommon.NewValueString(diskUsageTypeAttributeValue))
-	dp.Attributes().Insert(A.VolumeOperationType, pcommon.NewValueString(volumeOperationTypeAttributeValue))
+	dp.Attributes().Insert("path", pcommon.NewValueString(pathAttributeValue))
+	dp.Attributes().Insert("usage_type", pcommon.NewValueString(diskUsageTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(volumeOperationTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3025,9 +3025,9 @@ func (m *metricSaphanaVolumeOperationSize) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Path, pcommon.NewValueString(pathAttributeValue))
-	dp.Attributes().Insert(A.DiskUsageType, pcommon.NewValueString(diskUsageTypeAttributeValue))
-	dp.Attributes().Insert(A.VolumeOperationType, pcommon.NewValueString(volumeOperationTypeAttributeValue))
+	dp.Attributes().Insert("path", pcommon.NewValueString(pathAttributeValue))
+	dp.Attributes().Insert("usage_type", pcommon.NewValueString(diskUsageTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(volumeOperationTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3080,9 +3080,9 @@ func (m *metricSaphanaVolumeOperationTime) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Path, pcommon.NewValueString(pathAttributeValue))
-	dp.Attributes().Insert(A.DiskUsageType, pcommon.NewValueString(diskUsageTypeAttributeValue))
-	dp.Attributes().Insert(A.VolumeOperationType, pcommon.NewValueString(volumeOperationTypeAttributeValue))
+	dp.Attributes().Insert("path", pcommon.NewValueString(pathAttributeValue))
+	dp.Attributes().Insert("usage_type", pcommon.NewValueString(diskUsageTypeAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(volumeOperationTypeAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -3789,104 +3789,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// ActivePendingRequestState (The state of network request.)
-	ActivePendingRequestState string
-	// AlertRating (The alert rating.)
-	AlertRating string
-	// ColumnMemorySubtype (The subtype of column store memory.)
-	ColumnMemorySubtype string
-	// ColumnMemoryType (The type of column store memory.)
-	ColumnMemoryType string
-	// Component (The SAP HANA component.)
-	Component string
-	// ConnectionStatus (The connection status.)
-	ConnectionStatus string
-	// CPUType (The type of cpu.)
-	CPUType string
-	// Database (The SAP HANA database.)
-	Database string
-	// DiskStateUsedFree (The state of the disk storage.)
-	DiskStateUsedFree string
-	// DiskUsageType (The SAP HANA disk & volume usage type.)
-	DiskUsageType string
-	// HostSwapState (The state of swap data.)
-	HostSwapState string
-	// InternalExternalRequestType (The type of network request.)
-	InternalExternalRequestType string
-	// MemoryStateUsedFree (The state of memory.)
-	MemoryStateUsedFree string
-	// Path (The SAP HANA disk path.)
-	Path string
-	// Port (The SAP HANA port.)
-	Port string
-	// PrimaryHost (The primary SAP HANA host in replication.)
-	PrimaryHost string
-	// Product (The SAP HANA product.)
-	Product string
-	// ReplicationMode (The replication mode.)
-	ReplicationMode string
-	// RowMemoryType (The type of row store memory.)
-	RowMemoryType string
-	// Schema (The SAP HANA schema.)
-	Schema string
-	// SchemaMemoryType (The type of schema memory.)
-	SchemaMemoryType string
-	// SchemaOperationType (The type of operation.)
-	SchemaOperationType string
-	// SchemaRecordType (The type of schema record.)
-	SchemaRecordType string
-	// SecondaryHost (The secondary SAP HANA host in replication.)
-	SecondaryHost string
-	// Service (The SAP HANA service.)
-	Service string
-	// ServiceMemoryUsedType (The type of service memory.)
-	ServiceMemoryUsedType string
-	// ServiceStatus (The status of services.)
-	ServiceStatus string
-	// System (The SAP HANA system.)
-	System string
-	// ThreadStatus (The status of threads.)
-	ThreadStatus string
-	// TransactionType (The transaction type.)
-	TransactionType string
-	// VolumeOperationType (The type of operation.)
-	VolumeOperationType string
-}{
-	"state",
-	"rating",
-	"subtype",
-	"type",
-	"component",
-	"status",
-	"type",
-	"database",
-	"state",
-	"usage_type",
-	"state",
-	"type",
-	"state",
-	"path",
-	"port",
-	"primary",
-	"product",
-	"mode",
-	"type",
-	"schema",
-	"type",
-	"type",
-	"type",
-	"secondary",
-	"service",
-	"type",
-	"status",
-	"system",
-	"status",
-	"type",
-	"type",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_v2.go
@@ -593,7 +593,7 @@ func (m *metricSqlserverPageOperationRate) recordDataPoint(start pcommon.Timesta
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleVal(val)
-	dp.Attributes().Insert(A.PageOperations, pcommon.NewValueString(pageOperationsAttributeValue))
+	dp.Attributes().Insert("type", pcommon.NewValueString(pageOperationsAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1362,14 +1362,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// PageOperations (The page operation types.)
-	PageOperations string
-}{
-	"type",
-}
-
-// A is an alias for Attributes.
-var A = Attributes

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
@@ -413,7 +413,7 @@ func (m *metricZookeeperFollowerCount) recordDataPoint(start pcommon.Timestamp, 
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.State, pcommon.NewValueString(stateAttributeValue))
+	dp.Attributes().Insert("state", pcommon.NewValueString(stateAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -664,7 +664,7 @@ func (m *metricZookeeperPacketCount) recordDataPoint(start pcommon.Timestamp, ts
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert(A.Direction, pcommon.NewValueString(directionAttributeValue))
+	dp.Attributes().Insert("direction", pcommon.NewValueString(directionAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1110,17 +1110,3 @@ func (mb *MetricsBuilder) Reset(options ...metricBuilderOption) {
 		op(mb)
 	}
 }
-
-// Attributes contains the possible metric attributes that can be used.
-var Attributes = struct {
-	// Direction (State of a packet based on io direction.)
-	Direction string
-	// State (State of followers)
-	State string
-}{
-	"direction",
-	"state",
-}
-
-// A is an alias for Attributes.
-var A = Attributes


### PR DESCRIPTION
The struct is not needed anymore after Resource attributes option was introduced and enum attribute values are moved to typed constants

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8842