### PR TITLE
[testbed] Wait longer when possible garbage collection is observed

### DIFF
--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -132,7 +132,7 @@ func TestBallastMemory(t *testing.T) {
 				tc.WaitForN(func() bool {
 					rss, vms, _ = tc.AgentMemoryInfo()
 					return float32(rss) <= lenientMax
-				}, time.Second, rssTooHigh)
+				}, time.Second*5, rssTooHigh)
 			} else {
 				assert.LessOrEqual(t, float32(rss), lenientMax, rssTooHigh)
 			}


### PR DESCRIPTION
Follow up to #6927 and #10359.

I believe 10359 has substantially improved the rate of failure on this test. However, [failures have occurred](https://github.com/open-telemetry/opentelemetry-collector-contrib/runs/6733274809?check_suite_focus=true#step:14:30) a few times since then. I suspect garbage collection is taking longer than 1s in some cases and would like to allow more time before failing the test.