### PR TITLE
Add IgnoreResourceAttributeValue CompareOption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `prometheusreceiver`: Improve performance of metrics builder (#10546)
 - `transformprocessor`: Add functions for conversion of scalar metric types (`gauge_to_sum` and `sum_to_gauge`) (#10255)
 - `dynatraceexporter`: Truncate unmarshalable responses to avoid long log lines (#10568)
+- `scrapertest`: Add `IgnoreResourceAttributeValue` option to metric comparison (#10828)
 
 ### 🧰 Bug fixes 🧰
 

--- a/internal/scrapertest/compare_test.go
+++ b/internal/scrapertest/compare_test.go
@@ -379,6 +379,50 @@ func TestCompareMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "ignore-one-resource-attribute",
+			compareOptions: []CompareOption{
+				IgnoreResourceAttributeValue("node_id"),
+			},
+			withoutOptions: expectation{
+				err: multierr.Combine(
+					errors.New("missing expected resource with attributes: map[node_id:a-different-random-id]"),
+					errors.New("extra resource with attributes: map[node_id:a-random-id]"),
+				),
+				reason: "An unpredictable resource attribute will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err:    nil,
+				reason: "The unpredictable resource attribute was ignored on each resource that carried it.",
+			},
+		},
+		{
+			name: "ignore-one-resource-attribute-multiple-resources",
+			compareOptions: []CompareOption{
+				IgnoreResourceAttributeValue("node_id"),
+			},
+			withoutOptions: expectation{
+				err: multierr.Combine(
+					errors.New("missing expected resource with attributes: map[node_id:BB902-expected]"),
+					errors.New("missing expected resource with attributes: map[namespace:test node_id:BB902-expected]"),
+					errors.New("missing expected resource with attributes: map[node_id:BB904-expected]"),
+					errors.New("missing expected resource with attributes: map[namespace:test node_id:BB904-expected]"),
+					errors.New("missing expected resource with attributes: map[node_id:BB903-expected]"),
+					errors.New("missing expected resource with attributes: map[namespace:test node_id:BB903-expected]"),
+					errors.New("extra resource with attributes: map[node_id:BB902-actual]"),
+					errors.New("extra resource with attributes: map[namespace:test node_id:BB902-actual]"),
+					errors.New("extra resource with attributes: map[node_id:BB904-actual]"),
+					errors.New("extra resource with attributes: map[namespace:test node_id:BB904-actual]"),
+					errors.New("extra resource with attributes: map[node_id:BB903-actual]"),
+					errors.New("extra resource with attributes: map[namespace:test node_id:BB903-actual]"),
+				),
+				reason: "An unpredictable resource attribute will cause failures if not ignored.",
+			},
+			withOptions: expectation{
+				err:    nil,
+				reason: "The unpredictable resource attribute was ignored on each resource that carried it, but the predictable attributes were preserved.",
+			},
+		},
+		{
 			name: "ignore-each-attribute-value",
 			compareOptions: []CompareOption{
 				IgnoreMetricAttributeValue("hostname", "gauge.one", "sum.one"),

--- a/internal/scrapertest/mask.go
+++ b/internal/scrapertest/mask.go
@@ -134,3 +134,29 @@ func maskDataPointSliceAttributeValues(dataPoints pmetric.NumberDataPointSlice, 
 		}
 	}
 }
+
+// IgnoreResourceAttributeValue is a CompareOption that removes a resource attribute
+// from all resources
+func IgnoreResourceAttributeValue(attributeName string) CompareOption {
+	return ignoreResourceAttributeValue{
+		attributeName: attributeName,
+	}
+}
+
+type ignoreResourceAttributeValue struct {
+	attributeName string
+}
+
+func (opt ignoreResourceAttributeValue) apply(expected, actual pmetric.Metrics) {
+	maskResourceAttributeValue(expected, opt)
+	maskResourceAttributeValue(actual, opt)
+}
+
+func maskResourceAttributeValue(metrics pmetric.Metrics, opt ignoreResourceAttributeValue) {
+	rms := metrics.ResourceMetrics()
+	for i := 0; i < rms.Len(); i++ {
+		if _, ok := rms.At(i).Resource().Attributes().Get(opt.attributeName); ok {
+			rms.At(i).Resource().Attributes().Remove(opt.attributeName)
+		}
+	}
+}

--- a/internal/scrapertest/testdata/ignore-one-resource-attribute-multiple-resources/actual.json
+++ b/internal/scrapertest/testdata/ignore-one-resource-attribute-multiple-resources/actual.json
@@ -1,0 +1,1657 @@
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB902-actual"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.node.connection.count",
+                            "description": "Number of connections opened and closed to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "3"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "aerospike.node.connection.open",
+                            "description": "Number of open connections to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "namespace",
+                        "value": {
+                            "stringValue": "test"
+                        }
+                    },
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB902-actual"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8513765"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41913920"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB904-actual"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.node.connection.count",
+                            "description": "Number of connections opened and closed to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "aerospike.node.connection.open",
+                            "description": "Number of open connections to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "namespace",
+                        "value": {
+                            "stringValue": "test"
+                        }
+                    },
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB904-actual"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8522202"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41955456"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB903-actual"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.node.connection.count",
+                            "description": "Number of connections opened and closed to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "aerospike.node.connection.open",
+                            "description": "Number of open connections to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "namespace",
+                        "value": {
+                            "stringValue": "test"
+                        }
+                    },
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB903-actual"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8343140"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41073920"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-one-resource-attribute-multiple-resources/expected.json
+++ b/internal/scrapertest/testdata/ignore-one-resource-attribute-multiple-resources/expected.json
@@ -1,0 +1,1657 @@
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB902-expected"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.node.connection.count",
+                            "description": "Number of connections opened and closed to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "3"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "aerospike.node.connection.open",
+                            "description": "Number of open connections to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "namespace",
+                        "value": {
+                            "stringValue": "test"
+                        }
+                    },
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB902-expected"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8513765"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41913920"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB904-expected"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.node.connection.count",
+                            "description": "Number of connections opened and closed to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "aerospike.node.connection.open",
+                            "description": "Number of open connections to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "namespace",
+                        "value": {
+                            "stringValue": "test"
+                        }
+                    },
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB904-expected"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8522202"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41955456"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB903-expected"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.node.connection.count",
+                            "description": "Number of connections opened and closed to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "aerospike.node.connection.open",
+                            "description": "Number of open connections to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "namespace",
+                        "value": {
+                            "stringValue": "test"
+                        }
+                    },
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "BB903-expected"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.namespace.disk.available",
+                            "description": "Minimum percentage of contiguous disk space free to the namespace across all devices",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "98"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.free",
+                            "description": "Percentage of the namespace's memory which is still free",
+                            "unit": "%",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "95"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.memory.usage",
+                            "description": "Memory currently used by each component of the namespace",
+                            "unit": "By",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "data"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "8343140"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "41073920"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "sindex"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "component",
+                                                "value": {
+                                                    "stringValue": "set_index"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        },
+                        {
+                            "name": "aerospike.namespace.scan.count",
+                            "description": "Number of scan operations performed on the namespace",
+                            "unit": "{scans}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "aggr"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "basic"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "ops_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "abort"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "complete"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "udf_bg"
+                                                }
+                                            },
+                                            {
+                                                "key": "result",
+                                                "value": {
+                                                    "stringValue": "error"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1653329630290831862",
+                                        "timeUnixNano": "1653329645321022166",
+                                        "asInt": "0"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-one-resource-attribute/actual.json
+++ b/internal/scrapertest/testdata/ignore-one-resource-attribute/actual.json
@@ -1,0 +1,199 @@
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "a-random-id"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.node.connection.count",
+                            "description": "Number of connections opened and closed to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "149"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "150"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "aerospike.node.connection.open",
+                            "description": "Number of open connections to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/internal/scrapertest/testdata/ignore-one-resource-attribute/expected.json
+++ b/internal/scrapertest/testdata/ignore-one-resource-attribute/expected.json
@@ -1,0 +1,199 @@
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "node_id",
+                        "value": {
+                            "stringValue": "a-different-random-id"
+                        }
+                    }
+                ]
+            },
+            "instrumentationLibraryMetrics": [
+                {
+                    "instrumentationLibrary": {
+                        "name": "otelcol/aerospikereceiver"
+                    },
+                    "metrics": [
+                        {
+                            "name": "aerospike.node.connection.count",
+                            "description": "Number of connections opened and closed to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "149"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "150"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "close"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "0"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            },
+                                            {
+                                                "key": "op",
+                                                "value": {
+                                                    "stringValue": "open"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                                "isMonotonic": true
+                            }
+                        },
+                        {
+                            "name": "aerospike.node.connection.open",
+                            "description": "Number of open connections to the node",
+                            "unit": "{connections}",
+                            "sum": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "client"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "1"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "fabric"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "48"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "heartbeat"
+                                                }
+                                            }
+                                        ],
+                                        "startTimeUnixNano": "1652734551332787000",
+                                        "timeUnixNano": "1652734556334562000",
+                                        "asInt": "2"
+                                    }
+                                ],
+                                "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
**Description:** Adds `IgnoreResourceAttributeValue` CompareOption, copying pattern of `IgnoreMetricAttributeValue`. This new option removes resource attributes from expected and actual metrics when comparing metrics. This is desirable for integration tests in cases where a resource attribute is unpredictable, for example random UUID or MAC address.

**Link to tracking Issue:** #10129

**Testing:** Additional test cases were added to `TestCompareMetrics` using the new option. The cases test masking the sole resource attribute from a resource, and removing masking one attribute but preserving other predictable attributes.

**Documentation:** The exported `IgnoreResourceAttributeValue` method is documented with a description of what it does