### PR TITLE
[CI] add error suggestion to check-links workflow

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -38,4 +38,5 @@ jobs:
           markdown-link-check \
             --verbose \
             --config .github/workflows/check_links_config.json \
-            ${{needs.changedfiles.outputs.md}}
+            ${{needs.changedfiles.outputs.md}} \
+            || { echo "Check that anchor links are lowercase"; exit 1; }


### PR DESCRIPTION
**Description:**
Recently the check-links CI failed due to anchor links containing uppercase letter(s).  It felt like an obscure error and caused confusion on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/10319.  To prevent confusion in the future I added a suggestion if the link checker fails.

**Testing:**
[Confirmed the error message is written out and the workflow fails.](https://github.com/TylerHelmuth/opentelemetry-collector-contrib/runs/6612763290?check_suite_focus=true)
