### PR TITLE
[receiver/dotnetdiagnosticsreceiver] fix panic when using .net6

### DIFF
--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
@@ -140,14 +140,14 @@ func createProviders(intervalSec int, names ...string) (ps []provider) {
 }
 
 // from https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventlevel
-const verboseEventLevel = 5
+const verboseEventLevel = 2
 
 func createProvider(name string, intervalSec int) provider {
 	s := strconv.Itoa(intervalSec)
 	return provider{
 		name:       name,
 		eventLevel: verboseEventLevel,
-		keywords:   math.MaxInt64,
+		keywords:   0, // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventkeywords
 		args:       providerArgs{"EventCounterIntervalSec": s},
 	}
 }

--- a/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
+++ b/receiver/dotnetdiagnosticsreceiver/dotnet/request.go
@@ -19,7 +19,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"math"
 	"sort"
 	"strconv"
 	"strings"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
keywords value is wrong

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracing.eventkeywords
https://github.com/dotnet/diagnostics/blob/main/src/Tools/dotnet-counters/CounterMonitor.cs#L774