### PR TITLE
signalfxreceiver: allow multiple Start() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `tanzuobservabilityexporter`: remove calls to deprecated `NewProxySender` methods. (#11510)
 - `aerospikereceiver`: Fix issue where namespaces would not be collected (#11465)
+- `signalfxreceiver`: Fix issue where component instance use in multiple pipelines leads to start failures (#11513)
 
 ## v0.54.0
 

--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -131,6 +131,10 @@ func (r *sfxReceiver) Start(_ context.Context, host component.Host) error {
 		return component.ErrNilNextConsumer
 	}
 
+	if r.server != nil {
+		return nil
+	}
+
 	// set up the listener
 	ln, err := r.config.HTTPServerSettings.ToListener()
 	if err != nil {

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -107,6 +107,7 @@ func Test_signalfxeceiver_EndToEnd(t *testing.T) {
 	r.RegisterMetricsConsumer(sink)
 
 	require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
 	runtime.Gosched()
 	defer r.Shutdown(context.Background())
 


### PR DESCRIPTION
**Description:**
Fixing a bug - With https://github.com/open-telemetry/opentelemetry-collector/commit/b05c0f3ffcecc5913cadb139db49414fa8e3b138 using the signalfx receiver in multiple pipelines causes a port conflict by trying to recreate an existing server. These changes ensure subsequent `Start()` calls are noops.

**Testing:** Updated existing test with repeated Start invocation.

**Documentation:** Changelog update