### PR TITLE
[sqlqueryreceiver] - add optional `static_attributes` to metrics. 

### DIFF
--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -30,7 +30,7 @@ Each _metric_ in the configuration will produce one OTel metric per row returned
 * `aggregation` (optional): only applicable for `data_type=sum`; can be `cumulative` or `delta`; defaults to `cumulative`.
 * `description` (optional): the description applied to the metric.
 * `unit` (optional): the units applied to the metric.
-* `static_attributes` (optional): static labels applied to the metrics
+* `static_attributes` (optional): static attributes applied to the metrics
 
 ### Example
 

--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -30,6 +30,7 @@ Each _metric_ in the configuration will produce one OTel metric per row returned
 * `aggregation` (optional): only applicable for `data_type=sum`; can be `cumulative` or `delta`; defaults to `cumulative`.
 * `description` (optional): the description applied to the metric.
 * `unit` (optional): the units applied to the metric.
+* `tags` (optional): tags applied to the metrics
 
 ### Example
 
@@ -44,6 +45,8 @@ receivers:
           - metric_name: movie.genres
             value_column: "count"
             attribute_columns: [ "genre" ]
+            tags: 
+               dbinstance: mydbinstance
 ```
 
 Given a `movie` table with three rows:
@@ -72,6 +75,7 @@ Descriptor:
 NumberDataPoints #0
 Data point attributes:
      -> genre: STRING(sci-fi)
+     -> dbinstance: STRING(mydbinstance)     
 Value: 2
 
 Metric #1
@@ -81,5 +85,6 @@ Descriptor:
 NumberDataPoints #0
 Data point attributes:
      -> genre: STRING(action)
+     -> dbinstance: STRING(mydbinstance)
 Value: 1
 ```

--- a/receiver/sqlqueryreceiver/README.md
+++ b/receiver/sqlqueryreceiver/README.md
@@ -30,7 +30,7 @@ Each _metric_ in the configuration will produce one OTel metric per row returned
 * `aggregation` (optional): only applicable for `data_type=sum`; can be `cumulative` or `delta`; defaults to `cumulative`.
 * `description` (optional): the description applied to the metric.
 * `unit` (optional): the units applied to the metric.
-* `tags` (optional): tags applied to the metrics
+* `static_attributes` (optional): static labels applied to the metrics
 
 ### Example
 
@@ -45,7 +45,7 @@ receivers:
           - metric_name: movie.genres
             value_column: "count"
             attribute_columns: [ "genre" ]
-            tags: 
+            static_attributes: 
                dbinstance: mydbinstance
 ```
 

--- a/receiver/sqlqueryreceiver/config.go
+++ b/receiver/sqlqueryreceiver/config.go
@@ -80,6 +80,7 @@ type MetricCfg struct {
 	Aggregation      MetricAggregation `mapstructure:"aggregation"`
 	Unit             string            `mapstructure:"unit"`
 	Description      string            `mapstructure:"description"`
+	Tags             map[string]string `mapstructure:"tags"`
 }
 
 func (c MetricCfg) Validate() error {

--- a/receiver/sqlqueryreceiver/config.go
+++ b/receiver/sqlqueryreceiver/config.go
@@ -80,7 +80,7 @@ type MetricCfg struct {
 	Aggregation      MetricAggregation `mapstructure:"aggregation"`
 	Unit             string            `mapstructure:"unit"`
 	Description      string            `mapstructure:"description"`
-	Tags             map[string]string `mapstructure:"tags"`
+	StaticAttributes map[string]string `mapstructure:"static_attributes"`
 }
 
 func (c MetricCfg) Validate() error {

--- a/receiver/sqlqueryreceiver/config_test.go
+++ b/receiver/sqlqueryreceiver/config_test.go
@@ -47,7 +47,7 @@ func TestParseConfig(t *testing.T) {
 	assert.Equal(t, false, metric.Monotonic)
 	assert.Equal(t, MetricDataTypeSum, metric.DataType)
 	assert.Equal(t, MetricValueTypeInt, metric.ValueType)
-	assert.Equal(t, map[string]string{"foo": "bar"}, metric.Tags)
+	assert.Equal(t, map[string]string{"foo": "bar"}, metric.StaticAttributes)
 	assert.Equal(t, MetricAggregationCumulative, metric.Aggregation)
 }
 

--- a/receiver/sqlqueryreceiver/config_test.go
+++ b/receiver/sqlqueryreceiver/config_test.go
@@ -47,6 +47,7 @@ func TestParseConfig(t *testing.T) {
 	assert.Equal(t, false, metric.Monotonic)
 	assert.Equal(t, MetricDataTypeSum, metric.DataType)
 	assert.Equal(t, MetricValueTypeInt, metric.ValueType)
+	assert.Equal(t, map[string]string{"foo": "bar"}, metric.Tags)
 	assert.Equal(t, MetricAggregationCumulative, metric.Aggregation)
 }
 

--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -43,7 +43,7 @@ func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric) error {
 			return fmt.Errorf("rowToMetric: attribute_column not found: '%s'", columnName)
 		}
 	}
-	for k, v := range cfg.Tags {
+	for k, v := range cfg.StaticAttributes {
 		attrs.InsertString(k, v)
 	}
 	return nil

--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -17,7 +17,9 @@ package sqlqueryreceiver // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"fmt"
 	"strconv"
+	"time"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -27,6 +29,9 @@ func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric) error {
 	dest.SetUnit(cfg.Unit)
 	dataPointSlice := setMetricFields(cfg, dest)
 	dataPoint := dataPointSlice.AppendEmpty()
+	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	value, found := row[cfg.ValueColumn]
 	if !found {
 		return fmt.Errorf("rowToMetric: value_column '%s' not found in result set", cfg.ValueColumn)

--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -17,9 +17,7 @@ package sqlqueryreceiver // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"fmt"
 	"strconv"
-	"time"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -29,8 +27,6 @@ func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric) error {
 	dest.SetUnit(cfg.Unit)
 	dataPointSlice := setMetricFields(cfg, dest)
 	dataPoint := dataPointSlice.AppendEmpty()
-	dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	value, found := row[cfg.ValueColumn]
 	if !found {
 		return fmt.Errorf("rowToMetric: value_column '%s' not found in result set", cfg.ValueColumn)

--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -29,7 +29,6 @@ func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric) error {
 	dest.SetUnit(cfg.Unit)
 	dataPointSlice := setMetricFields(cfg, dest)
 	dataPoint := dataPointSlice.AppendEmpty()
-	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	dataPoint.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	value, found := row[cfg.ValueColumn]
@@ -47,6 +46,9 @@ func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric) error {
 		} else {
 			return fmt.Errorf("rowToMetric: attribute_column not found: '%s'", columnName)
 		}
+	}
+	for k, v := range cfg.Tags {
+		attrs.InsertString(k, v)
 	}
 	return nil
 }

--- a/receiver/sqlqueryreceiver/testdata/config.yaml
+++ b/receiver/sqlqueryreceiver/testdata/config.yaml
@@ -13,6 +13,8 @@ receivers:
             value_type: int
             monotonic: false
             aggregation: cumulative
+            tags: 
+              foo: bar
 exporters:
   nop:
 service:

--- a/receiver/sqlqueryreceiver/testdata/config.yaml
+++ b/receiver/sqlqueryreceiver/testdata/config.yaml
@@ -13,7 +13,7 @@ receivers:
             value_type: int
             monotonic: false
             aggregation: cumulative
-            tags: 
+            static_attributes: 
               foo: bar
 exporters:
   nop:

--- a/unreleased/sqlqueryreceiver-tags.yaml
+++ b/unreleased/sqlqueryreceiver-tags.yaml
@@ -8,4 +8,4 @@ component: sqlqueryreceiver
 note: Add `static_attributes` optional configuration to allow adding attributes/tags to queried metrics. 
 
 # One or more tracking issues related to the change
-issues: []
+issues: [#11868]

--- a/unreleased/sqlqueryreceiver-tags.yaml
+++ b/unreleased/sqlqueryreceiver-tags.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sqlqueryreceiver
+
+# A brief description of the change
+note: Add `static_attributes` optional configuration to allow adding attributes/tags to queried metrics. 
+
+# One or more tracking issues related to the change
+issues: []

--- a/unreleased/sqlqueryreceiver-tags.yaml
+++ b/unreleased/sqlqueryreceiver-tags.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: sqlqueryreceiver
 
 # A brief description of the change
-note: Add `static_attributes` optional configuration to allow adding attributes/tags to queried metrics. 
+note: Add static_attributes optional configuration to allow adding attributes/tags to queried metrics. 
 
 # One or more tracking issues related to the change
-issues: [#11868]
+issues: [11868]


### PR DESCRIPTION
**Description:** 

Adding a feature:
 - Add ability to set static tags for metrics returned from queries

**Testing:** 
- Added config test to validate config is loading a map of strings for tags. 

**Documentation:** 
- Entry added to README.md to specify static tag usage. 
FYI @pmcollins 