### PR TITLE
redactionprocessor: respect allow_all_keys configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### 🧰 Bug fixes 🧰
 
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)
+
 ### Unmaintained components
 
 - `simpleprometheusreceiver`(#11133)

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -107,10 +107,12 @@ func (s *redaction) processAttrs(_ context.Context, attributes *pcommon.Map) {
 	// - Don't mask any values if the whole attribute is slated for deletion
 	attributes.Range(func(k string, value pcommon.Value) bool {
 		// Make a list of attribute keys to redact
-		if _, allowed := s.allowList[k]; !allowed {
-			toDelete = append(toDelete, k)
-			// Skip to the next attribute
-			return true
+		if !s.config.AllowAllKeys {
+			if _, allowed := s.allowList[k]; !allowed {
+				toDelete = append(toDelete, k)
+				// Skip to the next attribute
+				return true
+			}
 		}
 
 		// Mask any blocked values for the other attributes


### PR DESCRIPTION
**Description:** Skip redacting keys if `allow_all_keys` is configured to `true`

fixes #11450

**Testing:** Added a test to ensure keys are not redacted and a test to ensure values are still masked if applicable