### PR TITLE
[receiver/kubeletstats] Do not use multiple metrics builders

### DIFF
--- a/receiver/kubeletstatsreceiver/internal/kubelet/accumulator_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/accumulator_test.go
@@ -212,11 +212,7 @@ func TestMetadataErrorCases(t *testing.T) {
 				metadata:              tt.metadata,
 				logger:                logger,
 				metricGroupsToCollect: tt.metricGroupsToCollect,
-				mbs: &metadata.MetricsBuilders{
-					NodeMetricsBuilder:  metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings()),
-					PodMetricsBuilder:   metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings()),
-					OtherMetricsBuilder: metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings()),
-				},
+				mb:                    metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings()),
 			}
 
 			tt.testScenario(acc)
@@ -238,12 +234,7 @@ func TestNilHandling(t *testing.T) {
 			ContainerMetricGroup: true,
 			VolumeMetricGroup:    true,
 		},
-		mbs: &metadata.MetricsBuilders{
-			NodeMetricsBuilder:      metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings()),
-			PodMetricsBuilder:       metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings()),
-			ContainerMetricsBuilder: metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings()),
-			OtherMetricsBuilder:     metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings()),
-		},
+		mb: metadata.NewMetricsBuilder(metadata.DefaultMetricsSettings()),
 	}
 	assert.NotPanics(t, func() {
 		acc.nodeStats(stats.NodeStats{})

--- a/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go
@@ -21,15 +21,15 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/internal/metadata"
 )
 
-func addCPUMetrics(mb *metadata.MetricsBuilder, cpuMetrics metadata.CPUMetrics, s *stats.CPUStats, currentTime pcommon.Timestamp) {
+func recordCPUMetrics(mb *metadata.MetricsBuilder, cpuMetrics metadata.CPUMetrics, s *stats.CPUStats, currentTime pcommon.Timestamp) {
 	if s == nil {
 		return
 	}
-	addCPUUsageMetric(mb, cpuMetrics.Utilization, s, currentTime)
-	addCPUTimeMetric(mb, cpuMetrics.Time, s, currentTime)
+	recordCPUUsageMetric(mb, cpuMetrics.Utilization, s, currentTime)
+	recordCPUTimeMetric(mb, cpuMetrics.Time, s, currentTime)
 }
 
-func addCPUUsageMetric(mb *metadata.MetricsBuilder, recordDataPoint metadata.RecordDoubleDataPointFunc, s *stats.CPUStats, currentTime pcommon.Timestamp) {
+func recordCPUUsageMetric(mb *metadata.MetricsBuilder, recordDataPoint metadata.RecordDoubleDataPointFunc, s *stats.CPUStats, currentTime pcommon.Timestamp) {
 	if s.UsageNanoCores == nil {
 		return
 	}
@@ -37,7 +37,7 @@ func addCPUUsageMetric(mb *metadata.MetricsBuilder, recordDataPoint metadata.Rec
 	recordDataPoint(mb, currentTime, value)
 }
 
-func addCPUTimeMetric(mb *metadata.MetricsBuilder, recordDataPoint metadata.RecordDoubleDataPointFunc, s *stats.CPUStats, currentTime pcommon.Timestamp) {
+func recordCPUTimeMetric(mb *metadata.MetricsBuilder, recordDataPoint metadata.RecordDoubleDataPointFunc, s *stats.CPUStats, currentTime pcommon.Timestamp) {
 	if s.UsageCoreNanoSeconds == nil {
 		return
 	}

--- a/receiver/kubeletstatsreceiver/internal/kubelet/fs.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/fs.go
@@ -21,7 +21,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/internal/metadata"
 )
 
-func addFilesystemMetrics(mb *metadata.MetricsBuilder, filesystemMetrics metadata.FilesystemMetrics, s *stats.FsStats, currentTime pcommon.Timestamp) {
+func recordFilesystemMetrics(mb *metadata.MetricsBuilder, filesystemMetrics metadata.FilesystemMetrics, s *stats.FsStats, currentTime pcommon.Timestamp) {
 	if s == nil {
 		return
 	}

--- a/receiver/kubeletstatsreceiver/internal/kubelet/mem.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/mem.go
@@ -21,7 +21,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/internal/metadata"
 )
 
-func addMemoryMetrics(mb *metadata.MetricsBuilder, memoryMetrics metadata.MemoryMetrics, s *stats.MemoryStats, currentTime pcommon.Timestamp) {
+func recordMemoryMetrics(mb *metadata.MetricsBuilder, memoryMetrics metadata.MemoryMetrics, s *stats.MemoryStats, currentTime pcommon.Timestamp) {
 	if s == nil {
 		return
 	}

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metrics.go
@@ -17,24 +17,23 @@ package kubelet // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"time"
 
-	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 	stats "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/internal/metadata"
 )
 
-func MetricsData(
+func ScrapeMetrics(
 	logger *zap.Logger, summary *stats.Summary,
 	metadata Metadata,
 	metricGroupsToCollect map[MetricGroup]bool,
-	mbs *metadata.MetricsBuilders) []pmetric.Metrics {
+	mb *metadata.MetricsBuilder) {
 	acc := &metricDataAccumulator{
 		metadata:              metadata,
 		logger:                logger,
 		metricGroupsToCollect: metricGroupsToCollect,
 		time:                  time.Now(),
-		mbs:                   mbs,
+		mb:                    mb,
 	}
 	acc.nodeStats(summary.Node)
 	for _, podStats := range summary.Pods {
@@ -49,5 +48,4 @@ func MetricsData(
 			acc.volumeStats(podStats, volumeStats)
 		}
 	}
-	return acc.m
 }

--- a/receiver/kubeletstatsreceiver/internal/kubelet/network.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/network.go
@@ -21,7 +21,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver/internal/metadata"
 )
 
-func addNetworkMetrics(mb *metadata.MetricsBuilder, networkMetrics metadata.NetworkMetrics, s *stats.NetworkStats, currentTime pcommon.Timestamp) {
+func recordNetworkMetrics(mb *metadata.MetricsBuilder, networkMetrics metadata.NetworkMetrics, s *stats.NetworkStats, currentTime pcommon.Timestamp) {
 	if s == nil {
 		return
 	}

--- a/receiver/kubeletstatsreceiver/internal/metadata/metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/metrics.go
@@ -22,13 +22,6 @@ type RecordIntDataPointFunc func(*MetricsBuilder, pcommon.Timestamp, int64)
 
 type RecordIntDataPointWithDirectionFunc func(*MetricsBuilder, pcommon.Timestamp, int64, string, AttributeDirection)
 
-type MetricsBuilders struct {
-	NodeMetricsBuilder      *MetricsBuilder
-	PodMetricsBuilder       *MetricsBuilder
-	ContainerMetricsBuilder *MetricsBuilder
-	OtherMetricsBuilder     *MetricsBuilder
-}
-
 type CPUMetrics struct {
 	Time        RecordDoubleDataPointFunc
 	Utilization RecordDoubleDataPointFunc


### PR DESCRIPTION
This is a refactoring change to replace multiple metrics builder with one instance.
