### PR TITLE
Simplify for all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ $(GOMODULES):
 	@echo "Running target '$(TARGET)' in module '$@'"
 	$(MAKE) -C $@ $(TARGET)
 
-# Define a target that requires each module's delegation target
+# Triggers each module's delegation target
 .PHONY: for-all-target
 for-all-target: $(GOMODULES)
 

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,7 @@ $(GOMODULES):
 .PHONY: for-all-target
 for-all-target: $(GOMODULES)
 
+# Debugging target, which helps to quickly determine whether for-all-target is working or not.
 .PHONY: all-pwd
 all-pwd:
 	$(MAKE) for-all-target TARGET="pwd"

--- a/Makefile
+++ b/Makefile
@@ -159,13 +159,22 @@ gendependabot:
 		echo "      interval: \"weekly\"" >> ${DEPENDABOT_PATH}; \
 	done
 
+# Append root module to all modules
 GOMODULES = $(ALL_MODULES) $(PWD)
+
+# Define a delegation target for each module
 .PHONY: $(GOMODULES)
-MODULEDIRS = $(GOMODULES:%=for-all-target-%)
-for-all-target: $(MODULEDIRS)
-$(MODULEDIRS):
-	$(MAKE) -C $(@:for-all-target-%=%) $(TARGET)
+$(GOMODULES):
+	@echo "Running target '$(TARGET)' in module '$@'"
+	$(MAKE) -C $@ $(TARGET)
+
+# Define a target that requires each module's delegation target
 .PHONY: for-all-target
+for-all-target: $(GOMODULES)
+
+.PHONY: all-pwd
+all-pwd:
+	$(MAKE) for-all-target TARGET="pwd"
 
 TOOLS_MOD_DIR := ./internal/tools
 .PHONY: install-tools

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -33,6 +33,9 @@ ALL_SRC_AND_DOC := $(shell find $(ALL_PKG_DIRS) -name "*.md" -o -name "*.go" -o 
 # ALL_PKGS is used with 'go cover'
 ALL_PKGS := $(shell $(GOCMD) list $(sort $(dir $(ALL_SRC))))
 
+pwd:
+	@pwd
+
 all-pkgs:
 	@echo $(ALL_PKGS) | tr ' ' '\n' | sort
 


### PR DESCRIPTION
This is a small step towards speeding up CI. A proof of concept was demonstrated in #9127, but it is necessary to rework the way `for-all-target` runs. Having now gained a better understanding of that target, I've simplified it and captured the meaning of each step in comments. This also adds a debugging target, `all-pwd`, which helps to quickly test whether `for-all-target` is working or not.