### PR TITLE
[exporter/datadog] Fix hostname reported on GKE

### DIFF
--- a/exporter/datadogexporter/internal/metadata/internal/gcp/provider.go
+++ b/exporter/datadogexporter/internal/metadata/internal/gcp/provider.go
@@ -41,10 +41,28 @@ type Provider struct {
 	detector gcpDetector
 }
 
+func platformDescription(platform gcp.Platform) string {
+	switch platform {
+	case gcp.UnknownPlatform:
+		return "Unknown platform"
+	case gcp.GKE:
+		return "Google Kubernetes Engine"
+	case gcp.GCE:
+		return "Google Cloud Engine"
+	case gcp.CloudRun:
+		return "Google Cloud Run"
+	case gcp.CloudFunctions:
+		return "Google Cloud Functions"
+	case gcp.AppEngineStandard, gcp.AppEngineFlex:
+		return "Google AppEngine"
+	}
+	return "Unrecognized platform"
+}
+
 // Hostname returns the GCP cloud integration hostname.
 func (p *Provider) Source(context.Context) (source.Source, error) {
-	if p.detector.CloudPlatform() != gcp.GCE {
-		return source.Source{}, fmt.Errorf("not on Google Cloud Engine")
+	if platform := p.detector.CloudPlatform(); platform != gcp.GCE && platform != gcp.GKE {
+		return source.Source{}, fmt.Errorf("not on GCE or GKE (platform: %s)", platformDescription(platform))
 	}
 
 	name, err := p.detector.GCEHostName()

--- a/exporter/datadogexporter/internal/metadata/internal/gcp/provider_test.go
+++ b/exporter/datadogexporter/internal/metadata/internal/gcp/provider_test.go
@@ -41,12 +41,13 @@ var (
 var _ gcpDetector = (*mockDetector)(nil)
 
 type mockDetector struct {
+	platform     gcp.Platform
 	projectID    string
 	instanceName string
 }
 
 func (m *mockDetector) CloudPlatform() gcp.Platform {
-	return gcp.GCE
+	return m.platform
 }
 
 func (m *mockDetector) ProjectID() (string, error) {
@@ -65,17 +66,20 @@ func TestProvider(t *testing.T) {
 	tests := []struct {
 		name         string
 		projectID    string
+		platform     gcp.Platform
 		instanceName string
 		hostname     string
 	}{
 		{
 			name:         "good hostname",
+			platform:     gcp.GCE,
 			projectID:    testCloudAccount,
 			instanceName: testHostname,
 			hostname:     testGCPIntegrationHostname,
 		},
 		{
 			name:         "bad hostname",
+			platform:     gcp.GKE,
 			projectID:    testCloudAccount,
 			instanceName: testBadHostname,
 			hostname:     testGCPIntegrationBadHostname,
@@ -85,6 +89,7 @@ func TestProvider(t *testing.T) {
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
 			provider := &Provider{detector: &mockDetector{
+				platform:     testInstance.platform,
 				projectID:    testInstance.projectID,
 				instanceName: testInstance.instanceName,
 			}}

--- a/unreleased/datadog-exporter-gke-hostname.yaml
+++ b/unreleased/datadog-exporter-gke-hostname.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change
+note: (Under `exporter.datadog.hostname.preview` feature gate) Make the hostname reported on GKE match the Datadog GCP integration hostname.
+
+# One or more tracking issues related to the change
+issues: [11893]


### PR DESCRIPTION
**Description:** 

Make the Google Cloud hostname provider run correctly on GKE.

**Link to tracking Issue:** Fixes #11893
