### PR TITLE
docs: link to local `/pkg/stanza` directory instead of `opentelemetry-log-collection` repo

### DIFF
--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -223,7 +223,7 @@ of the opentelemetry-collector-contrib log receivers, such as the [filelogreceiv
 
 Log entries must contain any Cloud Logging-specific fields as a matching OpenTelemetry attribute (as shown in examples from the 
 [logs data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#google-cloud-logging)). 
-These attributes can be parsed using the various [log collection operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available) available upstream.
+These attributes can be parsed using the various [log collection operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available) available upstream.
 
 For example, the following config parses the [HTTPRequest field](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) from Apache log entries saved in `/var/log/apache.log`. 
 It also parses out the `timestamp` and inserts a non-default `log_name` attribute and GCP [MonitoredResource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/MonitoredResource) attribute.
@@ -325,8 +325,8 @@ to a matching GCP log severity:
 |23 / Fatal|Alert|
 |24 / Fatal|Emergency|
 
-The upstream [severity parser](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/severity.md) (along 
-with the [regex parser](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/regex_parser.md)) allows for 
+The upstream [severity parser](../../pkg/stanza/docs/types/severity.md) (along 
+with the [regex parser](../../pkg/stanza/docs/operators/regex_parser.md)) allows for 
 additional flexibility in parsing log severity from incoming entries.
 
 ## Recommendations

--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -14,7 +14,7 @@ Supported pipeline types: logs
 | `exclude`                    | []               | A list of file glob patterns to exclude from reading                                                               |
 | `start_at`                   | `end`            | At startup, where to start reading logs from the file. Options are `beginning` or `end`                            |
 | `multiline`                  |                  | A `multiline` configuration block. See below for more details                                                      |
-| `force_flush_period`         | `500ms`          | Time since last read of data from file, after which currently buffered log should be send to pipeline. Takes [duration](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/duration.md) as value. Zero means waiting for new data forever |
+| `force_flush_period`         | `500ms`          | Time since last read of data from file, after which currently buffered log should be send to pipeline. Takes [duration](../../pkg/stanza/docs/types/duration.md) as value. Zero means waiting for new data forever |
 | `encoding`                   | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `include_file_name`          | `true`           | Whether to add the file name as the attribute `log.file.name`. |
 | `include_file_path`          | `false`          | Whether to add the file path as the attribute `log.file.path`. |
@@ -26,7 +26,7 @@ Supported pipeline types: logs
 | `max_concurrent_files`       | 1024             | The maximum number of log files from which logs will be read concurrently. If the number of files matched in the `include` pattern exceeds this number, then files will be processed in batches. One batch will be processed per `poll_interval` |
 | `attributes`                 | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
 | `resource`                   | {}               | A map of `key: value` pairs to add to the entry's resource                                                    |
-| `operators`                  | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
+| `operators`                  | []               | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
 | `converter`                  | <pre lang="jsonp">{<br>  max_flush_count: 100,<br>  flush_interval: 100ms,<br>  worker_count: max(1,runtime.NumCPU()/4)<br>}</pre> | A map of `key: value` pairs to configure the [`entry.Entry`][entry_link] to [`plog.LogRecord`][pdata_logrecord_link] converter, more info can be found [here][converter_link] |
 
 [entry_link]: https://github.com/open-telemetry/opentelemetry-log-collection/blob/v0.23.0/entry/entry.go#L43-L54
@@ -66,11 +66,11 @@ Other less common encodings are supported on a best-effort basis. See [https://w
 
 ## Additional Terminology and Features
 
-- An [entry](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/entry.md) is the base representation of log data as it moves through a pipeline. All operators either create, modify, or consume entries.
-- A [field](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/field.md) is used to reference values in an entry.
-- A common [expression](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/expression.md) syntax is used in several operators. For example, expressions can be used to [filter](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/filter.md) or [route](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/router.md) entries.
-- [timestamp](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/timestamp.md) parsing is available as a block within all parser operators, and also as a standalone operator. Many common timestamp layouts are supported.
-- [severity](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/severity.md) parsing is available as a block within all parser operators, and also as a standalone operator. Stanza uses a flexible severity representation which is automatically interpreted by the stanza receiver.
+- An [entry](../../pkg/stanza/docs/types/entry.md) is the base representation of log data as it moves through a pipeline. All operators either create, modify, or consume entries.
+- A [field](../../pkg/stanza/docs/types/field.md) is used to reference values in an entry.
+- A common [expression](../../pkg/stanza/docs/types/expression.md) syntax is used in several operators. For example, expressions can be used to [filter](../../pkg/stanza/docs/operators/filter.md) or [route](../../pkg/stanza/docs/operators/router.md) entries.
+- [timestamp](../../pkg/stanza/docs/types/timestamp.md) parsing is available as a block within all parser operators, and also as a standalone operator. Many common timestamp layouts are supported.
+- [severity](../../pkg/stanza/docs/types/severity.md) parsing is available as a block within all parser operators, and also as a standalone operator. Stanza uses a flexible severity representation which is automatically interpreted by the stanza receiver.
 
 
 ## Example - Tailing a simple json file

--- a/receiver/syslogreceiver/README.md
+++ b/receiver/syslogreceiver/README.md
@@ -15,11 +15,11 @@ Supported pipeline types: logs
 | `udp`      |`nil`                | Defined udp_input operator. (see the UDP configuration section)  |
 | `protocol`    | required         | The protocol to parse the syslog messages as. Options are `rfc3164` and `rfc5424` |
 | `location`    | `UTC`            | The geographic location (timezone) to use when parsing the timestamp (Syslog RFC 3164 only). The available locations depend on the local IANA Time Zone database. [This page](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) contains many examples, such as `America/New_York`. |
-| `timestamp`   | `nil`            | An optional [timestamp](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator                                                                                               |
-| `severity`    | `nil`            | An optional [severity](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator
+| `timestamp`   | `nil`            | An optional [timestamp](../../pkg/stanza/docs/types/timestamp.md) block which will parse a timestamp field before passing the entry to the output operator                                                                                               |
+| `severity`    | `nil`            | An optional [severity](../../pkg/stanza/docs/docs/types/severity.md) block which will parse a severity field before passing the entry to the output operator
 | `attributes`   | {}               | A map of `key: value` labels to add to the entry's attributes    |
 | `resource` | {}               | A map of `key: value` labels to add to the entry's resource  |
-| `operators`            | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
+| `operators`            | []               | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
 
 ### Operators
 
@@ -57,11 +57,11 @@ The `tcp_input` operator supports TLS, disabled by default.
 
 ## Additional Terminology and Features
 
-- An [entry](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/entry.md) is the base representation of log data as it moves through a pipeline. All operators either create, modify, or consume entries.
-- A [field](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/field.md) is used to reference values in an entry.
-- A common [expression](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/expression.md) syntax is used in several operators. For example, expressions can be used to [filter](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/filter.md) or [route](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/router.md) entries.
-- [timestamp](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/timestamp.md) parsing is available as a block within all parser operators, and also as a standalone operator. Many common timestamp layouts are supported.
-- [severity](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/severity.md) parsing is available as a block within all parser operators, and also as a standalone operator. Stanza uses a flexible severity representation which is automatically interpreted by the stanza receiver.
+- An [entry](../../pkg/stanza/docs/types/entry.md) is the base representation of log data as it moves through a pipeline. All operators either create, modify, or consume entries.
+- A [field](../../pkg/stanza/docs/types/field.md) is used to reference values in an entry.
+- A common [expression](../../pkg/stanza/docs/types/expression.md) syntax is used in several operators. For example, expressions can be used to [filter](../../pkg/stanza/docs/operators/filter.md) or [route](../../pkg/stanza/docs/operators/router.md) entries.
+- [timestamp](../../pkg/stanza/docs/types/timestamp.md) parsing is available as a block within all parser operators, and also as a standalone operator. Many common timestamp layouts are supported.
+- [severity](../../pkg/stanza/docs/types/severity.md) parsing is available as a block within all parser operators, and also as a standalone operator. Stanza uses a flexible severity representation which is automatically interpreted by the stanza receiver.
 
 ## Example Configurations
 

--- a/receiver/tcplogreceiver/README.md
+++ b/receiver/tcplogreceiver/README.md
@@ -19,7 +19,7 @@ Supported pipeline types: logs
 | `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
 | `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
 | `encoding`        | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
-| `operators`       | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
+| `operators`       | []               | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
 
 ### TLS Configuration
 

--- a/receiver/udplogreceiver/README.md
+++ b/receiver/udplogreceiver/README.md
@@ -17,7 +17,7 @@ Supported pipeline types: logs
 | `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
 | `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
 | `encoding`        | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
-| `operators`       | []               | An array of [operators](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/operators/README.md#what-operators-are-available). See below for more details |
+| `operators`       | []               | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
 
 ### Operators
 


### PR DESCRIPTION
**Description:**

Changing the links in documentation that lead to https://github.com/open-telemetry/opentelemetry-log-collection/tree/main/docs to point to the local [pkg/stanza/docs](./pkg/stanza/docs) directory. 

The `/pkg/stanza/` directory contains code moved from https://github.com/open-telemetry/opentelemetry-log-collection/ repository. We are currently during a transition period, after which the local code in `pkg/stanza` will be used in places where code from `opentelemetry-log-collection` repo is currently used. I believe we are already at a point where we should use the local files when linking to docs instead of the remote repo.