### PR TITLE
signalfx event ingest requires Event Type to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - `pkg/stanza`: Fix access to atomic variable without using atomic package (#11023)
 - `exporter/awsemfexporter:`: Fix dead links in README.md. (#11027)
 - `googlecloudexporter`: Fix (self-obs) point_count metric calculation, concurrent map write panic, and dropped log attributes (#11051)
+- `signalfxexporter`: Event Type is a required field, if not set, set it to `unknown` to prevent signalfx ingest from dropping it (#11121)
 
 ## v0.53.0
 

--- a/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
+++ b/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
@@ -121,6 +121,12 @@ func convertLogRecord(lr plog.LogRecord, resourceAttrs pcommon.Map, logger *zap.
 	// SignalFx event timestamps.
 	event.Timestamp = int64(lr.Timestamp()) / 1e6
 
+	// EventType is a required field, if not set sfx event ingest will drop it
+	if event.EventType == "" {
+		logger.Debug("EventType is not set; setting it to unknown")
+		event.EventType = "unknown"
+	}
+
 	return &event, true
 }
 

--- a/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2_test.go
+++ b/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2_test.go
@@ -112,6 +112,20 @@ func TestLogDataToSignalFxEvents(t *testing.T) {
 				return logs
 			}(),
 		},
+		{
+			name: "missing event type",
+			sfxEvents: func() []*sfxpb.Event {
+				e := buildDefaultSFxEvent()
+				e.EventType = "unknown"
+				return []*sfxpb.Event{e}
+			}(),
+			logData: func() plog.Logs {
+				logs := buildDefaultLogs()
+				lrs := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+				lrs.At(0).Attributes().Remove("com.splunk.signalfx.event_type")
+				return logs
+			}(),
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/signalfxreceiver/signalfxv2_event_to_logdata.go
+++ b/receiver/signalfxreceiver/signalfxv2_event_to_logdata.go
@@ -37,9 +37,11 @@ func signalFxV2EventsToLogRecords(events []*sfxpb.Event, lrs plog.LogRecordSlice
 		attrs.EnsureCapacity(2 + len(event.Dimensions) + len(event.Properties))
 
 		// The EventType field is stored as an attribute.
-		if event.EventType != "" {
-			attrs.InsertString(splunk.SFxEventType, event.EventType)
+		eventType := event.EventType
+		if eventType == "" {
+			eventType = "unknown"
 		}
+		attrs.InsertString(splunk.SFxEventType, eventType)
 
 		// SignalFx timestamps are in millis so convert to nanos by multiplying
 		// by 1 million.


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

**Description:** <Describe what has changed.>
The signalfx event ingest requires the `EventType` attribute to be set, otherwise it will not process and drop the event silently.

**Testing:** <Describe what testing was performed and which tests were added.>
Existing unit test was expanded to cover this use case.

**Documentation:** <Describe the documentation added.>