### PR TITLE
[processor/metricstransform] Migrate the processor from OC to pdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 ### 💡 Enhancements 💡
 
 - `cmd/mdatagen`: Allow attribute values of any types (#9245)
+- `metricstransformprocessor`: Migrate the processor from OC to pdata (#10817)
+  - This behavior can be reverted by disabling the `processor.metricstransformprocessor.UseOTLPDataModel` feature gate.
 - `transformprocessor`: Add byte slice literal to the grammar.  Add new SpanID and TraceID functions that take a byte slice and return a Span/Trace ID. (#10487)
 - `elasticsearchreceiver`: Add integration test for elasticsearch receiver (#10165)
 - `datadogexporter`: Some config validation and unmarshaling steps are now done on `Validate` and `Unmarshal` instead of `Sanitize` (#8829)

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -197,12 +197,16 @@ type OperationAction string
 
 const (
 	// AddLabel adds a new label to an existing metric.
+	// Metric has to match the FilterConfig with all its data points if used with Update ConfigAction,
+	// otherwise the operation will be ignored.
 	AddLabel OperationAction = "add_label"
 
 	// UpdateLabel applies name changes to label and/or label values.
 	UpdateLabel OperationAction = "update_label"
 
 	// DeleteLabelValue deletes a label value by also removing all the points associated with this label value
+	// Metric has to match the FilterConfig with all its data points if used with Update ConfigAction,
+	// otherwise the operation will be ignored.
 	DeleteLabelValue OperationAction = "delete_label_value"
 
 	// ToggleScalarDataType changes the data type from int64 to double, or vice-versa
@@ -213,10 +217,14 @@ const (
 
 	// AggregateLabels aggregates away all labels other than the ones in Operation.LabelSet
 	// by the method indicated by Operation.AggregationType.
+	// Metric has to match the FilterConfig with all its data points if used with Update ConfigAction,
+	// otherwise the operation will be ignored.
 	AggregateLabels OperationAction = "aggregate_labels"
 
 	// AggregateLabelValues aggregates away the values in Operation.AggregatedValues
 	// by the method indicated by Operation.AggregationType.
+	// Metric has to match the FilterConfig with all its data points if used with Update ConfigAction,
+	// otherwise the operation will be ignored.
 	AggregateLabelValues OperationAction = "aggregate_label_values"
 )
 

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -196,13 +196,13 @@ func createFilter(filterConfig FilterConfig) (internalFilter, error) {
 		if err != nil {
 			return nil, err
 		}
-		return internalFilterStrict{include: filterConfig.Include, matchLabels: matchers}, nil
+		return internalFilterStrict{include: filterConfig.Include, attrMatchers: matchers}, nil
 	case RegexpMatchType:
 		matchers, err := getMatcherMap(filterConfig.MatchLabels, func(str string) (StringMatcher, error) { return regexp.Compile(str) })
 		if err != nil {
 			return nil, err
 		}
-		return internalFilterRegexp{include: regexp.MustCompile(filterConfig.Include), matchLabels: matchers}, nil
+		return internalFilterRegexp{include: regexp.MustCompile(filterConfig.Include), attrMatchers: matchers}, nil
 	}
 
 	return nil, fmt.Errorf("invalid match type: %v", filterConfig.MatchType)

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -1,0 +1,543 @@
+// Copyright 2020 OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
+
+import (
+	"fmt"
+	"strconv"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// extractAndRemoveMatchedMetrics extracts matched metrics from ms metric slice and returns a new slice.
+// Extracted metrics can have reduced number of data point if not all of them match the filter.
+// All matched metrics, including metrics with only a subset of matched data points,
+// are removed from the original ms metric slice.
+func extractAndRemoveMatchedMetrics(f internalFilter, ms pmetric.MetricSlice) pmetric.MetricSlice {
+	extractedMetrics := pmetric.NewMetricSlice()
+	ms.RemoveIf(func(metric pmetric.Metric) bool {
+		if extractedMetric := f.extractMatchedMetric(metric); extractedMetric != (pmetric.Metric{}) {
+			extractedMetric.MoveTo(extractedMetrics.AppendEmpty())
+			return true
+		}
+		return false
+	})
+	return extractedMetrics
+}
+
+// matchMetrics returns a slice of metrics matching the filter f. Original metrics slice is not affected.
+func matchMetrics(f internalFilter, metrics pmetric.MetricSlice) []pmetric.Metric {
+	mm := make([]pmetric.Metric, 0, metrics.Len())
+	for i := 0; i < metrics.Len(); i++ {
+		if f.matchMetric(metrics.At(i)) {
+			mm = append(mm, metrics.At(i))
+		}
+	}
+	return mm
+}
+
+// extractMatchedMetric returns a metric matching the filter.
+// If provided metric matches the filter with all its data points, the original metric returned as is.
+// If only part of data points match the filter, a new metric is returned with data points matching the filter.
+// Otherwise, an invalid metric is returned.
+func (f internalFilterStrict) extractMatchedMetric(metric pmetric.Metric) pmetric.Metric {
+	if metric.Name() == f.include {
+		return extractMetricWithMatchingAttrs(metric, f)
+	}
+	return pmetric.Metric{}
+}
+
+func (f internalFilterStrict) matchMetric(metric pmetric.Metric) bool {
+	if metric.Name() == f.include {
+		return matchAnyDps(metric, f)
+	}
+	return false
+}
+
+func (f internalFilterStrict) submatches(_ pmetric.Metric) []int {
+	return nil
+}
+
+func (f internalFilterStrict) expand(_, _ string) string {
+	return ""
+}
+
+func (f internalFilterStrict) matchAttrs(attrs pcommon.Map) bool {
+	return matchAttrs(f.attrMatchers, attrs)
+}
+
+// extractMatchedMetric returns a metric matching the filter.
+// If provided metric matches the filter with all its data points, the original metric returned as is.
+// If only part of data points match the filter, a new metric is returned with data points matching the filter.
+// Otherwise, an invalid metric is returned.
+func (f internalFilterRegexp) extractMatchedMetric(metric pmetric.Metric) pmetric.Metric {
+	if submatches := f.include.FindStringSubmatchIndex(metric.Name()); submatches != nil {
+		return extractMetricWithMatchingAttrs(metric, f)
+	}
+	return pmetric.Metric{}
+}
+
+func (f internalFilterRegexp) matchMetric(metric pmetric.Metric) bool {
+	if submatches := f.include.FindStringSubmatchIndex(metric.Name()); submatches != nil {
+		return matchAnyDps(metric, f)
+	}
+	return false
+}
+
+func (f internalFilterRegexp) submatches(metric pmetric.Metric) []int {
+	return f.include.FindStringSubmatchIndex(metric.Name())
+}
+
+func (f internalFilterRegexp) expand(metricTempate, metricName string) string {
+	if submatches := f.include.FindStringSubmatchIndex(metricName); submatches != nil {
+		return string(f.include.ExpandString([]byte{}, metricTempate, metricName, submatches))
+	}
+	return ""
+}
+
+func (f internalFilterRegexp) matchAttrs(attrs pcommon.Map) bool {
+	return matchAttrs(f.attrMatchers, attrs)
+}
+
+// matchAnyDps checks whether any metric data points match the filter, returns true if metric has no data points.
+func matchAnyDps(metric pmetric.Metric, f internalFilter) bool {
+	match := true
+	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
+		if f.matchAttrs(attrs) {
+			match = true
+			return false
+		}
+		match = false
+		return true
+	})
+	return match
+}
+
+// matchAllDps checks whether all metric data points match the filter, returns true if metric has no data points.
+func matchAllDps(metric pmetric.Metric, f internalFilter) bool {
+	match := true
+	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
+		if !f.matchAttrs(attrs) {
+			match = false
+			return false
+		}
+		return true
+	})
+	return match
+}
+
+// matchDps returns a slice of bool values representing data points matches following by the total number of matched
+// data points.
+// For example, for a metric with 3 data points where only first and third match the filter, the output will be:
+// ([]bool{true, false, true}, 2).
+func matchDps(metric pmetric.Metric, f internalFilter) (matchedDps []bool, matchedDpsCount int) {
+	matchedDps = []bool{}
+	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
+		match := f.matchAttrs(attrs)
+		if match {
+			matchedDpsCount++
+		}
+		matchedDps = append(matchedDps, match)
+		return true
+	})
+	return
+}
+
+// extractMetricWithMatchingAttrs returns a metric with data points matching attrMatchers.
+// New metric is returned if part of data points match the filter,
+// original metric returned if all data points match the filter,
+// and invalid metric returned if no data points match the filter.
+func extractMetricWithMatchingAttrs(metric pmetric.Metric, f internalFilter) pmetric.Metric {
+	dpsMatches, matchedDpsCount := matchDps(metric, f)
+	if matchedDpsCount == len(dpsMatches) {
+		return metric
+	}
+	if matchedDpsCount == 0 {
+		return pmetric.Metric{}
+	}
+
+	newMetric := pmetric.NewMetric()
+	newMetric.SetDataType(metric.DataType())
+	newMetric.SetName(metric.Name())
+	newMetric.SetDescription(metric.Description())
+	newMetric.SetUnit(metric.Unit())
+
+	switch metric.DataType() {
+	case pmetric.MetricDataTypeGauge:
+		newMetric.Gauge().DataPoints().EnsureCapacity(matchedDpsCount)
+		for i := 0; i < metric.Gauge().DataPoints().Len(); i++ {
+			if dpsMatches[i] {
+				metric.Gauge().DataPoints().At(i).CopyTo(newMetric.Gauge().DataPoints().AppendEmpty())
+			}
+		}
+	case pmetric.MetricDataTypeSum:
+		newMetric.Sum().DataPoints().EnsureCapacity(matchedDpsCount)
+		for i := 0; i < metric.Sum().DataPoints().Len(); i++ {
+			if dpsMatches[i] {
+				metric.Sum().DataPoints().At(i).CopyTo(newMetric.Sum().DataPoints().AppendEmpty())
+			}
+		}
+		newMetric.Sum().SetAggregationTemporality(metric.Sum().AggregationTemporality())
+		newMetric.Sum().SetIsMonotonic(metric.Sum().IsMonotonic())
+	case pmetric.MetricDataTypeHistogram:
+		newMetric.Histogram().DataPoints().EnsureCapacity(matchedDpsCount)
+		for i := 0; i < metric.Histogram().DataPoints().Len(); i++ {
+			if dpsMatches[i] {
+				metric.Histogram().DataPoints().At(i).CopyTo(newMetric.Histogram().DataPoints().AppendEmpty())
+			}
+		}
+		newMetric.Histogram().SetAggregationTemporality(metric.Histogram().AggregationTemporality())
+	case pmetric.MetricDataTypeExponentialHistogram:
+		newMetric.ExponentialHistogram().DataPoints().EnsureCapacity(matchedDpsCount)
+		for i := 0; i < metric.ExponentialHistogram().DataPoints().Len(); i++ {
+			if dpsMatches[i] {
+				metric.ExponentialHistogram().DataPoints().At(i).CopyTo(newMetric.ExponentialHistogram().DataPoints().AppendEmpty())
+			}
+		}
+		newMetric.ExponentialHistogram().SetAggregationTemporality(metric.ExponentialHistogram().AggregationTemporality())
+	case pmetric.MetricDataTypeSummary:
+		newMetric.Summary().DataPoints().EnsureCapacity(matchedDpsCount)
+		for i := 0; i < metric.Summary().DataPoints().Len(); i++ {
+			if dpsMatches[i] {
+				metric.Summary().DataPoints().At(i).CopyTo(newMetric.Summary().DataPoints().AppendEmpty())
+			}
+		}
+	}
+
+	return newMetric
+}
+
+func matchAttrs(attrMatchers map[string]StringMatcher, attrs pcommon.Map) bool {
+	for k, v := range attrMatchers {
+		attrVal, ok := attrs.Get(k)
+		// attribute values doesn't match, drop datapoint
+		if ok && !v.MatchString(attrVal.StringVal()) {
+			return false
+		}
+
+		// if a label-key is not found then return nil only if the given label-value is non-empty. If a given label-value is empty
+		// and the key is not found then move forward. In this approach we can make sure certain key is not present which is a valid use case.
+		if !ok && !v.MatchString("") {
+			return false
+		}
+	}
+	return true
+}
+
+// processOTLPMetrics process metrics using OTLP data model.
+func (mtp *metricsTransformProcessor) processOTLPMetrics(md pmetric.Metrics) (pmetric.Metrics, error) {
+	rms := md.ResourceMetrics()
+	groupedRMs := pmetric.NewResourceMetricsSlice()
+
+	rms.RemoveIf(func(rm pmetric.ResourceMetrics) bool {
+		rm.ScopeMetrics().RemoveIf(func(sm pmetric.ScopeMetrics) bool {
+			metrics := sm.Metrics()
+
+			for _, transform := range mtp.transforms {
+				if transform.Action == Group {
+					extractedMetrics := extractAndRemoveMatchedMetrics(transform.MetricIncludeFilter, metrics)
+					groupMatchedMetrics(rm.Resource(), sm.Scope(), extractedMetrics,
+						transform).CopyTo(groupedRMs.AppendEmpty())
+				}
+
+				matchedMetrics := matchMetrics(transform.MetricIncludeFilter, metrics)
+				if len(matchedMetrics) == 0 {
+					continue
+				}
+
+				if transform.Action == Combine {
+
+					if err := canBeCombined(matchedMetrics); err != nil {
+						// TODO: report via trace / metric instead
+						mtp.logger.Warn(err.Error())
+						continue
+					}
+
+					extractedMetrics := extractAndRemoveMatchedMetrics(transform.MetricIncludeFilter, metrics)
+					combinedMetric := metrics.AppendEmpty()
+					combine(transform, extractedMetrics).MoveTo(combinedMetric)
+
+					// set matchedMetrics to the combined metric so that any additional operations are performed on
+					// the combined metric
+					matchedMetrics = []pmetric.Metric{combinedMetric}
+				}
+
+				for _, metric := range matchedMetrics {
+					if transform.Action == Insert {
+						matchedMetric := transform.MetricIncludeFilter.extractMatchedMetric(metric)
+						newMetric := metrics.AppendEmpty()
+						matchedMetric.CopyTo(newMetric)
+						metric = newMetric
+					}
+					transformMetric(metric, transform)
+				}
+			}
+
+			return metrics.Len() == 0
+		})
+
+		return rm.ScopeMetrics().Len() == 0
+	})
+
+	groupedRMs.MoveAndAppendTo(rms)
+
+	return md, nil
+}
+
+// groupMatchedMetrics groups matched metrics by moving them from matchedMetrics into a new pmetric.ResourceMetrics.
+func groupMatchedMetrics(resource pcommon.Resource, scope pcommon.InstrumentationScope, metrics pmetric.MetricSlice,
+	transform internalTransform) pmetric.ResourceMetrics {
+	rm := pmetric.NewResourceMetrics()
+	resource.CopyTo(rm.Resource())
+
+	for k, v := range transform.GroupResourceLabels {
+		rm.Resource().Attributes().UpsertString(k, v)
+	}
+
+	sm := rm.ScopeMetrics().AppendEmpty()
+	scope.CopyTo(sm.Scope())
+	metrics.MoveAndAppendTo(sm.Metrics())
+	return rm
+}
+
+// canBeCombined returns true if all the provided metrics share the same type, unit, and labels
+func canBeCombined(metrics []pmetric.Metric) error {
+	if len(metrics) <= 1 {
+		return nil
+	}
+
+	var firstMetric pmetric.Metric
+	for _, metric := range metrics {
+		if metric.DataType() == pmetric.MetricDataTypeSummary {
+			return fmt.Errorf("Summary metrics cannot be combined: %v ", metric.Name())
+		}
+
+		if firstMetric == (pmetric.Metric{}) {
+			firstMetric = metric
+			continue
+		}
+
+		if firstMetric.DataType() != metric.DataType() {
+			return fmt.Errorf("metrics cannot be combined as they are of different types: %v (%v) and %v (%v)",
+				firstMetric.Name(), firstMetric.DataType(), metric.Name(), metric.DataType())
+		}
+		if firstMetric.Unit() != metric.Unit() {
+			return fmt.Errorf("metrics cannot be combined as they have different units: %v (%v) and %v (%v)",
+				firstMetric.Name(), firstMetric.Unit(), metric.Name(), metric.Unit())
+		}
+
+		firstMetricAttrKeys := metricAttributeKeys(firstMetric)
+		metricAttrKeys := metricAttributeKeys(metric)
+		if len(firstMetricAttrKeys) != len(metricAttrKeys) {
+			return fmt.Errorf("metrics cannot be combined as they have different attributes: %v (%v) and %v (%v)",
+				firstMetric.Name(), firstMetricAttrKeys, metric.Name(), metricAttrKeys)
+		}
+
+		for attr := range metricAttrKeys {
+			if _, ok := firstMetricAttrKeys[attr]; !ok {
+				return fmt.Errorf("metrics cannot be combined as they have different attributes: %v (%v) and %v (%v)",
+					firstMetric.Name(), firstMetricAttrKeys, metric.Name(), metricAttrKeys)
+			}
+		}
+
+		switch firstMetric.DataType() {
+		case pmetric.MetricDataTypeSum:
+			if firstMetric.Sum().AggregationTemporality() != metric.Sum().AggregationTemporality() {
+				return fmt.Errorf(
+					"metrics cannot be combined as they have different aggregation temporalities: %v (%v) and %v (%v)",
+					firstMetric.Name(), firstMetric.Sum().AggregationTemporality(), metric.Name(), metric.Sum().AggregationTemporality())
+			}
+			if firstMetric.Sum().IsMonotonic() != metric.Sum().IsMonotonic() {
+				return fmt.Errorf(
+					"metrics cannot be combined as they have different monotonicity: %v (%v) and %v (%v)",
+					firstMetric.Name(), firstMetric.Sum().IsMonotonic(), metric.Name(), metric.Sum().IsMonotonic())
+			}
+		case pmetric.MetricDataTypeHistogram:
+			if firstMetric.Histogram().AggregationTemporality() != metric.Histogram().AggregationTemporality() {
+				return fmt.Errorf(
+					"metrics cannot be combined as they have different aggregation temporalities: %v (%v) and %v (%v)",
+					firstMetric.Name(), firstMetric.Histogram().AggregationTemporality(), metric.Name(),
+					metric.Histogram().AggregationTemporality())
+
+			}
+		case pmetric.MetricDataTypeExponentialHistogram:
+			if firstMetric.ExponentialHistogram().AggregationTemporality() != metric.ExponentialHistogram().AggregationTemporality() {
+				return fmt.Errorf(
+					"metrics cannot be combined as they have different aggregation temporalities: %v (%v) and %v (%v)",
+					firstMetric.Name(), firstMetric.ExponentialHistogram().AggregationTemporality(), metric.Name(),
+					metric.ExponentialHistogram().AggregationTemporality())
+
+			}
+		}
+	}
+
+	return nil
+}
+
+func metricAttributeKeys(metric pmetric.Metric) map[string]struct{} {
+	attrKeys := map[string]struct{}{}
+	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
+		attrs.Range(func(k string, _ pcommon.Value) bool {
+			attrKeys[k] = struct{}{}
+			return true
+		})
+		return true
+	})
+	return attrKeys
+}
+
+// combine combines the metrics based on the supplied filter.
+// canBeCombined must be called before.
+func combine(transform internalTransform, metrics pmetric.MetricSlice) pmetric.Metric {
+	firstMetric := metrics.At(0)
+
+	// create combined metric with relevant name & descriptor
+	combinedMetric := pmetric.NewMetric()
+	copyMetricDetails(firstMetric, combinedMetric)
+	combinedMetric.SetName(transform.NewName)
+
+	// append attribute keys based on the transform filter's named capturing groups
+	subexprNames := transform.MetricIncludeFilter.getSubexpNames()
+	reAttrKeys := make([]string, len(subexprNames))
+	for i := 1; i < len(subexprNames); i++ {
+		// if the subexpression is not named, use regexp notation, e.g. $1
+		name := subexprNames[i]
+		if name == "" {
+			name = "$" + strconv.Itoa(i)
+		}
+		reAttrKeys[i] = name
+	}
+
+	for i := 0; i < metrics.Len(); i++ {
+		metric := metrics.At(i)
+
+		// append attr values based on regex submatches
+		submatches := transform.MetricIncludeFilter.submatches(metric)
+		if len(submatches) > 0 {
+			rangeDataPointAttributes(metric, func(m pcommon.Map) bool {
+				for i := 1; i < len(submatches)/2; i++ {
+					submatch := metric.Name()[submatches[2*i]:submatches[2*i+1]]
+					submatch = replaceCaseOfSubmatch(transform.SubmatchCase, submatch)
+					if submatch != "" {
+						m.UpsertString(reAttrKeys[i], submatch)
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	groupMetrics(metrics, transform.AggregationType, combinedMetric)
+
+	return combinedMetric
+}
+
+func copyMetricDetails(from, to pmetric.Metric) {
+	to.SetName(from.Name())
+	to.SetDataType(from.DataType())
+	to.SetUnit(from.Unit())
+	switch from.DataType() {
+	case pmetric.MetricDataTypeSum:
+		to.Sum().SetAggregationTemporality(from.Sum().AggregationTemporality())
+		to.Sum().SetIsMonotonic(from.Sum().IsMonotonic())
+	case pmetric.MetricDataTypeHistogram:
+		to.Histogram().SetAggregationTemporality(from.Histogram().AggregationTemporality())
+	case pmetric.MetricDataTypeExponentialHistogram:
+		to.ExponentialHistogram().SetAggregationTemporality(from.Histogram().AggregationTemporality())
+	}
+}
+
+// rangeDataPointAttributes calls f sequentially on attributes of every metric data point.
+// The iteration terminates if f returns false.
+func rangeDataPointAttributes(metric pmetric.Metric, f func(pcommon.Map) bool) {
+	switch metric.DataType() {
+	case pmetric.MetricDataTypeGauge:
+		for i := 0; i < metric.Gauge().DataPoints().Len(); i++ {
+			dp := metric.Gauge().DataPoints().At(i)
+			if !f(dp.Attributes()) {
+				return
+			}
+		}
+	case pmetric.MetricDataTypeSum:
+		for i := 0; i < metric.Sum().DataPoints().Len(); i++ {
+			dp := metric.Sum().DataPoints().At(i)
+			if !f(dp.Attributes()) {
+				return
+			}
+		}
+	case pmetric.MetricDataTypeHistogram:
+		for i := 0; i < metric.Histogram().DataPoints().Len(); i++ {
+			dp := metric.Histogram().DataPoints().At(i)
+			if !f(dp.Attributes()) {
+				return
+			}
+		}
+	case pmetric.MetricDataTypeExponentialHistogram:
+		for i := 0; i < metric.ExponentialHistogram().DataPoints().Len(); i++ {
+			dp := metric.ExponentialHistogram().DataPoints().At(i)
+			if !f(dp.Attributes()) {
+				return
+			}
+		}
+	case pmetric.MetricDataTypeSummary:
+		for i := 0; i < metric.Summary().DataPoints().Len(); i++ {
+			dp := metric.Summary().DataPoints().At(i)
+			if !f(dp.Attributes()) {
+				return
+			}
+		}
+	}
+}
+
+// transformMetric updates the metric content based on operations indicated in transform.
+func transformMetric(metric pmetric.Metric, transform internalTransform) {
+	canChangeMetric := transform.Action != Update || matchAllDps(metric, transform.MetricIncludeFilter)
+
+	if transform.NewName != "" && canChangeMetric {
+		if newName := transform.MetricIncludeFilter.expand(transform.NewName, metric.Name()); newName != "" {
+			metric.SetName(newName)
+		} else {
+			metric.SetName(transform.NewName)
+		}
+	}
+
+	for _, op := range transform.Operations {
+		switch op.configOperation.Action {
+		case UpdateLabel:
+			updateLabelOp(metric, op, transform.MetricIncludeFilter)
+		case AggregateLabels:
+			if canChangeMetric {
+				aggregateLabelsOp(metric, op)
+			}
+		case AggregateLabelValues:
+			if canChangeMetric {
+				aggregateLabelValuesOp(metric, op)
+			}
+		case ToggleScalarDataType:
+			toggleScalarDataTypeOp(metric, transform.MetricIncludeFilter)
+		case ScaleValue:
+			scaleValueOp(metric, op, transform.MetricIncludeFilter)
+		case AddLabel:
+			if canChangeMetric {
+				addLabelOp(metric, op)
+			}
+		case DeleteLabelValue:
+			if canChangeMetric {
+				deleteLabelValueOp(metric, op)
+			}
+		}
+	}
+}

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -17,6 +17,8 @@ package metricstransformprocessor
 
 import (
 	"context"
+	"sort"
+	"strings"
 	"testing"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
@@ -33,44 +35,52 @@ import (
 )
 
 func TestMetricsTransformProcessor(t *testing.T) {
-	for _, test := range standardTests {
-		t.Run(test.name, func(t *testing.T) {
-			next := new(consumertest.MetricsSink)
+	for _, useOTLP := range []bool{false, true} {
+		for _, test := range standardTests {
+			t.Run(test.name, func(t *testing.T) {
+				next := new(consumertest.MetricsSink)
 
-			p := newMetricsTransformProcessor(zap.NewExample(), test.transforms)
-
-			mtp, err := processorhelper.NewMetricsProcessor(
-				&Config{
-					ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
-				},
-				next,
-				p.processMetrics,
-				processorhelper.WithCapabilities(consumerCapabilities))
-			require.NoError(t, err)
-
-			caps := mtp.Capabilities()
-			assert.Equal(t, true, caps.MutatesData)
-			ctx := context.Background()
-
-			// process
-			cErr := mtp.ConsumeMetrics(context.Background(), internaldata.OCToMetrics(nil, nil, test.in))
-			assert.NoError(t, cErr)
-
-			// get and check results
-			got := next.AllMetrics()
-			require.Equal(t, 1, len(got))
-			_, _, actualOutMetrics := internaldata.ResourceMetricsToOC(got[0].ResourceMetrics().At(0))
-			require.Equal(t, len(test.out), len(actualOutMetrics))
-
-			for idx, out := range test.out {
-				actualOut := actualOutMetrics[idx]
-				if diff := cmp.Diff(actualOut, out, protocmp.Transform()); diff != "" {
-					t.Errorf("Unexpected difference:\n%v", diff)
+				p := &metricsTransformProcessor{
+					transforms:               test.transforms,
+					logger:                   zap.NewExample(),
+					otlpDataModelGateEnabled: useOTLP,
 				}
-			}
 
-			assert.NoError(t, mtp.Shutdown(ctx))
-		})
+				mtp, err := processorhelper.NewMetricsProcessor(
+					&Config{
+						ProcessorSettings: config.NewProcessorSettings(config.NewComponentID(typeStr)),
+					},
+					next,
+					p.processMetrics,
+					processorhelper.WithCapabilities(consumerCapabilities))
+				require.NoError(t, err)
+
+				caps := mtp.Capabilities()
+				assert.Equal(t, true, caps.MutatesData)
+				ctx := context.Background()
+
+				// process
+				cErr := mtp.ConsumeMetrics(context.Background(), internaldata.OCToMetrics(nil, nil, test.in))
+				assert.NoError(t, cErr)
+
+				// get and check results
+				got := next.AllMetrics()
+				require.Equal(t, 1, len(got))
+				_, _, actualOutMetrics := internaldata.ResourceMetricsToOC(got[0].ResourceMetrics().At(0))
+				require.Equal(t, len(test.out), len(actualOutMetrics))
+
+				for idx, out := range test.out {
+					actualOut := actualOutMetrics[idx]
+					sortTimeseries(actualOut.Timeseries)
+					sortTimeseries(out.Timeseries)
+					if diff := cmp.Diff(actualOut, out, protocmp.Transform()); diff != "" {
+						t.Errorf("Unexpected difference:\n%v", diff)
+					}
+				}
+
+				assert.NoError(t, mtp.Shutdown(ctx))
+			})
+		}
 	}
 }
 
@@ -80,6 +90,12 @@ func TestExemplars(t *testing.T) {
 	exe2 := &metricspb.DistributionValue_Exemplar{Value: 2}
 	picked := p.pickExemplar(exe1, exe2)
 	assert.True(t, picked == exe1 || picked == exe2)
+}
+
+func sortTimeseries(ts []*metricspb.TimeSeries) {
+	sort.Slice(ts, func(i, j int) bool {
+		return strings.Compare(ts[i].String(), ts[j].String()) < 0
+	})
 }
 
 func BenchmarkMetricsTransformProcessorRenameMetrics(b *testing.B) {

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -566,7 +566,7 @@ var (
 			transforms: []internalTransform{
 				{
 					MetricIncludeFilter: internalFilterStrict{include: "metric1",
-						matchLabels: map[string]StringMatcher{"label0": strictMatcher("label0-value1")}},
+						attrMatchers: map[string]StringMatcher{"label0": strictMatcher("label0-value1")}},
 					Action:  Insert,
 					NewName: "new/metric1",
 					Operations: []internalOperation{
@@ -701,7 +701,7 @@ var (
 			transforms: []internalTransform{
 				{
 					MetricIncludeFilter: internalFilterStrict{include: "metric1",
-						matchLabels: map[string]StringMatcher{"label1": strictMatcher("label1-value1")}},
+						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("label1-value1")}},
 					Action: Update,
 					Operations: []internalOperation{
 						{
@@ -817,9 +817,10 @@ var (
 			name: "metric_name_insert_with_match_label_strict",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]StringMatcher{"label1": strictMatcher("value1")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "metric1",
+						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -846,9 +847,10 @@ var (
 			name: "metric_name_insert_with_match_label_regexp",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile(`(.|\s)*\S(.|\s)*`)}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
+						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile(`(.|\s)*\S(.|\s)*`)}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -875,9 +877,10 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_two_datapoints_positive",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value3")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
+						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value3")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -908,9 +911,10 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_two_datapoints_negative",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value3")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
+						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value3")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -936,9 +940,10 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_with_full_value",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value1")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
+						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value1")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -965,9 +970,10 @@ var (
 			name: "metric_name_insert_with_match_label_strict_negative",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]StringMatcher{"label1": strictMatcher("wrong_value")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "metric1",
+						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("wrong_value")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -989,9 +995,10 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_negative",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile(".*wrong_ending")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
+						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile(".*wrong_ending")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -1013,9 +1020,10 @@ var (
 			name: "metric_name_insert_with_match_label_strict_missing_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1", matchLabels: map[string]StringMatcher{"missing_key": strictMatcher("value1")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterStrict{include: "metric1",
+						attrMatchers: map[string]StringMatcher{"missing_key": strictMatcher("value1")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -1037,9 +1045,10 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_missing_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"missing_key": regexp.MustCompile("value1")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
+						attrMatchers: map[string]StringMatcher{"missing_key": regexp.MustCompile("value1")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -1061,9 +1070,11 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_missing_and_present_key",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value1"), "missing_key": regexp.MustCompile("value2")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
+						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value1"),
+							"missing_key": regexp.MustCompile("value2")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -1085,9 +1096,11 @@ var (
 			name: "metric_name_insert_with_match_label_regexp_missing_key_with_empty_expression",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"), matchLabels: map[string]StringMatcher{"label1": regexp.MustCompile("value1"), "missing_key": regexp.MustCompile("^$")}},
-					Action:              Insert,
-					NewName:             "new/metric1",
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
+						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value1"),
+							"missing_key": regexp.MustCompile("^$")}},
+					Action:  Insert,
+					NewName: "new/metric1",
 				},
 			},
 			in: []*metricspb.Metric{
@@ -1531,7 +1544,7 @@ var (
 					addTimeseries(1, nil).addInt64Point(0, 1, 1).
 					build(),
 				metricBuilder().setName("metric2").
-					setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
+					setDataType(metricspb.MetricDescriptor_CUMULATIVE_DOUBLE).
 					addTimeseries(1, nil).addDoublePoint(0, 2, 1).
 					build(),
 				metricBuilder().setName("metric3").
@@ -1545,7 +1558,7 @@ var (
 					addTimeseries(1, nil).addInt64Point(0, 1, 1).
 					build(),
 				metricBuilder().setName("metric2").
-					setDataType(metricspb.MetricDescriptor_GAUGE_DOUBLE).
+					setDataType(metricspb.MetricDescriptor_CUMULATIVE_DOUBLE).
 					addTimeseries(1, nil).addDoublePoint(0, 2, 1).
 					build(),
 				metricBuilder().setName("metric3").
@@ -1874,7 +1887,7 @@ var (
 			transforms: []internalTransform{
 				{
 					MetricIncludeFilter: internalFilterStrict{include: "metric1",
-						matchLabels: map[string]StringMatcher{"label1": strictMatcher("value1")}},
+						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")}},
 					Action: Update,
 					Operations: []internalOperation{
 						{

--- a/processor/metricstransformprocessor/operation_add_label.go
+++ b/processor/metricstransformprocessor/operation_add_label.go
@@ -14,7 +14,11 @@
 
 package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 
-import metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+import (
+	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
 
 func (mtp *metricsTransformProcessor) addLabelOp(metric *metricspb.Metric, op internalOperation) {
 	var lb = metricspb.LabelKey{
@@ -28,4 +32,12 @@ func (mtp *metricsTransformProcessor) addLabelOp(metric *metricspb.Metric, op in
 		}
 		ts.LabelValues = append(ts.LabelValues, lv)
 	}
+}
+
+// addLabelOp add a new attribute to metric data points.
+func addLabelOp(metric pmetric.Metric, op internalOperation) {
+	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
+		attrs.InsertString(op.configOperation.NewLabel, op.configOperation.NewValue)
+		return true
+	})
 }

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -15,10 +15,14 @@
 package metricstransformprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor"
 
 import (
+	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 // aggregateLabelsOp aggregates points that have the labels excluded in label_set
@@ -77,4 +81,245 @@ func (mtp *metricsTransformProcessor) selectedLabelsAsKey(labelIdxs []int, times
 		newLabelValues[i] = timeseries.LabelValues[vidx]
 	}
 	return key, newLabelValues
+}
+
+type aggGroups struct {
+	gauge        map[string]pmetric.NumberDataPointSlice
+	sum          map[string]pmetric.NumberDataPointSlice
+	histogram    map[string]pmetric.HistogramDataPointSlice
+	expHistogram map[string]pmetric.ExponentialHistogramDataPointSlice
+}
+
+// aggregateLabelsOp aggregates points that have the labels excluded in label_set
+func aggregateLabelsOp(metric pmetric.Metric, mtpOp internalOperation) {
+	filterAttrs(metric, mtpOp.labelSetMap)
+	newMetric := pmetric.NewMetric()
+	copyMetricDetails(metric, newMetric)
+	ag := groupDataPoints(metric, aggGroups{})
+	mergeDataPoints(newMetric, mtpOp.configOperation.AggregationType, ag)
+	newMetric.MoveTo(metric)
+}
+
+// groupMetrics groups all the provided timeseries that will be aggregated together based on all the label values.
+// Returns a map of grouped timeseries and the corresponding selected labels
+// canBeCombined must be callled before.
+func groupMetrics(metrics pmetric.MetricSlice, aggType AggregationType, to pmetric.Metric) {
+	var ag aggGroups
+	for i := 0; i < metrics.Len(); i++ {
+		ag = groupDataPoints(metrics.At(i), ag)
+	}
+	mergeDataPoints(to, aggType, ag)
+}
+
+func groupDataPoints(metric pmetric.Metric, ag aggGroups) aggGroups {
+	switch metric.DataType() {
+	case pmetric.MetricDataTypeGauge:
+		if ag.gauge == nil {
+			ag.gauge = map[string]pmetric.NumberDataPointSlice{}
+		}
+		groupNumberDataPoints(metric.Gauge().DataPoints(), ag.gauge)
+	case pmetric.MetricDataTypeSum:
+		if ag.sum == nil {
+			ag.sum = map[string]pmetric.NumberDataPointSlice{}
+		}
+		groupNumberDataPoints(metric.Sum().DataPoints(), ag.sum)
+	case pmetric.MetricDataTypeHistogram:
+		if ag.histogram == nil {
+			ag.histogram = map[string]pmetric.HistogramDataPointSlice{}
+		}
+		groupHistogramDataPoints(metric.Histogram().DataPoints(), ag.histogram)
+	case pmetric.MetricDataTypeExponentialHistogram:
+		if ag.expHistogram == nil {
+			ag.expHistogram = map[string]pmetric.ExponentialHistogramDataPointSlice{}
+		}
+		groupExponentialHistogramDataPoints(metric.ExponentialHistogram().DataPoints(), ag.expHistogram)
+	}
+	return ag
+}
+
+func mergeDataPoints(to pmetric.Metric, aggType AggregationType, ag aggGroups) {
+	switch to.DataType() {
+	case pmetric.MetricDataTypeGauge:
+		mergeNumberDataPoints(ag.gauge, aggType, to.Gauge().DataPoints())
+	case pmetric.MetricDataTypeSum:
+		mergeNumberDataPoints(ag.sum, aggType, to.Sum().DataPoints())
+	case pmetric.MetricDataTypeHistogram:
+		mergeHistogramDataPoints(ag.histogram, to.Histogram().DataPoints())
+	case pmetric.MetricDataTypeExponentialHistogram:
+		mergeExponentialHistogramDataPoints(ag.expHistogram, to.ExponentialHistogram().DataPoints())
+	}
+}
+
+func groupNumberDataPoints(dps pmetric.NumberDataPointSlice, dpsByAttrsAndTs map[string]pmetric.NumberDataPointSlice) {
+	for i := 0; i < dps.Len(); i++ {
+		key := dataPointHashKey(dps.At(i).Attributes(), dps.At(i).StartTimestamp(), dps.At(i).Timestamp())
+		if _, ok := dpsByAttrsAndTs[key]; !ok {
+			dpsByAttrsAndTs[key] = pmetric.NewNumberDataPointSlice()
+		}
+		dps.At(i).MoveTo(dpsByAttrsAndTs[key].AppendEmpty())
+	}
+}
+
+func groupHistogramDataPoints(dps pmetric.HistogramDataPointSlice,
+	dpsByAttrsAndTs map[string]pmetric.HistogramDataPointSlice) {
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		keyHashParts := make([]interface{}, 0, len(dp.MExplicitBounds())+3)
+		for _, b := range dp.MExplicitBounds() {
+			keyHashParts = append(keyHashParts, b)
+		}
+		keyHashParts = append(keyHashParts, dp.HasMin(), dp.HasMax(), dp.Flags())
+		key := dataPointHashKey(dps.At(i).Attributes(), dp.StartTimestamp(), dp.Timestamp(), keyHashParts...)
+		if _, ok := dpsByAttrsAndTs[key]; !ok {
+			dpsByAttrsAndTs[key] = pmetric.NewHistogramDataPointSlice()
+		}
+		dp.MoveTo(dpsByAttrsAndTs[key].AppendEmpty())
+	}
+}
+
+func groupExponentialHistogramDataPoints(dps pmetric.ExponentialHistogramDataPointSlice,
+	dpsByAttrsAndTs map[string]pmetric.ExponentialHistogramDataPointSlice) {
+	for i := 0; i < dps.Len(); i++ {
+		dp := dps.At(i)
+		keyHashParts := make([]interface{}, 0, 4)
+		keyHashParts = append(keyHashParts, dp.Scale(), dp.HasMin(), dp.HasMax(), dp.Flags(), dp.Negative().Offset(),
+			dp.Positive().Offset())
+		key := dataPointHashKey(dps.At(i).Attributes(), dp.StartTimestamp(), dp.Timestamp(), keyHashParts...)
+		if _, ok := dpsByAttrsAndTs[key]; !ok {
+			dpsByAttrsAndTs[key] = pmetric.NewExponentialHistogramDataPointSlice()
+		}
+		dp.MoveTo(dpsByAttrsAndTs[key].AppendEmpty())
+	}
+}
+
+func filterAttrs(metric pmetric.Metric, filterAttrKeys map[string]bool) {
+	if filterAttrKeys == nil {
+		return
+	}
+	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
+		attrs.RemoveIf(func(k string, v pcommon.Value) bool {
+			return !filterAttrKeys[k]
+		})
+		return true
+	})
+}
+
+func dataPointHashKey(atts pcommon.Map, start pcommon.Timestamp, ts pcommon.Timestamp, other ...interface{}) string {
+	hashParts := []interface{}{atts.AsRaw(), start.String(), ts.String()}
+	jsonStr, _ := json.Marshal(append(hashParts, other...))
+	return string(jsonStr)
+}
+
+func mergeNumberDataPoints(dpsMap map[string]pmetric.NumberDataPointSlice, agg AggregationType, to pmetric.NumberDataPointSlice) {
+	for _, dps := range dpsMap {
+		dp := to.AppendEmpty()
+		dps.At(0).MoveTo(dp)
+		switch dp.ValueType() {
+		case pmetric.NumberDataPointValueTypeDouble:
+			for i := 1; i < dps.Len(); i++ {
+				switch agg {
+				case Sum, Mean:
+					dp.SetDoubleVal(dp.DoubleVal() + doubleVal(dps.At(i)))
+				case Max:
+					dp.SetDoubleVal(math.Max(dp.DoubleVal(), doubleVal(dps.At(i))))
+				case Min:
+					dp.SetDoubleVal(math.Min(dp.DoubleVal(), doubleVal(dps.At(i))))
+				}
+			}
+			if agg == Mean {
+				dp.SetDoubleVal(dp.DoubleVal() / float64(dps.Len()))
+			}
+		case pmetric.NumberDataPointValueTypeInt:
+			for i := 1; i < dps.Len(); i++ {
+				switch agg {
+				case Sum, Mean:
+					dp.SetIntVal(dp.IntVal() + dps.At(i).IntVal())
+				case Max:
+					if dp.IntVal() < intVal(dps.At(i)) {
+						dp.SetIntVal(intVal(dps.At(i)))
+					}
+				case Min:
+					if dp.IntVal() > intVal(dps.At(i)) {
+						dp.SetIntVal(intVal(dps.At(i)))
+					}
+				}
+			}
+			if agg == Mean {
+				dp.SetIntVal(dp.IntVal() / int64(dps.Len()))
+			}
+		}
+	}
+}
+
+func doubleVal(dp pmetric.NumberDataPoint) float64 {
+	switch dp.ValueType() {
+	case pmetric.NumberDataPointValueTypeDouble:
+		return dp.DoubleVal()
+	case pmetric.NumberDataPointValueTypeInt:
+		return float64(dp.IntVal())
+	}
+	return 0
+}
+
+func intVal(dp pmetric.NumberDataPoint) int64 {
+	switch dp.ValueType() {
+	case pmetric.NumberDataPointValueTypeDouble:
+		return int64(dp.DoubleVal())
+	case pmetric.NumberDataPointValueTypeInt:
+		return dp.IntVal()
+	}
+	return 0
+}
+
+func mergeHistogramDataPoints(dpsMap map[string]pmetric.HistogramDataPointSlice, to pmetric.HistogramDataPointSlice) {
+	for _, dps := range dpsMap {
+		dp := to.AppendEmpty()
+		dps.At(0).MoveTo(dp)
+		for i := 1; i < dps.Len(); i++ {
+			if dps.At(i).Count() == 0 {
+				continue
+			}
+			dp.SetCount(dp.Count() + dps.At(i).Count())
+			dp.SetSum(dp.Sum() + dps.At(i).Sum())
+			if dp.HasMin() && dp.Min() > dps.At(i).Min() {
+				dp.SetMin(dps.At(i).Min())
+			}
+			if dp.HasMax() && dp.Max() < dps.At(i).Max() {
+				dp.SetMax(dps.At(i).Max())
+			}
+			dps.At(i).Exemplars().MoveAndAppendTo(dp.Exemplars())
+			for b, bc := range dps.At(i).MBucketCounts() {
+				dp.MBucketCounts()[b] = dp.MBucketCounts()[b] + bc
+			}
+			dps.At(i).Exemplars().MoveAndAppendTo(dp.Exemplars())
+		}
+	}
+}
+
+func mergeExponentialHistogramDataPoints(dpsMap map[string]pmetric.ExponentialHistogramDataPointSlice,
+	to pmetric.ExponentialHistogramDataPointSlice) {
+	for _, dps := range dpsMap {
+		dp := to.AppendEmpty()
+		dps.At(0).MoveTo(dp)
+		for i := 1; i < dps.Len(); i++ {
+			if dps.At(i).Count() == 0 {
+				continue
+			}
+			dp.SetCount(dp.Count() + dps.At(i).Count())
+			dp.SetSum(dp.Sum() + dps.At(i).Sum())
+			if dp.HasMin() && dp.Min() > dps.At(i).Min() {
+				dp.SetMin(dps.At(i).Min())
+			}
+			if dp.HasMax() && dp.Max() < dps.At(i).Max() {
+				dp.SetMax(dps.At(i).Max())
+			}
+			for b, bc := range dps.At(i).Negative().MBucketCounts() {
+				dps.At(i).Negative().MBucketCounts()[b] = dps.At(i).Negative().MBucketCounts()[b] + bc
+			}
+			for b, bc := range dps.At(i).Positive().MBucketCounts() {
+				dps.At(i).Positive().MBucketCounts()[b] = dps.At(i).Positive().MBucketCounts()[b] + bc
+			}
+			dps.At(i).Exemplars().MoveAndAppendTo(dp.Exemplars())
+		}
+	}
 }


### PR DESCRIPTION
As side effect this change:
- Reduces CPU/memory utilization
- Fixes issues caused by OC<->OTLP translation, e.g. undesired conversion of non-monothonic sum metrics to gauges.
- Scope info (name + version) is not dropped anymore
- Adds support of exponential histograms
- Adds ability to aggregate numeric data points with different value type (int, double)

This change can be reverted by disabling the `processor.metricstransformprocessor.UseOTLPDataModel` feature gate (add `--feature-gates=-processor.metricstransformprocessor.UseOTLPDataModel` command line argument).

Benchmark results:
```
goos: darwin
goarch: amd64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
```

before:
```
BenchmarkMetricsTransformProcessorRenameMetrics-16    	    2390	    487938 ns/op
```

after:
```
BenchmarkMetricsTransformProcessorRenameMetrics-16    	   11220	    105151 ns/op
```

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10575

Also fixes 
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10420
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7071
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4390