### PR TITLE
[CI] Add go fmt check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,6 +128,10 @@ jobs:
         run: |
           make goporto
           git diff --exit-code || (echo 'Porto links are out of date, please run "make goporto" and commit the changes in this PR.' && exit 1)
+      - name: Check for gofmt changes
+        run: |
+          make gofmt
+          git diff --exit-code || (echo 'go fmt changes detected, please run "make gofmt" and commit the changes in this PR.' && exit 1)
       - name: Check for go mod dependency changes
         run: |
           make gotidy


### PR DESCRIPTION
See #11432 

Our CI process is currently not ensuring that `go fmt` has been run.