### PR TITLE
[exporter/awsemfexporter] Include min and max for histograms when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 💡 Enhancements 💡
 
+- `awsemfexporter`: Add min and max support for histograms
 - `tailsamplingprocessor`: Add support for string invert matching to `and` policy (#9553)
 - `mezemoexporter`: Add user agent string to outgoing HTTP requests (#10470)
 - `transformprocessor`: Add functions for conversion of scalar metric types (`gauge_to_sum` and `sum_to_gauge`) (#10255)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 💡 Enhancements 💡
 
-- `awsemfexporter`: Add min and max support for histograms
+- `awsemfexporter`: Add min and max support for histograms (#10577)
 - `tailsamplingprocessor`: Add support for string invert matching to `and` policy (#9553)
 - `mezemoexporter`: Add user agent string to outgoing HTTP requests (#10470)
 - `transformprocessor`: Add functions for conversion of scalar metric types (`gauge_to_sum` and `sum_to_gauge`) (#10255)

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -154,6 +154,8 @@ func (dps histogramDataPointSlice) At(i int) (dataPoint, bool) {
 		value: &cWMetricStats{
 			Count: metric.Count(),
 			Sum:   metric.Sum(),
+			Max:   metric.Max(),
+			Min:   metric.Min(),
 		},
 		labels:      labels,
 		timestampMs: timestamp,

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -426,6 +426,74 @@ func TestHistogramDataPointSliceAt(t *testing.T) {
 	assert.Equal(t, expectedDP, dp)
 }
 
+func TestHistogramDataPointSliceAtWithMinMax(t *testing.T){
+	instrLibName := "cloudwatch-otel"
+	labels := map[string]interface{}{"label1": "value1"}
+
+	testDPS := pmetric.NewHistogramDataPointSlice()
+	testDP := testDPS.AppendEmpty()
+	testDP.SetCount(uint64(17))
+	testDP.SetSum(17.13)
+	testDP.SetMin(10)
+	testDP.SetMax(30)
+	pcommon.NewMapFromRaw(labels).CopyTo(testDP.Attributes())
+
+	dps := histogramDataPointSlice{
+		instrLibName,
+		testDPS,
+	}
+
+	expectedDP := dataPoint{
+		value: &cWMetricStats{
+			Sum:   17.13,
+			Count: 17,
+			Min: 10,
+			Max: 30,
+		},
+		labels: map[string]string{
+			oTellibDimensionKey: instrLibName,
+			"label1":            "value1",
+		},
+	}
+
+	assert.Equal(t, 1, dps.Len())
+	dp, _ := dps.At(0)
+	assert.Equal(t, expectedDP, dp)
+}
+
+func TestHistogramDataPointSliceAtWithoutMinMax(t *testing.T){
+	instrLibName := "cloudwatch-otel"
+	labels := map[string]interface{}{"label1": "value1"}
+
+	testDPS := pmetric.NewHistogramDataPointSlice()
+	testDP := testDPS.AppendEmpty()
+	testDP.SetCount(uint64(17))
+	testDP.SetSum(17.13)
+	pcommon.NewMapFromRaw(labels).CopyTo(testDP.Attributes())
+
+	dps := histogramDataPointSlice{
+		instrLibName,
+		testDPS,
+	}
+
+	expectedDP := dataPoint{
+		value: &cWMetricStats{
+			Sum:   17.13,
+			Count: 17,
+			Min: 0,
+			Max: 0,
+		},
+		labels: map[string]string{
+			oTellibDimensionKey: instrLibName,
+			"label1":            "value1",
+		},
+	}
+
+	assert.Equal(t, 1, dps.Len())
+	dp, _ := dps.At(0)
+	assert.Equal(t, expectedDP, dp)
+}
+
 func TestSummaryDataPointSliceAt(t *testing.T) {
 	setupDataPointCache()
 

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -426,7 +426,7 @@ func TestHistogramDataPointSliceAt(t *testing.T) {
 	assert.Equal(t, expectedDP, dp)
 }
 
-func TestHistogramDataPointSliceAtWithMinMax(t *testing.T){
+func TestHistogramDataPointSliceAtWithMinMax(t *testing.T) {
 	instrLibName := "cloudwatch-otel"
 	labels := map[string]interface{}{"label1": "value1"}
 
@@ -447,8 +447,8 @@ func TestHistogramDataPointSliceAtWithMinMax(t *testing.T){
 		value: &cWMetricStats{
 			Sum:   17.13,
 			Count: 17,
-			Min: 10,
-			Max: 30,
+			Min:   10,
+			Max:   30,
 		},
 		labels: map[string]string{
 			oTellibDimensionKey: instrLibName,
@@ -461,7 +461,7 @@ func TestHistogramDataPointSliceAtWithMinMax(t *testing.T){
 	assert.Equal(t, expectedDP, dp)
 }
 
-func TestHistogramDataPointSliceAtWithoutMinMax(t *testing.T){
+func TestHistogramDataPointSliceAtWithoutMinMax(t *testing.T) {
 	instrLibName := "cloudwatch-otel"
 	labels := map[string]interface{}{"label1": "value1"}
 
@@ -480,8 +480,8 @@ func TestHistogramDataPointSliceAtWithoutMinMax(t *testing.T){
 		value: &cWMetricStats{
 			Sum:   17.13,
 			Count: 17,
-			Min: 0,
-			Max: 0,
+			Min:   0,
+			Max:   0,
 		},
 		labels: map[string]string{
 			oTellibDimensionKey: instrLibName,

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -426,6 +426,74 @@ func TestHistogramDataPointSliceAt(t *testing.T) {
 	assert.Equal(t, expectedDP, dp)
 }
 
+func TestHistogramDataPointSliceAtWithMinMax(t *testing.T){
+    instrLibName := "cloudwatch-otel"
+    labels := map[string]interface{}{"label1": "value1"}
+
+    testDPS := pmetric.NewHistogramDataPointSlice()
+    testDP := testDPS.AppendEmpty()
+    testDP.SetCount(uint64(17))
+    testDP.SetSum(17.13)
+    testDP.SetMin(10)
+    testDP.SetMax(30)
+    pcommon.NewMapFromRaw(labels).CopyTo(testDP.Attributes())
+
+    dps := histogramDataPointSlice{
+        instrLibName,
+        testDPS,
+    }
+
+    expectedDP := dataPoint{
+        value: &cWMetricStats{
+            Sum:   17.13,
+            Count: 17,
+            Min: 10,
+            Max: 30,
+        },
+        labels: map[string]string{
+            oTellibDimensionKey: instrLibName,
+            "label1":            "value1",
+        },
+    }
+
+    assert.Equal(t, 1, dps.Len())
+    dp, _ := dps.At(0)
+    assert.Equal(t, expectedDP, dp)
+}
+
+func TestHistogramDataPointSliceAtWithoutMinMax(t *testing.T){
+    instrLibName := "cloudwatch-otel"
+    labels := map[string]interface{}{"label1": "value1"}
+
+    testDPS := pmetric.NewHistogramDataPointSlice()
+    testDP := testDPS.AppendEmpty()
+    testDP.SetCount(uint64(17))
+    testDP.SetSum(17.13)
+    pcommon.NewMapFromRaw(labels).CopyTo(testDP.Attributes())
+
+    dps := histogramDataPointSlice{
+        instrLibName,
+        testDPS,
+    }
+
+    expectedDP := dataPoint{
+        value: &cWMetricStats{
+            Sum:   17.13,
+            Count: 17,
+            Min: 0,
+            Max: 0,
+        },
+        labels: map[string]string{
+            oTellibDimensionKey: instrLibName,
+            "label1":            "value1",
+        },
+    }
+
+    assert.Equal(t, 1, dps.Len())
+    dp, _ := dps.At(0)
+    assert.Equal(t, expectedDP, dp)
+}
+
 func TestSummaryDataPointSliceAt(t *testing.T) {
 	setupDataPointCache()
 

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -427,71 +427,71 @@ func TestHistogramDataPointSliceAt(t *testing.T) {
 }
 
 func TestHistogramDataPointSliceAtWithMinMax(t *testing.T){
-    instrLibName := "cloudwatch-otel"
-    labels := map[string]interface{}{"label1": "value1"}
+	instrLibName := "cloudwatch-otel"
+	labels := map[string]interface{}{"label1": "value1"}
 
-    testDPS := pmetric.NewHistogramDataPointSlice()
-    testDP := testDPS.AppendEmpty()
-    testDP.SetCount(uint64(17))
-    testDP.SetSum(17.13)
-    testDP.SetMin(10)
-    testDP.SetMax(30)
-    pcommon.NewMapFromRaw(labels).CopyTo(testDP.Attributes())
+	testDPS := pmetric.NewHistogramDataPointSlice()
+	testDP := testDPS.AppendEmpty()
+	testDP.SetCount(uint64(17))
+	testDP.SetSum(17.13)
+	testDP.SetMin(10)
+	testDP.SetMax(30)
+	pcommon.NewMapFromRaw(labels).CopyTo(testDP.Attributes())
 
-    dps := histogramDataPointSlice{
-        instrLibName,
-        testDPS,
-    }
+	dps := histogramDataPointSlice{
+		instrLibName,
+		testDPS,
+	}
 
-    expectedDP := dataPoint{
-        value: &cWMetricStats{
-            Sum:   17.13,
-            Count: 17,
-            Min: 10,
-            Max: 30,
-        },
-        labels: map[string]string{
-            oTellibDimensionKey: instrLibName,
-            "label1":            "value1",
-        },
-    }
+	expectedDP := dataPoint{
+		value: &cWMetricStats{
+			Sum:   17.13,
+			Count: 17,
+			Min: 10,
+			Max: 30,
+		},
+		labels: map[string]string{
+			oTellibDimensionKey: instrLibName,
+			"label1":            "value1",
+		},
+	}
 
-    assert.Equal(t, 1, dps.Len())
-    dp, _ := dps.At(0)
-    assert.Equal(t, expectedDP, dp)
+	assert.Equal(t, 1, dps.Len())
+	dp, _ := dps.At(0)
+	assert.Equal(t, expectedDP, dp)
 }
 
 func TestHistogramDataPointSliceAtWithoutMinMax(t *testing.T){
-    instrLibName := "cloudwatch-otel"
-    labels := map[string]interface{}{"label1": "value1"}
+	instrLibName := "cloudwatch-otel"
+	labels := map[string]interface{}{"label1": "value1"}
 
-    testDPS := pmetric.NewHistogramDataPointSlice()
-    testDP := testDPS.AppendEmpty()
-    testDP.SetCount(uint64(17))
-    testDP.SetSum(17.13)
-    pcommon.NewMapFromRaw(labels).CopyTo(testDP.Attributes())
+	testDPS := pmetric.NewHistogramDataPointSlice()
+	testDP := testDPS.AppendEmpty()
+	testDP.SetCount(uint64(17))
+	testDP.SetSum(17.13)
+	pcommon.NewMapFromRaw(labels).CopyTo(testDP.Attributes())
 
-    dps := histogramDataPointSlice{
-        instrLibName,
-        testDPS,
-    }
+	dps := histogramDataPointSlice{
+		instrLibName,
+		testDPS,
+	}
 
-    expectedDP := dataPoint{
-        value: &cWMetricStats{
-            Sum:   17.13,
-            Count: 17,
-            Min: 0,
-            Max: 0,
-        },
-        labels: map[string]string{
-            oTellibDimensionKey: instrLibName,
-            "label1":            "value1",
-        },
-    }
+	expectedDP := dataPoint{
+		value: &cWMetricStats{
+			Sum:   17.13,
+			Count: 17,
+			Min: 0,
+			Max: 0,
+		},
+		labels: map[string]string{
+			oTellibDimensionKey: instrLibName,
+			"label1":            "value1",
+		},
+	}
 
-    assert.Equal(t, 1, dps.Len())
-    dp, _ := dps.At(0)
-    assert.Equal(t, expectedDP, dp)
+	assert.Equal(t, 1, dps.Len())
+	dp, _ := dps.At(0)
+	assert.Equal(t, expectedDP, dp)
 }
 
 func TestSummaryDataPointSliceAt(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Add min and max for histograms when available. Min and max are optional.

**Link to tracking Issue:** <Issue number if applicable>
[#10545](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10545)

**Testing:** <Describe what testing was performed and which tests were added.>
Added two tests

1. Test that min and max can be set
2. Test that if min and max are not set, they default to 0
