### PR TITLE
[processor/resourcedetection]: add "cname" and "lookup" hostname sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `transformprocessor`: Add new `limit` function to allow limiting the number of items in a map, such as the number of attributes in `attributes` or `resource.attributes` (#9552)
 - `processor/attributes`: Support attributes set by server authenticator (#9420)
 - `datadogexporter`: Experimental support for Exponential Histograms with delta aggregation temporality (#8350)
+- `resourcedetectionprocessor`: Add "cname" and "lookup" hostname sources
 
 ### 🧰 Bug fixes 🧰
 

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -26,6 +26,8 @@ processors:
 
 ### System metadata
 
+Note: use the Docker detector (see below) if running the Collector as a Docker container.
+
 Queries the host machine to retrieve the following resource attributes:
 
     * host.name
@@ -47,8 +49,30 @@ processors:
 * all valid options for `hostname_sources`:
     * "dns"
     * "os"
+    * "cname"
+    * "lookup"
 
-Note: use the Docker detector (see below) if running the Collector as a Docker container.
+#### Hostname Sources
+
+##### dns
+
+The "dns" hostname source uses multiple sources to get the fully qualified domain name. First, it looks up the
+host name in the local machine's `hosts` file. If that fails, it looks up the CNAME. Lastly, if that fails,
+it does a reverse DNS query. Note: this hostname source may produce unreliable results on Windows. To produce
+a FQDN, Windows hosts might have better results using the "lookup" hostname source, which is mentioned below.
+
+##### os
+
+The "os" hostname source provides the hostname provided by the local machine's kernel.
+
+##### cname
+
+The "cname" hostname source provides the canonical name, as provided by net.LookupCNAME in the Go standard library.
+Note: this hostname source may produce unreliable results on Windows.
+
+##### lookup
+
+The "lookup" hostname source does a reverse DNS lookup of the current host's IP address.
 
 ### Docker metadata
 

--- a/processor/resourcedetectionprocessor/internal/system/metadata_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/metadata_test.go
@@ -75,7 +75,7 @@ func fakeLinuxNameInfoProvider() nameInfoProvider {
 			return []string{"172.24.0.4"}, nil
 		},
 		lookupAddr: func(s string) ([]string, error) {
-			return []string{"my-linux-vm.internal.cloudapp.net."}, nil
+			return []string{"my-linux-vm.internal.foo.net."}, nil
 		},
 	}
 }

--- a/processor/resourcedetectionprocessor/internal/system/metadata_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/metadata_test.go
@@ -41,7 +41,7 @@ func TestReverseLookupHost_Linux(t *testing.T) {
 	p := fakeLinuxSystemMetadataProvider()
 	fqdn, err := p.ReverseLookupHost()
 	require.NoError(t, err)
-	assert.Equal(t, "my-linux-vm.internal.cloudapp.net", fqdn)
+	assert.Equal(t, "my-linux-vm.internal.foo.net", fqdn)
 }
 
 func TestReverseLookupHost_Windows(t *testing.T) {

--- a/processor/resourcedetectionprocessor/internal/system/metadata_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/metadata_test.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package system
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupCNAME_Linux(t *testing.T) {
+	p := fakeLinuxSystemMetadataProvider()
+	cname, err := p.LookupCNAME()
+	require.NoError(t, err)
+	assert.Equal(t, "my-linux-vm.abcdefghijklmnopqrstuvwxyz.xx.internal.foo.net", cname)
+}
+
+func TestLookupCNAME_Windows(t *testing.T) {
+	p := fakeWindowsSystemMetadataProvider()
+	cname, err := p.LookupCNAME()
+	require.NoError(t, err)
+	assert.Equal(t, "my-windows-vm.abcdefghijklmnopqrstuvwxyz.xx.internal.foo.net", cname)
+}
+
+func TestReverseLookupHost_Linux(t *testing.T) {
+	p := fakeLinuxSystemMetadataProvider()
+	fqdn, err := p.ReverseLookupHost()
+	require.NoError(t, err)
+	assert.Equal(t, "my-linux-vm.internal.cloudapp.net", fqdn)
+}
+
+func TestReverseLookupHost_Windows(t *testing.T) {
+	p := fakeWindowsSystemMetadataProvider()
+	fqdn, err := p.ReverseLookupHost()
+	require.NoError(t, err)
+	assert.Equal(t, "my-windows-vm.abcdefghijklmnopqrstuvwxyz.xx.internal.foo.net", fqdn)
+}
+
+func fakeLinuxSystemMetadataProvider() *systemMetadataProvider {
+	return &systemMetadataProvider{
+		nameInfoProvider: fakeLinuxNameInfoProvider(),
+	}
+}
+
+func fakeWindowsSystemMetadataProvider() *systemMetadataProvider {
+	return &systemMetadataProvider{
+		nameInfoProvider: fakeWindowsNameInfoProvider(),
+	}
+}
+
+func fakeLinuxNameInfoProvider() nameInfoProvider {
+	return nameInfoProvider{
+		osHostname: func() (string, error) {
+			return "my-linux-vm", nil
+		},
+		lookupCNAME: func(s string) (string, error) {
+			return "my-linux-vm.abcdefghijklmnopqrstuvwxyz.xx.internal.foo.net.", nil
+		},
+		lookupHost: func(s string) ([]string, error) {
+			return []string{"172.24.0.4"}, nil
+		},
+		lookupAddr: func(s string) ([]string, error) {
+			return []string{"my-linux-vm.internal.cloudapp.net."}, nil
+		},
+	}
+}
+
+func fakeWindowsNameInfoProvider() nameInfoProvider {
+	fqdn := "my-windows-vm.abcdefghijklmnopqrstuvwxyz.xx.internal.foo.net."
+	return nameInfoProvider{
+		osHostname: func() (string, error) {
+			return "my-windows-vm", nil
+		},
+		lookupCNAME: func(s string) (string, error) {
+			return fqdn, nil
+		},
+		lookupHost: func(s string) ([]string, error) {
+			return []string{"ffff::0000:1111:2222:3333%Ethernet", "1.2.3.4"}, nil
+		},
+		lookupAddr: func(s string) ([]string, error) {
+			if strings.HasSuffix(s, "%Ethernet") {
+				return nil, fmt.Errorf("lookup %s: unrecognized address", s)
+			}
+			return []string{fqdn}, nil
+		},
+	}
+}

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -43,7 +43,7 @@ var _ internal.Detector = (*Detector)(nil)
 
 // Detector is a system metadata detector
 type Detector struct {
-	provider        systemMetadata
+	provider        metadataProvider
 	logger          *zap.Logger
 	hostnameSources []string
 }
@@ -55,7 +55,7 @@ func NewDetector(p component.ProcessorCreateSettings, dcfg internal.DetectorConf
 		cfg.HostnameSources = []string{"dns", "os"}
 	}
 
-	return &Detector{provider: &systemMetadataImpl{}, logger: p.Logger, hostnameSources: cfg.HostnameSources}, nil
+	return &Detector{provider: newSystemMetadataProvider(), logger: p.Logger, hostnameSources: cfg.HostnameSources}, nil
 }
 
 // Detect detects system metadata and returns a resource with the available ones

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -48,6 +48,16 @@ func (m *mockMetadata) OSType() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
+func (m *mockMetadata) LookupCNAME() (string, error) {
+	args := m.MethodCalled("LookupCNAME")
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockMetadata) ReverseLookupHost() (string, error) {
+	args := m.MethodCalled("ReverseLookupHost")
+	return args.String(0), args.Error(1)
+}
+
 func TestNewDetector(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
[processor/resourcedetection]: add "cname" and "lookup" hostname sources

The existing "dns" hostname source uses the Showmax/go-fqdn library, whose `FqdnHostname()`
function tries to get the fully qualified domain name of the current host by
1) Reading the hosts file and looking for a match of the `os.Hostname` and a corresponding fqdn
on that line. If that fails, then it falls back to:
2) Getting the canonical name via `net.LookupCNAME`. If that fails, then it falls back to:
3) Getting the current IP address, and doing a reverse DNS lookup of that address

A problem that least one Collector user encountered while running on Windows in Azure,
is that the call to `net.LookupCNAME` just returns the simple hostname, which
then gets returned by `FqdnHostname()`, even though on a Linux host, deployed in the same
environment, `net.LookupCNAME` returns a fully qualified domain name.

Instead of trying to work around what might be an issue with `net.LookupCNAME` by modifying
the Showmax/go-fqdn code, which has hard-coded fallback logic, and changing behavior for
existing users, this change proposes creating two new hostname sources, "cname", and "lookup".
The "cname" source corresponds to a call to `net.LookupCNAME`, and the "lookup" source corresponds
to a call to `net.LookupHost` and then a call to `net.LookupAddr` for each ip address it returns.
The "lookup" source produces the same result on Windows as `net.LookupCNAME` does on Linux and would
solve the problem of the Azure user in question. In addition, users can then build the fallback logic that they prefer.
Eventually, we could also add a "hostfile" hostname source that uses the same logic as the
corresponding part of the Showmax/"dns" implementation, so that users could replace the "dns"
hostname source with the equivalent three sources, explicitly indicating the fallback logic rather
than using Showmax's hard-coded logic:

```
processors:
  resourcedetection:
    detectors: ["system"]
    system:
      hostname_sources: ["hostsfile", "cname", "lookup"]
```

At that point, we could deprecate the "dns" source or make it effectively an alias for ["hostsfile",
"cname", "lookup"] and remove the dependency.

For now, the customer that would benefit from this change, however, will just use the "lookup" source on
their Windows hosts, as "cname" on Windows doesn't produce a useful result.