### PR TITLE
common/testutil: Exclude port ranges for both TCP and UDP

### DIFF
--- a/internal/common/testutil/testutil.go
+++ b/internal/common/testutil/testutil.go
@@ -85,11 +85,16 @@ func GetAvailablePort(t *testing.T) uint16 {
 
 // Get excluded ports on Windows from the command: netsh interface ipv4 show excludedportrange protocol=tcp
 func getExclusionsList(t *testing.T) []portpair {
-	cmd := exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=tcp")
-	output, err := cmd.CombinedOutput()
-	require.NoError(t, err)
+	cmdTCP := exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=tcp")
+	outputTCP, errTCP := cmdTCP.CombinedOutput()
+	require.NoError(t, errTCP)
+	exclusions := createExclusionsList(string(outputTCP), t)
 
-	exclusions := createExclusionsList(string(output), t)
+	cmdUDP := exec.Command("netsh", "interface", "ipv4", "show", "excludedportrange", "protocol=udp")
+	outputUDP, errUDP := cmdUDP.CombinedOutput()
+	require.NoError(t, errUDP)
+	exclusions = append(exclusions, createExclusionsList(string(outputUDP), t)...)
+
 	return exclusions
 }
 

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -47,12 +47,7 @@ import (
 
 var jaegerAgent = config.NewComponentIDWithName(typeStr, "agent_test")
 
-var skip = func(t *testing.T, why string) {
-	t.Skip(why)
-}
-
 func TestJaegerAgentUDP_ThriftCompact(t *testing.T) {
-	skip(t, "Flaky Test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10368")
 	port := testutil.GetAvailablePort(t)
 	addrForClient := fmt.Sprintf(":%d", port)
 	testJaegerAgent(t, addrForClient, &configuration{
@@ -76,7 +71,6 @@ func TestJaegerAgentUDP_ThriftCompact_InvalidPort(t *testing.T) {
 }
 
 func TestJaegerAgentUDP_ThriftBinary(t *testing.T) {
-	skip(t, "Flaky Test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10369")
 	port := testutil.GetAvailablePort(t)
 	addrForClient := fmt.Sprintf(":%d", port)
 	testJaegerAgent(t, addrForClient, &configuration{
@@ -86,7 +80,6 @@ func TestJaegerAgentUDP_ThriftBinary(t *testing.T) {
 }
 
 func TestJaegerAgentUDP_ThriftBinary_PortInUse(t *testing.T) {
-	skip(t, "Flaky Test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10370")
 	// This test confirms that the thrift binary port is opened correctly.  This is all we can test at the moment.  See above.
 	port := testutil.GetAvailablePort(t)
 

--- a/receiver/statsdreceiver/receiver_test.go
+++ b/receiver/statsdreceiver/receiver_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -94,9 +93,6 @@ func TestStatsdReceiver_Flush(t *testing.T) {
 }
 
 func Test_statsdreceiver_EndToEnd(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10151")
-	}
 	addr := testutil.GetAvailableLocalAddress(t)
 	host, portStr, err := net.SplitHostPort(addr)
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #10370
Fixes #10369 
Fixes #10368 
Fixes #10151
Fixes #1391

I printed the output of the commands on github actions:

```terminal
=== RUN   TestTCPAndUDP
    testutil_test.go:87: TCP Command
    testutil_test.go:88: 
        Protocol tcp Port Exclusion Ranges
        Start Port    End Port      
        ----------    --------      
                80          80      
              5986        5986      
             47001       47001      
             51417       51516      
             51517       51616      
        * - Administered port exclusions.
    testutil_test.go:95: UDP Command
    testutil_test.go:96: 
        Protocol udp Port Exclusion Ranges
        Start Port    End Port      
        ----------    --------      
             56030       56129      
             56130       56229      
        * - Administered port exclusions.
```

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
