### PR TITLE
[sqlqueryreceiver] - add timestamp to metrics 

### DIFF
--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -51,15 +51,17 @@ func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric, ts pcommon.T
 }
 
 func setTimestamp(cfg MetricCfg, dp pmetric.NumberDataPoint, ts pcommon.Timestamp, scrapeCfg scraperhelper.ScraperControllerSettings) {
+	// default is gauge but add ts to all metrics
+	// start time is not needed on gauge metrics
 	dp.SetTimestamp(ts)
 
-	switch cfg.Aggregation {
 	// Cumulative sum should have a start time set to the beginning of the data points cumulation
-	case MetricAggregationCumulative:
+	if cfg.Aggregation == MetricAggregationCumulative && cfg.DataType != MetricDataTypeGauge {
 		dp.SetStartTimestamp(ts)
+	}
 
 	// Non-cumulative sum should have a start time set to the previous endpoint
-	case MetricAggregationDelta:
+	if cfg.Aggregation == MetricAggregationDelta && cfg.DataType != MetricDataTypeGauge {
 		dp.SetStartTimestamp(pcommon.NewTimestampFromTime(ts.AsTime().Add(-scrapeCfg.CollectionInterval)))
 	}
 }

--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -17,20 +17,21 @@ package sqlqueryreceiver // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 // gauge metrics only need a timestamp, not a
-func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric, ts pcommon.Timestamp) error {
+func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric, startTs pcommon.Timestamp) error {
 	dest.SetName(cfg.MetricName)
 	dest.SetDescription(cfg.Description)
 	dest.SetUnit(cfg.Unit)
 	dataPointSlice := setMetricFields(cfg, dest)
 	dataPoint := dataPointSlice.AppendEmpty()
-	dataPoint.SetStartTimestamp(ts)
-	dataPoint.SetTimestamp(ts)
+	dataPoint.SetStartTimestamp(startTs)
+	dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 	value, found := row[cfg.ValueColumn]
 	if !found {
 		return fmt.Errorf("rowToMetric: value_column '%s' not found in result set", cfg.ValueColumn)

--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 )
 
-// gauge metrics only need a timestamp, not a
 func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric, startTime pcommon.Timestamp, ts pcommon.Timestamp, scrapeCfg scraperhelper.ScraperControllerSettings) error {
 	dest.SetName(cfg.MetricName)
 	dest.SetDescription(cfg.Description)

--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -18,15 +18,19 @@ import (
 	"fmt"
 	"strconv"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric) error {
+// gauge metrics only need a timestamp, not a
+func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric, ts pcommon.Timestamp) error {
 	dest.SetName(cfg.MetricName)
 	dest.SetDescription(cfg.Description)
 	dest.SetUnit(cfg.Unit)
 	dataPointSlice := setMetricFields(cfg, dest)
 	dataPoint := dataPointSlice.AppendEmpty()
+	dataPoint.SetStartTimestamp(ts)
+	dataPoint.SetTimestamp(ts)
 	value, found := row[cfg.ValueColumn]
 	if !found {
 		return fmt.Errorf("rowToMetric: value_column '%s' not found in result set", cfg.ValueColumn)

--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -24,13 +24,13 @@ import (
 )
 
 // gauge metrics only need a timestamp, not a
-func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric, ts pcommon.Timestamp, scrapeCfg scraperhelper.ScraperControllerSettings) error {
+func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric, startTime pcommon.Timestamp, ts pcommon.Timestamp, scrapeCfg scraperhelper.ScraperControllerSettings) error {
 	dest.SetName(cfg.MetricName)
 	dest.SetDescription(cfg.Description)
 	dest.SetUnit(cfg.Unit)
 	dataPointSlice := setMetricFields(cfg, dest)
 	dataPoint := dataPointSlice.AppendEmpty()
-	setTimestamp(cfg, dataPoint, ts, scrapeCfg)
+	setTimestamp(cfg, dataPoint, startTime, ts, scrapeCfg)
 	value, found := row[cfg.ValueColumn]
 	if !found {
 		return fmt.Errorf("rowToMetric: value_column '%s' not found in result set", cfg.ValueColumn)
@@ -50,12 +50,12 @@ func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric, ts pcommon.T
 	return nil
 }
 
-func setTimestamp(cfg MetricCfg, dp pmetric.NumberDataPoint, ts pcommon.Timestamp, scrapeCfg scraperhelper.ScraperControllerSettings) {
+func setTimestamp(cfg MetricCfg, dp pmetric.NumberDataPoint, startTime pcommon.Timestamp, ts pcommon.Timestamp, scrapeCfg scraperhelper.ScraperControllerSettings) {
 	dp.SetTimestamp(ts)
 
 	// Cumulative sum should have a start time set to the beginning of the data points cumulation
 	if cfg.Aggregation == MetricAggregationCumulative && cfg.DataType != MetricDataTypeGauge {
-		dp.SetStartTimestamp(ts)
+		dp.SetStartTimestamp(startTime)
 	}
 
 	// Non-cumulative sum should have a start time set to the previous endpoint

--- a/receiver/sqlqueryreceiver/metrics.go
+++ b/receiver/sqlqueryreceiver/metrics.go
@@ -51,8 +51,6 @@ func rowToMetric(row metricRow, cfg MetricCfg, dest pmetric.Metric, ts pcommon.T
 }
 
 func setTimestamp(cfg MetricCfg, dp pmetric.NumberDataPoint, ts pcommon.Timestamp, scrapeCfg scraperhelper.ScraperControllerSettings) {
-	// default is gauge but add ts to all metrics
-	// start time is not needed on gauge metrics
 	dp.SetTimestamp(ts)
 
 	// Cumulative sum should have a start time set to the beginning of the data points cumulation

--- a/receiver/sqlqueryreceiver/receiver.go
+++ b/receiver/sqlqueryreceiver/receiver.go
@@ -44,9 +44,10 @@ func createReceiverFunc(sqlOpenerFunc sqlOpenerFunc, clientProviderFunc clientPr
 		for i, query := range sqlCfg.Queries {
 			id := config.NewComponentIDWithName("sqlqueryreceiver", fmt.Sprintf("query-%d: %s", i, query.SQL))
 			mp := &scraper{
-				id:     id,
-				query:  query,
-				logger: settings.TelemetrySettings.Logger,
+				id:        id,
+				query:     query,
+				scrapeCfg: sqlCfg.ScraperControllerSettings,
+				logger:    settings.TelemetrySettings.Logger,
 				dbProviderFunc: func() (*sql.DB, error) {
 					return sqlOpenerFunc(sqlCfg.Driver, sqlCfg.DataSource)
 				},

--- a/receiver/sqlqueryreceiver/scraper.go
+++ b/receiver/sqlqueryreceiver/scraper.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 	"go.uber.org/multierr"
@@ -64,10 +66,11 @@ func (s scraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 	sms := rm.ScopeMetrics()
 	sm := sms.AppendEmpty()
 	ms := sm.Metrics()
+	ts := pcommon.NewTimestampFromTime(time.Now())
 	var errs error
 	for _, metricCfg := range s.query.Metrics {
 		for i, row := range rows {
-			if err = rowToMetric(row, metricCfg, ms.AppendEmpty()); err != nil {
+			if err = rowToMetric(row, metricCfg, ms.AppendEmpty(), ts); err != nil {
 				err = fmt.Errorf("row %d: %w", i, err)
 				errs = multierr.Append(errs, err)
 			}

--- a/receiver/sqlqueryreceiver/scraper.go
+++ b/receiver/sqlqueryreceiver/scraper.go
@@ -57,6 +57,7 @@ func (s *scraper) Start(context.Context, component.Host) error {
 
 func (s scraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 	out := pmetric.NewMetrics()
+	ts := pcommon.NewTimestampFromTime(time.Now())
 	rows, err := s.client.metricRows(ctx)
 	if err != nil {
 		return out, fmt.Errorf("scraper: %w", err)
@@ -66,7 +67,6 @@ func (s scraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 	sms := rm.ScopeMetrics()
 	sm := sms.AppendEmpty()
 	ms := sm.Metrics()
-	ts := pcommon.NewTimestampFromTime(time.Now())
 	var errs error
 	for _, metricCfg := range s.query.Metrics {
 		for i, row := range rows {

--- a/receiver/sqlqueryreceiver/scraper.go
+++ b/receiver/sqlqueryreceiver/scraper.go
@@ -32,6 +32,7 @@ import (
 type scraper struct {
 	id                 config.ComponentID
 	query              Query
+	scrapeCfg          scraperhelper.ScraperControllerSettings
 	clientProviderFunc clientProviderFunc
 	dbProviderFunc     dbProviderFunc
 	logger             *zap.Logger
@@ -70,7 +71,7 @@ func (s scraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 	var errs error
 	for _, metricCfg := range s.query.Metrics {
 		for i, row := range rows {
-			if err = rowToMetric(row, metricCfg, ms.AppendEmpty(), ts); err != nil {
+			if err = rowToMetric(row, metricCfg, ms.AppendEmpty(), ts, s.scrapeCfg); err != nil {
 				err = fmt.Errorf("row %d: %w", i, err)
 				errs = multierr.Append(errs, err)
 			}

--- a/unreleased/sqlqr-ts.yaml
+++ b/unreleased/sqlqr-ts.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: sqlqueryreceiver
 
 # A brief description of the change
-note: Metrics did not container a timestamp. Timestamps are required for a variety of backends, especially prometheus. In order to work with prometheus we must set the metrics timestamp because metrics with the default timestamp (year 1970) will be dropped by prometheus backends. 
+note: Metrics did not contain a timestamp. Timestamps are required for a variety of backends, especially prometheus. In order to work with prometheus we must set the metrics timestamp because metrics with the default timestamp (year 1970) will be dropped by prometheus backends. 
 
 # One or more tracking issues related to the change
 issues: [12088]

--- a/unreleased/sqlqr-ts.yaml
+++ b/unreleased/sqlqr-ts.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: sqlqueryreceiver
 
 # A brief description of the change
-note: Metrics did not container a timestamp. Timestampts are required for a variety of backends, especially prometheus. In order to work with prometheus we must set the metrics timestamp because metrics with the default timestamp (year 1970) will be dropped by prometheus backends. 
+note: Metrics did not container a timestamp. Timestamps are required for a variety of backends, especially prometheus. In order to work with prometheus we must set the metrics timestamp because metrics with the default timestamp (year 1970) will be dropped by prometheus backends. 
 
 # One or more tracking issues related to the change
 issues: [12088]

--- a/unreleased/sqlqr-ts.yaml
+++ b/unreleased/sqlqr-ts.yaml
@@ -2,11 +2,10 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: `sqlqueryreceiver`
+component: sqlqueryreceiver
 
 # A brief description of the change
-note: Metrics did not container a timestamp. Timestampts are required for a variety of backends, especially prometheus. In order to work with prometheus we must set the metrics timestamp
-because metrics with the default timestamp (year 1970) will be dropped by prometheus backends. 
+note: Metrics did not container a timestamp. Timestampts are required for a variety of backends, especially prometheus. In order to work with prometheus we must set the metrics timestamp because metrics with the default timestamp (year 1970) will be dropped by prometheus backends. 
 
 # One or more tracking issues related to the change
-issues: [#12088]
+issues: [12088]

--- a/unreleased/sqlqr-ts.yaml
+++ b/unreleased/sqlqr-ts.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: `sqlqueryreceiver`
+
+# A brief description of the change
+note: Metrics did not container a timestamp. Timestampts are required for a variety of backends, especially prometheus. In order to work with prometheus we must set the metrics timestamp
+because metrics with the default timestamp (year 1970) will be dropped by prometheus backends. 
+
+# One or more tracking issues related to the change
+issues: [#12088]


### PR DESCRIPTION
**Description:** 
Fixing a bug - Make sure metrics have a timestamp attribute. Prometheus refuses metrics whose timestamps exceed x amount of minutes and the default timestamp is yea 1970 so metrics get dropped

**Testing:** 
- validate that metrics contain a timestamp and are acceptable from prometheus
