### PR TITLE
[dockerobserver] incorporate EndpointsWatcher and fix startup bug

### DIFF
--- a/extension/observer/dockerobserver/extension.go
+++ b/extension/observer/dockerobserver/extension.go
@@ -16,39 +16,48 @@ package dockerobserver // import "github.com/open-telemetry/opentelemetry-collec
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	dtypes "github.com/docker/docker/api/types"
-	dfilters "github.com/docker/docker/api/types/filters"
 	"github.com/docker/go-connections/nat"
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 	dcommon "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/docker"
-	docker "github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker"
 )
-
-var _ (component.Extension) = (*dockerObserver)(nil)
-var _ observer.Observable = (*dockerObserver)(nil)
 
 const (
 	defaultDockerAPIVersion         = 1.22
 	minimalRequiredDockerAPIVersion = 1.22
-	clientReconnectTimeout          = 3 * time.Second
 )
 
+var _ component.Extension = (*dockerObserver)(nil)
+var _ observer.EndpointsLister = (*dockerObserver)(nil)
+var _ observer.Observable = (*dockerObserver)(nil)
+
 type dockerObserver struct {
-	logger            *zap.Logger
-	config            *Config
-	cancel            func()
-	existingEndpoints map[string][]observer.Endpoint
-	ctx               context.Context
-	dClient           *docker.Client
+	*observer.EndpointsWatcher
+	logger  *zap.Logger
+	config  *Config
+	cancel  func()
+	once    *sync.Once
+	ctx     context.Context
+	dClient *docker.Client
+}
+
+// newObserver creates a new docker observer extension.
+func newObserver(logger *zap.Logger, config *Config) (component.Extension, error) {
+	d := &dockerObserver{
+		logger: logger, config: config,
+		once: &sync.Once{},
+	}
+	d.EndpointsWatcher = &observer.EndpointsWatcher{Endpointslister: d, RefreshInterval: time.Second}
+	return d, nil
 }
 
 // Start will instantiate required components needed by the Docker observer
@@ -56,7 +65,6 @@ func (d *dockerObserver) Start(ctx context.Context, host component.Host) error {
 	dCtx, cancel := context.WithCancel(context.Background())
 	d.cancel = cancel
 	d.ctx = dCtx
-	var err error
 
 	// Create new Docker client
 	dConfig, err := docker.NewConfig(d.config.Endpoint, d.config.Timeout, d.config.ExcludedImages, d.config.DockerAPIVersion)
@@ -69,13 +77,35 @@ func (d *dockerObserver) Start(ctx context.Context, host component.Host) error {
 		return fmt.Errorf("could not create docker client: %w", err)
 	}
 
-	// Load initial set of containers
-	err = d.dClient.LoadContainerList(d.ctx)
-	if err != nil {
-		return fmt.Errorf("could not load initial list of containers: %w", err)
+	if err = d.dClient.LoadContainerList(ctx); err != nil {
+		return err
 	}
 
-	d.existingEndpoints = make(map[string][]observer.Endpoint)
+	d.once.Do(
+		func() {
+			go func() {
+				cacheRefreshTicker := time.NewTicker(d.config.CacheSyncInterval)
+				defer cacheRefreshTicker.Stop()
+
+				clientCtx, clientCancel := context.WithCancel(d.ctx)
+
+				go d.dClient.ContainerEventLoop(clientCtx)
+
+				for {
+					select {
+					case <-d.ctx.Done():
+						clientCancel()
+						return
+					case <-cacheRefreshTicker.C:
+						err = d.dClient.LoadContainerList(clientCtx)
+						if err != nil {
+							d.logger.Error("Could not sync container cache", zap.Error(err))
+						}
+					}
+				}
+			}()
+		},
+	)
 
 	return nil
 }
@@ -85,177 +115,21 @@ func (d *dockerObserver) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-// ListAndWatch provides initial state sync as well as change notification.
-// Emits initial list of endpoints loaded upon extension Start. It then goes into
-// a loop to sync the container cache periodically, watch for docker events,
-// and notify the observer listener of endpoint changes.
-func (d *dockerObserver) ListAndWatch(listener observer.Notify) {
-	d.emitContainerEndpoints(listener)
-	go func() {
-		cacheRefreshTicker := time.NewTicker(d.config.CacheSyncInterval)
-		defer cacheRefreshTicker.Stop()
-		// timestamp to begin looking back for events
-		lastTime := time.Now()
-		var eventErr error
-
-		// loop for re-connecting to events channel if a client error occurs
-		for {
-			// watchContainerEvents will only return when an error occurs, or the context is cancelled
-			lastTime, eventErr = d.watchContainerEvents(listener, cacheRefreshTicker, lastTime)
-
-			if d.ctx.Err() != nil {
-				return
-			}
-			// Either decoding or connection error has occurred, so we should resume the event loop after
-			// waiting a moment.  In cases of extended daemon unavailability this will retry until
-			// collector teardown or background context is closed.
-			d.logger.Error("Error watching docker container events, attempting to retry", zap.Error(eventErr))
-			time.Sleep(clientReconnectTimeout)
-		}
-	}()
+func (d *dockerObserver) ListEndpoints() []observer.Endpoint {
+	var endpoints []observer.Endpoint
+	for _, container := range d.dClient.Containers() {
+		endpoints = append(endpoints, d.containerEndpoints(container.ContainerJSON)...)
+	}
+	return endpoints
 }
 
-func (d *dockerObserver) watchContainerEvents(listener observer.Notify, cacheRefreshTicker *time.Ticker, lastEventTime time.Time) (time.Time, error) {
-	// build filter list for container events
-	filters := dfilters.NewArgs([]dfilters.KeyValuePair{
-		{Key: "type", Value: "container"},
-		{Key: "event", Value: "destroy"},
-		{Key: "event", Value: "die"},
-		{Key: "event", Value: "pause"},
-		{Key: "event", Value: "rename"},
-		{Key: "event", Value: "stop"},
-		{Key: "event", Value: "start"},
-		{Key: "event", Value: "unpause"},
-		{Key: "event", Value: "update"},
-	}...)
-
-	opts := dtypes.EventsOptions{
-		Filters: filters,
-		Since:   lastEventTime.Format(time.RFC3339Nano),
-	}
-
-	eventsCh, errCh := d.dClient.Events(d.ctx, opts)
-
-	for {
-		select {
-		case <-d.ctx.Done():
-			return lastEventTime, nil
-		case <-cacheRefreshTicker.C:
-			err := d.syncContainerList(listener)
-			if err != nil {
-				d.logger.Error("Could not sync container cache", zap.Error(err))
-			}
-		case event := <-eventsCh:
-			switch event.Action {
-			case "destroy":
-				d.updateEndpointsByContainerID(listener, event.ID, nil)
-				d.dClient.RemoveContainer(event.ID)
-			default:
-				if c, ok := d.dClient.InspectAndPersistContainer(d.ctx, event.ID); ok {
-					endpointsMap := d.endpointsForContainer(c)
-					d.updateEndpointsByContainerID(listener, c.ID, endpointsMap)
-				}
-			}
-			if event.TimeNano > lastEventTime.UnixNano() {
-				lastEventTime = time.Unix(0, event.TimeNano)
-			}
-
-		case err := <-errCh:
-			return lastEventTime, err
-		}
-	}
-}
-
-// emitContainerEndpoints notifies the listener of all changes
-// by loading all current containers the client has cached and
-// creating endpoints for each.
-func (d *dockerObserver) emitContainerEndpoints(listener observer.Notify) {
-	for _, c := range d.dClient.Containers() {
-		endpointsMap := d.endpointsForContainer(c.ContainerJSON)
-		d.updateEndpointsByContainerID(listener, c.ContainerJSON.ID, endpointsMap)
-	}
-}
-
-// syncContainerList refreshes the client's container cache and
-// uses the listener to notify endpoint changes.
-func (d *dockerObserver) syncContainerList(listener observer.Notify) error {
-	err := d.dClient.LoadContainerList(d.ctx)
-	if err != nil {
-		return err
-	}
-	d.emitContainerEndpoints(listener)
-	return nil
-}
-
-// updateEndpointsByID uses the listener to add / remove / update endpoints by container ID.
-// latestEndpointsMap is a map of latest endpoints for the given container ID.
-// If an endpoint is in the cache but NOT in latestEndpoints, the endpoint will be removed
-func (d *dockerObserver) updateEndpointsByContainerID(listener observer.Notify, cid string, latestEndpointsMap map[observer.EndpointID]observer.Endpoint) {
-	var removedEndpoints, addedEndpoints, updatedEndpoints []observer.Endpoint
-
-	if latestEndpointsMap != nil || len(latestEndpointsMap) != 0 {
-		// map of EndpointID to endpoint to help with lookups
-		existingEndpointsMap := make(map[observer.EndpointID]observer.Endpoint)
-		if endpoints, ok := d.existingEndpoints[cid]; ok {
-			for _, e := range endpoints {
-				existingEndpointsMap[e.ID] = e
-			}
-		}
-
-		// If the endpoint is present in existingEndpoints but is not
-		// present in latestEndpointsMap, then it needs to be removed.
-		for id, e := range existingEndpointsMap {
-			if _, ok := latestEndpointsMap[id]; !ok {
-				removedEndpoints = append(removedEndpoints, e)
-			}
-		}
-
-		// if the endpoint is present in latestEndpointsMap, check if it exists
-		// already in existingEndpoints.
-		for _, e := range latestEndpointsMap {
-			// If it does not exist already, it is a new endpoint. Add it.
-			if existingEndpoint, ok := existingEndpointsMap[e.ID]; !ok {
-				addedEndpoints = append(addedEndpoints, e)
-			} else if !reflect.DeepEqual(existingEndpoint, e) {
-				// if it already exists, see if it's equal.
-				// if it's not equal, update it
-				// if its equal, no-op.
-				updatedEndpoints = append(updatedEndpoints, e)
-			}
-		}
-
-		// reset endpoints for this container
-		d.existingEndpoints[cid] = nil
-		// set the current known endpoints to the latest endpoints
-		for _, e := range latestEndpointsMap {
-			d.existingEndpoints[cid] = append(d.existingEndpoints[cid], e)
-		}
-	} else {
-		// if latestEndpointsMap is nil, we are removing all endpoints for the container
-		removedEndpoints = append(removedEndpoints, d.existingEndpoints[cid]...)
-		delete(d.existingEndpoints, cid)
-	}
-
-	if len(removedEndpoints) > 0 {
-		listener.OnRemove(removedEndpoints)
-	}
-
-	if len(addedEndpoints) > 0 {
-		listener.OnAdd(addedEndpoints)
-	}
-
-	if len(updatedEndpoints) > 0 {
-		listener.OnChange(updatedEndpoints)
-	}
-}
-
-// endpointsForContainer generates a list of observer.Endpoint given a Docker ContainerJSON.
+// containerEndpoints generates a list of observer.Endpoint given a Docker ContainerJSON.
 // This function will only generate endpoints if a container is in the Running state and not Paused.
-func (d *dockerObserver) endpointsForContainer(c *dtypes.ContainerJSON) map[observer.EndpointID]observer.Endpoint {
-	endpointsMap := make(map[observer.EndpointID]observer.Endpoint)
+func (d *dockerObserver) containerEndpoints(c *dtypes.ContainerJSON) []observer.Endpoint {
+	var endpoints []observer.Endpoint
 
 	if !c.State.Running || c.State.Running && c.State.Paused {
-		return endpointsMap
+		return endpoints
 	}
 
 	knownPorts := map[nat.Port]bool{}
@@ -270,19 +144,10 @@ func (d *dockerObserver) endpointsForContainer(c *dtypes.ContainerJSON) map[obse
 		if endpoint == nil {
 			continue
 		}
-		endpointsMap[endpoint.ID] = *endpoint
+		endpoints = append(endpoints, *endpoint)
 	}
 
-	if len(endpointsMap) == 0 {
-		return nil
-	}
-
-	for _, e := range endpointsMap {
-		s, _ := json.MarshalIndent(e, "", "\t")
-		d.logger.Debug("Discovered Docker container endpoint", zap.Any("endpoint", s))
-	}
-
-	return endpointsMap
+	return endpoints
 }
 
 // endpointForPort creates an observer.Endpoint for a given port that is exposed in a Docker container.
@@ -386,9 +251,4 @@ func portProtoToTransport(proto string) observer.Transport {
 		return observer.ProtocolUDP
 	}
 	return observer.ProtocolUnknown
-}
-
-// newObserver creates a new docker observer extension.
-func newObserver(logger *zap.Logger, config *Config) (component.Extension, error) {
-	return &dockerObserver{logger: logger, config: config}, nil
 }

--- a/extension/observer/dockerobserver/extension_test.go
+++ b/extension/observer/dockerobserver/extension_test.go
@@ -78,10 +78,10 @@ func TestCollectEndpointsDefaultConfig(t *testing.T) {
 	require.True(t, ok)
 
 	c := containerJSON(t)
-	cEndpoints := obvs.endpointsForContainer(&c)
+	cEndpoints := obvs.containerEndpoints(&c)
 
-	want := map[observer.EndpointID]observer.Endpoint{
-		"babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080": {
+	want := []observer.Endpoint{
+		{
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "172.17.0.2:80",
 			Details: &observer.Container{
@@ -126,10 +126,10 @@ func TestCollectEndpointsAllConfigSettings(t *testing.T) {
 	obvs := ext.(*dockerObserver)
 
 	c := containerJSON(t)
-	cEndpoints := obvs.endpointsForContainer(&c)
+	cEndpoints := obvs.containerEndpoints(&c)
 
-	want := map[observer.EndpointID]observer.Endpoint{
-		"babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080": {
+	want := []observer.Endpoint{
+		{
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "127.0.0.1:8080",
 			Details: &observer.Container{
@@ -174,10 +174,10 @@ func TestCollectEndpointsUseHostnameIfPresent(t *testing.T) {
 	obvs := ext.(*dockerObserver)
 
 	c := containerJSON(t)
-	cEndpoints := obvs.endpointsForContainer(&c)
+	cEndpoints := obvs.containerEndpoints(&c)
 
-	want := map[observer.EndpointID]observer.Endpoint{
-		"babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080": {
+	want := []observer.Endpoint{
+		{
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "babc5a6d7af2:80",
 			Details: &observer.Container{
@@ -222,10 +222,10 @@ func TestCollectEndpointsUseHostBindings(t *testing.T) {
 	obvs := ext.(*dockerObserver)
 
 	c := containerJSON(t)
-	cEndpoints := obvs.endpointsForContainer(&c)
+	cEndpoints := obvs.containerEndpoints(&c)
 
-	want := map[observer.EndpointID]observer.Endpoint{
-		"babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080": {
+	want := []observer.Endpoint{
+		{
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "127.0.0.1:8080",
 			Details: &observer.Container{
@@ -270,10 +270,10 @@ func TestCollectEndpointsIgnoreNonHostBindings(t *testing.T) {
 	obvs := ext.(*dockerObserver)
 
 	c := containerJSON(t)
-	cEndpoints := obvs.endpointsForContainer(&c)
+	cEndpoints := obvs.containerEndpoints(&c)
 
-	want := map[observer.EndpointID]observer.Endpoint{
-		"babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080": {
+	want := []observer.Endpoint{
+		{
 			ID:     "babc5a6d7af2a48e7f52e1da26047024dcf98b737e754c9c3459bb84d1e4f80c:8080",
 			Target: "172.17.0.2:80",
 			Details: &observer.Container{

--- a/extension/observer/dockerobserver/go.mod
+++ b/extension/observer/dockerobserver/go.mod
@@ -16,9 +16,8 @@ require (
 )
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
-	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.0-beta.1+incompatible // indirect

--- a/extension/observer/dockerobserver/go.sum
+++ b/extension/observer/dockerobserver/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
-github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.5.1 h1:aPJp2QD7OOrhO5tQXqQoGSJc+DjDtWTGLOmNyAm6FgY=
@@ -22,7 +22,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
-github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -279,6 +278,7 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/extension/observer/dockerobserver/integration_test.go
+++ b/extension/observer/dockerobserver/integration_test.go
@@ -27,9 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/containertest"
@@ -46,14 +44,6 @@ func (h *testHost) ReportFatalError(err error) {
 }
 
 var _ component.Host = (*testHost)(nil)
-
-func paramsAndContext(t *testing.T) (component.ExtensionCreateSettings, context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
-	settings := componenttest.NewNopExtensionCreateSettings()
-	settings.Logger = logger
-	return settings, ctx, cancel
-}
 
 func TestObserverEmitsEndpointsIntegration(t *testing.T) {
 	c := containertest.New(t)

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -216,6 +216,7 @@ func (dc *Client) ContainerEventLoop(ctx context.Context) {
 		{Key: "event", Value: "destroy"},
 		{Key: "event", Value: "die"},
 		{Key: "event", Value: "pause"},
+		{Key: "event", Value: "rename"},
 		{Key: "event", Value: "stop"},
 		{Key: "event", Value: "start"},
 		{Key: "event", Value: "unpause"},

--- a/unreleased/dockerendpointswatcher.yaml
+++ b/unreleased/dockerendpointswatcher.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: dockerobserver
+note: incorporate observer.EndpointsWatcher in preparation of multiple event subscribers and use existing internal event loop watcher
+issues: [10830, 11541]


### PR DESCRIPTION
**Description:** 
Adding a feature - These changes move the docker observer to include the existing observer.EndpointsWatcher functionality in preparation for supporting multiple subscribers. They also fix a bug that prevented existing containers from being reported as endpoints at startup.

edit: I've updated this PR to remove its redundant logic from what's available in the internal docker client helper.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10830

**Testing:** updated existing tests for functional changes

**Documentation:** changelog update