### PR TITLE
filterprocessor: fix unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 ### 🧰 Bug fixes 🧰
 
 - `kubletetstatsreceiver`: Bring back `k8s.container.name` attribute (#10848)
-- `filterprocessor`: Fix unit tests (#10886)
 
 ## v0.53.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### 🧰 Bug fixes 🧰
 
 - `kubletetstatsreceiver`: Bring back `k8s.container.name` attribute (#10848)
+- `filterprocessor`: Fix unit tests (#10886)
 
 ## v0.53.0
 

--- a/processor/filterprocessor/filter_processor_logs_test.go
+++ b/processor/filterprocessor/filter_processor_logs_test.go
@@ -376,9 +376,7 @@ func TestFilterLogProcessor(t *testing.T) {
 				assert.Equal(t, len(wantOut), gotLogs.Len())
 				for idx := range wantOut {
 					val, ok := gotLogs.At(idx).Attributes().Get("name")
-					if !ok {
-						continue
-					}
+					require.True(t, ok)
 					assert.Equal(t, wantOut[idx], val.AsString())
 				}
 			}
@@ -399,9 +397,7 @@ func testResourceLogs(lwrs []logWithResource) plog.Logs {
 		for _, name := range lwr.logNames {
 			l := ls.AppendEmpty()
 			// Add record level attributes
-			for k := 0; k < ls.Len(); k++ {
-				pcommon.NewMapFromRaw(lwrs[i].recordAttributes).CopyTo(ls.At(k).Attributes())
-			}
+			pcommon.NewMapFromRaw(lwrs[i].recordAttributes).CopyTo(l.Attributes())
 			l.Attributes().InsertString("name", name)
 		}
 	}

--- a/processor/filterprocessor/filter_processor_logs_test.go
+++ b/processor/filterprocessor/filter_processor_logs_test.go
@@ -393,7 +393,7 @@ func testResourceLogs(lwrs []logWithResource) plog.Logs {
 	for i, lwr := range lwrs {
 		rl := ld.ResourceLogs().AppendEmpty()
 
-		// Add resource level attribtues
+		// Add resource level attributes
 		pcommon.NewMapFromRaw(lwr.resourceAttributes).CopyTo(rl.Resource().Attributes())
 		ls := rl.ScopeLogs().AppendEmpty().LogRecords()
 		for _, name := range lwr.logNames {

--- a/processor/filterprocessor/filter_processor_logs_test.go
+++ b/processor/filterprocessor/filter_processor_logs_test.go
@@ -398,11 +398,11 @@ func testResourceLogs(lwrs []logWithResource) plog.Logs {
 		ls := rl.ScopeLogs().AppendEmpty().LogRecords()
 		for _, name := range lwr.logNames {
 			l := ls.AppendEmpty()
-			l.Attributes().InsertString("name", name)
-			// Add record level attribtues
+			// Add record level attributes
 			for k := 0; k < ls.Len(); k++ {
 				pcommon.NewMapFromRaw(lwrs[i].recordAttributes).CopyTo(ls.At(k).Attributes())
 			}
+			l.Attributes().InsertString("name", name)
 		}
 	}
 	return ld


### PR DESCRIPTION
seems that `pcommon.NewMapFromRaw(lwrs[i].recordAttributes).CopyTo(ls.At(k).Attributes())` overrides `l.Attributes()` what leads to ignoring setting `name` attribute.
I discovered it while developing some changes in `filterprocessor`