### PR TITLE
Upgrade github.com/influxdata/influxdb-observability dependancy

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -172,9 +172,9 @@ require (
 	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6 // indirect
-	github.com/influxdata/influxdb-observability/common v0.2.20 // indirect
+	github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de // indirect
 	github.com/influxdata/influxdb-observability/influx2otel v0.2.20 // indirect
-	github.com/influxdata/influxdb-observability/otel2influx v0.2.20 // indirect
+	github.com/influxdata/influxdb-observability/otel2influx v0.2.21-0.20220517160208-05f925d616de // indirect
 	github.com/influxdata/line-protocol/v2 v2.2.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.12.1 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -1259,12 +1259,12 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6 h1:s9ZL6ZhFF8y6ebnm1FLvobkzoIu5xwDQUcRPk/IEhpM=
 github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6/go.mod h1:aXdIdfn2OcGnMhOTojXmwZqXKgC3MU5riiNvzwwG9OY=
-github.com/influxdata/influxdb-observability/common v0.2.20 h1:gCDrsHnhkWm4nFH2PGHAtUx6IgR7u48bDASem+pQjms=
-github.com/influxdata/influxdb-observability/common v0.2.20/go.mod h1:9t4MDkYRImBa4Wuatb3URr6tlimGT1JUYv9O8y5L/C8=
+github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de h1:f9p3iKS31+/p6cvqdmTJ45lrTlH+GDj2sK4EdVbuMI4=
+github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de/go.mod h1:9t4MDkYRImBa4Wuatb3URr6tlimGT1JUYv9O8y5L/C8=
 github.com/influxdata/influxdb-observability/influx2otel v0.2.20 h1:A0XKklwAa+INyirFMcFFOBkXSOBduD+zET1Eoo4HPaM=
 github.com/influxdata/influxdb-observability/influx2otel v0.2.20/go.mod h1:rWuw8bSmCbj6h3JLtj8QyXvoDnFtXKfGIzlcPMyH4Q8=
-github.com/influxdata/influxdb-observability/otel2influx v0.2.20 h1:pBAzvwHvcXtQ+Fa+xSTJ0ddagqdend23+vKTThjBdm0=
-github.com/influxdata/influxdb-observability/otel2influx v0.2.20/go.mod h1:AWkadnBhKwYeGgGquzIE9K88AgVB5xTwsw4WNugsFGc=
+github.com/influxdata/influxdb-observability/otel2influx v0.2.21-0.20220517160208-05f925d616de h1:KZBtAaNAHzBNJXLwYHeDXuUFWhjGa4B47T7N6HKcwnk=
+github.com/influxdata/influxdb-observability/otel2influx v0.2.21-0.20220517160208-05f925d616de/go.mod h1:AWkadnBhKwYeGgGquzIE9K88AgVB5xTwsw4WNugsFGc=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210519164801-ca6fa5da0184/go.mod h1:03nmhxzZ7Xk2pdG+lmMd7mHDfeVOYFyhOgwO61qWU98=

--- a/exporter/influxdbexporter/go.mod
+++ b/exporter/influxdbexporter/go.mod
@@ -3,8 +3,8 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/influx
 go 1.17
 
 require (
-	github.com/influxdata/influxdb-observability/common v0.2.20
-	github.com/influxdata/influxdb-observability/otel2influx v0.2.20
+	github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de
+	github.com/influxdata/influxdb-observability/otel2influx v0.2.21-0.20220517160208-05f925d616de
 	github.com/influxdata/line-protocol/v2 v2.2.1
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/collector v0.51.0

--- a/exporter/influxdbexporter/go.sum
+++ b/exporter/influxdbexporter/go.sum
@@ -123,10 +123,10 @@ github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoI
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/influxdata/influxdb-observability/common v0.2.20 h1:gCDrsHnhkWm4nFH2PGHAtUx6IgR7u48bDASem+pQjms=
-github.com/influxdata/influxdb-observability/common v0.2.20/go.mod h1:9t4MDkYRImBa4Wuatb3URr6tlimGT1JUYv9O8y5L/C8=
-github.com/influxdata/influxdb-observability/otel2influx v0.2.20 h1:pBAzvwHvcXtQ+Fa+xSTJ0ddagqdend23+vKTThjBdm0=
-github.com/influxdata/influxdb-observability/otel2influx v0.2.20/go.mod h1:AWkadnBhKwYeGgGquzIE9K88AgVB5xTwsw4WNugsFGc=
+github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de h1:f9p3iKS31+/p6cvqdmTJ45lrTlH+GDj2sK4EdVbuMI4=
+github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de/go.mod h1:9t4MDkYRImBa4Wuatb3URr6tlimGT1JUYv9O8y5L/C8=
+github.com/influxdata/influxdb-observability/otel2influx v0.2.21-0.20220517160208-05f925d616de h1:KZBtAaNAHzBNJXLwYHeDXuUFWhjGa4B47T7N6HKcwnk=
+github.com/influxdata/influxdb-observability/otel2influx v0.2.21-0.20220517160208-05f925d616de/go.mod h1:AWkadnBhKwYeGgGquzIE9K88AgVB5xTwsw4WNugsFGc=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210519164801-ca6fa5da0184/go.mod h1:03nmhxzZ7Xk2pdG+lmMd7mHDfeVOYFyhOgwO61qWU98=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210922080147-aa28ccfb8937 h1:MHJNQ+p99hFATQm6ORoLmpUCF7ovjwEFshs/NHzAbig=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210922080147-aa28ccfb8937/go.mod h1:BKR9c0uHSmRgM/se9JhFHtTT7JTO67X23MtKMHtZcpo=

--- a/go.mod
+++ b/go.mod
@@ -302,9 +302,9 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6 // indirect
-	github.com/influxdata/influxdb-observability/common v0.2.20 // indirect
+	github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de // indirect
 	github.com/influxdata/influxdb-observability/influx2otel v0.2.20 // indirect
-	github.com/influxdata/influxdb-observability/otel2influx v0.2.20 // indirect
+	github.com/influxdata/influxdb-observability/otel2influx v0.2.21-0.20220517160208-05f925d616de // indirect
 	github.com/influxdata/line-protocol/v2 v2.2.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.12.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1257,12 +1257,12 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6 h1:s9ZL6ZhFF8y6ebnm1FLvobkzoIu5xwDQUcRPk/IEhpM=
 github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6/go.mod h1:aXdIdfn2OcGnMhOTojXmwZqXKgC3MU5riiNvzwwG9OY=
-github.com/influxdata/influxdb-observability/common v0.2.20 h1:gCDrsHnhkWm4nFH2PGHAtUx6IgR7u48bDASem+pQjms=
-github.com/influxdata/influxdb-observability/common v0.2.20/go.mod h1:9t4MDkYRImBa4Wuatb3URr6tlimGT1JUYv9O8y5L/C8=
+github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de h1:f9p3iKS31+/p6cvqdmTJ45lrTlH+GDj2sK4EdVbuMI4=
+github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de/go.mod h1:9t4MDkYRImBa4Wuatb3URr6tlimGT1JUYv9O8y5L/C8=
 github.com/influxdata/influxdb-observability/influx2otel v0.2.20 h1:A0XKklwAa+INyirFMcFFOBkXSOBduD+zET1Eoo4HPaM=
 github.com/influxdata/influxdb-observability/influx2otel v0.2.20/go.mod h1:rWuw8bSmCbj6h3JLtj8QyXvoDnFtXKfGIzlcPMyH4Q8=
-github.com/influxdata/influxdb-observability/otel2influx v0.2.20 h1:pBAzvwHvcXtQ+Fa+xSTJ0ddagqdend23+vKTThjBdm0=
-github.com/influxdata/influxdb-observability/otel2influx v0.2.20/go.mod h1:AWkadnBhKwYeGgGquzIE9K88AgVB5xTwsw4WNugsFGc=
+github.com/influxdata/influxdb-observability/otel2influx v0.2.21-0.20220517160208-05f925d616de h1:KZBtAaNAHzBNJXLwYHeDXuUFWhjGa4B47T7N6HKcwnk=
+github.com/influxdata/influxdb-observability/otel2influx v0.2.21-0.20220517160208-05f925d616de/go.mod h1:AWkadnBhKwYeGgGquzIE9K88AgVB5xTwsw4WNugsFGc=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210519164801-ca6fa5da0184/go.mod h1:03nmhxzZ7Xk2pdG+lmMd7mHDfeVOYFyhOgwO61qWU98=

--- a/receiver/influxdbreceiver/go.mod
+++ b/receiver/influxdbreceiver/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influx
 go 1.17
 
 require (
-	github.com/influxdata/influxdb-observability/common v0.2.20
+	github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de
 	github.com/influxdata/influxdb-observability/influx2otel v0.2.20
 	github.com/influxdata/line-protocol/v2 v2.2.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.51.0

--- a/receiver/influxdbreceiver/go.sum
+++ b/receiver/influxdbreceiver/go.sum
@@ -118,8 +118,8 @@ github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoI
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/influxdata/influxdb-observability/common v0.2.20 h1:gCDrsHnhkWm4nFH2PGHAtUx6IgR7u48bDASem+pQjms=
-github.com/influxdata/influxdb-observability/common v0.2.20/go.mod h1:9t4MDkYRImBa4Wuatb3URr6tlimGT1JUYv9O8y5L/C8=
+github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de h1:f9p3iKS31+/p6cvqdmTJ45lrTlH+GDj2sK4EdVbuMI4=
+github.com/influxdata/influxdb-observability/common v0.2.21-0.20220517160208-05f925d616de/go.mod h1:9t4MDkYRImBa4Wuatb3URr6tlimGT1JUYv9O8y5L/C8=
 github.com/influxdata/influxdb-observability/influx2otel v0.2.20 h1:A0XKklwAa+INyirFMcFFOBkXSOBduD+zET1Eoo4HPaM=
 github.com/influxdata/influxdb-observability/influx2otel v0.2.20/go.mod h1:rWuw8bSmCbj6h3JLtj8QyXvoDnFtXKfGIzlcPMyH4Q8=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210519164801-ca6fa5da0184/go.mod h1:03nmhxzZ7Xk2pdG+lmMd7mHDfeVOYFyhOgwO61qWU98=


### PR DESCRIPTION
To pull https://github.com/influxdata/influxdb-observability/pull/78 that unblocks removal of deprecated pdata methods for primitive slices in https://github.com/open-telemetry/opentelemetry-collector/pull/5347