### PR TITLE
[processor/metricstransform] Migrate group operation tests to OTLP

### DIFF
--- a/processor/metricstransformprocessor/go.mod
+++ b/processor/metricstransformprocessor/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/google/go-cmp v0.5.8
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest v0.52.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.52.0
 	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/collector v0.52.0
@@ -29,6 +30,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.52.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.52.0 // indirect
 	go.opentelemetry.io/otel v1.7.0 // indirect
@@ -48,3 +50,5 @@ require (
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus => ../../pkg/translator/opencensus
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest => ../../internal/scrapertest

--- a/processor/metricstransformprocessor/go.sum
+++ b/processor/metricstransformprocessor/go.sum
@@ -128,8 +128,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.15.4 h1:1kn4/7MepF/CHmYub99/nNX8az0IJjfSOU/jbnTVfqQ=
 github.com/knadh/koanf v1.4.1 h1:Z0VGW/uo8NJmjd+L1Dc3S5frq6c62w5xQ9Yf4Mg3wFQ=
 github.com/knadh/koanf v1.4.1/go.mod h1:1cfH5223ZeZUOs8FU2UdTmaNfHpqgtjV0+NHjRO43gs=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -162,6 +162,7 @@ github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144T
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -170,6 +171,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
@@ -327,6 +330,7 @@ gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUy
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -16,31 +16,24 @@ package metricstransformprocessor
 
 import (
 	"context"
+	"path/filepath"
 	"regexp"
-	"sort"
-	"strings"
 	"testing"
 
-	agentmetricspb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/metrics/v1"
-	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
-	resourcepb "github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1"
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/testing/protocmp"
 
-	internaldata "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/scrapertest/golden"
 )
 
 type metricsGroupingTest struct {
 	name       string // test name
 	transforms []internalTransform
-	in         *agentmetricspb.ExportMetricsServiceRequest
-	out        []*agentmetricspb.ExportMetricsServiceRequest
 }
 
 var (
@@ -52,44 +45,6 @@ var (
 					MetricIncludeFilter: internalFilterStrict{include: "foo/metric"},
 					Action:              Group,
 					GroupResourceLabels: map[string]string{"resource.type": "foo"},
-				},
-			},
-			in: &agentmetricspb.ExportMetricsServiceRequest{
-				Resource: &resourcepb.Resource{
-					Labels: map[string]string{
-						"original": "label",
-					},
-				},
-				Metrics: []*metricspb.Metric{
-					metricBuilder().setName("foo/metric").
-						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-					metricBuilder().setName("bar/metric").
-						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-				},
-			},
-			out: []*agentmetricspb.ExportMetricsServiceRequest{
-				{
-					Resource: &resourcepb.Resource{
-						Labels: map[string]string{
-							"original": "label",
-						},
-					},
-					Metrics: []*metricspb.Metric{
-						metricBuilder().setName("bar/metric").
-							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-					},
-				},
-				{
-					Resource: &resourcepb.Resource{
-						Labels: map[string]string{
-							"original":      "label",
-							"resource.type": "foo",
-						},
-					},
-					Metrics: []*metricspb.Metric{
-						metricBuilder().setName("foo/metric").
-							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-					},
 				},
 			},
 		},
@@ -107,65 +62,9 @@ var (
 					GroupResourceLabels: map[string]string{"resource.type": "k8s.pod"},
 				},
 			},
-			in: &agentmetricspb.ExportMetricsServiceRequest{
-				Metrics: []*metricspb.Metric{
-					metricBuilder().setName("container.cpu.utilization").
-						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-					metricBuilder().setName("container.memory.usage").
-						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-					metricBuilder().setName("k8s.pod.cpu.utilization").
-						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-					metricBuilder().setName("k8s.pod.memory.usage").
-						setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-				},
-			},
-			out: []*agentmetricspb.ExportMetricsServiceRequest{
-				{
-					Resource: &resourcepb.Resource{
-						Labels: map[string]string{
-							"resource.type": "container",
-						},
-					},
-					Metrics: []*metricspb.Metric{
-						metricBuilder().setName("container.cpu.utilization").
-							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-						metricBuilder().setName("container.memory.usage").
-							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-					},
-				},
-				{
-					Resource: &resourcepb.Resource{
-						Labels: map[string]string{
-							"resource.type": "k8s.pod",
-						},
-					},
-					Metrics: []*metricspb.Metric{
-						metricBuilder().setName("k8s.pod.cpu.utilization").
-							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-						metricBuilder().setName("k8s.pod.memory.usage").
-							setDataType(metricspb.MetricDescriptor_GAUGE_INT64).build(),
-					},
-				},
-			},
 		},
 	}
 )
-
-func sortResourceMetricsByResourceType(l []*agentmetricspb.ExportMetricsServiceRequest) {
-	sort.Slice(l, func(i, j int) bool {
-		return strings.Compare(
-			l[i].Resource.GetLabels()["resource.type"],
-			l[j].Resource.GetLabels()["resource.type"]) < 0
-	})
-}
-
-func sortMetricsByMetricName(m []*metricspb.Metric) {
-	sort.Slice(m, func(i, j int) bool {
-		return strings.Compare(
-			m[i].MetricDescriptor.GetName(),
-			m[j].MetricDescriptor.GetName()) < 0
-	})
-}
 
 func TestMetricsGrouping(t *testing.T) {
 	for _, test := range groupingTests {
@@ -176,49 +75,24 @@ func TestMetricsGrouping(t *testing.T) {
 			mtp, err := processorhelper.NewMetricsProcessor(&Config{
 				ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
 			}, next, p.processMetrics, processorhelper.WithCapabilities(consumerCapabilities))
-
 			require.NoError(t, err)
 
 			caps := mtp.Capabilities()
 			assert.Equal(t, true, caps.MutatesData)
 
-			// process
-			cErr := mtp.ConsumeMetrics(context.Background(), internaldata.OCToMetrics(test.in.Node, test.in.Resource, test.in.Metrics))
-			assert.NoError(t, cErr)
+			input, err := golden.ReadMetrics(filepath.Join("testdata", "operation_group", test.name+"_in.json"))
+			require.NoError(t, err)
+			expected, err := golden.ReadMetrics(filepath.Join("testdata", "operation_group", test.name+"_out.json"))
+			require.NoError(t, err)
 
-			// get and check results
+			cErr := mtp.ConsumeMetrics(context.Background(), input)
+			assert.NoError(t, cErr)
 
 			got := next.AllMetrics()
 			require.Equal(t, 1, len(got))
+			require.NoError(t, scrapertest.CompareMetrics(expected, got[0], scrapertest.IgnoreMetricValues()))
 
-			var gotMD []*agentmetricspb.ExportMetricsServiceRequest
-			for i := 0; i < got[0].ResourceMetrics().Len(); i++ {
-				ocmd := &agentmetricspb.ExportMetricsServiceRequest{}
-				ocmd.Node, ocmd.Resource, ocmd.Metrics = internaldata.ResourceMetricsToOC(got[0].ResourceMetrics().At(i))
-				gotMD = append(gotMD, ocmd)
-			}
-			require.Equal(t, len(test.out), len(gotMD))
-
-			sortResourceMetricsByResourceType(gotMD)
-			sortResourceMetricsByResourceType(test.out)
-
-			for idx, out := range gotMD {
-				if diff := cmp.Diff(test.out[idx].Resource, out.Resource, protocmp.Transform()); diff != "" {
-					t.Errorf("Unexpected difference in resource labels:\n%v", diff)
-				}
-
-				sortMetricsByMetricName(out.Metrics)
-				sortMetricsByMetricName(test.out[idx].Metrics)
-
-				require.Equal(t, len(test.out[idx].Metrics), len(out.Metrics))
-				if diff := cmp.Diff(test.out[idx].Metrics, out.Metrics, protocmp.Transform()); diff != "" {
-					t.Errorf("Unexpected difference in Metrics:\n%v", diff)
-				}
-			}
-
-			ctx := context.Background()
-			assert.NoError(t, mtp.Shutdown(ctx))
-
+			assert.NoError(t, mtp.Shutdown(context.Background()))
 		})
 	}
 }

--- a/processor/metricstransformprocessor/testdata/operation_group/metric_group_by_strict_name_in.json
+++ b/processor/metricstransformprocessor/testdata/operation_group/metric_group_by_strict_name_in.json
@@ -1,0 +1,30 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "original",
+            "value": {
+              "stringValue": "label"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "foo/metric",
+              "gauge": {}
+            },
+            {
+              "name": "bar/metric",
+              "gauge": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/processor/metricstransformprocessor/testdata/operation_group/metric_group_by_strict_name_out.json
+++ b/processor/metricstransformprocessor/testdata/operation_group/metric_group_by_strict_name_out.json
@@ -1,0 +1,54 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "original",
+            "value": {
+              "stringValue": "label"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "bar/metric",
+              "gauge": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "original",
+            "value": {
+              "stringValue": "label"
+            }
+          },
+          {
+            "key": "resource.type",
+            "value": {
+              "stringValue": "foo"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "foo/metric",
+              "gauge": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/processor/metricstransformprocessor/testdata/operation_group/metric_group_regex_multiple_empty_resource_in.json
+++ b/processor/metricstransformprocessor/testdata/operation_group/metric_group_regex_multiple_empty_resource_in.json
@@ -1,0 +1,28 @@
+{
+  "resourceMetrics": [
+    {
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "container.cpu.utilization",
+              "gauge": {}
+            },
+            {
+              "name": "container.memory.usage",
+              "gauge": {}
+            },
+            {
+              "name": "k8s.pod.cpu.utilization",
+              "gauge": {}
+            },
+            {
+              "name": "k8s.pod.memory.usage",
+              "gauge": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/processor/metricstransformprocessor/testdata/operation_group/metric_group_regex_multiple_empty_resource_out.json
+++ b/processor/metricstransformprocessor/testdata/operation_group/metric_group_regex_multiple_empty_resource_out.json
@@ -1,0 +1,56 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "resource.type",
+            "value": {
+              "stringValue": "container"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "container.cpu.utilization",
+              "gauge": {}
+            },
+            {
+              "name": "container.memory.usage",
+              "gauge": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "resource.type",
+            "value": {
+              "stringValue": "k8s.pod"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "k8s.pod.cpu.utilization",
+              "gauge": {}
+            },
+            {
+              "name": "k8s.pod.memory.usage",
+              "gauge": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is the first change in a series of commits to migrate metricstransform processor from OpenCensus to OTLP.

Updates: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10575