### PR TITLE
[receiver/mongodbatlasreceiver] Fixes wrong record function in getRecordFunc switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - `signalfxexporter`: Event Type is a required field, if not set, set it to `unknown` to prevent signalfx ingest from dropping it (#11121)
 - `prometheusreceiver`: validate that combined metric points (e.g. histograms) have the same timestamp (#9385)
 - `splunkhecexporter`: Fix flaky test when exporting traces (#11418)
+- `mongodbatlasexporter`: Fix mongodbatlas.system.memory.usage.max not being reported (#11126)
 
 ## v0.53.0
 

--- a/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
@@ -597,7 +597,7 @@ func getRecordFunc(metricName string) metricRecordFunc {
 		}
 	case "MAX_SYSTEM_MEMORY_FREE":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
-			mb.RecordMongodbatlasSystemMemoryUsageAverageDataPoint(ts, float64(*dp.Value), AttributeMemoryStatusFree)
+			mb.RecordMongodbatlasSystemMemoryUsageMaxDataPoint(ts, float64(*dp.Value), AttributeMemoryStatusFree)
 		}
 	case "SYSTEM_MEMORY_SHARED":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {


### PR DESCRIPTION
**Description:** 
Fixed wrong record function in getRecordFunc for MongoDB Atlas Receiver. There was a typo which resulted in the same exact metric being added twice for a collection.

**Issue:**
#11126 

**Testing:** 
Manual test to see that wrong metric now shows up correctly

**Documentation:** 
None needed as this was just a bug