### PR TITLE
[receiver/filelog] Read lost files first in a poll cycle

### DIFF
--- a/pkg/stanza/internal/fileconsumer/design.md
+++ b/pkg/stanza/internal/fileconsumer/design.md
@@ -25,6 +25,15 @@ If logs are replicated to multiple files, or if log files are copied manually, i
 
 In some rare circumstances, a logger may print a very verbose preamble to each log file. When this occurs, fingerprinting may fail to differentiate files from one another. This can be overcome by customizing the size of the fingerprint using the `fingerprint_size` setting.
 
+### Log line ordering across file rotations
+
+In general, we offer no guarantees as to the relative ordering of log lines originating from different files. For the common use case of files being rotated outside the watched pattern, we make a best-effort attempt at reading the rotated file to the end before reading the new file. This guarantees log line ordering across rotations, assuming the following conditions are met:
+
+* rotated file names don't match the watched pattern
+* rotated files aren't written to after the rotation
+
+A minor reordering of log lines often doesn't matter, but it can when using the recombine operator later in the pipeline, for example.
+
 # Readers
 
 Readers are a convenience struct, which exist for the purpose of managing files and their associated metadata. 

--- a/pkg/stanza/internal/fileconsumer/file.go
+++ b/pkg/stanza/internal/fileconsumer/file.go
@@ -146,6 +146,11 @@ func (f *Input) poll(ctx context.Context) {
 	readers := f.makeReaders(matches)
 	f.firstCheck = false
 
+	// take care of files which disappeared from the pattern since the last poll cycle
+	// this can mean either files which were removed, or rotated into a name not matching the pattern
+	// we do this before reading existing files to ensure we emit older log lines before newer ones
+	f.roller.readLostFiles(ctx, readers)
+
 	var wg sync.WaitGroup
 	for _, reader := range readers {
 		wg.Add(1)

--- a/pkg/stanza/internal/fileconsumer/roller.go
+++ b/pkg/stanza/internal/fileconsumer/roller.go
@@ -17,6 +17,7 @@ package fileconsumer // import "github.com/open-telemetry/opentelemetry-collecto
 import "context"
 
 type roller interface {
+	readLostFiles(context.Context, []*Reader)
 	roll(context.Context, []*Reader)
 	cleanup()
 }

--- a/pkg/stanza/internal/fileconsumer/roller_other.go
+++ b/pkg/stanza/internal/fileconsumer/roller_other.go
@@ -30,7 +30,7 @@ func newRoller() roller {
 	return &detectLostFiles{[]*Reader{}}
 }
 
-func (r *detectLostFiles) roll(ctx context.Context, readers []*Reader) {
+func (r *detectLostFiles) readLostFiles(ctx context.Context, readers []*Reader) {
 	// Detect files that have been rotated out of matching pattern
 	lostReaders := make([]*Reader, 0, len(r.oldReaders))
 OUTER:
@@ -52,7 +52,9 @@ OUTER:
 		}(reader)
 	}
 	lostWG.Wait()
+}
 
+func (r *detectLostFiles) roll(ctx context.Context, readers []*Reader) {
 	for _, reader := range r.oldReaders {
 		reader.Close()
 	}

--- a/pkg/stanza/internal/fileconsumer/roller_windows.go
+++ b/pkg/stanza/internal/fileconsumer/roller_windows.go
@@ -25,6 +25,10 @@ func newRoller() roller {
 	return &closeImmediately{}
 }
 
+func (r *closeImmediately) readLostFiles(ctx context.Context, readers []*Reader) {
+	return
+}
+
 func (r *closeImmediately) roll(_ context.Context, readers []*Reader) {
 	for _, reader := range readers {
 		reader.Close()

--- a/unreleased/filelog-read-lost-files-first.yaml
+++ b/unreleased/filelog-read-lost-files-first.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change
+note: Read log lines from lost files first in a poll cycle
+
+# One or more tracking issues related to the change
+issues: [12084]


### PR DESCRIPTION
**Description:**
We currently read lost files at the end of each poll cycle. As a result, we will always read lines from rotated files after reading them from newly created files, resulting in them being emitted in a different order than they were written. This usually doesn't matter, but it does when using the recombine operator. We ran into this when handling multipart logs generated by container runtimes in K8s.

This change moves handling lost files to the start of the poll cycle, directly after files for the cycle are detected and opened. I believe that it guarantees both durability and ordering if the rotation behaves reasonably, that is:
* files aren't written to after having been rotated
* rotated files don't match the pattern

@djaglowski please check me on this. My reasoning goes as follows:
* files read in a given cycle are determined in `makeReaders`, when we Open them to calculate Fingerprints
* a file is lost if it was present in the previous cycle, but not the current one
* even if a file is rotated during a cycle, it'll be considered lost in the next one, and ordering will be maintained

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12084

**Testing:**
Added a test verifying that we actually get log lines in the right order. This test fails without the other changes.

**Documentation:**
Added a section about log line ordering across rotations to design.md.