### PR TITLE
docs: document `resource_to_telemetry_conversion`

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -46,6 +46,8 @@ The following settings can be optionally configured:
   - `enabled`: enable the sending queue
   - `queue_size`: number of OTLP metrics that can be queued. Ignored if `enabled` is `false`
   - `num_consumers`: minimum number of workers to use to fan out the outgoing requests.
+- `resource_to_telemetry_conversion`
+  - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 
 Example:
 
@@ -57,6 +59,8 @@ exporters:
       directory: ./prom_rw # The directory to store the WAL in
       buffer_size: 100 # Optional count of elements to be read from the WAL before truncating; default of 300
       truncate_frequency: 45s # Optional frequency for how often the WAL should be truncated. It is a time.ParseDuration; default of 1m
+    resource_to_telemetry_conversion:
+      enabled: true # Convert resource attributes to metric labels
 ```
 
 Example:


### PR DESCRIPTION
Closes #10115

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This edit documents the `resource_to_telemetry_conversion` feature of `prometheusremotewriteexporter`.

**Link to tracking Issue:** #10115 

**Testing:** @jack78901 successfully used this configuration with `prometheusremotewriteexporter` by taking inspiration from `prometheusexporter`'s documentation.

**Documentation:** N/A