### PR TITLE
[processor/transform] Add functions for conversion of scalar metric types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - `tailsamplingprocessor`: Add support for string invert matching to `and` policy (#9553)
 - `mezemoexporter`: Add user agent string to outgoing HTTP requests (#10470)
+- `transformprocessor`: Add functions for conversion of scalar metric types (`gauge_to_sum` and `sum_to_gauge`) (#10255)
 
 ### 🧰 Bug fixes 🧰
 
@@ -44,7 +45,6 @@
 
 - `transformprocessor`: Add transformation of metrics (#10100)
 - `transformprocessor`: Include transform processor in components (#10134)
-- `transformprocessor`: Add functions for conversion of scalar metric types (#10255)
 - `kubeletstatsreceiver`: Update receiver to use new Metrics Builder. All emitted metrics remain the same. (#9744)
 - `transformprocessor`: Add new `replace_match` and `replace_all_matches` functions (#10132)
 - `resourcedetectionprocessor`: Add "cname" and "lookup" hostname sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 - `transformprocessor`: Add transformation of metrics (#10100)
 - `transformprocessor`: Include transform processor in components (#10134)
+- `transformprocessor`: Add functions for conversion of scalar metric types (#10255)
 - `kubeletstatsreceiver`: Update receiver to use new Metrics Builder. All emitted metrics remain the same. (#9744)
 - `transformprocessor`: Add new `replace_match` and `replace_all_matches` functions (#10132)
 - `resourcedetectionprocessor`: Add "cname" and "lookup" hostname sources

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -37,7 +37,7 @@ the fields specified by the list of strings. e.g., `keep_keys(attributes, "http.
 
 - `replace_all_matches(target, pattern, replacement)` - `target` is a path expression to a map type field, `pattern` is a string following [filepath.Match syntax](https://pkg.go.dev/path/filepath#Match), and `replacement` is a string. Each string value in `target` that matches `pattern` will get replaced with `replacement`. e.g., `replace_all_matches(attributes, "/user/*/list/*", "/user/{userId}/list/{listId}")`
 
-Supported functions (metrics only):
+Metric only functions:
 - `convert_sum_to_gauge()` - Converts incoming metrics of type "Sum" to type "Gauge", retaining the metric's datapoints. Noop for metrics that are not of type "Sum".
 
 - `convert_gauge_to_sum(aggregation_temporality, is_monotonic)` - `aggregation_temporality` specifies the resultant metric's aggregation temporality. `aggregation_temporality` may be `"cumulative"` or `"delta"`. `is_monotonic` specifies the resultant metric's monotonicity. `is_monotonic` is a boolean. Converts incoming metrics of type "Gauge" to type "Sum", retaining the metric's datapoints and setting its aggregation temporality and monotonicity accordingly. Noop for metrics that are not of type "Gauge".

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -37,6 +37,11 @@ the fields specified by the list of strings. e.g., `keep_keys(attributes, "http.
 
 - `replace_all_matches(target, pattern, replacement)` - `target` is a path expression to a map type field, `pattern` is a string following [filepath.Match syntax](https://pkg.go.dev/path/filepath#Match), and `replacement` is a string. Each string value in `target` that matches `pattern` will get replaced with `replacement`. e.g., `replace_all_matches(attributes, "/user/*/list/*", "/user/{userId}/list/{listId}")`
 
+Supported functions (metrics only):
+- `convert_sum_to_gauge()` - Converts incoming metrics of type "Sum" to type "Gauge", retaining the metric's datapoints. Noop for metrics that are not of type "Sum".
+
+- `convert_gauge_to_sum(aggregation_temporality, is_monotonic)` - `aggregation_temporality` specifies the resultant metric's aggregation temporality. `aggregation_temporality` may be `"cumulative"` or `"delta"`. `is_monotonic` specifies the resultant metric's monotonicity. `is_monotonic` is a boolean. Converts incoming metrics of type "Gauge" to type "Sum", retaining the metric's datapoints and setting its aggregation temporality and monotonicity accordingly. Noop for metrics that are not of type "Gauge".
+
 Supported where operations:
 - `==` - matches telemetry where the values are equal to each other
 - `!=` - matches telemetry where the values are not equal to each other

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -38,9 +38,11 @@ the fields specified by the list of strings. e.g., `keep_keys(attributes, "http.
 - `replace_all_matches(target, pattern, replacement)` - `target` is a path expression to a map type field, `pattern` is a string following [filepath.Match syntax](https://pkg.go.dev/path/filepath#Match), and `replacement` is a string. Each string value in `target` that matches `pattern` will get replaced with `replacement`. e.g., `replace_all_matches(attributes, "/user/*/list/*", "/user/{userId}/list/{listId}")`
 
 Metric only functions:
-- `convert_sum_to_gauge()` - Converts incoming metrics of type "Sum" to type "Gauge", retaining the metric's datapoints. Noop for metrics that are not of type "Sum".
+- `convert_sum_to_gauge()` - Converts incoming metrics of type "Sum" to type "Gauge", retaining the metric's datapoints. Noop for metrics that are not of type "Sum". 
+**NOTE:** This function may cause a metric to break semantics for [Gauge metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#gauge). Use at your own risk.
 
-- `convert_gauge_to_sum(aggregation_temporality, is_monotonic)` - `aggregation_temporality` specifies the resultant metric's aggregation temporality. `aggregation_temporality` may be `"cumulative"` or `"delta"`. `is_monotonic` specifies the resultant metric's monotonicity. `is_monotonic` is a boolean. Converts incoming metrics of type "Gauge" to type "Sum", retaining the metric's datapoints and setting its aggregation temporality and monotonicity accordingly. Noop for metrics that are not of type "Gauge".
+- `convert_gauge_to_sum(aggregation_temporality, is_monotonic)` - `aggregation_temporality` specifies the resultant metric's aggregation temporality. `aggregation_temporality` may be `"cumulative"` or `"delta"`. `is_monotonic` specifies the resultant metric's monotonicity. `is_monotonic` is a boolean. Converts incoming metrics of type "Gauge" to type "Sum", retaining the metric's datapoints and setting its aggregation temporality and monotonicity accordingly. Noop for metrics that are not of type "Gauge". 
+**NOTE:** This function may cause a metric to break semantics for [Sum metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/datamodel.md#sums). Use at your own risk.
 
 Supported where operations:
 - `==` - matches telemetry where the values are equal to each other

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -116,7 +116,7 @@ All metrics and their data points
 6) Truncate all data point attributes such that no string value has more than 4096 characters.
 7) Truncate all resource attributes such that no string value has more than 4096 characters.
 8) Convert all metrics with name `system.processes.count` from a Sum to Gauge.
-9) Convert all metrics with name `prometheus_metric` from Gauge to a cumulative, non-monotonic sum.
+9) Convert all metrics with name `prometheus_metric` from Gauge to a cumulative, non-monotonic Sum.
 
 All logs
 

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -75,6 +75,8 @@ processors:
         - limit(attributes, 100)
         - truncate_all(attributes, 4096)
         - truncate_all(resource.attributes, 4096)
+        - convert_sum_to_gauge() where metric.name == "system.processes.count"
+        - convert_gauge_to_sum("cumulative", false) where metric.name == "prometheus_metric"
     logs:
       queries:
         - set(severity_text, "FAIL") where body == "request failed"
@@ -113,6 +115,8 @@ All metrics and their data points
 4) Limit all data point attributes such that each data point has no more than 100 attributes.
 6) Truncate all data point attributes such that no string value has more than 4096 characters.
 7) Truncate all resource attributes such that no string value has more than 4096 characters.
+8) Convert all metrics with name `system.processes.count` from a Sum to Gauge.
+9) Convert all metrics with name `prometheus_metric` from Gauge to a cumulative, non-monotonic sum.
 
 All logs
 

--- a/processor/transformprocessor/config_test.go
+++ b/processor/transformprocessor/config_test.go
@@ -41,7 +41,7 @@ func TestLoadingConfig(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	p0 := cfg.Processors[config.NewComponentID(typeStr)]
-	assert.EqualValues(t, p0, &Config{
+	assert.Equal(t, p0, &Config{
 		ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
 		Traces: SignalConfig{
 			Queries: []string{

--- a/processor/transformprocessor/config_test.go
+++ b/processor/transformprocessor/config_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/service/servicetest"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/traces"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/logs"
@@ -40,7 +41,7 @@ func TestLoadingConfig(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	p0 := cfg.Processors[config.NewComponentID(typeStr)]
-	assert.Equal(t, p0, &Config{
+	assert.EqualValues(t, p0, &Config{
 		ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
 		Traces: SignalConfig{
 			Queries: []string{
@@ -56,7 +57,7 @@ func TestLoadingConfig(t *testing.T) {
 				`keep_keys(attributes, "http.method", "http.path")`,
 			},
 
-			functions: traces.DefaultFunctions(),
+			functions: metrics.DefaultFunctions(),
 		},
 		Logs: SignalConfig{
 			Queries: []string{

--- a/processor/transformprocessor/factory_test.go
+++ b/processor/transformprocessor/factory_test.go
@@ -27,6 +27,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/traces"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/logs"
@@ -50,7 +51,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 		Metrics: SignalConfig{
 			Queries: []string{},
 
-			functions: traces.DefaultFunctions(),
+			functions: metrics.DefaultFunctions(),
 		},
 		Logs: SignalConfig{
 			Queries: []string{},

--- a/processor/transformprocessor/internal/common/functions.go
+++ b/processor/transformprocessor/internal/common/functions.go
@@ -247,6 +247,11 @@ func NewFunctionCall(inv Invocation, functions map[string]interface{}, pathParse
 					return nil, fmt.Errorf("invalid argument at position %v, must be a string", i)
 				}
 				args = append(args, reflect.ValueOf(*argDef.String))
+			case "bool":
+				if argDef.Bool == nil {
+					return nil, fmt.Errorf("invalid argument at position %v, must be a bool", i)
+				}
+				args = append(args, reflect.ValueOf(bool(*argDef.Bool)))
 			}
 		}
 		val := reflect.ValueOf(f)

--- a/processor/transformprocessor/internal/common/parser.go
+++ b/processor/transformprocessor/internal/common/parser.go
@@ -56,10 +56,10 @@ type Invocation struct {
 // nolint:govet
 type Value struct {
 	Invocation *Invocation `( @@`
-	Bool       *Boolean    `| @("true" | "false")`
 	String     *string     `| @String`
 	Float      *float64    `| @Float`
 	Int        *int64      `| @Int`
+	Bool       *Boolean    `| @("true" | "false")`
 	Path       *Path       `| @@ )`
 }
 

--- a/processor/transformprocessor/internal/common/parser.go
+++ b/processor/transformprocessor/internal/common/parser.go
@@ -20,6 +20,15 @@ import (
 	"go.uber.org/multierr"
 )
 
+// Type for capturing booleans, see:
+// https://github.com/alecthomas/participle#capturing-boolean-value
+type Boolean bool
+
+func (b *Boolean) Capture(values []string) error {
+	*b = values[0] == "true"
+	return nil
+}
+
 // ParsedQuery represents a parsed query. It is the entry point into the query DSL.
 // nolint:govet
 type ParsedQuery struct {
@@ -47,6 +56,7 @@ type Invocation struct {
 // nolint:govet
 type Value struct {
 	Invocation *Invocation `( @@`
+	Bool       *Boolean    `| @("true" | "false")`
 	String     *string     `| @String`
 	Float      *float64    `| @Float`
 	Int        *int64      `| @Int`

--- a/processor/transformprocessor/internal/common/parser_test.go
+++ b/processor/transformprocessor/internal/common/parser_test.go
@@ -285,10 +285,10 @@ func Test_parse(t *testing.T) {
 					Function: "convert_gauge_to_sum",
 					Arguments: []Value{
 						{
-							String: strp("cumulative"),
+							String: testhelper.Strp("cumulative"),
 						},
 						{
-							Bool: boolp(false),
+							Bool: (*Boolean)(testhelper.Boolp(false)),
 						},
 					},
 				},
@@ -302,10 +302,10 @@ func Test_parse(t *testing.T) {
 					Function: "convert_gauge_to_sum",
 					Arguments: []Value{
 						{
-							String: strp("cumulative"),
+							String: testhelper.Strp("cumulative"),
 						},
 						{
-							Bool: boolp(true),
+							Bool: (*Boolean)(testhelper.Boolp(true)),
 						},
 					},
 				},
@@ -337,20 +337,4 @@ func Test_parse_failure(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
-}
-
-func strp(s string) *string {
-	return &s
-}
-
-func floatp(f float64) *float64 {
-	return &f
-}
-
-func intp(i int64) *int64 {
-	return &i
-}
-
-func boolp(b bool) *Boolean {
-	return (*Boolean)(&b)
 }

--- a/processor/transformprocessor/internal/common/parser_test.go
+++ b/processor/transformprocessor/internal/common/parser_test.go
@@ -278,6 +278,40 @@ func Test_parse(t *testing.T) {
 				Condition: nil,
 			},
 		},
+		{
+			query: `convert_gauge_to_sum("cumulative", false)`,
+			expected: &ParsedQuery{
+				Invocation: Invocation{
+					Function: "convert_gauge_to_sum",
+					Arguments: []Value{
+						{
+							String: strp("cumulative"),
+						},
+						{
+							Bool: boolp(false),
+						},
+					},
+				},
+				Condition: nil,
+			},
+		},
+		{
+			query: `convert_gauge_to_sum("cumulative", true)`,
+			expected: &ParsedQuery{
+				Invocation: Invocation{
+					Function: "convert_gauge_to_sum",
+					Arguments: []Value{
+						{
+							String: strp("cumulative"),
+						},
+						{
+							Bool: boolp(true),
+						},
+					},
+				},
+				Condition: nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -303,4 +337,20 @@ func Test_parse_failure(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func strp(s string) *string {
+	return &s
+}
+
+func floatp(f float64) *float64 {
+	return &f
+}
+
+func intp(i int64) *int64 {
+	return &i
+}
+
+func boolp(b bool) *Boolean {
+	return (*Boolean)(&b)
 }

--- a/processor/transformprocessor/internal/common/testhelper/testhelper.go
+++ b/processor/transformprocessor/internal/common/testhelper/testhelper.go
@@ -25,3 +25,7 @@ func Floatp(f float64) *float64 {
 func Intp(i int64) *int64 {
 	return &i
 }
+
+func Boolp(b bool) *bool {
+	return &b
+}

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -15,10 +15,82 @@
 package metrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
 
 import (
+	"fmt"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
+// registry is a map of names to functions for metrics pipelines only
+var registry = map[string]interface{}{
+	"convert_sum_to_gauge": convertSumToGauge,
+	"convert_gauge_to_sum": convertGaugeToSum,
+}
+
+func init() {
+	// Init metrics registry with default functions common to all signals
+	for k, v := range common.DefaultFunctions() {
+		registry[k] = v
+	}
+}
+
 func DefaultFunctions() map[string]interface{} {
-	// No metric-only functions yet.
-	return common.DefaultFunctions()
+	return registry
+}
+
+func convertSumToGauge() (common.ExprFunc, error) {
+	return func(ctx common.TransformContext) interface{} {
+		mtc, ok := ctx.(metricTransformContext)
+		if !ok {
+			return nil
+		}
+
+		metric := mtc.GetMetric()
+		if metric.DataType() != pmetric.MetricDataTypeSum {
+			return nil
+		}
+
+		dps := metric.Sum().DataPoints()
+
+		metric.SetDataType(pmetric.MetricDataTypeGauge)
+		// Setting the data type removed all the data points, so we must copy them back to the metric.
+		dps.CopyTo(metric.Gauge().DataPoints())
+
+		return nil
+	}, nil
+}
+
+func convertGaugeToSum(stringAggTemp string, monotonic bool) (common.ExprFunc, error) {
+	var aggTemp pmetric.MetricAggregationTemporality
+	switch stringAggTemp {
+	case "delta":
+		aggTemp = pmetric.MetricAggregationTemporalityDelta
+	case "cumulative":
+		aggTemp = pmetric.MetricAggregationTemporalityCumulative
+	default:
+		return nil, fmt.Errorf("unknown aggregation temporality: %s", stringAggTemp)
+	}
+
+	return func(ctx common.TransformContext) interface{} {
+		mtc, ok := ctx.(metricTransformContext)
+		if !ok {
+			return nil
+		}
+
+		metric := mtc.GetMetric()
+		if metric.DataType() != pmetric.MetricDataTypeGauge {
+			return nil
+		}
+
+		dps := metric.Gauge().DataPoints()
+
+		metric.SetDataType(pmetric.MetricDataTypeSum)
+		metric.Sum().SetAggregationTemporality(aggTemp)
+		metric.Sum().SetIsMonotonic(monotonic)
+
+		// Setting the data type removed all the data points, so we must copy them back to the metric.
+		dps.CopyTo(metric.Sum().DataPoints())
+
+		return nil
+	}, nil
 }

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -17,8 +17,9 @@ package metrics // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"fmt"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
 // registry is a map of names to functions for metrics pipelines only

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common"
 )
 
-// registry is a map of names to functions for metrics pipelines only
+// registry is a map of names to functions for metrics pipelines
 var registry = map[string]interface{}{
 	"convert_sum_to_gauge": convertSumToGauge,
 	"convert_gauge_to_sum": convertGaugeToSum,

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -26,6 +26,33 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/common/testhelper"
 )
 
+func Test_newFunctionCall_invalid(t *testing.T) {
+	tests := []struct {
+		name string
+		inv  common.Invocation
+	}{
+		{
+			name: "invalid aggregation temporality",
+			inv: common.Invocation{
+				Function: "convert_gauge_to_sum",
+				Arguments: []common.Value{
+					{
+						String: strp("invalid_agg_temp"),
+					},
+					{
+						Bool: boolp(true),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := common.NewFunctionCall(tt.inv, DefaultFunctions(), ParsePath)
+			assert.Error(t, err)
+		})
+	}
+}
 func Test_newFunctionCall_NumberDataPoint(t *testing.T) {
 	input := pmetric.NewNumberDataPoint()
 	attrs := pcommon.NewMap()
@@ -1656,6 +1683,169 @@ func Test_newFunctionCall_Metric(t *testing.T) {
 			want: func(metric pmetric.Metric) {
 				input.CopyTo(metric)
 				metric.SetName("ending name")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := pmetric.NewMetric()
+			input.CopyTo(metric)
+
+			evaluate, err := common.NewFunctionCall(tt.inv, DefaultFunctions(), ParsePath)
+			assert.NoError(t, err)
+			evaluate(metricTransformContext{
+				metric:   metric,
+				il:       pcommon.NewInstrumentationScope(),
+				resource: pcommon.NewResource(),
+			})
+
+			expected := pmetric.NewMetric()
+			tt.want(expected)
+			assert.Equal(t, expected, metric)
+		})
+	}
+}
+
+func Test_newFunctionCall_Metric_Sum(t *testing.T) {
+	input := pmetric.NewMetric()
+	input.SetDataType(pmetric.MetricDataTypeSum)
+
+	dp1 := input.Sum().DataPoints().AppendEmpty()
+	dp1.SetIntVal(10)
+
+	dp2 := input.Sum().DataPoints().AppendEmpty()
+	dp2.SetDoubleVal(14.5)
+
+	tests := []struct {
+		name string
+		inv  common.Invocation
+		want func(pmetric.Metric)
+	}{
+		{
+			name: "convert sum to gauge",
+			inv: common.Invocation{
+				Function:  "convert_sum_to_gauge",
+				Arguments: []common.Value{},
+			},
+			want: func(metric pmetric.Metric) {
+				input.CopyTo(metric)
+
+				dps := input.Sum().DataPoints()
+				metric.SetDataType(pmetric.MetricDataTypeGauge)
+				dps.CopyTo(metric.Gauge().DataPoints())
+			},
+		},
+		{
+			name: "convert gauge to sum (noop)",
+			inv: common.Invocation{
+				Function: "convert_gauge_to_sum",
+				Arguments: []common.Value{
+					{
+						String: strp("delta"),
+					},
+					{
+						Bool: boolp(false),
+					},
+				},
+			},
+			want: func(metric pmetric.Metric) {
+				input.CopyTo(metric)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metric := pmetric.NewMetric()
+			input.CopyTo(metric)
+
+			evaluate, err := common.NewFunctionCall(tt.inv, DefaultFunctions(), ParsePath)
+			assert.NoError(t, err)
+			evaluate(metricTransformContext{
+				metric:   metric,
+				il:       pcommon.NewInstrumentationScope(),
+				resource: pcommon.NewResource(),
+			})
+
+			expected := pmetric.NewMetric()
+			tt.want(expected)
+			assert.Equal(t, expected, metric)
+		})
+	}
+}
+
+func Test_newFunctionCall_Metric_Gauge(t *testing.T) {
+	input := pmetric.NewMetric()
+	input.SetDataType(pmetric.MetricDataTypeGauge)
+
+	dp1 := input.Gauge().DataPoints().AppendEmpty()
+	dp1.SetIntVal(10)
+
+	dp2 := input.Gauge().DataPoints().AppendEmpty()
+	dp2.SetDoubleVal(14.5)
+
+	tests := []struct {
+		name string
+		inv  common.Invocation
+		want func(pmetric.Metric)
+	}{
+		{
+			name: "convert gauge to sum 1",
+			inv: common.Invocation{
+				Function: "convert_gauge_to_sum",
+				Arguments: []common.Value{
+					{
+						String: strp("cumulative"),
+					},
+					{
+						Bool: boolp(false),
+					},
+				},
+			},
+			want: func(metric pmetric.Metric) {
+				input.CopyTo(metric)
+
+				dps := input.Gauge().DataPoints()
+
+				metric.SetDataType(pmetric.MetricDataTypeSum)
+				metric.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+				metric.Sum().SetIsMonotonic(false)
+
+				dps.CopyTo(metric.Sum().DataPoints())
+			},
+		},
+		{
+			name: "convert gauge to sum 2",
+			inv: common.Invocation{
+				Function: "convert_gauge_to_sum",
+				Arguments: []common.Value{
+					{
+						String: strp("delta"),
+					},
+					{
+						Bool: boolp(true),
+					},
+				},
+			},
+			want: func(metric pmetric.Metric) {
+				input.CopyTo(metric)
+
+				dps := input.Gauge().DataPoints()
+
+				metric.SetDataType(pmetric.MetricDataTypeSum)
+				metric.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityDelta)
+				metric.Sum().SetIsMonotonic(true)
+
+				dps.CopyTo(metric.Sum().DataPoints())
+			},
+		},
+		{
+			name: "convert sum to gauge (no-op)",
+			inv: common.Invocation{
+				Function:  "convert_sum_to_gauge",
+				Arguments: []common.Value{},
+			},
+			want: func(metric pmetric.Metric) {
+				input.CopyTo(metric)
 			},
 		},
 	}

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -37,10 +37,10 @@ func Test_newFunctionCall_invalid(t *testing.T) {
 				Function: "convert_gauge_to_sum",
 				Arguments: []common.Value{
 					{
-						String: strp("invalid_agg_temp"),
+						String: testhelper.Strp("invalid_agg_temp"),
 					},
 					{
-						Bool: boolp(true),
+						Bool: (*common.Boolean)(testhelper.Boolp(true)),
 					},
 				},
 			},
@@ -1741,10 +1741,10 @@ func Test_newFunctionCall_Metric_Sum(t *testing.T) {
 				Function: "convert_gauge_to_sum",
 				Arguments: []common.Value{
 					{
-						String: strp("delta"),
+						String: testhelper.Strp("delta"),
 					},
 					{
-						Bool: boolp(false),
+						Bool: (*common.Boolean)(testhelper.Boolp(false)),
 					},
 				},
 			},
@@ -1794,10 +1794,10 @@ func Test_newFunctionCall_Metric_Gauge(t *testing.T) {
 				Function: "convert_gauge_to_sum",
 				Arguments: []common.Value{
 					{
-						String: strp("cumulative"),
+						String: testhelper.Strp("cumulative"),
 					},
 					{
-						Bool: boolp(false),
+						Bool: (*common.Boolean)(testhelper.Boolp(false)),
 					},
 				},
 			},
@@ -1819,10 +1819,10 @@ func Test_newFunctionCall_Metric_Gauge(t *testing.T) {
 				Function: "convert_gauge_to_sum",
 				Arguments: []common.Value{
 					{
-						String: strp("delta"),
+						String: testhelper.Strp("delta"),
 					},
 					{
-						Bool: boolp(true),
+						Bool: (*common.Boolean)(testhelper.Boolp(true)),
 					},
 				},
 			},

--- a/processor/transformprocessor/internal/metrics/metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/metrics_test.go
@@ -1618,15 +1618,3 @@ func createNewTelemetry() (pmetric.ExemplarSlice, pcommon.Map, pcommon.Value, pc
 
 	return newExemplars, newAttrs, newArrStr, newArrBool, newArrInt, newArrFloat, newArrBytes
 }
-
-func strp(s string) *string {
-	return &s
-}
-
-func intp(i int64) *int64 {
-	return &i
-}
-
-func boolp(b bool) *common.Boolean {
-	return (*common.Boolean)(&b)
-}

--- a/processor/transformprocessor/internal/metrics/metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/metrics_test.go
@@ -1618,3 +1618,15 @@ func createNewTelemetry() (pmetric.ExemplarSlice, pcommon.Map, pcommon.Value, pc
 
 	return newExemplars, newAttrs, newArrStr, newArrBool, newArrInt, newArrFloat, newArrBytes
 }
+
+func strp(s string) *string {
+	return &s
+}
+
+func intp(i int64) *int64 {
+	return &i
+}
+
+func boolp(b bool) *common.Boolean {
+	return (*common.Boolean)(&b)
+}


### PR DESCRIPTION
**Description:**
* Add `convert_gauge_to_sum` and `convert_sum_to_gauge` functions
  * I added in resolution of bool parameters to support the `is_monotonic` parameter, as well.

**Link to tracking Issue:** #10130

**Testing:**
Added some unit tests. Manually tested converting metrics with the processor.

**Documentation:**
Added new functions to docs under a "metrics only" section of the config.