### PR TITLE
[receiver/apache] Remove 'dead' link in documentation

### DIFF
--- a/receiver/apachereceiver/documentation.md
+++ b/receiver/apachereceiver/documentation.md
@@ -10,7 +10,7 @@ These are the metrics available for this scraper.
 | ---- | ----------- | ---- | ---- | ---------- |
 | **apache.current_connections** | The number of active connections currently attached to the HTTP server. | {connections} | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.requests** | The number of requests serviced by the HTTP server per second. | {requests} | Sum(Int) | <ul> <li>server_name</li> </ul> |
-| **apache.scoreboard** | The number of workers in each state. The apache scoreboard is an encoded representation of the state of all the server's workers. This metric decodes the scoreboard and presents a count of workers in each state. Additional details can be found [here](https://support.cpanel.net/hc/en-us/articles/360052040234-Understanding-the-Apache-scoreboard). | {workers} | Sum(Int) | <ul> <li>server_name</li> <li>scoreboard_state</li> </ul> |
+| **apache.scoreboard** | The number of workers in each state. The apache scoreboard is an encoded representation of the state of all the server's workers. This metric decodes the scoreboard and presents a count of workers in each state. Additional details can be found [here](https://metacpan.org/pod/Apache::Scoreboard#DESCRIPTION). | {workers} | Sum(Int) | <ul> <li>server_name</li> <li>scoreboard_state</li> </ul> |
 | **apache.traffic** | Total HTTP server traffic. | By | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.uptime** | The amount of time that the server has been running in seconds. | s | Sum(Int) | <ul> <li>server_name</li> </ul> |
 | **apache.workers** | The number of workers currently attached to the HTTP server. | {workers} | Sum(Int) | <ul> <li>server_name</li> <li>workers_state</li> </ul> |

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -82,7 +82,7 @@ metrics:
     extended_documentation: >-
       The apache scoreboard is an encoded representation of the state of all the server's workers.
       This metric decodes the scoreboard and presents a count of workers in each state.
-      Additional details can be found [here](https://support.cpanel.net/hc/en-us/articles/360052040234-Understanding-the-Apache-scoreboard).
+      Additional details can be found [here](https://metacpan.org/pod/Apache::Scoreboard#DESCRIPTION).
     unit: "{workers}"
     sum:
       value_type: int


### PR DESCRIPTION
Resolves #10878