### PR TITLE
[receiver/filelog] nit: reduce logger.Print call

### DIFF
--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -207,7 +207,7 @@ func (rt *rotationTest) Run(t *testing.T) {
 		require.NoError(t, converter.Batch([]*entry.Entry{e}))
 
 		// ... and write the logs lines to the actual file consumed by receiver.
-		logger.Print(fmt.Sprintf("2020-08-25 %s", msg))
+		logger.Printf("2020-08-25 %s", msg)
 		time.Sleep(time.Millisecond)
 	}
 


### PR DESCRIPTION
Caught by new version of golangci-lint in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9993