### PR TITLE
Fix changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 ## Unreleased
-- `filterprocessor`: Ability to filter `Spans` (#6341)
-- 
+
 ## 🛑 Breaking changes 🛑
 
 - `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
@@ -17,6 +16,8 @@
 - `prometheusreceiver`: Add `target_info` labels to resource attributes. (#11034)
 - `saphanareceiver`: Fix component memory query, add better error handling (#11507)
 - `sapmexporter`: Add config option to log responses from Splunk APM. (#11425)
+- `filterprocessor`: Add ability to filter `Spans` (#6341)
+- `tracegen`: support add additional resource attributes. (#11145)
 
 ### 🧰 Bug fixes 🧰
 
@@ -78,7 +79,6 @@
 - `jmxreceiver`: Add latest releases of jmx metrics gatherer & wildfly jar to supported jars hash list (#11134)
 - `rabbitmqreceiver`: Add integration test for rabbitmq receiver (#10865)
 - `transformprocessor`: Allow using trace_state with key-value struct (#11029)
-- `cmd/tracegen`: support add additional resource attributes. (#11145)
 
 ### 🧰 Bug fixes 🧰
 


### PR DESCRIPTION
**Description:**

Fix changelog format: one entry was outside of any section, while another one was put in the wrong version.
