### PR TITLE
[receiver/mongodbatlasreceiver] Add a config toggle for mongodb atlas database metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `resourcedetectionprocessor`: 'gke' and 'gce' resource detectors are replaced with a single 'gcp' detector (#10347)
 - `pkg/stanza`: Removed reference to deprecated `ClusterName` (#10426)
 - `couchbasereceiver`: Fully removed unimplemented Couchbase receiver (#10482)
+- `mongodbatlasreceiver`: Add a new default config parameter `enable_database_metrics` (#10576)
 
 ### 🚩 Deprecations 🚩
 

--- a/receiver/mongodbatlasreceiver/README.md
+++ b/receiver/mongodbatlasreceiver/README.md
@@ -15,6 +15,7 @@ below both values are being pulled from the environment.
 - `public_key`
 - `private_key`
 - `granularity` (default `PT1M` - See [MongoDB Atlas Documentation](https://docs.atlas.mongodb.com/reference/api/process-measurements/))
+- `enable_database_metrics` (default true)
 - `retry_on_failure`
   - `enabled` (default true)
   - `initial_interval` (default 5s)

--- a/receiver/mongodbatlasreceiver/config.go
+++ b/receiver/mongodbatlasreceiver/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	PrivateKey                              string                   `mapstructure:"private_key"`
 	Granularity                             string                   `mapstructure:"granularity"`
 	Metrics                                 metadata.MetricsSettings `mapstructure:"metrics"`
+	EnableDatabaseMetrics                   bool                     `mapstructure:"enable_database_metrics"`
 
 	RetrySettings exporterhelper.RetrySettings `mapstructure:"retry_on_failure"`
 }

--- a/receiver/mongodbatlasreceiver/factory.go
+++ b/receiver/mongodbatlasreceiver/factory.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	typeStr            = "mongodbatlas"
-	defaultGranularity = "PT1M" // 1-minute, as per https://docs.atlas.mongodb.com/reference/api/process-measurements/
+	typeStr                      = "mongodbatlas"
+	defaultGranularity           = "PT1M" // 1-minute, as per https://docs.atlas.mongodb.com/reference/api/process-measurements/
+	defaultEnableDatabaseMetrics = true
 )
 
 // NewFactory creates a factory for MongoDB Atlas receiver
@@ -61,5 +62,6 @@ func createDefaultConfig() config.Receiver {
 		Granularity:               defaultGranularity,
 		RetrySettings:             exporterhelper.NewDefaultRetrySettings(),
 		Metrics:                   metadata.DefaultMetricsSettings(),
+		EnableDatabaseMetrics:     defaultEnableDatabaseMetrics,
 	}
 }

--- a/receiver/mongodbatlasreceiver/receiver.go
+++ b/receiver/mongodbatlasreceiver/receiver.go
@@ -146,11 +146,13 @@ func (s *receiver) extractProcessMetrics(
 		)
 	}
 
-	if err := s.extractProcessDatabaseMetrics(ctx, time, orgName, project, process); err != nil {
-		return errors.Wrap(
-			err,
-			"error when polling process database metrics from MongoDB Atlas",
-		)
+	if s.cfg.EnableDatabaseMetrics {
+		if err := s.extractProcessDatabaseMetrics(ctx, time, orgName, project, process); err != nil {
+			return errors.Wrap(
+				err,
+				"error when polling process database metrics from MongoDB Atlas",
+			)
+		}
 	}
 
 	if err := s.extractProcessDiskMetrics(ctx, time, orgName, project, process); err != nil {


### PR DESCRIPTION
**Description:** Add a config toggle for mongodb atlas database metrics so that mongodb atlas users that have clusters with lots of databases don't hit the metrics api rate limit while using this receiver

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10569

**Documentation:** Added the new config option to the md file