### PR TITLE
[docs] Add status header for zookeeperreceiver

### DIFF
--- a/receiver/zookeeperreceiver/README.md
+++ b/receiver/zookeeperreceiver/README.md
@@ -1,6 +1,10 @@
-**Under development - not ready for use.**
-
 # Zookeeper Receiver
+
+| Status                   |                  |
+| ------------------------ | ---------------- |
+| Stability                | [in development] |
+| Supported pipeline types | traces           |
+| Distributions            | [contrib]        |
 
 The Zookeeper receiver collects metrics from a Zookeeper instance, using the `mntr` command. The `mntr` 4 letter word command needs
 to be enabled for the receiver to be able to collect metrics.
@@ -18,3 +22,6 @@ receivers:
     endpoint: "localhost:2181"
     collection_interval: 20s
 ```
+
+[in development]: https://github.com/open-telemetry/opentelemetry-collector#in-development
+[contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
Add status header for zookeeperreceiver

fix:https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10116