### PR TITLE
[receiver/awsxrayreceiver] allow cause without message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - `prometheusreceiver`: validate that combined metric points (e.g. histograms) have the same timestamp (#9385)
 - `splunkhecexporter`: Fix flaky test when exporting traces (#11418)
 - `mongodbatlasexporter`: Fix mongodbatlas.system.memory.usage.max not being reported (#11126)
+- `awsxrayreceiver`: allow cause without message. (#11419)
 
 ## v0.53.0
 

--- a/receiver/awsxrayreceiver/internal/translator/cause.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause.go
@@ -91,10 +91,14 @@ func convertStackFramesToStackTraceStr(excp awsxray.Exception) string {
 	// "<*excp.Type>: <*excp.Message>\n" +
 	// "\tat <*frameN.Label>(<*frameN.Path>: <*frameN.Line>)\n"
 	var b strings.Builder
-	b.Grow(len(*excp.Type) + len(": ") + len(*excp.Message) + len("\n"))
+	message := "<no message>"
+	if excp.Message != nil {
+		message = *excp.Message
+	}
+	b.Grow(len(*excp.Type) + len(": ") + len(message) + len("\n"))
 	b.WriteString(*excp.Type)
 	b.WriteString(": ")
-	b.WriteString(*excp.Message)
+	b.WriteString(message)
 	b.WriteString("\n")
 	for _, frame := range excp.Stack {
 		label := awsxray.StringOrEmpty(frame.Label)

--- a/receiver/awsxrayreceiver/internal/translator/cause_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause_test.go
@@ -103,3 +103,13 @@ func TestConvertStackFramesToStackTraceStrNoLabel(t *testing.T) {
 	actual := convertStackFramesToStackTraceStr(excp)
 	assert.Equal(t, actual, "exceptionType: exceptionMessage\n\tat label0(path0: 10)\n\tat (path1: 11)\n")
 }
+
+func TestConvertNilMessage(t *testing.T) {
+	excp := awsxray.Exception{
+		Type:    awsxray.String("exceptionType"),
+		Message: nil,
+		Stack:   []awsxray.StackFrame{},
+	}
+	actual := convertStackFramesToStackTraceStr(excp)
+	assert.Equal(t, actual, "exceptionType: <no message>\n")
+}


### PR DESCRIPTION
awsxray.Exception.Message is optional fix crash in translation logic
when it is missing.

Fixes #11064

**Description:** <Describe what has changed.>
Making exception translation more robust.

**Link to tracking Issue:** #11064

**Testing:** Add unit test

**Documentation:** No need