### PR TITLE
[mezmoexporter] Add user-agent string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Enhancements 💡
 
 - `tailsamplingprocessor`: Add support for string invert matching to `and` policy (#9553)
+- `mezemoexporter`: Add user agent string to outgoing HTTP requests (#10470)
 
 ### 🧰 Bug fixes 🧰
 

--- a/exporter/mezmoexporter/factory.go
+++ b/exporter/mezmoexporter/factory.go
@@ -56,7 +56,7 @@ func createLogsExporter(ctx context.Context, settings component.ExporterCreateSe
 		return nil, err
 	}
 
-	exp := newLogsExporter(expCfg, settings.TelemetrySettings)
+	exp := newLogsExporter(expCfg, settings.TelemetrySettings, settings.BuildInfo)
 
 	return exporterhelper.NewLogsExporter(
 		expCfg,


### PR DESCRIPTION
This commit adds a `user-agent` string to the outgoing HTTP
requests from the Mezmo exporter.
