### PR TITLE
[processor/transform] Added testhelper

### DIFF
--- a/processor/transformprocessor/internal/common/condition_test.go
+++ b/processor/transformprocessor/internal/common/condition_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 func Test_newConditionEvaluator(t *testing.T) {
@@ -35,10 +37,10 @@ func Test_newConditionEvaluator(t *testing.T) {
 			name: "literals match",
 			cond: &Condition{
 				Left: Value{
-					String: strp("hello"),
+					String: testhelper.Strp("hello"),
 				},
 				Right: Value{
-					String: strp("hello"),
+					String: testhelper.Strp("hello"),
 				},
 				Op: "==",
 			},
@@ -48,10 +50,10 @@ func Test_newConditionEvaluator(t *testing.T) {
 			name: "literals don't match",
 			cond: &Condition{
 				Left: Value{
-					String: strp("hello"),
+					String: testhelper.Strp("hello"),
 				},
 				Right: Value{
-					String: strp("goodbye"),
+					String: testhelper.Strp("goodbye"),
 				},
 				Op: "!=",
 			},
@@ -70,7 +72,7 @@ func Test_newConditionEvaluator(t *testing.T) {
 					},
 				},
 				Right: Value{
-					String: strp("bear"),
+					String: testhelper.Strp("bear"),
 				},
 				Op: "==",
 			},
@@ -89,7 +91,7 @@ func Test_newConditionEvaluator(t *testing.T) {
 					},
 				},
 				Right: Value{
-					String: strp("cat"),
+					String: testhelper.Strp("cat"),
 				},
 				Op: "!=",
 			},
@@ -116,11 +118,11 @@ func Test_newConditionEvaluator(t *testing.T) {
 	t.Run("invalid", func(t *testing.T) {
 		_, err := newConditionEvaluator(&Condition{
 			Left: Value{
-				String: strp("bear"),
+				String: testhelper.Strp("bear"),
 			},
 			Op: "<>",
 			Right: Value{
-				String: strp("cat"),
+				String: testhelper.Strp("cat"),
 			},
 		}, DefaultFunctions(), testParsePath)
 		assert.Error(t, err)

--- a/processor/transformprocessor/internal/common/expression_test.go
+++ b/processor/transformprocessor/internal/common/expression_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 func hello() (ExprFunc, error) {
@@ -39,21 +41,21 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "string literal",
 			val: Value{
-				String: strp("str"),
+				String: testhelper.Strp("str"),
 			},
 			want: "str",
 		},
 		{
 			name: "float literal",
 			val: Value{
-				Float: floatp(1.2),
+				Float: testhelper.Floatp(1.2),
 			},
 			want: 1.2,
 		},
 		{
 			name: "int literal",
 			val: Value{
-				Int: intp(12),
+				Int: testhelper.Intp(12),
 			},
 			want: int64(12),
 		},

--- a/processor/transformprocessor/internal/common/functions_test.go
+++ b/processor/transformprocessor/internal/common/functions_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 // Test for valid functions are in internal/traces/functions_test.go as there are many different data model cases.
@@ -41,10 +43,10 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 				Function: "set",
 				Arguments: []Value{
 					{
-						String: strp("not path"),
+						String: testhelper.Strp("not path"),
 					},
 					{
-						String: strp("cat"),
+						String: testhelper.Strp("cat"),
 					},
 				},
 			},
@@ -108,7 +110,7 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(10),
+						Int: testhelper.Intp(10),
 					},
 				},
 			},
@@ -128,7 +130,7 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 						},
 					},
 					{
-						String: strp("not an int"),
+						String: testhelper.Strp("not an int"),
 					},
 				},
 			},
@@ -148,7 +150,7 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(-1),
+						Int: testhelper.Intp(-1),
 					},
 				},
 			},
@@ -168,7 +170,7 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 						},
 					},
 					{
-						String: strp("not an int"),
+						String: testhelper.Strp("not an int"),
 					},
 				},
 			},
@@ -188,7 +190,7 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(-1),
+						Int: testhelper.Intp(-1),
 					},
 				},
 			},

--- a/processor/transformprocessor/internal/common/parser_test.go
+++ b/processor/transformprocessor/internal/common/parser_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 func Test_parse(t *testing.T) {
@@ -32,7 +34,7 @@ func Test_parse(t *testing.T) {
 					Function: "set",
 					Arguments: []Value{
 						{
-							String: strp("foo"),
+							String: testhelper.Strp("foo"),
 						},
 					},
 				},
@@ -46,7 +48,7 @@ func Test_parse(t *testing.T) {
 					Function: "met",
 					Arguments: []Value{
 						{
-							Float: floatp(1.2),
+							Float: testhelper.Floatp(1.2),
 						},
 					},
 				},
@@ -60,7 +62,7 @@ func Test_parse(t *testing.T) {
 					Function: "fff",
 					Arguments: []Value{
 						{
-							Int: intp(12),
+							Int: testhelper.Intp(12),
 						},
 					},
 				},
@@ -74,7 +76,7 @@ func Test_parse(t *testing.T) {
 					Function: "set",
 					Arguments: []Value{
 						{
-							String: strp("foo"),
+							String: testhelper.Strp("foo"),
 						},
 						{
 							Invocation: &Invocation{
@@ -114,7 +116,7 @@ func Test_parse(t *testing.T) {
 									},
 									{
 										Name:   "attributes",
-										MapKey: strp("bar"),
+										MapKey: testhelper.Strp("bar"),
 									},
 									{
 										Name: "cat",
@@ -123,7 +125,7 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							String: strp("dog"),
+							String: testhelper.Strp("dog"),
 						},
 					},
 				},
@@ -144,7 +146,7 @@ func Test_parse(t *testing.T) {
 									},
 									{
 										Name:   "attributes",
-										MapKey: strp("bar"),
+										MapKey: testhelper.Strp("bar"),
 									},
 									{
 										Name: "cat",
@@ -153,7 +155,7 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							String: strp("dog"),
+							String: testhelper.Strp("dog"),
 						},
 					},
 				},
@@ -169,7 +171,7 @@ func Test_parse(t *testing.T) {
 					},
 					Op: "==",
 					Right: Value{
-						String: strp("fido"),
+						String: testhelper.Strp("fido"),
 					},
 				},
 			},
@@ -188,7 +190,7 @@ func Test_parse(t *testing.T) {
 									},
 									{
 										Name:   "attributes",
-										MapKey: strp("bar"),
+										MapKey: testhelper.Strp("bar"),
 									},
 									{
 										Name: "cat",
@@ -197,7 +199,7 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							String: strp("dog"),
+							String: testhelper.Strp("dog"),
 						},
 					},
 				},
@@ -213,7 +215,7 @@ func Test_parse(t *testing.T) {
 					},
 					Op: "!=",
 					Right: Value{
-						String: strp("fido"),
+						String: testhelper.Strp("fido"),
 					},
 				},
 			},
@@ -232,7 +234,7 @@ func Test_parse(t *testing.T) {
 									},
 									{
 										Name:   "attributes",
-										MapKey: strp("bar"),
+										MapKey: testhelper.Strp("bar"),
 									},
 									{
 										Name: "cat",
@@ -241,7 +243,7 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							String: strp("dog"),
+							String: testhelper.Strp("dog"),
 						},
 					},
 				},
@@ -257,7 +259,7 @@ func Test_parse(t *testing.T) {
 					},
 					Op: "==",
 					Right: Value{
-						String: strp("fido"),
+						String: testhelper.Strp("fido"),
 					},
 				},
 			},
@@ -269,7 +271,7 @@ func Test_parse(t *testing.T) {
 					Function: "set",
 					Arguments: []Value{
 						{
-							String: strp("fo\"o"),
+							String: testhelper.Strp("fo\"o"),
 						},
 					},
 				},
@@ -301,16 +303,4 @@ func Test_parse_failure(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
-}
-
-func strp(s string) *string {
-	return &s
-}
-
-func floatp(f float64) *float64 {
-	return &f
-}
-
-func intp(i int64) *int64 {
-	return &i
 }

--- a/processor/transformprocessor/internal/common/testhelper/testhelper.go
+++ b/processor/transformprocessor/internal/common/testhelper/testhelper.go
@@ -1,0 +1,27 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelper // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
+
+func Strp(s string) *string {
+	return &s
+}
+
+func Floatp(f float64) *float64 {
+	return &f
+}
+
+func Intp(i int64) *int64 {
+	return &i
+}

--- a/processor/transformprocessor/internal/logs/functions_test.go
+++ b/processor/transformprocessor/internal/logs/functions_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 func Test_newFunctionCall(t *testing.T) {
@@ -52,7 +53,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						String: strp("fail"),
+						String: testhelper.Strp("fail"),
 					},
 				},
 			},
@@ -76,7 +77,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 				},
 			},
@@ -103,10 +104,10 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 					{
-						String: strp("test2"),
+						String: testhelper.Strp("test2"),
 					},
 				},
 			},

--- a/processor/transformprocessor/internal/logs/logs_test.go
+++ b/processor/transformprocessor/internal/logs/logs_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 var (
@@ -184,7 +185,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("str"),
+					MapKey: testhelper.Strp("str"),
 				},
 			},
 			orig: "val",
@@ -198,7 +199,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bool"),
+					MapKey: testhelper.Strp("bool"),
 				},
 			},
 			orig: true,
@@ -212,7 +213,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("int"),
+					MapKey: testhelper.Strp("int"),
 				},
 			},
 			orig: int64(10),
@@ -226,7 +227,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("double"),
+					MapKey: testhelper.Strp("double"),
 				},
 			},
 			orig: float64(1.2),
@@ -240,7 +241,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bytes"),
+					MapKey: testhelper.Strp("bytes"),
 				},
 			},
 			orig: []byte{1, 3, 2},
@@ -254,7 +255,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_str"),
+					MapKey: testhelper.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -271,7 +272,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bool"),
+					MapKey: testhelper.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -288,7 +289,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_int"),
+					MapKey: testhelper.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -305,7 +306,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_float"),
+					MapKey: testhelper.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -322,7 +323,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bytes"),
+					MapKey: testhelper.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -404,7 +405,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("str"),
+					MapKey: testhelper.Strp("str"),
 				},
 			},
 			orig: "val",
@@ -421,7 +422,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("bool"),
+					MapKey: testhelper.Strp("bool"),
 				},
 			},
 			orig: true,
@@ -438,7 +439,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("int"),
+					MapKey: testhelper.Strp("int"),
 				},
 			},
 			orig: int64(10),
@@ -455,7 +456,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("double"),
+					MapKey: testhelper.Strp("double"),
 				},
 			},
 			orig: float64(1.2),
@@ -472,7 +473,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("bytes"),
+					MapKey: testhelper.Strp("bytes"),
 				},
 			},
 			orig: []byte{1, 3, 2},
@@ -489,7 +490,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_str"),
+					MapKey: testhelper.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -509,7 +510,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bool"),
+					MapKey: testhelper.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -529,7 +530,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_int"),
+					MapKey: testhelper.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -549,7 +550,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_float"),
+					MapKey: testhelper.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -569,7 +570,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bytes"),
+					MapKey: testhelper.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -665,8 +666,4 @@ func createTelemetry() (plog.LogRecord, pcommon.InstrumentationScope, pcommon.Re
 	log.Attributes().CopyTo(resource.Attributes())
 
 	return log, il, resource
-}
-
-func strp(s string) *string {
-	return &s
 }

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
@@ -53,7 +54,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(int64(100_000_000)),
+						Int: testhelper.Intp(int64(100_000_000)),
 					},
 				},
 			},
@@ -77,7 +78,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 				},
 			},
@@ -104,10 +105,10 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 					{
-						String: strp("test2"),
+						String: testhelper.Strp("test2"),
 					},
 				},
 			},
@@ -156,7 +157,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -185,7 +186,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -214,7 +215,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -243,7 +244,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -275,7 +276,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -304,7 +305,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -331,7 +332,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -357,7 +358,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -389,7 +390,7 @@ func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -452,7 +453,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(int64(100_000_000)),
+						Int: testhelper.Intp(int64(100_000_000)),
 					},
 				},
 			},
@@ -476,7 +477,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 				},
 			},
@@ -503,10 +504,10 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 					{
-						String: strp("test2"),
+						String: testhelper.Strp("test2"),
 					},
 				},
 			},
@@ -555,7 +556,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -584,7 +585,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -613,7 +614,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -642,7 +643,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -674,7 +675,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -703,7 +704,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -730,7 +731,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -756,7 +757,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -788,7 +789,7 @@ func Test_newFunctionCall_HistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -851,7 +852,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(int64(100_000_000)),
+						Int: testhelper.Intp(int64(100_000_000)),
 					},
 				},
 			},
@@ -875,7 +876,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 				},
 			},
@@ -902,10 +903,10 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 					{
-						String: strp("test2"),
+						String: testhelper.Strp("test2"),
 					},
 				},
 			},
@@ -954,7 +955,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -983,7 +984,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -1012,7 +1013,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -1041,7 +1042,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -1073,7 +1074,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -1102,7 +1103,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -1129,7 +1130,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -1155,7 +1156,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -1187,7 +1188,7 @@ func Test_newFunctionCall_ExponentialHistogramDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -1250,7 +1251,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(int64(100_000_000)),
+						Int: testhelper.Intp(int64(100_000_000)),
 					},
 				},
 			},
@@ -1274,7 +1275,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 				},
 			},
@@ -1301,10 +1302,10 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 					{
-						String: strp("test2"),
+						String: testhelper.Strp("test2"),
 					},
 				},
 			},
@@ -1353,7 +1354,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -1382,7 +1383,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -1411,7 +1412,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -1440,7 +1441,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -1472,7 +1473,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -1501,7 +1502,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -1528,7 +1529,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -1554,7 +1555,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -1586,7 +1587,7 @@ func Test_newFunctionCall_SummaryDataPoint(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -1648,7 +1649,7 @@ func Test_newFunctionCall_Metric(t *testing.T) {
 						},
 					},
 					{
-						String: strp("ending name"),
+						String: testhelper.Strp("ending name"),
 					},
 				},
 			},

--- a/processor/transformprocessor/internal/metrics/metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
@@ -135,7 +136,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("str"),
+					MapKey: testhelper.Strp("str"),
 				},
 			},
 			orig: "val",
@@ -149,7 +150,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bool"),
+					MapKey: testhelper.Strp("bool"),
 				},
 			},
 			orig: true,
@@ -163,7 +164,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("int"),
+					MapKey: testhelper.Strp("int"),
 				},
 			},
 			orig: int64(10),
@@ -177,7 +178,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("double"),
+					MapKey: testhelper.Strp("double"),
 				},
 			},
 			orig: float64(1.2),
@@ -191,7 +192,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bytes"),
+					MapKey: testhelper.Strp("bytes"),
 				},
 			},
 			orig: []byte{1, 3, 2},
@@ -205,7 +206,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_str"),
+					MapKey: testhelper.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -222,7 +223,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bool"),
+					MapKey: testhelper.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -239,7 +240,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_int"),
+					MapKey: testhelper.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -256,7 +257,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_float"),
+					MapKey: testhelper.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -273,7 +274,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bytes"),
+					MapKey: testhelper.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -467,7 +468,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("str"),
+					MapKey: testhelper.Strp("str"),
 				},
 			},
 			orig: "val",
@@ -481,7 +482,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bool"),
+					MapKey: testhelper.Strp("bool"),
 				},
 			},
 			orig: true,
@@ -495,7 +496,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("int"),
+					MapKey: testhelper.Strp("int"),
 				},
 			},
 			orig: int64(10),
@@ -509,7 +510,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("double"),
+					MapKey: testhelper.Strp("double"),
 				},
 			},
 			orig: float64(1.2),
@@ -523,7 +524,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bytes"),
+					MapKey: testhelper.Strp("bytes"),
 				},
 			},
 			orig: []byte{1, 3, 2},
@@ -537,7 +538,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_str"),
+					MapKey: testhelper.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -554,7 +555,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bool"),
+					MapKey: testhelper.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -571,7 +572,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_int"),
+					MapKey: testhelper.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -588,7 +589,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_float"),
+					MapKey: testhelper.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -605,7 +606,7 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bytes"),
+					MapKey: testhelper.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -895,7 +896,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("str"),
+					MapKey: testhelper.Strp("str"),
 				},
 			},
 			orig: "val",
@@ -909,7 +910,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bool"),
+					MapKey: testhelper.Strp("bool"),
 				},
 			},
 			orig: true,
@@ -923,7 +924,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("int"),
+					MapKey: testhelper.Strp("int"),
 				},
 			},
 			orig: int64(10),
@@ -937,7 +938,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("double"),
+					MapKey: testhelper.Strp("double"),
 				},
 			},
 			orig: 1.2,
@@ -951,7 +952,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bytes"),
+					MapKey: testhelper.Strp("bytes"),
 				},
 			},
 			orig: []byte{1, 3, 2},
@@ -965,7 +966,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_str"),
+					MapKey: testhelper.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -982,7 +983,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bool"),
+					MapKey: testhelper.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -999,7 +1000,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_int"),
+					MapKey: testhelper.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1016,7 +1017,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_float"),
+					MapKey: testhelper.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1033,7 +1034,7 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bytes"),
+					MapKey: testhelper.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1208,7 +1209,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("str"),
+					MapKey: testhelper.Strp("str"),
 				},
 			},
 			orig: "val",
@@ -1222,7 +1223,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bool"),
+					MapKey: testhelper.Strp("bool"),
 				},
 			},
 			orig: true,
@@ -1236,7 +1237,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("int"),
+					MapKey: testhelper.Strp("int"),
 				},
 			},
 			orig: int64(10),
@@ -1250,7 +1251,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("double"),
+					MapKey: testhelper.Strp("double"),
 				},
 			},
 			orig: 1.2,
@@ -1264,7 +1265,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bytes"),
+					MapKey: testhelper.Strp("bytes"),
 				},
 			},
 			orig: []byte{1, 3, 2},
@@ -1278,7 +1279,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_str"),
+					MapKey: testhelper.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1295,7 +1296,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bool"),
+					MapKey: testhelper.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1312,7 +1313,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_int"),
+					MapKey: testhelper.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1329,7 +1330,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_float"),
+					MapKey: testhelper.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1346,7 +1347,7 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bytes"),
+					MapKey: testhelper.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1616,12 +1617,4 @@ func createNewTelemetry() (pmetric.ExemplarSlice, pcommon.Map, pcommon.Value, pc
 	newArrBytes.SliceVal().AppendEmpty().SetMBytesVal([]byte{9, 6, 4})
 
 	return newExemplars, newAttrs, newArrStr, newArrBool, newArrInt, newArrFloat, newArrBytes
-}
-
-func strp(s string) *string {
-	return &s
-}
-
-func intp(i int64) *int64 {
-	return &i
 }

--- a/processor/transformprocessor/internal/traces/functions_test.go
+++ b/processor/transformprocessor/internal/traces/functions_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 func Test_newFunctionCall(t *testing.T) {
@@ -53,7 +54,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						String: strp("cat"),
+						String: testhelper.Strp("cat"),
 					},
 				},
 			},
@@ -80,7 +81,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -104,7 +105,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 				},
 			},
@@ -131,10 +132,10 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						String: strp("test"),
+						String: testhelper.Strp("test"),
 					},
 					{
-						String: strp("test2"),
+						String: testhelper.Strp("test2"),
 					},
 				},
 			},
@@ -183,7 +184,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -212,7 +213,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -241,7 +242,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -270,7 +271,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -302,7 +303,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(11),
+						Int: testhelper.Intp(11),
 					},
 				},
 			},
@@ -331,7 +332,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},
@@ -358,7 +359,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(0),
+						Int: testhelper.Intp(0),
 					},
 				},
 			},
@@ -384,7 +385,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(100),
+						Int: testhelper.Intp(100),
 					},
 				},
 			},
@@ -416,7 +417,7 @@ func Test_newFunctionCall(t *testing.T) {
 						},
 					},
 					{
-						Int: intp(1),
+						Int: testhelper.Intp(1),
 					},
 				},
 			},

--- a/processor/transformprocessor/internal/traces/traces_test.go
+++ b/processor/transformprocessor/internal/traces/traces_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
 var (
@@ -193,7 +194,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("str"),
+					MapKey: testhelper.Strp("str"),
 				},
 			},
 			orig: "val",
@@ -207,7 +208,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bool"),
+					MapKey: testhelper.Strp("bool"),
 				},
 			},
 			orig: true,
@@ -221,7 +222,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("int"),
+					MapKey: testhelper.Strp("int"),
 				},
 			},
 			orig: int64(10),
@@ -235,7 +236,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("double"),
+					MapKey: testhelper.Strp("double"),
 				},
 			},
 			orig: float64(1.2),
@@ -249,7 +250,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("bytes"),
+					MapKey: testhelper.Strp("bytes"),
 				},
 			},
 			orig: []byte{1, 3, 2},
@@ -263,7 +264,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_str"),
+					MapKey: testhelper.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -280,7 +281,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bool"),
+					MapKey: testhelper.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -297,7 +298,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_int"),
+					MapKey: testhelper.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -314,7 +315,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_float"),
+					MapKey: testhelper.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -331,7 +332,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			path: []common.Field{
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bytes"),
+					MapKey: testhelper.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -484,7 +485,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("str"),
+					MapKey: testhelper.Strp("str"),
 				},
 			},
 			orig: "val",
@@ -501,7 +502,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("bool"),
+					MapKey: testhelper.Strp("bool"),
 				},
 			},
 			orig: true,
@@ -518,7 +519,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("int"),
+					MapKey: testhelper.Strp("int"),
 				},
 			},
 			orig: int64(10),
@@ -535,7 +536,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("double"),
+					MapKey: testhelper.Strp("double"),
 				},
 			},
 			orig: float64(1.2),
@@ -552,7 +553,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("bytes"),
+					MapKey: testhelper.Strp("bytes"),
 				},
 			},
 			orig: []byte{1, 3, 2},
@@ -569,7 +570,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_str"),
+					MapKey: testhelper.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -589,7 +590,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bool"),
+					MapKey: testhelper.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -609,7 +610,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_int"),
+					MapKey: testhelper.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -629,7 +630,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_float"),
+					MapKey: testhelper.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -649,7 +650,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				},
 				{
 					Name:   "attributes",
-					MapKey: strp("arr_bytes"),
+					MapKey: testhelper.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -752,12 +753,4 @@ func createTelemetry() (ptrace.Span, pcommon.InstrumentationScope, pcommon.Resou
 	span.Attributes().CopyTo(resource.Attributes())
 
 	return span, il, resource
-}
-
-func strp(s string) *string {
-	return &s
-}
-
-func intp(i int64) *int64 {
-	return &i
 }


### PR DESCRIPTION
**Description:** 
While preparing to refactor functions into their own files I moved all the individual instances of `strp`, `floatp`, and `intp` into a test helper to be used across everything in `internal`.  To prevent a huge PR, I'm submitting this change first.

**Testing:**
Existing unit tests pass