### PR TITLE
sapmreceiver: allow multiple Start() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🧰 Bug fixes 🧰
+
+- `sapmreceiver`: Fix issue where component instance use in multiple pipelines leads to start failures (#11518)
+
 ## v0.54.0
 
 ## 🛑 Breaking changes 🛑

--- a/receiver/sapmreceiver/trace_receiver.go
+++ b/receiver/sapmreceiver/trace_receiver.go
@@ -156,6 +156,10 @@ func (sr *sapmReceiver) HTTPHandlerFunc(rw http.ResponseWriter, req *http.Reques
 
 // Start starts the sapmReceiver's server.
 func (sr *sapmReceiver) Start(_ context.Context, host component.Host) error {
+	// server.Handler will be nil on initial call, otherwise noop.
+	if sr.server != nil && sr.server.Handler != nil {
+		return nil
+	}
 	// set up the listener
 	ln, err := sr.config.HTTPServerSettings.ToListener()
 	if err != nil {

--- a/receiver/sapmreceiver/trace_receiver_test.go
+++ b/receiver/sapmreceiver/trace_receiver_test.go
@@ -214,6 +214,7 @@ func setupReceiver(t *testing.T, config *Config, sink *consumertest.TracesSink) 
 
 	mh := newAssertNoErrorHost(t)
 	require.NoError(t, sr.Start(context.Background(), mh), "should not have failed to start trace reception")
+	require.NoError(t, sr.Start(context.Background(), mh), "should not fail to start log on second Start call")
 
 	// If there are errors reported through host.ReportFatalError() this will retrieve it.
 	<-time.After(500 * time.Millisecond)


### PR DESCRIPTION
Description:

Fixing a bug - With open-telemetry/opentelemetry-collector@b05c0f3 using the splunk_hec receiver in multiple pipelines causes a port conflict by trying to recreate an existing server. These changes ensure subsequent Start() calls are noops.

Testing: Updated existing test with repeated Start invocation.

Documentation: Changelog update
