### PR TITLE
Revert "[exporter/signalfx]  Enable the exporting of seven Kubernetes metrics used in Splunk/SignalFx content by default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@
 - `dynatraceexporter`: Provide better estimated summaries for partial histograms. (#11044)
 - `mongodbreceiver`: Add integration test for mongodb receiver (#10864)
 - `mezmoexporter`: add logging for HTTP errors (#10875)
-- `signalfxexporter`: Enable the exporting of seven Kubernetes metrics used in Splunk/SignalFx content by default (#11032)
 - `googlecloudexporter`: Support writing to multiple GCP projects by setting the `gcp.project.id` resource attribute, and support service account impersonation (#11051)
 - `k8sattributeprocessor`: Add debug logs to help identify missing attributes (#11060)
 - `jmxreceiver`: Add latest releases of jmx metrics gatherer & wildfly jar to supported jars hash list (#11134)

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -658,7 +658,7 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	require.NoError(t, err)
 
 	md := getMetrics(metrics)
-	require.Equal(t, 65, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, 71, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	dps := converter.MetricsToSignalFxV2(md)
 	require.Equal(t, 0, len(dps))
 }

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -118,17 +118,10 @@ exclude_metrics:
   - '!k8s.container.memory_limit'
   - '!k8s.container.cpu_limit'
 
-  # matches all container request metrics but k8s.container.cpu_request and k8s.container.memory_request
   - /^k8s\.container\..+_request$/
-  - '!k8s.container.memory_request'
-  - '!k8s.container.cpu_request'
 
-  # matches any node condition but memory_pressure, network_unavailable, out_of_disk, p_i_d_pressure, and ready
+  # matches any node condition but k8s.node.condition_ready
   - /^k8s\.node\.condition_.+$/
-  - '!k8s.node.condition_memory_pressure'
-  - '!k8s.node.condition_network_unavailable'
-  - '!k8s.node.condition_out_of_disk'
-  - '!k8s.node.condition_p_i_d_pressure'
   - '!k8s.node.condition_ready'
 
   # kubelet metrics
@@ -148,8 +141,8 @@ exclude_metrics:
   # matches (k8s.node|k8s.pod).cpu.time
   - /^k8s\.(?i:(node)|(pod))\.cpu\.time$/
 
-  # matches (k8s.node|k8s.pod).cpu.utilization
-  - /^(?i:(k8s\.node)|(k8s\.pod))\.cpu\.utilization$/
+  # matches (container|k8s.node|k8s.pod).cpu.utilization
+  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.cpu\.utilization$/
 
   # matches k8s.node.network.io and k8s.node.network.errors
   - /^k8s\.node\.network\.(?:(io)|(errors))$/

--- a/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
+++ b/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
@@ -102,10 +102,28 @@
     "k8s.hpa.desired_replicas": null
   },
   {
+    "k8s.container.cpu_request": null
+  },
+  {
     "k8s.container.ephemeral-storage_limit": null
   },
   {
     "k8s.container.ephemeral-storage_request": null
+  },
+  {
+    "k8s.container.memory_request": null
+  },
+  {
+    "k8s.node.condition_memory_pressure": null
+  },
+  {
+    "k8s.node.condition_network_unavailable": null
+  },
+  {
+    "k8s.node.condition_out_of_disk": null
+  },
+  {
+    "k8s.node.condition_p_i_d_pressure": null
   },
   {
     "container.memory.available": null


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#11032

Description:
After doing more research, I would like to revert these changes for now. I have to update some internal Splunk resources before these changes can go out to users safely.