### PR TITLE
[receiver/simpleprometheus] mark as unmaintained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@
 - `receiver/awsxrayreceiver`: Fix null span exception fields causing null pointer exception (#11431)
 - `pkg/stanza`: use ObservedTimestamp to decide if flush log for recombine operator (#11433)
 
+
+### Unmaintained components
+
+- `simpleprometheusreceiver`(#11133)
+
 ## v0.53.0
 
 ### 🛑 Breaking changes 🛑
@@ -2128,15 +2133,15 @@ The OpenTelemetry Collector Contrib contains everything in the [opentelemetry-co
 
 ### Receivers
 
-| Traces | Metrics |
-|:-------:|:-------:|
-| Jaeger Legacy | Carbon |
-| SAPM (SignalFx APM) | Collectd |
-| Zipkin Scribe | K8s Cluster |
-| | Redis |
-| |  SignalFx |
-| | Simple Prometheus |
-| | Wavefront |
+|       Traces        |      Metrics      |
+| :-----------------: | :---------------: |
+|    Jaeger Legacy    |      Carbon       |
+| SAPM (SignalFx APM) |     Collectd      |
+|    Zipkin Scribe    |    K8s Cluster    |
+|                     |       Redis       |
+|                     |     SignalFx      |
+|                     | Simple Prometheus |
+|                     |     Wavefront     |
 
 ### Processors
 
@@ -2144,18 +2149,18 @@ The OpenTelemetry Collector Contrib contains everything in the [opentelemetry-co
 
 ### Exporters
 
-| Commercial | Community |
-|:------------:|:-----------:|
-| Alibaba Cloud Log Service | Carbon |
-| AWS X-ray | Elastic |
-| Azure Monitor | Jaeger Thrift |
-| Honeycomb | Kinesis |
-| Lightstep |
-| New Relic |
-| SAPM (SignalFx APM) |
-| SignalFx (Metrics) |
-| Splunk HEC |
-| Stackdriver (Google) |
+|        Commercial         |   Community   |
+| :-----------------------: | :-----------: |
+| Alibaba Cloud Log Service |    Carbon     |
+|         AWS X-ray         |    Elastic    |
+|       Azure Monitor       | Jaeger Thrift |
+|         Honeycomb         |    Kinesis    |
+|         Lightstep         |
+|         New Relic         |
+|    SAPM (SignalFx APM)    |
+|    SignalFx (Metrics)     |
+|        Splunk HEC         |
+|   Stackdriver (Google)    |
 
 ### Extensions
 

--- a/receiver/simpleprometheusreceiver/README.md
+++ b/receiver/simpleprometheusreceiver/README.md
@@ -1,10 +1,10 @@
 # Simple Prometheus Receiver
 
-| Status                   |           |
-| ------------------------ |-----------|
-| Stability                | [beta]    |
-| Supported pipeline types | metrics   |
-| Distributions            | [contrib] |
+| Status                   |                |
+| ------------------------ | -------------- |
+| Stability                | [unmaintained] |
+| Supported pipeline types | metrics        |
+| Distributions            | [contrib]      |
 
 The `prometheus_simple` receiver is a wrapper around the [prometheus
 receiver](../prometheusreceiver).
@@ -72,5 +72,5 @@ Example:
 The full list of settings exposed for this receiver are documented [here](./config.go)
 with detailed sample configurations [here](./testdata/config.yaml).
 
-[beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
+[unmaintained]:https://github.com/open-telemetry/opentelemetry-collector#unmaintained
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/simpleprometheusreceiver/factory.go
+++ b/receiver/simpleprometheusreceiver/factory.go
@@ -16,12 +16,14 @@ package simpleprometheusreceiver // import "github.com/open-telemetry/openteleme
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
+	"go.uber.org/zap"
 )
 
 // This file implements factory for prometheus_simple receiver
@@ -32,6 +34,8 @@ const (
 	defaultEndpoint    = "localhost:9090"
 	defaultMetricsPath = "/metrics"
 )
+
+var once sync.Once
 
 var defaultCollectionInterval = 10 * time.Second
 
@@ -54,6 +58,12 @@ func createDefaultConfig() config.Receiver {
 	}
 }
 
+func logStatus(logger *zap.Logger) {
+	once.Do(func() {
+		logger.Warn("prometheus_simple receiver is unmaintained and actively looking for contributors.")
+	})
+}
+
 func createMetricsReceiver(
 	_ context.Context,
 	params component.ReceiverCreateSettings,
@@ -61,5 +71,6 @@ func createMetricsReceiver(
 	nextConsumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
 	rCfg := cfg.(*Config)
+	logStatus(params.Logger)
 	return new(params, rCfg, nextConsumer), nil
 }

--- a/receiver/simpleprometheusreceiver/go.mod
+++ b/receiver/simpleprometheusreceiver/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/prometheus/prometheus v0.36.2
 	github.com/stretchr/testify v1.7.4
 	go.opentelemetry.io/collector v0.54.0
+	go.uber.org/zap v1.21.0
 	k8s.io/client-go v0.24.2
 )
 
@@ -118,7 +119,6 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220607020251-c690dde0001d // indirect


### PR DESCRIPTION
The following PR identifies the simpleprometheusreceiver as unmaintained and logs a warning on start.
