### PR TITLE
pkg/stanza: use ObservedTimestamp to decide if flush log for recombine operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - `prometheusreceiver`: validate that combined metric points (e.g. histograms) have the same timestamp (#9385)
 - `splunkhecexporter`: Fix flaky test when exporting traces (#11418)
 - `mongodbatlasexporter`: Fix mongodbatlas.system.memory.usage.max not being reported (#11126)
+- `pkg/stanza`: use ObservedTimestamp to decide if flush log for recombine operator (#11433)
 
 ## v0.53.0
 

--- a/pkg/stanza/operator/transformer/recombine/recombine.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine.go
@@ -156,7 +156,7 @@ func (r *Transformer) flushLoop() {
 			r.Lock()
 			timeNow := time.Now()
 			for source, entries := range r.batchMap {
-				lastEntryTs := entries[len(entries)-1].Timestamp
+				lastEntryTs := entries[len(entries)-1].ObservedTimestamp
 				timeSinceLastEntry := timeNow.Sub(lastEntryTs)
 				if timeSinceLastEntry < r.forceFlushTimeout {
 					continue


### PR DESCRIPTION
**Description:** 

Now Timestamp is taken into consideration while deciding to flush log in recombine operator.
The issue is that timestamp comes from log body and can be behind the time log has been read.
Switching it to `ObservedTimestamp`, so time of reading logs will be taken instead

**Link to tracking Issue:** N/A

**Testing:** manual only
