### PR TITLE
[Makefile/CI] Parallelize lint and unit test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Check Collector Module Version
         run: ./.github/workflows/scripts/check-collector-module-version.sh
-  lint:
+  lint-matrix:
+    strategy:
+      matrix:
+        group:
+          - receivers
+          - processors
+          - exporters
+          - extensions
+          - others
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
@@ -72,7 +80,13 @@ jobs:
           path: ~/.cache/go-build
           key: go-lint-build-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Lint
-        run: make -j2 golint
+        run: make -j2 golint GROUP=${{ matrix.group }}
+  lint:
+    runs-on: ubuntu-latest
+    needs: [setup-environment, lint-matrix]
+    steps:
+      - name: Unit Tests Complete
+        run: echo "lint complete"
   checks:
     runs-on: ubuntu-latest
     needs: [setup-environment]
@@ -111,10 +125,16 @@ jobs:
           git diff --exit-code ':!*go.sum' || (echo 'Generated code is out of date, please run "make generate" and commit the changes in this PR.' && exit 1)
       - name: MultimodVerify
         run: make multimod-verify
-  unittest:
+  unittest-matrix:
     strategy:
       matrix:
         go-version: [1.18, 1.17]
+        group:
+          - receivers
+          - processors
+          - exporters
+          - extensions
+          - others
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
@@ -142,7 +162,17 @@ jobs:
           path: ~/.cache/go-build
           key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
-        run: make gotest
+        run: make gotest GROUP=${{ matrix.group }}
+  unittest:
+    strategy:
+      matrix:
+        go-version: [1.18, 1.17]
+    runs-on: ubuntu-latest
+    needs: [setup-environment, unittest-matrix]
+    steps:
+      - name: Unit Tests Complete
+        run: echo "unittest (${{ matrix.go-version }}) complete"
+
   integration-tests:
     runs-on: ubuntu-latest
     needs: [setup-environment]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,6 +52,7 @@ jobs:
           - processors
           - exporters
           - extensions
+          - internals
           - others
     runs-on: ubuntu-latest
     needs: [setup-environment]
@@ -134,6 +135,7 @@ jobs:
           - processors
           - exporters
           - extensions
+          - internals
           - others
     runs-on: ubuntu-latest
     needs: [setup-environment]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,12 +48,13 @@ jobs:
     strategy:
       matrix:
         group:
-          - receivers
-          - processors
-          - exporters
-          - extensions
-          - internals
-          - others
+          - receiver-0
+          - receiver-1
+          - processor
+          - exporter
+          - extension
+          - internal
+          - other
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
@@ -131,12 +132,13 @@ jobs:
       matrix:
         go-version: [1.18, 1.17]
         group:
-          - receivers
-          - processors
-          - exporters
-          - extensions
-          - internals
-          - others
+          - receiver-0
+          - receiver-1
+          - processor
+          - exporter
+          - extension
+          - internal
+          - other
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ $(GOMODULES):
 	@echo "Running target '$(TARGET)' in module '$@'"
 	$(MAKE) -C $@ $(TARGET)
 
-# Triggers each module's delegation target
+# Trigger each module's delegation target
 .PHONY: for-all-target
 for-all-target: $(GOMODULES)
 

--- a/Makefile
+++ b/Makefile
@@ -20,27 +20,37 @@ TO_MOD_DIR=dirname {} \; | sort | egrep  '^./'
 EX_COMPONENTS=-not -path "./receiver/*" -not -path "./processor/*" -not -path "./exporter/*" -not -path "./extension/*"
 EX_INTERNAL=-not -path "./internal/*"
 
-FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
-
 # NONROOT_MODS includes ./* dirs (excludes . dir)
-NONROOT_MODS := $(shell find . $(FIND_MOD_ARGS) $(TO_MOD_DIR) )
+NONROOT_MODS := $(shell find . $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 
-RECEIVER_MODS := $(shell find ./receiver/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
+RECEIVER_MODS_0 := $(shell find ./receiver/[a-k]* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
+RECEIVER_MODS_1 := $(shell find ./receiver/[l-z]* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
+RECEIVER_MODS := $(RECEIVER_MODS_0) $(RECEIVER_MODS_1)
 PROCESSOR_MODS := $(shell find ./processor/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 EXPORTER_MODS := $(shell find ./exporter/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 EXTENSION_MODS := $(shell find ./extension/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 INTERNAL_MODS := $(shell find ./internal/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
-ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(OTHER_MODS)
-INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) )
+ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(INTERNAL_MODS) $(OTHER_MODS)
+
+# find -exec dirname cannot be used to process multiple matching patterns
+FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
+INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | uniq | xargs $(TO_MOD_DIR) )
 
 .DEFAULT_GOAL := all
 
-int-mods:
-	@echo $(INTEGRATION_MODS) | tr ' ' '\n' | sort
-
 all-modules:
 	@echo $(NONROOT_MODS) | tr ' ' '\n' | sort
+
+all-groups:
+	@echo "receiver-0: $(RECEIVER_MODS_0)"
+	@echo "\nreceiver-1: $(RECEIVER_MODS_1)"
+	@echo "\nreceiver: $(RECEIVER_MODS)"
+	@echo "\nprocessor: $(PROCESSOR_MODS)"
+	@echo "\nexporter: $(EXPORTER_MODS)"
+	@echo "\nextension: $(EXTENSION_MODS)"
+	@echo "\ninternal: $(INTERNAL_MODS)"
+	@echo "\nother: $(OTHER_MODS)"
 
 .PHONY: all
 all: all-common gotest otelcontribcol otelcontribcol-unstable
@@ -174,23 +184,29 @@ $(ALL_MODS):
 .PHONY: for-all-target
 for-all-target: $(ALL_MODS)
 
-.PHONY: for-receivers-target
-for-receivers-target: $(RECEIVER_MODS)
+.PHONY: for-receiver-target
+for-receiver-target: $(RECEIVER_MODS)
 
-.PHONY: for-processors-target
-for-processors-target: $(PROCESSOR_MODS)
+.PHONY: for-receiver-0-target
+for-receiver-0-target: $(RECEIVER_MODS_0)
 
-.PHONY: for-exporters-target
-for-exporters-target: $(EXPORTER_MODS)
+.PHONY: for-receiver-1-target
+for-receiver-1-target: $(RECEIVER_MODS_1)
 
-.PHONY: for-extensions-target
-for-extensions-target: $(EXTENSION_MODS)
+.PHONY: for-processor-target
+for-processor-target: $(PROCESSOR_MODS)
 
-.PHONY: for-internals-target
-for-internals-target: $(INTERNAL_MODS)
+.PHONY: for-exporter-target
+for-exporter-target: $(EXPORTER_MODS)
 
-.PHONY: for-others-target
-for-others-target: $(OTHER_MODS)
+.PHONY: for-extension-target
+for-extension-target: $(EXTENSION_MODS)
+
+.PHONY: for-internal-target
+for-internal-target: $(INTERNAL_MODS)
+
+.PHONY: for-other-target
+for-other-target: $(OTHER_MODS)
 
 # Debugging target, which helps to quickly determine whether for-all-target is working or not.
 .PHONY: all-pwd

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ TEMP_EX_STANZA=-not -path "./pkg/stanza/*"
 FIND_MOD_ARGS=-type f -name "go.mod" $(TEMP_EX_STANZA)
 TO_MOD_DIR=dirname {} \; | sort | egrep  '^./'
 EX_COMPONENTS=-not -path "./receiver/*" -not -path "./processor/*" -not -path "./exporter/*" -not -path "./extension/*"
+EX_INTERNAL=-not -path "./internal/*"
 
-FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . f -name "*e2e_test.go" -not -path "./testbed/*"; }
+FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
 
 # NONROOT_MODS includes ./* dirs (excludes . dir)
 NONROOT_MODS := $(shell find . $(FIND_MOD_ARGS) $(TO_MOD_DIR) )
@@ -28,7 +29,8 @@ RECEIVER_MODS := $(shell find ./receiver/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) 
 PROCESSOR_MODS := $(shell find ./processor/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 EXPORTER_MODS := $(shell find ./exporter/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 EXTENSION_MODS := $(shell find ./extension/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
-OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
+INTERNAL_MODS := $(shell find ./internal/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
+OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(OTHER_MODS)
 INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) )
 
@@ -183,6 +185,9 @@ for-exporters-target: $(EXPORTER_MODS)
 
 .PHONY: for-extensions-target
 for-extensions-target: $(EXTENSION_MODS)
+
+.PHONY: for-internals-target
+for-internals-target: $(INTERNAL_MODS)
 
 .PHONY: for-others-target
 for-others-target: $(OTHER_MODS)


### PR DESCRIPTION
This change introduces a mechanism for grouping and parallelizing per-module make tasks. This should cut some notable time off of the CI process and give developers feedback sooner when a failure is detected. It also enables developers to run more targeted tests locally as well.

This PR parallelizes the `lint` and `unittest` CI jobs, which currently run for 15-30 minutes. With the change, run times on these jobs appear to stay below 10 minutes.

This change impacted the way that integration tests were run, so that target was updated as well. Modules containing integration tests previously needed to be hardcoded into the Makefile. This has repeatedly led to oversights, omitting new modules from integration tests. The new pattern is that any module containing a file named `*integration_test.go` or `*e2e_test.go` will be included in the target. This currently picks all integration tests in the repo (excluding testbed) and is less likely to be overlooked than the hardcoded list in the Makefile.