### PR TITLE
Enable depguard linter, ensure no usage of sync/atomic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -105,6 +105,7 @@ linters-settings:
 
 linters:
   enable:
+    - depguard
     - errcheck
     - errorlint
     - exportloopref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `pkg/stanza`: Skip building fingerprint in case of configuration change (#10485)
 - `transformprocessor`: Fix issue where some metric fields were not working correctly in conditions. (#10473)
 - `windowseventlogreceiver`: Fixed example config in readme (#10971)
+- `pkg/stanza`: Fix access to atomic variable without using atomic package (#11023)
 
 ## v0.53.0
 

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.53.0
 	go.opentelemetry.io/collector/pdata v0.53.0
+	go.uber.org/atomic v1.9.0
 	go.uber.org/multierr v1.8.0
 )
 
@@ -64,7 +65,6 @@ require (
 	go.opentelemetry.io/otel v1.7.0 // indirect
 	go.opentelemetry.io/otel/metric v0.30.0 // indirect
 	go.opentelemetry.io/otel/trace v1.7.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/pkg/stanza/operator/parser/regex/cache_test.go
+++ b/pkg/stanza/operator/parser/regex/cache_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestNewMemoryCache(t *testing.T) {
@@ -225,7 +226,7 @@ func TestThrottledLimiter(t *testing.T) {
 	// has not been called yet, so the reset go routine is not running
 	l := atomicLimiter{
 		max:      max,
-		count:    max + 1,
+		count:    atomic.NewUint64(max + 1),
 		interval: 1,
 	}
 


### PR DESCRIPTION
This fixes a bug in the pkg/stanza, since access to an atomic variable was made without using atomic package.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>