### PR TITLE
exporter/datadogexporter: increase wait time to 1s

### DIFF
--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -271,7 +271,7 @@ func TestTraceExporter(t *testing.T) {
 	ctx := context.Background()
 	err = exporter.ConsumeTraces(ctx, simpleTraces())
 	assert.NoError(t, err)
-	time.Sleep(10 * time.Millisecond) // we need a bit of time for channels to receive things
+	time.Sleep(time.Second) // we need a bit of time for channels to receive things
 	require.NoError(t, exporter.Shutdown(context.Background()))
 	require.Equal(t, "application/x-protobuf", got)
 }


### PR DESCRIPTION
As a final attempt to eliminate the flakiness of this test, I am
proposing increasing the sleep time to 1s, which in theory should be
plenty for a channel to receive a send. If it turns out to remain flaky,
we can temporarily disable this test until it is fixed or until the
scenario is covered in an alternative way.

Updates #11836