### PR TITLE
[processor/spanmetrics] Remove manually added catch-all bucket

### DIFF
--- a/processor/spanmetricsprocessor/factory_test.go
+++ b/processor/spanmetricsprocessor/factory_test.go
@@ -39,18 +39,13 @@ func TestNewProcessor(t *testing.T) {
 			wantLatencyHistogramBuckets: defaultLatencyHistogramBucketsMs,
 		},
 		{
-			name:                        "latency histogram configured with catch-all bucket to check no additional catch-all bucket inserted",
-			latencyHistogramBuckets:     []time.Duration{2 * time.Millisecond, maxDuration},
-			wantLatencyHistogramBuckets: []float64{2, maxDurationMs},
-		},
-		{
-			name:                    "full config with no catch-all bucket and check the catch-all bucket is inserted",
+			name:                    "full config with 1 explicit bucket configured should have 1 latency bounds bucket",
 			latencyHistogramBuckets: []time.Duration{2 * time.Millisecond},
 			dimensions: []Dimension{
 				{"http.method", &defaultMethod},
 				{"http.status_code", nil},
 			},
-			wantLatencyHistogramBuckets: []float64{2, maxDurationMs},
+			wantLatencyHistogramBuckets: []float64{2},
 			wantDimensions: []Dimension{
 				{"http.method", &defaultMethod},
 				{"http.status_code", nil},

--- a/processor/spanmetricsprocessor/factory_test.go
+++ b/processor/spanmetricsprocessor/factory_test.go
@@ -39,7 +39,7 @@ func TestNewProcessor(t *testing.T) {
 			wantLatencyHistogramBuckets: defaultLatencyHistogramBucketsMs,
 		},
 		{
-			name:                    "full config with 1 explicit bucket configured should have 1 latency bounds bucket",
+			name:                    "1 configured latency histogram bucket should result in 1 explicit latency bucket (+1 implicit +Inf bucket)",
 			latencyHistogramBuckets: []time.Duration{2 * time.Millisecond},
 			dimensions: []Dimension{
 				{"http.method", &defaultMethod},

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -162,7 +162,7 @@ func TestConfigureLatencyBounds(t *testing.T) {
 	// Verify
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
-	assert.Equal(t, []float64{0.000003, 0.003, 3, 3000, maxDurationMs}, p.latencyBounds)
+	assert.Equal(t, []float64{0.000003, 0.003, 3, 3000}, p.latencyBounds)
 }
 
 func TestProcessorCapabilities(t *testing.T) {
@@ -451,7 +451,13 @@ func verifyConsumeMetricsInput(t testing.TB, input pmetric.Metrics, expectedTemp
 		assert.Equal(t, sampleLatency*float64(numCumulativeConsumptions), dp.Sum(), "Should be a 11ms latency measurement, multiplied by the number of stateful accumulations.")
 		assert.NotZero(t, dp.Timestamp(), "Timestamp should be set")
 
-		// Verify bucket counts. Firstly, find the bucket index where the 11ms latency should belong in.
+		// Verify bucket counts.
+
+		// The bucket counts should be 1 greater than the explicit bounds as documented in:
+		// https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto.
+		assert.Equal(t, dp.ExplicitBounds().Len()+1, dp.BucketCounts().Len())
+
+		// Find the bucket index where the 11ms latency should belong in.
 		var foundLatencyIndex int
 		for foundLatencyIndex = 0; foundLatencyIndex < dp.ExplicitBounds().Len(); foundLatencyIndex++ {
 			if dp.ExplicitBounds().At(foundLatencyIndex) > sampleLatency {
@@ -774,7 +780,7 @@ func TestSanitize(t *testing.T) {
 	require.Equal(t, "key_0test", sanitize("0test", cfg.skipSanitizeLabel))
 	require.Equal(t, "test", sanitize("test", cfg.skipSanitizeLabel))
 	require.Equal(t, "test__", sanitize("test_/", cfg.skipSanitizeLabel))
-	//testcases with skipSanitizeLabel flag turned on
+	// testcases with skipSanitizeLabel flag turned on
 	cfg.skipSanitizeLabel = true
 	require.Equal(t, "", sanitize("", cfg.skipSanitizeLabel), "")
 	require.Equal(t, "_test", sanitize("_test", cfg.skipSanitizeLabel))

--- a/unreleased/spanmetricsproc-fix-bucket-counts.yaml
+++ b/unreleased/spanmetricsproc-fix-bucket-counts.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsprocessor
+
+# A brief description of the change
+note: Fixes the number of explicit bucket counts by removing the manually added "catch-all" bucket.
+
+# One or more tracking issues related to the change
+issues: [11784]


### PR DESCRIPTION
**Description:** 
Removes the manually added "catch-all" histogram bucket, which is not necessary. 

As described in [metrics.proto](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L424-L425):

>  // The number of elements in bucket_counts array must be by one greater than
>  // the number of elements in explicit_bounds array.

Prior to this PR, the counts between explicit bounds and buckets are equal, whereas the
"catch-all"/"+Inf" bucket should be implicit based on the bucket count/sum.

**Link to tracking Issue:** #11784

**Testing:** 

- Update unit tests.
- Manually tested to confirm that the number of buckets is 1 greater than the explicit bounds.

```
otel_collector_1  | Metric #7
otel_collector_1  | Descriptor:
otel_collector_1  |      -> Name: latency
otel_collector_1  |      -> Description:
otel_collector_1  |      -> Unit:
otel_collector_1  |      -> DataType: Histogram
otel_collector_1  |      -> AggregationTemporality: AGGREGATION_TEMPORALITY_CUMULATIVE
otel_collector_1  | HistogramDataPoints #0
otel_collector_1  | Data point attributes:
otel_collector_1  |      -> service.name: STRING(frontend)
otel_collector_1  |      -> operation: STRING(HTTP GET)
otel_collector_1  |      -> span.kind: STRING(SPAN_KIND_CLIENT)
otel_collector_1  |      -> status.code: STRING(STATUS_CODE_UNSET)
otel_collector_1  | StartTimestamp: 2022-07-02 13:32:44.75737753 +0000 UTC
otel_collector_1  | Timestamp: 2022-07-02 13:32:48.149191643 +0000 UTC
otel_collector_1  | Count: 3
otel_collector_1  | Sum: 102.793000
otel_collector_1  | ExplicitBounds #0: 1.000000
otel_collector_1  | ExplicitBounds #1: 10.000000
otel_collector_1  | ExplicitBounds #2: 100.000000
otel_collector_1  | ExplicitBounds #3: 1000.000000
otel_collector_1  | ExplicitBounds #4: 10000.000000
otel_collector_1  | ExplicitBounds #5: 60000.000000
otel_collector_1  | Buckets #0, Count: 0
otel_collector_1  | Buckets #1, Count: 0
otel_collector_1  | Buckets #2, Count: 3
otel_collector_1  | Buckets #3, Count: 0
otel_collector_1  | Buckets #4, Count: 0
otel_collector_1  | Buckets #5, Count: 0
otel_collector_1  | Buckets #6, Count: 0
```

**Documentation:** No updates to README are necessary.
