### PR TITLE
[Metrics builder] Remove support of histogram metrics

### DIFF
--- a/cmd/mdatagen/documentation.tmpl
+++ b/cmd/mdatagen/documentation.tmpl
@@ -10,8 +10,7 @@ These are the metrics available for this scraper.
 | ---- | ----------- | ---- | ---- | ---------- |
 {{- range $metricName, $metricInfo := .Metrics }}
 | {{ if $metricInfo.IsEnabled }}**{{ end }}{{ $metricName }}{{ if $metricInfo.IsEnabled }}**
-{{- end }} | {{ $metricInfo.Description }}{{ if $metricInfo.ExtendedDocumentation }} {{ $metricInfo.ExtendedDocumentation }}{{ end }} | {{ $metricInfo.Unit }} | {{ $metricInfo.Data.Type }}
-{{- if $metricInfo.Data.HasMetricValueType }}({{ $metricInfo.Data.MetricValueType }}){{- end }} | <ul>
+{{- end }} | {{ $metricInfo.Description }}{{ if $metricInfo.ExtendedDocumentation }} {{ $metricInfo.ExtendedDocumentation }}{{ end }} | {{ $metricInfo.Unit }} | {{ $metricInfo.Data.Type }}({{ $metricInfo.Data.MetricValueType }}) | <ul>
 {{- range $index, $attributeName := $metricInfo.Attributes }} <li>{{ $attributeName }}</li> {{- end }} </ul> |
 {{- end }}
 

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -117,8 +117,6 @@ type metric struct {
 	Sum *sum `yaml:"sum"`
 	// Gauge stores metadata for gauge metric type
 	Gauge *gauge `yaml:"gauge"`
-	// Histogram stores metadata for histogram metric type
-	Histogram *histogram `yaml:"histogram"`
 
 	// Attributes is the list of attributes that the metric emits.
 	Attributes []attributeName
@@ -130,9 +128,6 @@ func (m metric) Data() MetricData {
 	}
 	if m.Gauge != nil {
 		return m.Gauge
-	}
-	if m.Histogram != nil {
-		return m.Histogram
 	}
 	return nil
 }
@@ -246,16 +241,13 @@ func validateMetadata(out metadata) error {
 		if v.Gauge != nil {
 			dataTypesSet++
 		}
-		if v.Histogram != nil {
-			dataTypesSet++
-		}
 		if dataTypesSet == 0 {
 			return fmt.Errorf("metric %v doesn't have a metric type key, "+
-				"one of the following has to be specified: sum, gauge, histogram", k)
+				"one of the following has to be specified: sum, gauge", k)
 		}
 		if dataTypesSet > 1 {
 			return fmt.Errorf("metric %v has more than one metric type keys, "+
-				"only one of the following has to be specified: sum, gauge, histogram", k)
+				"only one of the following has to be specified: sum, gauge", k)
 		}
 	}
 

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -83,7 +83,7 @@ func Test_loadMetadata(t *testing.T) {
 			yml:  "no_metric_type.yaml",
 			want: metadata{},
 			wantErr: "metric system.cpu.time doesn't have a metric type key, " +
-				"one of the following has to be specified: sum, gauge, histogram",
+				"one of the following has to be specified: sum, gauge",
 		},
 		{
 			name:    "no enabled",
@@ -96,7 +96,7 @@ func Test_loadMetadata(t *testing.T) {
 			yml:  "two_metric_types.yaml",
 			want: metadata{},
 			wantErr: "metric system.cpu.time has more than one metric type keys, " +
-				"only one of the following has to be specified: sum, gauge, histogram",
+				"only one of the following has to be specified: sum, gauge",
 		},
 		{
 			name: "no number types",

--- a/cmd/mdatagen/metric-metadata.yaml
+++ b/cmd/mdatagen/metric-metadata.yaml
@@ -38,12 +38,12 @@ metrics:
     # Required: metric unit as defined by https://ucum.org/ucum.html.
     unit:
     # Required: metric type with its settings.
-    <sum|gauge|histogram>:
+    <sum|gauge>:
       # Required for sum and gauge metrics: type of number data point values.
       value_type: # int | double
       # Required for sum metric: whether the metric is monotonic (no negative delta values).
       monotonic: # true | false
-      # Required for sum and histogram metrics: whether reported values incorporate previous measurements
+      # Required for sum metric: whether reported values incorporate previous measurements
       # (cumulative) or not (delta).
       aggregation: # delta | cumulative
     # Optional: array of attributes that were defined in the attributes section that are emitted by this metric.

--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -23,7 +23,6 @@ import (
 var (
 	_ MetricData = &gauge{}
 	_ MetricData = &sum{}
-	_ MetricData = &histogram{}
 )
 
 // MetricData is generic interface for all metric datatypes.
@@ -31,7 +30,6 @@ type MetricData interface {
 	Type() string
 	HasMonotonic() bool
 	HasAggregated() bool
-	HasMetricValueType() bool
 	HasMetricInputType() bool
 }
 
@@ -124,10 +122,6 @@ func (d gauge) HasAggregated() bool {
 	return false
 }
 
-func (d gauge) HasMetricValueType() bool {
-	return true
-}
-
 func (d gauge) HasMetricInputType() bool {
 	return d.InputType != ""
 }
@@ -151,34 +145,6 @@ func (d sum) HasAggregated() bool {
 	return true
 }
 
-func (d sum) HasMetricValueType() bool {
-	return true
-}
-
 func (d sum) HasMetricInputType() bool {
 	return d.InputType != ""
-}
-
-type histogram struct {
-	Aggregated `mapstructure:",squash"`
-}
-
-func (d histogram) Type() string {
-	return "Histogram"
-}
-
-func (d histogram) HasMonotonic() bool {
-	return false
-}
-
-func (d histogram) HasAggregated() bool {
-	return true
-}
-
-func (d histogram) HasMetricValueType() bool {
-	return false
-}
-
-func (d histogram) HasMetricInputType() bool {
-	return false
 }

--- a/cmd/mdatagen/metricdata_test.go
+++ b/cmd/mdatagen/metricdata_test.go
@@ -29,7 +29,6 @@ func TestMetricData(t *testing.T) {
 	}{
 		{&gauge{}, "Gauge", false, false},
 		{&sum{}, "Sum", true, true},
-		{&histogram{}, "Histogram", true, false},
 	} {
 		assert.Equal(t, arg.typ, arg.metricData.Type())
 		assert.Equal(t, arg.hasAggregated, arg.metricData.HasAggregated())

--- a/cmd/mdatagen/metrics_v2.tmpl
+++ b/cmd/mdatagen/metrics_v2.tmpl
@@ -95,8 +95,7 @@ func (m *metric{{ $name.Render }}) init() {
 	{{- end }}
 }
 
-func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp
-{{- if $metric.Data.HasMetricValueType }}, val {{ $metric.Data.MetricValueType.BasicType }}{{ end }}
+func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val {{ $metric.Data.MetricValueType.BasicType }}
 {{- range $metric.Attributes -}}, {{ .RenderUnexported }}AttributeValue string {{ end }}) {
 	if !m.settings.Enabled {
 		return
@@ -104,9 +103,7 @@ func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts p
 	dp := m.data.{{ $metric.Data.Type }}().DataPoints().AppendEmpty()
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
-	{{- if $metric.Data.HasMetricValueType }}
 	dp.Set{{ $metric.Data.MetricValueType }}Val(val)
-	{{- end }}
 	{{- range $metric.Attributes }}
 	dp.Attributes().Insert("{{ attributeKey .}}", pcommon.NewValueString({{ .RenderUnexported }}AttributeValue))
 	{{- end }}
@@ -201,9 +198,9 @@ func With{{ $name.Render }}(val {{ $attr.Type.Primitive }}) ResourceMetricsOptio
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()
@@ -257,15 +254,13 @@ func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 // Record{{ $name.Render }}DataPoint adds a data point to {{ $name }} metric.
 func (mb *MetricsBuilder) Record{{ $name.Render }}DataPoint(ts pcommon.Timestamp
 	{{- if $metric.Data.HasMetricInputType }}, inputVal {{ $metric.Data.MetricInputType.String }}
-	{{- else }}
-	{{- if $metric.Data.HasMetricValueType }}, val {{ $metric.Data.MetricValueType.BasicType }}{{- end }}
-	{{- end -}}
+	{{- else }}, val {{ $metric.Data.MetricValueType.BasicType }}
+	{{- end }}
 	{{- range $metric.Attributes -}}
 	, {{ .RenderUnexported }}AttributeValue {{ if (attributeInfo .).Enum }}Attribute{{ .Render }}{{ else }}string{{ end }}
 	{{- end }})
 	{{- if $metric.Data.HasMetricInputType }} error{{ end }} {
 	{{- if $metric.Data.HasMetricInputType }}
-	{{- if $metric.Data.HasMetricValueType }}
 	{{- if eq $metric.Data.MetricValueType.BasicType "float64" }}
 	val, err := strconv.ParseFloat(inputVal, 64)
 	{{- else if eq $metric.Data.MetricValueType.BasicType "int64" }}
@@ -275,9 +270,7 @@ func (mb *MetricsBuilder) Record{{ $name.Render }}DataPoint(ts pcommon.Timestamp
 		return fmt.Errorf("failed to parse {{ $metric.Data.MetricValueType.BasicType }} for {{ $name.Render }}, value was %s: %w", inputVal, err)
 	}
 	{{- end }}
-	{{- end }}
-	mb.metric{{ $name.Render }}.recordDataPoint(mb.startTime, ts
-		{{- if $metric.Data.HasMetricValueType }}, val {{ end }}
+	mb.metric{{ $name.Render }}.recordDataPoint(mb.startTime, ts, val
 		{{- range $metric.Attributes -}}
 		, {{ .RenderUnexported }}AttributeValue{{ if (attributeInfo .).Enum }}.String(){{ end }}
 		{{- end }})

--- a/receiver/activedirectorydsreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/activedirectorydsreceiver/internal/metadata/generated_metrics_v2.go
@@ -1300,9 +1300,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/apachereceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics_v2.go
@@ -520,9 +520,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/bigipreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/bigipreceiver/internal/metadata/generated_metrics_v2.go
@@ -1784,9 +1784,9 @@ func WithBigipVirtualServerName(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/couchbasereceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/couchbasereceiver/internal/metadata/generated_metrics_v2.go
@@ -69,9 +69,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/couchdbreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_metrics_v2.go
@@ -637,9 +637,9 @@ func WithCouchdbNodeName(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_v2.go
@@ -2059,9 +2059,9 @@ func WithElasticsearchNodeName(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_v2.go
@@ -239,9 +239,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics_v2.go
@@ -514,9 +514,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_v2.go
@@ -287,9 +287,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics_v2.go
@@ -236,9 +236,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_v2.go
@@ -233,9 +233,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics_v2.go
@@ -419,9 +419,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics_v2.go
@@ -390,9 +390,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics_v2.go
@@ -257,9 +257,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_v2.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_v2.go
@@ -401,9 +401,9 @@ func WithProcessPid(val int64) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/iisreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/iisreceiver/internal/metadata/generated_metrics_v2.go
@@ -828,9 +828,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_v2.go
@@ -2537,9 +2537,9 @@ func WithPartition(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/memcachedreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_metrics_v2.go
@@ -846,9 +846,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_v2.go
@@ -4435,9 +4435,9 @@ func WithMongodbAtlasProjectName(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_v2.go
@@ -909,9 +909,9 @@ func WithDatabase(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_v2.go
@@ -1575,9 +1575,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/nginxreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_metrics_v2.go
@@ -332,9 +332,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/nsxtreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/nsxtreceiver/internal/metadata/generated_metrics_v2.go
@@ -610,9 +610,9 @@ func WithNsxtNodeType(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_v2.go
@@ -599,9 +599,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/rabbitmqreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/rabbitmqreceiver/internal/metadata/generated_metrics_v2.go
@@ -461,9 +461,9 @@ func WithRabbitmqVhostName(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/redisreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics_v2.go
@@ -1703,9 +1703,9 @@ type ResourceMetricsOption func(pmetric.ResourceMetrics)
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/riakreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/riakreceiver/internal/metadata/generated_metrics_v2.go
@@ -481,9 +481,9 @@ func WithRiakNodeName(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/saphanareceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/saphanareceiver/internal/metadata/generated_metrics_v2.go
@@ -3261,9 +3261,9 @@ func WithSaphanaHost(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_v2.go
@@ -1209,9 +1209,9 @@ func WithSqlserverDatabaseName(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics_v2.go
@@ -987,9 +987,9 @@ func WithZkVersion(val string) ResourceMetricsOption {
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
+		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
-			dps := pmetric.NewNumberDataPointSlice()
 			switch metrics.At(i).DataType() {
 			case pmetric.MetricDataTypeGauge:
 				dps = metrics.At(i).Gauge().DataPoints()


### PR DESCRIPTION
Currently metadata.yaml supports setting histogram metric type (not exponential histogram), but the metrics builder doesn't generate code for reporting histogram data points. It doesn't look right to have such partial support. 

We don't have any scrapers that need reporting histogram metrics at this point. Once we have that need, we can introduce full support of histograms to the metrics builder.
