### PR TITLE
[prometheusremotewrite] Export `target_info` not `target`

### DIFF
--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -52,7 +52,7 @@ const (
 	traceIDKey       = "trace_id"
 	spanIDKey        = "span_id"
 	infoType         = "info"
-	targetMetricName = "target"
+	targetMetricName = "target_info"
 )
 
 type bucketBoundsData struct {

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -478,11 +478,11 @@ func TestAddResourceTargetInfo(t *testing.T) {
 			resource:  testdata.GenerateMetricsNoLibraries().ResourceMetrics().At(0).Resource(),
 			timestamp: testdata.TestMetricStartTimestamp,
 			expected: map[string]*prompb.TimeSeries{
-				"info-__name__-target-resource_attr-resource-attr-val-1": {
+				"info-__name__-target_info-resource_attr-resource-attr-val-1": {
 					Labels: []prompb.Label{
 						{
 							Name:  "__name__",
-							Value: "target",
+							Value: "target_info",
 						},
 						{
 							Name:  "resource_attr",
@@ -504,11 +504,11 @@ func TestAddResourceTargetInfo(t *testing.T) {
 			timestamp: testdata.TestMetricStartTimestamp,
 			settings:  Settings{Namespace: "foo"},
 			expected: map[string]*prompb.TimeSeries{
-				"info-__name__-foo_target-resource_attr-resource-attr-val-1": {
+				"info-__name__-foo_target_info-resource_attr-resource-attr-val-1": {
 					Labels: []prompb.Label{
 						{
 							Name:  "__name__",
-							Value: "foo_target",
+							Value: "foo_target_info",
 						},
 						{
 							Name:  "resource_attr",
@@ -529,11 +529,11 @@ func TestAddResourceTargetInfo(t *testing.T) {
 			resource:  resourceWithServiceAttrs,
 			timestamp: testdata.TestMetricStartTimestamp,
 			expected: map[string]*prompb.TimeSeries{
-				"info-__name__-target-instance-service-instance-id-job-service-namespace/service-name-resource_attr-resource-attr-val-1": {
+				"info-__name__-target_info-instance-service-instance-id-job-service-namespace/service-name-resource_attr-resource-attr-val-1": {
 					Labels: []prompb.Label{
 						{
 							Name:  "__name__",
-							Value: "target",
+							Value: "target_info",
 						},
 						{
 							Name:  "instance",

--- a/unreleased/prometheusrw-exp-export-target-info.yaml
+++ b/unreleased/prometheusrw-exp-export-target-info.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking 
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change
+note: Export `target_info` not `target` for resource attributes
+
+# One or more tracking issues related to the change
+issues: [ 12079 ]


### PR DESCRIPTION
See: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#supporting-target-metadata-in-both-push-based-and-pull-based-systems
**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12079