### PR TITLE
[chore] don't run the same dep update multiple times

### DIFF
--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -7,7 +7,7 @@ PR_NAME=dependabot-prs/`date +'%Y-%m-%dT%H%M%S'`
 git checkout -b $PR_NAME
 
 IFS=$'\n'
-requests=$(gh pr list --search "author:app/dependabot" --json number,title --template '{{range .}}{{tablerow .title}}{{end}}' | sort)
+requests=$(gh pr list --limit 200 --search "author:app/dependabot" --json number,title --template '{{range .}}{{tablerow .title}}{{end}}' | sort)
 message=""
 
 last_updated=""

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -7,8 +7,10 @@ PR_NAME=dependabot-prs/`date +'%Y-%m-%dT%H%M%S'`
 git checkout -b $PR_NAME
 
 IFS=$'\n'
-requests=$(gh pr list --search "author:app/dependabot" --json number,title --template '{{range .}}{{tablerow .title}}{{end}}')
+requests=$(gh pr list --search "author:app/dependabot" --json number,title --template '{{range .}}{{tablerow .title}}{{end}}' | sort)
 message=""
+
+last_updated=""
 
 for line in $requests; do
     if [[ $line != Bump* ]]; then 
@@ -20,9 +22,13 @@ for line in $requests; do
         continue
     fi
     version=$(echo $line | cut -f 6 -d " ")
-    make for-all CMD="$GITHUB_WORKSPACE/internal/buildscripts/update-dep" MODULE=$module VERSION=v$version
     message+=$line
     message+=$'\n'
+    if [[ "$last_updated" == "$module $version" ]]; then
+        continue
+    fi
+    last_updated="$module $version"
+    make for-all CMD="$GITHUB_WORKSPACE/internal/buildscripts/update-dep" MODULE=$module VERSION=v$version
 done
 
 make gotidy


### PR DESCRIPTION
This adds a check in the dependabot script to prevent it from running multiple times for each dependency update. It already updates the dependency for all packages using `make for-all`.
