### PR TITLE
add workflow to create dependabot pr

### DIFF
--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -1,0 +1,15 @@
+name: dependabot-pr
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run dependabot-pr.sh
+        run: ./.github/workflows/scripts/dependabot-pr.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -3,7 +3,7 @@
 git config user.name $GITHUB_ACTOR
 git config user.email $GITHUB_ACTOR@users.noreply.github.com
 
-PR_NAME=dependabot-prs/`date +'%Y-%m-%d-%H%M%S'`
+PR_NAME=dependabot-prs/`date +'%Y-%m-%dT%H%M%S'`
 git checkout -b $PR_NAME
 
 IFS=$'\n'

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -ex
+
+git config user.name $GITHUB_ACTOR
+git config user.email $GITHUB_ACTOR@users.noreply.github.com
+
+PR_NAME=dependabot-prs/`date +'%Y-%m-%d-%H%M%S'`
+git checkout -b $PR_NAME
+
+IFS=$'\n'
+requests=$(gh pr list --search "author:app/dependabot" --json number,title --template '{{range .}}{{tablerow .title}}{{end}}')
+message=""
+
+for line in $requests; do
+    if [[ $line != Bump* ]]; then 
+        continue
+    fi
+
+    module=$(echo $line | cut -f 2 -d " ")
+    if [[ $module == go.opentelemetry.io/collecto* ]]; then
+        continue
+    fi
+    version=$(echo $line | cut -f 6 -d " ")
+    make for-all CMD="$GITHUB_WORKSPACE/internal/buildscripts/update-dep" MODULE=$module VERSION=v$version
+    message+=$line
+    message+=$'\n'
+done
+
+make gotidy
+make otelcontribcol
+
+git add go.sum go.mod
+git add "**/go.sum" "**/go.mod"
+git commit -m "dependabot updates `date`
+$message"
+git push origin $PR_NAME
+
+gh pr create --title "dependabot updates `date`" --body "$message" -l "Skip Changelog"

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -16,7 +16,7 @@ for line in $requests; do
     fi
 
     module=$(echo $line | cut -f 2 -d " ")
-    if [[ $module == go.opentelemetry.io/collecto* ]]; then
+    if [[ $module == go.opentelemetry.io/collector* ]]; then
         continue
     fi
     version=$(echo $line | cut -f 6 -d " ")

--- a/internal/buildscripts/update-dep
+++ b/internal/buildscripts/update-dep
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
 # Updates MODULE inside go.mod if it is already present to version VERSION.
 


### PR DESCRIPTION
This pr adds a workflow to replace the manual work required to commit all the dependabot PRs. The workflow:
- checks out the code
- runs .github/workflows/scripts/dependabot-pr.sh which looks for all dependabot PRs and applies the dependency update
- runs tidy/builds the collector
- commits a change and creates a PR

The workflow is triggered manually and the PR will be opened by the github-actions bot
