### PR TITLE
[pkg/stanza] Localize encoding concerns

### DIFF
--- a/pkg/stanza/internal/fileconsumer/config_test.go
+++ b/pkg/stanza/internal/fileconsumer/config_test.go
@@ -486,7 +486,7 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *Config {
 				cfg := NewConfig()
-				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "utf-16le"}
+				cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "utf-16le"}
 				return cfg
 			}(),
 		},
@@ -495,7 +495,7 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *Config {
 				cfg := NewConfig()
-				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "UTF-16lE"}
+				cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "UTF-16lE"}
 				return cfg
 			}(),
 		},
@@ -587,7 +587,7 @@ func TestBuild(t *testing.T) {
 		{
 			"InvalidEncoding",
 			func(f *Config) {
-				f.Splitter.Encoding = helper.EncodingConfig{Encoding: "UTF-3233"}
+				f.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "UTF-3233"}
 			},
 			require.Error,
 			nil,
@@ -667,7 +667,7 @@ func NewTestConfig() *Config {
 		LineEndPattern:   "end",
 	}
 	cfg.FingerprintSize = 1024
-	cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "utf16"}
+	cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "utf16"}
 	return cfg
 }
 

--- a/pkg/stanza/internal/fileconsumer/config_test.go
+++ b/pkg/stanza/internal/fileconsumer/config_test.go
@@ -486,7 +486,7 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *Config {
 				cfg := NewConfig()
-				cfg.Encoding = helper.EncodingConfig{Encoding: "utf-16le"}
+				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "utf-16le"}
 				return cfg
 			}(),
 		},
@@ -495,7 +495,7 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *Config {
 				cfg := NewConfig()
-				cfg.Encoding = helper.EncodingConfig{Encoding: "UTF-16lE"}
+				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "UTF-16lE"}
 				return cfg
 			}(),
 		},
@@ -587,7 +587,7 @@ func TestBuild(t *testing.T) {
 		{
 			"InvalidEncoding",
 			func(f *Config) {
-				f.Encoding = helper.EncodingConfig{Encoding: "UTF-3233"}
+				f.Splitter.Encoding = helper.EncodingConfig{Encoding: "UTF-3233"}
 			},
 			require.Error,
 			nil,
@@ -667,7 +667,7 @@ func NewTestConfig() *Config {
 		LineEndPattern:   "end",
 	}
 	cfg.FingerprintSize = 1024
-	cfg.Encoding = helper.EncodingConfig{Encoding: "utf16"}
+	cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "utf16"}
 	return cfg
 }
 

--- a/pkg/stanza/internal/fileconsumer/file.go
+++ b/pkg/stanza/internal/fileconsumer/file.go
@@ -40,7 +40,7 @@ type Input struct {
 	captureFileNameResolved bool
 	captureFilePathResolved bool
 	PollInterval            time.Duration
-	Splitter                helper.SplitterConfig
+	SplitterConfig          helper.SplitterConfig
 	MaxLogSize              int
 	MaxConcurrentFiles      int
 	SeenPaths               map[string]struct{}
@@ -55,8 +55,6 @@ type Input struct {
 	startAtBeginning bool
 
 	fingerprintSize int
-
-	Encoding helper.Encoding // TODO can this be skipped and handled by caller?
 
 	firstCheck bool
 	wg         sync.WaitGroup
@@ -363,5 +361,5 @@ func (f *Input) loadLastPollFiles(ctx context.Context) error {
 
 // getMultiline returns helper.Splitter structure and error eventually
 func (f *Input) getMultiline() (*helper.Splitter, error) {
-	return f.Splitter.Build(f.Encoding.Encoding, false, f.MaxLogSize)
+	return f.SplitterConfig.Build(false, f.MaxLogSize)
 }

--- a/pkg/stanza/internal/fileconsumer/file_test.go
+++ b/pkg/stanza/internal/fileconsumer/file_test.go
@@ -262,7 +262,7 @@ func TestReadUsingNopEncoding(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			operator, emitCalls, tempDir := newTestScenario(t, func(cfg *Config) {
 				cfg.MaxLogSize = 8
-				cfg.Splitter.Encoding.Encoding = "nop"
+				cfg.Splitter.EncodingConfig.Encoding = "nop"
 			})
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -342,7 +342,7 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			operator, emitCalls, tempDir := newTestScenario(t, func(cfg *Config) {
 				cfg.MaxLogSize = tc.maxLogSize
-				cfg.Splitter.Encoding.Encoding = "nop"
+				cfg.Splitter.EncodingConfig.Encoding = "nop"
 			})
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -1068,7 +1068,7 @@ func TestEncodings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			operator, emitCalls, tempDir := newTestScenario(t, func(cfg *Config) {
-				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: tc.encoding}
+				cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: tc.encoding}
 			})
 
 			// Populate the file

--- a/pkg/stanza/internal/fileconsumer/file_test.go
+++ b/pkg/stanza/internal/fileconsumer/file_test.go
@@ -262,7 +262,7 @@ func TestReadUsingNopEncoding(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			operator, emitCalls, tempDir := newTestScenario(t, func(cfg *Config) {
 				cfg.MaxLogSize = 8
-				cfg.Encoding.Encoding = "nop"
+				cfg.Splitter.Encoding.Encoding = "nop"
 			})
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -342,7 +342,7 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			operator, emitCalls, tempDir := newTestScenario(t, func(cfg *Config) {
 				cfg.MaxLogSize = tc.maxLogSize
-				cfg.Encoding.Encoding = "nop"
+				cfg.Splitter.Encoding.Encoding = "nop"
 			})
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -1006,89 +1006,89 @@ func TestFingerprintChangeSize(t *testing.T) {
 	}
 }
 
-// func TestEncodings(t *testing.T) {
-// 	t.Parallel()
-// 	cases := []struct {
-// 		name     string
-// 		contents []byte
-// 		encoding string
-// 		expected [][]byte
-// 	}{
-// 		{
-// 			"Nop",
-// 			[]byte{0xc5, '\n'},
-// 			"",
-// 			[][]byte{{0xc5}},
-// 		},
-// 		{
-// 			"InvalidUTFReplacement",
-// 			[]byte{0xc5, '\n'},
-// 			"utf8",
-// 			[][]byte{{0xef, 0xbf, 0xbd}},
-// 		},
-// 		{
-// 			"ValidUTF8",
-// 			[]byte("foo\n"),
-// 			"utf8",
-// 			[][]byte{[]byte("foo")},
-// 		},
-// 		{
-// 			"ChineseCharacter",
-// 			[]byte{230, 138, 152, '\n'}, // 折\n
-// 			"utf8",
-// 			[][]byte{{230, 138, 152}},
-// 		},
-// 		{
-// 			"SmileyFaceUTF16",
-// 			[]byte{216, 61, 222, 0, 0, 10}, // 😀\n
-// 			"utf-16be",
-// 			[][]byte{{240, 159, 152, 128}},
-// 		},
-// 		{
-// 			"SmileyFaceNewlineUTF16",
-// 			[]byte{216, 61, 222, 0, 0, 10, 0, 102, 0, 111, 0, 111}, // 😀\nfoo
-// 			"utf-16be",
-// 			[][]byte{{240, 159, 152, 128}, {102, 111, 111}},
-// 		},
-// 		{
-// 			"SmileyFaceNewlineUTF16LE",
-// 			[]byte{61, 216, 0, 222, 10, 0, 102, 0, 111, 0, 111, 0}, // 😀\nfoo
-// 			"utf-16le",
-// 			[][]byte{{240, 159, 152, 128}, {102, 111, 111}},
-// 		},
-// 		{
-// 			"ChineseCharacterBig5",
-// 			[]byte{167, 233, 10}, // 折\n
-// 			"big5",
-// 			[][]byte{{230, 138, 152}},
-// 		},
-// 	}
+func TestEncodings(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		contents []byte
+		encoding string
+		expected [][]byte
+	}{
+		{
+			"Nop",
+			[]byte{0xc5, '\n'},
+			"",
+			[][]byte{{0xc5}},
+		},
+		{
+			"InvalidUTFReplacement",
+			[]byte{0xc5, '\n'},
+			"utf8",
+			[][]byte{{0xef, 0xbf, 0xbd}},
+		},
+		{
+			"ValidUTF8",
+			[]byte("foo\n"),
+			"utf8",
+			[][]byte{[]byte("foo")},
+		},
+		{
+			"ChineseCharacter",
+			[]byte{230, 138, 152, '\n'}, // 折\n
+			"utf8",
+			[][]byte{{230, 138, 152}},
+		},
+		{
+			"SmileyFaceUTF16",
+			[]byte{216, 61, 222, 0, 0, 10}, // 😀\n
+			"utf-16be",
+			[][]byte{{240, 159, 152, 128}},
+		},
+		{
+			"SmileyFaceNewlineUTF16",
+			[]byte{216, 61, 222, 0, 0, 10, 0, 102, 0, 111, 0, 111}, // 😀\nfoo
+			"utf-16be",
+			[][]byte{{240, 159, 152, 128}, {102, 111, 111}},
+		},
+		{
+			"SmileyFaceNewlineUTF16LE",
+			[]byte{61, 216, 0, 222, 10, 0, 102, 0, 111, 0, 111, 0}, // 😀\nfoo
+			"utf-16le",
+			[][]byte{{240, 159, 152, 128}, {102, 111, 111}},
+		},
+		{
+			"ChineseCharacterBig5",
+			[]byte{167, 233, 10}, // 折\n
+			"big5",
+			[][]byte{{230, 138, 152}},
+		},
+	}
 
-// 	for _, tc := range cases {
-// 		t.Run(tc.name, func(t *testing.T) {
-// 			t.Parallel()
-// 			operator, receivedEntries, tempDir := newTestScenario(t, func(cfg *Config) {
-// 				cfg.Encoding = helper.EncodingConfig{Encoding: tc.encoding}
-// 			})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			operator, emitCalls, tempDir := newTestScenario(t, func(cfg *Config) {
+				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: tc.encoding}
+			})
 
-// 			// Popualte the file
-// 			temp := openTemp(t, tempDir)
-// 			_, err := temp.Write(tc.contents)
-// 			require.NoError(t, err)
+			// Populate the file
+			temp := openTemp(t, tempDir)
+			_, err := temp.Write(tc.contents)
+			require.NoError(t, err)
 
-// 			require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
-// 			defer func() {
-// 				require.NoError(t, operator.Stop())
-// 			}()
+			require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+			defer func() {
+				require.NoError(t, operator.Stop())
+			}()
 
-// 			for _, expected := range tc.expected {
-// 				select {
-// 				case entry := <-receivedEntries:
-// 					require.Equal(t, expected, []byte(entry.Body.(string)))
-// 				case <-time.After(500 * time.Millisecond):
-// 					require.FailNow(t, "Timed out waiting for entry to be read")
-// 				}
-// 			}
-// 		})
-// 	}
-// }
+			for _, expected := range tc.expected {
+				select {
+				case call := <-emitCalls:
+					require.Equal(t, expected, call.token)
+				case <-time.After(500 * time.Millisecond):
+					require.FailNow(t, "Timed out waiting for entry to be read")
+				}
+			}
+		})
+	}
+}

--- a/pkg/stanza/internal/fileconsumer/reader.go
+++ b/pkg/stanza/internal/fileconsumer/reader.go
@@ -131,7 +131,13 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 			break
 		}
 
-		r.fileInput.emit(ctx, r.fileAttributes, scanner.Bytes())
+		token, err := r.splitter.Encoding.Decode(scanner.Bytes())
+		if err != nil {
+			r.Errorw("decode: %w", zap.Error(err))
+		} else {
+			r.fileInput.emit(ctx, r.fileAttributes, token)
+		}
+
 		r.Offset = scanner.Pos()
 	}
 }

--- a/pkg/stanza/operator/helper/multiline.go
+++ b/pkg/stanza/operator/helper/multiline.go
@@ -136,12 +136,12 @@ type MultilineConfig struct {
 }
 
 // Build will build a Multiline operator.
-func (c MultilineConfig) Build(encoding encoding.Encoding, flushAtEOF bool, force *Flusher, maxLogSize int) (bufio.SplitFunc, error) {
-	return c.getSplitFunc(encoding, flushAtEOF, force, maxLogSize)
+func (c MultilineConfig) Build(enc encoding.Encoding, flushAtEOF bool, force *Flusher, maxLogSize int) (bufio.SplitFunc, error) {
+	return c.getSplitFunc(enc, flushAtEOF, force, maxLogSize)
 }
 
 // getSplitFunc returns split function for bufio.Scanner basing on configured pattern
-func (c MultilineConfig) getSplitFunc(encodingVar encoding.Encoding, flushAtEOF bool, force *Flusher, maxLogSize int) (bufio.SplitFunc, error) {
+func (c MultilineConfig) getSplitFunc(enc encoding.Encoding, flushAtEOF bool, force *Flusher, maxLogSize int) (bufio.SplitFunc, error) {
 	endPattern := c.LineEndPattern
 	startPattern := c.LineStartPattern
 
@@ -153,12 +153,12 @@ func (c MultilineConfig) getSplitFunc(encodingVar encoding.Encoding, flushAtEOF 
 	switch {
 	case endPattern != "" && startPattern != "":
 		return nil, fmt.Errorf("only one of line_start_pattern or line_end_pattern can be set")
-	case encodingVar == encoding.Nop && (endPattern != "" || startPattern != ""):
+	case enc == encoding.Nop && (endPattern != "" || startPattern != ""):
 		return nil, fmt.Errorf("line_start_pattern or line_end_pattern should not be set when using nop encoding")
-	case encodingVar == encoding.Nop:
+	case enc == encoding.Nop:
 		return SplitNone(maxLogSize), nil
 	case endPattern == "" && startPattern == "":
-		splitFunc, err = NewNewlineSplitFunc(encodingVar, flushAtEOF)
+		splitFunc, err = NewNewlineSplitFunc(enc, flushAtEOF)
 
 		if err != nil {
 			return nil, err
@@ -288,13 +288,13 @@ func NewLineEndSplitFunc(re *regexp.Regexp, flushAtEOF bool) bufio.SplitFunc {
 
 // NewNewlineSplitFunc splits log lines by newline, just as bufio.ScanLines, but
 // never returning an token using EOF as a terminator
-func NewNewlineSplitFunc(encoding encoding.Encoding, flushAtEOF bool) (bufio.SplitFunc, error) {
-	newline, err := encodedNewline(encoding)
+func NewNewlineSplitFunc(enc encoding.Encoding, flushAtEOF bool) (bufio.SplitFunc, error) {
+	newline, err := encodedNewline(enc)
 	if err != nil {
 		return nil, err
 	}
 
-	carriageReturn, err := encodedCarriageReturn(encoding)
+	carriageReturn, err := encodedCarriageReturn(enc)
 	if err != nil {
 		return nil, err
 	}
@@ -323,15 +323,15 @@ func NewNewlineSplitFunc(encoding encoding.Encoding, flushAtEOF bool) (bufio.Spl
 	}, nil
 }
 
-func encodedNewline(encoding encoding.Encoding) ([]byte, error) {
+func encodedNewline(enc encoding.Encoding) ([]byte, error) {
 	out := make([]byte, 10)
-	nDst, _, err := encoding.NewEncoder().Transform(out, []byte{'\n'}, true)
+	nDst, _, err := enc.NewEncoder().Transform(out, []byte{'\n'}, true)
 	return out[:nDst], err
 }
 
-func encodedCarriageReturn(encoding encoding.Encoding) ([]byte, error) {
+func encodedCarriageReturn(enc encoding.Encoding) ([]byte, error) {
 	out := make([]byte, 10)
-	nDst, _, err := encoding.NewEncoder().Transform(out, []byte{'\r'}, true)
+	nDst, _, err := enc.NewEncoder().Transform(out, []byte{'\r'}, true)
 	return out[:nDst], err
 }
 
@@ -349,6 +349,7 @@ func trimWhitespaces(data []byte) []byte {
 
 // SplitterConfig consolidates MultilineConfig and FlusherConfig
 type SplitterConfig struct {
+	Encoding  EncodingConfig  `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
 	Multiline MultilineConfig `mapstructure:"multiline,omitempty"                      json:"multiline,omitempty"                     yaml:"multiline,omitempty"`
 	Flusher   FlusherConfig   `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
 }
@@ -356,21 +357,28 @@ type SplitterConfig struct {
 // NewSplitterConfig returns default SplitterConfig
 func NewSplitterConfig() SplitterConfig {
 	return SplitterConfig{
+		Encoding:  NewEncodingConfig(),
 		Multiline: NewMultilineConfig(),
 		Flusher:   NewFlusherConfig(),
 	}
 }
 
 // Build builds Splitter struct
-func (c *SplitterConfig) Build(encoding encoding.Encoding, flushAtEOF bool, maxLogSize int) (*Splitter, error) {
+func (c *SplitterConfig) Build(flushAtEOF bool, maxLogSize int) (*Splitter, error) {
+	enc, err := c.Encoding.Build()
+	if err != nil {
+		return nil, err
+	}
+
 	flusher := c.Flusher.Build()
-	splitFunc, err := c.Multiline.Build(encoding, flushAtEOF, flusher, maxLogSize)
+	splitFunc, err := c.Multiline.Build(enc.Encoding, flushAtEOF, flusher, maxLogSize)
 
 	if err != nil {
 		return nil, err
 	}
 
 	return &Splitter{
+		Encoding:  enc,
 		Flusher:   flusher,
 		SplitFunc: splitFunc,
 	}, nil
@@ -378,6 +386,7 @@ func (c *SplitterConfig) Build(encoding encoding.Encoding, flushAtEOF bool, maxL
 
 // Splitter consolidates Flusher and dependent splitFunc
 type Splitter struct {
+	Encoding  Encoding
 	SplitFunc bufio.SplitFunc
 	Flusher   *Flusher
 }

--- a/pkg/stanza/operator/helper/multiline.go
+++ b/pkg/stanza/operator/helper/multiline.go
@@ -349,23 +349,23 @@ func trimWhitespaces(data []byte) []byte {
 
 // SplitterConfig consolidates MultilineConfig and FlusherConfig
 type SplitterConfig struct {
-	Encoding  EncodingConfig  `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
-	Multiline MultilineConfig `mapstructure:"multiline,omitempty"                      json:"multiline,omitempty"                     yaml:"multiline,omitempty"`
-	Flusher   FlusherConfig   `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
+	EncodingConfig EncodingConfig  `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
+	Multiline      MultilineConfig `mapstructure:"multiline,omitempty"                      json:"multiline,omitempty"                     yaml:"multiline,omitempty"`
+	Flusher        FlusherConfig   `mapstructure:",squash,omitempty"                        json:",inline,omitempty"                       yaml:",inline,omitempty"`
 }
 
 // NewSplitterConfig returns default SplitterConfig
 func NewSplitterConfig() SplitterConfig {
 	return SplitterConfig{
-		Encoding:  NewEncodingConfig(),
-		Multiline: NewMultilineConfig(),
-		Flusher:   NewFlusherConfig(),
+		EncodingConfig: NewEncodingConfig(),
+		Multiline:      NewMultilineConfig(),
+		Flusher:        NewFlusherConfig(),
 	}
 }
 
 // Build builds Splitter struct
 func (c *SplitterConfig) Build(flushAtEOF bool, maxLogSize int) (*Splitter, error) {
-	enc, err := c.Encoding.Build()
+	enc, err := c.EncodingConfig.Build()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -71,7 +71,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	var toBody toBodyFunc = func(token []byte) interface{} {
 		return string(token)
 	}
-	if helper.IsNop(c.Config.Splitter.Encoding.Encoding) {
+	if helper.IsNop(c.Config.Splitter.EncodingConfig.Encoding) {
 		toBody = func(token []byte) interface{} {
 			return token
 		}

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -68,12 +68,22 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		filePathResolvedField = entry.NewAttributeField("log.file.path_resolved")
 	}
 
+	var toBody toBodyFunc = func(token []byte) interface{} {
+		return string(token)
+	}
+	if helper.IsNop(c.Config.Splitter.Encoding.Encoding) {
+		toBody = func(token []byte) interface{} {
+			return token
+		}
+	}
+
 	input := &Input{
 		InputOperator:         inputOperator,
 		FilePathField:         filePathField,
 		FileNameField:         fileNameField,
 		FilePathResolvedField: filePathResolvedField,
 		FileNameResolvedField: fileNameResolvedField,
+		toBody:                toBody,
 	}
 
 	input.fileConsumer, err = c.Config.Build(logger, input.emit)

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -492,7 +492,7 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *Config {
 				cfg := defaultCfg()
-				cfg.Encoding = helper.EncodingConfig{Encoding: "utf-16le"}
+				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "utf-16le"}
 				return cfg
 			}(),
 		},
@@ -501,7 +501,7 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *Config {
 				cfg := defaultCfg()
-				cfg.Encoding = helper.EncodingConfig{Encoding: "UTF-16lE"}
+				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "UTF-16lE"}
 				return cfg
 			}(),
 		},
@@ -596,7 +596,7 @@ func TestBuild(t *testing.T) {
 		{
 			"InvalidEncoding",
 			func(f *Config) {
-				f.Encoding = helper.EncodingConfig{Encoding: "UTF-3233"}
+				f.Splitter.Encoding = helper.EncodingConfig{Encoding: "UTF-3233"}
 			},
 			require.Error,
 			nil,
@@ -682,7 +682,7 @@ func NewTestConfig() *Config {
 		LineEndPattern:   "end",
 	}
 	cfg.FingerprintSize = 1024
-	cfg.Encoding = helper.EncodingConfig{Encoding: "utf16"}
+	cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "utf16"}
 	return cfg
 }
 

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -492,7 +492,7 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *Config {
 				cfg := defaultCfg()
-				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "utf-16le"}
+				cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "utf-16le"}
 				return cfg
 			}(),
 		},
@@ -501,7 +501,7 @@ func TestUnmarshal(t *testing.T) {
 			ExpectErr: false,
 			Expect: func() *Config {
 				cfg := defaultCfg()
-				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "UTF-16lE"}
+				cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "UTF-16lE"}
 				return cfg
 			}(),
 		},
@@ -596,7 +596,7 @@ func TestBuild(t *testing.T) {
 		{
 			"InvalidEncoding",
 			func(f *Config) {
-				f.Splitter.Encoding = helper.EncodingConfig{Encoding: "UTF-3233"}
+				f.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "UTF-3233"}
 			},
 			require.Error,
 			nil,
@@ -682,7 +682,7 @@ func NewTestConfig() *Config {
 		LineEndPattern:   "end",
 	}
 	cfg.FingerprintSize = 1024
-	cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: "utf16"}
+	cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: "utf16"}
 	return cfg
 }
 

--- a/pkg/stanza/operator/input/file/file.go
+++ b/pkg/stanza/operator/input/file/file.go
@@ -17,13 +17,13 @@ package file // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 
-	"golang.org/x/text/encoding"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/internal/fileconsumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
+
+type toBodyFunc func([]byte) interface{}
 
 // Input is an operator that monitors files for entries
 type Input struct {
@@ -35,6 +35,8 @@ type Input struct {
 	FileNameField         entry.Field
 	FilePathResolvedField entry.Field
 	FileNameResolvedField entry.Field
+
+	toBody toBodyFunc
 }
 
 // Start will start the file monitoring process
@@ -52,18 +54,8 @@ func (f *Input) emit(ctx context.Context, attrs *fileconsumer.FileAttributes, to
 	if len(token) == 0 {
 		return
 	}
-	var body interface{} = token
-	var err error
-	if f.fileConsumer.Encoding.Encoding != encoding.Nop {
-		// TODO push decode logic down to reader, so it can reuse decoder
-		body, err = f.fileConsumer.Encoding.Decode(token)
-		if err != nil {
-			f.Errorf("decode: %w", err)
-			return
-		}
-	}
 
-	ent, err := f.NewEntry(body)
+	ent, err := f.NewEntry(f.toBody(token))
 	if err != nil {
 		f.Errorf("create entry: %w", err)
 		return

--- a/pkg/stanza/operator/input/file/file_test.go
+++ b/pkg/stanza/operator/input/file/file_test.go
@@ -262,7 +262,7 @@ func TestReadUsingNopEncoding(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
 				cfg.MaxLogSize = 8
-				cfg.Splitter.Encoding.Encoding = "nop"
+				cfg.Splitter.EncodingConfig.Encoding = "nop"
 			}, nil)
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -342,7 +342,7 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
 				cfg.MaxLogSize = tc.maxLogSize
-				cfg.Splitter.Encoding.Encoding = "nop"
+				cfg.Splitter.EncodingConfig.Encoding = "nop"
 			}, nil)
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -816,7 +816,7 @@ func TestEncodings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			operator, receivedEntries, tempDir := newTestFileOperator(t, func(cfg *Config) {
-				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: tc.encoding}
+				cfg.Splitter.EncodingConfig = helper.EncodingConfig{Encoding: tc.encoding}
 			}, nil)
 
 			// Popualte the file

--- a/pkg/stanza/operator/input/file/file_test.go
+++ b/pkg/stanza/operator/input/file/file_test.go
@@ -262,7 +262,7 @@ func TestReadUsingNopEncoding(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
 				cfg.MaxLogSize = 8
-				cfg.Encoding.Encoding = "nop"
+				cfg.Splitter.Encoding.Encoding = "nop"
 			}, nil)
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -342,7 +342,7 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			operator, logReceived, tempDir := newTestFileOperator(t, func(cfg *Config) {
 				cfg.MaxLogSize = tc.maxLogSize
-				cfg.Encoding.Encoding = "nop"
+				cfg.Splitter.Encoding.Encoding = "nop"
 			}, nil)
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
@@ -816,7 +816,7 @@ func TestEncodings(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			operator, receivedEntries, tempDir := newTestFileOperator(t, func(cfg *Config) {
-				cfg.Encoding = helper.EncodingConfig{Encoding: tc.encoding}
+				cfg.Splitter.Encoding = helper.EncodingConfig{Encoding: tc.encoding}
 			}, nil)
 
 			// Popualte the file

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -253,7 +253,7 @@ func (t *Input) goHandleMessages(ctx context.Context, conn net.Conn, cancel cont
 				continue
 			}
 
-			entry, err := t.NewEntry(decoded)
+			entry, err := t.NewEntry(string(decoded))
 			if err != nil {
 				t.Errorw("Failed to create entry", zap.Error(err))
 				continue

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -173,7 +173,7 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 					continue
 				}
 
-				entry, err := u.NewEntry(decoded)
+				entry, err := u.NewEntry(string(decoded))
 				if err != nil {
 					u.Errorw("Failed to create entry", zap.Error(err))
 					continue


### PR DESCRIPTION
Followup to #11076 

Resolves #11428 

This cleans up the interface between the fileconsumer and its caller by encapsulating encoding/decoding concerns at a deeper level. Callers to fileconsumer can now assume encoding has been handled appropriately. 

This also cleans up some related field and variable names.