### PR TITLE
[Makefile] Add targets for markdown-link-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,10 @@ build-examples:
 checkdoc:
 	checkdoc --project-path $(CURDIR) --component-rel-path $(COMP_REL_PATH) --module-name $(MOD_NAME)
 
+.PHONY: all-checklinks
+all-checklinks:
+	$(MAKE) $(FOR_GROUP_TARGET) TARGET="checklinks"
+
 # Function to execute a command. Note the empty line before endef to make sure each command
 # gets executed separately instead of concatenated with previous one.
 # Accepts command to execute as first parameter.

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -12,6 +12,7 @@ GOTEST=$(GOCMD) test
 GOOS=$(shell $(GOCMD) env GOOS)
 GOARCH=$(shell $(GOCMD) env GOARCH)
 ADDLICENCESE= addlicense
+MDLINKCHECK=markdown-link-check
 MISSPELL=misspell -error
 MISSPELL_CORRECTION=misspell -w
 LINT=golangci-lint
@@ -94,6 +95,12 @@ checklicense:
 		else \
 			echo "Check License finished successfully"; \
 		fi
+
+.PHONY: checklinks
+checklinks:
+	command -v $(MDLINKCHECK) >/dev/null 2>&1 || { echo >&2 "$(MDLINKCHECK) not installed. Run 'npm install -g markdown-link-check'"; exit 1; }
+	find . -name \*.md -print0 | xargs -0 -n1 \
+		$(MDLINKCHECK) -q -c $(SRC_ROOT)/.github/workflows/check_links_config.json || true
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
This adds tooling for checking links in markdown files throughout the repo.
- Check links in all markdown files: `make all-checklinks`
- Check links in all markdown files in a [module group](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/Makefile#L25-L32): `make all-checklinks GROUP=receiver`
- Check links in a specific module: `(cd my/module && make checklinks)`