### PR TITLE
[reciever/windowseventlogreceiver] Fixed incorrect example config for Windows Event Log Receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - `kubletetstatsreceiver`: Bring back `k8s.container.name` attribute (#10848)
 - `pkg/stanza`: Skip building fingerprint in case of configuration change (#10485)
 - `transformprocessor`: Fix issue where some metric fields were not working correctly in conditions. (#10473)
-- `windowseventlogreceiver`: Fixed example config in readme ()
+- `windowseventlogreceiver`: Fixed example config in readme (#10971)
 
 ## v0.53.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `kubletetstatsreceiver`: Bring back `k8s.container.name` attribute (#10848)
 - `pkg/stanza`: Skip building fingerprint in case of configuration change (#10485)
 - `transformprocessor`: Fix issue where some metric fields were not working correctly in conditions. (#10473)
+- `windowseventlogreceiver`: Fixed example config in readme ()
 
 ## v0.53.0
 

--- a/receiver/windowseventlogreceiver/README.md
+++ b/receiver/windowseventlogreceiver/README.md
@@ -44,8 +44,9 @@ Each operator performs a simple responsibility, such as parsing a timestamp or J
 
 Configuration:
 ```yaml
-- type: windowseventlog
-  channel: application
+receivers:
+    windowseventlog:
+        channel: application
 ```
 
 Output entry sample:


### PR DESCRIPTION
**Description:** Readme in the Windows Log Event Receiver was incorrect referring to an older style configuration. Updated it to be correct

