### PR TITLE
[tracegen/cmd] support add additional resource attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - `jmxreceiver`: Add latest releases of jmx metrics gatherer & wildfly jar to supported jars hash list (#11134)
 - `rabbitmqreceiver`: Add integration test for rabbitmq receiver (#10865)
 - `transformprocessor`: Allow using trace_state with key-value struct (#11029)
+- `cmd/tracegen`: support add additional resource attributes. (#11145)
 
 ### 🧰 Bug fixes 🧰
 

--- a/tracegen/internal/tracegen/config.go
+++ b/tracegen/internal/tracegen/config.go
@@ -55,9 +55,14 @@ func (v *KeyValue) String() string {
 func (v *KeyValue) Set(s string) error {
 	kv := strings.SplitN(s, "=", 2)
 	if len(kv) != 2 {
-		return fmt.Errorf("value should be of the format key=value")
+		return fmt.Errorf("value should be of the format key=\"value\"")
 	}
-	(*v)[kv[0]] = kv[1]
+	val := kv[1]
+	if len(val) < 2 || !strings.HasPrefix(val, "\"") || !strings.HasSuffix(val, "\"") {
+		return fmt.Errorf("value should be a string wrapped in double quotes")
+	}
+
+	(*v)[kv[0]] = val[1 : len(val)-1]
 	return nil
 }
 

--- a/tracegen/internal/tracegen/config.go
+++ b/tracegen/internal/tracegen/config.go
@@ -37,21 +37,22 @@ type Config struct {
 	ServiceName      string
 
 	// OTLP config
-	Endpoint string
-	Insecure bool
-	UseHTTP  bool
-	Headers  HeaderValue
+	Endpoint           string
+	Insecure           bool
+	UseHTTP            bool
+	Headers            KeyValue
+	ResourceAttributes KeyValue
 }
 
-type HeaderValue map[string]string
+type KeyValue map[string]string
 
-var _ flag.Value = (*HeaderValue)(nil)
+var _ flag.Value = (*KeyValue)(nil)
 
-func (v *HeaderValue) String() string {
+func (v *KeyValue) String() string {
 	return ""
 }
 
-func (v *HeaderValue) Set(s string) error {
+func (v *KeyValue) Set(s string) error {
 	kv := strings.SplitN(s, "=", 2)
 	if len(kv) != 2 {
 		return fmt.Errorf("value should be of the format key=value")
@@ -78,6 +79,11 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 	c.Headers = make(map[string]string)
 	fs.Var(&c.Headers, "otlp-header", "Custom header to be passed along with each OTLP request. The value is expected in the format key=value."+
 		"Flag may be repeated to set multiple headers (e.g -otlp-header key1=value1 -otlp-header key2=value2)")
+
+	// custom resource attributes
+	c.ResourceAttributes = make(map[string]string)
+	fs.Var(&c.ResourceAttributes, "otlp-attributes", "Custom resource attributes to use. The value is expected in the format key=value."+
+		"Flag may be repeated to set multiple attributes (e.g -otlp-attributes key1=value1 -otlp-attributes key2=value2)")
 }
 
 // Run executes the test scenario.

--- a/tracegen/internal/tracegen/config.go
+++ b/tracegen/internal/tracegen/config.go
@@ -87,8 +87,8 @@ func (c *Config) Flags(fs *flag.FlagSet) {
 
 	// custom resource attributes
 	c.ResourceAttributes = make(map[string]string)
-	fs.Var(&c.ResourceAttributes, "otlp-attributes", "Custom resource attributes to use. The value is expected in the format key=value."+
-		"Flag may be repeated to set multiple attributes (e.g -otlp-attributes key1=value1 -otlp-attributes key2=value2)")
+	fs.Var(&c.ResourceAttributes, "otlp-attributes", "Custom resource attributes to use. The value is expected in the format key=\"value\"."+
+		"Flag may be repeated to set multiple attributes (e.g -otlp-attributes key1=\"value1\" -otlp-attributes key2=\"value2\")")
 }
 
 // Run executes the test scenario.

--- a/tracegen/main.go
+++ b/tracegen/main.go
@@ -103,7 +103,7 @@ func main() {
 	}()
 
 	var attributes []attribute.KeyValue
-	// may be overridden by `-otlp-attributes service.name=foo`
+	// may be overridden by `-otlp-attributes service.name="foo"`
 	attributes = append(attributes, semconv.ServiceNameKey.String(cfg.ServiceName))
 
 	if len(cfg.ResourceAttributes) > 0 {

--- a/tracegen/main.go
+++ b/tracegen/main.go
@@ -102,13 +102,14 @@ func main() {
 	}()
 
 	attributes := []attribute.KeyValue{}
+	// may be overridden by `-otlp-attributes service.name=foo`
+	attributes = append(attributes, semconv.ServiceNameKey.String(cfg.ServiceName))
+
 	if len(cfg.ResourceAttributes) > 0 {
 		for k, v := range cfg.ResourceAttributes {
 			attributes = append(attributes, attribute.String(k, v))
 		}
 	}
-
-	attributes = append(attributes, semconv.ServiceNameKey.String(cfg.ServiceName))
 
 	tracerProvider := sdktrace.NewTracerProvider(
 		sdktrace.WithResource(resource.NewWithAttributes(semconv.SchemaURL, attributes...)),

--- a/tracegen/main.go
+++ b/tracegen/main.go
@@ -19,8 +19,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"go.opentelemetry.io/otel/attribute"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	grpcZap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"go.opentelemetry.io/otel"

--- a/tracegen/main.go
+++ b/tracegen/main.go
@@ -101,7 +101,7 @@ func main() {
 		}
 	}()
 
-	attributes := []attribute.KeyValue{}
+	var attributes []attribute.KeyValue
 	// may be overridden by `-otlp-attributes service.name=foo`
 	attributes = append(attributes, semconv.ServiceNameKey.String(cfg.ServiceName))
 


### PR DESCRIPTION
Signed-off-by: jian.tan <jian.tan@daocloud.io>

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
refer the implementation of `otlp-headers` :
```bash
tracegen -otlp-insecure -duration 5s -otlp-attributes key1=value1 -otlp-attributes key2=value2
```

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11144

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>