### PR TITLE
Fixing null pointer exception on span count sampler

### DIFF
--- a/processor/tailsamplingprocessor/and_helper.go
+++ b/processor/tailsamplingprocessor/and_helper.go
@@ -54,6 +54,9 @@ func getAndSubPolicyEvaluator(logger *zap.Logger, cfg *AndSubPolicyCfg) (samplin
 	case TraceState:
 		tsfCfg := cfg.TraceStateCfg
 		return sampling.NewTraceStateFilter(logger, tsfCfg.Key, tsfCfg.Values), nil
+	case SpanCount:
+		scfCfg := cfg.SpanCountCfg
+		return sampling.NewSpanCount(logger, scfCfg.MinSpans), nil
 	default:
 		return nil, fmt.Errorf("unknown sampling policy type %s", cfg.Type)
 	}

--- a/processor/tailsamplingprocessor/and_helper_test.go
+++ b/processor/tailsamplingprocessor/and_helper_test.go
@@ -1,0 +1,54 @@
+// Copyright  The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tailsamplingprocessor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config"
+	"go.uber.org/zap"
+)
+
+func TestAndHelper(t *testing.T) {
+	cfg := &Config{
+		ProcessorSettings:       config.NewProcessorSettings(config.NewComponentID(typeStr)),
+		DecisionWait:            10 * time.Second,
+		NumTraces:               100,
+		ExpectedNewTracesPerSec: 10,
+		PolicyCfgs: []PolicyCfg{
+			{
+				Name: "and-policy-1",
+				Type: And,
+				AndCfg: AndCfg{
+					SubPolicyCfg: []AndSubPolicyCfg{
+						{
+							Name:         "test-and-policy-1",
+							Type:         SpanCount,
+							SpanCountCfg: SpanCountCfg{MinSpans: 2},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	andCfg := cfg.PolicyCfgs[0].AndCfg
+	andSubPolicyConfig := andCfg.SubPolicyCfg[0]
+	result, e := getAndSubPolicyEvaluator(zap.NewNop(), &andSubPolicyConfig)
+	require.NotNil(t, result)
+	require.NoError(t, e)
+}

--- a/processor/tailsamplingprocessor/and_helper_test.go
+++ b/processor/tailsamplingprocessor/and_helper_test.go
@@ -15,9 +15,10 @@
 package tailsamplingprocessor
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"testing"
 )
 
 func TestAndHelper(t *testing.T) {

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler.go
@@ -35,15 +35,14 @@ func NewSpanCount(logger *zap.Logger, minSpans int32) PolicyEvaluator {
 }
 
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
-func (c spanCount) Evaluate(_ pcommon.TraceID, traceData *TraceData) (Decision, error) {
+func (c *spanCount) Evaluate(_ pcommon.TraceID, traceData *TraceData) (Decision, error) {
 	c.logger.Debug("Evaluating spans counts in filter")
 
 	traceData.Lock()
 	batches := traceData.ReceivedBatches
 	traceData.Unlock()
 
-	for i := range batches {
-		trace := batches[i]
+	for _, trace := range batches {
 		if trace.SpanCount() >= int(c.minSpans) {
 			return Sampled, nil
 		}

--- a/unreleased/span-count-null-pointer.yaml
+++ b/unreleased/span-count-null-pointer.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: tailsamplingprocessor
+note: Fixing null pointer exception for span count sampling strategy.
+issues: [12745]


### PR DESCRIPTION
**Description:** 
Fixing a null pointer exception bug that happens when the span_count policy is used in the tailsamplingprocessor

Fixes #12745

**Testing:** 
No tests were added

**Documentation:** 
No changes were made to the documentation