### PR TITLE
[receiver/filelog] docs: update `include_file_name` and similar parameters' descriptions

### DIFF
--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -8,26 +8,26 @@ Supported pipeline types: logs
 
 ## Configuration
 
-
-
-| Field                  | Default          | Description                                                                                                        |
-| ---                    | ---              | ---                                                                                                                |
-| `include`              | required         | A list of file glob patterns that match the file paths to be read                                                  |
-| `exclude`              | []               | A list of file glob patterns to exclude from reading                                                               |
-| `start_at`             | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
-| `multiline`            |                  | A `multiline` configuration block. See below for more details                                                      |
-| `force_flush_period`   | `500ms`          | Time since last read of data from file, after which currently buffered log should be send to pipeline. Takes [duration](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/duration.md) as value. Zero means waiting for new data forever |
-| `encoding`             | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
-| `include_file_name`    | `true`           | Whether to add the file name as the label `file_name`                                                              |
-| `include_file_path`    | `false`          | Whether to add the file path as the label `file_path`                                                              |
-| `poll_interval`        | 200ms            | The duration between filesystem polls                                                                              |
-| `fingerprint_size`     | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time) |
-| `max_log_size`         | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
-| `max_concurrent_files` | 1024             | The maximum number of log files from which logs will be read concurrently. If the number of files matched in the `include` pattern exceeds this number, then files will be processed in batches. One batch will be processed per `poll_interval` |
-| `attributes`           | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
-| `resource`             | {}               | A map of `key: value` pairs to add to the entry's resource                                                    |
-| `operators`            | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
-| `converter`            | <pre lang="jsonp">{<br>  max_flush_count: 100,<br>  flush_interval: 100ms,<br>  worker_count: max(1,runtime.NumCPU()/4)<br>}</pre> | A map of `key: value` pairs to configure the [`entry.Entry`][entry_link] to [`plog.LogRecord`][pdata_logrecord_link] converter, more info can be found [here][converter_link] |
+| Field                        | Default          | Description                                                                                                        |
+| ---                          | ---              | ---                                                                                                                |
+| `include`                    | required         | A list of file glob patterns that match the file paths to be read                                                  |
+| `exclude`                    | []               | A list of file glob patterns to exclude from reading                                                               |
+| `start_at`                   | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
+| `multiline`                  |                  | A `multiline` configuration block. See below for more details                                                      |
+| `force_flush_period`         | `500ms`          | Time since last read of data from file, after which currently buffered log should be send to pipeline. Takes [duration](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/duration.md) as value. Zero means waiting for new data forever |
+| `encoding`                   | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
+| `include_file_name`          | `true`           | Whether to add the file name as the attribute `log.file.name`. |
+| `include_file_path`          | `false`          | Whether to add the file path as the attribute `log.file.path`. |
+| `include_file_name_resolved` | `false`          | Whether to add the file name after symlinks resolution as the attribute `log.file.name_resolved`. |
+| `include_file_path_resolved` | `false`          | Whether to add the file path after symlinks resolution as the attribute `log.file.path_resolved`. |
+| `poll_interval`              | 200ms            | The duration between filesystem polls                                                                              |
+| `fingerprint_size`           | `1kb`            | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time) |
+| `max_log_size`               | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
+| `max_concurrent_files`       | 1024             | The maximum number of log files from which logs will be read concurrently. If the number of files matched in the `include` pattern exceeds this number, then files will be processed in batches. One batch will be processed per `poll_interval` |
+| `attributes`                 | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
+| `resource`                   | {}               | A map of `key: value` pairs to add to the entry's resource                                                    |
+| `operators`                  | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
+| `converter`                  | <pre lang="jsonp">{<br>  max_flush_count: 100,<br>  flush_interval: 100ms,<br>  worker_count: max(1,runtime.NumCPU()/4)<br>}</pre> | A map of `key: value` pairs to configure the [`entry.Entry`][entry_link] to [`plog.LogRecord`][pdata_logrecord_link] converter, more info can be found [here][converter_link] |
 
 [entry_link]: https://github.com/open-telemetry/opentelemetry-log-collection/blob/v0.23.0/entry/entry.go#L43-L54
 [pdata_logrecord_link]: https://github.com/open-telemetry/opentelemetry-collector/blob/v0.40.0/model/pdata/generated_log.go#L553-L564


### PR DESCRIPTION
**Description:**

Fixing documentation for the following configuration parameters:

- `include_file_name`
- `include_file_name_resolved`
- `include_file_path`
- `include_file_path_resolved`

The descriptions of those parameters have been long outdated (or missing).
Copied the latest descriptions from https://github.com/open-telemetry/opentelemetry-log-collection/blob/v0.29.1/docs/operators/file_input.md.

_Note:_ It's easier to see the changes in GitHub UI when you select the `Hide whitespace` checkbox in diff settings.