### PR TITLE
[exporter/datadog/examples] Fix RBAC rules on Kubernetes example

### DIFF
--- a/exporter/datadogexporter/example/example_k8s_manifest.yaml
+++ b/exporter/datadogexporter/example/example_k8s_manifest.yaml
@@ -282,7 +282,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["watch", "list"]
+  verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Description:** Fixes RBAC permissions on example Kubernetes file to account for changes on #10911. I mistakenly thought that `watch` and `list` would imply `get`, but after double checking this we also need to add `get` for the Datadog exporter.

Since #10911 has not been released on any tagged version, this does not need a changelog.