### PR TITLE
[receiver/kubeletstats] Bring back k8s.container.name attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🧰 Bug fixes 🧰
 
+- `kubletetstatsreceiver`: Bring back `k8s.container.name` attribute (#10848)
+
 ## v0.53.0
 
 ### 🛑 Breaking changes 🛑

--- a/receiver/kubeletstatsreceiver/documentation.md
+++ b/receiver/kubeletstatsreceiver/documentation.md
@@ -66,11 +66,11 @@ metrics:
 | ---- | ----------- | ---- |
 | aws.volume.id | The id of the AWS Volume | String |
 | container.id | Container id used to identify container | String |
-| container.name | Container name used by container runtime | String |
 | fs.type | The filesystem type of the Volume | String |
 | gce.pd.name | The name of the persistent disk in GCE | String |
 | glusterfs.endpoints.name | The endpoint name that details Glusterfs topology | String |
 | glusterfs.path | Glusterfs volume path | String |
+| k8s.container.name | Container name used by container runtime | String |
 | k8s.namespace.name | The name of the namespace that the pod is running in | String |
 | k8s.node.name | The name of the Node | String |
 | k8s.persistentvolumeclaim.name | The name of the Persistent Volume Claim | String |

--- a/receiver/kubeletstatsreceiver/internal/kubelet/resource.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/resource.go
@@ -29,7 +29,7 @@ func getContainerResourceOptions(sPod stats.PodStats, sContainer stats.Container
 		metadata.WithK8sPodUID(sPod.PodRef.UID),
 		metadata.WithK8sPodName(sPod.PodRef.Name),
 		metadata.WithK8sNamespaceName(sPod.PodRef.Namespace),
-		metadata.WithContainerName(sContainer.Name),
+		metadata.WithK8sContainerName(sContainer.Name),
 	}
 
 	extraResources, err := k8sMetadata.getExtraResources(sPod.PodRef, MetadataLabelContainerID, sContainer.Name)

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_v2.go
@@ -2445,13 +2445,6 @@ func WithContainerID(val string) ResourceMetricsOption {
 	}
 }
 
-// WithContainerName sets provided value as "container.name" attribute for current resource.
-func WithContainerName(val string) ResourceMetricsOption {
-	return func(rm pmetric.ResourceMetrics) {
-		rm.Resource().Attributes().UpsertString("container.name", val)
-	}
-}
-
 // WithFsType sets provided value as "fs.type" attribute for current resource.
 func WithFsType(val string) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
@@ -2477,6 +2470,13 @@ func WithGlusterfsEndpointsName(val string) ResourceMetricsOption {
 func WithGlusterfsPath(val string) ResourceMetricsOption {
 	return func(rm pmetric.ResourceMetrics) {
 		rm.Resource().Attributes().UpsertString("glusterfs.path", val)
+	}
+}
+
+// WithK8sContainerName sets provided value as "k8s.container.name" attribute for current resource.
+func WithK8sContainerName(val string) ResourceMetricsOption {
+	return func(rm pmetric.ResourceMetrics) {
+		rm.Resource().Attributes().UpsertString("k8s.container.name", val)
 	}
 }
 

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -13,7 +13,7 @@ resource_attributes:
   k8s.namespace.name:
     description: "The name of the namespace that the pod is running in"
     type: string
-  container.name:
+  k8s.container.name:
     description: "Container name used by container runtime"
     type: string
   container.id:


### PR DESCRIPTION
`k8s.container.name` attribute was recently unintentionally changed to `container.name`. This change brings `k8s.container.name` back
 
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10842