### PR TITLE
[receiver/metricstransform] Remove calculation of SumOfSquaredDeviation

### DIFF
--- a/processor/metricstransformprocessor/datapoint_aggregation.go
+++ b/processor/metricstransformprocessor/datapoint_aggregation.go
@@ -193,24 +193,11 @@ func (mtp *metricsTransformProcessor) computeDistVals(val1 *metricspb.Distributi
 				},
 			},
 		},
-		Count:                 val1.Count + val2.Count,
-		Sum:                   val1.Sum + val2.Sum,
-		Buckets:               buckets,
-		SumOfSquaredDeviation: mtp.computeSumOfSquaredDeviation(val1, val2),
+		Count:   val1.Count + val2.Count,
+		Sum:     val1.Sum + val2.Sum,
+		Buckets: buckets,
 	}
 	return newDistVal
-}
-
-// computeSumOfSquaredDeviation computes the combined SumOfSquaredDeviation from the two points
-// Formula derived from https://math.stackexchange.com/questions/2971315/how-do-i-combine-standard-deviations-of-two-groups
-// SSDcomb = SSD1 + n(ave(x) - ave(z))^2 + SSD2 +n(ave(y) - ave(z))^2
-func (mtp *metricsTransformProcessor) computeSumOfSquaredDeviation(val1 *metricspb.DistributionValue, val2 *metricspb.DistributionValue) float64 {
-	mean1 := val1.Sum / float64(val1.Count)
-	mean2 := val2.Sum / float64(val2.Count)
-	meanCombined := (val1.Sum + val2.Sum) / float64(val1.Count+val2.Count)
-	squaredMeanDiff1 := math.Pow(mean1-meanCombined, 2)
-	squaredMeanDiff2 := math.Pow(mean2-meanCombined, 2)
-	return val1.SumOfSquaredDeviation + (float64(val1.Count) * squaredMeanDiff1) + val2.SumOfSquaredDeviation + (float64(val2.Count) * squaredMeanDiff2)
 }
 
 // pickExemplar picks an exemplar from 2 randomly with each haing a 50% chance of getting picked

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -17,7 +17,6 @@ package metricstransformprocessor
 
 import (
 	"context"
-	"math"
 	"testing"
 
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"
@@ -73,72 +72,6 @@ func TestMetricsTransformProcessor(t *testing.T) {
 			assert.NoError(t, mtp.Shutdown(ctx))
 		})
 	}
-}
-
-func TestComputeDistVals(t *testing.T) {
-	ssdTests := []struct {
-		name        string
-		pointGroup1 []float64
-		pointGroup2 []float64
-	}{
-		{
-			name:        "similar point groups",
-			pointGroup1: []float64{1, 2, 3, 7, 4},
-			pointGroup2: []float64{1, 2, 3, 3, 1},
-		},
-		{
-			name:        "different size point groups",
-			pointGroup1: []float64{1, 2, 3, 7, 4},
-			pointGroup2: []float64{1},
-		},
-		{
-			name:        "point groups with an outlier",
-			pointGroup1: []float64{1, 2, 3, 7, 1000},
-			pointGroup2: []float64{1, 2, 5},
-		},
-	}
-
-	for _, test := range ssdTests {
-		t.Run(test.name, func(t *testing.T) {
-			p := newMetricsTransformProcessor(nil, nil)
-
-			pointGroup1 := test.pointGroup1
-			pointGroup2 := test.pointGroup2
-			sum1, sumOfSquaredDeviation1 := calculateSumOfSquaredDeviation(pointGroup1)
-			sum2, sumOfSquaredDeviation2 := calculateSumOfSquaredDeviation(pointGroup2)
-			_, sumOfSquaredDeviation := calculateSumOfSquaredDeviation(append(pointGroup1, pointGroup2...))
-
-			val1 := &metricspb.DistributionValue{
-				Count:                 int64(len(pointGroup1)),
-				Sum:                   sum1,
-				SumOfSquaredDeviation: sumOfSquaredDeviation1,
-			}
-
-			val2 := &metricspb.DistributionValue{
-				Count:                 int64(len(pointGroup2)),
-				Sum:                   sum2,
-				SumOfSquaredDeviation: sumOfSquaredDeviation2,
-			}
-
-			outVal := p.computeSumOfSquaredDeviation(val1, val2)
-
-			assert.Equal(t, sumOfSquaredDeviation, outVal)
-		})
-	}
-}
-
-// calculateSumOfSquaredDeviation returns the sum and the sumOfSquaredDeviation for this slice
-func calculateSumOfSquaredDeviation(slice []float64) (sum float64, sumOfSquaredDeviation float64) {
-	sum = 0
-	for _, e := range slice {
-		sum += e
-	}
-	ave := sum / float64(len(slice))
-	sumOfSquaredDeviation = 0
-	for _, e := range slice {
-		sumOfSquaredDeviation += math.Pow((e - ave), 2)
-	}
-	return
 }
 
 func TestExemplars(t *testing.T) {


### PR DESCRIPTION
This change removes calculation of `SumOfSquaredDeviation` field of OpenCensus distribution metric which is not being used anymore, because OTLP doesn't have such field: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/15b930b99dd777eba20391fbf5b5ece3cda0ff8d/pkg/translator/opencensus/metrics_to_oc.go#L271. This code used to work when collector was using the OC metric format as pipeline data, now this is essentially dead code.
