### PR TITLE
fix errcheck and gocritic lint issue for exporter splunk

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -367,7 +367,7 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 		// Writing truncated bytes back to buffer.
 		if _, err = state.tmpBuf.WriteTo(state.buf); err != nil {
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(
-				fmt.Errorf("write truncated bytes back to buffer failed, error: %v", err)))
+				fmt.Errorf("write truncated bytes back to buffer failed, error: %w", err)))
 		}
 
 		if state.buf.Len() > 0 {
@@ -437,7 +437,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 		// Writing truncated bytes back to buffer.
 		if _, err := state.tmpBuf.WriteTo(state.buf); err != nil {
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(
-				fmt.Errorf("write truncated bytes back to buffer failed, error: %v", err)))
+				fmt.Errorf("write truncated bytes back to buffer failed, error: %w", err)))
 		}
 
 		if state.buf.Len() > 0 {
@@ -505,7 +505,7 @@ func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSli
 		// Writing truncated bytes back to buffer.
 		if _, err = state.tmpBuf.WriteTo(state.buf); err != nil {
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(
-				fmt.Errorf("write truncated bytes back to buffer failed, error: %v", err)))
+				fmt.Errorf("write truncated bytes back to buffer failed, error: %w", err)))
 		}
 
 		if state.buf.Len() > 0 {

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:errcheck
 package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
 
 import (
@@ -366,7 +365,7 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 		state.buf.Reset()
 
 		// Writing truncated bytes back to buffer.
-		state.tmpBuf.WriteTo(state.buf)
+		_, _ = state.tmpBuf.WriteTo(state.buf)
 
 		if state.buf.Len() > 0 {
 			// This means that the current record had overflown the buffer and was not sent
@@ -433,7 +432,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 		state.buf.Reset()
 
 		// Writing truncated bytes back to buffer.
-		state.tmpBuf.WriteTo(state.buf)
+		_, _ = state.tmpBuf.WriteTo(state.buf)
 
 		if state.buf.Len() > 0 {
 			// This means that the current record had overflown the buffer and was not sent
@@ -498,7 +497,7 @@ func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSli
 		state.buf.Reset()
 
 		// Writing truncated bytes back to buffer.
-		state.tmpBuf.WriteTo(state.buf)
+		_, _ = state.tmpBuf.WriteTo(state.buf)
 
 		if state.buf.Len() > 0 {
 			// This means that the current record had overflown the buffer and was not sent
@@ -612,7 +611,7 @@ func (c *client) postEvents(ctx context.Context, events io.Reader, headers map[s
 
 	err = splunk.HandleHTTPCode(resp)
 
-	io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(ioutil.Discard, resp.Body)
 
 	return err
 }

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -623,8 +623,8 @@ func (c *client) postEvents(ctx context.Context, events io.Reader, headers map[s
 		return err
 	}
 
-	_, err = io.Copy(ioutil.Discard, resp.Body)
-	return err
+	_, errCopy := io.Copy(ioutil.Discard, resp.Body)
+	return multierr.Combine(err, errCopy)
 }
 
 // subLogs returns a subset of `ld` starting from `profilingBufFront` for profiling data

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:errcheck,gocritic
 package splunkhecexporter
 
 import (
@@ -224,7 +223,10 @@ func runMetricsExport(cfg *Config, metrics pmetric.Metrics, t *testing.T) ([]rec
 	exporter, err := factory.CreateMetricsExporter(context.Background(), params, cfg)
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
-	defer exporter.Shutdown(context.Background())
+	defer func() {
+		err = exporter.Shutdown(context.Background())
+		assert.NoError(t, err)
+	}()
 
 	err = exporter.ConsumeMetrics(context.Background(), metrics)
 	assert.NoError(t, err)
@@ -268,7 +270,10 @@ func runTraceExport(testConfig *Config, traces ptrace.Traces, t *testing.T) ([]r
 	exporter, err := factory.CreateTracesExporter(context.Background(), params, cfg)
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
-	defer exporter.Shutdown(context.Background())
+	defer func() {
+		err = exporter.Shutdown(context.Background())
+		assert.NoError(t, err)
+	}()
 
 	err = exporter.ConsumeTraces(context.Background(), traces)
 	assert.NoError(t, err)
@@ -320,7 +325,10 @@ func runLogExport(cfg *Config, ld plog.Logs, t *testing.T) ([]receivedRequest, e
 	exporter, err := NewFactory().CreateLogsExporter(context.Background(), params, cfg)
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
-	defer exporter.Shutdown(context.Background())
+	defer func() {
+		err = exporter.Shutdown(context.Background())
+		assert.NoError(t, err)
+	}()
 
 	err = exporter.ConsumeLogs(context.Background(), ld)
 	assert.NoError(t, err)
@@ -754,7 +762,10 @@ func TestErrorReceived(t *testing.T) {
 	exporter, err := factory.CreateTracesExporter(context.Background(), params, cfg)
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
-	defer exporter.Shutdown(context.Background())
+	defer func() {
+		err = exporter.Shutdown(context.Background())
+		assert.NoError(t, err)
+	}()
 
 	td := createTraceData(3)
 
@@ -794,8 +805,10 @@ func TestInvalidURL(t *testing.T) {
 	exporter, err := factory.CreateTracesExporter(context.Background(), params, cfg)
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
-	defer exporter.Shutdown(context.Background())
-
+	defer func() {
+		err = exporter.Shutdown(context.Background())
+		assert.NoError(t, err)
+	}()
 	td := createTraceData(2)
 
 	err = exporter.ConsumeTraces(context.Background(), td)
@@ -1008,7 +1021,7 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	// Sending logs using the client.
 	err := splunkClient.pushLogData(context.Background(), logs)
 	// TODO: Uncomment after consumererror.Logs implements method Unwrap.
-	//require.True(t, consumererror.IsPermanent(err), "Expecting permanent error")
+	// require.True(t, consumererror.IsPermanent(err), "Expecting permanent error")
 	require.Contains(t, err.Error(), "HTTP/0.0 400")
 	// The returned error should contain the response body responseBody.
 	assert.Contains(t, err.Error(), responseBody)
@@ -1018,7 +1031,7 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	// Sending logs using the client.
 	err = splunkClient.pushLogData(context.Background(), logs)
 	// TODO: Uncomment after consumererror.Logs implements method Unwrap.
-	//require.False(t, consumererror.IsPermanent(err), "Expecting non-permanent error")
+	// require.False(t, consumererror.IsPermanent(err), "Expecting non-permanent error")
 	require.Contains(t, err.Error(), "HTTP 500")
 	// The returned error should not contain the response body responseBody.
 	assert.NotContains(t, err.Error(), responseBody)

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -224,8 +224,7 @@ func runMetricsExport(cfg *Config, metrics pmetric.Metrics, t *testing.T) ([]rec
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
 	defer func() {
-		err = exporter.Shutdown(context.Background())
-		assert.NoError(t, err)
+		assert.NoError(t, exporter.Shutdown(context.Background()))
 	}()
 
 	err = exporter.ConsumeMetrics(context.Background(), metrics)
@@ -271,8 +270,7 @@ func runTraceExport(testConfig *Config, traces ptrace.Traces, t *testing.T) ([]r
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
 	defer func() {
-		err = exporter.Shutdown(context.Background())
-		assert.NoError(t, err)
+		assert.NoError(t, exporter.Shutdown(context.Background()))
 	}()
 
 	err = exporter.ConsumeTraces(context.Background(), traces)
@@ -326,8 +324,7 @@ func runLogExport(cfg *Config, ld plog.Logs, t *testing.T) ([]receivedRequest, e
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
 	defer func() {
-		err = exporter.Shutdown(context.Background())
-		assert.NoError(t, err)
+		assert.NoError(t, exporter.Shutdown(context.Background()))
 	}()
 
 	err = exporter.ConsumeLogs(context.Background(), ld)
@@ -763,8 +760,7 @@ func TestErrorReceived(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
 	defer func() {
-		err = exporter.Shutdown(context.Background())
-		assert.NoError(t, err)
+		assert.NoError(t, exporter.Shutdown(context.Background()))
 	}()
 
 	td := createTraceData(3)
@@ -806,8 +802,7 @@ func TestInvalidURL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, exporter.Start(context.Background(), componenttest.NewNopHost()))
 	defer func() {
-		err = exporter.Shutdown(context.Background())
-		assert.NoError(t, err)
+		assert.NoError(t, exporter.Shutdown(context.Background()))
 	}()
 	td := createTraceData(2)
 


### PR DESCRIPTION
Signed-off-by: Ziqi Zhao <zhaoziqi9146@gmail.com>

**Description:** <Describe what has changed.>
fix gocritic and gocritic issue for splunk exporter

the code is modified as following
```
_, _ = state.tmpBuf.WriteTo(state.buf)
```

because in function ```makeBlankBufferState```, the tmpBuf is already initialized with smaller spaces than buf
```
func makeBlankBufferState(bufCap uint) bufferState {
	// Buffer of JSON encoded Splunk events, last record is expected to overflow bufCap, hence the padding
	var buf = bytes.NewBuffer(make([]byte, 0, bufCap+bufCapPadding))

	// Buffer for overflown records that do not fit in the main buffer
	var tmpBuf = bytes.NewBuffer(make([]byte, 0, bufCapPadding))

	return bufferState{
		buf:      buf,
		tmpBuf:   tmpBuf,
		bufFront: nil, // Index of the log record of the first unsent event in buffer.
		bufLen:   0,   // Length of data in buffer excluding the last record if it overflows bufCap
		resource: 0,   // Index of currently processed Resource
		library:  0,   // Index of currently processed Library
	}
}
```

**Link to tracking Issue:** <Issue number if applicable>
#10466 #9749 

