### PR TITLE
[exporter/sapm] Disable ingest link check

### DIFF
--- a/exporter/sapmexporter/README.md
+++ b/exporter/sapmexporter/README.md
@@ -20,8 +20,8 @@ another backend that supports the SAPM proto. The SignalFx access token can be o
 web app. For details on how to do so please refer the documentation [here](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#access-tokens).
 - `endpoint` (no default): This is the destination to where traces will be sent to in SAPM
 format. It must be a full URL and include the scheme, port and path e.g,
-https://ingest.us0.signalfx.com/v2/trace. This can be pointed to the SignalFx backend or to
-another Otel collector that has the SAPM receiver enabled.
+<!-- markdown-link-check-disable-line -->https://ingest.us0.signalfx.com/v2/trace. This can be pointed to the SignalFx 
+backend or to another Otel collector that has the SAPM receiver enabled.
 
 The following configuration options can also be configured:
 


### PR DESCRIPTION
The endpoint doesn't support GET requests, so it shouldn't be checked

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11449