### PR TITLE
[pkg/stanza] Deduplicate design doc, remove operator fields

### DIFF
--- a/pkg/stanza/internal/fileconsumer/config_test.go
+++ b/pkg/stanza/internal/fileconsumer/config_test.go
@@ -30,17 +30,6 @@ import (
 func TestUnmarshal(t *testing.T) {
 	cases := []operatortest.ConfigUnmarshalTest{
 		{
-			Name:      "default",
-			ExpectErr: false,
-			Expect:    NewConfig(),
-		},
-		{
-
-			Name:      "extra_field",
-			ExpectErr: false,
-			Expect:    NewConfig(),
-		},
-		{
 			Name:      "include_one",
 			ExpectErr: false,
 			Expect: func() *Config {
@@ -272,111 +261,6 @@ func TestUnmarshal(t *testing.T) {
 				cfg.FingerprintSize = helper.ByteSize(1100)
 				return cfg
 			}(),
-		},
-		{
-			Name:      "include_file_name_lower",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFileName = true
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_name_upper",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFileName = true
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_name_on",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFileName = true
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_name_yes",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFileName = true
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_path_lower",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFilePath = true
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_path_upper",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFilePath = true
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_path_on",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFilePath = true
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_path_yes",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFilePath = true
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_path_off",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFilePath = false
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_path_no",
-			ExpectErr: false,
-			Expect: func() *Config {
-				cfg := NewConfig()
-				cfg.Include = append(cfg.Include, "one.log")
-				cfg.IncludeFilePath = false
-				return cfg
-			}(),
-		},
-		{
-			Name:      "include_file_path_nonbool",
-			ExpectErr: true,
-			Expect:    nil,
 		},
 		{
 			Name:      "multiline_line_start_string",

--- a/pkg/stanza/internal/fileconsumer/testdata/default.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/default.yaml
@@ -1,1 +1,0 @@
-type: file_input

--- a/pkg/stanza/internal/fileconsumer/testdata/encoding_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/encoding_lower.yaml
@@ -1,2 +1,1 @@
-type: file_input
 encoding: "utf-16le"

--- a/pkg/stanza/internal/fileconsumer/testdata/encoding_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/encoding_upper.yaml
@@ -1,2 +1,1 @@
-type: file_input
 encoding: "UTF-16lE"

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_glob.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_glob.yaml
@@ -1,4 +1,3 @@
-type: file_input
 include:
   - "*.log"
 exclude:

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk.yaml
@@ -1,4 +1,3 @@
-type: file_input
 include:
   - "*.log"
 exclude:

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk_nested.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk_nested.yaml
@@ -1,4 +1,3 @@
-type: file_input
 include:
   - "*.log"
 exclude:

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk_prefix.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_glob_double_asterisk_prefix.yaml
@@ -1,4 +1,3 @@
-type: file_input
 include:
   - "*.log"
 exclude:

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_inline.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_inline.yaml
@@ -1,3 +1,2 @@
-type: file_input
 include: [ "*.log" ]
 exclude: [ "a.log", "b.log" ]

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_invalid.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_invalid.yaml
@@ -1,4 +1,3 @@
-type: file_input
 include:
   - "*.log"
 exclude: "aRandomString"

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_multi.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_multi.yaml
@@ -1,4 +1,3 @@
-type: file_input
 include:
   - "*.log"
 exclude:

--- a/pkg/stanza/internal/fileconsumer/testdata/exclude_one.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/exclude_one.yaml
@@ -1,4 +1,3 @@
-type: file_input
 include:
   - "*.log"
 exclude:

--- a/pkg/stanza/internal/fileconsumer/testdata/extra_field.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/extra_field.yaml
@@ -1,2 +1,0 @@
-type: file_input
-hello: world

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1KB.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1KB.yaml
@@ -1,2 +1,1 @@
-type: file_input
 fingerprint_size: 1KB

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1KiB.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1KiB.yaml
@@ -1,2 +1,1 @@
-type: file_input
 fingerprint_size: 1KiB

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1kb_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1kb_lower.yaml
@@ -1,2 +1,1 @@
-type: file_input
 fingerprint_size: 1kb

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1kib_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_1kib_lower.yaml
@@ -1,2 +1,1 @@
-type: file_input
 fingerprint_size: 1kib

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_float.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_float.yaml
@@ -1,2 +1,1 @@
-type: file_input
 fingerprint_size: 1.1kb

--- a/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_no_units.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/fingerprint_size_no_units.yaml
@@ -1,2 +1,1 @@
-type: file_input
 fingerprint_size: 1000

--- a/pkg/stanza/internal/fileconsumer/testdata/id_custom.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/id_custom.yaml
@@ -1,2 +1,0 @@
-type: file_input
-id: test_id

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_name_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_name_lower.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_name: true

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_name_on.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_name_on.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_name: on

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_name_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_name_upper.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_name: TRUE

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_name_yes.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_name_yes.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_name: yes

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_lower.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_path: true

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_no.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_no.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_path: no

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_nonbool.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_nonbool.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_path: asdf

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_off.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_off.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_path: off

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_on.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_on.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_path: on

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_upper.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_path: TRUE

--- a/pkg/stanza/internal/fileconsumer/testdata/include_file_path_yes.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_file_path_yes.yaml
@@ -1,4 +1,0 @@
-type: file_input
-include:
-  - one.log
-include_file_path: yes

--- a/pkg/stanza/internal/fileconsumer/testdata/include_glob.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_glob.yaml
@@ -1,3 +1,2 @@
-type: file_input
 include:
   - "*.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk.yaml
@@ -1,3 +1,2 @@
-type: file_input
 include:
   - "**.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk_nested.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk_nested.yaml
@@ -1,3 +1,2 @@
-type: file_input
 include:
   - "directory/**/*.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk_prefix.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_glob_double_asterisk_prefix.yaml
@@ -1,3 +1,2 @@
-type: file_input
 include:
   - "**/directory/**/*.log"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_inline.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_inline.yaml
@@ -1,2 +1,1 @@
-type: file_input
 include: [ "a.log", "b.log" ]

--- a/pkg/stanza/internal/fileconsumer/testdata/include_invalid.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_invalid.yaml
@@ -1,2 +1,1 @@
-type: file_input
 include: "justwords"

--- a/pkg/stanza/internal/fileconsumer/testdata/include_multi.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_multi.yaml
@@ -1,4 +1,3 @@
-type: file_input
 include:
   - one.log
   - two.log

--- a/pkg/stanza/internal/fileconsumer/testdata/include_one.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/include_one.yaml
@@ -1,3 +1,2 @@
-type: file_input
 include:
   - one.log

--- a/pkg/stanza/internal/fileconsumer/testdata/max_concurrent_large.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_concurrent_large.yaml
@@ -1,2 +1,1 @@
-type: file_input
 max_concurrent_files: 9223372036854775807

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_invalid_unit.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_invalid_unit.yaml
@@ -1,2 +1,1 @@
-type: file_input
 max_log_size: 1TOFU

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mb_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mb_lower.yaml
@@ -1,2 +1,1 @@
-type: file_input
 max_log_size: 1mib

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mb_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mb_upper.yaml
@@ -1,2 +1,1 @@
-type: file_input
 max_log_size: 1MiB

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mib_lower.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mib_lower.yaml
@@ -1,2 +1,1 @@
-type: file_input
 max_log_size: 1mib

--- a/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mib_upper.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/max_log_size_mib_upper.yaml
@@ -1,2 +1,1 @@
-type: file_input
 max_log_size: 1MiB

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_extra_field.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_extra_field.yaml
@@ -1,3 +1,2 @@
-type: file_input
 multiline:
   that_random_field: "this should go nowhere"

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_line_end_special.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_line_end_special.yaml
@@ -1,3 +1,2 @@
-type: file_input
 multiline:
   line_end_pattern: '%'

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_line_end_string.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_line_end_string.yaml
@@ -1,3 +1,2 @@
-type: file_input
 multiline:
   line_end_pattern: 'Start'

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_line_start_special.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_line_start_special.yaml
@@ -1,3 +1,2 @@
-type: file_input
 multiline:
   line_start_pattern: '%'

--- a/pkg/stanza/internal/fileconsumer/testdata/multiline_line_start_string.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/multiline_line_start_string.yaml
@@ -1,3 +1,2 @@
-type: file_input
 multiline:
   line_start_pattern: 'Start'

--- a/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1000ms.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1000ms.yaml
@@ -1,2 +1,1 @@
-type: file_input
 poll_interval: 1000ms

--- a/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1ms.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1ms.yaml
@@ -1,2 +1,1 @@
-type: file_input
 poll_interval: 1ms

--- a/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1s.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/poll_interval_1s.yaml
@@ -1,2 +1,1 @@
-type: file_input
 poll_interval: 1s

--- a/pkg/stanza/internal/fileconsumer/testdata/poll_interval_no_units.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/poll_interval_no_units.yaml
@@ -1,2 +1,1 @@
-type: file_input
 poll_interval: 1

--- a/pkg/stanza/internal/fileconsumer/testdata/start_at_string.yaml
+++ b/pkg/stanza/internal/fileconsumer/testdata/start_at_string.yaml
@@ -1,2 +1,1 @@
-type: file_input
 start_at: "beginning"


### PR DESCRIPTION
Followup to #11076 

Minor cleanup:
- Remove duplicate design doc
- Remove stanza fields like `type` and `id` from `fileconsumer`'s golden config file tests