### PR TITLE
[prometheusexporter] Export target_info metrics

### DIFF
--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -167,6 +167,9 @@ func TestEndToEndSummarySupport(t *testing.T) {
 		`. HELP test_up The scraping was successful`,
 		`. TYPE test_up gauge`,
 		`test_up.instance="127.0.0.1:.*",job="otel-collector". 1 .*`,
+		`. HELP test_target_info Target metadata`,
+		`. TYPE test_target_info gauge`,
+		`test_target_info.http_scheme="http",instance="127.0.0.1:.*",job="otel-collector",net_host_port=".*". 1`,
 	}
 
 	// 5.5: Perform a complete line by line prefix verification to ensure we extract back the inputs

--- a/unreleased/export-target-info-prometheusexporter.yaml
+++ b/unreleased/export-target-info-prometheusexporter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Export target_info metrics with the resource attributes.
+
+# One or more tracking issues related to the change
+issues: [8265]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
This finally fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8265

The issue is that we have the resource attributes sent in each metric, and we need to dedupe to unique resourceAttributes based on job + instance labels.

I kinda hacked together something, not sure if this is the way to go. Looking forward to some feedback before I proceed further.