### PR TITLE
[exporter/datadog] Remove useless logs

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -164,7 +164,6 @@ func (f *factory) createMetricsExporter(
 
 	cfg := c.(*ddconfig.Config)
 
-	set.Logger.Info("sanitizing Datadog metrics exporter configuration")
 	if err := cfg.Sanitize(set.Logger); err != nil {
 		return nil, err
 	}
@@ -229,7 +228,6 @@ func (f *factory) createTracesExporter(
 
 	cfg := c.(*ddconfig.Config)
 
-	set.Logger.Info("sanitizing Datadog traces exporter configuration")
 	if err := cfg.Sanitize(set.Logger); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description:** Remove logs that duplicate those of the service.

I think this does not warrant a changelog entry.

**Link to tracking Issue:** Mentioned in #10875
