### PR TITLE
[chore] exclude dependabot for CI

### DIFF
--- a/.github/workflows/auto-assign-owners.yml
+++ b/.github/workflows/auto-assign-owners.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   add-owner:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: run
         uses: kentaro-m/auto-assign-action@v1.2.1

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -21,6 +21,7 @@ jobs:
           - internal
           - other
     runs-on: windows-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   setup-environment:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+      - '!dependabot/go_modules/**'
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,7 +9,6 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
-      - '!dependabot/go_modules/**'
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -8,6 +8,7 @@ jobs:
   changedfiles:
     name: changed files
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       md: ${{ steps.changes.outputs.md }}
     steps:

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   setup-environment:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       loadtest_matrix: ${{ steps.splitloadtest.outputs.loadtest_matrix }}
     steps:

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   prometheus-compliance-tests:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   setup-environment:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       stabilitytest_matrix: ${{ steps.splitstabilitytest.outputs.stabilitytest_matrix}}
     steps:

--- a/.github/workflows/tracegen.yml
+++ b/.github/workflows/tracegen.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-dev:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
PRs created by dependabot don't get merged as-is, there's no point in running the CI for them all. Adding a bypass for CI for pull requests created by the `dependabot` actor
