### PR TITLE
[exporter/observiq] Deprecate observiq exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### 🚩 Deprecations 🚩
 
 - `datadogexporter`: Deprecate `Sanitize` method of `Config` struct (#8829)
-
+- `observiqexporter`: Deprecate the observiq exporter (#10977)
 ### 🚀 New components 🚀
 
 - `expvarreceiver`: Include `expvarreceiver` in components (#10847)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - `datadogexporter`: Deprecate `Sanitize` method of `Config` struct (#8829)
 - `observiqexporter`: Deprecate the observiq exporter (#10977)
+
 ### 🚀 New components 🚀
 
 - `expvarreceiver`: Include `expvarreceiver` in components (#10847)

--- a/exporter/observiqexporter/README.md
+++ b/exporter/observiqexporter/README.md
@@ -1,10 +1,10 @@
 # observIQ Exporter
 
-| Status                   |                    |
-| ------------------------ |--------------------|
-| Stability                | [in development]   |
-| Supported pipeline types | logs               |
-| Distributions            | none               |
+| Status                   |              |
+|--------------------------|--------------|
+| Stability                | [deprecated] |
+| Supported pipeline types | logs         |
+| Distributions            | none         |
 
 This exporter supports sending log data to [observIQ](https://observiq.com/)
 
@@ -37,4 +37,4 @@ The full list of settings exposed for this exporter are documented [here](config
 This exporter also offers proxy support as documented
 [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter#proxy-support).
 
-[in development]:https://github.com/open-telemetry/opentelemetry-collector#in-development
+[deprecated]:https://github.com/open-telemetry/opentelemetry-collector#deprecated

--- a/exporter/observiqexporter/README.md
+++ b/exporter/observiqexporter/README.md
@@ -8,6 +8,8 @@
 
 This exporter supports sending log data to [observIQ](https://observiq.com/)
 
+** NOTE: ** This exporter is deprecated and is scheduled to be removed in v0.56.0
+
 ## Configuration
 
 One of the following configuration options are required:

--- a/exporter/observiqexporter/factory.go
+++ b/exporter/observiqexporter/factory.go
@@ -17,11 +17,13 @@ package observiqexporter // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.uber.org/zap"
 )
 
 const (
@@ -30,6 +32,8 @@ const (
 	defaultEndpoint      = "https://nozzle.app.observiq.com/v1/add"
 	defaultDialerTimeout = 10 * time.Second
 )
+
+var logOnce sync.Once
 
 // NewFactory creates a factory for observIQ exporter
 func NewFactory() component.ExporterFactory {
@@ -60,9 +64,16 @@ func createLogsExporter(
 	params component.ExporterCreateSettings,
 	config config.Exporter,
 ) (exporter component.LogsExporter, err error) {
+	logDeprecation(params.Logger)
 	if config == nil {
 		return nil, errors.New("nil config")
 	}
 	exporterConfig := config.(*Config)
 	return newObservIQLogExporter(exporterConfig, params)
+}
+
+func logDeprecation(logger *zap.Logger) {
+	logOnce.Do(func() {
+		logger.Warn("The observiq exporter is deprecated and will be removed in future versions.")
+	})
 }

--- a/exporter/observiqexporter/factory.go
+++ b/exporter/observiqexporter/factory.go
@@ -17,13 +17,11 @@ package observiqexporter // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"context"
 	"errors"
-	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.uber.org/zap"
 )
 
 const (
@@ -32,8 +30,6 @@ const (
 	defaultEndpoint      = "https://nozzle.app.observiq.com/v1/add"
 	defaultDialerTimeout = 10 * time.Second
 )
-
-var logOnce sync.Once
 
 // NewFactory creates a factory for observIQ exporter
 func NewFactory() component.ExporterFactory {
@@ -64,16 +60,10 @@ func createLogsExporter(
 	params component.ExporterCreateSettings,
 	config config.Exporter,
 ) (exporter component.LogsExporter, err error) {
-	logDeprecation(params.Logger)
+	params.Logger.Warn("The observiq exporter is deprecated and will be removed in future versions.")
 	if config == nil {
 		return nil, errors.New("nil config")
 	}
 	exporterConfig := config.(*Config)
 	return newObservIQLogExporter(exporterConfig, params)
-}
-
-func logDeprecation(logger *zap.Logger) {
-	logOnce.Do(func() {
-		logger.Warn("The observiq exporter is deprecated and will be removed in future versions.")
-	})
 }

--- a/exporter/observiqexporter/factory.go
+++ b/exporter/observiqexporter/factory.go
@@ -60,7 +60,7 @@ func createLogsExporter(
 	params component.ExporterCreateSettings,
 	config config.Exporter,
 ) (exporter component.LogsExporter, err error) {
-	params.Logger.Warn("The observiq exporter is deprecated and will be removed in future versions.")
+	params.Logger.Warn("The observiq exporter is deprecated and will be removed in v0.56.0.")
 	if config == nil {
 		return nil, errors.New("nil config")
 	}

--- a/exporter/observiqexporter/go.mod
+++ b/exporter/observiqexporter/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: elasticexporter exporter is deprecated and will be removed in future versions.
 module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/observiqexporter
 
 go 1.17


### PR DESCRIPTION
**Description:** <Describe what has changed.>
* Changed observiq exporter status to "deprecated"
* Added logging statement warning of deprecation

As observIQ cloud is being sunsetted, this component will no longer be useful to users, and will be removed in a future version.

**Testing:** <Describe what testing was performed and which tests were added.>
* Manually tested to make sure the deprecation statement is logged.

**Documentation:** <Describe the documentation added.>
Changed status to deprecated