### PR TITLE
Fix gcp resource detection when using workload identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - `tanzuobservabilityexporter`: Improve how negative values in exponential histograms are handled. (#10135)
 - `resourcedetectionprocessor`: GCP resource detector now properly detects zone/region on GKE (#10347)
+- `resourcedetectionprocessor`: GCP resource detector no longer fails to detect resource when using workload identity (#10486)
 
 ## v0.52.0
 

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -66,7 +66,6 @@ func (d *detector) Detect(context.Context) (resource pcommon.Resource, schemaURL
 		b.addZoneOrRegion(d.detector.GKEAvailabilityZoneOrRegion)
 		b.add(conventions.AttributeK8SClusterName, d.detector.GKEClusterName)
 		b.add(conventions.AttributeHostID, d.detector.GKEHostID)
-		b.add(conventions.AttributeHostName, d.detector.GKEHostName)
 	case gcp.CloudRun:
 		b.attrs.InsertString(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformGCPCloudRun)
 		b.add(conventions.AttributeFaaSName, d.detector.FaaSName)

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
@@ -46,7 +46,6 @@ func TestDetect(t *testing.T) {
 				projectID:           "my-project",
 				cloudPlatform:       gcp.GKE,
 				gkeHostID:           "1472385723456792345",
-				gkeHostName:         "my-gke-node-1234",
 				gkeClusterName:      "my-cluster",
 				gkeAvailabilityZone: "us-central1-c",
 			}},
@@ -57,7 +56,6 @@ func TestDetect(t *testing.T) {
 				conventions.AttributeK8SClusterName:        "my-cluster",
 				conventions.AttributeCloudAvailabilityZone: "us-central1-c",
 				conventions.AttributeHostID:                "1472385723456792345",
-				conventions.AttributeHostName:              "my-gke-node-1234",
 			}),
 		},
 		{
@@ -66,7 +64,6 @@ func TestDetect(t *testing.T) {
 				projectID:      "my-project",
 				cloudPlatform:  gcp.GKE,
 				gkeHostID:      "1472385723456792345",
-				gkeHostName:    "my-gke-node-1234",
 				gkeClusterName: "my-cluster",
 				gkeRegion:      "us-central1",
 			}},
@@ -77,7 +74,6 @@ func TestDetect(t *testing.T) {
 				conventions.AttributeK8SClusterName: "my-cluster",
 				conventions.AttributeCloudRegion:    "us-central1",
 				conventions.AttributeHostID:         "1472385723456792345",
-				conventions.AttributeHostName:       "my-gke-node-1234",
 			}),
 		},
 		{
@@ -210,7 +206,6 @@ type fakeGCPDetector struct {
 	gkeRegion                 string
 	gkeClusterName            string
 	gkeHostID                 string
-	gkeHostName               string
 	faaSName                  string
 	faaSVersion               string
 	faaSID                    string
@@ -260,13 +255,6 @@ func (f *fakeGCPDetector) GKEHostID() (string, error) {
 		return "", f.err
 	}
 	return f.gkeHostID, nil
-}
-
-func (f *fakeGCPDetector) GKEHostName() (string, error) {
-	if f.err != nil {
-		return "", f.err
-	}
-	return f.gkeHostName, nil
 }
 
 func (f *fakeGCPDetector) FaaSName() (string, error) {

--- a/processor/resourcedetectionprocessor/internal/gcp/types.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/types.go
@@ -26,7 +26,6 @@ type gcpDetector interface {
 	GKEAvailabilityZoneOrRegion() (string, gcp.LocationType, error)
 	GKEClusterName() (string, error)
 	GKEHostID() (string, error)
-	GKEHostName() (string, error)
 	FaaSName() (string, error)
 	FaaSVersion() (string, error)
 	FaaSID() (string, error)


### PR DESCRIPTION
**Description:**

I was testing #10347, which updated gcp resource detection, and got this error on clusters with workload identity: `failed to detect resource	{"kind": "processor", "name": "resourcedetection", "pipeline": "logs", "error": "metadata: GCE metadata \"instance/name\" not defined"}`.  It turns out that [on GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#metadata_server), only `instance/hostname` is available, not `instance/name`. Hostname is an fqdn, not the name of the instance.  E.g. `gke-wi-collector-test-default-pool-5a7b28f7-nxwt.c.my-project.internal`, so we shouldn't use that as the hostname.  It would be nice to have the instance name, but that might need to be obtained through the downward API instead of the GKE metadata server...

**Testing:**

Fixed unit tests, and manually tested.