### PR TITLE
Bump go version to 1.18 on CI

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,7 @@
 name: build-and-test
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -141,7 +141,6 @@ jobs:
   unittest-matrix:
     strategy:
       matrix:
-        go-version: [1.18, 1.17]
         group:
           - receiver-0
           - receiver-1
@@ -158,7 +157,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -181,9 +180,6 @@ jobs:
       - name: Run Unit Tests
         run: make gotest GROUP=${{ matrix.group }}
   unittest:
-    strategy:
-      matrix:
-        go-version: [1.18, 1.17]
     runs-on: ubuntu-latest
     needs: [setup-environment, unittest-matrix]
     steps:
@@ -199,7 +195,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -220,7 +216,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -246,7 +242,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -302,7 +298,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -433,7 +429,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Mkdir bin and dist
         run: |
           mkdir bin/ dist/
@@ -470,14 +466,14 @@ jobs:
       - name: Build Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-            make docker-otelcontribcol
-            docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
-            docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:latest
+          make docker-otelcontribcol
+          docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
+          docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:latest
       - name: Validate Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-            docker run otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA --version
-            docker run otel/opentelemetry-collector-contrib-dev:latest --version
+          docker run otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA --version
+          docker run otel/opentelemetry-collector-contrib-dev:latest --version
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -486,8 +482,8 @@ jobs:
       - name: Push Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-            docker push otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
-            docker push otel/opentelemetry-collector-contrib-dev:latest
+          docker push otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
+          docker push otel/opentelemetry-collector-contrib-dev:latest
   publish-stable:
     runs-on: ubuntu-latest
     needs: [lint, unittest, integration-tests, build-package]
@@ -498,7 +494,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Mkdir bin and dist
         run: |
           mkdir bin/ dist/

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: prometheus/compliance
           path: compliance
-          ref: f0482884578bac67b053e3eaa1ca7f783d146557 
+          ref: f0482884578bac67b053e3eaa1ca7f783d146557
       - name: Copy binary to compliance directory
         run: mkdir compliance/remote_write_sender/bin && cp ./bin/otelcontribcol_linux_amd64 compliance/remote_write_sender/bin/otelcol_linux_amd64
       - name: Run compliance tests

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3


### PR DESCRIPTION
Some dependancies started using generics, e.g. https://github.com/alecthomas/participle.

We cannot upgrade them if we keep using 1.17 on CI
