### PR TITLE
[receiver/skywalking] Fix skywalking traceid and spanid convertion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,16 +64,6 @@
 - `transformprocessor`: replace_pattern` and `replace_all_patterns` use regex for pattern matching and replacing text in attributes/metrics (#11125)
 
 ### 🧰 Bug fixes 🧰
-<<<<<<< HEAD
-=======
-
-- `redactionprocessor`: respect allow_all_keys configuration (#11542)
-- `skywalkingreceiver`: Fix skywalking traceid and spanid convertion. (#11562)
-
-### Unmaintained components
-
-- `simpleprometheusreceiver`(#11133)
->>>>>>> Update CHANGELOG.md
 - `aerospikereceiver`: Fix issue where namespaces would not be collected (#11465)
 - `aerospikereceiver`: Fix typo in metric name. Ensure namespace transactions are collected (#12085) (#12083)
 - `coralogixexporter`: Fix metrics bearer token (#11831)
@@ -91,7 +81,11 @@
 - `sapmreceiver`: Fix issue where component instance use in multiple pipelines leads to start failures (#11518)
 - `signalfxreceiver`: Fix issue where component instance use in multiple pipelines leads to start failures (#11513)
 - `splunkhecreceiver`: Fix issue where component instance use in multiple pipelines leads to start failures (#11517)
+<<<<<<< HEAD
 
+=======
+- `skywalkingreceiver`: Fix skywalking traceid and spanid convertion (#11562)
+>>>>>>> [receiver/skywalking] fix skywalking-rcv tid convertion
 
 ## v0.54.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@
 - `transformprocessor`: replace_pattern` and `replace_all_patterns` use regex for pattern matching and replacing text in attributes/metrics (#11125)
 
 ### 🧰 Bug fixes 🧰
+<<<<<<< HEAD
+=======
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)
+- `skywalkingreceiver`: Fix skywalking traceid and spanid convertion. (#11562)
+
+### Unmaintained components
+
+- `simpleprometheusreceiver`(#11133)
+>>>>>>> Update CHANGELOG.md
 - `aerospikereceiver`: Fix issue where namespaces would not be collected (#11465)
 - `aerospikereceiver`: Fix typo in metric name. Ensure namespace transactions are collected (#12085) (#12083)
 - `coralogixexporter`: Fix metrics bearer token (#11831)

--- a/receiver/skywalkingreceiver/go.mod
+++ b/receiver/skywalkingreceiver/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywal
 go 1.17
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.55.0
@@ -24,7 +25,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.15.7 // indirect
 	github.com/knadh/koanf v1.4.2 // indirect

--- a/receiver/skywalkingreceiver/go.mod
+++ b/receiver/skywalkingreceiver/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.15.7 // indirect
 	github.com/knadh/koanf v1.4.2 // indirect

--- a/receiver/skywalkingreceiver/go.sum
+++ b/receiver/skywalkingreceiver/go.sum
@@ -191,6 +191,8 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=

--- a/receiver/skywalkingreceiver/skywalkingproto_to_traces_test.go
+++ b/receiver/skywalkingreceiver/skywalkingproto_to_traces_test.go
@@ -171,12 +171,12 @@ func Test_stringToTraceID(t *testing.T) {
 		want          [16]byte
 	}{
 		{
-			name:          "mock-sw-normal-trace-id",
+			name:          "mock-sw-normal-trace-id-rfc4122v4",
 			segmentObject: args{traceID: "de5980b8-fce3-4a37-aab9-b4ac3af7eedd"},
 			want:          [16]byte{222, 89, 128, 184, 252, 227, 74, 55, 170, 185, 180, 172, 58, 247, 238, 221},
 		},
 		{
-			name:          "mock-sw-normal-trace-id",
+			name:          "mock-sw-normal-trace-id-rfc4122",
 			segmentObject: args{traceID: "de5980b8fce34a37aab9b4ac3af7eedd"},
 			want:          [16]byte{222, 89, 128, 184, 252, 227, 74, 55, 170, 185, 180, 172, 58, 247, 238, 221},
 		},
@@ -186,9 +186,9 @@ func Test_stringToTraceID(t *testing.T) {
 			want:          [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 		{
-			name:          "mock-sw-trace-id-length-overflow",
+			name:          "mock-sw-trace-id-length-java-agent",
 			segmentObject: args{traceID: "de5980b8fce34a37aab9b4ac3af7eedd.1.16563474296430001"},
-			want:          [16]byte{222, 89, 128, 184, 252, 227, 74, 55, 170, 185, 180, 172, 58, 247, 238, 221},
+			want:          [16]byte{222, 89, 128, 184, 253, 227, 74, 55, 27, 228, 27, 205, 94, 47, 212, 221},
 		},
 		{
 			name:          "mock-sw-trace-id-illegal",
@@ -198,10 +198,40 @@ func Test_stringToTraceID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := stringToTraceID(tt.segmentObject.traceID)
+			got := swTraceIDToTraceID(tt.segmentObject.traceID)
 			assert.Equal(t, tt.want, got.Bytes())
 		})
 	}
+}
+
+func Test_stringToTraceID_Unique(t *testing.T) {
+	type args struct {
+		traceID string
+	}
+	tests := []struct {
+		name          string
+		segmentObject args
+	}{
+		{
+			name:          "mock-sw-trace-id-unique-1",
+			segmentObject: args{traceID: "de5980b8fce34a37aab9b4ac3af7eedd.133.16563474296430001"},
+		},
+		{
+			name:          "mock-sw-trace-id-unique-2",
+			segmentObject: args{traceID: "de5980b8fce34a37aab9b4ac3af7eedd.133.16534574123430001"},
+		},
+	}
+
+	var results [2][16]byte
+	for i := 0; i < 2; i++ {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			got := swTraceIDToTraceID(tt.segmentObject.traceID)
+			results[i] = got.Bytes()
+		})
+	}
+	assert.NotEqual(t, tests[0].segmentObject.traceID, t, tests[1].segmentObject.traceID)
+	assert.NotEqual(t, results[0], results[1])
 }
 
 func Test_segmentIdToSpanId(t *testing.T) {
@@ -217,12 +247,17 @@ func Test_segmentIdToSpanId(t *testing.T) {
 		{
 			name: "mock-sw-span-id-normal",
 			args: args{segmentID: "4f2f27748b8e44ecaf18fe0347194e86.33.16560607369950066", spanID: 123},
-			want: [8]byte{123, 86, 6, 7, 54, 153, 80, 6},
+			want: [8]byte{233, 196, 85, 168, 37, 66, 48, 106},
+		},
+		{
+			name: "mock-sw-span-id-python-agent",
+			args: args{segmentID: "4f2f27748b8e44ecaf18fe0347194e86", spanID: 123},
+			want: [8]byte{155, 55, 217, 119, 204, 151, 10, 106},
 		},
 		{
 			name: "mock-sw-span-id-short",
 			args: args{segmentID: "16560607369950066", spanID: 12},
-			want: [8]byte{12, 86, 6, 7, 54, 153, 80, 6},
+			want: [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		},
 		{
 			name: "mock-sw-span-id-illegal-1",
@@ -241,6 +276,36 @@ func Test_segmentIdToSpanId(t *testing.T) {
 			assert.Equal(t, tt.want, got.Bytes())
 		})
 	}
+}
+
+func Test_segmentIdToSpanId_Unique(t *testing.T) {
+	type args struct {
+		segmentID string
+		spanID    uint32
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "mock-sw-span-id-unique-1",
+			args: args{segmentID: "4f2f27748b8e44ecaf18fe0347194e86.33.16560607369950066", spanID: 123},
+		},
+		{
+			name: "mock-sw-span-id-unique-2",
+			args: args{segmentID: "4f2f27748b8e44ecaf18fe0347194e86.33.16560607369950066", spanID: 1},
+		},
+	}
+	var results [2][8]byte
+	for i := 0; i < 2; i++ {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			got := segmentIDToSpanID(tt.args.segmentID, tt.args.spanID)
+			results[i] = got.Bytes()
+		})
+	}
+
+	assert.NotEqual(t, results[0], results[1])
 }
 
 func generateTracesOneEmptyResourceSpans() ptrace.Span {

--- a/receiver/skywalkingreceiver/skywalkingproto_to_traces_test.go
+++ b/receiver/skywalkingreceiver/skywalkingproto_to_traces_test.go
@@ -187,7 +187,7 @@ func Test_stringToTraceID(t *testing.T) {
 		},
 		{
 			name:          "mock-sw-trace-id-length-overflow",
-			segmentObject: args{traceID: "de5980b8fce34a37aab9b4ac3af7eeddddddde5980"},
+			segmentObject: args{traceID: "de5980b8fce34a37aab9b4ac3af7eedd.1.16563474296430001"},
 			want:          [16]byte{222, 89, 128, 184, 252, 227, 74, 55, 170, 185, 180, 172, 58, 247, 238, 221},
 		},
 		{

--- a/receiver/skywalkingreceiver/trace_receiver.go
+++ b/receiver/skywalkingreceiver/trace_receiver.go
@@ -222,7 +222,7 @@ func (sr *swReceiver) httpHandler(rsp http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, segment := range data {
-		err = consumeTraces(context.Background(), segment, sr.nextConsumer)
+		err = consumeTraces(r.Context(), segment, sr.nextConsumer)
 		if err != nil {
 			fmt.Printf("cannot consume traces, %v", err)
 		}

--- a/receiver/skywalkingreceiver/tracing_report_service.go
+++ b/receiver/skywalkingreceiver/tracing_report_service.go
@@ -41,7 +41,7 @@ func (s *traceSegmentReportService) Collect(stream agent.TraceSegmentReportServi
 			return err
 		}
 
-		err = consumeTraces(context.Background(), segmentObject, s.sr.nextConsumer)
+		err = consumeTraces(stream.Context(), segmentObject, s.sr.nextConsumer)
 		if err != nil {
 			return stream.SendAndClose(&common.Commands{})
 		}

--- a/unreleased/skywalkingreceiver-fix.yaml
+++ b/unreleased/skywalkingreceiver-fix.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: skywalkingreceiver
+note: Fix skywalking traceid and spanid convertion
+issues: [11562]


### PR DESCRIPTION
**Description:**
- Backgrounds:
  - [Skywalking](https://skywalking.apache.org/) use `segments` to cover spans as a group. Also `SegmentId` + `SpanId` to identify an unique span in `TraceData`.
  -  Protocols could be found [here](https://github.com/apache/skywalking/blob/master/docs/en/protocols/Trace-Data-Protocol-v3.md).
  - The Skywalking receive server handle one segment object in each http request. Those segments have different `segmentId` and share the same `traceId`.

- Code Changes:
  - Use a new rule to convert `Skywalking-TraceId` to `Opentelemetry-TraceId`. (The old rules breaks relations between segments because it use pointer of strings to generate a new `traceId`.)
    - Skywalking-TraceId format be like: `de5980b8-fce3-4a37-aab9-b4ac3af7eedd`([RFC4122](https://datatracker.ietf.org/doc/html/rfc4122)) or `56a5e1c519ae4c76a2b8b11d92cead7f.1.16563474296430001`.
  - Use `SegmentId` in the convertion of `SpanId` to make sure the `SpanId` is globally unique.
    - `SegmentId` format be like: `4f2f27748b8e44ecaf18fe0347194e86.33.16560607369950066`.
    - The first part of `SegmentId`(`4f2f27748b8e44ecaf18fe0347194e86`) will repeat multiple times in a `TraceData`, so the last part is the real unique identifier of segments.


**Testing:** 
- Add `Test_stringToTraceID()`: Make sure Skywalking-TraceId convert to the Otel-TraceId by a rule.
- Add `Test_segmentIdToSpanId()`: Using Skywalking segmentId & spanId to generate a new Otel-SpanId.

**Documentation:** 
No changes.