### PR TITLE
declare expvarreceiver as alpha and add to components.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🚀 New components 🚀
 
+- `expvarreceiver`: Include `expvarreceiver` in components (#10847)
+
 ### 💡 Enhancements 💡
 
 ### 🧰 Bug fixes 🧰

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -355,6 +355,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.53.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver v0.53.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.53.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver v0.53.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.53.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver v0.53.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.53.0 // indirect
@@ -774,6 +775,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/docke
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver => ../../receiver/dotnetdiagnosticsreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver => ../../receiver/elasticsearchreceiver
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver => ../../receiver/expvarreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver => ../../receiver/filelogreceiver
 

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver v0.53.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver v0.53.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.53.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver v0.53.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.53.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver v0.53.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.53.0
@@ -779,6 +780,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/docke
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver => ./receiver/dotnetdiagnosticsreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver => ./receiver/elasticsearchreceiver
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver => ./receiver/expvarreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver => ./receiver/filelogreceiver
 

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -113,6 +113,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver"
@@ -206,6 +207,7 @@ func Components() (component.Factories, error) {
 		dockerstatsreceiver.NewFactory(),
 		dotnetdiagnosticsreceiver.NewFactory(),
 		elasticsearchreceiver.NewFactory(),
+		expvarreceiver.NewFactory(),
 		filelogreceiver.NewFactory(),
 		flinkmetricsreceiver.NewFactory(),
 		fluentforwardreceiver.NewFactory(),

--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -107,6 +107,9 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "elasticsearch",
 		},
 		{
+			receiver: "expvar",
+		},
+		{
 			receiver: "filelog",
 			getConfigFn: func() config.Receiver {
 				cfg := rcvrFactories["filelog"].CreateDefaultConfig().(*filelogreceiver.FileLogConfig)

--- a/receiver/expvarreceiver/README.md
+++ b/receiver/expvarreceiver/README.md
@@ -50,3 +50,6 @@ receivers:
       process.runtime.memstats.mallocs:
         enabled: false
 ```
+
+[alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/expvarreceiver/README.md
+++ b/receiver/expvarreceiver/README.md
@@ -1,11 +1,15 @@
 # Expvar Receiver
 
+| Status                   |           |
+| ------------------------ |-----------|
+| Stability                | [beta]    |
+| Supported pipeline types | metrics   |
+| Distributions            | [contrib] |
+
 An Expvar Receiver scrapes metrics from [expvar](https://pkg.go.dev/expvar), 
 which exposes data in JSON format from an HTTP endpoint. The metrics are 
 extracted from the `expvar` variable [memstats](https://pkg.go.dev/runtime#MemStats), 
 which exposes various information about the Go runtime.
-
-> :construction: This component is in alpha and configuration fields are subject to change.
 
 ## Configuration 
 

--- a/receiver/expvarreceiver/README.md
+++ b/receiver/expvarreceiver/README.md
@@ -5,7 +5,7 @@ which exposes data in JSON format from an HTTP endpoint. The metrics are
 extracted from the `expvar` variable [memstats](https://pkg.go.dev/runtime#MemStats), 
 which exposes various information about the Go runtime.
 
-> :construction: This receiver is in development and incomplete. It should not be used yet.
+> :construction: This component is in alpha and configuration fields are subject to change.
 
 ## Configuration 
 

--- a/receiver/expvarreceiver/README.md
+++ b/receiver/expvarreceiver/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |           |
 | ------------------------ |-----------|
-| Stability                | [beta]    |
+| Stability                | [alpha]   |
 | Supported pipeline types | metrics   |
 | Distributions            | [contrib] |
 


### PR DESCRIPTION
**Description:** 

* Add expvar receiver to components list.
* Declare component as alpha

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9592
