### PR TITLE
[testbed] Fix remaining attempts

### DIFF
--- a/testbed/testbed/child_process_collector.go
+++ b/testbed/testbed/child_process_collector.go
@@ -337,7 +337,6 @@ func (cp *childProcessCollector) WatchResourceConsumption() error {
 				}
 				return err
 			}
-			remainingFailures = cp.resourceSpec.MaxConsecutiveFailures
 
 		case <-cp.doneSignal:
 			log.Printf("Stopping process monitor.")

--- a/testbed/testbed/child_process_collector.go
+++ b/testbed/testbed/child_process_collector.go
@@ -327,8 +327,8 @@ func (cp *childProcessCollector) WatchResourceConsumption() error {
 			cp.fetchCPUUsage()
 
 			if err := cp.checkAllowedResourceUsage(); err != nil {
-				remainingFailures--
 				if remainingFailures > 0 {
+					remainingFailures--
 					log.Printf("Resource utilization too high. Remaining attempts: %d", remainingFailures)
 					continue
 				}

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -105,7 +105,7 @@ func TestBallastMemory(t *testing.T) {
 					testbed.ResourceSpec{
 						ExpectedMaxRAM:         test.maxRSS,
 						ResourceCheckPeriod:    time.Second,
-						MaxConsecutiveFailures: 3,
+						MaxConsecutiveFailures: 5,
 					},
 				),
 			)
@@ -119,7 +119,7 @@ func TestBallastMemory(t *testing.T) {
 			tc.WaitForN(func() bool {
 				rss, vms, _ = tc.AgentMemoryInfo()
 				return vms > test.ballastSize
-			}, time.Second*2, fmt.Sprintf("VMS must be greater than %d", test.ballastSize))
+			}, time.Second*5, fmt.Sprintf("VMS must be greater than %d", test.ballastSize))
 
 			// https://github.com/open-telemetry/opentelemetry-collector/issues/3233
 			// given that the maxRSS isn't an absolute maximum and that the actual maximum might be a bit off,


### PR DESCRIPTION
Followup to #10944 

The retry counter was [decremented unnecessarily](https://github.com/open-telemetry/opentelemetry-collector-contrib/runs/6945940585?check_suite_focus=true#step:14:33), causing overflow when the counter was at 0. The linked case also shows that only 2 seconds total were still allowed before failing the test. This PR also extends this to 5 seconds, which I believe may be more likely to see the memory usage resolved.