### PR TITLE
[exporter/googlecloud] configure service account impersonation

### DIFF
--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -137,6 +137,10 @@ The following configuration options are supported:
     User should calculate this as `num_seconds * requests_per_second` where:
     - `num_seconds` is the number of seconds to buffer in case of a backend outage
     - `requests_per_second` is the average number of requests per seconds.
+- `impersonate` (optional): Configuration for [service account impersonation](https://cloud.google.com/iam/docs/impersonating-service-accounts)
+  - `target_principal`: Email address of the service account to impersonate.
+  - `delegates` (default = []): Service account email addresses in a delegation chain.
+  - `subject` (default = ""): `sub` field of a JWT. This field should only be set if you wish to impersonate as a user.
 
 Note: These `retry_on_failure` and `sending_queue` are provided (and documented) by the [Exporter Helper](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/exporterhelper#configuration)
 

--- a/exporter/googlecloudexporter/config.go
+++ b/exporter/googlecloudexporter/config.go
@@ -31,6 +31,14 @@ type Config struct {
 	exporterhelper.TimeoutSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	exporterhelper.QueueSettings   `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
+
+	ImpersonateSettings `mapstructure:"impersonate"`
+}
+
+type ImpersonateSettings struct {
+	TargetPrincipal string   `mapstructure:"target_principal"`
+	Delegates       []string `mapstructure:"delegates"`
+	Subject         string   `mapstructure:"subject"`
 }
 
 func (cfg *Config) Validate() error {


### PR DESCRIPTION
**Description:** <Describe what has changed.>

GCP supports authentication using short-lived credentials obtained by
"impersonating" a service account:
https://cloud.google.com/iam/docs/impersonating-service-accounts. This
patch adds support for service account delegation to the logs, traces,
and metrics google cloud exporters.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:**

TBD; I'll add tests if you all are willing to support the feature.

**Documentation:**

Updated docs in relevant README.