### PR TITLE
[exporter/tanzuobservability] Bump to wavefront-sdk-go@v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Unmaintained components
 
 - `simpleprometheusreceiver`(#11133)
+- `tanzuobservabilityexporter`: remove calls to deprecated `NewProxySender` methods. (#11510)
 - `aerospikereceiver`: Fix issue where namespaces would not be collected (#11465)
 - `signalfxreceiver`: Fix issue where component instance use in multiple pipelines leads to start failures (#11513)
 - `splunkhecreceiver`: Fix issue where component instance use in multiple pipelines leads to start failures (#11517)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 ### Unmaintained components
 
 - `simpleprometheusreceiver`(#11133)
-- `tanzuobservabilityexporter`: remove calls to deprecated `NewProxySender` methods. (#11510)
+- `tanzuobservabilityexporter`: remove calls to deprecated `NewProxySender` methods. (#11545)
 - `aerospikereceiver`: Fix issue where namespaces would not be collected (#11465)
 - `signalfxreceiver`: Fix issue where component instance use in multiple pipelines leads to start failures (#11513)
 - `splunkhecreceiver`: Fix issue where component instance use in multiple pipelines leads to start failures (#11517)

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib v0.54.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.54.0
-	github.com/stretchr/testify v1.7.4
+	github.com/stretchr/testify v1.7.5
 	go.opentelemetry.io/collector v0.54.0
 	go.opentelemetry.io/collector/pdata v0.54.0
 	go.uber.org/multierr v1.8.0
@@ -480,7 +480,7 @@ require (
 	github.com/vmware/go-vmware-nsxt v0.0.0-20220328155605-f49a14c1ef5f // indirect
 	github.com/vmware/govmomi v0.28.0 // indirect
 	github.com/vultr/govultr/v2 v2.17.0 // indirect
-	github.com/wavefronthq/wavefront-sdk-go v0.10.0 // indirect
+	github.com/wavefronthq/wavefront-sdk-go v0.10.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -480,7 +480,7 @@ require (
 	github.com/vmware/go-vmware-nsxt v0.0.0-20220328155605-f49a14c1ef5f // indirect
 	github.com/vmware/govmomi v0.28.0 // indirect
 	github.com/vultr/govultr/v2 v2.17.0 // indirect
-	github.com/wavefronthq/wavefront-sdk-go v0.9.11 // indirect
+	github.com/wavefronthq/wavefront-sdk-go v0.10.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -1961,8 +1961,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
-github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
+github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -2071,8 +2071,8 @@ github.com/vmware/govmomi v0.28.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4
 github.com/vultr/govultr/v2 v2.17.0 h1:BHa6MQvQn4YNOw+ecfrbISOf4+3cvgofEQHKBSXt6t0=
 github.com/vultr/govultr/v2 v2.17.0/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
-github.com/wavefronthq/wavefront-sdk-go v0.10.0 h1:TsU0YqY3HjSMgZDiHqbZmpn/2gYLY05ugvsy4Qr03n8=
-github.com/wavefronthq/wavefront-sdk-go v0.10.0/go.mod h1:ehUsQr+LkZrwnFlEtBEcQjqlGiMa9xcTmxYZoAsHPig=
+github.com/wavefronthq/wavefront-sdk-go v0.10.1 h1:my6q/yDaSi4bADHr9006YrHBhTdjEtpU0UpT0NDaSw8=
+github.com/wavefronthq/wavefront-sdk-go v0.10.1/go.mod h1:JHflWDtew1icwZB6OEvHedBFD9T1h7Se/m+dBSjywu8=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -2071,8 +2071,8 @@ github.com/vmware/govmomi v0.28.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4
 github.com/vultr/govultr/v2 v2.17.0 h1:BHa6MQvQn4YNOw+ecfrbISOf4+3cvgofEQHKBSXt6t0=
 github.com/vultr/govultr/v2 v2.17.0/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
-github.com/wavefronthq/wavefront-sdk-go v0.9.11 h1:3qv/yyNNyLKPQftQWFrfHGUv50e/gMxKlUQnILlvHKw=
-github.com/wavefronthq/wavefront-sdk-go v0.9.11/go.mod h1:AcW8zJJcYodB7B9KYzoxVH6K0fmYd6MgpmXE1LMo+OU=
+github.com/wavefronthq/wavefront-sdk-go v0.10.0 h1:TsU0YqY3HjSMgZDiHqbZmpn/2gYLY05ugvsy4Qr03n8=
+github.com/wavefronthq/wavefront-sdk-go v0.10.0/go.mod h1:ehUsQr+LkZrwnFlEtBEcQjqlGiMa9xcTmxYZoAsHPig=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=

--- a/exporter/tanzuobservabilityexporter/exporter.go
+++ b/exporter/tanzuobservabilityexporter/exporter.go
@@ -70,7 +70,7 @@ func newTracesExporter(settings component.ExporterCreateSettings, c config.Expor
 	if !cfg.hasTracesEndpoint() {
 		return nil, fmt.Errorf("traces.endpoint required")
 	}
-	tracingHost, tracingPort, err := cfg.parseTracesEndpoint()
+	_, _, err := cfg.parseTracesEndpoint()
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse traces.endpoint: %w", err)
 	}
@@ -84,13 +84,11 @@ func newTracesExporter(settings component.ExporterCreateSettings, c config.Expor
 
 	// we specify a MetricsPort so the SDK can report its internal metrics
 	// but don't currently export any metrics from the pipeline
-	s, err := senders.NewProxySender(&senders.ProxyConfiguration{
-		Host:                 tracingHost,
-		MetricsPort:          metricsPort,
-		TracingPort:          tracingPort,
-		FlushIntervalSeconds: 1,
-		SDKMetricsTags:       map[string]string{"otel.traces.collector_version": settings.BuildInfo.Version},
-	})
+	s, err := senders.NewSender(cfg.Traces.Endpoint,
+		senders.MetricsPort(metricsPort),
+		senders.FlushIntervalSeconds(1),
+		senders.SDKMetricsTags(map[string]string{"otel.traces.collector_version": settings.BuildInfo.Version}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy sender: %w", err)
 	}

--- a/exporter/tanzuobservabilityexporter/go.mod
+++ b/exporter/tanzuobservabilityexporter/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.54.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.54.0
 	github.com/stretchr/testify v1.7.4
-	github.com/wavefronthq/wavefront-sdk-go v0.9.11
+	github.com/wavefronthq/wavefront-sdk-go v0.10.0
 	go.opentelemetry.io/collector v0.54.0
 	go.opentelemetry.io/collector/pdata v0.54.0
 	go.opentelemetry.io/collector/semconv v0.54.0

--- a/exporter/tanzuobservabilityexporter/go.mod
+++ b/exporter/tanzuobservabilityexporter/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.54.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.54.0
-	github.com/stretchr/testify v1.7.4
-	github.com/wavefronthq/wavefront-sdk-go v0.10.0
+	github.com/stretchr/testify v1.7.5
+	github.com/wavefronthq/wavefront-sdk-go v0.10.1
 	go.opentelemetry.io/collector v0.54.0
 	go.opentelemetry.io/collector/pdata v0.54.0
 	go.opentelemetry.io/collector/semconv v0.54.0

--- a/exporter/tanzuobservabilityexporter/go.sum
+++ b/exporter/tanzuobservabilityexporter/go.sum
@@ -190,8 +190,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/wavefronthq/wavefront-sdk-go v0.9.11 h1:3qv/yyNNyLKPQftQWFrfHGUv50e/gMxKlUQnILlvHKw=
-github.com/wavefronthq/wavefront-sdk-go v0.9.11/go.mod h1:AcW8zJJcYodB7B9KYzoxVH6K0fmYd6MgpmXE1LMo+OU=
+github.com/wavefronthq/wavefront-sdk-go v0.10.0 h1:TsU0YqY3HjSMgZDiHqbZmpn/2gYLY05ugvsy4Qr03n8=
+github.com/wavefronthq/wavefront-sdk-go v0.10.0/go.mod h1:ehUsQr+LkZrwnFlEtBEcQjqlGiMa9xcTmxYZoAsHPig=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/exporter/tanzuobservabilityexporter/go.sum
+++ b/exporter/tanzuobservabilityexporter/go.sum
@@ -188,10 +188,10 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
-github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/wavefronthq/wavefront-sdk-go v0.10.0 h1:TsU0YqY3HjSMgZDiHqbZmpn/2gYLY05ugvsy4Qr03n8=
-github.com/wavefronthq/wavefront-sdk-go v0.10.0/go.mod h1:ehUsQr+LkZrwnFlEtBEcQjqlGiMa9xcTmxYZoAsHPig=
+github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
+github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/wavefronthq/wavefront-sdk-go v0.10.1 h1:my6q/yDaSi4bADHr9006YrHBhTdjEtpU0UpT0NDaSw8=
+github.com/wavefronthq/wavefront-sdk-go v0.10.1/go.mod h1:JHflWDtew1icwZB6OEvHedBFD9T1h7Se/m+dBSjywu8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/exporter/tanzuobservabilityexporter/metrics_exporter.go
+++ b/exporter/tanzuobservabilityexporter/metrics_exporter.go
@@ -28,14 +28,11 @@ type metricsExporter struct {
 	consumer *metricsConsumer
 }
 
-func createMetricsConsumer(hostName string, port int, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
-	s, err := senders.NewProxySender(&senders.ProxyConfiguration{
-		Host:                 hostName,
-		MetricsPort:          port,
-		DistributionPort:     port,
-		FlushIntervalSeconds: 1,
-		SDKMetricsTags:       map[string]string{"otel.metrics.collector_version": otelVersion},
-	})
+func createMetricsConsumer(endpoint string, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
+	s, err := senders.NewSender(endpoint,
+		senders.FlushIntervalSeconds(1),
+		senders.SDKMetricsTags(map[string]string{"otel.metrics.collector_version": otelVersion}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy sender: %w", err)
 	}
@@ -53,7 +50,7 @@ func createMetricsConsumer(hostName string, port int, settings component.Telemet
 		true), nil
 }
 
-type metricsConsumerCreator func(hostName string, port int, settings component.TelemetrySettings, otelVersion string) (
+type metricsConsumerCreator func(endpoint string, settings component.TelemetrySettings, otelVersion string) (
 	*metricsConsumer, error)
 
 func newMetricsExporter(settings component.ExporterCreateSettings, c config.Exporter, creator metricsConsumerCreator) (*metricsExporter, error) {
@@ -64,11 +61,10 @@ func newMetricsExporter(settings component.ExporterCreateSettings, c config.Expo
 	if !cfg.hasMetricsEndpoint() {
 		return nil, fmt.Errorf("metrics.endpoint required")
 	}
-	hostName, port, err := cfg.parseMetricsEndpoint()
-	if err != nil {
+	if _, _, err := cfg.parseMetricsEndpoint(); err != nil {
 		return nil, fmt.Errorf("failed to parse metrics.endpoint: %w", err)
 	}
-	consumer, err := creator(hostName, port, settings.TelemetrySettings, settings.BuildInfo.Version)
+	consumer, err := creator(cfg.Metrics.Endpoint, settings.TelemetrySettings, settings.BuildInfo.Version)
 	if err != nil {
 		return nil, err
 	}

--- a/exporter/tanzuobservabilityexporter/metrics_exporter_test.go
+++ b/exporter/tanzuobservabilityexporter/metrics_exporter_test.go
@@ -63,7 +63,7 @@ func createMockMetricsExporter(
 	ourConfig := cfg.(*Config)
 	ourConfig.Metrics.Endpoint = "http://localhost:2878"
 	creator := func(
-		hostName string, port int, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
+		endpoint string, settings component.TelemetrySettings, otelVersion string) (*metricsConsumer, error) {
 		return newMetricsConsumer(
 			[]typedMetricConsumer{
 				newGaugeConsumer(sender, settings),

--- a/go.mod
+++ b/go.mod
@@ -483,7 +483,7 @@ require (
 	github.com/vmware/go-vmware-nsxt v0.0.0-20220328155605-f49a14c1ef5f // indirect
 	github.com/vmware/govmomi v0.28.0 // indirect
 	github.com/vultr/govultr/v2 v2.17.0 // indirect
-	github.com/wavefronthq/wavefront-sdk-go v0.9.11 // indirect
+	github.com/wavefronthq/wavefront-sdk-go v0.10.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.54.0
 	github.com/open-telemetry/opentelemetry-log-collection v0.29.1
 	github.com/prometheus/prometheus v0.36.2
-	github.com/stretchr/testify v1.7.4
+	github.com/stretchr/testify v1.7.5
 	go.opentelemetry.io/collector v0.54.0
 	go.opentelemetry.io/collector/pdata v0.54.0
 	go.uber.org/multierr v1.8.0
@@ -483,7 +483,7 @@ require (
 	github.com/vmware/go-vmware-nsxt v0.0.0-20220328155605-f49a14c1ef5f // indirect
 	github.com/vmware/govmomi v0.28.0 // indirect
 	github.com/vultr/govultr/v2 v2.17.0 // indirect
-	github.com/wavefronthq/wavefront-sdk-go v0.10.0 // indirect
+	github.com/wavefronthq/wavefront-sdk-go v0.10.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1966,8 +1966,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
-github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
+github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -2076,8 +2076,8 @@ github.com/vmware/govmomi v0.28.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4
 github.com/vultr/govultr/v2 v2.17.0 h1:BHa6MQvQn4YNOw+ecfrbISOf4+3cvgofEQHKBSXt6t0=
 github.com/vultr/govultr/v2 v2.17.0/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
-github.com/wavefronthq/wavefront-sdk-go v0.10.0 h1:TsU0YqY3HjSMgZDiHqbZmpn/2gYLY05ugvsy4Qr03n8=
-github.com/wavefronthq/wavefront-sdk-go v0.10.0/go.mod h1:ehUsQr+LkZrwnFlEtBEcQjqlGiMa9xcTmxYZoAsHPig=
+github.com/wavefronthq/wavefront-sdk-go v0.10.1 h1:my6q/yDaSi4bADHr9006YrHBhTdjEtpU0UpT0NDaSw8=
+github.com/wavefronthq/wavefront-sdk-go v0.10.1/go.mod h1:JHflWDtew1icwZB6OEvHedBFD9T1h7Se/m+dBSjywu8=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=

--- a/go.sum
+++ b/go.sum
@@ -2076,8 +2076,8 @@ github.com/vmware/govmomi v0.28.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4
 github.com/vultr/govultr/v2 v2.17.0 h1:BHa6MQvQn4YNOw+ecfrbISOf4+3cvgofEQHKBSXt6t0=
 github.com/vultr/govultr/v2 v2.17.0/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
-github.com/wavefronthq/wavefront-sdk-go v0.9.11 h1:3qv/yyNNyLKPQftQWFrfHGUv50e/gMxKlUQnILlvHKw=
-github.com/wavefronthq/wavefront-sdk-go v0.9.11/go.mod h1:AcW8zJJcYodB7B9KYzoxVH6K0fmYd6MgpmXE1LMo+OU=
+github.com/wavefronthq/wavefront-sdk-go v0.10.0 h1:TsU0YqY3HjSMgZDiHqbZmpn/2gYLY05ugvsy4Qr03n8=
+github.com/wavefronthq/wavefront-sdk-go v0.10.0/go.mod h1:ehUsQr+LkZrwnFlEtBEcQjqlGiMa9xcTmxYZoAsHPig=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Depend on github.com/wavefronthq/wavefront-sdk-go@v0.10.1

**Testing:** 
Unit tests and end-to-end integration tests.