### PR TITLE
[receiver/statsd] Remove usage of deprecated net.Error.Temporary #9808

### DIFF
--- a/receiver/statsdreceiver/transport/udp_server.go
+++ b/receiver/statsdreceiver/transport/udp_server.go
@@ -72,7 +72,7 @@ func (u *udpServer) ListenAndServe(
 				err)
 			var netErr net.Error
 			if errors.As(err, &netErr) {
-				if netErr.Temporary() { // nolint SA1019
+				if netErr.Timeout() {
 					continue
 				}
 			}


### PR DESCRIPTION
Description:
net.Error.Temporary has been deprecated, so changed usage to net.Error.Timeout

Link to tracking Issue:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9808

Testing:
/receiver/statsdreceiver PASSED

Documentation:
n/a