### PR TITLE
Fix changelog entry for version 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🧰 Bug fixes 🧰
 
-## v0.50.0
+## v0.51.0
 
 ### 🛑 Breaking changes 🛑
 


### PR DESCRIPTION
I was fixing my changelog entry post-merge on another PR, noticed that the changelog entry wasn't correct for the recent release.