### PR TITLE
[test] use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -82,16 +81,12 @@ func Test_runContents(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpdir, err := ioutil.TempDir("", "metadata-test-*")
-			require.NoError(t, err)
-			t.Cleanup(func() {
-				require.NoError(t, os.RemoveAll(tmpdir))
-			})
+			tmpdir := t.TempDir()
 
 			metadataFile := filepath.Join(tmpdir, "metadata.yaml")
 			require.NoError(t, ioutil.WriteFile(metadataFile, []byte(tt.args.yml), 0600))
 
-			err = run(metadataFile, tt.args.useExpGen)
+			err := run(metadataFile, tt.args.useExpGen)
 
 			if tt.wantErr != "" {
 				require.Regexp(t, tt.wantErr, err)

--- a/extension/storage/dbstorage/extension_test.go
+++ b/extension/storage/dbstorage/extension_test.go
@@ -18,7 +18,6 @@ package dbstorage
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"sync"
 	"testing"
 
@@ -108,8 +107,7 @@ func TestExtensionIntegrity(t *testing.T) {
 }
 
 func newTestExtension(t *testing.T) storage.Extension {
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -52,6 +52,7 @@ func newClient(filePath string, timeout time.Duration) (*fileStorageClient, erro
 		return err
 	}
 	if err := db.Update(initBucket); err != nil {
+		_ = db.Close()
 		return nil, err
 	}
 

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -18,8 +18,6 @@ package filestorage
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -30,7 +28,7 @@ import (
 )
 
 func TestClientOperations(t *testing.T) {
-	tempDir := newTempDir(t)
+	tempDir := t.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -65,7 +63,7 @@ func TestClientOperations(t *testing.T) {
 }
 
 func TestClientBatchOperations(t *testing.T) {
-	tempDir := newTempDir(t)
+	tempDir := t.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -183,7 +181,7 @@ func TestNewClientTransactionErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			tempDir := newTempDir(t)
+			tempDir := t.TempDir()
 			dbFile := filepath.Join(tempDir, "my_db")
 
 			client, err := newClient(dbFile, timeout)
@@ -202,7 +200,7 @@ func TestNewClientErrorsOnInvalidBucket(t *testing.T) {
 	temp := defaultBucket
 	defaultBucket = nil
 
-	tempDir := newTempDir(t)
+	tempDir := t.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -213,7 +211,7 @@ func TestNewClientErrorsOnInvalidBucket(t *testing.T) {
 }
 
 func BenchmarkClientGet(b *testing.B) {
-	tempDir := newTempDir(b)
+	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -229,7 +227,7 @@ func BenchmarkClientGet(b *testing.B) {
 }
 
 func BenchmarkClientGet100(b *testing.B) {
-	tempDir := newTempDir(b)
+	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -249,7 +247,7 @@ func BenchmarkClientGet100(b *testing.B) {
 }
 
 func BenchmarkClientSet(b *testing.B) {
-	tempDir := newTempDir(b)
+	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -266,7 +264,7 @@ func BenchmarkClientSet(b *testing.B) {
 }
 
 func BenchmarkClientSet100(b *testing.B) {
-	tempDir := newTempDir(b)
+	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -286,7 +284,7 @@ func BenchmarkClientSet100(b *testing.B) {
 }
 
 func BenchmarkClientDelete(b *testing.B) {
-	tempDir := newTempDir(b)
+	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -309,7 +307,7 @@ func BenchmarkClientSetLargeDB(b *testing.B) {
 	entry := make([]byte, entrySizeInBytes)
 	var testKey string
 
-	tempDir := newTempDir(b)
+	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -343,7 +341,7 @@ func BenchmarkClientInitLargeDB(b *testing.B) {
 	entryCount := 2000
 	var testKey string
 
-	tempDir := newTempDir(b)
+	tempDir := b.TempDir()
 	dbFile := filepath.Join(tempDir, "my_db")
 
 	client, err := newClient(dbFile, time.Second)
@@ -369,11 +367,4 @@ func BenchmarkClientInitLargeDB(b *testing.B) {
 		require.NoError(b, err)
 		b.StartTimer()
 	}
-}
-
-func newTempDir(tb testing.TB) string {
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(tb, err)
-	tb.Cleanup(func() { os.RemoveAll(tempDir) })
-	return tempDir
 }

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -33,6 +33,9 @@ func TestClientOperations(t *testing.T) {
 
 	client, err := newClient(dbFile, time.Second)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close(context.TODO()))
+	})
 
 	ctx := context.Background()
 	testKey := "testKey"
@@ -68,6 +71,9 @@ func TestClientBatchOperations(t *testing.T) {
 
 	client, err := newClient(dbFile, time.Second)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close(context.TODO()))
+	})
 
 	ctx := context.Background()
 	testSetEntries := []storage.Operation{
@@ -192,6 +198,8 @@ func TestNewClientTransactionErrors(t *testing.T) {
 
 			// Validate expected behavior
 			tc.validate(t, client)
+
+			require.NoError(t, client.db.Close())
 		})
 	}
 }

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -188,8 +188,7 @@ func TestTwoClientsWithDifferentNames(t *testing.T) {
 func TestGetClientErrorsOnDeletedDirectory(t *testing.T) {
 	ctx := context.Background()
 
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
@@ -217,8 +216,7 @@ func TestGetClientErrorsOnDeletedDirectory(t *testing.T) {
 }
 
 func newTestExtension(t *testing.T) storage.Extension {
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
@@ -240,8 +238,7 @@ func newTestEntity(name string) config.ComponentID {
 func TestCompaction(t *testing.T) {
 	ctx := context.Background()
 
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
@@ -323,8 +320,7 @@ func TestCompaction(t *testing.T) {
 func TestCompactionRemoveTemp(t *testing.T) {
 	ctx := context.Background()
 
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
@@ -364,8 +360,7 @@ func TestCompactionRemoveTemp(t *testing.T) {
 	require.Equal(t, fileName, files[0].Name())
 
 	// perform compaction in different directory
-	emptyTempDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	emptyTempDir := t.TempDir()
 
 	c, ok = client.(*fileStorageClient)
 	require.True(t, ok)

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -55,6 +55,10 @@ func TestExtensionIntegrity(t *testing.T) {
 	for _, c := range components {
 		client, err := se.GetClient(ctx, c.kind, c.name, "")
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, client.Close(ctx))
+		})
+
 		clients[c.name] = client
 	}
 
@@ -116,6 +120,9 @@ func TestClientHandlesSimpleCases(t *testing.T) {
 
 	myBytes := []byte("value")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close(ctx))
+	})
 
 	// Set the data
 	err = client.Set(ctx, "key", myBytes)
@@ -156,6 +163,9 @@ func TestTwoClientsWithDifferentNames(t *testing.T) {
 		"foo",
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client1.Close(ctx))
+	})
 
 	client2, err := se.GetClient(
 		ctx,
@@ -164,6 +174,9 @@ func TestTwoClientsWithDifferentNames(t *testing.T) {
 		"bar",
 	)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client2.Close(ctx))
+	})
 
 	myBytes1 := []byte("value1")
 	myBytes2 := []byte("value2")
@@ -256,8 +269,10 @@ func TestCompaction(t *testing.T) {
 		newTestEntity("my_component"),
 		"",
 	)
-
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close(ctx))
+	})
 
 	files, err := ioutil.ReadDir(tempDir)
 	require.NoError(t, err)
@@ -287,8 +302,11 @@ func TestCompaction(t *testing.T) {
 	// compact the db
 	c, ok := client.(*fileStorageClient)
 	require.True(t, ok)
-	client, err = c.Compact(ctx, tempDir, cfg.Timeout, 1)
+	fsClient1, err := c.Compact(ctx, tempDir, cfg.Timeout, 1)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, fsClient1.Close(ctx))
+	})
 
 	// check size after compaction
 	newStats, err := os.Stat(path)
@@ -298,15 +316,16 @@ func TestCompaction(t *testing.T) {
 	// remove data from database
 	for i = 0; i < numEntries; i++ {
 		key = fmt.Sprintf("key_%d", i)
-		err = client.Delete(ctx, key)
+		err = fsClient1.Delete(ctx, key)
 		require.NoError(t, err)
 	}
 
 	// compact after data removal
-	c, ok = client.(*fileStorageClient)
-	require.True(t, ok)
-	_, err = c.Compact(ctx, tempDir, cfg.Timeout, 1)
+	fsClient2, err := fsClient1.Compact(ctx, tempDir, cfg.Timeout, 1)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, fsClient2.Close(ctx))
+	})
 
 	// check size
 	stats = newStats
@@ -338,8 +357,10 @@ func TestCompactionRemoveTemp(t *testing.T) {
 		newTestEntity("my_component"),
 		"",
 	)
-
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close(ctx))
+	})
 
 	// check if only db exists in tempDir
 	files, err := ioutil.ReadDir(tempDir)
@@ -350,8 +371,11 @@ func TestCompactionRemoveTemp(t *testing.T) {
 	// perform compaction in the same directory
 	c, ok := client.(*fileStorageClient)
 	require.True(t, ok)
-	client, err = c.Compact(ctx, tempDir, cfg.Timeout, 1)
+	fsClient1, err := c.Compact(ctx, tempDir, cfg.Timeout, 1)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, fsClient1.Close(ctx))
+	})
 
 	// check if only db exists in tempDir
 	files, err = ioutil.ReadDir(tempDir)
@@ -362,10 +386,11 @@ func TestCompactionRemoveTemp(t *testing.T) {
 	// perform compaction in different directory
 	emptyTempDir := t.TempDir()
 
-	c, ok = client.(*fileStorageClient)
-	require.True(t, ok)
-	_, err = c.Compact(ctx, emptyTempDir, cfg.Timeout, 1)
+	fsClient2, err := fsClient1.Compact(ctx, emptyTempDir, cfg.Timeout, 1)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, fsClient2.Close(ctx))
+	})
 
 	// check if emptyTempDir is empty after compaction
 	files, err = ioutil.ReadDir(emptyTempDir)

--- a/extension/storage/filestorage/factory_test.go
+++ b/extension/storage/filestorage/factory_test.go
@@ -16,7 +16,6 @@ package filestorage
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -53,9 +52,8 @@ func TestFactory(t *testing.T) {
 		{
 			name: "Default",
 			config: func() *Config {
-				tempDir, _ := ioutil.TempDir("", "")
 				return &Config{
-					Directory:  tempDir,
+					Directory:  t.TempDir(),
 					Compaction: &CompactionConfig{},
 				}
 			}(),

--- a/extension/storage/storagetest/storage_test.go
+++ b/extension/storage/storagetest/storage_test.go
@@ -15,24 +15,15 @@
 package storagetest
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewStorageHost(t *testing.T) {
-	host := NewStorageHost(t, newTempDir(t), "test")
+	host := NewStorageHost(t, t.TempDir(), "test")
 	require.Equal(t, 1, len(host.GetExtensions()))
 
-	hostWithTwo := NewStorageHost(t, newTempDir(t), "one", "two")
+	hostWithTwo := NewStorageHost(t, t.TempDir(), "one", "two")
 	require.Equal(t, 2, len(hostWithTwo.GetExtensions()))
-}
-
-func newTempDir(tb testing.TB) string {
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(tb, err)
-	tb.Cleanup(func() { os.RemoveAll(tempDir) })
-	return tempDir
 }

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -18,7 +18,6 @@ package adapter
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -104,11 +103,7 @@ func TestHandleConsumeError(t *testing.T) {
 
 func BenchmarkReadLine(b *testing.B) {
 
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		b.Errorf(err.Error())
-		b.FailNow()
-	}
+	tempDir := b.TempDir()
 
 	filePath := filepath.Join(tempDir, "bench.log")
 
@@ -153,11 +148,7 @@ func BenchmarkReadLine(b *testing.B) {
 
 func BenchmarkParseAndMap(b *testing.B) {
 
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		b.Errorf(err.Error())
-		b.FailNow()
-	}
+	tempDir := b.TempDir()
 
 	filePath := filepath.Join(tempDir, "bench.log")
 

--- a/pkg/stanza/adapter/storage_test.go
+++ b/pkg/stanza/adapter/storage_test.go
@@ -17,7 +17,6 @@ package adapter
 
 import (
 	"context"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,12 +29,11 @@ import (
 
 func TestStorage(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 
 	r := createReceiver(t)
 	host := storagetest.NewStorageHost(t, tempDir, "test")
-	err = r.Start(ctx, host)
+	err := r.Start(ctx, host)
 	require.NoError(t, err)
 
 	myBytes := []byte("my_value")
@@ -77,12 +75,11 @@ func TestStorage(t *testing.T) {
 
 func TestFailOnMultipleStorageExtensions(t *testing.T) {
 	ctx := context.Background()
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 
 	r := createReceiver(t)
 	host := storagetest.NewStorageHost(t, tempDir, "one", "two")
-	err = r.Start(ctx, host)
+	err := r.Start(ctx, host)
 	require.Error(t, err)
 	require.Equal(t, "storage client: multiple storage extensions found", err.Error())
 }

--- a/pkg/stanza/operator/input/file/benchmark_test.go
+++ b/pkg/stanza/operator/input/file/benchmark_test.go
@@ -15,7 +15,6 @@
 package file
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -143,8 +142,7 @@ func BenchmarkFileInput(b *testing.B) {
 
 	for _, bench := range cases {
 		b.Run(bench.name, func(b *testing.B) {
-			rootDir, err := ioutil.TempDir("", "")
-			require.NoError(b, err)
+			rootDir := b.TempDir()
 
 			files := []*benchFile{}
 			for _, path := range bench.paths {

--- a/pkg/stanza/operator/input/file/file_test.go
+++ b/pkg/stanza/operator/input/file/file_test.go
@@ -82,11 +82,13 @@ func TestAddFileResolvedFields(t *testing.T) {
 	}, nil)
 
 	// Create temp dir with log file
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	file, err := ioutil.TempFile(dir, "")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, file.Close())
+	})
 
 	// Create symbolic link in monitored directory
 	symLinkPath := filepath.Join(tempDir, "symlink")
@@ -112,10 +114,6 @@ func TestAddFileResolvedFields(t *testing.T) {
 	require.Equal(t, symLinkPath, e.Attributes["log.file.path"])
 	require.Equal(t, filepath.Base(resolved), e.Attributes["log.file.name_resolved"])
 	require.Equal(t, resolved, e.Attributes["log.file.path_resolved"])
-
-	// Clean up (linux based host)
-	// Ignore error on windows host (The process cannot access the file because it is being used by another process.)
-	os.RemoveAll(dir)
 }
 
 // AddFileResolvedFields tests that the `log.file.name_resolved` and `log.file.path_resolved` fields are included
@@ -133,14 +131,19 @@ func TestAddFileResolvedFieldsWithChangeOfSymlinkTarget(t *testing.T) {
 	}, nil)
 
 	// Create temp dir with log file
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	file1, err := ioutil.TempFile(dir, "")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, file1.Close())
+	})
 
 	file2, err := ioutil.TempFile(dir, "")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, file2.Close())
+	})
 
 	// Resolve paths
 	real1, err := filepath.EvalSymlinks(file1.Name())
@@ -190,10 +193,6 @@ func TestAddFileResolvedFieldsWithChangeOfSymlinkTarget(t *testing.T) {
 	require.Equal(t, symLinkPath, e.Attributes["log.file.path"])
 	require.Equal(t, filepath.Base(resolved2), e.Attributes["log.file.name_resolved"])
 	require.Equal(t, resolved2, e.Attributes["log.file.path_resolved"])
-
-	// Clean up (linux based host)
-	// Ignore error on windows host (The process cannot access the file because it is being used by another process.)
-	os.RemoveAll(dir)
 }
 
 // ReadExistingLogs tests that, when starting from beginning, we

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -18,7 +18,6 @@ package filelogreceiver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -169,7 +168,7 @@ type rotationTest struct {
 func (rt *rotationTest) Run(t *testing.T) {
 	t.Parallel()
 
-	tempDir := newTempDir(t)
+	tempDir := t.TempDir()
 
 	f := NewFactory()
 	sink := new(consumertest.LogsSink)
@@ -248,19 +247,6 @@ func newRotatingLogger(t *testing.T, tempDir string, maxLines, maxBackups int, c
 	t.Cleanup(func() { _ = rotator.Close() })
 
 	return log.New(rotator, "", 0)
-}
-
-func newTempDir(t *testing.T) string {
-	tempDir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-
-	t.Logf("Temp Dir: %s", tempDir)
-
-	t.Cleanup(func() {
-		os.RemoveAll(tempDir)
-	})
-
-	return tempDir
 }
 
 func expectNLogs(sink *consumertest.LogsSink, expected int) func() bool {

--- a/receiver/filelogreceiver/storage_test.go
+++ b/receiver/filelogreceiver/storage_test.go
@@ -37,8 +37,8 @@ func TestStorage(t *testing.T) {
 
 	ctx := context.Background()
 
-	logsDir := newTempDir(t)
-	storageDir := newTempDir(t)
+	logsDir := t.TempDir()
+	storageDir := t.TempDir()
 
 	f := NewFactory()
 

--- a/receiver/fluentforwardreceiver/receiver_test.go
+++ b/receiver/fluentforwardreceiver/receiver_test.go
@@ -18,9 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -349,10 +347,7 @@ func TestUnixEndpoint(t *testing.T) {
 
 	next := new(consumertest.LogsSink)
 
-	tmpdir, err := ioutil.TempDir("", "fluent-socket")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	conf := &Config{
 		ListenAddress: "unix://" + filepath.Join(tmpdir, "fluent.sock"),

--- a/receiver/podmanreceiver/podman_connection_test.go
+++ b/receiver/podmanreceiver/podman_connection_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,14 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
-
-func newTmpDir(t *testing.T) string {
-	dir, err := os.MkdirTemp("", "podman-tests")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dir
-}
 
 func TestNewPodmanConnectionUnsupported(t *testing.T) {
 	logger := zap.NewNop()
@@ -46,8 +37,7 @@ func TestNewPodmanConnectionUnsupported(t *testing.T) {
 }
 
 func TestNewPodmanConnectionUnix(t *testing.T) {
-	tmpDir := newTmpDir(t)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	socketPath := filepath.Join(tmpDir, "test.sock")
 	l, err := net.Listen("unix", socketPath)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoErrror(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```