### PR TITLE
[extension/filestorage] Copy values returned by Get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### 🧰 Bug fixes 🧰
 
 - `redactionprocessor`: respect allow_all_keys configuration (#11542)
+- `filestorageextension`: Copy values returned by Get (#11776)
 
 ### Unmaintained components
 

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -113,7 +113,15 @@ func (c *fileStorageClient) Batch(ctx context.Context, ops ...storage.Operation)
 		for _, op := range ops {
 			switch op.Type {
 			case storage.Get:
-				op.Value = bucket.Get([]byte(op.Key))
+				value := bucket.Get([]byte(op.Key))
+				if value != nil {
+					// the output of Bucket.Get is only valid within a transaction, so we need to make a copy
+					// to be able to return the value
+					op.Value = make([]byte, len(value))
+					copy(op.Value, value)
+				} else {
+					op.Value = nil
+				}
 			case storage.Set:
 				err = bucket.Put([]byte(op.Key), op.Value)
 			case storage.Delete:

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -286,7 +286,6 @@ func TestClientReboundCompaction(t *testing.T) {
 }
 
 func TestClientConcurrentCompaction(t *testing.T) {
-	t.Skip("skipping flaky test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11454")
 	logCore, logObserver := observer.New(zap.DebugLevel)
 	logger := zap.New(logCore)
 


### PR DESCRIPTION
**Description:**
Byte arrays returned by bbolt are only valid within transactions, and need to be copied if they are to be returned to the caller. See the documentation for [Bucket.Get](https://pkg.go.dev/go.etcd.io/bbolt#Bucket.Get) for reference.

In practice, this is a bit difficult to trigger, and I'm not sure what the conditions are exactly, other than a lot of concurrent access. An unrelated test caught it in GHA, and I'm re-enabling it in this change.

**Link to tracking Issue:** 
#11454 

**Testing:**
Re-enabled an unrelated test that originally caught this. I hadn't succeeded in reproducing it consistently, and it seems very hardware-dependent. In general, I don't think we should write tests that depend heavily on bbolt's implementation details.
