### PR TITLE
splunkhexexporter: allow merging metric events

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -53,10 +53,10 @@ jobs:
             echo "No changelog entry was added to the ./unreleased/ directory."
             echo "Please add a .yaml file to the ./unreleased/ directory."
             echo "See CONTRIBUTING.md for more details."
-            echo ""Alternately, add either \"[chore]\" to the title of the pull request or add the \"Skip Changelog\" label if this job should be skipped."
+            echo "Alternately, add either \"[chore]\" to the title of the pull request or add the \"Skip Changelog\" label if this job should be skipped."
             false
           else
-            echo "A changelog entry was added to the ./unreleased/ directory!"
+            echo "A changelog entry was added to the ./unreleased/ directory."
           fi
 
       - name: Validate ./unreleased/*.yaml changes

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -20,6 +20,7 @@ The following configuration options can also be configured:
 - `source` (no default): Optional Splunk source: https://docs.splunk.com/Splexicon:Source
 - `sourcetype` (no default): Optional Splunk source type: https://docs.splunk.com/Splexicon:Sourcetype
 - `index` (no default): Splunk index, optional name of the Splunk index targeted
+- `use_multi_metric_format` (default: false): Combines metrics with the same metadata to reduce ingest using the [multiple-metric JSON format](https://docs.splunk.com/Documentation/Splunk/9.0.0/Metrics/GetMetricsInOther#The_multiple-metric_JSON_format). Applicable in the `metrics` pipeline only.
 - `max_connections` (default: 100): Maximum HTTP connections to use simultaneously when sending data.
 - `disable_compression` (default: false): Whether to disable gzip compression over HTTP.
 - `timeout` (default: 10s): HTTP timeout when sending data.

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -396,6 +396,14 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 
 		// Parsing metric record to Splunk event.
 		events := mapMetricToSplunkEvent(res.Resource(), metrics.At(k), c.config, c.logger)
+		if c.config.UseMultiMetricFormat {
+			merged, err := mergeEventsToMultiMetricFormat(events)
+			if err != nil {
+				permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf("error merging events: %w", err)))
+			} else {
+				events = merged
+			}
+		}
 		for _, event := range events {
 			// JSON encoding event and writing to buffer.
 			b, err := jsoniter.Marshal(event)

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -404,7 +404,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 		}
 	}
 
-	for k := 0; k < len(events); k++ {
+	for k, event := range events
 		if state.bufFront == nil {
 			state.bufFront = &index{resource: state.resource, library: state.library, record: k}
 		}

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -404,7 +404,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 		}
 	}
 
-	for k, event := range events
+	for k, event := range events {
 		if state.bufFront == nil {
 			state.bufFront = &index{resource: state.resource, library: state.library, record: k}
 		}

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -107,6 +107,8 @@ type Config struct {
 	HecToOtelAttrs splunk.HecToOtelAttrs `mapstructure:"hec_metadata_to_otel_attrs"`
 	// HecFields creates a mapping from attributes to HEC fields.
 	HecFields OtelToHecFields `mapstructure:"otel_to_hec_fields"`
+	// UseMultiMetricFormat combines metric events to save space during ingestion.
+	UseMultiMetricFormat bool `mapstructure:"use_multi_metric_format"`
 }
 
 func (cfg *Config) getOptionsFromConfig() (*exporterOptions, error) {

--- a/exporter/splunkhecexporter/metricdata_to_splunk.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk.go
@@ -15,8 +15,12 @@
 package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
 
 import (
+	"hash/fnv"
 	"math"
 	"strconv"
+	"strings"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -232,7 +236,20 @@ func createEvent(timestamp pcommon.Timestamp, host string, source string, source
 		Event:      splunk.HecEventMetricType,
 		Fields:     fields,
 	}
+}
 
+func copyEventWithoutValues(event *splunk.Event) *splunk.Event {
+	return &splunk.Event{
+		Time:       event.Time,
+		Host:       event.Host,
+		Source:     event.Source,
+		SourceType: event.SourceType,
+		Index:      event.Index,
+		Event:      event.Event,
+		Fields: cloneMapWithSelector(event.Fields, func(key string) bool {
+			return !strings.HasPrefix(key, splunkMetricValue)
+		}),
+	}
 }
 
 func populateAttributes(fields map[string]interface{}, attributeMap pcommon.Map) {
@@ -246,6 +263,16 @@ func cloneMap(fields map[string]interface{}) map[string]interface{} {
 	newFields := make(map[string]interface{}, len(fields))
 	for k, v := range fields {
 		newFields[k] = v
+	}
+	return newFields
+}
+
+func cloneMapWithSelector(fields map[string]interface{}, selector func(string) bool) map[string]interface{} {
+	newFields := make(map[string]interface{}, len(fields))
+	for k, v := range fields {
+		if selector(k) {
+			newFields[k] = v
+		}
 	}
 	return newFields
 }
@@ -266,4 +293,64 @@ func timestampToSecondsWithMillisecondPrecision(ts pcommon.Timestamp) *float64 {
 
 func float64ToDimValue(f float64) string {
 	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// merge metric events to adhere to the multimetric format event.
+func mergeEventsToMultiMetricFormat(events []*splunk.Event) ([]*splunk.Event, error) {
+	merges := map[uint32][]int{}
+	hasher := fnv.New32a()
+	for i, e := range events {
+		cloned := copyEventWithoutValues(e)
+		data, err := jsoniter.Marshal(cloned)
+		if err != nil {
+			return nil, err
+		}
+		_, err = hasher.Write(data)
+		if err != nil {
+			return nil, err
+		}
+		hashed := hasher.Sum32()
+		hasher.Reset()
+		matches := merges[hashed]
+		if len(matches) == 0 {
+			merges[hashed] = []int{i}
+		} else {
+			merges[hashed] = append(merges[hashed], i)
+		}
+	}
+	var mergedEvents []*splunk.Event
+
+	for _, merge := range merges {
+		mergeDestination := events[merge[0]]
+		for j := 1; j < len(merge); j++ {
+			currentEvent := events[j]
+			// check no collision for this event values:
+			eventValues := map[string]interface{}{}
+			collisionFound := false
+			for field, value := range currentEvent.Fields {
+				if strings.HasPrefix(field, splunkMetricValue) {
+					if _, ok := mergeDestination.Fields[field]; ok {
+						// collision, same value. Stop iterating over the contents of the event.
+						collisionFound = true
+						break
+					}
+					eventValues[field] = value
+				}
+			}
+			// if we find those two events can indeed be merged as they don't have metric names in common,
+			// add the fields we collected to the merged event:
+			if !collisionFound {
+				for k, v := range eventValues {
+					mergeDestination.Fields[k] = v
+				}
+			} else {
+				// we found there was a collision, so add the event we were looking at to the list of events,
+				// and abandon merging its fields:
+				mergedEvents = append(mergedEvents, currentEvent)
+			}
+		}
+		mergedEvents = append(mergedEvents, mergeDestination)
+	}
+
+	return mergedEvents, nil
 }

--- a/exporter/splunkhecexporter/metricdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk_test.go
@@ -612,6 +612,167 @@ func Test_metricDataToSplunk(t *testing.T) {
 	}
 }
 
+func Test_mergeEventsToMultiMetricFormat(t *testing.T) {
+	unixSecs := int64(1574092046)
+	unixNSecs := int64(11 * time.Millisecond)
+	tsUnix := time.Unix(unixSecs, unixNSecs)
+	ts := pcommon.NewTimestampFromTime(tsUnix)
+	oneEvent := createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+		"foo":             "bar",
+		"metric_name:mem": 123,
+	})
+	tests := []struct {
+		name   string
+		events []*splunk.Event
+		merged []*splunk.Event
+	}{
+		{
+			name:   "no events",
+			events: []*splunk.Event{},
+			merged: []*splunk.Event{},
+		},
+		{
+			name: "two events that can merge",
+			events: []*splunk.Event{
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 123,
+				}),
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":                  "bar",
+					"metric_name:othermem": 1233.4,
+				}),
+			},
+			merged: []*splunk.Event{
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":                  "bar",
+					"metric_name:mem":      123,
+					"metric_name:othermem": 1233.4,
+				}),
+			},
+		},
+		{
+			name: "two events that cannot merge",
+			events: []*splunk.Event{
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 123,
+				}),
+				createEvent(ts, "host2", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":                  "bar",
+					"metric_name:othermem": 1233.4,
+				}),
+			},
+			merged: []*splunk.Event{
+				createEvent(ts, "host2", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":                  "bar",
+					"metric_name:othermem": 1233.4,
+				}),
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 123,
+				}),
+			},
+		},
+		{
+			name: "two events that cannot merge - collision",
+			events: []*splunk.Event{
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 123,
+				}),
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 1233.4,
+				}),
+			},
+			merged: []*splunk.Event{
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 1233.4,
+				}),
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 123,
+				}),
+			},
+		},
+		{
+			name: "two events that can merge surrounded by same event",
+			events: []*splunk.Event{
+				oneEvent,
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 123,
+				}),
+				oneEvent,
+				oneEvent,
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":              "bar",
+					"metric_name:mem2": 1233.4,
+				}),
+				oneEvent,
+			},
+			merged: []*splunk.Event{
+				oneEvent,
+				oneEvent,
+				oneEvent,
+				oneEvent,
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":              "bar",
+					"metric_name:mem":  123,
+					"metric_name:mem2": 1233.4,
+				}),
+			},
+		},
+		{
+			name: "two events that can merge with a third one offering a collision",
+			events: []*splunk.Event{
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 123,
+				}),
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 125,
+				}),
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":              "bar",
+					"metric_name:mem2": 1233.4,
+				}),
+			},
+			merged: []*splunk.Event{
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":             "bar",
+					"metric_name:mem": 125,
+				}),
+				createEvent(ts, "host", "source", "sourcetype", "index", map[string]interface{}{
+					"foo":              "bar",
+					"metric_name:mem":  123,
+					"metric_name:mem2": 1233.4,
+				}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged, err := mergeEventsToMultiMetricFormat(tt.events)
+			assert.NoError(t, err)
+			assert.Len(t, merged, len(tt.merged))
+			for _, want := range tt.merged {
+				found := false
+				for _, m := range merged {
+					if assert.ObjectsAreEqual(want, m) {
+						found = true
+						break
+					}
+				}
+				assert.Truef(t, found, "Event not found: %v", want)
+			}
+		})
+	}
+}
+
 func commonSplunkMetric(
 	metricName string,
 	ts *float64,

--- a/exporter/splunkhecexporter/testdata/config.yaml
+++ b/exporter/splunkhecexporter/testdata/config.yaml
@@ -16,6 +16,7 @@ exporters:
     index: "metrics"
     log_data_enabled: true
     profiling_data_enabled: true
+    use_multi_metric_format: false
     tls:
       insecure_skip_verify: false
       ca_file: ""

--- a/unreleased/splunkhec-merge-metric-events.yaml
+++ b/unreleased/splunkhec-merge-metric-events.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: splunkhecexporter
 
 # A brief description of the change
-note: Allow merging metric events.
+note: "Allow merging metric events."
 
 # One or more tracking issues related to the change
 issues: [11532]

--- a/unreleased/splunkhec-merge-metric-events.yaml
+++ b/unreleased/splunkhec-merge-metric-events.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change
+note: Allow merging metric events.
+
+# One or more tracking issues related to the change
+issues: [11532]


### PR DESCRIPTION
**Description:** 
Allows merging metric events to be exported to Splunk so they use less ingest.

This PR adds this optional behavior, disabled by default for now.

**Link to tracking Issue:**
Fixes #11459

**Testing:**
Unit tests.

**Documentation:**
Added to README