### PR TITLE
[receiver/hostmetrics] add udp connections

### DIFF
--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -179,8 +179,7 @@ The following feature gates control the transition process:
 - **receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without
   `direction` attribute are emitted by the receiver.
 - **receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with 
-  `direction`
-  attribute are emitted by the receiver.
+  `direction` attribute are emitted by the receiver.
 
 ##### Transition schedule:
 
@@ -241,6 +240,64 @@ receivers:
 
 - https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11815
 - https://github.com/open-telemetry/opentelemetry-specification/pull/2617
+
+#### Transition from metrics with "protocol" attribute
+
+Some host metrics reported are transitioning from being reported with a `protocol` attribute to being reported with the
+protocol included in the metric name to adhere to the OpenTelemetry specification
+(https://github.com/open-telemetry/opentelemetry-specification/pull/2675):
+
+- `network` scraper metrics:
+  - `system.network.connections` will become:
+    - `system.network.tcp.connections`
+    - `system.network.udp.connections`
+
+The following feature gates control the transition process:
+
+- **receiver.hostmetricsreceiver.emitMetricsWithoutProtocolAttribute**: controls if the new metrics without
+  `protocol` attribute are emitted by the receiver.
+- **receiver.hostmetricsreceiver.emitMetricsWithProtocolAttribute**: controls if the deprecated metrics with 
+  `protocol` attribute are emitted by the receiver.
+
+##### Transition schedule:
+
+1. v0.58.0, August 2022:
+
+- The new metrics are available for network scraper, but disabled by default, they can be enabled with the feature gates.
+- The old metrics with `protocol` attribute are deprecated with a warning.
+- `receiver.hostmetricsreceiver.emitMetricsWithProtocolAttribute` is enabled by default.
+- `receiver.hostmetricsreceiver.emitMetricsWithoutProtocolAttribute` is disabled by default.
+
+2. v0.60.0, September 2022:
+
+- The new metrics are enabled by default, deprecated metrics disabled, they can be enabled with the feature gates.
+- `receiver.hostmetricsreceiver.emitMetricsWithProtocolAttribute` is disabled by default.
+- `receiver.hostmetricsreceiver.emitMetricsWithoutProtocolAttribute` is enabled by default.
+
+3. v0.62.0, October 2022:
+
+- The feature gates are removed.
+- The new metrics without `protocol` attribute are always emitted.
+- The deprecated metrics with `protocol` attribute are no longer available.
+
+##### Usage:
+
+To enable the new metrics without `protocol` attribute and disable the deprecated metrics, run OTel Collector with the 
+following arguments:
+
+```sh
+otelcol --feature-gates=-receiver.hostmetricsreceiver.emitMetricsWithProtocolAttribute,+receiver.hostmetricsreceiver.emitMetricsWithoutProtocolAttribute
+```
+
+It's also possible to emit both the deprecated and the new metrics:
+
+```sh
+otelcol --feature-gates=+receiver.hostmetricsreceiver.emitMetricsWithProtocolAttribute,+receiver.hostmetricsreceiver.emitMetricsWithoutProtocolAttribute
+```
+
+##### More information:
+
+- https://github.com/open-telemetry/opentelemetry-specification/pull/2675
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/hostmetricsreceiver/internal/scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper.go
@@ -25,6 +25,8 @@ import (
 const (
 	EmitMetricsWithDirectionAttributeFeatureGateID    = "receiver.hostmetricsreceiver.emitMetricsWithDirectionAttribute"
 	EmitMetricsWithoutDirectionAttributeFeatureGateID = "receiver.hostmetricsreceiver.emitMetricsWithoutDirectionAttribute"
+	EmitMetricsWithProtocolAttributeFeatureGateID     = "receiver.hostmetricsreceiver.emitMetricsWithProtocolAttribute"
+	EmitMetricsWithoutProtocolAttributeFeatureGateID  = "receiver.hostmetricsreceiver.emitMetricsWithoutProtocolAttribute"
 )
 
 var (
@@ -47,11 +49,32 @@ var (
 			"attribute. For more details, see: " +
 			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md#feature-gate-configurations",
 	}
+	emitMetricsWithProtocolAttributeFeatureGate = featuregate.Gate{
+		ID:      EmitMetricsWithProtocolAttributeFeatureGateID,
+		Enabled: true,
+		Description: "Some process host metrics reported are transitioning from being reported with a protocol " +
+			"attribute to being reported with the protocol included in the metric name to adhere to the " +
+			"OpenTelemetry specification. This feature gate controls emitting the old metrics with the protocol " +
+			"attribute. For more details, see: " +
+			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md#feature-gate-configurations",
+	}
+
+	emitMetricsWithoutProtocolAttributeFeatureGate = featuregate.Gate{
+		ID:      EmitMetricsWithoutProtocolAttributeFeatureGateID,
+		Enabled: false,
+		Description: "Some process host metrics reported are transitioning from being reported with a protcol " +
+			"attribute to being reported with the protocol included in the metric name to adhere to the " +
+			"OpenTelemetry specification. This feature gate controls emitting the new metrics without the protocol " +
+			"attribute. For more details, see: " +
+			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md#feature-gate-configurations",
+	}
 )
 
 func init() {
 	featuregate.GetRegistry().MustRegister(emitMetricsWithDirectionAttributeFeatureGate)
 	featuregate.GetRegistry().MustRegister(emitMetricsWithoutDirectionAttributeFeatureGate)
+	featuregate.GetRegistry().MustRegister(emitMetricsWithProtocolAttributeFeatureGate)
+	featuregate.GetRegistry().MustRegister(emitMetricsWithoutProtocolAttributeFeatureGate)
 }
 
 // ScraperFactory can create a MetricScraper.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/documentation.md
@@ -23,6 +23,8 @@ These are the metrics available for this scraper.
 | **system.network.packets** | The number of packets transferred. (Deprecated) | {packets} | Sum(Int) | <ul> <li>device</li> <li>direction</li> </ul> |
 | **system.network.packets.receive** | The number of packets received. | {packets} | Sum(Int) | <ul> <li>device</li> </ul> |
 | **system.network.packets.transmit** | The number of packets transmitted. | {packets} | Sum(Int) | <ul> <li>device</li> </ul> |
+| **system.network.tcp.connections** | The number of TCP connections. | {connections} | Sum(Int) | <ul> <li>state</li> </ul> |
+| **system.network.udp.connections** | The number of UDP connections. | {connections} | Sum(Int) | <ul> </ul> |
 
 **Highlighted metrics** are emitted by default. Other metrics are optional and not emitted by default.
 Any metric can be enabled or disabled with the following scraper configuration:

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -150,6 +150,7 @@ metrics:
       monotonic: true
     attributes: [device]
 
+  # produced when receiver.hostmetricsreceiver.emitMetricsWithProtocolAttribute feature gate is enabled
   system.network.connections:
     enabled: true
     description: The number of connections.
@@ -159,6 +160,27 @@ metrics:
       aggregation: cumulative
       monotonic: false
     attributes: [protocol, state]
+
+  # produced when receiver.hostmetricsreceiver.emitMetricsWithoutProtocolAttribute feature gate is enabled
+  system.network.tcp.connections:
+    enabled: true
+    description: The number of TCP connections.
+    unit: "{connections}"
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
+    attributes: [state]
+
+  # produced when receiver.hostmetricsreceiver.emitMetricsWithoutProtocolAttribute feature gate is enabled
+  system.network.udp.connections:
+    enabled: true
+    description: The number of UDP connections.
+    unit: "{connections}"
+    sum:
+      value_type: int
+      aggregation: cumulative
+      monotonic: false
 
   system.network.conntrack.count:
     enabled: false

--- a/unreleased/hostmetrics-udp.yaml
+++ b/unreleased/hostmetrics-udp.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove protocol for network connection metrics. The feature gate: `receiver.hostmetricsreceiver.emitMetricsWithoutProtocolAttribute` can be set to apply the following "
+
+# One or more tracking issues related to the change
+issues: [11046]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |-
+    network scraper metrics:
+      - `system.network.connections` will become:
+        - `system.network.tcp.connections`
+        - `system.network.udp.connections`


### PR DESCRIPTION
This change adds a metric for UDP connections `system.network.udp.connections`.

As part of this I've renamed `system.network.connections` to `system.network.tcp.connections` as it wasn't clear to me that UDP and TCP provide any value when combined. Additionally, the state attribute didn't make sense for UDP connections.
