### PR TITLE
[Receiver/redisreceiver] Support More Redis Metrics

### DIFF
--- a/receiver/redisreceiver/client.go
+++ b/receiver/redisreceiver/client.go
@@ -48,5 +48,5 @@ func (c *redisClient) delimiter() string {
 
 // Retrieve Redis INFO. We retrieve all of the 'sections'.
 func (c *redisClient) retrieveInfo() (string, error) {
-	return c.client.Info().Result()
+	return c.client.Info("all").Result()
 }

--- a/receiver/redisreceiver/documentation.md
+++ b/receiver/redisreceiver/documentation.md
@@ -12,6 +12,8 @@ These are the metrics available for this scraper.
 | **redis.clients.connected** | Number of client connections (excluding connections from replicas) |  | Sum(Int) | <ul> </ul> |
 | **redis.clients.max_input_buffer** | Biggest input buffer among current client connections |  | Gauge(Int) | <ul> </ul> |
 | **redis.clients.max_output_buffer** | Longest output list among current client connections |  | Gauge(Int) | <ul> </ul> |
+| redis.cmd.calls | Total number of calls for a command |  | Sum(Int) | <ul> <li>cmd</li> </ul> |
+| redis.cmd.usec | Total time for all executions of this command | us | Sum(Int) | <ul> <li>cmd</li> </ul> |
 | **redis.commands** | Number of commands processed per second | {ops}/s | Gauge(Int) | <ul> </ul> |
 | **redis.commands.processed** | Total number of commands processed by the server |  | Sum(Int) | <ul> </ul> |
 | **redis.connections.received** | Total number of connections accepted by the server |  | Sum(Int) | <ul> </ul> |
@@ -25,6 +27,7 @@ These are the metrics available for this scraper.
 | **redis.keyspace.hits** | Number of successful lookup of keys in the main dictionary |  | Sum(Int) | <ul> </ul> |
 | **redis.keyspace.misses** | Number of failed lookup of keys in the main dictionary |  | Sum(Int) | <ul> </ul> |
 | **redis.latest_fork** | Duration of the latest fork operation in microseconds | us | Gauge(Int) | <ul> </ul> |
+| redis.maxmemory | The value of the maxmemory configuration directive | By | Gauge(Int) | <ul> </ul> |
 | **redis.memory.fragmentation_ratio** | Ratio between used_memory_rss and used_memory |  | Gauge(Double) | <ul> </ul> |
 | **redis.memory.lua** | Number of bytes used by the Lua engine | By | Gauge(Int) | <ul> </ul> |
 | **redis.memory.peak** | Peak memory consumed by Redis (in bytes) | By | Gauge(Int) | <ul> </ul> |
@@ -35,6 +38,7 @@ These are the metrics available for this scraper.
 | **redis.rdb.changes_since_last_save** | Number of changes since the last dump |  | Sum(Int) | <ul> </ul> |
 | **redis.replication.backlog_first_byte_offset** | The master offset of the replication backlog buffer |  | Gauge(Int) | <ul> </ul> |
 | **redis.replication.offset** | The server's current replication offset |  | Gauge(Int) | <ul> </ul> |
+| redis.role | Redis node's role |  | Sum(Int) | <ul> <li>role</li> </ul> |
 | **redis.slaves.connected** | Number of connected replicas |  | Sum(Int) | <ul> </ul> |
 | **redis.uptime** | Number of seconds since Redis server start | s | Sum(Int) | <ul> </ul> |
 
@@ -51,5 +55,7 @@ metrics:
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
+| cmd | Redis command name |  |
 | db | Redis database identifier |  |
+| role | Redis node's role | replica, primary |
 | state | Redis CPU usage state |  |

--- a/receiver/redisreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics_v2.go
@@ -21,6 +21,8 @@ type MetricsSettings struct {
 	RedisClientsConnected                  MetricSettings `mapstructure:"redis.clients.connected"`
 	RedisClientsMaxInputBuffer             MetricSettings `mapstructure:"redis.clients.max_input_buffer"`
 	RedisClientsMaxOutputBuffer            MetricSettings `mapstructure:"redis.clients.max_output_buffer"`
+	RedisCmdCalls                          MetricSettings `mapstructure:"redis.cmd.calls"`
+	RedisCmdUsec                           MetricSettings `mapstructure:"redis.cmd.usec"`
 	RedisCommands                          MetricSettings `mapstructure:"redis.commands"`
 	RedisCommandsProcessed                 MetricSettings `mapstructure:"redis.commands.processed"`
 	RedisConnectionsReceived               MetricSettings `mapstructure:"redis.connections.received"`
@@ -34,6 +36,7 @@ type MetricsSettings struct {
 	RedisKeyspaceHits                      MetricSettings `mapstructure:"redis.keyspace.hits"`
 	RedisKeyspaceMisses                    MetricSettings `mapstructure:"redis.keyspace.misses"`
 	RedisLatestFork                        MetricSettings `mapstructure:"redis.latest_fork"`
+	RedisMaxmemory                         MetricSettings `mapstructure:"redis.maxmemory"`
 	RedisMemoryFragmentationRatio          MetricSettings `mapstructure:"redis.memory.fragmentation_ratio"`
 	RedisMemoryLua                         MetricSettings `mapstructure:"redis.memory.lua"`
 	RedisMemoryPeak                        MetricSettings `mapstructure:"redis.memory.peak"`
@@ -44,6 +47,7 @@ type MetricsSettings struct {
 	RedisRdbChangesSinceLastSave           MetricSettings `mapstructure:"redis.rdb.changes_since_last_save"`
 	RedisReplicationBacklogFirstByteOffset MetricSettings `mapstructure:"redis.replication.backlog_first_byte_offset"`
 	RedisReplicationOffset                 MetricSettings `mapstructure:"redis.replication.offset"`
+	RedisRole                              MetricSettings `mapstructure:"redis.role"`
 	RedisSlavesConnected                   MetricSettings `mapstructure:"redis.slaves.connected"`
 	RedisUptime                            MetricSettings `mapstructure:"redis.uptime"`
 }
@@ -61,6 +65,12 @@ func DefaultMetricsSettings() MetricsSettings {
 		},
 		RedisClientsMaxOutputBuffer: MetricSettings{
 			Enabled: true,
+		},
+		RedisCmdCalls: MetricSettings{
+			Enabled: false,
+		},
+		RedisCmdUsec: MetricSettings{
+			Enabled: false,
 		},
 		RedisCommands: MetricSettings{
 			Enabled: true,
@@ -101,6 +111,9 @@ func DefaultMetricsSettings() MetricsSettings {
 		RedisLatestFork: MetricSettings{
 			Enabled: true,
 		},
+		RedisMaxmemory: MetricSettings{
+			Enabled: false,
+		},
 		RedisMemoryFragmentationRatio: MetricSettings{
 			Enabled: true,
 		},
@@ -131,6 +144,9 @@ func DefaultMetricsSettings() MetricsSettings {
 		RedisReplicationOffset: MetricSettings{
 			Enabled: true,
 		},
+		RedisRole: MetricSettings{
+			Enabled: false,
+		},
 		RedisSlavesConnected: MetricSettings{
 			Enabled: true,
 		},
@@ -138,6 +154,32 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 	}
+}
+
+// AttributeRole specifies the a value role attribute.
+type AttributeRole int
+
+const (
+	_ AttributeRole = iota
+	AttributeRoleReplica
+	AttributeRolePrimary
+)
+
+// String returns the string representation of the AttributeRole.
+func (av AttributeRole) String() string {
+	switch av {
+	case AttributeRoleReplica:
+		return "replica"
+	case AttributeRolePrimary:
+		return "primary"
+	}
+	return ""
+}
+
+// MapAttributeRole is a helper map of string to AttributeRole attribute value.
+var MapAttributeRole = map[string]AttributeRole{
+	"replica": AttributeRoleReplica,
+	"primary": AttributeRolePrimary,
 }
 
 type metricRedisClientsBlocked struct {
@@ -333,6 +375,112 @@ func (m *metricRedisClientsMaxOutputBuffer) emit(metrics pmetric.MetricSlice) {
 
 func newMetricRedisClientsMaxOutputBuffer(settings MetricSettings) metricRedisClientsMaxOutputBuffer {
 	m := metricRedisClientsMaxOutputBuffer{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricRedisCmdCalls struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills redis.cmd.calls metric with initial data.
+func (m *metricRedisCmdCalls) init() {
+	m.data.SetName("redis.cmd.calls")
+	m.data.SetDescription("Total number of calls for a command")
+	m.data.SetUnit("")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricRedisCmdCalls) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cmdAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("cmd", pcommon.NewValueString(cmdAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricRedisCmdCalls) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricRedisCmdCalls) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricRedisCmdCalls(settings MetricSettings) metricRedisCmdCalls {
+	m := metricRedisCmdCalls{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricRedisCmdUsec struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills redis.cmd.usec metric with initial data.
+func (m *metricRedisCmdUsec) init() {
+	m.data.SetName("redis.cmd.usec")
+	m.data.SetDescription("Total time for all executions of this command")
+	m.data.SetUnit("us")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(true)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricRedisCmdUsec) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cmdAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("cmd", pcommon.NewValueString(cmdAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricRedisCmdUsec) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricRedisCmdUsec) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricRedisCmdUsec(settings MetricSettings) metricRedisCmdUsec {
+	m := metricRedisCmdUsec{settings: settings}
 	if settings.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
@@ -1001,6 +1149,55 @@ func newMetricRedisLatestFork(settings MetricSettings) metricRedisLatestFork {
 	return m
 }
 
+type metricRedisMaxmemory struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills redis.maxmemory metric with initial data.
+func (m *metricRedisMaxmemory) init() {
+	m.data.SetName("redis.maxmemory")
+	m.data.SetDescription("The value of the maxmemory configuration directive")
+	m.data.SetUnit("By")
+	m.data.SetDataType(pmetric.MetricDataTypeGauge)
+}
+
+func (m *metricRedisMaxmemory) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Gauge().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricRedisMaxmemory) updateCapacity() {
+	if m.data.Gauge().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Gauge().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricRedisMaxmemory) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricRedisMaxmemory(settings MetricSettings) metricRedisMaxmemory {
+	m := metricRedisMaxmemory{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricRedisMemoryFragmentationRatio struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1497,6 +1694,59 @@ func newMetricRedisReplicationOffset(settings MetricSettings) metricRedisReplica
 	return m
 }
 
+type metricRedisRole struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	settings MetricSettings // metric settings provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills redis.role metric with initial data.
+func (m *metricRedisRole) init() {
+	m.data.SetName("redis.role")
+	m.data.SetDescription("Redis node's role")
+	m.data.SetUnit("")
+	m.data.SetDataType(pmetric.MetricDataTypeSum)
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.MetricAggregationTemporalityCumulative)
+	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
+}
+
+func (m *metricRedisRole) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, roleAttributeValue string) {
+	if !m.settings.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntVal(val)
+	dp.Attributes().Insert("role", pcommon.NewValueString(roleAttributeValue))
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricRedisRole) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricRedisRole) emit(metrics pmetric.MetricSlice) {
+	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricRedisRole(settings MetricSettings) metricRedisRole {
+	m := metricRedisRole{settings: settings}
+	if settings.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricRedisSlavesConnected struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -1611,6 +1861,8 @@ type MetricsBuilder struct {
 	metricRedisClientsConnected                  metricRedisClientsConnected
 	metricRedisClientsMaxInputBuffer             metricRedisClientsMaxInputBuffer
 	metricRedisClientsMaxOutputBuffer            metricRedisClientsMaxOutputBuffer
+	metricRedisCmdCalls                          metricRedisCmdCalls
+	metricRedisCmdUsec                           metricRedisCmdUsec
 	metricRedisCommands                          metricRedisCommands
 	metricRedisCommandsProcessed                 metricRedisCommandsProcessed
 	metricRedisConnectionsReceived               metricRedisConnectionsReceived
@@ -1624,6 +1876,7 @@ type MetricsBuilder struct {
 	metricRedisKeyspaceHits                      metricRedisKeyspaceHits
 	metricRedisKeyspaceMisses                    metricRedisKeyspaceMisses
 	metricRedisLatestFork                        metricRedisLatestFork
+	metricRedisMaxmemory                         metricRedisMaxmemory
 	metricRedisMemoryFragmentationRatio          metricRedisMemoryFragmentationRatio
 	metricRedisMemoryLua                         metricRedisMemoryLua
 	metricRedisMemoryPeak                        metricRedisMemoryPeak
@@ -1634,6 +1887,7 @@ type MetricsBuilder struct {
 	metricRedisRdbChangesSinceLastSave           metricRedisRdbChangesSinceLastSave
 	metricRedisReplicationBacklogFirstByteOffset metricRedisReplicationBacklogFirstByteOffset
 	metricRedisReplicationOffset                 metricRedisReplicationOffset
+	metricRedisRole                              metricRedisRole
 	metricRedisSlavesConnected                   metricRedisSlavesConnected
 	metricRedisUptime                            metricRedisUptime
 }
@@ -1657,6 +1911,8 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		metricRedisClientsConnected:                  newMetricRedisClientsConnected(settings.RedisClientsConnected),
 		metricRedisClientsMaxInputBuffer:             newMetricRedisClientsMaxInputBuffer(settings.RedisClientsMaxInputBuffer),
 		metricRedisClientsMaxOutputBuffer:            newMetricRedisClientsMaxOutputBuffer(settings.RedisClientsMaxOutputBuffer),
+		metricRedisCmdCalls:                          newMetricRedisCmdCalls(settings.RedisCmdCalls),
+		metricRedisCmdUsec:                           newMetricRedisCmdUsec(settings.RedisCmdUsec),
 		metricRedisCommands:                          newMetricRedisCommands(settings.RedisCommands),
 		metricRedisCommandsProcessed:                 newMetricRedisCommandsProcessed(settings.RedisCommandsProcessed),
 		metricRedisConnectionsReceived:               newMetricRedisConnectionsReceived(settings.RedisConnectionsReceived),
@@ -1670,6 +1926,7 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		metricRedisKeyspaceHits:                      newMetricRedisKeyspaceHits(settings.RedisKeyspaceHits),
 		metricRedisKeyspaceMisses:                    newMetricRedisKeyspaceMisses(settings.RedisKeyspaceMisses),
 		metricRedisLatestFork:                        newMetricRedisLatestFork(settings.RedisLatestFork),
+		metricRedisMaxmemory:                         newMetricRedisMaxmemory(settings.RedisMaxmemory),
 		metricRedisMemoryFragmentationRatio:          newMetricRedisMemoryFragmentationRatio(settings.RedisMemoryFragmentationRatio),
 		metricRedisMemoryLua:                         newMetricRedisMemoryLua(settings.RedisMemoryLua),
 		metricRedisMemoryPeak:                        newMetricRedisMemoryPeak(settings.RedisMemoryPeak),
@@ -1680,6 +1937,7 @@ func NewMetricsBuilder(settings MetricsSettings, buildInfo component.BuildInfo, 
 		metricRedisRdbChangesSinceLastSave:           newMetricRedisRdbChangesSinceLastSave(settings.RedisRdbChangesSinceLastSave),
 		metricRedisReplicationBacklogFirstByteOffset: newMetricRedisReplicationBacklogFirstByteOffset(settings.RedisReplicationBacklogFirstByteOffset),
 		metricRedisReplicationOffset:                 newMetricRedisReplicationOffset(settings.RedisReplicationOffset),
+		metricRedisRole:                              newMetricRedisRole(settings.RedisRole),
 		metricRedisSlavesConnected:                   newMetricRedisSlavesConnected(settings.RedisSlavesConnected),
 		metricRedisUptime:                            newMetricRedisUptime(settings.RedisUptime),
 	}
@@ -1738,6 +1996,8 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricRedisClientsConnected.emit(ils.Metrics())
 	mb.metricRedisClientsMaxInputBuffer.emit(ils.Metrics())
 	mb.metricRedisClientsMaxOutputBuffer.emit(ils.Metrics())
+	mb.metricRedisCmdCalls.emit(ils.Metrics())
+	mb.metricRedisCmdUsec.emit(ils.Metrics())
 	mb.metricRedisCommands.emit(ils.Metrics())
 	mb.metricRedisCommandsProcessed.emit(ils.Metrics())
 	mb.metricRedisConnectionsReceived.emit(ils.Metrics())
@@ -1751,6 +2011,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricRedisKeyspaceHits.emit(ils.Metrics())
 	mb.metricRedisKeyspaceMisses.emit(ils.Metrics())
 	mb.metricRedisLatestFork.emit(ils.Metrics())
+	mb.metricRedisMaxmemory.emit(ils.Metrics())
 	mb.metricRedisMemoryFragmentationRatio.emit(ils.Metrics())
 	mb.metricRedisMemoryLua.emit(ils.Metrics())
 	mb.metricRedisMemoryPeak.emit(ils.Metrics())
@@ -1761,6 +2022,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricRedisRdbChangesSinceLastSave.emit(ils.Metrics())
 	mb.metricRedisReplicationBacklogFirstByteOffset.emit(ils.Metrics())
 	mb.metricRedisReplicationOffset.emit(ils.Metrics())
+	mb.metricRedisRole.emit(ils.Metrics())
 	mb.metricRedisSlavesConnected.emit(ils.Metrics())
 	mb.metricRedisUptime.emit(ils.Metrics())
 	for _, op := range rmo {
@@ -1800,6 +2062,16 @@ func (mb *MetricsBuilder) RecordRedisClientsMaxInputBufferDataPoint(ts pcommon.T
 // RecordRedisClientsMaxOutputBufferDataPoint adds a data point to redis.clients.max_output_buffer metric.
 func (mb *MetricsBuilder) RecordRedisClientsMaxOutputBufferDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricRedisClientsMaxOutputBuffer.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordRedisCmdCallsDataPoint adds a data point to redis.cmd.calls metric.
+func (mb *MetricsBuilder) RecordRedisCmdCallsDataPoint(ts pcommon.Timestamp, val int64, cmdAttributeValue string) {
+	mb.metricRedisCmdCalls.recordDataPoint(mb.startTime, ts, val, cmdAttributeValue)
+}
+
+// RecordRedisCmdUsecDataPoint adds a data point to redis.cmd.usec metric.
+func (mb *MetricsBuilder) RecordRedisCmdUsecDataPoint(ts pcommon.Timestamp, val int64, cmdAttributeValue string) {
+	mb.metricRedisCmdUsec.recordDataPoint(mb.startTime, ts, val, cmdAttributeValue)
 }
 
 // RecordRedisCommandsDataPoint adds a data point to redis.commands metric.
@@ -1867,6 +2139,11 @@ func (mb *MetricsBuilder) RecordRedisLatestForkDataPoint(ts pcommon.Timestamp, v
 	mb.metricRedisLatestFork.recordDataPoint(mb.startTime, ts, val)
 }
 
+// RecordRedisMaxmemoryDataPoint adds a data point to redis.maxmemory metric.
+func (mb *MetricsBuilder) RecordRedisMaxmemoryDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricRedisMaxmemory.recordDataPoint(mb.startTime, ts, val)
+}
+
 // RecordRedisMemoryFragmentationRatioDataPoint adds a data point to redis.memory.fragmentation_ratio metric.
 func (mb *MetricsBuilder) RecordRedisMemoryFragmentationRatioDataPoint(ts pcommon.Timestamp, val float64) {
 	mb.metricRedisMemoryFragmentationRatio.recordDataPoint(mb.startTime, ts, val)
@@ -1915,6 +2192,11 @@ func (mb *MetricsBuilder) RecordRedisReplicationBacklogFirstByteOffsetDataPoint(
 // RecordRedisReplicationOffsetDataPoint adds a data point to redis.replication.offset metric.
 func (mb *MetricsBuilder) RecordRedisReplicationOffsetDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricRedisReplicationOffset.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordRedisRoleDataPoint adds a data point to redis.role metric.
+func (mb *MetricsBuilder) RecordRedisRoleDataPoint(ts pcommon.Timestamp, val int64, roleAttributeValue AttributeRole) {
+	mb.metricRedisRole.recordDataPoint(mb.startTime, ts, val, roleAttributeValue.String())
 }
 
 // RecordRedisSlavesConnectedDataPoint adds a data point to redis.slaves.connected metric.

--- a/receiver/redisreceiver/metadata.yaml
+++ b/receiver/redisreceiver/metadata.yaml
@@ -5,8 +5,51 @@ attributes:
     description: Redis CPU usage state
   db:
     description: Redis database identifier
+  role:
+    description: Redis node's role
+    enum:
+      - replica
+      - primary
+  cmd:
+    description: Redis command name
 
 metrics:
+  redis.maxmemory:
+    enabled: false
+    description: The value of the maxmemory configuration directive
+    unit: By
+    gauge:
+      value_type: int
+
+  redis.role:
+    enabled: false
+    description: Redis node's role
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation: cumulative
+    attributes: [role]
+
+  redis.cmd.calls:
+    enabled: false
+    description: Total number of calls for a command
+    unit: ""
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative
+    attributes: [cmd]
+
+  redis.cmd.usec:
+    enabled: false
+    description: Total time for all executions of this command
+    unit: us
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative
+    attributes: [cmd]
+
   redis.uptime:
     enabled: true
     description: Number of seconds since Redis server start

--- a/receiver/redisreceiver/metric_functions.go
+++ b/receiver/redisreceiver/metric_functions.go
@@ -32,6 +32,7 @@ func (rs *redisScraper) dataPointRecorders() map[string]interface{} {
 		"keyspace_misses":                 rs.mb.RecordRedisKeyspaceMissesDataPoint,
 		"latest_fork_usec":                rs.mb.RecordRedisLatestForkDataPoint,
 		"master_repl_offset":              rs.mb.RecordRedisReplicationOffsetDataPoint,
+		"maxmemory":                       rs.mb.RecordRedisMaxmemoryDataPoint,
 		"mem_fragmentation_ratio":         rs.mb.RecordRedisMemoryFragmentationRatioDataPoint,
 		"rdb_changes_since_last_save":     rs.mb.RecordRedisRdbChangesSinceLastSaveDataPoint,
 		"rejected_connections":            rs.mb.RecordRedisConnectionsRejectedDataPoint,

--- a/receiver/redisreceiver/redis_scraper_test.go
+++ b/receiver/redisreceiver/redis_scraper_test.go
@@ -38,7 +38,8 @@ func TestRedisRunnable(t *testing.T) {
 	md, err := runner.Scrape(context.Background())
 	require.NoError(t, err)
 	// + 6 because there are two keyspace entries each of which has three metrics
-	assert.Equal(t, len(rs.dataPointRecorders())+6, md.DataPointCount())
+	// -1 because maxmemory is by default disabled, so recorder is there, but there won't be data point
+	assert.Equal(t, len(rs.dataPointRecorders())+6-1, md.DataPointCount())
 	rm := md.ResourceMetrics().At(0)
 	ilm := rm.ScopeMetrics().At(0)
 	il := ilm.Scope()

--- a/receiver/redisreceiver/redis_svc_test.go
+++ b/receiver/redisreceiver/redis_svc_test.go
@@ -28,6 +28,6 @@ func TestParser(t *testing.T) {
 	s := newFakeAPIParser()
 	info, err := s.info()
 	require.Nil(t, err)
-	require.Equal(t, 123, len(info))
+	require.Equal(t, 128, len(info))
 	require.Equal(t, "1.24", info["allocator_frag_ratio"]) // spot check
 }

--- a/receiver/redisreceiver/testdata/info.txt
+++ b/receiver/redisreceiver/testdata/info.txt
@@ -138,3 +138,10 @@ cluster_enabled:0
 # Keyspace
 db0:keys=1,expires=2,avg_ttl=3
 db1:keys=4,expires=5,avg_ttl=6
+
+# Commandstats
+cmdstat_ssubscribe:calls=0,usec=0,usec_per_call=0.00,rejected_calls=3,failed_calls=0
+cmdstat_zrem:calls=641,usec=1884,usec_per_call=2.94,rejected_calls=0,failed_calls=0
+cmdstat_incrbyfloat:calls=50340,usec=902409,usec_per_call=17.93,rejected_calls=0,failed_calls=0
+cmdstat_lrange:calls=12495,usec=48886,usec_per_call=3.91,rejected_calls=0,failed_calls=14
+cmdstat_mset:calls=4505,usec=65693,usec_per_call=14.58,rejected_calls=0,failed_calls=3

--- a/unreleased/redisreceiver.yaml
+++ b/unreleased/redisreceiver.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: redisreceiver
+
+# A brief description of the change
+note: Add more metrics, `redis.maxmemory`, `redis.role`, `redis.cmd.calls` `redis.cmd.usec`
+
+# One or more tracking issues related to the change
+issues: [11090]


### PR DESCRIPTION
**Descriptions**
- Add support for maxmemory metric [gauge]
- Add support for role metric [updown counter]
  With `replica` and `primary` added as an attribute
- Add support for cmdstat metric
   Currently add calls and usec as two new metrics [sum], and cmd as the attribute for both.
- Fixed info call with `all` parameter because the comments says all of the 'sections' and command stats is not in the default section.

**Related Discussions**
https://github.com/open-telemetry/opentelemetry-proto/issues/401
#11025

**Tests**
Manual tests to see that metrics are added.
Also the existing tests has been updated to fit the new metrics

**Documentation**
In-place documents added. There are also auto generated document for new metrics.