### PR TITLE
[receiver/vcenter] Change `host_effective` attribute to bool type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 🛑 Breaking changes 🛑
 
+- `vcenterreceiver`: Changed the attribute `effective` on `vcenter.cluster.host.count` as it will now be reported as a bool rather than a string (#10914)
+
 ### 🚩 Deprecations 🚩
 
 - `datadogexporter`: Deprecate `Sanitize` method of `Config` struct (#8829)

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -71,7 +71,7 @@ metrics:
 | disk_direction (direction) | The direction of disk latency. | read, write |
 | disk_state | The state of storage and whether it is already allocated or free. | available, used |
 | disk_type | The type of storage device that is being recorded. | virtual, physical |
-| host_effective (effective) | Whether the host is effective in the vCenter cluster. | true, false |
+| host_effective (effective) | Whether the host is effective in the vCenter cluster. |  |
 | latency_type (type) | The type of disk latency being reported. | kernel, device |
 | throughput_direction (direction) | The direction of network throughput. | transmitted, received |
 | vm_count_power_state (power_state) | Whether the virtual machines are powered on or off. | on, off |

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_v2.go
@@ -242,32 +242,6 @@ var MapAttributeDiskType = map[string]AttributeDiskType{
 	"physical": AttributeDiskTypePhysical,
 }
 
-// AttributeHostEffective specifies the a value host_effective attribute.
-type AttributeHostEffective int
-
-const (
-	_ AttributeHostEffective = iota
-	AttributeHostEffectiveTrue
-	AttributeHostEffectiveFalse
-)
-
-// String returns the string representation of the AttributeHostEffective.
-func (av AttributeHostEffective) String() string {
-	switch av {
-	case AttributeHostEffectiveTrue:
-		return "true"
-	case AttributeHostEffectiveFalse:
-		return "false"
-	}
-	return ""
-}
-
-// MapAttributeHostEffective is a helper map of string to AttributeHostEffective attribute value.
-var MapAttributeHostEffective = map[string]AttributeHostEffective{
-	"true":  AttributeHostEffectiveTrue,
-	"false": AttributeHostEffectiveFalse,
-}
-
 // AttributeLatencyType specifies the a value latency_type attribute.
 type AttributeLatencyType int
 
@@ -465,7 +439,7 @@ func (m *metricVcenterClusterHostCount) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricVcenterClusterHostCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, hostEffectiveAttributeValue string) {
+func (m *metricVcenterClusterHostCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, hostEffectiveAttributeValue bool) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -473,7 +447,7 @@ func (m *metricVcenterClusterHostCount) recordDataPoint(start pcommon.Timestamp,
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetIntVal(val)
-	dp.Attributes().Insert("effective", pcommon.NewValueString(hostEffectiveAttributeValue))
+	dp.Attributes().Insert("effective", pcommon.NewValueBool(hostEffectiveAttributeValue))
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2392,8 +2366,8 @@ func (mb *MetricsBuilder) RecordVcenterClusterCPULimitDataPoint(ts pcommon.Times
 }
 
 // RecordVcenterClusterHostCountDataPoint adds a data point to vcenter.cluster.host.count metric.
-func (mb *MetricsBuilder) RecordVcenterClusterHostCountDataPoint(ts pcommon.Timestamp, val int64, hostEffectiveAttributeValue AttributeHostEffective) {
-	mb.metricVcenterClusterHostCount.recordDataPoint(mb.startTime, ts, val, hostEffectiveAttributeValue.String())
+func (mb *MetricsBuilder) RecordVcenterClusterHostCountDataPoint(ts pcommon.Timestamp, val int64, hostEffectiveAttributeValue bool) {
+	mb.metricVcenterClusterHostCount.recordDataPoint(mb.startTime, ts, val, hostEffectiveAttributeValue)
 }
 
 // RecordVcenterClusterMemoryEffectiveDataPoint adds a data point to vcenter.cluster.memory.effective metric.

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -34,11 +34,9 @@ attributes:
       - virtual
       - physical
   host_effective:
+    type: bool
     value: effective
     description: Whether the host is effective in the vCenter cluster.
-    enum:
-      - "true"
-      - "false"
   disk_direction:
     value: direction
     description: The direction of disk latency.

--- a/receiver/vcenterreceiver/scraper.go
+++ b/receiver/vcenterreceiver/scraper.go
@@ -130,8 +130,8 @@ func (v *vcenterMetricScraper) collectCluster(
 	v.mb.RecordVcenterClusterCPUEffectiveDataPoint(now, int64(s.EffectiveCpu))
 	v.mb.RecordVcenterClusterMemoryEffectiveDataPoint(now, s.EffectiveMemory)
 	v.mb.RecordVcenterClusterMemoryLimitDataPoint(now, s.TotalMemory)
-	v.mb.RecordVcenterClusterHostCountDataPoint(now, int64(s.NumHosts-s.NumEffectiveHosts), metadata.AttributeHostEffectiveFalse)
-	v.mb.RecordVcenterClusterHostCountDataPoint(now, int64(s.NumEffectiveHosts), metadata.AttributeHostEffectiveTrue)
+	v.mb.RecordVcenterClusterHostCountDataPoint(now, int64(s.NumHosts-s.NumEffectiveHosts), false)
+	v.mb.RecordVcenterClusterHostCountDataPoint(now, int64(s.NumEffectiveHosts), true)
 	v.mb.EmitForResource(
 		metadata.WithVcenterClusterName(c.Name()),
 	)

--- a/receiver/vcenterreceiver/testdata/metrics/expected.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.json
@@ -3783,7 +3783,7 @@
                                             {
                                                 "key": "effective",
                                                 "value": {
-                                                    "stringValue": "false"
+                                                    "boolValue": false
                                                 }
                                             }
                                         ],
@@ -3796,7 +3796,7 @@
                                             {
                                                 "key": "effective",
                                                 "value": {
-                                                    "stringValue": "true"
+                                                    "boolValue": true
                                                 }
                                             }
                                         ],

--- a/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
+++ b/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
@@ -813,7 +813,7 @@
                                             {
                                                 "key": "effective",
                                                 "value": {
-                                                    "stringValue": "false"
+                                                    "boolValue": false
                                                 }
                                             }
                                         ],
@@ -826,7 +826,7 @@
                                             {
                                                 "key": "effective",
                                                 "value": {
-                                                    "stringValue": "true"
+                                                    "boolValue": true
                                                 }
                                             }
                                         ],


### PR DESCRIPTION
**Description:**  Breaking change for the `vcenter.cluster.host.count` metric as the attribute `effective` will now be reported as a bool rather than a string.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** Resolves #10914 

**Testing:** Catched in current `scraper_test.go` and `integration_test`

**Documentation:** Changelog entry and auto-generated `documentation.md`