### PR TITLE
[exporter/prometheusremotewrite] Fix OTEL SUM metric conversion

### DIFF
--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -263,6 +263,10 @@ func validateMetrics(metric pmetric.Metric) bool {
 func addSingleNumberDataPoint(pt pmetric.NumberDataPoint, resource pcommon.Resource, metric pmetric.Metric, settings Settings, tsMap map[string]*prompb.TimeSeries) {
 	// create parameters for addSample
 	name := prometheustranslator.BuildPromCompliantName(metric, settings.Namespace)
+	// Sum metric points MUST have _total added as a suffix to the metric name.
+	if metric.DataType() == pmetric.MetricDataTypeSum && !strings.HasSuffix(name, "_total") {
+		name = name + "_total"
+	}
 	labels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, name)
 	sample := &prompb.Sample{
 		// convert ns to ms

--- a/unreleased/prometheus-fix-sum-conversion.yaml
+++ b/unreleased/prometheus-fix-sum-conversion.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewrite
+
+# A brief description of the change
+note: Fix Prometheus metric conversion issue where sum metric types do not have `_total` suffix
+
+# One or more tracking issues related to the change
+issues: [ 11838 ]


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Fixing a bug - Adding `_total` suffix for conversion from SUM type to Prometheus Counter.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11837

**Testing:**

Did local testing.

**Documentation:** <Describe the documentation added.>