### PR TITLE
[receiver/sqlquery] Add Oracle DB support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -208,6 +208,10 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+      - name: Setup Oracle DB Docker Image Dependency
+        shell: bash
+        run: |
+          docker pull container-registry.oracle.com/database/express:latest
       - name: Run Integration Tests
         run: make integration-tests-with-cover
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -208,6 +208,7 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+      - name: Run Integration Tests
         run: make integration-tests-with-cover
 
   correctness-traces:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -208,8 +208,20 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+      - name: Setup Oracle DB Docker Image Dependency
+        shell: bash
+        run: |
+          git clone https://github.com/oracle/docker-images.git
+          pushd docker-images/OracleDatabase/SingleInstance/dockerfiles
+          ./buildContainerImage.sh -v 21.3.0 -x
+          popd
       - name: Run Integration Tests
         run: make integration-tests-with-cover
+      - name: Delete Oracle DB dependencies
+        shell: bash
+        run: |
+          docker image rm oracle/database:21.3.0-xe
+          rm -rf docker-images/
 
   correctness-traces:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -208,10 +208,6 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-      - name: Setup Oracle DB Docker Image Dependency
-        shell: bash
-        run: |
-          docker pull container-registry.oracle.com/database/express:latest
       - name: Run Integration Tests
         run: make integration-tests-with-cover
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -208,11 +208,6 @@ jobs:
             ~/go/bin
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-      - name: Setup Oracle DB Docker Image Dependency
-        shell: bash
-        run: |
-          docker pull container-registry.oracle.com/database/express:latest
-      - name: Run Integration Tests
         run: make integration-tests-with-cover
 
   correctness-traces:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -211,17 +211,9 @@ jobs:
       - name: Setup Oracle DB Docker Image Dependency
         shell: bash
         run: |
-          git clone https://github.com/oracle/docker-images.git
-          pushd docker-images/OracleDatabase/SingleInstance/dockerfiles
-          ./buildContainerImage.sh -v 21.3.0 -x
-          popd
+          docker pull container-registry.oracle.com/database/express:latest
       - name: Run Integration Tests
         run: make integration-tests-with-cover
-      - name: Delete Oracle DB dependencies
-        shell: bash
-        run: |
-          docker image rm oracle/database:21.3.0-xe
-          rm -rf docker-images/
 
   correctness-traces:
     runs-on: ubuntu-latest

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -4,7 +4,7 @@ SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
-GOTEST_INTEGRATION_OPT?= -race -timeout 120s
+GOTEST_INTEGRATION_OPT?= -race -timeout 300s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -4,7 +4,7 @@ SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
-GOTEST_INTEGRATION_OPT?= -race -timeout 300s
+GOTEST_INTEGRATION_OPT?= -race -timeout 180s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -4,7 +4,7 @@ SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
-GOTEST_INTEGRATION_OPT?= -race -timeout 180s
+GOTEST_INTEGRATION_OPT?= -race -timeout 300s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -4,7 +4,7 @@ SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
-GOTEST_INTEGRATION_OPT?= -race -timeout 900s
+GOTEST_INTEGRATION_OPT?= -race -timeout 120s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -4,7 +4,7 @@ SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
-GOTEST_INTEGRATION_OPT?= -race -timeout 120s
+GOTEST_INTEGRATION_OPT?= -race -timeout 900s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -462,6 +462,7 @@ require (
 	github.com/signalfx/golib/v3 v3.3.37 // indirect
 	github.com/signalfx/sapm-proto v0.11.0 // indirect
 	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201202163743-65b4fa925fc8 // indirect
+	github.com/sijms/go-ora/v2 v2.4.26 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/snowflakedb/gosnowflake v1.6.10 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -1652,6 +1652,8 @@ github.com/signalfx/sapm-proto v0.11.0 h1:TIbJNKJ/J00yyASLlbF1DlVZv+X1bY4/BiaYSU
 github.com/signalfx/sapm-proto v0.11.0/go.mod h1:bYZgdl2ZoMriE4arrRThWH8M6DkVbN7+xsxg4v2HP8Q=
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201202163743-65b4fa925fc8 h1:pK1/PlwhBPVa2+SqAo7nVfwE/zbGz1p3WlcqwcoLSBk=
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201202163743-65b4fa925fc8/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
+github.com/sijms/go-ora/v2 v2.4.26 h1:nHDCq1jROHU5r+hGh0wxrIJ32qTUtDuEoo3x/XTGNRY=
+github.com/sijms/go-ora/v2 v2.4.26/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/go.mod
+++ b/go.mod
@@ -463,6 +463,7 @@ require (
 	github.com/signalfx/golib/v3 v3.3.13 // indirect
 	github.com/signalfx/sapm-proto v0.11.0 // indirect
 	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201202163743-65b4fa925fc8 // indirect
+	github.com/sijms/go-ora/v2 v2.4.26 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/snowflakedb/gosnowflake v1.6.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1656,6 +1656,8 @@ github.com/signalfx/sapm-proto v0.11.0 h1:TIbJNKJ/J00yyASLlbF1DlVZv+X1bY4/BiaYSU
 github.com/signalfx/sapm-proto v0.11.0/go.mod h1:bYZgdl2ZoMriE4arrRThWH8M6DkVbN7+xsxg4v2HP8Q=
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201202163743-65b4fa925fc8 h1:pK1/PlwhBPVa2+SqAo7nVfwE/zbGz1p3WlcqwcoLSBk=
 github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20201202163743-65b4fa925fc8/go.mod h1:pNaqfprM2bSCBhE8sTT2NtasSWEsIJbrmnIF0ap/Cvg=
+github.com/sijms/go-ora/v2 v2.4.26 h1:nHDCq1jROHU5r+hGh0wxrIJ32qTUtDuEoo3x/XTGNRY=
+github.com/sijms/go-ora/v2 v2.4.26/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -8,9 +8,10 @@ The SQL Query Receiver uses custom SQL queries to generate metrics from a databa
 
 The configuration supports the following top-level fields:
 
-- `driver`(required): The name of the database driver: one of _postgres_, _mysql_, _snowflake_, _sqlserver_, or _hdb_ (SAP HANA).
-- `datasource`(required): The datasourcename value passed to [sql.Open](https://pkg.go.dev/database/sql#Open). This is 
-a driver-specific string usually consisting of at least a database name and connection information.
+- `driver`(required): The name of the database driver: one of _postgres_, _mysql_, _snowflake_, _sqlserver_, _hdb_ (SAP HANA), or _oracle_ (Oracle DB).
+- `datasource`(required): The datasource value passed to [sql.Open](https://pkg.go.dev/database/sql#Open). This is
+a driver-specific string usually consisting of at least a database name and connection information. This is sometimes
+referred to as the "connection string" in driver documentation.
 e.g. _host=localhost port=5432 user=me password=s3cr3t sslmode=disable_
 - `queries`(required): A list of queries, where a query is a sql statement and one or more metrics (details below).
 - `collection_interval`(optional): The time interval between query executions. Defaults to _10s_.
@@ -22,8 +23,8 @@ A _query_ consists of a sql statement and one or more _metrics_, where each metr
 Each _metric_ in the configuration will produce one OTel metric per row returned from its sql query.
 
 * `metric_name`(required): the name assigned to the OTel metric.
-* `value_column`(required): the column name in the returned dataset used to set the value of the metric's datapoint. The column's values must be of an integer type.
-* `attribute_columns`(optional): a list of column names in the returned dataset used to set attibutes on the datapoint.
+* `value_column`(required): the column name in the returned dataset used to set the value of the metric's datapoint. The column's values must be of an integer type. This may be case-sensitive, depending on the driver (i.e. Oracle DB).
+* `attribute_columns`(optional): a list of column names in the returned dataset used to set attibutes on the datapoint. These attributes may be case-sensitive, depending on the driver (i.e. Oracle DB).
 * `data_type` (optional): can be `gauge` or `sum`; defaults to `gauge`.
 * `value_type` (optional): can be `int` or `double`; defaults to `int`.
 * `monotonic` (optional): boolean; whether a cumulative sum's value is monotonically increasing (i.e. never rolls over or resets); defaults to false.
@@ -83,3 +84,9 @@ Data point attributes:
      -> genre: STRING(action)
 Value: 1
 ```
+
+#### Oracle DB Driver Example
+Refer to the config file [provided](./testdata/oracledb-receiver-config.yaml) for an example of using the
+Oracle DB driver to connect and query the same table schema and contents as the example above.
+The Oracle DB driver documentation can be found [here.](https://github.com/sijms/go-ora)
+Another usage example is the `go_ora` example [here.](https://blogs.oracle.com/developers/post/connecting-a-go-application-to-oracle-database)

--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -23,8 +23,8 @@ A _query_ consists of a sql statement and one or more _metrics_, where each metr
 Each _metric_ in the configuration will produce one OTel metric per row returned from its sql query.
 
 * `metric_name`(required): the name assigned to the OTel metric.
-* `value_column`(required): the column name in the returned dataset used to set the value of the metric's datapoint. The column's values must be of an integer type. This may be case-sensitive, depending on the driver (i.e. Oracle DB).
-* `attribute_columns`(optional): a list of column names in the returned dataset used to set attibutes on the datapoint. These attributes may be case-sensitive, depending on the driver (i.e. Oracle DB).
+* `value_column`(required): the column name in the returned dataset used to set the value of the metric's datapoint. This may be case-sensitive, depending on the driver (e.g. Oracle DB).
+* `attribute_columns`(optional): a list of column names in the returned dataset used to set attibutes on the datapoint. These attributes may be case-sensitive, depending on the driver (e.g. Oracle DB).
 * `data_type` (optional): can be `gauge` or `sum`; defaults to `gauge`.
 * `value_type` (optional): can be `int` or `double`; defaults to `int`.
 * `monotonic` (optional): boolean; whether a cumulative sum's value is monotonically increasing (i.e. never rolls over or resets); defaults to false.

--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -86,6 +86,7 @@ Value: 1
 ```
 
 #### Oracle DB Driver Example
+
 Refer to the config file [provided](./testdata/oracledb-receiver-config.yaml) for an example of using the
 Oracle DB driver to connect and query the same table schema and contents as the example above.
 The Oracle DB driver documentation can be found [here.](https://github.com/sijms/go-ora)

--- a/receiver/sqlqueryreceiver/db_client.go
+++ b/receiver/sqlqueryreceiver/db_client.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/denisenkom/go-mssqldb"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/lib/pq"
+	_ "github.com/sijms/go-ora/v2"
 	_ "github.com/snowflakedb/gosnowflake"
 	"go.uber.org/zap"
 )

--- a/receiver/sqlqueryreceiver/go.mod
+++ b/receiver/sqlqueryreceiver/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/lib/pq v1.10.6
+	github.com/sijms/go-ora/v2 v2.4.26
 	github.com/snowflakedb/gosnowflake v1.6.10
 	github.com/stretchr/testify v1.8.0
 	github.com/testcontainers/testcontainers-go v0.13.0

--- a/receiver/sqlqueryreceiver/go.sum
+++ b/receiver/sqlqueryreceiver/go.sum
@@ -750,6 +750,8 @@ github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiB
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sijms/go-ora/v2 v2.4.26 h1:nHDCq1jROHU5r+hGh0wxrIJ32qTUtDuEoo3x/XTGNRY=
+github.com/sijms/go-ora/v2 v2.4.26/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -25,11 +25,13 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 func testMovieMetrics(t *testing.T, rm pmetric.ResourceMetrics, genreAttrKey string) {

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -25,11 +25,13 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 func TestPostgresIntegration(t *testing.T) {

--- a/receiver/sqlqueryreceiver/testdata/integration/Dockerfile.oracledb
+++ b/receiver/sqlqueryreceiver/testdata/integration/Dockerfile.oracledb
@@ -1,4 +1,4 @@
-FROM oracle/database:21.3.0-xe
+FROM container-registry.oracle.com/database/express:latest
 
 ENV ORACLE_PWD=mysecurepassword
 

--- a/receiver/sqlqueryreceiver/testdata/integration/Dockerfile.oracledb
+++ b/receiver/sqlqueryreceiver/testdata/integration/Dockerfile.oracledb
@@ -1,0 +1,5 @@
+FROM oracle/database:21.3.0-xe
+
+ENV ORACLE_PWD=mysecurepassword
+
+COPY initOracleDB.sql $ORACLE_BASE/scripts/startup

--- a/receiver/sqlqueryreceiver/testdata/integration/initOracleDB.sql
+++ b/receiver/sqlqueryreceiver/testdata/integration/initOracleDB.sql
@@ -1,0 +1,24 @@
+create table movie
+(
+    title       VARCHAR2(256),
+    genre       VARCHAR(256),
+    imdb_rating NUMBER
+);
+
+insert into movie (title, genre, imdb_rating)
+values ('E.T.', 'SciFi', 7.9);
+insert into movie (title, genre, imdb_rating)
+values ('Blade Runner', 'SciFi', 8.1);
+insert into movie (title, genre, imdb_rating)
+values ('Star Wars', 'SciFi', 8.6);
+insert into movie (title, genre, imdb_rating)
+values ('Die Hard', 'Action', 8.2);
+insert into movie (title, genre, imdb_rating)
+values ('Mission Impossible', 'Action', 7.1);
+
+/* The alter session command is required to enable user creation in an Oracle docker container
+   This command shouldn't be used outside of test environments. */
+alter session set "_ORACLE_SCRIPT"=true;
+CREATE USER OTEL IDENTIFIED BY password;
+GRANT CREATE SESSION TO OTEL;
+GRANT ALL ON movie TO OTEL;

--- a/receiver/sqlqueryreceiver/testdata/oracledb-receiver-config.yaml
+++ b/receiver/sqlqueryreceiver/testdata/oracledb-receiver-config.yaml
@@ -10,7 +10,7 @@ receivers:
     datasource: "oracle://otel:password@localhost:51521/XE"
     driver: oracle
     queries:
-      # Note: The table name may need to be preceeded by the name of the user who created the table.
+      # Note: The table name may need to be preceded by the name of the user who created the table.
       # If the table is created by an initialization script within a docker container, it would be referred
       # to as "sys.movie", as the sys user runs initialization scripts. Permission would need to be granted
       # to the "otel" user to access or modify the table in that case.

--- a/receiver/sqlqueryreceiver/testdata/oracledb-receiver-config.yaml
+++ b/receiver/sqlqueryreceiver/testdata/oracledb-receiver-config.yaml
@@ -1,0 +1,37 @@
+receivers:
+  sqlquery:
+    # driver name: oracle
+    # username: otel
+    # password: password
+    # host: localhost
+    # container exposed port: 51521
+    # Oracle DB service name: XE
+    # Refer to Oracle Go Driver go_ora documentation for full connection string options
+    datasource: "oracle://otel:password@localhost:51521/XE"
+    driver: oracle
+    queries:
+      # Note: The table name may need to be preceeded by the name of the user who created the table.
+      # If the table is created by an initialization script within a docker container, it would be referred
+      # to as "sys.movie", as the sys user runs initialization scripts. Permission would need to be granted
+      # to the "otel" user to access or modify the table in that case.
+      # This example assumes "otel" created the movie table.
+      - sql: "select count(*) as count, genre, avg(imdb_rating) as avg from otel.movie group by genre"
+        metrics:
+          - metric_name: genre.count
+            # Note that COUNT and GENRE are now all capital letters, the queries will return nothing if this isn't
+            # accounted for.
+            value_column: "COUNT"
+            attribute_columns: [GENRE]
+          - metric_name: genre.imdb
+            value_column: "AVG"
+            attribute_columns: [GENRE]
+            value_type: "double"
+exporters:
+  nop:
+service:
+  pipelines:
+    metrics:
+      receivers:
+        - sqlquery
+      exporters:
+        - nop

--- a/unreleased/sqlqueryrec-oracle-db.yaml
+++ b/unreleased/sqlqueryrec-oracle-db.yaml
@@ -8,7 +8,7 @@ component: sqlqueryreceiver
 note: Add Oracle DB Support
 
 # One or more tracking issues related to the change
-issues: []
+issues: [12137]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/unreleased/sqlqueryrec-oracle-db.yaml
+++ b/unreleased/sqlqueryrec-oracle-db.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sqlqueryreceiver
+
+# A brief description of the change
+note: Add Oracle DB Support
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This adds support for an Oracle DB driver to be used with the sqlquery receiver. This also includes testing to make
sure the receiver can connect and query metrics from a docker container running an Oracle DB. The README has
been updated, and a sample config has also been provided. The integration test suite has been updated to allow the
docker image for the Oracle DB to be created pre-test, and deleted post-test.

**Link to tracking Issue:** <Issue number if applicable>
[12137](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12137)

**Testing:** <Describe what testing was performed and which tests were added.>
Integration test added

**Documentation:** <Describe the documentation added.>
README updated and sample config file provided.