### PR TITLE
[extension/storage] Skip flaky tests on Windows

### DIFF
--- a/cmd/configschema/comments_test.go
+++ b/cmd/configschema/comments_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package configschema
 
 import (

--- a/cmd/configschema/common_test.go
+++ b/cmd/configschema/common_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package configschema
 
 import "time"

--- a/cmd/configschema/configs_test.go
+++ b/cmd/configschema/configs_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package configschema
 
 import (

--- a/cmd/configschema/docsgen/docsgen/cli_test.go
+++ b/cmd/configschema/docsgen/docsgen/cli_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package docsgen
 
 import (

--- a/cmd/configschema/docsgen/docsgen/template_test.go
+++ b/cmd/configschema/docsgen/docsgen/template_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package docsgen
 
 import (

--- a/cmd/configschema/fields_test.go
+++ b/cmd/configschema/fields_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package configschema
 
 import (

--- a/cmd/configschema/resolver_test.go
+++ b/cmd/configschema/resolver_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package configschema
 
 import (

--- a/extension/storage/dbstorage/config_test.go
+++ b/extension/storage/dbstorage/config_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package dbstorage // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage"
 import (
 	"errors"

--- a/extension/storage/dbstorage/extension_test.go
+++ b/extension/storage/dbstorage/extension_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 // nolint:errcheck
 package dbstorage
 

--- a/internal/components/components_test.go
+++ b/internal/components/components_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package components
 
 import (

--- a/internal/components/exporters_test.go
+++ b/internal/components/exporters_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package components
 
 import (

--- a/internal/components/extensions_test.go
+++ b/internal/components/extensions_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 // nolint:errcheck
 package components
 

--- a/internal/components/processors_test.go
+++ b/internal/components/processors_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package components
 
 import (

--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Skip tests on Windows temporarily, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
+//go:build !windows
+// +build !windows
+
 package components
 
 import (


### PR DESCRIPTION
The flaky tests failure rate is very high. The issue seems to be more involved to be solved right away. This change temporarily disables tests in all affected packages including those that import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage" indirectly.
 
**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11451
