### PR TITLE
[receiver/hostmetrics] Set process metrics start time to process create time

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -34,6 +34,7 @@ type processMetadata struct {
 	command    *commandMetadata
 	username   string
 	handle     processHandle
+	createTime int64
 }
 
 type executableMetadata struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/shirou/gopsutil/v3/host"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -50,7 +49,7 @@ type scraper struct {
 	excludeFS          filterset.FilterSet
 	scrapeProcessDelay time.Duration
 	// for mocking
-	bootTime                             func() (uint64, error)
+	getProcessCreateTime                 func(p processHandle) (int64, error)
 	getProcessHandles                    func() (processHandles, error)
 	emitMetricsWithDirectionAttribute    bool
 	emitMetricsWithoutDirectionAttribute bool
@@ -61,7 +60,7 @@ func newProcessScraper(settings component.ReceiverCreateSettings, cfg *Config) (
 	scraper := &scraper{
 		settings:                             settings,
 		config:                               cfg,
-		bootTime:                             host.BootTime,
+		getProcessCreateTime:                 processHandle.CreateTime,
 		getProcessHandles:                    getProcessHandlesInternal,
 		emitMetricsWithDirectionAttribute:    featuregate.GetRegistry().IsEnabled(internal.EmitMetricsWithDirectionAttributeFeatureGateID),
 		emitMetricsWithoutDirectionAttribute: featuregate.GetRegistry().IsEnabled(internal.EmitMetricsWithoutDirectionAttributeFeatureGateID),
@@ -88,12 +87,7 @@ func newProcessScraper(settings component.ReceiverCreateSettings, cfg *Config) (
 }
 
 func (s *scraper) start(context.Context, component.Host) error {
-	bootTime, err := s.bootTime()
-	if err != nil {
-		return err
-	}
-
-	s.mb = metadata.NewMetricsBuilder(s.config.Metrics, s.settings.BuildInfo, metadata.WithStartTime(pcommon.Timestamp(bootTime*1e9)))
+	s.mb = metadata.NewMetricsBuilder(s.config.Metrics, s.settings.BuildInfo)
 	return nil
 }
 
@@ -129,7 +123,8 @@ func (s *scraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 			errs.AddPartial(threadMetricsLen, fmt.Errorf("error reading thread info for process %q (pid %v): %w", md.executable.name, md.pid, err))
 		}
 
-		s.mb.EmitForResource(md.resourceOptions()...)
+		options := append(md.resourceOptions(), metadata.WithStartTimeOverride(pcommon.Timestamp(md.createTime*1e6)))
+		s.mb.EmitForResource(options...)
 	}
 
 	return s.mb.Emit(), errs.Combine()
@@ -176,7 +171,7 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 			errs.AddPartial(0, fmt.Errorf("error reading username for process %q (pid %v): %w", executable.name, pid, err))
 		}
 
-		createTime, err := handle.CreateTime()
+		createTime, err := s.getProcessCreateTime(handle)
 		if err != nil {
 			errs.AddPartial(0, fmt.Errorf("error reading create time for process %q (pid %v): %w", executable.name, pid, err))
 			// set the start time to now to avoid including this when a scrape_process_delay is set
@@ -198,6 +193,7 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 			command:    command,
 			username:   username,
 			handle:     handle,
+			createTime: createTime,
 		}
 
 		data = append(data, md)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -83,8 +83,8 @@ func TestScrape(t *testing.T) {
 		},
 	}
 
-	const bootTime = 100
-	const expectedStartTime = 100 * 1e9
+	const createTime = 100
+	const expectedStartTime = 100 * 1e6
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestScrape(t *testing.T) {
 			if test.mutateScraper != nil {
 				test.mutateScraper(scraper)
 			}
-			scraper.bootTime = func() (uint64, error) { return bootTime, nil }
+			scraper.getProcessCreateTime = func(p processHandle) (int64, error) { return createTime, nil }
 			require.NoError(t, err, "Failed to create process scraper: %v", err)
 			err = scraper.start(context.Background(), componenttest.NewNopHost())
 			require.NoError(t, err, "Failed to initialize process scraper: %v", err)

--- a/unreleased/11446-set-create-time.yaml
+++ b/unreleased/11446-set-create-time.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set process metrics start time to process create time
+
+# One or more tracking issues related to the change
+issues: [11447]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** The start time of process metrics is currently set to the boot time of the system. This means that if a user repeatedly runs the same command, eventually the user will get two processes with the same PID and command, with the same start time (the system boot time). This makes the two data points indistinguishable and creates an association where there is none.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11447

**Testing:**  Ran related unit tests through `make test`