### PR TITLE
[docs] Add status header for SignalFx receiver

### DIFF
--- a/receiver/signalfxreceiver/README.md
+++ b/receiver/signalfxreceiver/README.md
@@ -1,10 +1,10 @@
 # SignalFx Receiver
 
-| Status                   |               |
-| ------------------------ |---------------|
-| Stability                | [beta]        |
-| Supported pipeline types | traces, logs  |
-| Distributions            | [contrib]     |
+| Status                   |              |
+| ------------------------ |--------------|
+| Stability                | [stable]     |
+| Supported pipeline types | traces, logs |
+| Distributions            | [contrib]    |
 
 The SignalFx receiver accepts:
 
@@ -68,5 +68,5 @@ service:
       exporters: [signalfx]
 ```
 
-[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
+[stable]: https://github.com/open-telemetry/opentelemetry-collector#stable
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/signalfxreceiver/README.md
+++ b/receiver/signalfxreceiver/README.md
@@ -1,10 +1,10 @@
 # SignalFx Receiver
 
-| Status                   |              |
-| ------------------------ |--------------|
-| Stability                | [stable]     |
-| Supported pipeline types | traces, logs |
-| Distributions            | [contrib]    |
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [stable]      |
+| Supported pipeline types | metrics, logs |
+| Distributions            | [contrib]     |
 
 The SignalFx receiver accepts:
 

--- a/receiver/signalfxreceiver/README.md
+++ b/receiver/signalfxreceiver/README.md
@@ -1,5 +1,11 @@
 # SignalFx Receiver
 
+| Status                   |               |
+| ------------------------ |---------------|
+| Stability                | [beta]        |
+| Supported pipeline types | traces, logs  |
+| Distributions            | [contrib]     |
+
 The SignalFx receiver accepts:
 
 - Metrics in the [SignalFx proto
@@ -9,8 +15,6 @@ format](https://github.com/signalfx/com_signalfx_metrics_protobuf/blob/master/pr
 More information about sending custom events can be found in the [SignalFx
 Developers
 Guide](https://developers.signalfx.com/ingest_data_reference.html#tag/Send-Custom-Events).
-
-Supported pipeline types: logs, metrics
 
 ## Configuration
 
@@ -63,3 +67,6 @@ service:
       processors: [memory_limiter, batch]
       exporters: [signalfx]
 ```
+
+[beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
+[contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
**Description:** 
Add status header for SignalFx receiver

/cc @pjanotti @dmitryax as code owners to verify new status header