### PR TITLE
[internal/k8s/k8sclient] Skip flaky TestPodClient_NamespaceToRunningP…

### DIFF
--- a/internal/aws/k8s/k8sclient/pod_test.go
+++ b/internal/aws/k8s/k8sclient/pod_test.go
@@ -175,6 +175,7 @@ var podArray = []interface{}{
 }
 
 func TestPodClient_NamespaceToRunningPodNum(t *testing.T) {
+	t.Skip("Flaky test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11078")
 	setOption := podSyncCheckerOption(&mockReflectorSyncChecker{})
 
 	fakeClientSet := fake.NewSimpleClientset()

--- a/internal/aws/k8s/k8sclient/pod_test.go
+++ b/internal/aws/k8s/k8sclient/pod_test.go
@@ -174,8 +174,13 @@ var podArray = []interface{}{
 	},
 }
 
+// workaround to avoid "unused" lint errors which test is skipped
+var skip = func(t *testing.T, why string) {
+	t.Skip(why)
+}
+
 func TestPodClient_NamespaceToRunningPodNum(t *testing.T) {
-	t.Skip("Flaky test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11078")
+	skip(t, "Flaky test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11078")
 	setOption := podSyncCheckerOption(&mockReflectorSyncChecker{})
 
 	fakeClientSet := fake.NewSimpleClientset()


### PR DESCRIPTION
See #11078 