### PR TITLE
[receiver/filelog] Fix test that fails when resource not closed

### DIFF
--- a/receiver/filelogreceiver/storage_test.go
+++ b/receiver/filelogreceiver/storage_test.go
@@ -144,9 +144,11 @@ func TestStorage(t *testing.T) {
 	for _, e := range host.GetExtensions() {
 		require.NoError(t, e.Shutdown(ctx))
 	}
+	require.NoError(t, logger.close())
 }
 
 type recallLogger struct {
+	logFile *os.File
 	*log.Logger
 	written []string
 }
@@ -157,6 +159,7 @@ func newRecallLogger(t *testing.T, tempDir string) *recallLogger {
 	require.NoError(t, err)
 
 	return &recallLogger{
+		logFile: logFile,
 		Logger:  log.New(logFile, "", 0),
 		written: []string{},
 	}
@@ -170,6 +173,10 @@ func (l *recallLogger) log(s string) {
 func (l *recallLogger) recall() []string {
 	defer func() { l.written = []string{} }()
 	return l.written
+}
+
+func (l *recallLogger) close() error {
+	return l.logFile.Close()
 }
 
 // TODO use stateless Convert() from #3125 to generate exact plog.Logs


### PR DESCRIPTION
Closes #10808

I believe recent changes to the way test directories are managed has exposed a race condition for closing files within those directories. Likely we just need to close this file manually before the test ends.