### PR TITLE
[docs] move stability definitions to core

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,27 +54,7 @@ Each component has its own support levels, as defined in the following sections.
 
 ## Stability levels
 
-While we intend to provide high-quality components as part of this repository, we acknowledge that not all of them are ready for prime time. As such, each component should list its current stability level for each telemetry signal, according to the following definitions:
-
-### In development
-
-Not all pieces of the component are in place yet and it might not be available as part of any distributions yet. Bugs and performance issues should be reported, but it is likely that the component owners might not give them much attention. Your feedback is still desired, especially when it comes to the user-experience (configuration options, component observability, technical implementation details, ...). Configuration options might break often depending on how things evolve. The component should not be used in production.
-
-### Alpha
-
-The component is ready to be used for limited non-critical workloads and the authors of this component would welcome your feedback. Bugs and performance problems should be reported, but component owners might not work on them right away. The configuration options might change often without backwards compatibility guarantees.
-
-### Beta
-
-Same as Alpha, but the configuration options are deemed stable. While there might be breaking changes between releases, component owners should try to minimize them. A component at this stage is expected to have had exposure to non-critical production workloads already during its **Alpha** phase, making it suitable for broader usage.
-
-### Stable
-
-The component is ready for general availability. Bugs and performance problems should be reported and there's an expectation that the component owners will work on them. Breaking changes, including configuration options and the component's output are not expected to happen without prior notice, unless under special circumstances.
-
-### Deprecated
-
-The component is planned to be removed in a future version and no further support will be provided. Note that new issues will likely not be worked on. When a component enters "deprecated" mode, it is expected to exist for at least two minor releases. See the component's readme file for more details on when a component will cease to exist.
+Stability level for components in this repository follow the [definitions](https://github.com/open-telemetry/opentelemetry-collector#stability-levels) from the OpenTelemetry Collector repository.
 
 ## Gated features
 

--- a/processor/cumulativetodeltaprocessor/README.md
+++ b/processor/cumulativetodeltaprocessor/README.md
@@ -75,5 +75,5 @@ processors:
         # convert all cumulative sum metrics to delta
 ```
 
-[beta]: https://github.com/open-telemetry/opentelemetry-collector-contrib#beta
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -167,6 +167,6 @@ The probabilistic sampling policy makes decision based upon the trace ID, so wai
 You are already incurring the cost of running the tail sampling processor, adding the probabilistic policy will be negligible.
 Additionally, using the policy within the tail sampling processor will ensure traces that are sampled by other policies will not be dropped.
 
-[beta]: https://github.com/open-telemetry/opentelemetry-collector-contrib#beta
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [probabilistic_sampling_processor]: ../probabilisticsamplerprocessor

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -90,4 +90,4 @@ All spans
 6) Truncate all span attributes such that no string value has more than 4096 characters.
 7) Truncate all resource attributes such that no string value has more than 4096 characters.
 
-[In development]: https://github.com/open-telemetry/opentelemetry-collector-contrib#in-development
+[In development]: https://github.com/open-telemetry/opentelemetry-collector#in-development


### PR DESCRIPTION
Move the stability definitions to the core repo. Added a link in README to those definitions. Updated the links in components to point to the core repo.
