### PR TITLE
[receiver/filelogreceiver] Fix testdata parse_from and test

### DIFF
--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -276,11 +276,11 @@ func testdataConfigYamlAsMap() *FileLogConfig {
 					"type":  "regex_parser",
 					"regex": "^(?P<time>\\d{4}-\\d{2}-\\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$",
 					"severity": map[string]interface{}{
-						"parse_from": "body.sev",
+						"parse_from": "attributes.sev",
 					},
 					"timestamp": map[string]interface{}{
 						"layout":     "%Y-%m-%d",
-						"parse_from": "body.time",
+						"parse_from": "attributes.time",
 					},
 				},
 			},

--- a/receiver/filelogreceiver/testdata/config.yaml
+++ b/receiver/filelogreceiver/testdata/config.yaml
@@ -6,10 +6,10 @@ receivers:
       - type: regex_parser
         regex: '^(?P<time>\d{4}-\d{2}-\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$'
         timestamp:
-          parse_from: body.time
+          parse_from: attributes.time 
           layout: '%Y-%m-%d'
         severity:
-          parse_from: body.sev
+          parse_from: attributes.sev
     converter:
       max_flush_count: 100
       flush_interval: 100ms


### PR DESCRIPTION
**Description:** 

When running the actual `config.yaml` example got errors below. Fixed the references in `config.yaml` to accommodate recent changes. 

**Was:**
...
```
2022-05-12T00:44:51.347Z        error   helper/transformer.go:110       Failed to process entry {"kind": "receiver", "name": "filelog", "operator_id": "regex_parser", "operator_type": "regex_parser", "error": {"description": "time parser: log entry does not have the expected parse_from field", "suggestion": "ensure that all entries forwarded to this parser contain the parse_fro\
m field", "details": {"parse_from": "body.time"}}, "action": "send", "entry": {"observed_timestamp":"2022-05-12T00:44:51.347132293Z","timestamp":"0001-01-01T00:00:00Z","body":"2020-08-25 INFO Something routine","attributes":{"log.file.name":"simple.log","msg":"Something routine","sev":"INFO","time":"2020-08-25"},"severity":0,"scope_name":""}}
```
...
...and...

```
          "logRecords": [
            {
              "observedTimeUnixNano": "1652316291347132293",
              "body": {
                "stringValue": "2020-08-25 INFO Something routine"
              },
```
...

**Now:** no errors and fields are parsed correctly with tests passing.
...
```
          "logRecords": [
            {
              "timeUnixNano": "1598313600000000000",
              "observedTimeUnixNano": "1652316379391504515",
              "severityNumber": "SEVERITY_NUMBER_INFO",
              "severityText": "Info",
              "body": {
                "stringValue": "2020-08-25 INFO Something routine"
              },
```
...

**Tests:**

```
../filelogreceiver$ go test
PASS
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver      0.611s
```
