### PR TITLE
Revert "[chore] skip builds for readme changes (#11174)"

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -5,8 +5,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
-    paths-ignore:
-      - '**/README.md'
 env:
   TEST_RESULTS: testbed/tests/results/junit/results.xml
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,8 +5,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
-    paths-ignore:
-      - '**/README.md'
 env:
   TEST_RESULTS: testbed/tests/results/junit/results.xml
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,8 +9,6 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
-    paths-ignore:
-      - '**/README.md'
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -5,8 +5,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
-    paths-ignore:
-      - '**/README.md'
 
 jobs:
   setup-environment:

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -5,8 +5,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
-    paths-ignore:
-      - '**/README.md'
 
 jobs:
   prometheus-compliance-tests:

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -5,8 +5,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
-    paths-ignore:
-      - '**/README.md'
 
 jobs:
   setup-environment:

--- a/.github/workflows/tracegen.yml
+++ b/.github/workflows/tracegen.yml
@@ -5,8 +5,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
-    paths-ignore:
-      - '**/README.md'
 
 jobs:
   build-dev:


### PR DESCRIPTION
This reverts commit b49332ce47ef14b2db3b4ab48604009e195bbbe8.

The required checks fail to run when the pull requests skips them altogether. Will work on a workaround.