### PR TITLE
[exporter/loadbalancing] fix duplicate component IDs of OTLP exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `tailsamplingprocessor`: Fix composite sampler with inverse policy
 - `awsprometheusremotewriteexporter`: Fix signing of empty request bodies. (#10578)
 - `sigv4authextension`: Fix signing of empty request bodies. (#10578)
+- `loadbalancingexporter`: Fix metrics missing caused by duplicate component IDs of OTLP exporters. (#10591)
 
 ## v0.52.0
 

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -66,7 +66,7 @@ func newTracesExporter(params component.ExporterCreateSettings, cfg config.Expor
 
 func buildExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
 	oCfg := cfg.Protocol.OTLP
-	oCfg.ExporterSettings = config.NewExporterSettings(config.NewComponentID("otlp"))
+	oCfg.ExporterSettings = config.NewExporterSettings(config.NewComponentIDWithName("otlp", endpoint))
 	oCfg.Endpoint = endpoint
 	return oCfg
 }

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -278,7 +278,10 @@ func TestBuildExporterConfig(t *testing.T) {
 	grpcSettings.Endpoint = "the-endpoint"
 	assert.Equal(t, grpcSettings, exporterCfg.GRPCClientSettings)
 
-	assert.Equal(t, defaultCfg.ExporterSettings, exporterCfg.ExporterSettings)
+	exporterSettings := defaultCfg.ExporterSettings
+	exporterSettings.SetIDName("the-endpoint")
+	assert.Equal(t, exporterSettings, exporterCfg.ExporterSettings)
+
 	assert.Equal(t, defaultCfg.TimeoutSettings, exporterCfg.TimeoutSettings)
 	assert.Equal(t, defaultCfg.QueueSettings, exporterCfg.QueueSettings)
 	assert.Equal(t, defaultCfg.RetrySettings, exporterCfg.RetrySettings)


### PR DESCRIPTION
**Description:** Component IDs of OTLP exporters maintained by load balancing exporter are [supposed to be unique](https://github.com/open-telemetry/opentelemetry-collector/blob/6fb884b2dbdc37ef2e1aea924040822ce38584bd/config/identifiable.go#L37), but currently they're always "otlp". This leads to missing metrics of exporter helper, which is used by the OTLP exporter.

Before fix:
```
otelcol_exporter_queue_size{exporter="otlp",service_instance_id="479b7ec6-c35b-42f3-877a-002be5abc337",service_version="latest"} 0
```

After fix:
```
otelcol_exporter_queue_size{exporter="otlp/otel-collector-1:4317",service_instance_id="479b7ec6-c35b-42f3-877a-002be5abc337",service_version="latest"} 0
otelcol_exporter_queue_size{exporter="otlp/otel-collector-2:4317",service_instance_id="479b7ec6-c35b-42f3-877a-002be5abc337",service_version="latest"} 0
otelcol_exporter_queue_size{exporter="otlp/otel-collector-3:4317",service_instance_id="479b7ec6-c35b-42f3-877a-002be5abc337",service_version="latest"} 0
```