### PR TITLE
[mezmoexporter] Log HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `filestorageextension`: Add background compaction capability (#9327)
 - `googlecloudpubsubreceiver`: Added new `Endpoint` and `Insecure` connection configuration options. (#10845)
 - `mongodbreceiver`: Add integration test for mongodb receiver (#10864)
+- `mezmoexporter`: add logging for HTTP errors (#10875)
 
 ### 🧰 Bug fixes 🧰
 

--- a/exporter/mezmoexporter/README.md
+++ b/exporter/mezmoexporter/README.md
@@ -4,7 +4,7 @@ This exporter supports sending OpenTelemetry log data to [LogDNA (Mezmo)](https:
 
 # Configuration options:
 
-- `ingest_url` (optional): Specifies the URL to send ingested logs to.  If not specified, will default to `https://logs.logdna.com/log/ingest`.
+- `ingest_url` (optional): Specifies the URL to send ingested logs to.  If not specified, will default to `https://logs.logdna.com/logs/ingest`.
 - `ingest_key` (required): Ingestion key used to send log data to LogDNA.  See [Ingestion Keys](https://docs.logdna.com/docs/ingestion-key) for more details.
 
 # Example:
@@ -19,7 +19,7 @@ receivers:
 
 exporters:
   mezmo:
-    ingest_url: "https://logs.logdna.com/log/ingest"
+    ingest_url: "https://logs.logdna.com/logs/ingest"
     ingest_key: "00000000000000000000000000000000"
 
 service:

--- a/exporter/mezmoexporter/factory.go
+++ b/exporter/mezmoexporter/factory.go
@@ -46,17 +46,19 @@ func createDefaultConfig() config.Exporter {
 }
 
 // Create a log exporter for exporting to Mezmo
-func createLogsExporter(ctx context.Context, settings component.ExporterCreateSettings, exporter config.Exporter) (component.LogsExporter, error) {
-	if exporter == nil {
+func createLogsExporter(ctx context.Context, settings component.ExporterCreateSettings, exporterConfig config.Exporter) (component.LogsExporter, error) {
+	log := settings.Logger
+
+	if exporterConfig == nil {
 		return nil, errors.New("nil config")
 	}
-	expCfg := exporter.(*Config)
+	expCfg := exporterConfig.(*Config)
 
 	if err := expCfg.Validate(); err != nil {
 		return nil, err
 	}
 
-	exp := newLogsExporter(expCfg, settings.TelemetrySettings, settings.BuildInfo)
+	exp := newLogsExporter(expCfg, settings.TelemetrySettings, settings.BuildInfo, log)
 
 	return exporterhelper.NewLogsExporter(
 		expCfg,

--- a/exporter/mezmoexporter/go.mod
+++ b/exporter/mezmoexporter/go.mod
@@ -7,6 +7,7 @@ require (
 	go.opentelemetry.io/collector v0.53.0
 	go.opentelemetry.io/collector/pdata v0.53.0
 	go.opentelemetry.io/collector/semconv v0.53.0
+	go.uber.org/zap v1.21.0
 )
 
 require (
@@ -35,7 +36,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.7.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
 	golang.org/x/text v0.3.7 // indirect


### PR DESCRIPTION
This change logs HTTP errors for increased visibility. We intend to follow
up at a later date with more robust error handling. This change is
meant to give users some insight into misconfigurations.