### PR TITLE
[receiver/zookeeper] Skip whole test TestZookeeperMetricsScraperScrape on Windows

### DIFF
--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -46,10 +46,12 @@ type logMsg struct {
 }
 
 func TestZookeeperMetricsScraperScrape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping flaky test on windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10171")
+	}
+
 	tests := []struct {
 		name                         string
-		skip                         bool
-		skipComment                  string
 		expectedMetricsFilename      string
 		expectedResourceAttributes   map[string]string
 		metricsSettings              func() metadata.MetricsSettings
@@ -64,8 +66,6 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 	}{
 		{
 			name:                         "Test correctness with v3.4.14",
-			skip:                         runtime.GOOS == "windows",
-			skipComment:                  "skipping test on windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10171",
 			mockedZKOutputSourceFilename: "mntr-3.4.14",
 			expectedMetricsFilename:      "correctness-v3.4.14",
 			expectedResourceAttributes: map[string]string{
@@ -214,11 +214,6 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.skip {
-				t.Log(tt.skipComment)
-				return
-			}
-
 			localAddr := testutil.GetAvailableLocalAddress(t)
 			if !tt.mockZKConnectionErr {
 				ms := mockedServer{ready: make(chan bool, 1)}


### PR DESCRIPTION
Appeared that more than one subtest is flaky.

Updates: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10171