### PR TITLE
New component issue template - Add vendor-specific clarification

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_component.md
+++ b/.github/ISSUE_TEMPLATE/new_component.md
@@ -8,22 +8,28 @@ assignees: ''
 ---
 
 ## The purpose and use-cases of the new component
-<!-- 
+<!--
 This information can be used later on to populate the README for the component. See an example overview [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver#overview).
 -->
 
 ## Example configuration for the component
-<!-- 
+<!--
 This will be used later on when creating `config.go` and added to README as well. See this receiver as an [example](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jaegerreceiver#getting-started).
 -->
 
 ## Telemetry data types supported
-<!-- 
+<!--
 Any combination of traces, metrics and/or logs is valid here.
 -->
 
+## Is this a vendor-specific component? If so, are you proposing to contribute this as a representative of the vendor?
+<!--
+A vendor-specific component directly interfaces with a vendor-specific API and is expected to be maintained by a representative of the same vendor.
+-->
+
+
 ## Sponsor (Optional)
-<!-- 
+<!--
 A sponsor is an approver who will be in charge of being the official reviewer of the code. For vendor-specific components, it's good to have a volunteer sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor components, having a sponsor means that your use case has been validated.
 
 If there are no sponsors yet for the component, it's fine: use the issue as a means to try to find a sponsor for your component.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,9 @@ providing the following information:
 
 * Who's the sponsor for your component. A sponsor is an approver who will be in charge of being the official reviewer of
   the code and become a code owner for the component. For vendor-specific components, it's good to have a volunteer
-  sponsor. If you can't find one, we'll assign one in a round-robin fashion. For non-vendor specific components, having
-  a sponsor means that your use case has been validated.
+  sponsor. If you can't find one, we'll assign one in a round-robin fashion. A vendor-specific component directly interfaces
+  with a vendor-specific API and is expected to be maintained by a representative of the same vendor. For non-vendor specific
+  components, having a sponsor means that your use case has been validated.
 * Some information about your component, such as the reasoning behind it, use-cases, telemetry data types supported, and
   anything else you think is relevant for us to make a decision about accepting the component.
 * The configuration options your component will accept. This will help us understand what it does and have an idea of


### PR DESCRIPTION
This is a proposal to clarify the meaning of a "vendor-specific component". It would add a simple definition to the contribution guidelines, and a corresponding question to the new component issue template. 

The motivation for this is to differentiate between component proposals that will be auto-assigned a sponsor vs those that require validation of the use case.