### PR TITLE
[docs] update observer list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- `observer`: Document available observers (#10889)
-
 ## 🛑 Breaking changes 🛑
 
 ### 🚩 Deprecations 🚩

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `observer`: Document available observers (#10889)
+
 ## 🛑 Breaking changes 🛑
 
 ### 🚩 Deprecations 🚩

--- a/extension/observer/README.md
+++ b/extension/observer/README.md
@@ -6,5 +6,8 @@ Currently the only component that uses observers is the [receiver_creator](../..
 
 ## Current Observers
 
-* [k8sobserver](k8sobserver/README.md)
-* [hostobserver](hostobserver/README.md)
+* [docker_observer](dockerobserver/README.md)
+* [ecs_observer](ecsobserver/README.md)
+* [ecs_task_observer](ecstaskobserver/README.md)
+* [host_observer](hostobserver/README.md)
+* [k8s_observer](k8sobserver/README.md)


### PR DESCRIPTION
**Description:**
These doc-only changes add missing observer entries and use the component id type values instead of the package name 

**Documentation:**
Updated observer readme.