### PR TITLE
[exporter/tanzuoservability] Update code to use latest core API

### DIFF
--- a/exporter/tanzuobservabilityexporter/metrics.go
+++ b/exporter/tanzuobservabilityexporter/metrics.go
@@ -472,8 +472,8 @@ func (c *cumulativeHistogramDataPointConsumer) Consume(
 	name := mi.Name()
 	tags := attributesToTagsForMetrics(histogram.Attributes(), mi.SourceKey)
 	ts := histogram.Timestamp().AsTime().Unix()
-	explicitBounds := histogram.ExplicitBounds()
-	bucketCounts := histogram.BucketCounts()
+	explicitBounds := histogram.MExplicitBounds()
+	bucketCounts := histogram.MBucketCounts()
 	if len(bucketCounts) != len(explicitBounds)+1 {
 		reporting.LogMalformed(mi.Metric)
 		return
@@ -518,8 +518,8 @@ func (d *deltaHistogramDataPointConsumer) Consume(
 	name := mi.Name()
 	tags := attributesToTagsForMetrics(his.Attributes(), mi.SourceKey)
 	ts := his.Timestamp().AsTime().Unix()
-	explicitBounds := his.ExplicitBounds()
-	bucketCounts := his.BucketCounts()
+	explicitBounds := his.MExplicitBounds()
+	bucketCounts := his.MBucketCounts()
 	if len(bucketCounts) != len(explicitBounds)+1 {
 		reporting.LogMalformed(mi.Metric)
 		return
@@ -553,8 +553,8 @@ func centroidValue(explicitBounds []float64, index int) float64 {
 // histogramDataPoint represents either a regular or exponential histogram data point
 type histogramDataPoint interface {
 	Count() uint64
-	ExplicitBounds() []float64
-	BucketCounts() []uint64
+	MExplicitBounds() []float64
+	MBucketCounts() []uint64
 	Attributes() pcommon.Map
 	Timestamp() pcommon.Timestamp
 }
@@ -801,11 +801,11 @@ func appendPositiveBucketsAndExplicitBounds(
 	*bucketCounts = append(*bucketCounts, 0)
 }
 
-func (e *exponentialHistogramDataPoint) ExplicitBounds() []float64 {
+func (e *exponentialHistogramDataPoint) MExplicitBounds() []float64 {
 	return e.explicitBounds
 }
 
-func (e *exponentialHistogramDataPoint) BucketCounts() []uint64 {
+func (e *exponentialHistogramDataPoint) MBucketCounts() []uint64 {
 	return e.bucketCounts
 }
 

--- a/exporter/tanzuobservabilityexporter/metrics_test.go
+++ b/exporter/tanzuobservabilityexporter/metrics_test.go
@@ -1102,11 +1102,11 @@ func TestExponentialHistogramDataPoint(t *testing.T) {
 	dataPoint.Attributes().UpsertString("baz", "7")
 	setDataPointTimestamp(1640198765, dataPoint)
 	h := newExponentialHistogramDataPoint(dataPoint)
-	assert.Equal(t, []uint64{0, 17, 16, 15, 2, 5, 6, 7, 8, 0}, h.BucketCounts())
+	assert.Equal(t, []uint64{0, 17, 16, 15, 2, 5, 6, 7, 8, 0}, h.MBucketCounts())
 	assert.InDeltaSlice(
 		t,
 		[]float64{-22.6274, -16.0, -11.3137, -8.0, 2.8284, 4.0, 5.6569, 8.0, 11.3137},
-		h.ExplicitBounds(),
+		h.MExplicitBounds(),
 		0.0001)
 	assert.Equal(t, map[string]string{"foo": "bar", "baz": "7"}, attributesToTags(h.Attributes()))
 	assert.Equal(t, int64(1640198765), h.Timestamp().AsTime().Unix())
@@ -1119,8 +1119,8 @@ func TestExponentialHistogramDataPoint_ZeroOnly(t *testing.T) {
 	dataPoint.Positive().SetOffset(1)
 	dataPoint.SetZeroCount(5)
 	h := newExponentialHistogramDataPoint(dataPoint)
-	assert.Equal(t, []uint64{0, 5, 0}, h.BucketCounts())
-	assert.InDeltaSlice(t, []float64{-4.0, 2.0}, h.ExplicitBounds(), 0.0001)
+	assert.Equal(t, []uint64{0, 5, 0}, h.MBucketCounts())
+	assert.InDeltaSlice(t, []float64{-4.0, 2.0}, h.MExplicitBounds(), 0.0001)
 }
 
 func TestAttributesToTagsForMetrics(t *testing.T) {


### PR DESCRIPTION
Replace deprecated HistogramDataPoint methods.