### PR TITLE
[processor/transform] Added nil to grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - `cmd/mdatagen`: Allow attribute values of any types (#9245)
 - `transformprocessor`: Add byte slice literal to the grammar.  Add new SpanID and TraceID functions that take a byte slice and return a Span/Trace ID. (#10487)
+- `transformprocessor`: Add nil literal to the grammar. (#11150)
 - `elasticsearchreceiver`: Add integration test for elasticsearch receiver (#10165)
 - `datadogexporter`: Some config validation and unmarshaling steps are now done on `Validate` and `Unmarshal` instead of `Sanitize` (#8829)
 - `examples`: Add an example for scraping Couchbase metrics (#10894)

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -17,8 +17,8 @@ in the OTLP protobuf definition. e.g., `status.code`, `attributes["http.method"]
   - Metric data types are `None`, `Gauge`, `Sum`, `Histogram`, `ExponentialHistogram`, and `Summary`
   - `aggregation_temporality` is converted to and from the [protobuf's numeric definition](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L291).  Interact with this field using 0, 1, or 2.
   - Until the grammar can handle booleans, `is_monotic` is handled via strings the strings `"true"` and `"false"`.
-- Literals: Strings, ints, floats, and bools can be referenced as literal values.  Byte slices can be references as a literal value via a hex string prefaced with `0x`, such as `0x0001`. 
-- Function invocations: Functions can be invoked with arguments matching the function's expected arguments
+- Literals: Strings, ints, floats, bools, and nil can be referenced as literal values.  Byte slices can be references as a literal value via a hex string prefaced with `0x`, such as `0x0001`. 
+- Function invocations: Functions can be invoked with arguments matching the function's expected arguments.  The literal nil cannot be used as a replacement for maps or slices in function calls.
 - Where clause: Telemetry to modify can be filtered by appending `where a <op> b`, with `a` and `b` being any of the above.
 
 Supported functions:

--- a/processor/transformprocessor/internal/common/expression.go
+++ b/processor/transformprocessor/internal/common/expression.go
@@ -58,6 +58,10 @@ func (g exprGetter) Get(ctx TransformContext) interface{} {
 }
 
 func NewGetter(val Value, functions map[string]interface{}, pathParser PathExpressionParser) (Getter, error) {
+	if val.IsNil != nil && *val.IsNil {
+		return &literal{value: nil}, nil
+	}
+
 	if s := val.String; s != nil {
 		return &literal{value: *s}, nil
 	}

--- a/processor/transformprocessor/internal/common/expression_test.go
+++ b/processor/transformprocessor/internal/common/expression_test.go
@@ -63,6 +63,13 @@ func Test_newGetter(t *testing.T) {
 			want: []byte{1, 2, 3, 4, 5, 6, 7, 8},
 		},
 		{
+			name: "nil literal",
+			val: Value{
+				IsNil: (*IsNil)(testhelper.Boolp(true)),
+			},
+			want: nil,
+		},
+		{
 			name: "bool literal",
 			val: Value{
 				Bool: (*Boolean)(testhelper.Boolp(true)),

--- a/processor/transformprocessor/internal/common/functions_test.go
+++ b/processor/transformprocessor/internal/common/functions_test.go
@@ -252,6 +252,17 @@ func Test_NewFunctionCall(t *testing.T) {
 			},
 		},
 		{
+			name: "getter arg with nil literal",
+			inv: Invocation{
+				Function: "testing_getter",
+				Arguments: []Value{
+					{
+						IsNil: (*IsNil)(testhelper.Boolp(true)),
+					},
+				},
+			},
+		},
+		{
 			name: "string arg",
 			inv: Invocation{
 				Function: "testing_string",

--- a/processor/transformprocessor/internal/common/parser.go
+++ b/processor/transformprocessor/internal/common/parser.go
@@ -56,6 +56,7 @@ type Value struct {
 	Float      *float64    `| @Float`
 	Int        *int64      `| @Int`
 	Bool       *Boolean    `| @("true" | "false")`
+	IsNil      *IsNil      `| @"nil"`
 	Path       *Path       `| @@ )`
 }
 
@@ -98,6 +99,13 @@ type Boolean bool
 
 func (b *Boolean) Capture(values []string) error {
 	*b = values[0] == "true"
+	return nil
+}
+
+type IsNil bool
+
+func (n *IsNil) Capture(_ []string) error {
+	*n = true
 	return nil
 }
 

--- a/processor/transformprocessor/internal/common/parser_test.go
+++ b/processor/transformprocessor/internal/common/parser_test.go
@@ -337,6 +337,30 @@ func Test_parse(t *testing.T) {
 				Condition: nil,
 			},
 		},
+		{
+			query: `set(attributes["test"], nil)`,
+			expected: &ParsedQuery{
+				Invocation: Invocation{
+					Function: "set",
+					Arguments: []Value{
+						{
+							Path: &Path{
+								Fields: []Field{
+									{
+										Name:   "attributes",
+										MapKey: testhelper.Strp("test"),
+									},
+								},
+							},
+						},
+						{
+							IsNil: (*IsNil)(testhelper.Boolp(true)),
+						},
+					},
+				},
+				Condition: nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -77,6 +77,13 @@ func TestProcess(t *testing.T) {
 				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().InsertString("test", "pass")
 			},
 		},
+		{
+			query: `set(attributes["test"], "pass") where attributes["doesnt exist"] == nil`,
+			want: func(td ptrace.Traces) {
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().InsertString("test", "pass")
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(1).Attributes().InsertString("test", "pass")
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:** 
This PR adds `nil` to the grammar as a literal, in a reduced manner.  `nil` can be used as a literal but cannot be used as a replacement for maps and slices in function calls.  The main goal is to allow nil checks in conditions, such as `... where attributes["test"] == nil`

**Link to tracking Issue:**
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11087

**Testing:** 
Updated unit tests

**Documentation:** 
Updated README