### PR TITLE
[k8sobserver] incorporate EndpointsWatcher

### DIFF
--- a/extension/observer/k8sobserver/extension_test.go
+++ b/extension/observer/k8sobserver/extension_test.go
@@ -85,6 +85,26 @@ func TestExtensionObservePods(t *testing.T) {
 		},
 	}, sink.added[0])
 
+	podListerWatcher.Modify(pod1V2)
+
+	requireSink(t, sink, func() bool {
+		return len(sink.changed) == 1
+	})
+
+	assert.Equal(t, observer.Endpoint{
+		ID:     "k8s_observer/pod1-UID",
+		Target: "1.2.3.4",
+		Details: &observer.Pod{
+			Name:      "pod1",
+			Namespace: "default",
+			UID:       "pod1-UID",
+			Labels: map[string]string{
+				"env":         "prod",
+				"pod-version": "2",
+			},
+		},
+	}, sink.changed[0])
+
 	podListerWatcher.Delete(pod1V2)
 
 	requireSink(t, sink, func() bool {
@@ -148,6 +168,32 @@ func TestExtensionObserveNodes(t *testing.T) {
 			KubeletEndpointPort: 1234,
 		},
 	}, sink.added[0])
+
+	nodeListerWatcher.Modify(node1V2)
+
+	requireSink(t, sink, func() bool {
+		return len(sink.changed) == 1
+	})
+
+	assert.Equal(t, observer.Endpoint{
+		ID:     "k8s_observer/node1-uid",
+		Target: "internalIP",
+		Details: &observer.K8sNode{
+			UID:         "uid",
+			Annotations: map[string]string{"annotation-key": "annotation-value"},
+			Labels: map[string]string{
+				"label-key":    "label-value",
+				"node-version": "2",
+			},
+			Name:                "node1",
+			InternalIP:          "internalIP",
+			InternalDNS:         "internalDNS",
+			Hostname:            "localhost",
+			ExternalIP:          "externalIP",
+			ExternalDNS:         "externalDNS",
+			KubeletEndpointPort: 1234,
+		},
+	}, sink.changed[0])
 
 	nodeListerWatcher.Delete(node1V2)
 

--- a/extension/observer/k8sobserver/mocks_test.go
+++ b/extension/observer/k8sobserver/mocks_test.go
@@ -57,5 +57,5 @@ func requireSink(t *testing.T, sink *endpointSink, f func() bool) {
 		sink.Lock()
 		defer sink.Unlock()
 		return f()
-	}, 1*time.Second, 100*time.Millisecond)
+	}, 2*time.Second, 100*time.Millisecond)
 }

--- a/unreleased/k8sendpointswatcher.yaml
+++ b/unreleased/k8sendpointswatcher.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: k8sobserver
+note: incorporate observer.EndpointsWatcher in preparation for multiple event subscribers
+issues: [10830, 11544]


### PR DESCRIPTION
**Description:** 
Adding a feature - These changes move the k8s observer to include the existing observer.EndpointsWatcher functionality in preparation for supporting multiple subscribers.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10830

**Testing:** updated existing tests for functional changes

**Documentation:** changelog update