### PR TITLE
[processor/k8sattributesprocessor] add debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `mezmoexporter`: add logging for HTTP errors (#10875)
 - `signalfxexporter`: Enable the exporting of seven Kubernetes metrics used in Splunk/SignalFx content by default (#11032)
 - `googlecloudexporter`: Support writing to multiple GCP projects by setting the `gcp.project.id` resource attribute, and support service account impersonation (#11051)
+- `k8sattributeprocessor`: Add debug logs to help identify missing attributes (#11060)
 
 ### 🧰 Bug fixes 🧰
 

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -108,6 +108,7 @@ func (kp *kubernetesprocessor) processLogs(ctx context.Context, ld plog.Logs) (p
 // processResource adds Pod metadata tags to resource based on pod association configuration
 func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pcommon.Resource) {
 	podIdentifierKey, podIdentifierValue := extractPodID(ctx, resource.Attributes(), kp.podAssociations)
+	kp.logger.Debug("evaluating pod identifier", zap.String("key", podIdentifierKey), zap.Any("value", podIdentifierValue))
 	if podIdentifierKey != "" {
 		resource.Attributes().InsertString(podIdentifierKey, string(podIdentifierValue))
 	}
@@ -118,6 +119,8 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 
 	if podIdentifierKey != "" {
 		if pod, ok := kp.kc.GetPod(podIdentifierValue); ok {
+			kp.logger.Debug("getting the pod", zap.String("key", podIdentifierKey), zap.Any("pod", pod))
+
 			for key, val := range pod.Attributes {
 				resource.Attributes().InsertString(key, val)
 			}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adding debug logs to k8sattributesprocessor - at the moment it is impossible to debug when the k8sattributeprocessor fails to add metadata. Adding debug logs for pod identification allows us to see the issue with pod association.
 
**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Tested locally:

Here are some examples of messages:

```
2022-06-10T07:08:12.818Z        debug   k8sattributesprocessor/processor.go:111 Evaluating Pod Identifier       {"kind": "processor", "name": "k8sattributes", "pipeline": "traces", "pod identifier key": "k8s.pod.ip", "pod identifier value": "10.244.0.179"}
```

```
2022-06-10T07:08:06.610Z        debug   k8sattributesprocessor/processor.go:111 Evaluating Pod Identifier       {"kind": "processor", "name": "k8sattributes", "pipeline": "metrics", "pod identifier key": "", "pod identifier value": ""}  
```
```
2022-06-10T07:08:12.818Z        debug   k8sattributesprocessor/processor.go:123 Getting the pod {"kind": "processor", "name": "k8sattributes", "pipeline": "traces", "pod identifier value": "k8s.pod.ip", "pod": {"Name":"jaeger-http-app-7f7c9657cd-h8rfb","Address":"10.244.0.179","PodUID":"293411d1-5132-46d0-aa6a-df138ca937aa","Attributes":{"":"jaeger-http-app","k8s.deployment.name":"jaeger-http-app","k8s.na
mespace.name":"sys-mon"},"StartTime":"2022-06-09T11:23:02Z","Ignore":false,"Namespace":"sys-mon","Containers":null,"DeletedAt":"0001-01-
01T00:00:00Z"}}       
```
**Documentation:** <Describe the documentation added.>