### PR TITLE
[processor/transform] Added 'like' to condition operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - `cmd/mdatagen`: Allow attribute values of any types (#9245)
 - `transformprocessor`: Add byte slice literal to the grammar.  Add new SpanID and TraceID functions that take a byte slice and return a Span/Trace ID. (#10487)
+`transformprocessor`: Add 'like' operator to the grammar that allows strings to be matched with a glob. (#11084)
 - `elasticsearchreceiver`: Add integration test for elasticsearch receiver (#10165)
 - `datadogexporter`: Some config validation and unmarshaling steps are now done on `Validate` and `Unmarshal` instead of `Sanitize` (#8829)
 - `examples`: Add an example for scraping Couchbase metrics (#10894)

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -51,6 +51,7 @@ Metric only functions:
 Supported where operations:
 - `==` - matches telemetry where the values are equal to each other
 - `!=` - matches telemetry where the values are not equal to each other
+- `like` - matches telemetry where the left string value matches the glob on the right.  If the right is not a string literal the processor will error during startup.  If the left value is not a string literal, is not a path to a string, or is not a function that returns a string, the processor will panic during processing.
 
 Example configuration:
 ```yaml

--- a/processor/transformprocessor/internal/common/parser.go
+++ b/processor/transformprocessor/internal/common/parser.go
@@ -35,7 +35,7 @@ type ParsedQuery struct {
 // nolint:govet
 type Condition struct {
 	Left  Value  `@@`
-	Op    string `@("==" | "!=")`
+	Op    string `@("==" | "!=" | "like")`
 	Right Value  `@@`
 }
 

--- a/processor/transformprocessor/internal/common/parser_test.go
+++ b/processor/transformprocessor/internal/common/parser_test.go
@@ -266,6 +266,50 @@ func Test_parse(t *testing.T) {
 			},
 		},
 		{
+			query: `set  ( foo.attributes[ "bar"].cat,   "dog")   where name like "fido*"`,
+			expected: &ParsedQuery{
+				Invocation: Invocation{
+					Function: "set",
+					Arguments: []Value{
+						{
+							Path: &Path{
+								Fields: []Field{
+									{
+										Name: "foo",
+									},
+									{
+										Name:   "attributes",
+										MapKey: testhelper.Strp("bar"),
+									},
+									{
+										Name: "cat",
+									},
+								},
+							},
+						},
+						{
+							String: testhelper.Strp("dog"),
+						},
+					},
+				},
+				Condition: &Condition{
+					Left: Value{
+						Path: &Path{
+							Fields: []Field{
+								{
+									Name: "name",
+								},
+							},
+						},
+					},
+					Op: "like",
+					Right: Value{
+						String: testhelper.Strp("fido*"),
+					},
+				},
+			},
+		},
+		{
 			query: `set("fo\"o")`,
 			expected: &ParsedQuery{
 				Invocation: Invocation{

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -65,6 +65,12 @@ func TestProcess(t *testing.T) {
 				td.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(1).SetSeverityText("ok")
 			},
 		},
+		{
+			query: `set(attributes["test"], "pass") where body like "*A"`,
+			want: func(td plog.Logs) {
+				td.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().InsertString("test", "pass")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -129,6 +129,13 @@ func TestProcess(t *testing.T) {
 				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(2).ExponentialHistogram().DataPoints().At(0).Attributes().InsertString("test", "pass")
 			},
 		},
+		{
+			query: `set(attributes["test"], "pass") where metric.name like "*A"`,
+			want: func(td pmetric.Metrics) {
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().InsertString("test", "pass")
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().InsertString("test", "pass")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -77,6 +77,12 @@ func TestProcess(t *testing.T) {
 				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().InsertString("test", "pass")
 			},
 		},
+		{
+			query: `set(attributes["test"], "pass") where name like "*A"`,
+			want: func(td ptrace.Traces) {
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().InsertString("test", "pass")
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:** 
This PR adds to the TQL the ability to use the `like` operator.  The `like` operator compares a string on the left to a glob on the right.  Negating of `like` will come after this PR.

**Link to tracking Issue:**
#11077

**Testing:**
Added/Updated unit tests

**Documentation:**
Updated readme