### PR TITLE
[receiver/carbon] Remove usage of deprecated net.Error.Temporary #9807

### DIFF
--- a/receiver/carbonreceiver/transport/tcp_server.go
+++ b/receiver/carbonreceiver/transport/tcp_server.go
@@ -108,9 +108,9 @@ func (t *tcpServer) ListenAndServe(
 			t.reporter.OnDebugf(
 				"TCP Transport (%s) - Accept (temporary=%v) net.Error: %v",
 				t.ln.Addr().String(),
-				netErr.Temporary(), // nolint SA1019
+				netErr.Timeout(),
 				netErr)
-			if netErr.Temporary() { // nolint SA1019
+			if netErr.Timeout() {
 				continue
 			}
 		}
@@ -201,7 +201,7 @@ func (t *tcpServer) handleConnection(
 		netErr := &net.OpError{}
 		if errors.As(err, &netErr) {
 			t.reporter.OnDebugf("TCP Transport (%s) - net.OpError: %v", t.ln.Addr(), netErr)
-			if !netErr.Temporary() || netErr.Timeout() {
+			if netErr.Timeout() {
 				// We want to end on timeout so idle connections are purged.
 				span.End()
 				return

--- a/receiver/carbonreceiver/transport/udp_server.go
+++ b/receiver/carbonreceiver/transport/udp_server.go
@@ -81,7 +81,7 @@ func (u *udpServer) ListenAndServe(
 				err)
 			var netErr net.Error
 			if errors.As(err, &netErr) {
-				if netErr.Temporary() { // nolint SA1019
+				if netErr.Timeout() {
 					continue
 				}
 			}


### PR DESCRIPTION
Description:
net.Error.Temporary has been deprecated, so changed usage to net.Error.Timeout

Link to tracking Issue:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9807

Testing:
/receiver/statsdreceiver PASSED

Documentation:
n/a