### PR TITLE
[docs] Ignore false faliures on flink markdown links

### DIFF
--- a/receiver/flinkmetricsreceiver/README.md
+++ b/receiver/flinkmetricsreceiver/README.md
@@ -6,14 +6,17 @@
 | Supported pipeline types | metrics   |
 | Distributions            | [contrib] |
 
+<!-- markdown-link-check-disable -->
 This receiver uses Flink's [REST API](https://nightlies.apache.org/flink/flink-docs-release-1.14/docs/ops/metrics/#rest-api-integration) to collect Jobmanager, Taskmanager, Job, Task and Operator metrics.
 
 ## Prerequisites
 
 This receiver supports Apache Flink versions `1.13.6` and `1.14.4`.
 
+<!-- markdown-link-check-disable -->
 By default, authentication is not required. However, [Flink recommends](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/security/security-ssl/#external--rest-connectivity) using a “side car proxy” that Binds the REST endpoint to the loopback interface and to start a REST proxy that authenticates and forwards the request to Flink.
 
+<!-- markdown-link-check-disable -->
 [SSL](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/security/security-ssl/#external--rest-connectivity) can be enabled with the following REST endpoint [options](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/security/security-ssl/#rest-endpoints-external-connectivity) for external connectivity and have a self signed certificate or be self signed.
 
 ## Configuration


### PR DESCRIPTION
Resolves #10992 

These links work fine, but the tool appears unable to resolve the anchors.