### PR TITLE
[dynatraceexporter] truncate long unmarshalable responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `tailsamplingprocessor`: Add support for string invert matching to `and` policy (#9553)
 - `mezemoexporter`: Add user agent string to outgoing HTTP requests (#10470)
 - `transformprocessor`: Add functions for conversion of scalar metric types (`gauge_to_sum` and `sum_to_gauge`) (#10255)
+- `dynatraceexporter`: Truncate unmarshalable responses to avoid long log lines (#10568)
 
 ### 🧰 Bug fixes 🧰
 

--- a/exporter/dynatraceexporter/metrics_exporter.go
+++ b/exporter/dynatraceexporter/metrics_exporter.go
@@ -227,7 +227,9 @@ func (e *exporter) sendBatch(ctx context.Context, lines []string) error {
 		responseBody := metricsResponse{}
 		if err := json.Unmarshal(bodyBytes, &responseBody); err != nil {
 			// if the response cannot be read, do not retry the batch as it may have been successful
-			e.settings.Logger.Error("Failed to unmarshal response from Dynatrace", zap.Error(err), zap.ByteString("body", bodyBytes))
+			bodyStr := string(bodyBytes)
+			bodyStr = truncateString(bodyStr, 1000)
+			e.settings.Logger.Error("Failed to unmarshal response from Dynatrace", zap.Error(err), zap.String("body", bodyStr))
 			return nil
 		}
 
@@ -277,6 +279,17 @@ func (e *exporter) start(_ context.Context, host component.Host) (err error) {
 	e.client = client
 
 	return nil
+}
+
+func truncateString(str string, num int) string {
+	truncated := str
+	if len(str) > num {
+		if num > 3 {
+			num -= 3
+		}
+		truncated = str[0:num] + "..."
+	}
+	return truncated
 }
 
 // Response from Dynatrace is expected to be in JSON format


### PR DESCRIPTION
When an endpoint does not return a valid JSON error (for example, the endpoint is incorrect or the server has an issue) truncate responses to 1000 characters in order to avoid spamming the logs with large payloads.