### PR TITLE
[processor/cumulativetodelta] Fix flaky Test_metricTracker_sweeper test

### DIFF
--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
@@ -251,7 +251,8 @@ func Test_metricTracker_sweeper(t *testing.T) {
 		}
 	}
 	cancel()
-	<-sweepEvent
+	for range sweepEvent {
+	}
 	if !closed.Load() {
 		t.Errorf("Sweeper did not terminate.")
 	}


### PR DESCRIPTION
**Description:** 
This PR fixes a race condition in the processor's `Test_metricTracker_sweeper` test.  I believe the issue is that in `sweeper`, there is a race condition between `<-ticker.C` and `<-ctx.Done()`.  When `cancel` is called, if `ticker.C` was able to be received one more time then `<-ctx.Done()` has to wait.  After cancel is called, the main thread blocks using `<-sweepEvent` expecting a closure of `sweepEvent` to unblock, but instead `onSweep` is called and sends an event to the channel, causing the main thread's `<-sweepEvent` to unblock and the test to check for `!closed.Load()`, which hasn't had a chance to be set to False yet.

```golang
func (t *MetricTracker) sweeper(ctx context.Context, remove func(pcommon.Timestamp)) {
	ticker := time.NewTicker(t.maxStaleness)
	for {
		select {
		case currentTime := <-ticker.C:
			staleBefore := pcommon.NewTimestampFromTime(currentTime.Add(-t.maxStaleness))
			remove(staleBefore)
		case <-ctx.Done():
			ticker.Stop()
			return
		}
	}
}

func Test_metricTracker_sweeper(t *testing.T) {
	ctx, cancel := context.WithCancel(context.Background())
	sweepEvent := make(chan pcommon.Timestamp)
	closed := atomic.NewBool(false)

	onSweep := func(staleBefore pcommon.Timestamp) {
		sweepEvent <- staleBefore
	}

	...

	go func() {
		tr.sweeper(ctx, onSweep)
		closed.Store(true)
		close(sweepEvent)
	}()

        ...

	cancel()
	<-sweepEvent // this will unblock if the channel is sent to or closed.
	if !closed.Load() {
		t.Errorf("Sweeper did not terminate.")
	}
}
```

The PR updates the block to truly block until the channel is closed.

**Link to tracking Issue:**
#9816 

**Testing:**
Was able to reproduce the issue locally before if I forced strange timing, but not with my change.