### PR TITLE
[receiver_creator] add receiver-specific resource attributes

### DIFF
--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -56,7 +56,13 @@ config:
    endpoint: '`endpoint`:8080'
 ```
 
-**receivers.&lt;receiver_type/id&gt;.resource_attributes**
+**receivers.resource_attributes**
+
+```yaml
+resource_attributes:
+  <endpoint type>:
+    <attribute>: <attribute value>
+```
 
 This setting controls what resource attributes are set on metrics emitted from the created receiver. These attributes can be set from [values in the endpoint](#rule-expressions) that was matched by the `rule`. These attributes vary based on the endpoint type. These defaults can be disabled by setting the attribute to be removed to an empty value. Note that the values can be dynamic and processed the same as in `config`.
 
@@ -97,6 +103,18 @@ None
 | k8s.node.uid       | \`uid\`           |
 
 See `redis/2` in [examples](#examples).
+
+
+**receivers.&lt;receiver_type/id&gt;.resource_attributes**
+
+```yaml
+receivers:
+  <receiver_type>:
+    resource_attributes:
+      <attribute>: <attribute string value>
+```
+
+Similar to the per-endpoint type `resource_attributes` described above but for individual receiver instances. Duplicate attribute entries (including the empty string) in this receiver-specific mapping take precedence. These attribute values also support expansion from endpoint environment content. At this time their values must be strings.
 
 ## Rule Expressions
 
@@ -190,6 +208,10 @@ receivers:
         config:
           metrics_path: '`"prometheus.io/path" in annotations ? annotations["prometheus.io/path"] : "/metrics"`'
           endpoint: '`endpoint`:`"prometheus.io/port" in annotations ? annotations["prometheus.io/port"] : 9090`'
+        resource_attributes:
+          an.attribute: a.value
+          # Dynamic configuration values
+          app.version: '`labels["app_version"]`'
 
       redis/1:
         # If this rule matches an instance of this receiver will be started.
@@ -205,9 +227,13 @@ receivers:
         rule: type == "port" && port == 6379
 
       resource_attributes:
-        # Dynamic configuration values
-        service.name: '`pod.labels["service_name"]`'
-        app: '`pod.labels["app"]`'
+        # Dynamic configuration values, overwriting default attributes`
+        pod:
+          service.name: '`labels["service_name"]`'
+          app: '`labels["app"]`'
+        port:
+          service.name: '`pod.labels["service_name"]`'
+          app: '`pod.labels["app"]`'
   receiver_creator/2:
     # Name of the extensions to watch for endpoints to start and stop.
     watch_observers: [host_observer]
@@ -215,8 +241,8 @@ receivers:
       redis/on_host:
         # If this rule matches an instance of this receiver will be started.
         rule: type == "port" && port == 6379 && is_ipv6 == true
-    resource_attributes:
-      service.name: redis_on_host
+      resource_attributes:
+        service.name: redis_on_host
   receiver_creator/3:
     watch_observers: [k8s_observer]
     receivers:

--- a/receiver/receivercreator/config_test.go
+++ b/receiver/receivercreator/config_test.go
@@ -93,6 +93,32 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, []config.Type{"mock_observer"}, r1.WatchObservers)
 }
 
+func TestInvalidResourceAttributeEndpointType(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	require.Nil(t, err)
+
+	factories.Receivers[("nop")] = &nopWithEndpointFactory{ReceiverFactory: componenttest.NewNopReceiverFactory()}
+
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "invalid-resource-attributes.yaml"), factories)
+	require.EqualError(t, err, "error reading receivers configuration for \"receiver_creator\": resource attributes for unsupported endpoint type \"not.a.real.type\"")
+	require.Nil(t, cfg)
+}
+
+func TestInvalidReceiverResourceAttributeValueType(t *testing.T) {
+	factories, err := componenttest.NopFactories()
+	require.Nil(t, err)
+
+	factories.Receivers[("nop")] = &nopWithEndpointFactory{ReceiverFactory: componenttest.NewNopReceiverFactory()}
+
+	factory := NewFactory()
+	factories.Receivers[typeStr] = factory
+	cfg, err := servicetest.LoadConfigAndValidate(filepath.Join("testdata", "invalid-receiver-resource-attributes.yaml"), factories)
+	require.EqualError(t, err, "error reading receivers configuration for \"receiver_creator\": unsupported `resource_attributes` \"one\" value <nil> in examplereceiver/1")
+	require.Nil(t, cfg)
+}
+
 type nopWithEndpointConfig struct {
 	config.ReceiverSettings `mapstructure:",squash"`
 	Endpoint                string `mapstructure:"endpoint"`

--- a/receiver/receivercreator/observerhandler.go
+++ b/receiver/receivercreator/observerhandler.go
@@ -111,10 +111,21 @@ func (obs *observerHandler) OnAdd(added []observer.Endpoint) {
 				continue
 			}
 
+			resAttrs := map[string]string{}
+			for k, v := range template.ResourceAttributes {
+				strVal, ok := v.(string)
+				if !ok {
+					obs.logger.Info(fmt.Sprintf("ignoring unsupported `resource_attributes` %q value %v", k, v))
+					continue
+				}
+				resAttrs[k] = strVal
+			}
+
 			// Adds default and/or configured resource attributes (e.g. k8s.pod.uid) to resources
 			// as telemetry is emitted.
 			resourceEnhancer, err := newResourceEnhancer(
 				obs.config.ResourceAttributes,
+				resAttrs,
 				env,
 				e,
 				obs.nextConsumer,

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -52,7 +52,7 @@ func TestOnAdd(t *testing.T) {
 	rcvrCfg := receiverConfig{id: config.NewComponentIDWithName("name", "1"), config: userConfigMap{"foo": "bar"}}
 	cfg := createDefaultConfig().(*Config)
 	cfg.receiverTemplates = map[string]receiverTemplate{
-		"name/1": {rcvrCfg, "", newRuleOrPanic(`type == "port"`)},
+		"name/1": {rcvrCfg, "", map[string]interface{}{}, newRuleOrPanic(`type == "port"`)},
 	}
 	handler := &observerHandler{
 		config:                cfg,
@@ -104,7 +104,7 @@ func TestOnChange(t *testing.T) {
 	newRcvr := &nopWithEndpointReceiver{}
 	cfg := createDefaultConfig().(*Config)
 	cfg.receiverTemplates = map[string]receiverTemplate{
-		"name/1": {rcvrCfg, "", newRuleOrPanic(`type == "port"`)},
+		"name/1": {rcvrCfg, "", map[string]interface{}{}, newRuleOrPanic(`type == "port"`)},
 	}
 	handler := &observerHandler{
 		config:                cfg,

--- a/receiver/receivercreator/resourceenhancer_test.go
+++ b/receiver/receivercreator/resourceenhancer_test.go
@@ -44,10 +44,11 @@ func Test_newResourceEnhancer(t *testing.T) {
 
 	cfg := createDefaultConfig().(*Config)
 	type args struct {
-		resources    resourceAttributes
-		env          observer.EndpointEnv
-		endpoint     observer.Endpoint
-		nextConsumer consumer.Metrics
+		resources          resourceAttributes
+		resourceAttributes map[string]string
+		env                observer.EndpointEnv
+		endpoint           observer.Endpoint
+		nextConsumer       consumer.Metrics
 	}
 	tests := []struct {
 		name    string
@@ -132,6 +133,39 @@ func Test_newResourceEnhancer(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "both forms of resource attributes",
+			args: args{
+				resources: func() resourceAttributes {
+					res := map[observer.EndpointType]map[string]string{observer.PodType: {}}
+					for k, v := range cfg.ResourceAttributes[observer.PodType] {
+						res[observer.PodType][k] = v
+					}
+					res[observer.PodType]["duplicate.resource.attribute"] = "pod.value"
+					res[observer.PodType]["delete.me"] = "pod.value"
+					return res
+				}(),
+				resourceAttributes: map[string]string{
+					"expanded.resource.attribute":  "`'labels' in pod ? pod.labels['region'] : labels['region']`",
+					"duplicate.resource.attribute": "receiver.value",
+					"delete.me":                    "",
+				},
+				env:          podEnv,
+				endpoint:     podEndpoint,
+				nextConsumer: nil,
+			},
+			want: &resourceEnhancer{
+				nextConsumer: nil,
+				attrs: map[string]string{
+					"k8s.namespace.name":           "default",
+					"k8s.pod.name":                 "pod-1",
+					"k8s.pod.uid":                  "uid-1",
+					"duplicate.resource.attribute": "receiver.value",
+					"expanded.resource.attribute":  "west-1",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "error",
 			args: args{
 				resources: func() resourceAttributes {
@@ -149,7 +183,7 @@ func Test_newResourceEnhancer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newResourceEnhancer(tt.args.resources, tt.args.env, tt.args.endpoint, tt.args.nextConsumer)
+			got, err := newResourceEnhancer(tt.args.resources, tt.args.resourceAttributes, tt.args.env, tt.args.endpoint, tt.args.nextConsumer)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("newResourceEnhancer() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/receiver/receivercreator/testdata/invalid-receiver-resource-attributes.yaml
+++ b/receiver/receivercreator/testdata/invalid-receiver-resource-attributes.yaml
@@ -1,0 +1,23 @@
+receivers:
+  receiver_creator:
+    watch_observers: [mock_observer]
+    receivers:
+      examplereceiver/1:
+        rule: type == "port"
+        config:
+          key: value
+        resource_attributes:
+          one: null
+
+processors:
+  nop:
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [receiver_creator]
+      processors: [nop]
+      exporters: [nop]

--- a/receiver/receivercreator/testdata/invalid-resource-attributes.yaml
+++ b/receiver/receivercreator/testdata/invalid-resource-attributes.yaml
@@ -1,6 +1,5 @@
 receivers:
   receiver_creator:
-  receiver_creator/1:
     watch_observers: [mock_observer]
     receivers:
       examplereceiver/1:
@@ -9,23 +8,11 @@ receivers:
           key: value
         resource_attributes:
           one: two
-      nop/1:
-        rule: type == "port"
-        config:
-          endpoint: localhost:12345
-        resource_attributes:
-          two: three
     resource_attributes:
-      container:
-        container.key: container.value
-      pod:
-        pod.key: pod.value
-      port:
-        port.key: port.value
-      hostport:
-        hostport.key: hostport.value
       k8s.node:
         k8s.node.key: k8s.node.value
+      not.a.real.type:
+        not: real
 
 processors:
   nop:
@@ -36,6 +23,6 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [receiver_creator/1]
+      receivers: [receiver_creator]
       processors: [nop]
       exporters: [nop]

--- a/unreleased/receivercreatorresourceattributes.yaml
+++ b/unreleased/receivercreatorresourceattributes.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: receivercreator
+note: add per-receiver `resource_attribute` and validate endpoint type keys on global
+issues: [11766]


### PR DESCRIPTION
**Description:**
Adding a feature - These changes add a new per-receiver `resource_attributes` config mapping that allows individual receivers to have additional resource attributes beyond those provided at the global level. They also correctly document the existing global `resource_attributes` expected format and add endpoint type validation.

**Testing:** Added additional unit tests.

**Documentation:** Update readme for new feature and correct example of global `resource_attributes` form.