### PR TITLE
Update docs to recommend honor_labels with prometheusexporter

### DIFF
--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -1,6 +1,7 @@
 # Prometheus Exporter
 
-Exports data to a [Prometheus](https://prometheus.io/) back-end.
+Exports data to a [Prometheus](https://prometheus.io/) back-end. We expose the `job` and `instance` labels hence it recommended to
+scrape the metrics exposed with `honor_labels: true`.
 
 Supported pipeline types: metrics
 


### PR DESCRIPTION
See: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9115#issuecomment-1098787829

But should I document how we generate the `job` and `instance` labels as well?
Like `service.name`, etc.
