### PR TITLE
[processor/transform] Remove reflection from NewFunctionCall

### DIFF
--- a/processor/transformprocessor/config.go
+++ b/processor/transformprocessor/config.go
@@ -27,14 +27,14 @@ type LogsConfig struct {
 	Queries []string `mapstructure:"queries"`
 
 	// The functions that have been registered in the extension for logs processing.
-	functions map[string]interface{} `mapstructure:"-"`
+	functions map[string]common.TransformFunction `mapstructure:"-"`
 }
 
 type TracesConfig struct {
 	Queries []string `mapstructure:"queries"`
 
 	// The functions that have been registered in the extension for traces processing.
-	functions map[string]interface{} `mapstructure:"-"`
+	functions map[string]common.TransformFunction `mapstructure:"-"`
 }
 
 type Config struct {

--- a/processor/transformprocessor/internal/common/condition.go
+++ b/processor/transformprocessor/internal/common/condition.go
@@ -24,7 +24,7 @@ var alwaysTrue = func(ctx TransformContext) bool {
 	return true
 }
 
-func newConditionEvaluator(cond *Condition, functions map[string]interface{}, pathParser PathExpressionParser) (condFunc, error) {
+func newConditionEvaluator(cond *Condition, functions map[string]TransformFunction, pathParser PathExpressionParser) (condFunc, error) {
 	if cond == nil {
 		return alwaysTrue, nil
 	}

--- a/processor/transformprocessor/internal/common/expression.go
+++ b/processor/transformprocessor/internal/common/expression.go
@@ -57,7 +57,7 @@ func (g exprGetter) Get(ctx TransformContext) interface{} {
 	return g.expr(ctx)
 }
 
-func NewGetter(val Value, functions map[string]interface{}, pathParser PathExpressionParser) (Getter, error) {
+func NewGetter(val Value, functions map[string]TransformFunction, pathParser PathExpressionParser) (Getter, error) {
 	if s := val.String; s != nil {
 		return &literal{value: *s}, nil
 	}

--- a/processor/transformprocessor/internal/common/expression_test.go
+++ b/processor/transformprocessor/internal/common/expression_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-func hello() (ExprFunc, error) {
+func hello(arguments []Value, pathParser PathExpressionParser, functions map[string]TransformFunction) (ExprFunc, error) {
 	return func(ctx TransformContext) interface{} {
 		return "world"
 	}, nil
@@ -81,7 +81,7 @@ func Test_newGetter(t *testing.T) {
 		},
 	}
 
-	functions := map[string]interface{}{"hello": hello}
+	functions := map[string]TransformFunction{"hello": hello}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/processor/transformprocessor/internal/common/functions.go
+++ b/processor/transformprocessor/internal/common/functions.go
@@ -16,25 +16,40 @@ package common // import "github.com/open-telemetry/opentelemetry-collector-cont
 
 import (
 	"fmt"
-	"reflect"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
-var registry = map[string]interface{}{
-	"keep_keys":    keepKeys,
+type TransformFunction func(arguments []Value, pathParser PathExpressionParser, functions map[string]TransformFunction) (ExprFunc, error)
+
+var registry = map[string]TransformFunction{
 	"set":          set,
+	"keep_keys":    keepKeys,
 	"truncate_all": truncateAll,
 	"limit":        limit,
 }
 
 type PathExpressionParser func(*Path) (GetSetter, error)
 
-func DefaultFunctions() map[string]interface{} {
+func DefaultFunctions() map[string]TransformFunction {
 	return registry
 }
 
-func set(target Setter, value Getter) (ExprFunc, error) {
+func set(arguments []Value, pathParser PathExpressionParser, functions map[string]TransformFunction) (ExprFunc, error) {
+	if len(arguments) != 2 {
+		return nil, fmt.Errorf("incorrect number of arguments for function 'set': received %v, expected 2", len(arguments))
+	}
+
+	target, err := toSetter(arguments[0], pathParser)
+	if err != nil {
+		return nil, err
+	}
+
+	value, err := toGetter(arguments[1], pathParser, functions)
+	if err != nil {
+		return nil, err
+	}
+
 	return func(ctx TransformContext) interface{} {
 		val := value.Get(ctx)
 		if val != nil {
@@ -44,7 +59,21 @@ func set(target Setter, value Getter) (ExprFunc, error) {
 	}, nil
 }
 
-func keepKeys(target GetSetter, keys []string) (ExprFunc, error) {
+func keepKeys(arguments []Value, pathParser PathExpressionParser, functions map[string]TransformFunction) (ExprFunc, error) {
+	if len(arguments) < 1 {
+		return nil, fmt.Errorf("incorrect number of arguments for function 'keep_keys': received %v, expected at least 1", len(arguments))
+	}
+
+	target, err := toGetSetter(arguments[0], pathParser)
+	if err != nil {
+		return nil, err
+	}
+
+	keys, err := toStringArray(arguments[1:])
+	if err != nil {
+		return nil, err
+	}
+
 	keySet := make(map[string]struct{}, len(keys))
 	for _, key := range keys {
 		keySet[key] = struct{}{}
@@ -72,12 +101,27 @@ func keepKeys(target GetSetter, keys []string) (ExprFunc, error) {
 	}, nil
 }
 
-func truncateAll(target GetSetter, limit int64) (ExprFunc, error) {
-	if limit < 0 {
-		return nil, fmt.Errorf("invalid limit for truncate_all function, %d cannot be negative", limit)
+func truncateAll(arguments []Value, pathParser PathExpressionParser, functions map[string]TransformFunction) (ExprFunc, error) {
+	if len(arguments) != 2 {
+		return nil, fmt.Errorf("incorrect number of arguments for function 'truncate_all': received %v, expected 2", len(arguments))
 	}
+
+	target, err := toGetSetter(arguments[0], pathParser)
+	if err != nil {
+		return nil, err
+	}
+
+	limitVal, err := toInt(arguments[1])
+	if err != nil {
+		return nil, err
+	}
+
+	if limitVal < 0 {
+		return nil, fmt.Errorf("invalid limit for truncate_all function, %d cannot be negative", limitVal)
+	}
+
 	return func(ctx TransformContext) interface{} {
-		if limit < 0 {
+		if limitVal < 0 {
 			return nil
 		}
 
@@ -91,8 +135,8 @@ func truncateAll(target GetSetter, limit int64) (ExprFunc, error) {
 			updated.EnsureCapacity(attrs.Len())
 			attrs.Range(func(key string, val pcommon.Value) bool {
 				stringVal := val.StringVal()
-				if int64(len(stringVal)) > limit {
-					updated.InsertString(key, stringVal[:limit])
+				if int64(len(stringVal)) > limitVal {
+					updated.InsertString(key, stringVal[:limitVal])
 				} else {
 					updated.Insert(key, val)
 				}
@@ -106,9 +150,23 @@ func truncateAll(target GetSetter, limit int64) (ExprFunc, error) {
 	}, nil
 }
 
-func limit(target GetSetter, limit int64) (ExprFunc, error) {
-	if limit < 0 {
-		return nil, fmt.Errorf("invalid limit for limit function, %d cannot be negative", limit)
+func limit(arguments []Value, pathParser PathExpressionParser, functions map[string]TransformFunction) (ExprFunc, error) {
+	if len(arguments) != 2 {
+		return nil, fmt.Errorf("incorrect number of arguments for function 'limit': received %v, expected 2", len(arguments))
+	}
+
+	target, err := toGetSetter(arguments[0], pathParser)
+	if err != nil {
+		return nil, err
+	}
+
+	limitVal, err := toInt(arguments[1])
+	if err != nil {
+		return nil, err
+	}
+
+	if limitVal < 0 {
+		return nil, fmt.Errorf("invalid limit for limit function, %d cannot be negative", limitVal)
 	}
 	return func(ctx TransformContext) interface{} {
 		val := target.Get(ctx)
@@ -117,7 +175,7 @@ func limit(target GetSetter, limit int64) (ExprFunc, error) {
 		}
 
 		if attrs, ok := val.(pcommon.Map); ok {
-			if int64(attrs.Len()) <= limit {
+			if int64(attrs.Len()) <= limitVal {
 				return nil
 			}
 
@@ -125,7 +183,7 @@ func limit(target GetSetter, limit int64) (ExprFunc, error) {
 			updated.EnsureCapacity(attrs.Len())
 			count := int64(0)
 			attrs.Range(func(key string, val pcommon.Value) bool {
-				if count < limit {
+				if count < limitVal {
 					updated.Insert(key, val)
 					count++
 					return true
@@ -140,71 +198,51 @@ func limit(target GetSetter, limit int64) (ExprFunc, error) {
 	}, nil
 }
 
-// TODO(anuraaga): See if reflection can be avoided without complicating definition of transform functions.
-// Visible for testing
-func NewFunctionCall(inv Invocation, functions map[string]interface{}, pathParser PathExpressionParser) (ExprFunc, error) {
+func toInt(arg Value) (int64, error) {
+	if arg.Int == nil {
+		return 0, fmt.Errorf("expected argument to be an int")
+	}
+	return *arg.Int, nil
+}
+
+func toStringArray(args []Value) ([]string, error) {
+	results := make([]string, len(args))
+	for _, arg := range args {
+		if arg.String == nil {
+			return nil, fmt.Errorf("invalid argument for slice parameter, must be string")
+		}
+		results = append(results, *arg.String)
+	}
+	return results, nil
+}
+
+func toSetter(arg Value, pathParser PathExpressionParser) (Setter, error) {
+	return toGetSetter(arg, pathParser)
+}
+
+func toGetter(arg Value, pathParser PathExpressionParser, functions map[string]TransformFunction) (Getter, error) {
+	getter, err := NewGetter(arg, functions, pathParser)
+	if err != nil {
+		return nil, fmt.Errorf("invalid argument, %w", err)
+	}
+	return getter, nil
+}
+
+func toGetSetter(arg Value, pathParser PathExpressionParser) (GetSetter, error) {
+	if arg.Path == nil {
+		return nil, fmt.Errorf("expected argument to be a path")
+	}
+	getSetter, err := pathParser(arg.Path)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse path, %v", err)
+	}
+	return getSetter, nil
+}
+
+// NewFunctionCall Visible for testing
+func NewFunctionCall(inv Invocation, functions map[string]TransformFunction, pathParser PathExpressionParser) (ExprFunc, error) {
 	if f, ok := functions[inv.Function]; ok {
-		fType := reflect.TypeOf(f)
-		args := make([]reflect.Value, 0)
-		for i := 0; i < fType.NumIn(); i++ {
-			argType := fType.In(i)
-
-			if argType.Kind() == reflect.Slice {
-				switch argType.Elem().Kind() {
-				case reflect.String:
-					arg := make([]string, 0)
-					for j := i; j < len(inv.Arguments); j++ {
-						if inv.Arguments[j].String == nil {
-							return nil, fmt.Errorf("invalid argument for slice parameter at position %v, must be string", j)
-						}
-						arg = append(arg, *inv.Arguments[j].String)
-					}
-					args = append(args, reflect.ValueOf(arg))
-				default:
-					return nil, fmt.Errorf("unsupported slice type for function %v", inv.Function)
-				}
-				continue
-			}
-
-			if i >= len(inv.Arguments) {
-				return nil, fmt.Errorf("not enough arguments for function %v", inv.Function)
-			}
-			argDef := inv.Arguments[i]
-			switch argType.Name() {
-			case "Setter":
-				fallthrough
-			case "GetSetter":
-				arg, err := pathParser(argDef.Path)
-				if err != nil {
-					return nil, fmt.Errorf("invalid argument at position %v %w", i, err)
-				}
-				args = append(args, reflect.ValueOf(arg))
-				continue
-			case "Getter":
-				arg, err := NewGetter(argDef, functions, pathParser)
-				if err != nil {
-					return nil, fmt.Errorf("invalid argument at position %v %w", i, err)
-				}
-				args = append(args, reflect.ValueOf(arg))
-				continue
-			case "int64":
-				if argDef.Int == nil {
-					return nil, fmt.Errorf("invalid argument at position %v, must be an int", i)
-				}
-				args = append(args, reflect.ValueOf(*argDef.Int))
-			}
-		}
-		val := reflect.ValueOf(f)
-		ret := val.Call(args)
-
-		var err error
-		if ret[1].IsNil() {
-			err = nil
-		} else {
-			err = ret[1].Interface().(error)
-		}
-
-		return ret[0].Interface().(ExprFunc), err
+		return f(inv.Arguments, pathParser, functions)
 	}
 	return nil, fmt.Errorf("undefined function %v", inv.Function)
 }

--- a/processor/transformprocessor/internal/common/functions_test.go
+++ b/processor/transformprocessor/internal/common/functions_test.go
@@ -212,7 +212,7 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 	}
 }
 
-func functionThatHasAnError() (ExprFunc, error) {
+func functionThatHasAnError(arguments []Value, pathParser PathExpressionParser, functions map[string]TransformFunction) (ExprFunc, error) {
 	err := errors.New("testing")
 	return func(ctx TransformContext) interface{} {
 		return "anything"

--- a/processor/transformprocessor/internal/common/parser.go
+++ b/processor/transformprocessor/internal/common/parser.go
@@ -73,7 +73,7 @@ type Query struct {
 	Condition condFunc
 }
 
-func ParseQueries(statements []string, functions map[string]interface{}, pathParser PathExpressionParser) ([]Query, error) {
+func ParseQueries(statements []string, functions map[string]TransformFunction, pathParser PathExpressionParser) ([]Query, error) {
 	queries := make([]Query, 0)
 	var errors error
 

--- a/processor/transformprocessor/internal/logs/functions.go
+++ b/processor/transformprocessor/internal/logs/functions.go
@@ -18,7 +18,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
-func DefaultFunctions() map[string]interface{} {
+func DefaultFunctions() map[string]common.TransformFunction {
 	// No logs-only functions yet.
 	return common.DefaultFunctions()
 }

--- a/processor/transformprocessor/internal/logs/processor.go
+++ b/processor/transformprocessor/internal/logs/processor.go
@@ -29,7 +29,7 @@ type Processor struct {
 	logger  *zap.Logger
 }
 
-func NewProcessor(statements []string, functions map[string]interface{}, settings component.ProcessorCreateSettings) (*Processor, error) {
+func NewProcessor(statements []string, functions map[string]common.TransformFunction, settings component.ProcessorCreateSettings) (*Processor, error) {
 	queries, err := common.ParseQueries(statements, functions, ParsePath)
 	if err != nil {
 		return nil, err

--- a/processor/transformprocessor/internal/traces/functions.go
+++ b/processor/transformprocessor/internal/traces/functions.go
@@ -18,7 +18,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
-func DefaultFunctions() map[string]interface{} {
+func DefaultFunctions() map[string]common.TransformFunction {
 	// No trace-only functions yet.
 	return common.DefaultFunctions()
 }

--- a/processor/transformprocessor/internal/traces/processor.go
+++ b/processor/transformprocessor/internal/traces/processor.go
@@ -29,7 +29,7 @@ type Processor struct {
 	logger  *zap.Logger
 }
 
-func NewProcessor(statements []string, functions map[string]interface{}, settings component.ProcessorCreateSettings) (*Processor, error) {
+func NewProcessor(statements []string, functions map[string]common.TransformFunction, settings component.ProcessorCreateSettings) (*Processor, error) {
 	queries, err := common.ParseQueries(statements, functions, ParsePath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description:**
This PR removes reflection from `NewFunctionCall`.  The intent is to streamline function definition so it is clearer when is happening when a function is registered/called.  Each function is now responsible for making assertions on the incoming []Values to ensure they are correct.  The logic for checking arguments remains the same as before, but it can be done directly on the Values instead of via reflection.

The `common/functions.go` file is now quite large, but I plan to break out each function into its own file/module in the future.

**Link to tracking Issue:**
#10101

**Testing:**
Ran existing unit tests.  Output of functions did not change, so did not need any new tests.