### PR TITLE
[receiver_creator] receivers log with their name field

### DIFF
--- a/receiver/receivercreator/config_test.go
+++ b/receiver/receivercreator/config_test.go
@@ -105,6 +105,7 @@ type nopWithEndpointFactory struct {
 type nopWithEndpointReceiver struct {
 	component.Component
 	consumer.Metrics
+	component.ReceiverCreateSettings
 }
 
 func (*nopWithEndpointFactory) CreateDefaultConfig() config.Receiver {
@@ -120,11 +121,12 @@ type mockComponent struct {
 
 func (*nopWithEndpointFactory) CreateMetricsReceiver(
 	ctx context.Context,
-	_ component.ReceiverCreateSettings,
+	rcs component.ReceiverCreateSettings,
 	_ config.Receiver,
 	nextConsumer consumer.Metrics) (component.MetricsReceiver, error) {
 	return &nopWithEndpointReceiver{
-		Component: mockComponent{},
-		Metrics:   nextConsumer,
+		Component:              mockComponent{},
+		Metrics:                nextConsumer,
+		ReceiverCreateSettings: rcs,
 	}, nil
 }

--- a/receiver/receivercreator/runner.go
+++ b/receiver/receivercreator/runner.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/consumer"
+	"go.uber.org/zap"
 )
 
 // runner starts and stops receiver instances.
@@ -110,5 +111,7 @@ func (run *receiverRunner) createRuntimeReceiver(
 	cfg config.Receiver,
 	nextConsumer consumer.Metrics,
 ) (component.MetricsReceiver, error) {
-	return factory.CreateMetricsReceiver(context.Background(), run.params, cfg, nextConsumer)
+	runParams := run.params
+	runParams.Logger = runParams.Logger.With(zap.String("name", cfg.ID().String()))
+	return factory.CreateMetricsReceiver(context.Background(), runParams, cfg, nextConsumer)
 }

--- a/receiver/receivercreator/runner_test.go
+++ b/receiver/receivercreator/runner_test.go
@@ -21,10 +21,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func Test_loadAndCreateRuntimeReceiver(t *testing.T) {
-	run := &receiverRunner{params: componenttest.NewNopReceiverCreateSettings(), idNamespace: config.NewComponentIDWithName(typeStr, "1")}
+	logCore, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(logCore).With(zap.String("name", "receiver_creator"))
+	rcs := componenttest.NewNopReceiverCreateSettings()
+	rcs.Logger = logger
+	run := &receiverRunner{params: rcs, idNamespace: config.NewComponentIDWithName(typeStr, "1")}
 	exampleFactory := &nopWithEndpointFactory{}
 	template, err := newReceiverTemplate("nop/1", nil)
 	require.NoError(t, err)
@@ -37,13 +43,25 @@ func Test_loadAndCreateRuntimeReceiver(t *testing.T) {
 	nopConfig := loadedConfig.(*nopWithEndpointConfig)
 	// Verify that the overridden endpoint is used instead of the one in the config file.
 	assert.Equal(t, "localhost:12345", nopConfig.Endpoint)
-	assert.Equal(t, "nop/1/receiver_creator/1{endpoint=\"localhost:12345\"}", nopConfig.ID().String())
+	expectedID := `nop/1/receiver_creator/1{endpoint="localhost:12345"}`
+	assert.Equal(t, expectedID, nopConfig.ID().String())
 
-	// Test that metric receiver can be created from loaded config.
+	// Test that metric receiver can be created from loaded config and it logs its id for the "name" field.
 	t.Run("test create receiver from loaded config", func(t *testing.T) {
 		recvr, err := run.createRuntimeReceiver(exampleFactory, loadedConfig, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, recvr)
 		assert.IsType(t, &nopWithEndpointReceiver{}, recvr)
+		recvr.(*nopWithEndpointReceiver).Logger.Warn("test message")
+		assert.True(t, func() bool {
+			var found bool
+			for _, entry := range logs.All() {
+				if name, ok := entry.ContextMap()["name"]; ok {
+					found = true
+					assert.Equal(t, expectedID, name)
+				}
+			}
+			return found
+		}())
 	})
 }

--- a/unreleased/receivercreatorlogging.yaml
+++ b/unreleased/receivercreatorlogging.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: receivercreator
+note: dynamically created receivers log with their `name` field
+issues: [16481]


### PR DESCRIPTION
**Description:**
Fixing a bug - Currently receivers created by the receiver creator have log statements with its `"name"` zap field instead of their own. These changes include the generated config id as the logger's name instead of sharing the same logger as the parent receiver.

**Testing:** Updated existing unit test.

**Documentation:** Changelog addition.