### PR TITLE
[receiver/fluentforward] Add newlines to avoid garbled test output

### DIFF
--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -215,7 +215,7 @@ func TestPackedForwardEventConversionWithErrors(t *testing.T) {
 		err := event.DecodeMsg(reader)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "gzip")
-		print(err.Error())
+		fmt.Println(err.Error())
 	})
 }
 

--- a/receiver/fluentforwardreceiver/receiver_test.go
+++ b/receiver/fluentforwardreceiver/receiver_test.go
@@ -180,7 +180,7 @@ func TestForwardEvent(t *testing.T) {
 
 func TestEventAcknowledgment(t *testing.T) {
 	connect, _, logs, cancel := setupServer(t)
-	defer func() { fmt.Printf("%v", logs.All()) }()
+	defer func() { fmt.Printf("%v\n", logs.All()) }()
 	defer cancel()
 
 	const chunkValue = "abcdef01234576789"


### PR DESCRIPTION
**Description:** 

Add new lines on prints done on test output, to avoid garbled output.

Found while working in #11861
