### PR TITLE
[exporter/datadog] Add 'usePreview' option when the hostname comes from attributes

### DIFF
--- a/exporter/datadogexporter/internal/metadata/metadata.go
+++ b/exporter/datadogexporter/internal/metadata/metadata.go
@@ -95,7 +95,10 @@ type Meta struct {
 func metadataFromAttributes(attrs pcommon.Map) *HostMetadata {
 	hm := &HostMetadata{Meta: &Meta{}, Tags: &HostTags{}}
 
-	if hostname, ok := attributes.HostnameFromAttributes(attrs); ok {
+	// TODO (#10424): Remove and replace by package constant.
+	const usePreviewHostnameLogic = false
+
+	if hostname, ok := attributes.HostnameFromAttributes(attrs, usePreviewHostnameLogic); ok {
 		hm.InternalHostname = hostname
 		hm.Meta.Hostname = hostname
 	}
@@ -108,11 +111,11 @@ func metadataFromAttributes(attrs pcommon.Map) *HostMetadata {
 		hm.Meta.EC2Hostname = ec2HostInfo.EC2Hostname
 		hm.Tags.OTel = append(hm.Tags.OTel, ec2HostInfo.EC2Tags...)
 	} else if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderGCP {
-		gcpHostInfo := gcp.HostInfoFromAttributes(attrs)
+		gcpHostInfo := gcp.HostInfoFromAttributes(attrs, usePreviewHostnameLogic)
 		hm.Tags.GCP = gcpHostInfo.GCPTags
 		hm.Meta.HostAliases = append(hm.Meta.HostAliases, gcpHostInfo.HostAliases...)
 	} else if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderAzure {
-		azureHostInfo := azure.HostInfoFromAttributes(attrs)
+		azureHostInfo := azure.HostInfoFromAttributes(attrs, usePreviewHostnameLogic)
 		hm.Meta.HostAliases = append(hm.Meta.HostAliases, azureHostInfo.HostAliases...)
 	}
 

--- a/exporter/datadogexporter/internal/model/attributes/azure/azure.go
+++ b/exporter/datadogexporter/internal/model/attributes/azure/azure.go
@@ -33,11 +33,11 @@ type HostInfo struct {
 
 // HostInfoFromAttributes gets Azure host info from attributes following
 // OpenTelemetry semantic conventions
-func HostInfoFromAttributes(attrs pcommon.Map) (hostInfo *HostInfo) {
+func HostInfoFromAttributes(attrs pcommon.Map, usePreviewRules bool) (hostInfo *HostInfo) {
 	hostInfo = &HostInfo{}
 
 	// Add Azure VM ID as a host alias if available for compatibility with Azure integration
-	if vmID, ok := attrs.Get(conventions.AttributeHostID); ok {
+	if vmID, ok := attrs.Get(conventions.AttributeHostID); ok && !usePreviewRules {
 		hostInfo.HostAliases = append(hostInfo.HostAliases, vmID.StringVal())
 	}
 
@@ -45,7 +45,11 @@ func HostInfoFromAttributes(attrs pcommon.Map) (hostInfo *HostInfo) {
 }
 
 // HostnameFromAttributes gets the Azure hostname from attributes
-func HostnameFromAttributes(attrs pcommon.Map) (string, bool) {
+func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
+	if vmID, ok := attrs.Get(conventions.AttributeHostID); usePreviewRules && ok {
+		return vmID.StringVal(), true
+	}
+
 	if hostname, ok := attrs.Get(conventions.AttributeHostName); ok {
 		return hostname.StringVal(), true
 	}

--- a/exporter/datadogexporter/internal/model/attributes/azure/azure_test.go
+++ b/exporter/datadogexporter/internal/model/attributes/azure/azure_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/internal/testutils"
@@ -38,22 +39,55 @@ var (
 )
 
 func TestHostInfoFromAttributes(t *testing.T) {
-	hostInfo := HostInfoFromAttributes(testAttrs)
-	require.NotNil(t, hostInfo)
-	assert.ElementsMatch(t, hostInfo.HostAliases, []string{testVMID})
+	tests := []struct {
+		name       string
+		attrs      pcommon.Map
+		usePreview bool
 
-	emptyHostInfo := HostInfoFromAttributes(testEmpty)
-	require.NotNil(t, emptyHostInfo)
-	assert.ElementsMatch(t, emptyHostInfo.HostAliases, []string{})
-}
+		ok       bool
+		hostname string
+		aliases  []string
+	}{
+		{
+			name:  "all attributes",
+			attrs: testAttrs,
 
-func TestHostnameFromAttributes(t *testing.T) {
-	hostname, ok := HostnameFromAttributes(testAttrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostname)
+			ok:       true,
+			hostname: testHostname,
+			aliases:  []string{testVMID},
+		},
+		{
+			name:  "empty",
+			attrs: testEmpty,
+		},
+		{
+			name:       "all attributes",
+			attrs:      testAttrs,
+			usePreview: true,
 
-	_, ok = HostnameFromAttributes(testEmpty)
-	assert.False(t, ok)
+			ok:       true,
+			hostname: testVMID,
+		},
+		{
+			name:       "empty",
+			attrs:      testEmpty,
+			usePreview: true,
+		},
+	}
+
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			hostInfo := HostInfoFromAttributes(testInstance.attrs, testInstance.usePreview)
+			require.NotNil(t, hostInfo)
+			assert.ElementsMatch(t, testInstance.aliases, hostInfo.HostAliases)
+			hostname, ok := HostnameFromAttributes(testInstance.attrs, testInstance.usePreview)
+
+			assert.Equal(t, testInstance.ok, ok)
+			if testInstance.ok || ok {
+				assert.Equal(t, testInstance.hostname, hostname)
+			}
+		})
+	}
 }
 
 func TestClusterNameFromAttributes(t *testing.T) {

--- a/exporter/datadogexporter/internal/model/attributes/azure/azure_test.go
+++ b/exporter/datadogexporter/internal/model/attributes/azure/azure_test.go
@@ -61,7 +61,7 @@ func TestHostInfoFromAttributes(t *testing.T) {
 			attrs: testEmpty,
 		},
 		{
-			name:       "all attributes",
+			name:       "all attributes with preview",
 			attrs:      testAttrs,
 			usePreview: true,
 
@@ -69,7 +69,7 @@ func TestHostInfoFromAttributes(t *testing.T) {
 			hostname: testVMID,
 		},
 		{
-			name:       "empty",
+			name:       "empty with preview",
 			attrs:      testEmpty,
 			usePreview: true,
 		},

--- a/exporter/datadogexporter/internal/model/attributes/ec2/ec2.go
+++ b/exporter/datadogexporter/internal/model/attributes/ec2/ec2.go
@@ -48,9 +48,10 @@ func isDefaultHostname(hostname string) bool {
 
 // HostnameFromAttributes gets a valid hostname from labels
 // if available
-func HostnameFromAttributes(attrs pcommon.Map) (string, bool) {
+func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
 	hostName, ok := attrs.Get(conventions.AttributeHostName)
-	if ok && !isDefaultHostname(hostName.StringVal()) {
+	// With hostname preview rules, return the EC2 instance id always.
+	if !usePreviewRules && ok && !isDefaultHostname(hostName.StringVal()) {
 		return hostName.StringVal(), true
 	}
 

--- a/exporter/datadogexporter/internal/model/attributes/ec2/ec2_test.go
+++ b/exporter/datadogexporter/internal/model/attributes/ec2/ec2_test.go
@@ -44,7 +44,11 @@ func TestHostnameFromAttributes(t *testing.T) {
 		conventions.AttributeHostID:        testInstanceID,
 		conventions.AttributeHostName:      testIP,
 	})
-	hostname, ok := HostnameFromAttributes(attrs)
+	hostname, ok := HostnameFromAttributes(attrs, false)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testInstanceID)
+
+	hostname, ok = HostnameFromAttributes(attrs, true)
 	assert.True(t, ok)
 	assert.Equal(t, hostname, testInstanceID)
 }

--- a/exporter/datadogexporter/internal/model/attributes/hostname.go
+++ b/exporter/datadogexporter/internal/model/attributes/hostname.go
@@ -55,7 +55,7 @@ func getClusterName(attrs pcommon.Map) (string, bool) {
 //   6. the host.name attribute.
 //
 //  It returns a boolean value indicated if any name was found
-func HostnameFromAttributes(attrs pcommon.Map) (string, bool) {
+func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
 	// Check if the host is localhost or 0.0.0.0, if so discard it.
 	// We don't do the more strict validation done for metadata,
 	// to avoid breaking users existing invalid-but-accepted hostnames.
@@ -68,14 +68,14 @@ func HostnameFromAttributes(attrs pcommon.Map) (string, bool) {
 		"ip6-localhost":           {},
 	}
 
-	candidateHost, ok := unsanitizedHostnameFromAttributes(attrs)
+	candidateHost, ok := unsanitizedHostnameFromAttributes(attrs, usePreviewRules)
 	if _, invalid := invalidHosts[candidateHost]; invalid {
 		return "", false
 	}
 	return candidateHost, ok
 }
 
-func unsanitizedHostnameFromAttributes(attrs pcommon.Map) (string, bool) {
+func unsanitizedHostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
 	// Custom hostname: useful for overriding in k8s/cloud envs
 	if customHostname, ok := attrs.Get(AttributeDatadogHostname); ok {
 		return customHostname.StringVal(), true
@@ -96,11 +96,11 @@ func unsanitizedHostnameFromAttributes(attrs pcommon.Map) (string, bool) {
 
 	cloudProvider, ok := attrs.Get(conventions.AttributeCloudProvider)
 	if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderAWS {
-		return ec2.HostnameFromAttributes(attrs)
+		return ec2.HostnameFromAttributes(attrs, usePreviewRules)
 	} else if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderGCP {
-		return gcp.HostnameFromAttributes(attrs)
+		return gcp.HostnameFromAttributes(attrs, usePreviewRules)
 	} else if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderAzure {
-		return azure.HostnameFromAttributes(attrs)
+		return azure.HostnameFromAttributes(attrs, usePreviewRules)
 	}
 
 	// host id from cloud provider
@@ -113,9 +113,11 @@ func unsanitizedHostnameFromAttributes(attrs pcommon.Map) (string, bool) {
 		return hostName.StringVal(), true
 	}
 
-	// container id (e.g. from Docker)
-	if containerID, ok := attrs.Get(conventions.AttributeContainerID); ok {
-		return containerID.StringVal(), true
+	if !usePreviewRules {
+		// container id (e.g. from Docker)
+		if containerID, ok := attrs.Get(conventions.AttributeContainerID); ok {
+			return containerID.StringVal(), true
+		}
 	}
 
 	return "", false

--- a/exporter/datadogexporter/internal/model/attributes/hostname_test.go
+++ b/exporter/datadogexporter/internal/model/attributes/hostname_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/model/attributes/azure"
@@ -34,91 +35,125 @@ const (
 )
 
 func TestHostnameFromAttributes(t *testing.T) {
-	// Custom hostname
-	attrs := testutils.NewAttributeMap(map[string]string{
-		AttributeDatadogHostname:            testCustomName,
-		AttributeK8sNodeName:                testNodeName,
-		conventions.AttributeK8SClusterName: testClusterName,
-		conventions.AttributeContainerID:    testContainerID,
-		conventions.AttributeHostID:         testHostID,
-		conventions.AttributeHostName:       testHostName,
-	})
-	hostname, ok := HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testCustomName)
+	tests := []struct {
+		name       string
+		attrs      pcommon.Map
+		usePreview bool
 
-	// Container ID
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeContainerID: testContainerID,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testContainerID)
+		ok       bool
+		hostname string
+	}{
+		{
+			name: "custom hostname",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				AttributeDatadogHostname:            testCustomName,
+				AttributeK8sNodeName:                testNodeName,
+				conventions.AttributeK8SClusterName: testClusterName,
+				conventions.AttributeContainerID:    testContainerID,
+				conventions.AttributeHostID:         testHostID,
+				conventions.AttributeHostName:       testHostName,
+			}),
+			ok:       true,
+			hostname: testCustomName,
+		},
+		{
+			name: "container ID",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeContainerID: testContainerID,
+			}),
+			ok:       true,
+			hostname: testContainerID,
+		},
+		{
+			name: "container ID, preview",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeContainerID: testContainerID,
+			}),
+			usePreview: true,
+		},
+		{
+			name: "AWS EC2",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testHostName,
+			}),
+			ok:       true,
+			hostname: testHostName,
+		},
+		{
+			name: "AWS EC2, preview",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testHostName,
+			}),
+			ok:         true,
+			hostname:   testHostID,
+			usePreview: true,
+		},
+		{
+			name: "ECS Fargate",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider:      conventions.AttributeCloudProviderAWS,
+				conventions.AttributeCloudPlatform:      conventions.AttributeCloudPlatformAWSECS,
+				conventions.AttributeAWSECSTaskARN:      "example-task-ARN",
+				conventions.AttributeAWSECSTaskFamily:   "example-task-family",
+				conventions.AttributeAWSECSTaskRevision: "example-task-revision",
+				conventions.AttributeAWSECSLaunchtype:   conventions.AttributeAWSECSLaunchtypeFargate,
+			}),
+			ok:       true,
+			hostname: "",
+		},
+		{
+			name: "GCP",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testHostName,
+			}),
+			ok:       true,
+			hostname: testHostName,
+		},
+		{
+			name: "azure",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testHostName,
+			}),
+			ok:       true,
+			hostname: testHostName,
+		},
+		{
+			name: "host id v. hostname",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeHostID:   testHostID,
+				conventions.AttributeHostName: testHostName,
+			}),
+			ok:       true,
+			hostname: testHostID,
+		},
+		{
+			name:  "no hostname",
+			attrs: testutils.NewAttributeMap(map[string]string{}),
+		},
+		{
+			name: "localhost",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				AttributeDatadogHostname: "127.0.0.1",
+			}),
+		},
+	}
 
-	// AWS cloud provider means relying on the EC2 function
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
-		conventions.AttributeHostID:        testHostID,
-		conventions.AttributeHostName:      testHostName,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostName)
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			hostname, ok := HostnameFromAttributes(testInstance.attrs, testInstance.usePreview)
+			assert.Equal(t, testInstance.ok, ok)
+			assert.Equal(t, testInstance.hostname, hostname)
+		})
 
-	// AWS cloud provider means relying on the EC2 function
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeCloudProvider:      conventions.AttributeCloudProviderAWS,
-		conventions.AttributeCloudPlatform:      conventions.AttributeCloudPlatformAWSECS,
-		conventions.AttributeAWSECSTaskARN:      "example-task-ARN",
-		conventions.AttributeAWSECSTaskFamily:   "example-task-family",
-		conventions.AttributeAWSECSTaskRevision: "example-task-revision",
-		conventions.AttributeAWSECSLaunchtype:   conventions.AttributeAWSECSLaunchtypeFargate,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Empty(t, hostname)
-
-	// GCP cloud provider means relying on the GCP function
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
-		conventions.AttributeHostID:        testHostID,
-		conventions.AttributeHostName:      testHostName,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostName)
-
-	// Azure cloud provider means relying on the Azure function
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
-		conventions.AttributeHostID:        testHostID,
-		conventions.AttributeHostName:      testHostName,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostName)
-
-	// Host Id takes preference
-	attrs = testutils.NewAttributeMap(map[string]string{
-		conventions.AttributeHostID:   testHostID,
-		conventions.AttributeHostName: testHostName,
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.True(t, ok)
-	assert.Equal(t, hostname, testHostID)
-
-	// No labels means no hostname
-	attrs = testutils.NewAttributeMap(map[string]string{})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.False(t, ok)
-	assert.Empty(t, hostname)
-
-	attrs = testutils.NewAttributeMap(map[string]string{
-		AttributeDatadogHostname: "127.0.0.1",
-	})
-	hostname, ok = HostnameFromAttributes(attrs)
-	assert.False(t, ok)
-	assert.Empty(t, hostname)
+	}
 }
 
 func TestGetClusterName(t *testing.T) {
@@ -163,7 +198,7 @@ func TestHostnameKubernetes(t *testing.T) {
 		conventions.AttributeHostID:         testHostID,
 		conventions.AttributeHostName:       testHostName,
 	})
-	hostname, ok := HostnameFromAttributes(attrs)
+	hostname, ok := HostnameFromAttributes(attrs, false)
 	assert.True(t, ok)
 	assert.Equal(t, hostname, "nodeName-clusterName")
 
@@ -174,7 +209,7 @@ func TestHostnameKubernetes(t *testing.T) {
 		conventions.AttributeHostID:      testHostID,
 		conventions.AttributeHostName:    testHostName,
 	})
-	hostname, ok = HostnameFromAttributes(attrs)
+	hostname, ok = HostnameFromAttributes(attrs, false)
 	assert.True(t, ok)
 	assert.Equal(t, hostname, "nodeName")
 
@@ -185,7 +220,7 @@ func TestHostnameKubernetes(t *testing.T) {
 		conventions.AttributeHostID:         testHostID,
 		conventions.AttributeHostName:       testHostName,
 	})
-	hostname, ok = HostnameFromAttributes(attrs)
+	hostname, ok = HostnameFromAttributes(attrs, false)
 	assert.True(t, ok)
 	// cluster name gets ignored, fallback to next option
 	assert.Equal(t, hostname, testHostID)

--- a/exporter/datadogexporter/internal/model/attributes/hostname_test.go
+++ b/exporter/datadogexporter/internal/model/attributes/hostname_test.go
@@ -26,12 +26,14 @@ import (
 )
 
 const (
-	testHostID      = "example-host-id"
-	testHostName    = "example-host-name"
-	testContainerID = "example-container-id"
-	testClusterName = "clusterName"
-	testNodeName    = "nodeName"
-	testCustomName  = "example-custom-host-name"
+	testHostID       = "example-host-id"
+	testHostName     = "example-host-name"
+	testContainerID  = "example-container-id"
+	testClusterName  = "clusterName"
+	testNodeName     = "nodeName"
+	testCustomName   = "example-custom-host-name"
+	testCloudAccount = "projectID"
+	testGCPHostname  = testHostName + ".c." + testCloudAccount + ".internal"
 )
 
 func TestHostnameFromAttributes(t *testing.T) {
@@ -110,10 +112,22 @@ func TestHostnameFromAttributes(t *testing.T) {
 			attrs: testutils.NewAttributeMap(map[string]string{
 				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
 				conventions.AttributeHostID:        testHostID,
-				conventions.AttributeHostName:      testHostName,
+				conventions.AttributeHostName:      testGCPHostname,
 			}),
 			ok:       true,
-			hostname: testHostName,
+			hostname: testGCPHostname,
+		},
+		{
+			name: "GCP, preview",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider:  conventions.AttributeCloudProviderGCP,
+				conventions.AttributeHostID:         testHostID,
+				conventions.AttributeHostName:       testGCPHostname,
+				conventions.AttributeCloudAccountID: testCloudAccount,
+			}),
+			usePreview: true,
+			ok:         true,
+			hostname:   testHostName + "." + testCloudAccount,
 		},
 		{
 			name: "azure",
@@ -124,6 +138,17 @@ func TestHostnameFromAttributes(t *testing.T) {
 			}),
 			ok:       true,
 			hostname: testHostName,
+		},
+		{
+			name: "azure, preview",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
+				conventions.AttributeHostID:        testHostID,
+				conventions.AttributeHostName:      testHostName,
+			}),
+			usePreview: true,
+			ok:         true,
+			hostname:   testHostID,
 		},
 		{
 			name: "host id v. hostname",

--- a/exporter/datadogexporter/internal/model/attributes/hostname_test.go
+++ b/exporter/datadogexporter/internal/model/attributes/hostname_test.go
@@ -26,14 +26,15 @@ import (
 )
 
 const (
-	testHostID       = "example-host-id"
-	testHostName     = "example-host-name"
-	testContainerID  = "example-container-id"
-	testClusterName  = "clusterName"
-	testNodeName     = "nodeName"
-	testCustomName   = "example-custom-host-name"
-	testCloudAccount = "projectID"
-	testGCPHostname  = testHostName + ".c." + testCloudAccount + ".internal"
+	testHostID                 = "example-host-id"
+	testHostName               = "example-host-name"
+	testContainerID            = "example-container-id"
+	testClusterName            = "clusterName"
+	testNodeName               = "nodeName"
+	testCustomName             = "example-custom-host-name"
+	testCloudAccount           = "projectID"
+	testGCPHostname            = testHostName + ".c." + testCloudAccount + ".internal"
+	testGCPIntegrationHostname = testHostName + "." + testCloudAccount
 )
 
 func TestHostnameFromAttributes(t *testing.T) {
@@ -127,7 +128,7 @@ func TestHostnameFromAttributes(t *testing.T) {
 			}),
 			usePreview: true,
 			ok:         true,
-			hostname:   testHostName + "." + testCloudAccount,
+			hostname:   testGCPIntegrationHostname,
 		},
 		{
 			name: "azure",

--- a/exporter/datadogexporter/internal/model/translator/config.go
+++ b/exporter/datadogexporter/internal/model/translator/config.go
@@ -30,7 +30,8 @@ type translatorConfig struct {
 	deltaTTL      int64
 
 	// hostname provider configuration
-	fallbackHostnameProvider HostnameProvider
+	previewHostnameFromAttributes bool
+	fallbackHostnameProvider      HostnameProvider
 }
 
 // Option is a translator creation option.
@@ -57,6 +58,14 @@ func WithDeltaTTL(deltaTTL int64) Option {
 func WithFallbackHostnameProvider(provider HostnameProvider) Option {
 	return func(t *translatorConfig) error {
 		t.fallbackHostnameProvider = provider
+		return nil
+	}
+}
+
+// WithPreviewHostnameFromAttributes enables the preview hostname algorithm.
+func WithPreviewHostnameFromAttributes() Option {
+	return func(t *translatorConfig) error {
+		t.previewHostnameFromAttributes = true
 		return nil
 	}
 }

--- a/exporter/datadogexporter/internal/model/translator/metrics_translator.go
+++ b/exporter/datadogexporter/internal/model/translator/metrics_translator.go
@@ -396,7 +396,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 		// Fetch tags from attributes.
 		attributeTags := attributes.TagsFromAttributes(rm.Resource().Attributes())
 
-		host, ok := attributes.HostnameFromAttributes(rm.Resource().Attributes())
+		host, ok := attributes.HostnameFromAttributes(rm.Resource().Attributes(), t.cfg.previewHostnameFromAttributes)
 		if !ok {
 			var err error
 			host, err = t.cfg.fallbackHostnameProvider.Hostname(context.Background())

--- a/exporter/datadogexporter/translate_traces.go
+++ b/exporter/datadogexporter/translate_traces.go
@@ -89,7 +89,9 @@ func convertToDatadogTd(td ptrace.Traces, fallbackHost string, cfg *config.Confi
 
 	for i := 0; i < resourceSpans.Len(); i++ {
 		rs := resourceSpans.At(i)
-		host, ok := attributes.HostnameFromAttributes(rs.Resource().Attributes())
+		// TODO (#10424): Remove and replace by package constant.
+		const usePreviewHostnameLogic = false
+		host, ok := attributes.HostnameFromAttributes(rs.Resource().Attributes(), usePreviewHostnameLogic)
 		if !ok {
 			host = fallbackHost
 		}


### PR DESCRIPTION
**Description:** 

Add a (currently internal) `usePreview` option to use the improved hostname mapping when getting the hostname from attributes. Eventually whether to use the old/new logic will be controlled by a feature flag, but right now it is unused.

**Link to tracking Issue:** #10424

**Testing:** Improved existing unit tests to avoid regressions 