### PR TITLE
[pkg/stanza] Copy file_input codebase to new package

### DIFF
--- a/pkg/stanza/internal/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/internal/fileconsumer/benchmark_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file
+package fileconsumer
 
 import (
 	"os"

--- a/pkg/stanza/internal/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/internal/fileconsumer/benchmark_test.go
@@ -1,0 +1,196 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+)
+
+type fileInputBenchmark struct {
+	name   string
+	paths  []string
+	config func() *Config
+}
+
+type benchFile struct {
+	*os.File
+	log func(int)
+}
+
+func simpleTextFile(b *testing.B, file *os.File) *benchFile {
+	line := stringWithLength(49) + "\n"
+	return &benchFile{
+		File: file,
+		log: func(_ int) {
+			_, err := file.WriteString(line)
+			require.NoError(b, err)
+		},
+	}
+}
+
+func BenchmarkFileInput(b *testing.B) {
+	cases := []fileInputBenchmark{
+		{
+			name: "Single",
+			paths: []string{
+				"file0.log",
+			},
+			config: func() *Config {
+				cfg := NewConfig("test_id")
+				cfg.Include = []string{
+					"file0.log",
+				}
+				return cfg
+			},
+		},
+		{
+			name: "Glob",
+			paths: []string{
+				"file0.log",
+				"file1.log",
+				"file2.log",
+				"file3.log",
+			},
+			config: func() *Config {
+				cfg := NewConfig("test_id")
+				cfg.Include = []string{"file*.log"}
+				return cfg
+			},
+		},
+		{
+			name: "MultiGlob",
+			paths: []string{
+				"file0.log",
+				"file1.log",
+				"log0.log",
+				"log1.log",
+			},
+			config: func() *Config {
+				cfg := NewConfig("test_id")
+				cfg.Include = []string{
+					"file*.log",
+					"log*.log",
+				}
+				return cfg
+			},
+		},
+		{
+			name: "MaxConcurrent",
+			paths: []string{
+				"file0.log",
+				"file1.log",
+				"file2.log",
+				"file3.log",
+			},
+			config: func() *Config {
+				cfg := NewConfig("test_id")
+				cfg.Include = []string{
+					"file*.log",
+				}
+				cfg.MaxConcurrentFiles = 2
+				return cfg
+			},
+		},
+		{
+			name: "FngrPrntLarge",
+			paths: []string{
+				"file0.log",
+			},
+			config: func() *Config {
+				cfg := NewConfig("test_id")
+				cfg.Include = []string{
+					"file*.log",
+				}
+				cfg.FingerprintSize = 10 * defaultFingerprintSize
+				return cfg
+			},
+		},
+		{
+			name: "FngrPrntSmall",
+			paths: []string{
+				"file0.log",
+			},
+			config: func() *Config {
+				cfg := NewConfig("test_id")
+				cfg.Include = []string{
+					"file*.log",
+				}
+				cfg.FingerprintSize = defaultFingerprintSize / 10
+				return cfg
+			},
+		},
+	}
+
+	for _, bench := range cases {
+		b.Run(bench.name, func(b *testing.B) {
+			rootDir := b.TempDir()
+
+			var files []*benchFile
+			for _, path := range bench.paths {
+				file := openFile(b, filepath.Join(rootDir, path))
+				files = append(files, simpleTextFile(b, file))
+			}
+
+			cfg := bench.config()
+			cfg.OutputIDs = []string{"fake"}
+			for i, inc := range cfg.Include {
+				cfg.Include[i] = filepath.Join(rootDir, inc)
+			}
+			cfg.StartAt = "beginning"
+
+			op, err := cfg.Build(testutil.Logger(b))
+			require.NoError(b, err)
+
+			fakeOutput := testutil.NewFakeOutput(b)
+			err = op.SetOutputs([]operator.Operator{fakeOutput})
+			require.NoError(b, err)
+
+			// write half the lines before starting
+			mid := b.N / 2
+			for i := 0; i < mid; i++ {
+				for _, file := range files {
+					file.log(i)
+				}
+			}
+
+			b.ResetTimer()
+			err = op.Start(testutil.NewMockPersister("test"))
+			defer func() {
+				require.NoError(b, op.Stop())
+			}()
+			require.NoError(b, err)
+
+			// write the remainder of lines while running
+			go func() {
+				for i := mid; i < b.N; i++ {
+					for _, file := range files {
+						file.log(i)
+					}
+				}
+			}()
+
+			for i := 0; i < b.N*len(files); i++ {
+				<-fakeOutput.Received
+			}
+		})
+	}
+}

--- a/pkg/stanza/internal/fileconsumer/config.go
+++ b/pkg/stanza/internal/fileconsumer/config.go
@@ -1,0 +1,177 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bmatcuk/doublestar/v3"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+)
+
+func init() {
+	operator.Register("file_input", func() operator.Builder { return NewConfig("") })
+}
+
+const (
+	defaultMaxLogSize         = 1024 * 1024
+	defaultMaxConcurrentFiles = 1024
+)
+
+// NewConfig creates a new input config with default values
+func NewConfig(operatorID string) *Config {
+	return &Config{
+		InputConfig:             helper.NewInputConfig(operatorID, "file_input"),
+		PollInterval:            helper.Duration{Duration: 200 * time.Millisecond},
+		IncludeFileName:         true,
+		IncludeFilePath:         false,
+		IncludeFileNameResolved: false,
+		IncludeFilePathResolved: false,
+		Splitter:                helper.NewSplitterConfig(),
+		StartAt:                 "end",
+		FingerprintSize:         defaultFingerprintSize,
+		MaxLogSize:              defaultMaxLogSize,
+		MaxConcurrentFiles:      defaultMaxConcurrentFiles,
+		Encoding:                helper.NewEncodingConfig(),
+	}
+}
+
+// Config is the configuration of a file input operator
+type Config struct {
+	helper.InputConfig `mapstructure:",squash" yaml:",inline"`
+	Finder             `mapstructure:",squash" yaml:",inline"`
+
+	PollInterval            helper.Duration       `mapstructure:"poll_interval,omitempty"                  json:"poll_interval,omitempty"                 yaml:"poll_interval,omitempty"`
+	IncludeFileName         bool                  `mapstructure:"include_file_name,omitempty"              json:"include_file_name,omitempty"             yaml:"include_file_name,omitempty"`
+	IncludeFilePath         bool                  `mapstructure:"include_file_path,omitempty"              json:"include_file_path,omitempty"             yaml:"include_file_path,omitempty"`
+	IncludeFileNameResolved bool                  `mapstructure:"include_file_name_resolved,omitempty"     json:"include_file_name_resolved,omitempty"    yaml:"include_file_name_resolved,omitempty"`
+	IncludeFilePathResolved bool                  `mapstructure:"include_file_path_resolved,omitempty"     json:"include_file_path_resolved,omitempty"    yaml:"include_file_path_resolved,omitempty"`
+	StartAt                 string                `mapstructure:"start_at,omitempty"                       json:"start_at,omitempty"                      yaml:"start_at,omitempty"`
+	FingerprintSize         helper.ByteSize       `mapstructure:"fingerprint_size,omitempty"               json:"fingerprint_size,omitempty"              yaml:"fingerprint_size,omitempty"`
+	MaxLogSize              helper.ByteSize       `mapstructure:"max_log_size,omitempty"                   json:"max_log_size,omitempty"                  yaml:"max_log_size,omitempty"`
+	MaxConcurrentFiles      int                   `mapstructure:"max_concurrent_files,omitempty"           json:"max_concurrent_files,omitempty"          yaml:"max_concurrent_files,omitempty"`
+	Encoding                helper.EncodingConfig `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
+	Splitter                helper.SplitterConfig `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
+}
+
+// Build will build a file input operator from the supplied configuration
+func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(c.Include) == 0 {
+		return nil, fmt.Errorf("required argument `include` is empty")
+	}
+
+	// Ensure includes can be parsed as globs
+	for _, include := range c.Include {
+		_, err = doublestar.PathMatch(include, "matchstring")
+		if err != nil {
+			return nil, fmt.Errorf("parse include glob: %w", err)
+		}
+	}
+
+	// Ensure excludes can be parsed as globs
+	for _, exclude := range c.Exclude {
+		_, err = doublestar.PathMatch(exclude, "matchstring")
+		if err != nil {
+			return nil, fmt.Errorf("parse exclude glob: %w", err)
+		}
+	}
+
+	if c.MaxLogSize <= 0 {
+		return nil, fmt.Errorf("`max_log_size` must be positive")
+	}
+
+	if c.MaxConcurrentFiles <= 1 {
+		return nil, fmt.Errorf("`max_concurrent_files` must be greater than 1")
+	}
+
+	if c.FingerprintSize == 0 {
+		c.FingerprintSize = defaultFingerprintSize
+	} else if c.FingerprintSize < minFingerprintSize {
+		return nil, fmt.Errorf("`fingerprint_size` must be at least %d bytes", minFingerprintSize)
+	}
+
+	encoding, err := c.Encoding.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that multiline is buildable
+	_, err = c.Splitter.Build(encoding.Encoding, false, int(c.MaxLogSize))
+	if err != nil {
+		return nil, err
+	}
+
+	var startAtBeginning bool
+	switch c.StartAt {
+	case "beginning":
+		startAtBeginning = true
+	case "end":
+		startAtBeginning = false
+	default:
+		return nil, fmt.Errorf("invalid start_at location '%s'", c.StartAt)
+	}
+
+	fileNameField := entry.NewNilField()
+	if c.IncludeFileName {
+		fileNameField = entry.NewAttributeField("log.file.name")
+	}
+
+	filePathField := entry.NewNilField()
+	if c.IncludeFilePath {
+		filePathField = entry.NewAttributeField("log.file.path")
+	}
+
+	fileNameResolvedField := entry.NewNilField()
+	if c.IncludeFileNameResolved {
+		fileNameResolvedField = entry.NewAttributeField("log.file.name_resolved")
+	}
+
+	filePathResolvedField := entry.NewNilField()
+	if c.IncludeFilePathResolved {
+		filePathResolvedField = entry.NewAttributeField("log.file.path_resolved")
+	}
+
+	return &Input{
+		InputOperator:         inputOperator,
+		finder:                c.Finder,
+		PollInterval:          c.PollInterval.Raw(),
+		FilePathField:         filePathField,
+		FileNameField:         fileNameField,
+		FilePathResolvedField: filePathResolvedField,
+		FileNameResolvedField: fileNameResolvedField,
+		startAtBeginning:      startAtBeginning,
+		Splitter:              c.Splitter,
+		queuedMatches:         make([]string, 0),
+		encoding:              encoding,
+		firstCheck:            true,
+		cancel:                func() {},
+		knownFiles:            make([]*Reader, 0, 10),
+		roller:                newRoller(),
+		fingerprintSize:       int(c.FingerprintSize),
+		MaxLogSize:            int(c.MaxLogSize),
+		MaxConcurrentFiles:    c.MaxConcurrentFiles,
+		SeenPaths:             make(map[string]struct{}, 100),
+	}, nil
+}

--- a/pkg/stanza/internal/fileconsumer/config.go
+++ b/pkg/stanza/internal/fileconsumer/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 
 import (
 	"fmt"

--- a/pkg/stanza/internal/fileconsumer/config_test.go
+++ b/pkg/stanza/internal/fileconsumer/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file
+package fileconsumer
 
 import (
 	"testing"

--- a/pkg/stanza/internal/fileconsumer/config_test.go
+++ b/pkg/stanza/internal/fileconsumer/config_test.go
@@ -1,0 +1,758 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper/operatortest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+)
+
+func TestUnmarshal(t *testing.T) {
+	cases := []operatortest.ConfigUnmarshalTest{
+		{
+			Name:      "default",
+			ExpectErr: false,
+			Expect:    defaultCfg(),
+		},
+		{
+
+			Name:      "extra_field",
+			ExpectErr: false,
+			Expect:    defaultCfg(),
+		},
+		{
+			Name:      "id_custom",
+			ExpectErr: false,
+			Expect:    NewConfig("test_id"),
+		},
+		{
+			Name:      "include_one",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_multi",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log", "two.log", "three.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_glob",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "*.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_glob_double_asterisk",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "**.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_glob_double_asterisk_nested",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "directory/**/*.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_glob_double_asterisk_prefix",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "**/directory/**/*.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_inline",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "a.log", "b.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_invalid",
+			ExpectErr: true,
+			Expect:    nil,
+		},
+		{
+			Name:      "exclude_one",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "*.log")
+				cfg.Exclude = append(cfg.Exclude, "one.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "exclude_multi",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "*.log")
+				cfg.Exclude = append(cfg.Exclude, "one.log", "two.log", "three.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "exclude_glob",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "*.log")
+				cfg.Exclude = append(cfg.Exclude, "not*.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "exclude_glob_double_asterisk",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "*.log")
+				cfg.Exclude = append(cfg.Exclude, "not**.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "exclude_glob_double_asterisk_nested",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "*.log")
+				cfg.Exclude = append(cfg.Exclude, "directory/**/not*.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "exclude_glob_double_asterisk_prefix",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "*.log")
+				cfg.Exclude = append(cfg.Exclude, "**/directory/**/not*.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "exclude_inline",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "*.log")
+				cfg.Exclude = append(cfg.Exclude, "a.log", "b.log")
+				return cfg
+			}(),
+		},
+		{
+			Name:      "exclude_invalid",
+			ExpectErr: true,
+			Expect:    nil,
+		},
+		{
+			Name:      "poll_interval_no_units",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.PollInterval = helper.NewDuration(time.Second)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "poll_interval_1s",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.PollInterval = helper.NewDuration(time.Second)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "poll_interval_1ms",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.PollInterval = helper.NewDuration(time.Millisecond)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "poll_interval_1000ms",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.PollInterval = helper.NewDuration(time.Second)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "fingerprint_size_no_units",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.FingerprintSize = helper.ByteSize(1000)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "fingerprint_size_1kb_lower",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.FingerprintSize = helper.ByteSize(1000)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "fingerprint_size_1KB",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.FingerprintSize = helper.ByteSize(1000)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "fingerprint_size_1kib_lower",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.FingerprintSize = helper.ByteSize(1024)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "fingerprint_size_1KiB",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.FingerprintSize = helper.ByteSize(1024)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "fingerprint_size_float",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.FingerprintSize = helper.ByteSize(1100)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_name_lower",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFileName = true
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_name_upper",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFileName = true
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_name_on",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFileName = true
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_name_yes",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFileName = true
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_path_lower",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFilePath = true
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_path_upper",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFilePath = true
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_path_on",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFilePath = true
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_path_yes",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFilePath = true
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_path_off",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFilePath = false
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_path_no",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Include = append(cfg.Include, "one.log")
+				cfg.IncludeFilePath = false
+				return cfg
+			}(),
+		},
+		{
+			Name:      "include_file_path_nonbool",
+			ExpectErr: true,
+			Expect:    nil,
+		},
+		{
+			Name:      "multiline_line_start_string",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				newSplit := helper.NewSplitterConfig()
+				newSplit.Multiline.LineStartPattern = "Start"
+				cfg.Splitter = newSplit
+				return cfg
+			}(),
+		},
+		{
+			Name:      "multiline_line_start_special",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				newSplit := helper.NewSplitterConfig()
+				newSplit.Multiline.LineStartPattern = "%"
+				cfg.Splitter = newSplit
+				return cfg
+			}(),
+		},
+		{
+			Name:      "multiline_line_end_string",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				newSplit := helper.NewSplitterConfig()
+				newSplit.Multiline.LineEndPattern = "Start"
+				cfg.Splitter = newSplit
+				return cfg
+			}(),
+		},
+		{
+			Name:      "multiline_line_end_special",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				newSplit := helper.NewSplitterConfig()
+				newSplit.Multiline.LineEndPattern = "%"
+				cfg.Splitter = newSplit
+				return cfg
+			}(),
+		},
+		{
+			Name:      "multiline_random",
+			ExpectErr: true,
+			Expect:    nil,
+		},
+		{
+			Name:      "start_at_string",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.StartAt = "beginning"
+				return cfg
+			}(),
+		},
+		{
+			Name:      "max_concurrent_large",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.MaxConcurrentFiles = 9223372036854775807
+				return cfg
+			}(),
+		},
+		{
+			Name:      "max_log_size_mib_lower",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.MaxLogSize = helper.ByteSize(1048576)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "max_log_size_mib_upper",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.MaxLogSize = helper.ByteSize(1048576)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "max_log_size_mb_upper",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.MaxLogSize = helper.ByteSize(1048576)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "max_log_size_mb_lower",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.MaxLogSize = helper.ByteSize(1048576)
+				return cfg
+			}(),
+		},
+		{
+			Name:      "encoding_lower",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Encoding = helper.EncodingConfig{Encoding: "utf-16le"}
+				return cfg
+			}(),
+		},
+		{
+			Name:      "encoding_upper",
+			ExpectErr: false,
+			Expect: func() *Config {
+				cfg := defaultCfg()
+				cfg.Encoding = helper.EncodingConfig{Encoding: "UTF-16lE"}
+				return cfg
+			}(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			tc.Run(t, defaultCfg())
+		})
+	}
+}
+
+func TestBuild(t *testing.T) {
+	t.Parallel()
+	fakeOutput := testutil.NewMockOperator("fake")
+
+	basicConfig := func() *Config {
+		cfg := NewConfig("testfile")
+		cfg.OutputIDs = []string{"fake"}
+		cfg.Include = []string{"/var/log/testpath.*"}
+		cfg.Exclude = []string{"/var/log/testpath.ex*"}
+		cfg.PollInterval = helper.Duration{Duration: 10 * time.Millisecond}
+		return cfg
+	}
+
+	cases := []struct {
+		name             string
+		modifyBaseConfig func(*Config)
+		errorRequirement require.ErrorAssertionFunc
+		validate         func(*testing.T, *Input)
+	}{
+		{
+			"Basic",
+			func(f *Config) {},
+			require.NoError,
+			func(t *testing.T, f *Input) {
+				require.Equal(t, f.OutputOperators[0], fakeOutput)
+				require.Equal(t, f.finder.Include, []string{"/var/log/testpath.*"})
+				require.Equal(t, f.FilePathField, entry.NewNilField())
+				require.Equal(t, f.FileNameField, entry.NewAttributeField("log.file.name"))
+				require.Equal(t, f.PollInterval, 10*time.Millisecond)
+			},
+		},
+		{
+			"BadIncludeGlob",
+			func(f *Config) {
+				f.Include = []string{"["}
+			},
+			require.Error,
+			nil,
+		},
+		{
+			"BadExcludeGlob",
+			func(f *Config) {
+				f.Include = []string{"["}
+			},
+			require.Error,
+			nil,
+		},
+		{
+			"MultilineConfiguredStartAndEndPatterns",
+			func(f *Config) {
+				f.Splitter = helper.NewSplitterConfig()
+				f.Splitter.Multiline = helper.MultilineConfig{
+					LineEndPattern:   "Exists",
+					LineStartPattern: "Exists",
+				}
+			},
+			require.Error,
+			nil,
+		},
+		{
+			"MultilineConfiguredStartPattern",
+			func(f *Config) {
+				f.Splitter = helper.NewSplitterConfig()
+				f.Splitter.Multiline = helper.MultilineConfig{
+					LineStartPattern: "START.*",
+				}
+			},
+			require.NoError,
+			func(t *testing.T, f *Input) {},
+		},
+		{
+			"MultilineConfiguredEndPattern",
+			func(f *Config) {
+				f.Splitter = helper.NewSplitterConfig()
+				f.Splitter.Multiline = helper.MultilineConfig{
+					LineEndPattern: "END.*",
+				}
+			},
+			require.NoError,
+			func(t *testing.T, f *Input) {},
+		},
+		{
+			"InvalidEncoding",
+			func(f *Config) {
+				f.Encoding = helper.EncodingConfig{Encoding: "UTF-3233"}
+			},
+			require.Error,
+			nil,
+		},
+		{
+			"LineStartAndEnd",
+			func(f *Config) {
+				f.Splitter = helper.NewSplitterConfig()
+				f.Splitter.Multiline = helper.MultilineConfig{
+					LineStartPattern: ".*",
+					LineEndPattern:   ".*",
+				}
+			},
+			require.Error,
+			nil,
+		},
+		{
+			"NoLineStartOrEnd",
+			func(f *Config) {
+				f.Splitter = helper.NewSplitterConfig()
+				f.Splitter.Multiline = helper.MultilineConfig{}
+			},
+			require.NoError,
+			func(t *testing.T, f *Input) {},
+		},
+		{
+			"InvalidLineStartRegex",
+			func(f *Config) {
+				f.Splitter = helper.NewSplitterConfig()
+				f.Splitter.Multiline = helper.MultilineConfig{
+					LineStartPattern: "(",
+				}
+			},
+			require.Error,
+			nil,
+		},
+		{
+			"InvalidLineEndRegex",
+			func(f *Config) {
+				f.Splitter = helper.NewSplitterConfig()
+				f.Splitter.Multiline = helper.MultilineConfig{
+					LineEndPattern: "(",
+				}
+			},
+			require.Error,
+			nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+			cfg := basicConfig()
+			tc.modifyBaseConfig(cfg)
+
+			op, err := cfg.Build(testutil.Logger(t))
+			tc.errorRequirement(t, err)
+			if err != nil {
+				return
+			}
+
+			err = op.SetOutputs([]operator.Operator{fakeOutput})
+			require.NoError(t, err)
+
+			fileInput := op.(*Input)
+			tc.validate(t, fileInput)
+		})
+	}
+}
+
+func defaultCfg() *Config {
+	return NewConfig("file_input")
+}
+
+func NewTestConfig() *Config {
+	cfg := NewConfig("config_test")
+	cfg.Include = []string{"i1", "i2"}
+	cfg.Exclude = []string{"e1", "e2"}
+	cfg.Splitter = helper.NewSplitterConfig()
+	cfg.Splitter.Multiline = helper.MultilineConfig{
+		LineStartPattern: "start",
+		LineEndPattern:   "end",
+	}
+	cfg.FingerprintSize = 1024
+	cfg.Encoding = helper.EncodingConfig{Encoding: "utf16"}
+	return cfg
+}
+
+func TestMapStructureDecodeConfigWithHook(t *testing.T) {
+	expect := NewTestConfig()
+	input := map[string]interface{}{
+		// Config
+		"id":            "config_test",
+		"type":          "file_input",
+		"attributes":    map[string]interface{}{},
+		"resource":      map[string]interface{}{},
+		"include":       expect.Include,
+		"exclude":       expect.Exclude,
+		"poll_interval": 0.2,
+		"multiline": map[string]interface{}{
+			"line_start_pattern": expect.Splitter.Multiline.LineStartPattern,
+			"line_end_pattern":   expect.Splitter.Multiline.LineEndPattern,
+		},
+		"force_flush_period":   0.5,
+		"include_file_name":    true,
+		"include_file_path":    false,
+		"start_at":             "end",
+		"fingerprint_size":     "1024",
+		"max_log_size":         "1mib",
+		"max_concurrent_files": 1024,
+		"encoding":             "utf16",
+	}
+
+	var actual Config
+	dc := &mapstructure.DecoderConfig{Result: &actual, DecodeHook: helper.JSONUnmarshalerHook()}
+	ms, err := mapstructure.NewDecoder(dc)
+	require.NoError(t, err)
+	err = ms.Decode(input)
+	require.NoError(t, err)
+	require.Equal(t, expect, &actual)
+}
+
+func TestMapStructureDecodeConfig(t *testing.T) {
+	expect := NewTestConfig()
+	input := map[string]interface{}{
+		// Config
+		"id":         "config_test",
+		"type":       "file_input",
+		"attributes": map[string]interface{}{},
+		"resource":   map[string]interface{}{},
+		"include":    expect.Include,
+		"exclude":    expect.Exclude,
+		"poll_interval": map[string]interface{}{
+			"Duration": 200 * 1000 * 1000,
+		},
+		"multiline": map[string]interface{}{
+			"line_start_pattern": expect.Splitter.Multiline.LineStartPattern,
+			"line_end_pattern":   expect.Splitter.Multiline.LineEndPattern,
+		},
+		"include_file_name":    true,
+		"include_file_path":    false,
+		"start_at":             "end",
+		"fingerprint_size":     1024,
+		"max_log_size":         1024 * 1024,
+		"max_concurrent_files": 1024,
+		"encoding":             "utf16",
+		"force_flush_period": map[string]interface{}{
+			"Duration": 500 * 1000 * 1000,
+		},
+	}
+
+	var actual Config
+	err := mapstructure.Decode(input, &actual)
+	require.NoError(t, err)
+	require.Equal(t, expect, &actual)
+}

--- a/pkg/stanza/internal/fileconsumer/design.md
+++ b/pkg/stanza/internal/fileconsumer/design.md
@@ -1,0 +1,181 @@
+# File Matching
+
+The operator searches the file system for files that meet the following requirements:
+1. The file's path matches one or more patterns specified in the `include` setting.
+2. The file's path does not match any pattern specified in the `exclude` setting.
+
+The set of files that satisfy these requirements are known in this document as "matched files". 
+The effective search space (`include - exclude`) is referred to colloquially as the operator's "matching pattern".
+
+# Fingerprints
+
+Files are identified and tracked using fingerprints. A fingerprint is the first `N` bytes of the file, with the default for `N` being `1000`. 
+
+### Fingerprint Growth
+
+When a file is smaller than `N` bytes, the fingerprint is the entire contents of the file. A fingerprint that is less than `N` bytes will be compared to other fingerprints using a prefix check. As the file grows, its fingerprint will be updated, until it reaches the full size of `N`.
+
+### Deduplication of Files
+
+Multiple files with the same fingerprint are handled as if they are the same file. 
+
+Most commonly, this circumstance is observed during file rotation that depends on a copy/truncate strategy. After copying the file, but before truncating the original, two files with the same content briefly exist. If the `file_input` operator happens to observe both files at the same time, it will detect a duplicate fingerprint and ingest only one of the files.
+
+If logs are replicated to multiple files, or if log files are copied manually, it is not understood to be of any significant value to ingest the duplicates. As a result, fingerprints are not designed to differentiate between these files, and double ingestion of the same content is not supported automatically.
+
+In some rare circumstances, a logger may print a very verbose preamble to each log file. When this occurs, fingerprinting may fail to differentiate files from one another. This can be overcome by customizing the size of the fingerprint using the `fingerprint_size` setting.
+
+# Readers
+
+Readers are a convenience struct, which exist for the purpose of managing files and their associated metadata. 
+
+### Contents
+
+A Reader contains the following:
+- File handle (may be open or closed)
+- File fingerprint
+- File offset (aka checkpoint)
+- File path
+- Decoder (dedicated instance to avoid concurrency issues)
+
+### Functionality
+
+As implied by the name, Readers are responsible for consuming data as it is written to a file.
+
+Before a Reader begins consuming, it will seek the file's last known offset. If no offset is known for the file, then the Reader will seek either the beginning or end of the file, according to the `start_at` setting. It will then begin reading from there.
+
+While a file is shorter than the length of a fingerprint, its Reader will continuously append to the fingerprint, as it consumes newly written data.
+
+A Reader consumes a file using a `bufio.Scanner`, with the Scanner's buffer size defined by the `max_log_size` setting, and the Scanner's split func defined by the `multiline` setting. 
+
+As each log is read from the file, it is decoded according to the `encoding` function, and then emitted from the operator. 
+
+The Reader's offset is updated accordingly whenever a log is emitted.
+
+
+### Persistence
+
+Readers are always instantiated with an open file handle. Eventually, the file handle is closed, but the Reader is not immediately discarded. Rather, it is maintained for a fixed number of "poll cycles" (see Polling section below) as a reference to the file's metadata, which may be useful for detecting files that have been moved or copied, and for recalling metadata such as the file's previous path.
+
+Readers are maintained for a fixed period of time, and then discarded.
+
+When the `file_input` operator makes use of a persistence mechanism to save and recall its state, it is simply Setting and Getting a slice of Readers. These Readers contain all the information necessary to pick up exactly where the operator left off.
+
+
+# Polling
+
+The file system is polled on a regular interval, defined by the `poll_interval` setting. 
+
+Each poll cycle runs through a series of steps which are presented below.
+
+### Detailed Poll Cycle
+
+1. Dequeuing
+    1. If any matches are queued from the previous cycle, an appropriate number are dequeued, and processed the same as would a newly matched set of files.
+2. Aging
+    1. If no queued files were left over from the previous cycle, then all previously matched files have been consumed, and we are ready to query the file system again. Prior to doing so, we will increment the "generation" of all historical Readers. Eventually, these Readers will be discarded based on their age. Until that point, they may be useful references.
+3. Matching
+    1. The file system is searched for files with a path that matches the `include` setting.
+    2. Files that match the `exclude` setting are discarded.
+    3. As a special case, on the first poll cycle, a warning is printed if no files are matched. Execution continues regardless.
+4. Queueing
+    1. If the number of matched files is less than or equal to the maximum degree of concurrency, as defined by the `max_concurrent_files` setting, then no queueing occurs.
+    2. Else, queueing occurs, which means the following:
+        - Matched files are split into two sets, such that the first is small enough to respect `max_concurrent_files`, and the second contains the remaining files (called the queue).
+        - The current poll interval will begin processing the first set of files, just as if they were the only ones found during the matching phase.
+        - Subsequent poll cycles will pull matches off of the queue, until the queue is empty.
+        - The `max_concurrent_files` setting is respected at all times.
+5. Opening
+    1. Each of the matched files is opened. Note:
+        - A small amount of time has passed since the file was matched.
+        - It is possible that it has been moved or deleted by this point.
+        - Only a minimum set of operations should occur between file matching and opening.
+        - If an error occurs while opening, it is logged.
+6. Fingerprinting
+    1. The first `N` bytes of each file are read. (See fingerprinting section above.)
+7. Exclusion
+    1. Empty files are closed immediately and discarded. (There is nothing to read.)
+    2. Fingerprints found in this batch are cross referenced against each other to detect duplicates. Duplicate files are closed immediately and discarded.
+        - In the vast majority of cases, this occurs during file rotation that uses the copy/truncate method. (See fingerprinting section above.)
+8. Reader Creation
+    1. Each file handle is wrapped into a `Reader` along with some metadata. (See Reader section above)
+        - During the creation of a `Reader`, the file's fingerprint is cross referenced with previously known fingerprints.
+        - If a file's fingerprint matches one that has recently been seen, then metadata is copied over from the previous iteration of the Reader. Most importantly, the offset is accurately maintained in this way.
+        - If a file's fingerprint does not match any recently seen files, then its offset is initialized according to the `start_at` setting.
+9. Detection of Lost Files
+    1. Fingerprints are used to cross reference the matched files from this poll cycle against the matched file from the previous poll cycle. Files that were matched in the previous cycle but were not matched in this cycle are referred to as "lost files".
+    2. File become "lost" for several reasons:
+        - The file may have been deleted, typically due to rotation limits or ttl-based pruning.
+        - The file may have been rotated to another location.
+            - If the file was moved, the open file handle from the previous poll cycle may be useful.
+10. Consumption
+    1. Lost files are consumed. In some cases, such as deletion, this operation will fail. However, if a file was moved, we may be able to consume the remainder of its content. 
+        - We do not expect to match this file again, so the best we can do is finish consuming their current contents.
+        - We can reasonably expect in most cases that these files are no longer being written to.
+    2. Matched files (from this poll cycle) are consumed.
+        - These file handles will be left open until the next poll cycle, when they will be used to detect and potentially consume lost files.
+        - Typically, we can expect to find most of these files again. However, these files are consumed greedily in case we do not see them again.
+    3. All open files are consumed concurrently. This includes both the lost files from the previous cycle, and the matched files from this cycle.
+11. Closing
+    1. All files from the previous poll cycle are closed.
+12. Archiving
+    1. Readers created in the current poll cycle are added to the historical record.
+    2. The same Readers are also retained as a separate slice, for easy access in the next poll cycle.
+13. Pruning
+    1. The historical record is purged of Readers that have existed for 3 generations.
+        - This number is somewhat arbitrary, and should probably be made configurable. However, its exact purpose is quite obscure.
+14. Persistence
+    1. The historical record of readers is synced to whatever persistence mechanism was provided to the operator.
+15. End Poll Cycle
+    1. At this point, the operator sits idle until the poll timer fires again.
+
+
+
+# Additional Details
+
+### Startup Logic
+
+Whenever the operator starts, it:
+- Requests the historical record of Readers, as described in steps 12-14 of the poll cycle.
+- Starts the polling timer.
+
+### Shutdown Logic
+
+When the operator shuts down, the following occurs:
+- If a poll cycle is not currently underway, the operator simply closes any open files.
+- Otherwise, the current poll cycle is signaled to stop immediately, which in turn signals all Readers to stop immediately.
+    - If a Reader is idle or in between log entries, it will return immediately. Otherwise it will return after consuming one final log entry.
+    - Once all Readers have stopped, the remainder of the poll cycle completes as usual, which includes the steps labeled `Closing`, `Archiving`, `Pruning`, and `Persistence`.
+
+The net effect of the shut down routine is that all files are checkpointed in a normal manner (i.e. not in the middle of a log entry), and all checkpoints are persisted.
+
+
+# Known Limitations
+
+### Potential data loss when maximum concurrency must be enforced
+
+The operator may lose a small percentage of logs, if both of the following conditions are true:
+1. The number of files being matched exceeds the maximum degree of concurrency allowed by the `max_concurrent_files` setting. 
+2. Files are being "lost". That is, file rotation is moving files out of the operator's matching pattern, such that subsequent polling cycles will not find these files.
+
+When both of these conditions occur, it is impossible for the operator to both:
+1. Respect the specified concurrency limitation.
+2. Guarantee that if a file is rotated out of the matching pattern, it may still be consumed before being closed.
+
+When this scenario occurs, a design tradeoff must be made. The choice is between:
+1. Ensure that `max_concurrent_files` is always respected.
+2. Risk losing a small percentage of log entries.
+
+The current design chooses to guarantee the maximum degree of concurrency because failure to do so risks harming the operator's host system. While the loss of logs is not ideal, it is less likely to harm the operator's host system, and is therefore considered the more acceptable of the two options.
+
+### Potential data loss when file rotation via copy/truncate rotates backup files out of operator's matching pattern
+
+The operator may lose a small percentage of logs, if both of the following conditions are true:
+1. Files are being rotated using the copy/truncate strategy.
+2. Files are being "lost". That is, file rotation is moving files out of the operator's matching pattern, such that subsequent polling cycles will not find these files.
+
+When both of these conditions occur, it is possible that a file is written to (then copied elsewhere) and then truncated before the operator has a chance to consume the new data.
+
+### Potential failure to consume files when file rotation via move/create is used on Windows
+
+On Windows, rotation of files using the Move/Create strategy may cause errors and loss of data, because Golang does not currently support the Windows mechanism for `FILE_SHARE_DELETE`.

--- a/pkg/stanza/internal/fileconsumer/file.go
+++ b/pkg/stanza/internal/fileconsumer/file.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 
 import (
 	"bytes"

--- a/pkg/stanza/internal/fileconsumer/file.go
+++ b/pkg/stanza/internal/fileconsumer/file.go
@@ -1,0 +1,366 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+)
+
+// Input is an operator that monitors files for entries
+type Input struct {
+	helper.InputOperator
+
+	finder                Finder
+	FilePathField         entry.Field
+	FileNameField         entry.Field
+	FilePathResolvedField entry.Field
+	FileNameResolvedField entry.Field
+	PollInterval          time.Duration
+	Splitter              helper.SplitterConfig
+	MaxLogSize            int
+	MaxConcurrentFiles    int
+	SeenPaths             map[string]struct{}
+
+	persister operator.Persister
+
+	knownFiles    []*Reader
+	queuedMatches []string
+	maxBatchFiles int
+	roller        roller
+
+	startAtBeginning bool
+
+	fingerprintSize int
+
+	encoding helper.Encoding
+
+	wg         sync.WaitGroup
+	firstCheck bool
+	cancel     context.CancelFunc
+}
+
+// Start will start the file monitoring process
+func (f *Input) Start(persister operator.Persister) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	f.cancel = cancel
+	f.firstCheck = true
+
+	f.persister = persister
+
+	// Load offsets from disk
+	if err := f.loadLastPollFiles(ctx); err != nil {
+		return fmt.Errorf("read known files from database: %w", err)
+	}
+
+	// Start polling goroutine
+	f.startPoller(ctx)
+
+	return nil
+}
+
+// Stop will stop the file monitoring process
+func (f *Input) Stop() error {
+	f.cancel()
+	f.wg.Wait()
+	f.roller.cleanup()
+	for _, reader := range f.knownFiles {
+		reader.Close()
+	}
+	f.knownFiles = nil
+	f.cancel = nil
+	return nil
+}
+
+// startPoller kicks off a goroutine that will poll the filesystem periodically,
+// checking if there are new files or new logs in the watched files
+func (f *Input) startPoller(ctx context.Context) {
+	f.wg.Add(1)
+	go func() {
+		defer f.wg.Done()
+		globTicker := time.NewTicker(f.PollInterval)
+		defer globTicker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-globTicker.C:
+			}
+
+			f.poll(ctx)
+		}
+	}()
+}
+
+// poll checks all the watched paths for new entries
+func (f *Input) poll(ctx context.Context) {
+	f.maxBatchFiles = f.MaxConcurrentFiles / 2
+	var matches []string
+	if len(f.queuedMatches) > f.maxBatchFiles {
+		matches, f.queuedMatches = f.queuedMatches[:f.maxBatchFiles], f.queuedMatches[f.maxBatchFiles:]
+	} else {
+		if len(f.queuedMatches) > 0 {
+			matches, f.queuedMatches = f.queuedMatches, make([]string, 0)
+		} else {
+			// Increment the generation on all known readers
+			// This is done here because the next generation is about to start
+			for i := 0; i < len(f.knownFiles); i++ {
+				f.knownFiles[i].generation++
+			}
+
+			// Get the list of paths on disk
+			matches = f.finder.FindFiles()
+			if f.firstCheck && len(matches) == 0 {
+				f.Warnw("no files match the configured include patterns",
+					"include", f.finder.Include,
+					"exclude", f.finder.Exclude)
+			} else if len(matches) > f.maxBatchFiles {
+				matches, f.queuedMatches = matches[:f.maxBatchFiles], matches[f.maxBatchFiles:]
+			}
+		}
+	}
+
+	readers := f.makeReaders(matches)
+	f.firstCheck = false
+
+	var wg sync.WaitGroup
+	for _, reader := range readers {
+		wg.Add(1)
+		go func(r *Reader) {
+			defer wg.Done()
+			r.ReadToEnd(ctx)
+		}(reader)
+	}
+	wg.Wait()
+
+	f.roller.roll(ctx, readers)
+	f.saveCurrent(readers)
+	f.syncLastPollFiles(ctx)
+}
+
+// makeReaders takes a list of paths, then creates readers from each of those paths,
+// discarding any that have a duplicate fingerprint to other files that have already
+// been read this polling interval
+func (f *Input) makeReaders(filesPaths []string) []*Reader {
+	// Open the files first to minimize the time between listing and opening
+	files := make([]*os.File, 0, len(filesPaths))
+	for _, path := range filesPaths {
+		if _, ok := f.SeenPaths[path]; !ok {
+			if f.startAtBeginning {
+				f.Infow("Started watching file", "path", path)
+			} else {
+				f.Infow("Started watching file from end. To read preexisting logs, configure the argument 'start_at' to 'beginning'", "path", path)
+			}
+			f.SeenPaths[path] = struct{}{}
+		}
+		file, err := os.Open(path) // #nosec - operator must read in files defined by user
+		if err != nil {
+			f.Debugf("Failed to open file", zap.Error(err))
+			continue
+		}
+		files = append(files, file)
+	}
+
+	// Get fingerprints for each file
+	fps := make([]*Fingerprint, 0, len(files))
+	for _, file := range files {
+		fp, err := f.NewFingerprint(file)
+		if err != nil {
+			f.Errorw("Failed creating fingerprint", zap.Error(err))
+			continue
+		}
+		fps = append(fps, fp)
+	}
+
+	// Exclude any empty fingerprints or duplicate fingerprints to avoid doubling up on copy-truncate files
+OUTER:
+	for i := 0; i < len(fps); i++ {
+		fp := fps[i]
+		if len(fp.FirstBytes) == 0 {
+			if err := files[i].Close(); err != nil {
+				f.Errorf("problem closing file", "file", files[i].Name())
+			}
+			// Empty file, don't read it until we can compare its fingerprint
+			fps = append(fps[:i], fps[i+1:]...)
+			files = append(files[:i], files[i+1:]...)
+			i--
+			continue
+		}
+		for j := i + 1; j < len(fps); j++ {
+			fp2 := fps[j]
+			if fp.StartsWith(fp2) || fp2.StartsWith(fp) {
+				// Exclude
+				if err := files[i].Close(); err != nil {
+					f.Errorf("problem closing file", "file", files[i].Name())
+				}
+				fps = append(fps[:i], fps[i+1:]...)
+				files = append(files[:i], files[i+1:]...)
+				i--
+				continue OUTER
+			}
+		}
+	}
+
+	readers := make([]*Reader, 0, len(fps))
+	for i := 0; i < len(fps); i++ {
+		reader, err := f.newReader(files[i], fps[i], f.firstCheck)
+		if err != nil {
+			f.Errorw("Failed to create reader", zap.Error(err))
+			continue
+		}
+		readers = append(readers, reader)
+	}
+
+	return readers
+}
+
+// saveCurrent adds the readers from this polling interval to this list of
+// known files, then increments the generation of all tracked old readers
+// before clearing out readers that have existed for 3 generations.
+func (f *Input) saveCurrent(readers []*Reader) {
+	// Add readers from the current, completed poll interval to the list of known files
+	f.knownFiles = append(f.knownFiles, readers...)
+
+	// Clear out old readers. They are sorted such that they are oldest first,
+	// so we can just find the first reader whose generation is less than our
+	// max, and keep every reader after that
+	for i := 0; i < len(f.knownFiles); i++ {
+		reader := f.knownFiles[i]
+		if reader.generation <= 3 {
+			f.knownFiles = f.knownFiles[i:]
+			break
+		}
+	}
+}
+
+func (f *Input) newReader(file *os.File, fp *Fingerprint, firstCheck bool) (*Reader, error) {
+	// Check if the new path has the same fingerprint as an old path
+	if oldReader, ok := f.findFingerprintMatch(fp); ok {
+		newReader, err := oldReader.Copy(file)
+		if err != nil {
+			return nil, err
+		}
+		newReader.fileAttributes = f.resolveFileAttributes(file.Name())
+		return newReader, nil
+	}
+
+	// If we don't match any previously known files, create a new reader from scratch
+	splitter, err := f.getMultiline()
+	if err != nil {
+		return nil, err
+	}
+	newReader, err := f.NewReader(file.Name(), file, fp, splitter)
+	if err != nil {
+		return nil, err
+	}
+	startAtBeginning := !firstCheck || f.startAtBeginning
+	if err := newReader.InitializeOffset(startAtBeginning); err != nil {
+		return nil, fmt.Errorf("initialize offset: %w", err)
+	}
+	return newReader, nil
+}
+
+func (f *Input) findFingerprintMatch(fp *Fingerprint) (*Reader, bool) {
+	// Iterate backwards to match newest first
+	for i := len(f.knownFiles) - 1; i >= 0; i-- {
+		oldReader := f.knownFiles[i]
+		if fp.StartsWith(oldReader.Fingerprint) {
+			return oldReader, true
+		}
+	}
+	return nil, false
+}
+
+const knownFilesKey = "knownFiles"
+
+// syncLastPollFiles syncs the most recent set of files to the database
+func (f *Input) syncLastPollFiles(ctx context.Context) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+
+	// Encode the number of known files
+	if err := enc.Encode(len(f.knownFiles)); err != nil {
+		f.Errorw("Failed to encode known files", zap.Error(err))
+		return
+	}
+
+	// Encode each known file
+	for _, fileReader := range f.knownFiles {
+		if err := enc.Encode(fileReader); err != nil {
+			f.Errorw("Failed to encode known files", zap.Error(err))
+		}
+	}
+
+	if err := f.persister.Set(ctx, knownFilesKey, buf.Bytes()); err != nil {
+		f.Errorw("Failed to sync to database", zap.Error(err))
+	}
+}
+
+// syncLastPollFiles loads the most recent set of files to the database
+func (f *Input) loadLastPollFiles(ctx context.Context) error {
+	encoded, err := f.persister.Get(ctx, knownFilesKey)
+	if err != nil {
+		return err
+	}
+
+	if encoded == nil {
+		f.knownFiles = make([]*Reader, 0, 10)
+		return nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(encoded))
+
+	// Decode the number of entries
+	var knownFileCount int
+	if err := dec.Decode(&knownFileCount); err != nil {
+		return fmt.Errorf("decoding file count: %w", err)
+	}
+
+	// Decode each of the known files
+	f.knownFiles = make([]*Reader, 0, knownFileCount)
+	for i := 0; i < knownFileCount; i++ {
+		splitter, err := f.getMultiline()
+		if err != nil {
+			return err
+		}
+		newReader, err := f.NewReader("", nil, nil, splitter)
+		if err != nil {
+			return err
+		}
+		if err = dec.Decode(newReader); err != nil {
+			return err
+		}
+		f.knownFiles = append(f.knownFiles, newReader)
+	}
+
+	return nil
+}
+
+// getMultiline returns helper.Splitter structure and error eventually
+func (f *Input) getMultiline() (*helper.Splitter, error) {
+	return f.Splitter.Build(f.encoding.Encoding, false, f.MaxLogSize)
+}

--- a/pkg/stanza/internal/fileconsumer/file_test.go
+++ b/pkg/stanza/internal/fileconsumer/file_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file
+package fileconsumer
 
 import (
 	"context"

--- a/pkg/stanza/internal/fileconsumer/file_test.go
+++ b/pkg/stanza/internal/fileconsumer/file_test.go
@@ -1,0 +1,1097 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+)
+
+func TestCleanStop(t *testing.T) {
+	t.Parallel()
+	t.Skip(`Skipping due to goroutine leak in opencensus.
+See this issue for details: https://github.com/census-instrumentation/opencensus-go/issues/1191#issuecomment-610440163`)
+	// defer goleak.VerifyNone(t)
+
+	operator, _, tempDir := newTestFileOperator(t, nil, nil)
+	_ = openTemp(t, tempDir)
+	err := operator.Start(testutil.NewMockPersister("test"))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+}
+
+// AddFields tests that the `log.file.name` and `log.file.path` fields are included
+// when IncludeFileName and IncludeFilePath are set to true
+func TestAddFileFields(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
+		cfg.IncludeFileName = true
+		cfg.IncludeFilePath = true
+	}, nil)
+
+	// Create a file, then start
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "testlog\n")
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	e := waitForOne(t, logReceived)
+	require.Equal(t, filepath.Base(temp.Name()), e.Attributes["log.file.name"])
+	require.Equal(t, temp.Name(), e.Attributes["log.file.path"])
+}
+
+// AddFileResolvedFields tests that the `log.file.name_resolved` and `log.file.path_resolved` fields are included
+// when IncludeFileNameResolved and IncludeFilePathResolved are set to true
+func TestAddFileResolvedFields(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
+		cfg.IncludeFileName = true
+		cfg.IncludeFilePath = true
+		cfg.IncludeFileNameResolved = true
+		cfg.IncludeFilePathResolved = true
+	}, nil)
+
+	// Create temp dir with log file
+	dir := t.TempDir()
+
+	file, err := ioutil.TempFile(dir, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, file.Close())
+	})
+
+	// Create symbolic link in monitored directory
+	symLinkPath := filepath.Join(tempDir, "symlink")
+	err = os.Symlink(file.Name(), symLinkPath)
+	require.NoError(t, err)
+
+	// Populate data
+	writeString(t, file, "testlog\n")
+
+	// Resolve path
+	real, err := filepath.EvalSymlinks(file.Name())
+	require.NoError(t, err)
+	resolved, err := filepath.Abs(real)
+	require.NoError(t, err)
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	e := waitForOne(t, logReceived)
+	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["log.file.name"])
+	require.Equal(t, symLinkPath, e.Attributes["log.file.path"])
+	require.Equal(t, filepath.Base(resolved), e.Attributes["log.file.name_resolved"])
+	require.Equal(t, resolved, e.Attributes["log.file.path_resolved"])
+}
+
+// AddFileResolvedFields tests that the `log.file.name_resolved` and `log.file.path_resolved` fields are included
+// when IncludeFileNameResolved and IncludeFilePathResolved are set to true and underlaying symlink change
+// Scenario:
+// monitored file (symlink) -> middleSymlink -> file_1
+// monitored file (symlink) -> middleSymlink -> file_2
+func TestAddFileResolvedFieldsWithChangeOfSymlinkTarget(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
+		cfg.IncludeFileName = true
+		cfg.IncludeFilePath = true
+		cfg.IncludeFileNameResolved = true
+		cfg.IncludeFilePathResolved = true
+	}, nil)
+
+	// Create temp dir with log file
+	dir := t.TempDir()
+
+	file1, err := ioutil.TempFile(dir, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, file1.Close())
+	})
+
+	file2, err := ioutil.TempFile(dir, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, file2.Close())
+	})
+
+	// Resolve paths
+	real1, err := filepath.EvalSymlinks(file1.Name())
+	require.NoError(t, err)
+	resolved1, err := filepath.Abs(real1)
+	require.NoError(t, err)
+
+	real2, err := filepath.EvalSymlinks(file2.Name())
+	require.NoError(t, err)
+	resolved2, err := filepath.Abs(real2)
+	require.NoError(t, err)
+
+	// Create symbolic link in monitored directory
+	// symLinkPath(target of file input) -> middleSymLinkPath -> file1
+	middleSymLinkPath := filepath.Join(dir, "symlink")
+	symLinkPath := filepath.Join(tempDir, "symlink")
+	err = os.Symlink(file1.Name(), middleSymLinkPath)
+	require.NoError(t, err)
+	err = os.Symlink(middleSymLinkPath, symLinkPath)
+	require.NoError(t, err)
+
+	// Populate data
+	writeString(t, file1, "testlog\n")
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	e := waitForOne(t, logReceived)
+	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["log.file.name"])
+	require.Equal(t, symLinkPath, e.Attributes["log.file.path"])
+	require.Equal(t, filepath.Base(resolved1), e.Attributes["log.file.name_resolved"])
+	require.Equal(t, resolved1, e.Attributes["log.file.path_resolved"])
+
+	// Change middleSymLink to point to file2
+	err = os.Remove(middleSymLinkPath)
+	require.NoError(t, err)
+	err = os.Symlink(file2.Name(), middleSymLinkPath)
+	require.NoError(t, err)
+
+	// Populate data (different content due to fingerprint)
+	writeString(t, file2, "testlog2\n")
+
+	e = waitForOne(t, logReceived)
+	require.Equal(t, filepath.Base(symLinkPath), e.Attributes["log.file.name"])
+	require.Equal(t, symLinkPath, e.Attributes["log.file.path"])
+	require.Equal(t, filepath.Base(resolved2), e.Attributes["log.file.name_resolved"])
+	require.Equal(t, resolved2, e.Attributes["log.file.path_resolved"])
+}
+
+// ReadExistingLogs tests that, when starting from beginning, we
+// read all the lines that are already there
+func TestReadExistingLogs(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	// Create a file, then start
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "testlog1\ntestlog2\n")
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForMessage(t, logReceived, "testlog1")
+	waitForMessage(t, logReceived, "testlog2")
+}
+
+// TestReadUsingNopEncoding tests when nop encoding is set, that the splitfunction returns all bytes unchanged.
+func TestReadUsingNopEncoding(t *testing.T) {
+	tcs := []struct {
+		testName string
+		input    []byte
+		test     func(*testing.T, chan *entry.Entry)
+	}{
+		{
+			"simple",
+			[]byte("testlog1"),
+			func(t *testing.T, c chan *entry.Entry) {
+				waitForByteMessage(t, c, []byte("testlog1"))
+			},
+		},
+		{
+			"longer than maxlogsize",
+			[]byte("testlog1testlog2testlog3"),
+			func(t *testing.T, c chan *entry.Entry) {
+				waitForByteMessage(t, c, []byte("testlog1"))
+				waitForByteMessage(t, c, []byte("testlog2"))
+				waitForByteMessage(t, c, []byte("testlog3"))
+			},
+		},
+		{
+			"doesn't hit max log size before eof",
+			[]byte("testlog1testlog2test"),
+			func(t *testing.T, c chan *entry.Entry) {
+				waitForByteMessage(t, c, []byte("testlog1"))
+				waitForByteMessage(t, c, []byte("testlog2"))
+				waitForByteMessage(t, c, []byte("test"))
+			},
+		},
+		{
+			"special characters",
+			[]byte("testlog1\n\ttestlog2\n\t"),
+			func(t *testing.T, c chan *entry.Entry) {
+				waitForByteMessage(t, c, []byte("testlog1"))
+				waitForByteMessage(t, c, []byte("\n\ttestlo"))
+				waitForByteMessage(t, c, []byte("g2\n\t"))
+			},
+		},
+	}
+
+	t.Parallel()
+
+	for _, tc := range tcs {
+		t.Run(tc.testName, func(t *testing.T) {
+			operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
+				cfg.MaxLogSize = 8
+				cfg.Encoding.Encoding = "nop"
+			}, nil)
+			// Create a file, then start
+			temp := openTemp(t, tempDir)
+			bytesWritten, err := temp.Write(tc.input)
+			require.Greater(t, bytesWritten, 0)
+			require.NoError(t, err)
+			require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+			defer func() {
+				require.NoError(t, operator.Stop())
+			}()
+
+			tc.test(t, logReceived)
+		})
+	}
+}
+
+func TestNopEncodingDifferentLogSizes(t *testing.T) {
+	tcs := []struct {
+		testName   string
+		input      []byte
+		test       func(*testing.T, chan *entry.Entry)
+		maxLogSize helper.ByteSize
+	}{
+		{
+			"same size",
+			[]byte("testlog1"),
+			func(t *testing.T, c chan *entry.Entry) {
+				waitForByteMessage(t, c, []byte("testlog1"))
+			},
+			8,
+		},
+		{
+			"massive log size",
+			[]byte("testlog1"),
+			func(t *testing.T, c chan *entry.Entry) {
+				waitForByteMessage(t, c, []byte("testlog1"))
+			},
+			8000000,
+		},
+		{
+			"slightly larger log size",
+			[]byte("testlog1"),
+			func(t *testing.T, c chan *entry.Entry) {
+				waitForByteMessage(t, c, []byte("testlog1"))
+			},
+			9,
+		},
+		{
+			"slightly smaller log size",
+			[]byte("testlog1"),
+			func(t *testing.T, c chan *entry.Entry) {
+				waitForByteMessage(t, c, []byte("testlog"))
+				waitForByteMessage(t, c, []byte("1"))
+			},
+			7,
+		},
+		{
+			"tiny log size",
+			[]byte("testlog1"),
+			func(t *testing.T, c chan *entry.Entry) {
+				waitForByteMessage(t, c, []byte("t"))
+				waitForByteMessage(t, c, []byte("e"))
+				waitForByteMessage(t, c, []byte("s"))
+				waitForByteMessage(t, c, []byte("t"))
+				waitForByteMessage(t, c, []byte("l"))
+				waitForByteMessage(t, c, []byte("o"))
+				waitForByteMessage(t, c, []byte("g"))
+				waitForByteMessage(t, c, []byte("1"))
+			},
+			1,
+		},
+	}
+
+	t.Parallel()
+
+	for _, tc := range tcs {
+		t.Run(tc.testName, func(t *testing.T) {
+			operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
+				cfg.MaxLogSize = tc.maxLogSize
+				cfg.Encoding.Encoding = "nop"
+			}, nil)
+			// Create a file, then start
+			temp := openTemp(t, tempDir)
+			bytesWritten, err := temp.Write(tc.input)
+			require.Greater(t, bytesWritten, 0)
+			require.NoError(t, err)
+			require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+			defer func() {
+				require.NoError(t, operator.Stop())
+			}()
+
+			tc.test(t, logReceived)
+		})
+	}
+}
+
+// ReadNewLogs tests that, after starting, if a new file is created
+// all the entries in that file are read from the beginning
+func TestReadNewLogs(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+
+	// Poll once so we know this isn't a new file
+	operator.poll(context.Background())
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	// Create a new file
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "testlog\n")
+
+	// Poll a second time after the file has been created
+	operator.poll(context.Background())
+
+	// Expect the message to come through
+	waitForMessage(t, logReceived, "testlog")
+}
+
+// ReadExistingAndNewLogs tests that, on startup, if start_at
+// is set to `beginning`, we read the logs that are there, and
+// we read any additional logs that are written after startup
+func TestReadExistingAndNewLogs(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	// Start with a file with an entry in it, and expect that entry
+	// to come through when we poll for the first time
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "testlog1\n")
+	operator.poll(context.Background())
+	waitForMessage(t, logReceived, "testlog1")
+
+	// Write a second entry, and expect that entry to come through
+	// as well
+	writeString(t, temp, "testlog2\n")
+	operator.poll(context.Background())
+	waitForMessage(t, logReceived, "testlog2")
+}
+
+// StartAtEnd tests that when `start_at` is configured to `end`,
+// we don't read any entries that were in the file before startup
+func TestStartAtEnd(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
+		cfg.StartAt = "end"
+	}, nil)
+	operator.persister = testutil.NewMockPersister("test")
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "testlog1\n")
+
+	// Expect no entries on the first poll
+	operator.poll(context.Background())
+	expectNoMessages(t, logReceived)
+
+	// Expect any new entries after the first poll
+	writeString(t, temp, "testlog2\n")
+	operator.poll(context.Background())
+	waitForMessage(t, logReceived, "testlog2")
+}
+
+// StartAtEndNewFile tests that when `start_at` is configured to `end`,
+// a file created after the operator has been started is read from the
+// beginning
+func TestStartAtEndNewFile(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+	operator.startAtBeginning = false
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	operator.poll(context.Background())
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "testlog1\ntestlog2\n")
+
+	operator.poll(context.Background())
+	waitForMessage(t, logReceived, "testlog1")
+	waitForMessage(t, logReceived, "testlog2")
+}
+
+// NoNewline tests that an entry will still be sent eventually
+// even if the file doesn't end in a newline
+func TestNoNewline(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
+		cfg.Splitter = helper.NewSplitterConfig()
+		cfg.Splitter.Flusher.Period.Duration = time.Nanosecond
+	}, nil)
+
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "testlog1\ntestlog2")
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForMessage(t, logReceived, "testlog1")
+	waitForMessage(t, logReceived, "testlog2")
+}
+
+// SkipEmpty tests that the any empty lines are skipped
+func TestSkipEmpty(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "testlog1\n\ntestlog2\n")
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForMessage(t, logReceived, "testlog1")
+	waitForMessage(t, logReceived, "testlog2")
+}
+
+// SplitWrite tests a line written in two writes
+// close together still is read as a single entry
+func TestSplitWrite(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "testlog1")
+
+	operator.poll(context.Background())
+
+	writeString(t, temp, "testlog2\n")
+
+	operator.poll(context.Background())
+	waitForMessage(t, logReceived, "testlog1testlog2")
+}
+
+func TestIgnoreEmptyFiles(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	temp := openTemp(t, tempDir)
+	temp2 := openTemp(t, tempDir)
+	temp3 := openTemp(t, tempDir)
+	temp4 := openTemp(t, tempDir)
+
+	writeString(t, temp, "testlog1\n")
+	writeString(t, temp3, "testlog2\n")
+	operator.poll(context.Background())
+
+	waitForMessages(t, logReceived, []string{"testlog1", "testlog2"})
+
+	writeString(t, temp2, "testlog3\n")
+	writeString(t, temp4, "testlog4\n")
+	operator.poll(context.Background())
+
+	waitForMessages(t, logReceived, []string{"testlog3", "testlog4"})
+}
+
+func TestDecodeBufferIsResized(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	temp := openTemp(t, tempDir)
+	expected := stringWithLength(1<<12 + 1)
+	writeString(t, temp, expected+"\n")
+
+	waitForMessage(t, logReceived, expected)
+}
+
+func TestMultiFileSimple(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	temp1 := openTemp(t, tempDir)
+	temp2 := openTemp(t, tempDir)
+
+	writeString(t, temp1, "testlog1\n")
+	writeString(t, temp2, "testlog2\n")
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForMessages(t, logReceived, []string{"testlog1", "testlog2"})
+}
+
+func TestMultiFileParallel_PreloadedFiles(t *testing.T) {
+	t.Parallel()
+
+	getMessage := func(f, m int) string { return fmt.Sprintf("file %d, message %d", f, m) }
+
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	numFiles := 10
+	numMessages := 100
+
+	expected := make([]string, 0, numFiles*numMessages)
+	for i := 0; i < numFiles; i++ {
+		for j := 0; j < numMessages; j++ {
+			expected = append(expected, getMessage(i, j))
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < numFiles; i++ {
+		temp := openTemp(t, tempDir)
+		wg.Add(1)
+		go func(tf *os.File, f int) {
+			defer wg.Done()
+			for j := 0; j < numMessages; j++ {
+				writeString(t, tf, getMessage(f, j)+"\n")
+			}
+		}(temp, i)
+	}
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForMessages(t, logReceived, expected)
+	wg.Wait()
+}
+
+func TestMultiFileParallel_LiveFiles(t *testing.T) {
+	t.Parallel()
+
+	getMessage := func(f, m int) string { return fmt.Sprintf("file %d, message %d", f, m) }
+
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	numFiles := 10
+	numMessages := 100
+
+	expected := make([]string, 0, numFiles*numMessages)
+	for i := 0; i < numFiles; i++ {
+		for j := 0; j < numMessages; j++ {
+			expected = append(expected, getMessage(i, j))
+		}
+	}
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	temps := make([]*os.File, 0, numFiles)
+	for i := 0; i < numFiles; i++ {
+		temps = append(temps, openTemp(t, tempDir))
+	}
+
+	var wg sync.WaitGroup
+	for i, temp := range temps {
+		wg.Add(1)
+		go func(tf *os.File, f int) {
+			defer wg.Done()
+			for j := 0; j < numMessages; j++ {
+				writeString(t, tf, getMessage(f, j)+"\n")
+			}
+		}(temp, i)
+	}
+
+	waitForMessages(t, logReceived, expected)
+	wg.Wait()
+}
+
+// OffsetsAfterRestart tests that a operator is able to load
+// its offsets after a restart
+func TestOffsetsAfterRestart(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	persister := testutil.NewMockPersister("test")
+
+	temp1 := openTemp(t, tempDir)
+	writeString(t, temp1, "testlog1\n")
+
+	// Start the operator and expect a message
+	require.NoError(t, operator.Start(persister))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+	waitForMessage(t, logReceived, "testlog1")
+
+	// Restart the operator. Stop and build a new
+	// one to guarantee freshness
+	require.NoError(t, operator.Stop())
+	require.NoError(t, operator.Start(persister))
+
+	// Write a new log and expect only that log
+	writeString(t, temp1, "testlog2\n")
+	waitForMessage(t, logReceived, "testlog2")
+}
+
+func TestOffsetsAfterRestart_BigFiles(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	persister := testutil.NewMockPersister("test")
+
+	log1 := stringWithLength(2000)
+	log2 := stringWithLength(2000)
+
+	temp1 := openTemp(t, tempDir)
+	writeString(t, temp1, log1+"\n")
+
+	// Start the operator
+	require.NoError(t, operator.Start(persister))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+	waitForMessage(t, logReceived, log1)
+
+	// Restart the operator
+	require.NoError(t, operator.Stop())
+	require.NoError(t, operator.Start(persister))
+
+	writeString(t, temp1, log2+"\n")
+	waitForMessage(t, logReceived, log2)
+}
+
+func TestOffsetsAfterRestart_BigFilesWrittenWhileOff(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	persister := testutil.NewMockPersister("test")
+
+	log1 := stringWithLength(2000)
+	log2 := stringWithLength(2000)
+
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, log1+"\n")
+
+	// Start the operator and expect the first message
+	require.NoError(t, operator.Start(persister))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+	waitForMessage(t, logReceived, log1)
+
+	// Stop the operator and write a new message
+	require.NoError(t, operator.Stop())
+	writeString(t, temp, log2+"\n")
+
+	// Start the operator and expect the message
+	require.NoError(t, operator.Start(persister))
+	waitForMessage(t, logReceived, log2)
+}
+
+func TestManyLogsDelivered(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	count := 1000
+	expectedMessages := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		expectedMessages = append(expectedMessages, strconv.Itoa(i))
+	}
+
+	// Start the operator
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	// Write lots of logs
+	temp := openTemp(t, tempDir)
+	for _, message := range expectedMessages {
+		_, err := temp.WriteString(message + "\n")
+		require.NoError(t, err)
+	}
+
+	// Expect each of them to come through once
+	for _, message := range expectedMessages {
+		waitForMessage(t, logReceived, message)
+	}
+	expectNoMessages(t, logReceived)
+}
+
+func TestFileBatching(t *testing.T) {
+	t.Parallel()
+
+	files := 100
+	linesPerFile := 10
+	maxConcurrentFiles := 20
+	maxBatchFiles := maxConcurrentFiles / 2
+
+	expectedBatches := files / maxBatchFiles // assumes no remainder
+	expectedLinesPerBatch := maxBatchFiles * linesPerFile
+
+	expectedMessages := make([]string, 0, files*linesPerFile)
+	actualMessages := make([]string, 0, files*linesPerFile)
+
+	operator, logReceived, tempDir := newTestFileOperator(t,
+		func(cfg *Config) {
+			cfg.MaxConcurrentFiles = maxConcurrentFiles
+		},
+		func(out *testutil.FakeOutput) {
+			out.Received = make(chan *entry.Entry, expectedLinesPerBatch*2)
+		},
+	)
+	operator.persister = testutil.NewMockPersister("test")
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	temps := make([]*os.File, 0, files)
+	for i := 0; i < files; i++ {
+		temps = append(temps, openTemp(t, tempDir))
+	}
+
+	// Write logs to each file
+	for i, temp := range temps {
+		for j := 0; j < linesPerFile; j++ {
+			message := fmt.Sprintf("%s %d %d", stringWithLength(100), i, j)
+			_, err := temp.WriteString(message + "\n")
+			require.NoError(t, err)
+			expectedMessages = append(expectedMessages, message)
+		}
+	}
+
+	for b := 0; b < expectedBatches; b++ {
+		// poll once so we can validate that files were batched
+		operator.poll(context.Background())
+		actualMessages = append(actualMessages, waitForN(t, logReceived, expectedLinesPerBatch)...)
+	}
+
+	require.ElementsMatch(t, expectedMessages, actualMessages)
+
+	// Write more logs to each file so we can validate that all files are still known
+	for i, temp := range temps {
+		for j := 0; j < linesPerFile; j++ {
+			message := fmt.Sprintf("%s %d %d", stringWithLength(20), i, j)
+			_, err := temp.WriteString(message + "\n")
+			require.NoError(t, err)
+			expectedMessages = append(expectedMessages, message)
+		}
+	}
+
+	for b := 0; b < expectedBatches; b++ {
+		// poll once so we can validate that files were batched
+		operator.poll(context.Background())
+		actualMessages = append(actualMessages, waitForN(t, logReceived, expectedLinesPerBatch)...)
+	}
+
+	require.ElementsMatch(t, expectedMessages, actualMessages)
+}
+
+func TestFileReader_FingerprintUpdated(t *testing.T) {
+	t.Parallel()
+
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	temp := openTemp(t, tempDir)
+	tempCopy := openFile(t, temp.Name())
+	fp, err := operator.NewFingerprint(temp)
+	require.NoError(t, err)
+
+	splitter, err := operator.getMultiline()
+	require.NoError(t, err)
+
+	reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	writeString(t, temp, "testlog1\n")
+	reader.ReadToEnd(context.Background())
+	waitForMessage(t, logReceived, "testlog1")
+	require.Equal(t, []byte("testlog1\n"), reader.Fingerprint.FirstBytes)
+}
+
+// Test that a fingerprint:
+// - Starts empty
+// - Updates as a file is read
+// - Stops updating when the max fingerprint size is reached
+// - Stops exactly at max fingerprint size, regardless of content
+func TestFingerprintGrowsAndStops(t *testing.T) {
+	t.Parallel()
+
+	// Use a number with many factors.
+	// Sometimes fingerprint length will align with
+	// the end of a line, sometimes not. Test both.
+	maxFP := 360
+
+	// Use prime numbers to ensure variation in
+	// whether or not they are factors of maxFP
+	lineLens := []int{3, 5, 7, 11, 13, 17, 19, 23, 27}
+
+	for _, lineLen := range lineLens {
+		t.Run(fmt.Sprintf("%d", lineLen), func(t *testing.T) {
+			t.Parallel()
+			operator, _, tempDir := newTestFileOperator(t, func(cfg *Config) {
+				cfg.FingerprintSize = helper.ByteSize(maxFP)
+			}, nil)
+			defer func() {
+				require.NoError(t, operator.Stop())
+			}()
+
+			temp := openTemp(t, tempDir)
+			tempCopy := openFile(t, temp.Name())
+			fp, err := operator.NewFingerprint(temp)
+			require.NoError(t, err)
+			require.Equal(t, []byte(""), fp.FirstBytes)
+
+			splitter, err := operator.getMultiline()
+			require.NoError(t, err)
+
+			reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter)
+			require.NoError(t, err)
+			defer reader.Close()
+
+			// keep track of what has been written to the file
+			fileContent := []byte{}
+
+			// keep track of expected fingerprint size
+			expectedFP := 0
+
+			// Write lines until file is much larger than the length of the fingerprint
+			for len(fileContent) < 2*maxFP {
+				expectedFP += lineLen
+				if expectedFP > maxFP {
+					expectedFP = maxFP
+				}
+
+				line := stringWithLength(lineLen-1) + "\n"
+				fileContent = append(fileContent, []byte(line)...)
+
+				writeString(t, temp, line)
+				reader.ReadToEnd(context.Background())
+				require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
+			}
+		})
+	}
+}
+
+// This is same test like TestFingerprintGrowsAndStops, but with additional check for fingerprint size check
+// Test that a fingerprint:
+// - Starts empty
+// - Updates as a file is read
+// - Stops updating when the max fingerprint size is reached
+// - Stops exactly at max fingerprint size, regardless of content
+// - Do not change size after fingerprint configuration change
+func TestFingerprintChangeSize(t *testing.T) {
+	t.Parallel()
+
+	// Use a number with many factors.
+	// Sometimes fingerprint length will align with
+	// the end of a line, sometimes not. Test both.
+	maxFP := 360
+
+	// Use prime numbers to ensure variation in
+	// whether or not they are factors of maxFP
+	lineLens := []int{3, 5, 7, 11, 13, 17, 19, 23, 27}
+
+	for _, lineLen := range lineLens {
+		t.Run(fmt.Sprintf("%d", lineLen), func(t *testing.T) {
+			t.Parallel()
+			operator, _, tempDir := newTestFileOperator(t, func(cfg *Config) {
+				cfg.FingerprintSize = helper.ByteSize(maxFP)
+			}, nil)
+			defer func() {
+				require.NoError(t, operator.Stop())
+			}()
+
+			temp := openTemp(t, tempDir)
+			tempCopy := openFile(t, temp.Name())
+			fp, err := operator.NewFingerprint(temp)
+			require.NoError(t, err)
+			require.Equal(t, []byte(""), fp.FirstBytes)
+
+			splitter, err := operator.getMultiline()
+			require.NoError(t, err)
+
+			reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter)
+			require.NoError(t, err)
+			defer reader.Close()
+
+			// keep track of what has been written to the file
+			fileContent := []byte{}
+
+			// keep track of expected fingerprint size
+			expectedFP := 0
+
+			// Write lines until file is much larger than the length of the fingerprint
+			for len(fileContent) < 2*maxFP {
+				expectedFP += lineLen
+				if expectedFP > maxFP {
+					expectedFP = maxFP
+				}
+
+				line := stringWithLength(lineLen-1) + "\n"
+				fileContent = append(fileContent, []byte(line)...)
+
+				writeString(t, temp, line)
+				reader.ReadToEnd(context.Background())
+				require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
+			}
+
+			// Test fingerprint change
+			// Change fingerprint and try to read file again
+			// We do not expect fingerprint change
+			// We test both increasing and decreasing fingerprint size
+			reader.fileInput.fingerprintSize = maxFP * (lineLen / 3)
+			line := stringWithLength(lineLen-1) + "\n"
+			fileContent = append(fileContent, []byte(line)...)
+
+			writeString(t, temp, line)
+			reader.ReadToEnd(context.Background())
+			require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
+
+			reader.fileInput.fingerprintSize = maxFP / 2
+			line = stringWithLength(lineLen-1) + "\n"
+			fileContent = append(fileContent, []byte(line)...)
+
+			writeString(t, temp, line)
+			reader.ReadToEnd(context.Background())
+			require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
+		})
+	}
+}
+
+func TestEncodings(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		contents []byte
+		encoding string
+		expected [][]byte
+	}{
+		{
+			"Nop",
+			[]byte{0xc5, '\n'},
+			"",
+			[][]byte{{0xc5}},
+		},
+		{
+			"InvalidUTFReplacement",
+			[]byte{0xc5, '\n'},
+			"utf8",
+			[][]byte{{0xef, 0xbf, 0xbd}},
+		},
+		{
+			"ValidUTF8",
+			[]byte("foo\n"),
+			"utf8",
+			[][]byte{[]byte("foo")},
+		},
+		{
+			"ChineseCharacter",
+			[]byte{230, 138, 152, '\n'}, // 折\n
+			"utf8",
+			[][]byte{{230, 138, 152}},
+		},
+		{
+			"SmileyFaceUTF16",
+			[]byte{216, 61, 222, 0, 0, 10}, // 😀\n
+			"utf-16be",
+			[][]byte{{240, 159, 152, 128}},
+		},
+		{
+			"SmileyFaceNewlineUTF16",
+			[]byte{216, 61, 222, 0, 0, 10, 0, 102, 0, 111, 0, 111}, // 😀\nfoo
+			"utf-16be",
+			[][]byte{{240, 159, 152, 128}, {102, 111, 111}},
+		},
+		{
+			"SmileyFaceNewlineUTF16LE",
+			[]byte{61, 216, 0, 222, 10, 0, 102, 0, 111, 0, 111, 0}, // 😀\nfoo
+			"utf-16le",
+			[][]byte{{240, 159, 152, 128}, {102, 111, 111}},
+		},
+		{
+			"ChineseCharacterBig5",
+			[]byte{167, 233, 10}, // 折\n
+			"big5",
+			[][]byte{{230, 138, 152}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			operator, receivedEntries, tempDir := newTestFileOperator(t, func(cfg *Config) {
+				cfg.Encoding = helper.EncodingConfig{Encoding: tc.encoding}
+			}, nil)
+
+			// Popualte the file
+			temp := openTemp(t, tempDir)
+			_, err := temp.Write(tc.contents)
+			require.NoError(t, err)
+
+			require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+			defer func() {
+				require.NoError(t, operator.Stop())
+			}()
+
+			for _, expected := range tc.expected {
+				select {
+				case entry := <-receivedEntries:
+					require.Equal(t, expected, []byte(entry.Body.(string)))
+				case <-time.After(500 * time.Millisecond):
+					require.FailNow(t, "Timed out waiting for entry to be read")
+				}
+			}
+		})
+	}
+}

--- a/pkg/stanza/internal/fileconsumer/finder.go
+++ b/pkg/stanza/internal/fileconsumer/finder.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+
+import (
+	"github.com/bmatcuk/doublestar/v3"
+)
+
+type Finder struct {
+	Include []string `mapstructure:"include,omitempty" json:"include,omitempty" yaml:"include,omitempty"`
+	Exclude []string `mapstructure:"exclude,omitempty" json:"exclude,omitempty" yaml:"exclude,omitempty"`
+}
+
+// FindFiles gets a list of paths given an array of glob patterns to include and exclude
+func (f Finder) FindFiles() []string {
+	all := make([]string, 0, len(f.Include))
+	for _, include := range f.Include {
+		matches, _ := doublestar.Glob(include) // compile error checked in build
+	INCLUDE:
+		for _, match := range matches {
+			for _, exclude := range f.Exclude {
+				if itMatches, _ := doublestar.PathMatch(exclude, match); itMatches {
+					continue INCLUDE
+				}
+			}
+
+			for _, existing := range all {
+				if existing == match {
+					continue INCLUDE
+				}
+			}
+
+			all = append(all, match)
+		}
+	}
+
+	return all
+}

--- a/pkg/stanza/internal/fileconsumer/finder.go
+++ b/pkg/stanza/internal/fileconsumer/finder.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 
 import (
 	"github.com/bmatcuk/doublestar/v3"

--- a/pkg/stanza/internal/fileconsumer/finder_test.go
+++ b/pkg/stanza/internal/fileconsumer/finder_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file
+package fileconsumer
 
 import (
 	"io/ioutil"

--- a/pkg/stanza/internal/fileconsumer/finder_test.go
+++ b/pkg/stanza/internal/fileconsumer/finder_test.go
@@ -1,0 +1,153 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinder(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		files    []string
+		include  []string
+		exclude  []string
+		expected []string
+	}{
+		{
+			name:     "IncludeOne",
+			files:    []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+			include:  []string{"a1.log"},
+			exclude:  []string{},
+			expected: []string{"a1.log"},
+		},
+		{
+			name:     "IncludeNone",
+			files:    []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+			include:  []string{"c*.log"},
+			exclude:  []string{},
+			expected: []string{},
+		},
+		{
+			name:     "IncludeAll",
+			files:    []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+			include:  []string{"*"},
+			exclude:  []string{},
+			expected: []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+		},
+		{
+			name:     "IncludeLogs",
+			files:    []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+			include:  []string{"*.log"},
+			exclude:  []string{},
+			expected: []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+		},
+		{
+			name:     "IncludeA",
+			files:    []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+			include:  []string{"a*.log"},
+			exclude:  []string{},
+			expected: []string{"a1.log", "a2.log"},
+		},
+		{
+			name:     "Include2s",
+			files:    []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+			include:  []string{"*2.log"},
+			exclude:  []string{},
+			expected: []string{"a2.log", "b2.log"},
+		},
+		{
+			name:     "Exclude",
+			files:    []string{"include.log", "exclude.log"},
+			include:  []string{"*"},
+			exclude:  []string{"exclude.log"},
+			expected: []string{"include.log"},
+		},
+		{
+			name:     "ExcludeMany",
+			files:    []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+			include:  []string{"*"},
+			exclude:  []string{"a*.log", "*2.log"},
+			expected: []string{"b1.log"},
+		},
+		{
+			name:     "ExcludeDuplicates",
+			files:    []string{"a1.log", "a2.log", "b1.log", "b2.log"},
+			include:  []string{"*1*", "a*"},
+			exclude:  []string{"a*.log", "*2.log"},
+			expected: []string{"b1.log"},
+		},
+		{
+			name:     "IncludeMultipleDirectories",
+			files:    []string{"a/1.log", "a/2.log", "b/1.log", "b/2.log"},
+			include:  []string{"a/*.log", "b/*.log"},
+			exclude:  []string{},
+			expected: []string{"a/1.log", "a/2.log", "b/1.log", "b/2.log"},
+		},
+		{
+			name:     "IncludeMultipleDirectoriesVaryingDepth",
+			files:    []string{"1.log", "a/1.log", "a/b/1.log", "c/1.log"},
+			include:  []string{"*.log", "a/*.log", "a/b/*.log", "c/*.log"},
+			exclude:  []string{},
+			expected: []string{"1.log", "a/1.log", "a/b/1.log", "c/1.log"},
+		},
+		{
+			name:     "DoubleStarSameDepth",
+			files:    []string{"a/1.log", "b/1.log", "c/1.log"},
+			include:  []string{"**/*.log"},
+			exclude:  []string{},
+			expected: []string{"a/1.log", "b/1.log", "c/1.log"},
+		},
+		{
+			name:     "DoubleStarVaryingDepth",
+			files:    []string{"1.log", "a/1.log", "a/b/1.log", "c/1.log"},
+			include:  []string{"**/*.log"},
+			exclude:  []string{},
+			expected: []string{"1.log", "a/1.log", "a/b/1.log", "c/1.log"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			files := absPath(tempDir, tc.files)
+			include := absPath(tempDir, tc.include)
+			exclude := absPath(tempDir, tc.exclude)
+			expected := absPath(tempDir, tc.expected)
+
+			for _, f := range files {
+				require.NoError(t, os.MkdirAll(filepath.Dir(f), 0700))
+				require.NoError(t, ioutil.WriteFile(f, []byte(filepath.Base(f)), 0000))
+			}
+
+			finder := Finder{include, exclude}
+			require.ElementsMatch(t, finder.FindFiles(), expected)
+		})
+	}
+}
+
+func absPath(tempDir string, files []string) []string {
+	absFiles := make([]string, 0, len(files))
+	for _, f := range files {
+		absFiles = append(absFiles, filepath.Join(tempDir, f))
+	}
+	return absFiles
+}

--- a/pkg/stanza/internal/fileconsumer/fingerprint.go
+++ b/pkg/stanza/internal/fileconsumer/fingerprint.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 
 import (
 	"bytes"

--- a/pkg/stanza/internal/fileconsumer/fingerprint.go
+++ b/pkg/stanza/internal/fileconsumer/fingerprint.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+const defaultFingerprintSize = 1000 // bytes
+const minFingerprintSize = 16       // bytes
+
+// Fingerprint is used to identify a file
+// A file's fingerprint is the first N bytes of the file,
+// where N is the fingerprintSize on the file_input operator
+type Fingerprint struct {
+	FirstBytes []byte
+}
+
+// NewFingerprint creates a new fingerprint from an open file
+func (f *Input) NewFingerprint(file *os.File) (*Fingerprint, error) {
+	buf := make([]byte, f.fingerprintSize)
+
+	n, err := file.ReadAt(buf, 0)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("reading fingerprint bytes: %w", err)
+	}
+
+	fp := &Fingerprint{
+		FirstBytes: buf[:n],
+	}
+
+	return fp, nil
+}
+
+// Copy creates a new copy of the fingerprint
+func (f Fingerprint) Copy() *Fingerprint {
+	buf := make([]byte, len(f.FirstBytes), cap(f.FirstBytes))
+	n := copy(buf, f.FirstBytes)
+	return &Fingerprint{
+		FirstBytes: buf[:n],
+	}
+}
+
+// StartsWith returns true if the fingerprints are the same
+// or if the new fingerprint starts with the old one
+// This is important functionality for tracking new files,
+// since their initial size is typically less than that of
+// a fingerprint. As the file grows, its fingerprint is updated
+// until it reaches a maximum size, as configured on the operator
+func (f Fingerprint) StartsWith(old *Fingerprint) bool {
+	l0 := len(old.FirstBytes)
+	if l0 == 0 {
+		return false
+	}
+	l1 := len(f.FirstBytes)
+	if l0 > l1 {
+		return false
+	}
+	return bytes.Equal(old.FirstBytes[:l0], f.FirstBytes[:l0])
+}

--- a/pkg/stanza/internal/fileconsumer/fingerprint_test.go
+++ b/pkg/stanza/internal/fileconsumer/fingerprint_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file
+package fileconsumer
 
 import (
 	"fmt"

--- a/pkg/stanza/internal/fileconsumer/fingerprint_test.go
+++ b/pkg/stanza/internal/fileconsumer/fingerprint_test.go
@@ -1,0 +1,279 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFingerprintDoesNotModifyOffset(t *testing.T) {
+	fingerprint := "this is the fingerprint"
+	next := "this comes after the fingerprint and is substantially longer than the fingerprint"
+	extra := "fin"
+
+	fileContents := fmt.Sprintf("%s%s%s\n", fingerprint, next, extra)
+
+	f, _, tempDir := newTestFileOperator(t, nil, nil)
+	f.fingerprintSize = len(fingerprint)
+
+	// Create a new file
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, fileContents)
+
+	// Validate that the file is actually the expected size after writing
+	info, err := temp.Stat()
+	require.NoError(t, err)
+	require.Equal(t, len(fileContents), int(info.Size()))
+
+	// Set the file descriptors pointer to the beginning of the file
+	_, err = temp.Seek(0, 0)
+	require.NoError(t, err)
+
+	fp, err := f.NewFingerprint(temp)
+	require.NoError(t, err)
+
+	// Validate the fingerprint is the correct size
+	require.Equal(t, len(fingerprint), len(fp.FirstBytes))
+
+	// Validate that reading the fingerprint did not adjust the
+	// file descriptor's internal offset (as using Seek does)
+	allButExtra := make([]byte, len(fingerprint)+len(next))
+	n, err := temp.Read(allButExtra)
+	require.NoError(t, err)
+	require.Equal(t, len(allButExtra), n)
+	require.Equal(t, fileContents[:len(allButExtra)], string(allButExtra))
+}
+
+func TestNewFingerprint(t *testing.T) {
+	cases := []struct {
+		name            string
+		fingerprintSize int
+		fileSize        int
+		expectedLen     int
+	}{
+		{
+			name:            "defaultExactFileSize",
+			fingerprintSize: defaultFingerprintSize,
+			fileSize:        defaultFingerprintSize,
+			expectedLen:     defaultFingerprintSize,
+		},
+		{
+			name:            "defaultWithFileHalfOfFingerprint",
+			fingerprintSize: defaultFingerprintSize,
+			fileSize:        defaultFingerprintSize / 2,
+			expectedLen:     defaultFingerprintSize / 2,
+		},
+		{
+			name:            "defaultWithFileTwiceFingerprint",
+			fingerprintSize: defaultFingerprintSize,
+			fileSize:        defaultFingerprintSize * 2,
+			expectedLen:     defaultFingerprintSize,
+		},
+		{
+			name:            "minFingerprintExactFileSize",
+			fingerprintSize: minFingerprintSize,
+			fileSize:        minFingerprintSize,
+			expectedLen:     minFingerprintSize,
+		},
+		{
+			name:            "minFingerprintWithSmallerFileSize",
+			fingerprintSize: minFingerprintSize,
+			fileSize:        minFingerprintSize / 2,
+			expectedLen:     minFingerprintSize / 2,
+		},
+		{
+			name:            "minFingerprintWithLargerFileSize",
+			fingerprintSize: minFingerprintSize,
+			fileSize:        defaultFingerprintSize,
+			expectedLen:     minFingerprintSize,
+		},
+		{
+			name:            "largeFingerprintSmallFile",
+			fingerprintSize: 1024 * 1024,
+			fileSize:        1024,
+			expectedLen:     1024,
+		},
+		{
+			name:            "largeFingerprintLargeFile",
+			fingerprintSize: 1024 * 8,
+			fileSize:        1024 * 128,
+			expectedLen:     1024 * 8,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f, _, tempDir := newTestFileOperator(t, nil, nil)
+			f.fingerprintSize = tc.fingerprintSize
+
+			// Create a new file
+			temp := openTemp(t, tempDir)
+			writeString(t, temp, stringWithLength(tc.fileSize))
+
+			// Validate that the file is actually the expected size after writing
+			info, err := temp.Stat()
+			require.NoError(t, err)
+			require.Equal(t, tc.fileSize, int(info.Size()))
+
+			fp, err := f.NewFingerprint(temp)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedLen, len(fp.FirstBytes))
+		})
+	}
+}
+
+func TestFingerprintCopy(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"",
+		"hello",
+		"asdfsfaddsfas",
+		stringWithLength(minFingerprintSize),
+		stringWithLength(defaultFingerprintSize),
+		stringWithLength(1234),
+	}
+
+	for _, tc := range cases {
+		fp := &Fingerprint{FirstBytes: []byte(tc)}
+
+		copy := fp.Copy()
+
+		// Did not change original
+		require.Equal(t, tc, string(fp.FirstBytes))
+
+		// Copy is also good
+		require.Equal(t, tc, string(copy.FirstBytes))
+
+		// Modify copy
+		copy.FirstBytes = append(copy.FirstBytes, []byte("also")...)
+
+		// Still did not change original
+		require.Equal(t, tc, string(fp.FirstBytes))
+
+		// Copy is modified
+		require.Equal(t, tc+"also", string(copy.FirstBytes))
+	}
+}
+
+func TestFingerprintStartsWith(t *testing.T) {
+	cases := []struct {
+		name string
+		a    string
+		b    string
+	}{
+		{
+			name: "same",
+			a:    "hello",
+			b:    "hello",
+		},
+		{
+			name: "aStartsWithB",
+			a:    "helloworld",
+			b:    "hello",
+		},
+		{
+			name: "bStartsWithA",
+			a:    "hello",
+			b:    "helloworld",
+		},
+		{
+			name: "neither",
+			a:    "hello",
+			b:    "world",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fa := &Fingerprint{FirstBytes: []byte(tc.a)}
+			fb := &Fingerprint{FirstBytes: []byte(tc.b)}
+
+			require.Equal(t, strings.HasPrefix(tc.a, tc.b), fa.StartsWith(fb))
+			require.Equal(t, strings.HasPrefix(tc.b, tc.a), fb.StartsWith(fa))
+		})
+	}
+}
+
+// Generates a file filled with many random bytes, then
+// writes the same bytes to a second file, one byte at a time.
+// Validates, after each byte is written, that fingerprint
+// matching would successfully associate the two files.
+// The static file can be thought of as the present state of
+// the file, while each iteration of the growing file represents
+// a possible state of the same file at a previous time.
+func TestFingerprintStartsWith_FromFile(t *testing.T) {
+	r := rand.New(rand.NewSource(112358))
+
+	operator, _, tempDir := newTestFileOperator(t, nil, nil)
+	operator.fingerprintSize *= 10
+
+	fileLength := 12 * operator.fingerprintSize
+
+	// Make a []byte we can write one at a time
+	content := make([]byte, fileLength)
+	r.Read(content) // Fill slice with random bytes
+
+	// Overwrite some bytes with \n to ensure
+	// we are testing a file with multiple lines
+	newlineMask := make([]byte, fileLength)
+	r.Read(newlineMask) // Fill slice with random bytes
+	for i, b := range newlineMask {
+		if b == 0 && i != 0 { // 1/256 chance, but never first byte
+			content[i] = byte('\n')
+		}
+	}
+
+	fullFile, err := ioutil.TempFile(tempDir, "")
+	require.NoError(t, err)
+	defer fullFile.Close()
+
+	_, err = fullFile.Write(content)
+	require.NoError(t, err)
+
+	fff, err := operator.NewFingerprint(fullFile)
+	require.NoError(t, err)
+
+	partialFile, err := ioutil.TempFile(tempDir, "")
+	require.NoError(t, err)
+	defer partialFile.Close()
+
+	// Write the first byte before comparing, since empty files will never match
+	_, err = partialFile.Write(content[:1])
+	require.NoError(t, err)
+	content = content[1:]
+
+	// Write one byte at a time and validate that
+	// full fingerprint still starts with updated partial
+	for i := range content {
+		_, err = partialFile.Write(content[i:i])
+		require.NoError(t, err)
+
+		pff, err := operator.NewFingerprint(partialFile)
+		require.NoError(t, err)
+
+		require.True(t, fff.StartsWith(pff))
+	}
+}
+
+// TODO TestConfig (config_test.go) - sets defaults, errors appropriately, etc

--- a/pkg/stanza/internal/fileconsumer/positional_scanner.go
+++ b/pkg/stanza/internal/fileconsumer/positional_scanner.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+
+import (
+	"bufio"
+	"io"
+)
+
+// PositionalScanner is a scanner that maintains position
+type PositionalScanner struct {
+	pos int64
+	*bufio.Scanner
+}
+
+// NewPositionalScanner creates a new positional scanner
+func NewPositionalScanner(r io.Reader, maxLogSize int, startOffset int64, splitFunc bufio.SplitFunc) *PositionalScanner {
+	ps := &PositionalScanner{
+		pos:     startOffset,
+		Scanner: bufio.NewScanner(r),
+	}
+
+	buf := make([]byte, 0, 16384)
+	ps.Scanner.Buffer(buf, maxLogSize)
+
+	scanFunc := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		advance, token, err = splitFunc(data, atEOF)
+		ps.pos += int64(advance)
+		return
+	}
+	ps.Scanner.Split(scanFunc)
+	return ps
+}
+
+// Pos returns the current position of the scanner
+func (ps *PositionalScanner) Pos() int64 {
+	return ps.pos
+}

--- a/pkg/stanza/internal/fileconsumer/positional_scanner.go
+++ b/pkg/stanza/internal/fileconsumer/positional_scanner.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 
 import (
 	"bufio"

--- a/pkg/stanza/internal/fileconsumer/reader.go
+++ b/pkg/stanza/internal/fileconsumer/reader.go
@@ -1,0 +1,255 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.uber.org/zap"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/transform"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	stanzaerrors "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+)
+
+// File attributes contains information about file paths
+type fileAttributes struct {
+	Name         string
+	Path         string
+	ResolvedName string
+	ResolvedPath string
+}
+
+// resolveFileAttributes resolves file attributes
+// and sets it to empty string in case of error
+func (f *Input) resolveFileAttributes(path string) *fileAttributes {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		f.Error(err)
+	}
+
+	abs, err := filepath.Abs(resolved)
+	if err != nil {
+		f.Error(err)
+	}
+
+	return &fileAttributes{
+		Path:         path,
+		Name:         filepath.Base(path),
+		ResolvedPath: abs,
+		ResolvedName: filepath.Base(abs),
+	}
+}
+
+// Reader manages a single file
+type Reader struct {
+	Fingerprint *Fingerprint
+	Offset      int64
+
+	generation     int
+	fileInput      *Input
+	file           *os.File
+	fileAttributes *fileAttributes
+
+	decoder      *encoding.Decoder
+	decodeBuffer []byte
+
+	splitter *helper.Splitter
+
+	*zap.SugaredLogger `json:"-"`
+}
+
+// NewReader creates a new file reader
+func (f *Input) NewReader(path string, file *os.File, fp *Fingerprint, splitter *helper.Splitter) (*Reader, error) {
+	r := &Reader{
+		Fingerprint:    fp,
+		file:           file,
+		fileInput:      f,
+		SugaredLogger:  f.SugaredLogger.With("path", path),
+		decoder:        f.encoding.Encoding.NewDecoder(),
+		decodeBuffer:   make([]byte, 1<<12),
+		fileAttributes: f.resolveFileAttributes(path),
+		splitter:       splitter,
+	}
+	return r, nil
+}
+
+// Copy creates a deep copy of a Reader
+func (r *Reader) Copy(file *os.File) (*Reader, error) {
+	reader, err := r.fileInput.NewReader(r.fileAttributes.Path, file, r.Fingerprint.Copy(), r.splitter)
+	if err != nil {
+		return nil, err
+	}
+	reader.Offset = r.Offset
+	return reader, nil
+}
+
+// InitializeOffset sets the starting offset
+func (r *Reader) InitializeOffset(startAtBeginning bool) error {
+	if !startAtBeginning {
+		info, err := r.file.Stat()
+		if err != nil {
+			return fmt.Errorf("stat: %w", err)
+		}
+		r.Offset = info.Size()
+	}
+	return nil
+}
+
+// ReadToEnd will read until the end of the file
+func (r *Reader) ReadToEnd(ctx context.Context) {
+	if _, err := r.file.Seek(r.Offset, 0); err != nil {
+		r.Errorw("Failed to seek", zap.Error(err))
+		return
+	}
+
+	scanner := NewPositionalScanner(r, r.fileInput.MaxLogSize, r.Offset, r.splitter.SplitFunc)
+
+	// Iterate over the tokenized file, emitting entries as we go
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		ok := scanner.Scan()
+		if !ok {
+			if err := getScannerError(scanner); err != nil {
+				r.Errorw("Failed during scan", zap.Error(err))
+			}
+			break
+		}
+
+		if err := r.emit(ctx, scanner.Bytes()); err != nil {
+			r.Error("Failed to emit entry", zap.Error(err))
+		}
+		r.Offset = scanner.Pos()
+	}
+}
+
+// Close will close the file
+func (r *Reader) Close() {
+	if r.file != nil {
+		if err := r.file.Close(); err != nil {
+			r.Debugw("Problem closing reader", zap.Error(err))
+		}
+	}
+}
+
+// Emit creates an entry with the decoded message and sends it to the next
+// operator in the pipeline
+func (r *Reader) emit(ctx context.Context, msgBuf []byte) error {
+	// Skip the entry if it's empty
+	if len(msgBuf) == 0 {
+		return nil
+	}
+	var e *entry.Entry
+	var err error
+	if r.fileInput.encoding.Encoding == encoding.Nop {
+		e, err = r.fileInput.NewEntry(msgBuf)
+		if err != nil {
+			return fmt.Errorf("create entry: %w", err)
+		}
+	} else {
+		msg, err := r.decode(msgBuf)
+		if err != nil {
+			return fmt.Errorf("decode: %w", err)
+		}
+		e, err = r.fileInput.NewEntry(msg)
+		if err != nil {
+			return fmt.Errorf("create entry: %w", err)
+		}
+	}
+
+	if err := e.Set(r.fileInput.FilePathField, r.fileAttributes.Path); err != nil {
+		return err
+	}
+	if err := e.Set(r.fileInput.FileNameField, r.fileAttributes.Name); err != nil {
+		return err
+	}
+
+	if err := e.Set(r.fileInput.FilePathResolvedField, r.fileAttributes.ResolvedPath); err != nil {
+		return err
+	}
+
+	if err := e.Set(r.fileInput.FileNameResolvedField, r.fileAttributes.ResolvedName); err != nil {
+		return err
+	}
+
+	r.fileInput.Write(ctx, e)
+	return nil
+}
+
+// decode converts the bytes in msgBuf to utf-8 from the configured encoding
+func (r *Reader) decode(msgBuf []byte) (string, error) {
+	for {
+		r.decoder.Reset()
+		nDst, _, err := r.decoder.Transform(r.decodeBuffer, msgBuf, true)
+		if errors.Is(err, transform.ErrShortDst) {
+			r.decodeBuffer = make([]byte, len(r.decodeBuffer)*2)
+			continue
+		} else if err != nil {
+			return "", fmt.Errorf("transform encoding: %w", err)
+		}
+		return string(r.decodeBuffer[:nDst]), nil
+	}
+}
+
+func getScannerError(scanner *PositionalScanner) error {
+	err := scanner.Err()
+	if errors.Is(err, bufio.ErrTooLong) {
+		return stanzaerrors.NewError("log entry too large", "increase max_log_size or ensure that multiline regex patterns terminate")
+	} else if err != nil {
+		return stanzaerrors.Wrap(err, "scanner error")
+	}
+	return nil
+}
+
+// Read from the file and update the fingerprint if necessary
+func (r *Reader) Read(dst []byte) (int, error) {
+	// Skip if fingerprint is already built
+	// or if fingerprint is behind Offset
+	if len(r.Fingerprint.FirstBytes) == r.fileInput.fingerprintSize || int(r.Offset) > len(r.Fingerprint.FirstBytes) {
+		return r.file.Read(dst)
+	}
+	n, err := r.file.Read(dst)
+	appendCount := min0(n, r.fileInput.fingerprintSize-int(r.Offset))
+	// return for n == 0 or r.Offset >= r.fileInput.fingerprintSize
+	if appendCount == 0 {
+		return n, err
+	}
+
+	// for appendCount==0, the following code would add `0` to fingerprint
+	r.Fingerprint.FirstBytes = append(r.Fingerprint.FirstBytes[:r.Offset], dst[:appendCount]...)
+	return n, err
+}
+
+func min0(a, b int) int {
+	if a < 0 || b < 0 {
+		return 0
+	}
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/stanza/internal/fileconsumer/reader.go
+++ b/pkg/stanza/internal/fileconsumer/reader.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 
 import (
 	"bufio"

--- a/pkg/stanza/internal/fileconsumer/roller.go
+++ b/pkg/stanza/internal/fileconsumer/roller.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+
+import "context"
+
+type roller interface {
+	roll(context.Context, []*Reader)
+	cleanup()
+}

--- a/pkg/stanza/internal/fileconsumer/roller.go
+++ b/pkg/stanza/internal/fileconsumer/roller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 
 import "context"
 

--- a/pkg/stanza/internal/fileconsumer/roller_other.go
+++ b/pkg/stanza/internal/fileconsumer/roller_other.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+
+import (
+	"context"
+	"sync"
+)
+
+type detectLostFiles struct {
+	oldReaders []*Reader
+}
+
+func newRoller() roller {
+	return &detectLostFiles{[]*Reader{}}
+}
+
+func (r *detectLostFiles) roll(ctx context.Context, readers []*Reader) {
+	// Detect files that have been rotated out of matching pattern
+	lostReaders := make([]*Reader, 0, len(r.oldReaders))
+OUTER:
+	for _, oldReader := range r.oldReaders {
+		for _, reader := range readers {
+			if reader.Fingerprint.StartsWith(oldReader.Fingerprint) {
+				continue OUTER
+			}
+		}
+		lostReaders = append(lostReaders, oldReader)
+	}
+
+	var lostWG sync.WaitGroup
+	for _, reader := range lostReaders {
+		lostWG.Add(1)
+		go func(r *Reader) {
+			defer lostWG.Done()
+			r.ReadToEnd(ctx)
+		}(reader)
+	}
+	lostWG.Wait()
+
+	for _, reader := range r.oldReaders {
+		reader.Close()
+	}
+
+	r.oldReaders = readers
+}
+
+func (r *detectLostFiles) cleanup() {
+	for _, reader := range r.oldReaders {
+		reader.Close()
+	}
+}

--- a/pkg/stanza/internal/fileconsumer/roller_other.go
+++ b/pkg/stanza/internal/fileconsumer/roller_other.go
@@ -15,7 +15,7 @@
 //go:build !windows
 // +build !windows
 
-package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 
 import (
 	"context"

--- a/pkg/stanza/internal/fileconsumer/roller_windows.go
+++ b/pkg/stanza/internal/fileconsumer/roller_windows.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+
+import "context"
+
+type closeImmediately struct{}
+
+func newRoller() roller {
+	return &closeImmediately{}
+}
+
+func (r *closeImmediately) roll(_ context.Context, readers []*Reader) {
+	for _, reader := range readers {
+		reader.Close()
+	}
+}
+
+func (r *closeImmediately) cleanup() {
+	return
+}

--- a/pkg/stanza/internal/fileconsumer/roller_windows.go
+++ b/pkg/stanza/internal/fileconsumer/roller_windows.go
@@ -15,7 +15,7 @@
 //go:build windows
 // +build windows
 
-package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 
 import "context"
 

--- a/pkg/stanza/internal/fileconsumer/rotation_test.go
+++ b/pkg/stanza/internal/fileconsumer/rotation_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file
+package fileconsumer
 
 import (
 	"context"

--- a/pkg/stanza/internal/fileconsumer/rotation_test.go
+++ b/pkg/stanza/internal/fileconsumer/rotation_test.go
@@ -1,0 +1,517 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+)
+
+const windowsOS = "windows"
+
+func TestMultiFileRotate(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		// Windows has very poor support for moving active files, so rotation is less commonly used
+		// This may possibly be handled better in Go 1.16: https://github.com/golang/go/issues/35358
+		t.Skip()
+	}
+	t.Parallel()
+
+	getMessage := func(f, k, m int) string { return fmt.Sprintf("file %d-%d, message %d", f, k, m) }
+
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	numFiles := 3
+	numMessages := 3
+	numRotations := 3
+
+	expected := make([]string, 0, numFiles*numMessages*numRotations)
+	for i := 0; i < numFiles; i++ {
+		for j := 0; j < numMessages; j++ {
+			for k := 0; k < numRotations; k++ {
+				expected = append(expected, getMessage(i, k, j))
+			}
+		}
+	}
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	temps := make([]*os.File, 0, numFiles)
+	for i := 0; i < numFiles; i++ {
+		temps = append(temps, openTemp(t, tempDir))
+	}
+
+	var wg sync.WaitGroup
+	for i, temp := range temps {
+		wg.Add(1)
+		go func(tf *os.File, f int) {
+			defer wg.Done()
+			for k := 0; k < numRotations; k++ {
+				for j := 0; j < numMessages; j++ {
+					writeString(t, tf, getMessage(f, k, j)+"\n")
+				}
+
+				require.NoError(t, tf.Close())
+				require.NoError(t, os.Rename(tf.Name(), fmt.Sprintf("%s.%d", tf.Name(), k)))
+				tf = reopenTemp(t, tf.Name())
+			}
+		}(temp, i)
+	}
+
+	waitForMessages(t, logReceived, expected)
+	wg.Wait()
+}
+
+func TestMultiFileRotateSlow(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		// Windows has very poor support for moving active files, so rotation is less commonly used
+		// This may possibly be handled better in Go 1.16: https://github.com/golang/go/issues/35358
+		t.Skip()
+	}
+
+	t.Parallel()
+
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	getMessage := func(f, k, m int) string { return fmt.Sprintf("file %d-%d, message %d", f, k, m) }
+	fileName := func(f, k int) string { return filepath.Join(tempDir, fmt.Sprintf("file%d.rot%d.log", f, k)) }
+	baseFileName := func(f int) string { return filepath.Join(tempDir, fmt.Sprintf("file%d.log", f)) }
+
+	numFiles := 3
+	numMessages := 30
+	numRotations := 3
+
+	expected := make([]string, 0, numFiles*numMessages*numRotations)
+	for i := 0; i < numFiles; i++ {
+		for j := 0; j < numMessages; j++ {
+			for k := 0; k < numRotations; k++ {
+				expected = append(expected, getMessage(i, k, j))
+			}
+		}
+	}
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	var wg sync.WaitGroup
+	for fileNum := 0; fileNum < numFiles; fileNum++ {
+		wg.Add(1)
+		go func(fn int) {
+			defer wg.Done()
+
+			for rotationNum := 0; rotationNum < numRotations; rotationNum++ {
+				file := openFile(t, baseFileName(fn))
+				for messageNum := 0; messageNum < numMessages; messageNum++ {
+					writeString(t, file, getMessage(fn, rotationNum, messageNum)+"\n")
+					time.Sleep(5 * time.Millisecond)
+				}
+
+				require.NoError(t, file.Close())
+				require.NoError(t, os.Rename(baseFileName(fn), fileName(fn, rotationNum)))
+			}
+		}(fileNum)
+	}
+
+	waitForMessages(t, logReceived, expected)
+	wg.Wait()
+}
+
+func TestMultiCopyTruncateSlow(t *testing.T) {
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+
+	getMessage := func(f, k, m int) string { return fmt.Sprintf("file %d-%d, message %d", f, k, m) }
+	fileName := func(f, k int) string { return filepath.Join(tempDir, fmt.Sprintf("file%d.rot%d.log", f, k)) }
+	baseFileName := func(f int) string { return filepath.Join(tempDir, fmt.Sprintf("file%d.log", f)) }
+
+	numFiles := 3
+	numMessages := 30
+	numRotations := 3
+
+	expected := make([]string, 0, numFiles*numMessages*numRotations)
+	for i := 0; i < numFiles; i++ {
+		for j := 0; j < numMessages; j++ {
+			for k := 0; k < numRotations; k++ {
+				expected = append(expected, getMessage(i, k, j))
+			}
+		}
+	}
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	var wg sync.WaitGroup
+	for fileNum := 0; fileNum < numFiles; fileNum++ {
+		wg.Add(1)
+		go func(fn int) {
+			defer wg.Done()
+
+			for rotationNum := 0; rotationNum < numRotations; rotationNum++ {
+				file := openFile(t, baseFileName(fn))
+				for messageNum := 0; messageNum < numMessages; messageNum++ {
+					writeString(t, file, getMessage(fn, rotationNum, messageNum)+"\n")
+					time.Sleep(5 * time.Millisecond)
+				}
+
+				_, err := file.Seek(0, 0)
+				require.NoError(t, err)
+				dst := openFile(t, fileName(fn, rotationNum))
+				_, err = io.Copy(dst, file)
+				require.NoError(t, err)
+				require.NoError(t, dst.Close())
+				require.NoError(t, file.Truncate(0))
+				_, err = file.Seek(0, 0)
+				require.NoError(t, err)
+				file.Close()
+			}
+		}(fileNum)
+	}
+
+	waitForMessages(t, logReceived, expected)
+	wg.Wait()
+}
+
+type rotationTest struct {
+	name            string
+	totalLines      int
+	maxLinesPerFile int
+	maxBackupFiles  int
+	writeInterval   time.Duration
+	pollInterval    time.Duration
+	ephemeralLines  bool
+}
+
+/*
+	When log files are rotated at extreme speeds, it is possible to miss some log entries.
+	This can happen when an individual log entry is written and deleted within the duration
+	of a single poll interval. For example, consider the following scenario:
+		- A log file may have up to 9 backups (10 total log files)
+		- Each log file may contain up to 10 entries
+		- Log entries are written at an interval of 10µs
+		- Log files are polled at an interval of 100ms
+	In this scenario, a log entry that is written may only exist on disk for about 1ms.
+	A polling interval of 100ms will most likely never produce a chance to read the log file.
+
+	In production settings, this consideration is not very likely to be a problem, but it is
+	easy to encounter the issue in tests, and difficult to deterministically simulate edge cases.
+	However, the above understanding does allow for some consistent expectations.
+		1) Cases that do not require deletion of old log entries should always pass.
+		2) Cases where the polling interval is sufficiently rapid should always pass.
+		3) When neither 1 nor 2 is true, there may be missing entries, but still no duplicates.
+
+	The following method is provided largely as documentation of how this is expected to behave.
+	In practice, timing is largely dependent on the responsiveness of system calls.
+*/
+func (rt rotationTest) expectEphemeralLines() bool {
+	// primary + backups
+	maxLinesInAllFiles := rt.maxLinesPerFile + rt.maxLinesPerFile*rt.maxBackupFiles
+
+	// Will the test write enough lines to result in deletion of oldest backups?
+	maxBackupsExceeded := rt.totalLines > maxLinesInAllFiles
+
+	// last line written in primary file will exist for l*b more writes
+	minTimeToLive := time.Duration(int(rt.writeInterval) * rt.maxLinesPerFile * rt.maxBackupFiles)
+
+	// can a line be written and then rotated to deletion before ever observed?
+	return maxBackupsExceeded && rt.pollInterval > minTimeToLive
+}
+
+func (rt rotationTest) run(tc rotationTest, copyTruncate, sequential bool) func(t *testing.T) {
+	return func(t *testing.T) {
+		operator, logReceived, tempDir := newTestFileOperator(t,
+			func(cfg *Config) {
+				cfg.PollInterval = helper.NewDuration(tc.pollInterval)
+			},
+			func(out *testutil.FakeOutput) {
+				out.Received = make(chan *entry.Entry, tc.totalLines)
+			},
+		)
+		logger := getRotatingLogger(t, tempDir, tc.maxLinesPerFile, tc.maxBackupFiles, copyTruncate, sequential)
+
+		expected := make([]string, 0, tc.totalLines)
+		baseStr := stringWithLength(46) // + ' 123'
+		for i := 0; i < tc.totalLines; i++ {
+			expected = append(expected, fmt.Sprintf("%s %3d", baseStr, i))
+		}
+
+		require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+		defer func() {
+			require.NoError(t, operator.Stop())
+		}()
+
+		for _, message := range expected {
+			logger.Println(message)
+			time.Sleep(tc.writeInterval)
+		}
+
+		received := make([]string, 0, tc.totalLines)
+	LOOP:
+		for {
+			select {
+			case e := <-logReceived:
+				received = append(received, e.Body.(string))
+			case <-time.After(200 * time.Millisecond):
+				break LOOP
+			}
+		}
+
+		if tc.ephemeralLines {
+			if !tc.expectEphemeralLines() {
+				// This is helpful for test development, and ensures the sample computation is used
+				t.Logf("Potentially unstable ephemerality expectation for test: %s", tc.name)
+			}
+			require.Subset(t, expected, received)
+		} else {
+			require.ElementsMatch(t, expected, received)
+		}
+	}
+}
+
+func TestRotation(t *testing.T) {
+	cases := []rotationTest{
+		{
+			name:            "NoRotation",
+			totalLines:      10,
+			maxLinesPerFile: 10,
+			maxBackupFiles:  1,
+			writeInterval:   time.Millisecond,
+			pollInterval:    10 * time.Millisecond,
+		},
+		{
+			name:            "NoDeletion",
+			totalLines:      20,
+			maxLinesPerFile: 10,
+			maxBackupFiles:  1,
+			writeInterval:   time.Millisecond,
+			pollInterval:    10 * time.Millisecond,
+		},
+		{
+			name:            "Deletion",
+			totalLines:      30,
+			maxLinesPerFile: 10,
+			maxBackupFiles:  1,
+			writeInterval:   time.Millisecond,
+			pollInterval:    10 * time.Millisecond,
+			ephemeralLines:  true,
+		},
+		{
+			name:            "Deletion/ExceedFingerprint",
+			totalLines:      300,
+			maxLinesPerFile: 100,
+			maxBackupFiles:  1,
+			writeInterval:   time.Millisecond,
+			pollInterval:    10 * time.Millisecond,
+			ephemeralLines:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		if runtime.GOOS != windowsOS {
+			// Windows has very poor support for moving active files, so rotation is less commonly used
+			// This may possibly be handled better in Go 1.16: https://github.com/golang/go/issues/35358
+			t.Run(fmt.Sprintf("%s/MoveCreateTimestamped", tc.name), tc.run(tc, false, false))
+			t.Run(fmt.Sprintf("%s/MoveCreateSequential", tc.name), tc.run(tc, false, true))
+		}
+		t.Run(fmt.Sprintf("%s/CopyTruncateTimestamped", tc.name), tc.run(tc, true, false))
+		t.Run(fmt.Sprintf("%s/CopyTruncateSequential", tc.name), tc.run(tc, true, true))
+	}
+}
+
+func TestMoveFile(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("Moving files while open is unsupported on Windows")
+	}
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+
+	temp1 := openTemp(t, tempDir)
+	writeString(t, temp1, "testlog1\n")
+	temp1.Close()
+
+	operator.poll(context.Background())
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForMessage(t, logReceived, "testlog1")
+
+	// Wait until all goroutines are finished before renaming
+	operator.wg.Wait()
+	err := os.Rename(temp1.Name(), fmt.Sprintf("%s.2", temp1.Name()))
+	require.NoError(t, err)
+
+	operator.poll(context.Background())
+	expectNoMessages(t, logReceived)
+}
+
+func TestTrackMovedAwayFiles(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("Moving files while open is unsupported on Windows")
+	}
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+
+	temp1 := openTemp(t, tempDir)
+	writeString(t, temp1, "testlog1\n")
+	temp1.Close()
+
+	operator.poll(context.Background())
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForMessage(t, logReceived, "testlog1")
+
+	// Wait until all goroutines are finished before renaming
+	operator.wg.Wait()
+
+	newDir := fmt.Sprintf("%s%s", tempDir[:len(tempDir)-1], "_new/")
+	err := os.Mkdir(newDir, 0777)
+	require.NoError(t, err)
+	newFileName := fmt.Sprintf("%s%s", newDir, "newfile.log")
+
+	err = os.Rename(temp1.Name(), newFileName)
+	require.NoError(t, err)
+
+	movedFile, err := os.OpenFile(newFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	require.NoError(t, err)
+	writeString(t, movedFile, "testlog2\n")
+	operator.poll(context.Background())
+
+	waitForMessage(t, logReceived, "testlog2")
+}
+
+// TruncateThenWrite tests that, after a file has been truncated,
+// any new writes are picked up
+func TestTruncateThenWrite(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+
+	temp1 := openTemp(t, tempDir)
+	writeString(t, temp1, "testlog1\ntestlog2\n")
+
+	operator.poll(context.Background())
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForMessage(t, logReceived, "testlog1")
+	waitForMessage(t, logReceived, "testlog2")
+
+	require.NoError(t, temp1.Truncate(0))
+	_, err := temp1.Seek(0, 0)
+	require.NoError(t, err)
+
+	writeString(t, temp1, "testlog3\n")
+	operator.poll(context.Background())
+	waitForMessage(t, logReceived, "testlog3")
+	expectNoMessages(t, logReceived)
+}
+
+// CopyTruncateWriteBoth tests that when a file is copied
+// with unread logs on the end, then the original is truncated,
+// we get the unread logs on the copy as well as any new logs
+// written to the truncated file
+func TestCopyTruncateWriteBoth(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	operator.persister = testutil.NewMockPersister("test")
+
+	temp1 := openTemp(t, tempDir)
+	writeString(t, temp1, "testlog1\ntestlog2\n")
+
+	operator.poll(context.Background())
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForMessage(t, logReceived, "testlog1")
+	waitForMessage(t, logReceived, "testlog2")
+	operator.wg.Wait() // wait for all goroutines to finish
+
+	// Copy the first file to a new file, and add another log
+	temp2 := openTemp(t, tempDir)
+	_, err := io.Copy(temp2, temp1)
+	require.NoError(t, err)
+
+	// Truncate original file
+	require.NoError(t, temp1.Truncate(0))
+	_, err = temp1.Seek(0, 0)
+	require.NoError(t, err)
+
+	// Write to original and new file
+	writeString(t, temp2, "testlog3\n")
+	writeString(t, temp1, "testlog4\n")
+
+	// Expect both messages to come through
+	operator.poll(context.Background())
+	waitForMessages(t, logReceived, []string{"testlog3", "testlog4"})
+}
+
+func TestFileMovedWhileOff_BigFiles(t *testing.T) {
+	t.Parallel()
+	operator, logReceived, tempDir := newTestFileOperator(t, nil, nil)
+	persister := testutil.NewMockPersister("test")
+
+	log1 := stringWithLength(1000)
+	log2 := stringWithLength(1000)
+
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, log1+"\n")
+	require.NoError(t, temp.Close())
+
+	// Start the operator
+	require.NoError(t, operator.Start(persister))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+	waitForMessage(t, logReceived, log1)
+
+	// Stop the operator, then rename and write a new log
+	require.NoError(t, operator.Stop())
+
+	err := os.Rename(temp.Name(), fmt.Sprintf("%s2", temp.Name()))
+	require.NoError(t, err)
+
+	temp = reopenTemp(t, temp.Name())
+	require.NoError(t, err)
+	writeString(t, temp, log2+"\n")
+
+	// Expect the message written to the new log to come through
+	require.NoError(t, operator.Start(persister))
+	waitForMessage(t, logReceived, log2)
+}

--- a/pkg/stanza/internal/fileconsumer/testdata/default.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/default.yaml
@@ -1,0 +1,1 @@
+type: file_input

--- a/pkg/stanza/internal/fileconsumer/testdata/encoding_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/encoding_lower.yaml
@@ -1,0 +1,2 @@
+type: file_input
+encoding: "utf-16le"

--- a/pkg/stanza/internal/fileconsumer/testdata/encoding_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/encoding_upper.yaml
@@ -1,0 +1,2 @@
+type: file_input
+encoding: "UTF-16lE"

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_glob.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_glob.yaml
@@ -1,0 +1,5 @@
+type: file_input
+include:
+  - "*.log"
+exclude:
+  - "not*.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk.yaml
@@ -1,0 +1,5 @@
+type: file_input
+include:
+  - "*.log"
+exclude:
+  - "not**.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk_nested.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk_nested.yaml
@@ -1,0 +1,5 @@
+type: file_input
+include:
+  - "*.log"
+exclude:
+  - "directory/**/not*.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk_prefix.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk_prefix.yaml
@@ -1,0 +1,5 @@
+type: file_input
+include:
+  - "*.log"
+exclude:
+  - "**/directory/**/not*.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_inline.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_inline.yaml
@@ -1,0 +1,3 @@
+type: file_input
+include: [ "*.log" ]
+exclude: [ "a.log", "b.log" ]

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_invalid.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_invalid.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - "*.log"
+exclude: "aRandomString"

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_multi.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_multi.yaml
@@ -1,0 +1,7 @@
+type: file_input
+include:
+  - "*.log"
+exclude:
+  - one.log
+  - two.log
+  - three.log

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_one.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_one.yaml
@@ -1,0 +1,5 @@
+type: file_input
+include:
+  - "*.log"
+exclude:
+  - one.log

--- a/pkg/stanza/internal/fileconsumer/testdata/extra_field.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/extra_field.yaml
@@ -1,0 +1,2 @@
+type: file_input
+hello: world

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1KB.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1KB.yaml
@@ -1,0 +1,2 @@
+type: file_input
+fingerprint_size: 1KB

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1KiB.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1KiB.yaml
@@ -1,0 +1,2 @@
+type: file_input
+fingerprint_size: 1KiB

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1kb_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1kb_lower.yaml
@@ -1,0 +1,2 @@
+type: file_input
+fingerprint_size: 1kb

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1kib_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1kib_lower.yaml
@@ -1,0 +1,2 @@
+type: file_input
+fingerprint_size: 1kib

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_float.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_float.yaml
@@ -1,0 +1,2 @@
+type: file_input
+fingerprint_size: 1.1kb

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_no_units.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_no_units.yaml
@@ -1,0 +1,2 @@
+type: file_input
+fingerprint_size: 1000

--- a/pkg/stanza/internal/fileconsumer/testdata/id_custom.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/id_custom.yaml
@@ -1,0 +1,2 @@
+type: file_input
+id: test_id

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_name_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_name_lower.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_name: true

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_name_on.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_name_on.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_name: on

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_name_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_name_upper.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_name: TRUE

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_name_yes.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_name_yes.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_name: yes

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_lower.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_path: true

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_no.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_no.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_path: no

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_nonbool.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_nonbool.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_path: asdf

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_off.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_off.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_path: off

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_on.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_on.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_path: on

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_upper.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_path: TRUE

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_yes.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_yes.yaml
@@ -1,0 +1,4 @@
+type: file_input
+include:
+  - one.log
+include_file_path: yes

--- a/pkg/stanza/internal/fileconsumer/testdata/include_glob.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_glob.yaml
@@ -1,0 +1,3 @@
+type: file_input
+include:
+  - "*.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk.yaml
@@ -1,0 +1,3 @@
+type: file_input
+include:
+  - "**.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk_nested.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk_nested.yaml
@@ -1,0 +1,3 @@
+type: file_input
+include:
+  - "directory/**/*.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk_prefix.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk_prefix.yaml
@@ -1,0 +1,3 @@
+type: file_input
+include:
+  - "**/directory/**/*.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_inline.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_inline.yaml
@@ -1,0 +1,2 @@
+type: file_input
+include: [ "a.log", "b.log" ]

--- a/pkg/stanza/internal/fileconsumer/testdata/include_invalid.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_invalid.yaml
@@ -1,0 +1,2 @@
+type: file_input
+include: "justwords"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_multi.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_multi.yaml
@@ -1,0 +1,5 @@
+type: file_input
+include:
+  - one.log
+  - two.log
+  - three.log

--- a/pkg/stanza/internal/fileconsumer/testdata/include_one.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_one.yaml
@@ -1,0 +1,3 @@
+type: file_input
+include:
+  - one.log

--- a/pkg/stanza/internal/fileconsumer/testdata/max_concurrent_large.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_concurrent_large.yaml
@@ -1,0 +1,2 @@
+type: file_input
+max_concurrent_files: 9223372036854775807

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_invalid_unit.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_invalid_unit.yaml
@@ -1,0 +1,2 @@
+type: file_input
+max_log_size: 1TOFU

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mb_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mb_lower.yaml
@@ -1,0 +1,2 @@
+type: file_input
+max_log_size: 1mib

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mb_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mb_upper.yaml
@@ -1,0 +1,2 @@
+type: file_input
+max_log_size: 1MiB

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mib_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mib_lower.yaml
@@ -1,0 +1,2 @@
+type: file_input
+max_log_size: 1mib

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mib_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mib_upper.yaml
@@ -1,0 +1,2 @@
+type: file_input
+max_log_size: 1MiB

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_extra_field.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_extra_field.yaml
@@ -1,0 +1,3 @@
+type: file_input
+multiline:
+  that_random_field: "this should go nowhere"

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_line_end_special.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_line_end_special.yaml
@@ -1,0 +1,3 @@
+type: file_input
+multiline:
+  line_end_pattern: '%'

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_line_end_string.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_line_end_string.yaml
@@ -1,0 +1,3 @@
+type: file_input
+multiline:
+  line_end_pattern: 'Start'

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_line_start_special.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_line_start_special.yaml
@@ -1,0 +1,3 @@
+type: file_input
+multiline:
+  line_start_pattern: '%'

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_line_start_string.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_line_start_string.yaml
@@ -1,0 +1,3 @@
+type: file_input
+multiline:
+  line_start_pattern: 'Start'

--- a/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1000ms.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1000ms.yaml
@@ -1,0 +1,2 @@
+type: file_input
+poll_interval: 1000ms

--- a/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1ms.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1ms.yaml
@@ -1,0 +1,2 @@
+type: file_input
+poll_interval: 1ms

--- a/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1s.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1s.yaml
@@ -1,0 +1,2 @@
+type: file_input
+poll_interval: 1s

--- a/pkg/stanza/internal/fileconsumer/testdata/poll_interval_no_units.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/poll_interval_no_units.yaml
@@ -1,0 +1,2 @@
+type: file_input
+poll_interval: 1

--- a/pkg/stanza/internal/fileconsumer/testdata/start_at_string.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/start_at_string.yaml
@@ -1,0 +1,2 @@
+type: file_input
+start_at: "beginning"

--- a/pkg/stanza/internal/fileconsumer/util_test.go
+++ b/pkg/stanza/internal/fileconsumer/util_test.go
@@ -1,0 +1,187 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/observiq/nanojack"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+)
+
+func newDefaultConfig(tempDir string) *Config {
+	cfg := NewConfig("testfile")
+	cfg.PollInterval = helper.Duration{Duration: 200 * time.Millisecond}
+	cfg.StartAt = "beginning"
+	cfg.Include = []string{fmt.Sprintf("%s/*", tempDir)}
+	cfg.OutputIDs = []string{"fake"}
+	return cfg
+}
+
+func newTestFileOperator(t *testing.T, cfgMod func(*Config), outMod func(*testutil.FakeOutput)) (*Input, chan *entry.Entry, string) {
+	fakeOutput := testutil.NewFakeOutput(t)
+	if outMod != nil {
+		outMod(fakeOutput)
+	}
+
+	tempDir := t.TempDir()
+
+	cfg := newDefaultConfig(tempDir)
+	if cfgMod != nil {
+		cfgMod(cfg)
+	}
+	op, err := cfg.Build(testutil.Logger(t))
+	require.NoError(t, err)
+
+	err = op.SetOutputs([]operator.Operator{fakeOutput})
+	require.NoError(t, err)
+
+	return op.(*Input), fakeOutput.Received, tempDir
+}
+
+func openFile(tb testing.TB, path string) *os.File {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = file.Close() })
+	return file
+}
+
+func openTemp(t testing.TB, tempDir string) *os.File {
+	return openTempWithPattern(t, tempDir, "")
+}
+
+func reopenTemp(t testing.TB, name string) *os.File {
+	return openTempWithPattern(t, filepath.Dir(name), filepath.Base(name))
+}
+
+func openTempWithPattern(t testing.TB, tempDir, pattern string) *os.File {
+	file, err := ioutil.TempFile(tempDir, pattern)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+	return file
+}
+
+func getRotatingLogger(t testing.TB, tempDir string, maxLines, maxBackups int, copyTruncate, sequential bool) *log.Logger {
+	file, err := ioutil.TempFile(tempDir, "")
+	require.NoError(t, err)
+	require.NoError(t, file.Close()) // will be managed by rotator
+
+	rotator := nanojack.Logger{
+		Filename:     file.Name(),
+		MaxLines:     maxLines,
+		MaxBackups:   maxBackups,
+		CopyTruncate: copyTruncate,
+		Sequential:   sequential,
+	}
+
+	t.Cleanup(func() { _ = rotator.Close() })
+
+	return log.New(&rotator, "", 0)
+}
+
+func writeString(t testing.TB, file *os.File, s string) {
+	_, err := file.WriteString(s)
+	require.NoError(t, err)
+}
+
+func stringWithLength(length int) string {
+	charset := "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func waitForOne(t *testing.T, c chan *entry.Entry) *entry.Entry {
+	select {
+	case e := <-c:
+		return e
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "Timed out waiting for message")
+		return nil
+	}
+}
+
+func waitForN(t *testing.T, c chan *entry.Entry, n int) []string {
+	messages := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		select {
+		case e := <-c:
+			messages = append(messages, e.Body.(string))
+		case <-time.After(3 * time.Second):
+			require.FailNow(t, "Timed out waiting for message")
+			return nil
+		}
+	}
+	return messages
+}
+
+func waitForMessage(t *testing.T, c chan *entry.Entry, expected string) {
+	select {
+	case e := <-c:
+		require.Equal(t, expected, e.Body.(string))
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "Timed out waiting for message", expected)
+	}
+}
+
+func waitForByteMessage(t *testing.T, c chan *entry.Entry, expected []byte) {
+	select {
+	case e := <-c:
+		require.Equal(t, expected, e.Body.([]byte))
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "Timed out waiting for message", expected)
+	}
+}
+
+func waitForMessages(t *testing.T, c chan *entry.Entry, expected []string) {
+	receivedMessages := make([]string, 0, len(expected))
+LOOP:
+	for {
+		select {
+		case e := <-c:
+			receivedMessages = append(receivedMessages, e.Body.(string))
+		case <-time.After(3 * time.Second):
+			break LOOP
+		}
+	}
+
+	require.ElementsMatch(t, expected, receivedMessages)
+}
+
+func expectNoMessages(t *testing.T, c chan *entry.Entry) {
+	expectNoMessagesUntil(t, c, 200*time.Millisecond)
+}
+
+func expectNoMessagesUntil(t *testing.T, c chan *entry.Entry, d time.Duration) {
+	select {
+	case e := <-c:
+		require.FailNow(t, "Received unexpected message", "Message: %s", e.Body.(string))
+	case <-time.After(d):
+	}
+}

--- a/pkg/stanza/internal/fileconsumer/util_test.go
+++ b/pkg/stanza/internal/fileconsumer/util_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package file
+package fileconsumer
 
 import (
 	"fmt"


### PR DESCRIPTION
This is a direct copy of `pkg/stanza/operator/input/file` to `pkg/stanza/internal/fileconsumer`.

The purpose is to simplify #11076 by preceding it with the bulk of the straightforward changes.