### PR TITLE
[reciever/awsxrayreceiver] removed deprecated net.Err.Temporary()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛑 Breaking changes 🛑
 
 - `jmxreceiver`: Remove properties & groovyscript parameters from JMX Receiver. Add ResourceAttributes & LogLevel parameter to supply some of the removed functionality with reduced attack surface (#9685)
+
 ### 🚩 Deprecations 🚩
 
 ### 🚀 New components 🚀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛑 Breaking changes 🛑
 
 - `jmxreceiver`: Remove properties & groovyscript parameters from JMX Receiver. Add ResourceAttributes & LogLevel parameter to supply some of the removed functionality with reduced attack surface (#9685)
-
+- `awsxrayreceiver`: Removed deprecated `net.Error.Temporary()` reference from code.
 ### 🚩 Deprecations 🚩
 
 ### 🚀 New components 🚀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### 🛑 Breaking changes 🛑
 
 - `jmxreceiver`: Remove properties & groovyscript parameters from JMX Receiver. Add ResourceAttributes & LogLevel parameter to supply some of the removed functionality with reduced attack surface (#9685)
-- `awsxrayreceiver`: Removed deprecated `net.Error.Temporary()` reference from code.
 ### 🚩 Deprecations 🚩
 
 ### 🚀 New components 🚀

--- a/receiver/awsxrayreceiver/internal/udppoller/poller.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller.go
@@ -153,13 +153,13 @@ func (p *poller) read(buf *[]byte) (int, error) {
 	if err == nil {
 		return rlen, nil
 	}
-	switch err := err.(type) {
+	switch terr := err.(type) {
 	case net.Error:
-		if !err.Temporary() { // nolint SA1019
-			return -1, fmt.Errorf("read from UDP socket: %w", &recvErr.ErrIrrecoverable{Err: err})
+		if !terr.Timeout() {
+			return -1, fmt.Errorf("read from UDP socket: %w", &recvErr.ErrIrrecoverable{Err: terr})
 		}
 	default:
-		return 0, fmt.Errorf("read from UDP socket: %w", &recvErr.ErrRecoverable{Err: err})
+		return 0, fmt.Errorf("read from UDP socket: %w", &recvErr.ErrRecoverable{Err: terr})
 	}
 	return 0, fmt.Errorf("read from UDP socket: %w", &recvErr.ErrRecoverable{Err: err})
 }

--- a/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
@@ -309,12 +309,12 @@ func TestSocketReadIrrecoverableNetError(t *testing.T) {
 	assert.NoError(t, obsreporttest.CheckReceiverTraces(tt, receiverID, Transport, 0, 1))
 }
 
-func TestSocketReadTemporaryNetError(t *testing.T) {
+func TestSocketReadTimeOutNetError(t *testing.T) {
 	tt, err := obsreporttest.SetupTelemetry()
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer tt.Shutdown(context.Background())
 
-	receiverID := config.NewComponentID("TestSocketReadTemporaryNetError")
+	receiverID := config.NewComponentID("TestSocketReadTimeOutNetError")
 
 	_, p, recordedLogs := createAndOptionallyStartPoller(t, receiverID, false, tt.ToReceiverCreateSettings())
 	// close the actual socket because we are going to mock it out below
@@ -326,7 +326,7 @@ func TestSocketReadTemporaryNetError(t *testing.T) {
 		expectedOutput: []byte("dontCare"),
 		expectedError: &mockNetError{
 			mockErrStr: randErrStr.String(),
-			temporary:  true,
+			timeout:    true,
 		},
 	}
 
@@ -381,7 +381,7 @@ func TestSocketGenericReadError(t *testing.T) {
 
 type mockNetError struct {
 	mockErrStr string
-	temporary  bool
+	timeout    bool
 }
 
 func (m *mockNetError) Error() string {
@@ -389,11 +389,11 @@ func (m *mockNetError) Error() string {
 }
 
 func (m *mockNetError) Timeout() bool {
-	return false
+	return m.timeout
 }
 
 func (m *mockNetError) Temporary() bool {
-	return m.temporary
+	return false
 }
 
 type mockGenericErr struct {
@@ -478,7 +478,7 @@ func writePacket(t *testing.T, addr, toWrite string) error {
 	if err != nil {
 		return err
 	}
-	assert.Equal(t, len(toWrite), n, "exunpected number of bytes written")
+	assert.Equal(t, len(toWrite), n, "unexpected number of bytes written")
 	return nil
 }
 


### PR DESCRIPTION
**Description:** Removed deprecated net.Err.Temporary() reference from the code as mentioned in #9782.  As per https://github.com/golang/go/issues/45729 TimeOut() correctly captures subset of Temporary() errors that could be retried. The rest of Temporary() errors should not be retried anyways (like syscall errors, out of file descriptors) as described [here](https://github.com/golang/go/issues/45729#issue-866319435) . 

**Link to tracking Issue:** #9806 

**Testing:** Unit tests
