### PR TITLE
Mark @dmitryax as code owner of metricstransformprocessor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,7 +109,7 @@ processor/groupbyattrsprocessor/                     @open-telemetry/collector-c
 processor/groupbytraceprocessor/                     @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/k8sattributesprocessor/                    @open-telemetry/collector-contrib-approvers @owais @dmitryax @pmm-sumo
 processor/logstransformprocessor/                    @open-telemetry/collector-contrib-approvers @djaglowski @dehaansa
-processor/metricstransformprocessor/                 @open-telemetry/collector-contrib-approvers @punya
+processor/metricstransformprocessor/                 @open-telemetry/collector-contrib-approvers @dmitryax
 processor/probabilisticsamplerprocessor/             @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/redactionprocessor/                        @open-telemetry/collector-contrib-approvers @leonsp-ai @dmitryax @mx-psi
 processor/resourcedetectionprocessor/                @open-telemetry/collector-contrib-approvers @jrcamp @pmm-sumo @Aneurysm9 @dashpole


### PR DESCRIPTION
I migrated the processor to pdata model recently. Therefore, I'm pretty familiar with it and can support it until it's replaced by the `transform` processor.
