### PR TITLE
[pkg/stanza]: Windows unsafe Pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
 - `datadogexporter`: add error checks for datadog exporter (#9964)
 - `groupbyattrsprocessor`: copied aggregationtemporality when grouping metrics. (#9088)
 - `mongodbreceiver`: Fix issue where receiver startup could hang (#10111)
-- `windowsinputoperator`: Fix windows unsafe pointers (#10167)
 
 ## v0.51.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `datadogexporter`: add error checks for datadog exporter (#9964)
 - `groupbyattrsprocessor`: copied aggregationtemporality when grouping metrics. (#9088)
 - `mongodbreceiver`: Fix issue where receiver startup could hang (#10111)
+- `windowsinputoperator`: Fix windows unsafe pointers (#10167)
 
 ## v0.51.0
 

--- a/pkg/stanza/operator/input/windows/api.go
+++ b/pkg/stanza/operator/input/windows/api.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
@@ -96,13 +97,15 @@ func evtNext(resultSet uintptr, eventsSize uint32, events *uintptr, timeout uint
 }
 
 // evtRender is the direct syscall implementation of EvtRender (https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtrender)
-func evtRender(context uintptr, fragment uintptr, flags uint32, bufferSize uint32, buffer *byte, bufferUsed *uint32, propertyCount *uint32) error {
+func evtRender(context uintptr, fragment uintptr, flags uint32, bufferSize uint32, buffer *byte) (*uint32, *uint32, error) {
+	bufferUsed := new(uint32)
+	propertyCount := new(uint32)
 	_, _, err := renderProc.Call(context, fragment, uintptr(flags), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)), uintptr(unsafe.Pointer(propertyCount)))
 	if err != ErrorSuccess {
-		return err
+		return nil, nil, err
 	}
 
-	return nil
+	return bufferUsed, propertyCount, nil
 }
 
 // evtClose is the direct syscall implementation of EvtClose (https://docs.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtclose)

--- a/pkg/stanza/operator/input/windows/bookmark.go
+++ b/pkg/stanza/operator/input/windows/bookmark.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
@@ -69,10 +70,9 @@ func (b *Bookmark) Render(buffer Buffer) (string, error) {
 		return "", fmt.Errorf("bookmark handle is not open")
 	}
 
-	var bufferUsed, propertyCount uint32
-	err := evtRender(0, b.handle, EvtRenderBookmark, buffer.SizeBytes(), buffer.FirstByte(), &bufferUsed, &propertyCount)
+	bufferUsed, _, err := evtRender(0, b.handle, EvtRenderBookmark, buffer.SizeBytes(), buffer.FirstByte())
 	if err == ErrorInsufficientBuffer {
-		buffer.UpdateSizeBytes(bufferUsed)
+		buffer.UpdateSizeBytes(*bufferUsed)
 		return b.Render(buffer)
 	}
 
@@ -80,7 +80,7 @@ func (b *Bookmark) Render(buffer Buffer) (string, error) {
 		return "", fmt.Errorf("syscall to 'EvtRender' failed: %s", err)
 	}
 
-	return buffer.ReadString(bufferUsed)
+	return buffer.ReadString(*bufferUsed)
 }
 
 // Close will close the bookmark handle.

--- a/pkg/stanza/operator/input/windows/event.go
+++ b/pkg/stanza/operator/input/windows/event.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
@@ -31,10 +32,9 @@ func (e *Event) RenderSimple(buffer Buffer) (EventXML, error) {
 		return EventXML{}, fmt.Errorf("event handle does not exist")
 	}
 
-	var bufferUsed, propertyCount uint32
-	err := evtRender(0, e.handle, EvtRenderEventXML, buffer.SizeBytes(), buffer.FirstByte(), &bufferUsed, &propertyCount)
+	bufferUsed, _, err := evtRender(0, e.handle, EvtRenderEventXML, buffer.SizeBytes(), buffer.FirstByte())
 	if err == ErrorInsufficientBuffer {
-		buffer.UpdateSizeBytes(bufferUsed)
+		buffer.UpdateSizeBytes(*bufferUsed)
 		return e.RenderSimple(buffer)
 	}
 
@@ -42,7 +42,7 @@ func (e *Event) RenderSimple(buffer Buffer) (EventXML, error) {
 		return EventXML{}, fmt.Errorf("syscall to 'EvtRender' failed: %s", err)
 	}
 
-	bytes, err := buffer.ReadBytes(bufferUsed)
+	bytes, err := buffer.ReadBytes(*bufferUsed)
 	if err != nil {
 		return EventXML{}, fmt.Errorf("failed to read bytes from buffer: %s", err)
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The Windows input operator was having some issues with pointers when attempt to render an `EventXML`. Specifically the RenderSimple method. What was happening is that the `bufferUsed` pointer being passed into `evtRender` from `RenderSimple` was not being written to properly. This resulted in `Go` occasionally tossing aside the pointer before windows had a chance to write to it.

**Fix**
 A fix we found is initializing `bufferUsed` in `evtRender` and then pass the pointer back to the calling function. This would still save the pointer as long as it was called to be used deeper in the stack.

**Testing:** <Describe what testing was performed and which tests were added.>
This newly changed repo was locally tested on a windows (2022) VM in which a `windowseventlog` receiver implements this piece of code for its log collection. The tests would write a Windows Event Log and have the receiver attempt to scrape those logs using the Windows input operator.
