### PR TITLE
[docs] add status headers to attribute/filter/span processors

### DIFF
--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -1,6 +1,10 @@
 # Attributes Processor
 
-Supported pipeline types: traces, logs, metrics.
+| Status                   |                       |
+| ------------------------ | --------------------- |
+| Stability                | [alpha]               |
+| Supported pipeline types | traces, metrics, logs |
+| Distributions            | [core], [contrib]     |
 
 The attributes processor modifies attributes of a span, log, or metric. Please refer to
 [config.go](./config.go) for the config spec.
@@ -256,3 +260,7 @@ regexp:
   # cachemaxnumentries is the max number of entries of the LRU cache; ignored if cacheenabled is false.
   cachemaxnumentries: <int>
 ```
+
+[alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
+[core]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -1,6 +1,10 @@
 # Filter Processor
 
-Supported pipeline types: logs, metrics
+| Status                   |                   |
+| ------------------------ | ----------------- |
+| Stability                | [alpha]           |
+| Supported pipeline types | metrics, logs     |
+| Distributions            | [core], [contrib] |
 
 The filter processor can be configured to include or exclude:
 
@@ -204,3 +208,7 @@ processors:
 ```
 
 In case the no metric names are provided, `matric_names` being empty, the filtering is only done at resource level.
+
+[alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
+[core]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/processor/spanprocessor/README.md
+++ b/processor/spanprocessor/README.md
@@ -9,7 +9,7 @@
 The span processor modifies the span name based on its attributes or extract span attributes from the span name. It also allows
 to change span status. Please refer to [config.go](./config.go) for the config spec.
 
-It optionally supports the ability to [include/exclude spans](../README.md#includeexclude-spans).
+It optionally supports the ability to [include/exclude spans](../attributesprocessor/README.md#includeexclude-filtering).
 
 The following actions are supported:
 

--- a/processor/spanprocessor/README.md
+++ b/processor/spanprocessor/README.md
@@ -1,6 +1,10 @@
 # Span Processor
 
-Supported pipeline types: traces
+| Status                   |                   |
+| ------------------------ | ----------------- |
+| Stability                | [alpha]           |
+| Supported pipeline types | traces            |
+| Distributions            | [core], [contrib] |
 
 The span processor modifies the span name based on its attributes or extract span attributes from the span name. It also allows
 to change span status. Please refer to [config.go](./config.go) for the config spec.
@@ -122,3 +126,7 @@ span/set_status:
 
 Refer to [config.yaml](./testdata/config.yaml) for detailed
 examples on using the processor.
+
+[alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
+[contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
+[core]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol


### PR DESCRIPTION
Marked them as `alpha` as it seems likely these will be folded into the transform processor in the near future.

Fixes #10988