### PR TITLE
[testbed] Provide mechanism to continue test when violations may be t…

### DIFF
--- a/testbed/testbed/options.go
+++ b/testbed/testbed/options.go
@@ -38,6 +38,10 @@ type ResourceSpec struct {
 	// Period during which CPU and RAM of the process are measured.
 	// Bigger numbers will result in more averaging of short spikes.
 	ResourceCheckPeriod time.Duration
+
+	// The number of consecutive violations necessary to trigger a failure.
+	// This is useful for tests which can tolerate transitory violations.
+	MaxConsecutiveFailures uint32
 }
 
 // isSpecified returns true if any part of ResourceSpec is specified,

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -101,7 +101,13 @@ func TestBallastMemory(t *testing.T) {
 				&testbed.PerfTestValidator{},
 				performanceResultsSummary,
 				testbed.WithSkipResults(),
-				testbed.WithResourceLimits(testbed.ResourceSpec{ExpectedMaxRAM: test.maxRSS}),
+				testbed.WithResourceLimits(
+					testbed.ResourceSpec{
+						ExpectedMaxRAM:         test.maxRSS,
+						ResourceCheckPeriod:    time.Second,
+						MaxConsecutiveFailures: 3,
+					},
+				),
 			)
 			tc.StartAgent()
 


### PR DESCRIPTION
This is another followup to #10359 and #10601.

This test fails sometimes due to active garbage collection causing a spike in memory usage. Previous attempts to fix this have missed the fact that a separate goroutine is also measuring and killing the sub-process.

It would be quite messy to introduce custom validation logic for this one case, so instead I am proposing to add a simple general mechanism that I believe may accommodate this case and also could be useful in the future. The mechanism basically allows for [debouncing](https://en.wiktionary.org/wiki/debounce) of the measurement (ie. allows the resource spec to require multiple consecutive failures before it is sure the test failed).

The previously added logic is also kept in place in order to validate that any exception to the normal expectation is within a narrowly defined scope (if memory is above nominal, it must be roughly nominal + ballast size).