### PR TITLE
add stability level to components

### DIFF
--- a/exporter/alibabacloudlogserviceexporter/factory.go
+++ b/exporter/alibabacloudlogserviceexporter/factory.go
@@ -24,6 +24,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "alibabacloud_logservice"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for AlibabaCloud LogService exporter.
@@ -31,9 +33,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability))
 }
 
 // CreateDefaultConfig creates the default configuration for exporter.

--- a/exporter/awscloudwatchlogsexporter/factory.go
+++ b/exporter/awscloudwatchlogsexporter/factory.go
@@ -27,13 +27,17 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil"
 )
 
-const typeStr = "awscloudwatchlogs"
+const (
+	typeStr = "awscloudwatchlogs"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
+)
 
 func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter))
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/awsemfexporter/factory.go
+++ b/exporter/awsemfexporter/factory.go
@@ -26,6 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "awsemf"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for AWS EMF exporter.
@@ -33,7 +35,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsExporter(createMetricsExporter))
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability))
 }
 
 // CreateDefaultConfig creates the default configuration for exporter.

--- a/exporter/awskinesisexporter/factory.go
+++ b/exporter/awskinesisexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "awskinesis"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 
 	defaultEncoding    = "otlp"
 	defaultCompression = "none"
@@ -37,9 +39,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(NewTracesExporter),
-		component.WithMetricsExporter(NewMetricsExporter),
-		component.WithLogsExporter(NewLogsExporter),
+		component.WithTracesExporterAndStabilityLevel(NewTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(NewMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(NewLogsExporter, stability),
 	)
 }
 

--- a/exporter/awsxrayexporter/factory.go
+++ b/exporter/awsxrayexporter/factory.go
@@ -26,6 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "awsxray"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for AWS-Xray exporter.
@@ -33,7 +35,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -43,8 +43,8 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(f.createTracesExporter),
-		component.WithLogsExporter(f.createLogsExporter))
+		component.WithTracesExporterAndStabilityLevel(f.createTracesExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(f.createLogsExporter, stability))
 }
 
 // Implements the interface from go.opentelemetry.io/collector/exporter/factory.go

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -27,7 +27,9 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr         = "azuremonitor"
+	typeStr = "azuremonitor"
+	// The stability level of the exporter.
+	stability       = component.StabilityLevelBeta
 	defaultEndpoint = "https://dc.services.visualstudio.com/v2/track"
 )
 

--- a/exporter/carbonexporter/factory.go
+++ b/exporter/carbonexporter/factory.go
@@ -24,6 +24,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "carbon"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for Carbon exporter.
@@ -31,7 +33,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsExporter(createMetricsExporter))
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/clickhouseexporter/factory.go
+++ b/exporter/clickhouseexporter/factory.go
@@ -26,6 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "clickhouse"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelAlpha
 )
 
 // NewFactory creates a factory for Elastic exporter.
@@ -33,7 +35,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
 	)
 }
 

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -17,6 +17,7 @@ package coralogixexporter // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -24,6 +25,8 @@ import (
 
 const (
 	typeStr = "coralogix"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // Config defines by Coralogix.

--- a/exporter/coralogixexporter/factory.go
+++ b/exporter/coralogixexporter/factory.go
@@ -30,8 +30,8 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTraceExporter),
-		component.WithMetricsExporter(createMetricsExporter),
+		component.WithTracesExporterAndStabilityLevel(createTraceExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
 	)
 }
 

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -41,6 +41,8 @@ import (
 const (
 	// typeStr is the type of the exporter
 	typeStr = "datadog"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 type factory struct {
@@ -65,8 +67,8 @@ func newFactoryWithRegistry(registry *featuregate.Registry) component.ExporterFa
 	return component.NewExporterFactory(
 		typeStr,
 		f.createDefaultConfig,
-		component.WithMetricsExporter(f.createMetricsExporter),
-		component.WithTracesExporter(f.createTracesExporter),
+		component.WithMetricsExporterAndStabilityLevel(f.createMetricsExporter, stability),
+		component.WithTracesExporterAndStabilityLevel(f.createTracesExporter, stability),
 	)
 }
 

--- a/exporter/dynatraceexporter/factory.go
+++ b/exporter/dynatraceexporter/factory.go
@@ -29,6 +29,8 @@ import (
 const (
 	// typeStr is the type of the exporter
 	typeStr = "dynatrace"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a Dynatrace exporter factory
@@ -36,7 +38,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsExporter(createMetricsExporter),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
 	)
 }
 

--- a/exporter/elasticexporter/factory.go
+++ b/exporter/elasticexporter/factory.go
@@ -26,6 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "elastic"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelDeprecated
 )
 
 var once sync.Once
@@ -35,8 +37,8 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
 	)
 }
 

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "elasticsearch"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for Elastic exporter.
@@ -34,7 +36,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
 	)
 }
 

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "file"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelAlpha
 )
 
 // NewFactory creates a factory for OTLP exporter.
@@ -34,9 +36,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -27,7 +27,9 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr                  = "googlecloud"
+	typeStr = "googlecloud"
+	// The stability level of the exporter.
+	stability                = component.StabilityLevelBeta
 	defaultTimeout           = 12 * time.Second // Consistent with Cloud Monitoring's timeout
 	pdataExporterFeatureGate = "exporter.googlecloud.OTLPDirect"
 )
@@ -45,9 +47,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
 	)
 }
 

--- a/exporter/googlecloudpubsubexporter/factory.go
+++ b/exporter/googlecloudpubsubexporter/factory.go
@@ -31,7 +31,9 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr        = "googlecloudpubsub"
+	typeStr = "googlecloudpubsub"
+	// The stability level of the exporter.
+	stability      = component.StabilityLevelBeta
 	defaultTimeout = 12 * time.Second
 )
 
@@ -40,9 +42,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability))
 }
 
 var exporters = map[*Config]*pubsubExporter{}

--- a/exporter/googlemanagedprometheusexporter/factory.go
+++ b/exporter/googlemanagedprometheusexporter/factory.go
@@ -26,7 +26,9 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr        = "googlemanagedprometheus"
+	typeStr = "googlemanagedprometheus"
+	// The stability level of the exporter.
+	stability      = component.StabilityLevelAlpha
 	defaultTimeout = 12 * time.Second // Consistent with Cloud Monitoring's timeout
 )
 
@@ -35,7 +37,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsExporter(createMetricsExporter),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
 	)
 }
 

--- a/exporter/honeycombexporter/factory.go
+++ b/exporter/honeycombexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "honeycomb"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelDeprecated
 )
 
 var once sync.Once
@@ -36,7 +38,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability))
 }
 
 func logDeprecation(logger *zap.Logger) {

--- a/exporter/humioexporter/factory.go
+++ b/exporter/humioexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The key used to refer to this exporter
 	typeStr = "humio"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates an exporter factory for Humio
@@ -34,7 +36,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
 	)
 }
 

--- a/exporter/influxdbexporter/config.go
+++ b/exporter/influxdbexporter/config.go
@@ -17,6 +17,7 @@ package influxdbexporter // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -25,6 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "influxdb"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // Config defines configuration for the InfluxDB exporter.

--- a/exporter/influxdbexporter/factory.go
+++ b/exporter/influxdbexporter/factory.go
@@ -29,9 +29,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTraceExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter),
+		component.WithTracesExporterAndStabilityLevel(createTraceExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
 	)
 }
 

--- a/exporter/jaegerexporter/factory.go
+++ b/exporter/jaegerexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "jaeger"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for Jaeger exporter
@@ -34,7 +36,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/jaegerthrifthttpexporter/factory.go
+++ b/exporter/jaegerthrifthttpexporter/factory.go
@@ -28,6 +28,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "jaeger_thrift"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for Jaeger Thrift over HTTP exporter.
@@ -35,7 +37,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -26,7 +26,9 @@ import (
 )
 
 const (
-	typeStr             = "kafka"
+	typeStr = "kafka"
+	// The stability level of the exporter.
+	stability           = component.StabilityLevelBeta
 	defaultTracesTopic  = "otlp_spans"
 	defaultMetricsTopic = "otlp_metrics"
 	defaultLogsTopic    = "otlp_logs"

--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -75,9 +75,9 @@ func NewFactory(options ...FactoryOption) component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(f.createTracesExporter),
-		component.WithMetricsExporter(f.createMetricsExporter),
-		component.WithLogsExporter(f.createLogsExporter),
+		component.WithTracesExporterAndStabilityLevel(f.createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(f.createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(f.createLogsExporter, stability),
 	)
 }
 

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "loadbalancing"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for the exporter.
@@ -36,8 +38,8 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithLogsExporter(createLogExporter),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogExporter, stability),
 	)
 }
 

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -212,13 +212,13 @@ func TestAddMissingExporters(t *testing.T) {
 	cfg := simpleConfig()
 	exporterFactory := component.NewExporterFactory("otlp", func() config.Exporter {
 		return &otlpexporter.Config{}
-	}, component.WithTracesExporter(func(
+	}, component.WithTracesExporterAndStabilityLevel(func(
 		_ context.Context,
 		_ component.ExporterCreateSettings,
 		_ config.Exporter,
 	) (component.TracesExporter, error) {
 		return newNopMockTracesExporter(), nil
-	}))
+	}, component.StabilityLevelInDevelopment))
 	fn := func(ctx context.Context, endpoint string) (component.Exporter, error) {
 		oCfg := cfg.Protocol.OTLP
 		oCfg.Endpoint = endpoint
@@ -246,13 +246,13 @@ func TestFailedToAddMissingExporters(t *testing.T) {
 	expectedErr := errors.New("some expected error")
 	exporterFactory := component.NewExporterFactory("otlp", func() config.Exporter {
 		return &otlpexporter.Config{}
-	}, component.WithTracesExporter(func(
+	}, component.WithTracesExporterAndStabilityLevel(func(
 		_ context.Context,
 		_ component.ExporterCreateSettings,
 		_ config.Exporter,
 	) (component.TracesExporter, error) {
 		return nil, expectedErr
-	}))
+	}, component.StabilityLevelInDevelopment))
 	fn := func(ctx context.Context, endpoint string) (component.Exporter, error) {
 		oCfg := cfg.Protocol.OTLP
 		oCfg.Endpoint = endpoint

--- a/exporter/logzioexporter/factory.go
+++ b/exporter/logzioexporter/factory.go
@@ -30,15 +30,19 @@ import (
 	"go.opentelemetry.io/collector/config"
 )
 
-const typeStr = "logzio"
+const (
+	typeStr = "logzio"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
+)
 
 // NewFactory creates a factory for Logz.io exporter.
 func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, component.StabilityLevelBeta))
 
 }
 

--- a/exporter/lokiexporter/factory.go
+++ b/exporter/lokiexporter/factory.go
@@ -24,14 +24,18 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
-const typeStr = "loki"
+const (
+	typeStr = "loki"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
+)
 
 // NewFactory creates a factory for Loki exporter.
 func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
 	)
 }
 

--- a/exporter/mezmoexporter/factory.go
+++ b/exporter/mezmoexporter/factory.go
@@ -23,14 +23,18 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
-const typeStr = "mezmo"
+const (
+	typeStr = "mezmo"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
+)
 
 // NewFactory creates a factory for Mezmo exporter.
 func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
 	)
 }
 

--- a/exporter/observiqexporter/factory.go
+++ b/exporter/observiqexporter/factory.go
@@ -25,7 +25,9 @@ import (
 )
 
 const (
-	typeStr              = "observiq"
+	typeStr = "observiq"
+	// The stability level of the exporter.
+	stability            = component.StabilityLevelDeprecated
 	defaultHTTPTimeout   = 20 * time.Second
 	defaultEndpoint      = "https://nozzle.app.observiq.com/v1/add"
 	defaultDialerTimeout = 10 * time.Second
@@ -36,7 +38,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
 	)
 }
 

--- a/exporter/opencensusexporter/factory.go
+++ b/exporter/opencensusexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "opencensus"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for OTLP exporter.
@@ -34,8 +36,8 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/parquetexporter/factory.go
+++ b/exporter/parquetexporter/factory.go
@@ -25,6 +25,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "parquet"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelInDevelopment
 )
 
 type Config struct {
@@ -37,9 +39,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/prometheusexporter/factory.go
+++ b/exporter/prometheusexporter/factory.go
@@ -29,6 +29,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "prometheus"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a new Prometheus exporter factory.
@@ -36,7 +38,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsExporter(createMetricsExporter))
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -30,6 +30,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "prometheusremotewrite"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a new Prometheus Remote Write exporter.
@@ -37,7 +39,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsExporter(createMetricsExporter))
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability))
 }
 
 func createMetricsExporter(_ context.Context, set component.ExporterCreateSettings,

--- a/exporter/sapmexporter/factory.go
+++ b/exporter/sapmexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "sapm"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for SAPM exporter.
@@ -34,7 +36,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/sentryexporter/factory.go
+++ b/exporter/sentryexporter/factory.go
@@ -24,6 +24,8 @@ import (
 
 const (
 	typeStr = "sentry"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for Sentry exporter.
@@ -31,7 +33,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
 	)
 }
 

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -37,6 +37,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "signalfx"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 
 	defaultHTTPTimeout = time.Second * 5
 )
@@ -46,9 +48,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter),
-		component.WithTracesExporter(createTracesExporter),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
 	)
 }
 

--- a/exporter/skywalkingexporter/factory.go
+++ b/exporter/skywalkingexporter/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "skywalking"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for Skywalking exporter.
@@ -34,8 +36,8 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter),
-		component.WithMetricsExporter(createMetricsExporter))
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -31,7 +31,9 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr            = "splunk_hec"
+	typeStr = "splunk_hec"
+	// The stability level of the exporter.
+	stability          = component.StabilityLevelBeta
 	defaultMaxIdleCons = 100
 	defaultHTTPTimeout = 10 * time.Second
 )
@@ -53,9 +55,9 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
-		component.WithLogsExporter(createLogsExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/exporter/sumologicexporter/factory.go
+++ b/exporter/sumologicexporter/factory.go
@@ -26,6 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "sumologic"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory returns a new factory for the sumologic exporter.
@@ -33,8 +35,8 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter),
-		component.WithMetricsExporter(createMetricsExporter),
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
 	)
 }
 

--- a/exporter/tanzuobservabilityexporter/factory.go
+++ b/exporter/tanzuobservabilityexporter/factory.go
@@ -25,15 +25,19 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry"
 )
 
-const exporterType = "tanzuobservability"
+const (
+	exporterType = "tanzuobservability"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
+)
 
 // NewFactory creates a factory for the exporter.
 func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		exporterType,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter),
-		component.WithMetricsExporter(createMetricsExporter),
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability),
+		component.WithMetricsExporterAndStabilityLevel(createMetricsExporter, stability),
 	)
 }
 

--- a/exporter/tencentcloudlogserviceexporter/factory.go
+++ b/exporter/tencentcloudlogserviceexporter/factory.go
@@ -24,6 +24,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "tencentcloud_logservice"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for tencentcloud LogService exporter.
@@ -31,7 +33,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsExporter(createLogsExporter))
+		component.WithLogsExporterAndStabilityLevel(createLogsExporter, stability))
 }
 
 // CreateDefaultConfig creates the default configuration for exporter.

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -28,6 +28,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "zipkin"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 
 	defaultTimeout = time.Second * 5
 
@@ -41,7 +43,7 @@ func NewFactory() component.ExporterFactory {
 	return component.NewExporterFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesExporter(createTracesExporter))
+		component.WithTracesExporterAndStabilityLevel(createTracesExporter, stability))
 }
 
 func createDefaultConfig() config.Exporter {

--- a/pkg/stanza/adapter/factory.go
+++ b/pkg/stanza/adapter/factory.go
@@ -35,11 +35,11 @@ type LogReceiverType interface {
 }
 
 // NewFactory creates a factory for a Stanza-based receiver
-func NewFactory(logReceiverType LogReceiverType) component.ReceiverFactory {
+func NewFactory(logReceiverType LogReceiverType, sl component.StabilityLevel) component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		logReceiverType.Type(),
 		logReceiverType.CreateDefaultConfig,
-		component.WithLogsReceiver(createLogsReceiver(logReceiverType)),
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver(logReceiverType), sl),
 	)
 }
 

--- a/pkg/stanza/adapter/factory_test.go
+++ b/pkg/stanza/adapter/factory_test.go
@@ -20,13 +20,14 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 )
 
 func TestCreateReceiver(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		factory := NewFactory(TestReceiverType{})
+		factory := NewFactory(TestReceiverType{}, component.StabilityLevelInDevelopment)
 		cfg := factory.CreateDefaultConfig().(*TestConfig)
 		cfg.Operators = []map[string]interface{}{
 			{
@@ -39,7 +40,7 @@ func TestCreateReceiver(t *testing.T) {
 	})
 
 	t.Run("Success with ConverterConfig", func(t *testing.T) {
-		factory := NewFactory(TestReceiverType{})
+		factory := NewFactory(TestReceiverType{}, component.StabilityLevelInDevelopment)
 		cfg := factory.CreateDefaultConfig().(*TestConfig)
 		cfg.Converter = ConverterConfig{
 			MaxFlushCount: 1,
@@ -51,7 +52,7 @@ func TestCreateReceiver(t *testing.T) {
 	})
 
 	t.Run("DecodeInputConfigFailure", func(t *testing.T) {
-		factory := NewFactory(TestReceiverType{})
+		factory := NewFactory(TestReceiverType{}, component.StabilityLevelInDevelopment)
 		badCfg := factory.CreateDefaultConfig().(*TestConfig)
 		badCfg.Input = map[string]interface{}{
 			"type": "unknown",
@@ -62,7 +63,7 @@ func TestCreateReceiver(t *testing.T) {
 	})
 
 	t.Run("DecodeOperatorConfigsFailureMissingFields", func(t *testing.T) {
-		factory := NewFactory(TestReceiverType{})
+		factory := NewFactory(TestReceiverType{}, component.StabilityLevelInDevelopment)
 		badCfg := factory.CreateDefaultConfig().(*TestConfig)
 		badCfg.Operators = []map[string]interface{}{
 			{

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.uber.org/zap"
@@ -36,7 +37,7 @@ import (
 func TestStart(t *testing.T) {
 	mockConsumer := &consumertest.LogsSink{}
 
-	factory := NewFactory(TestReceiverType{})
+	factory := NewFactory(TestReceiverType{}, component.StabilityLevelInDevelopment)
 
 	logsReceiver, err := factory.CreateLogsReceiver(
 		context.Background(),
@@ -65,7 +66,7 @@ func TestStart(t *testing.T) {
 func TestHandleStartError(t *testing.T) {
 	mockConsumer := &consumertest.LogsSink{}
 
-	factory := NewFactory(TestReceiverType{})
+	factory := NewFactory(TestReceiverType{}, component.StabilityLevelInDevelopment)
 
 	cfg := factory.CreateDefaultConfig().(*TestConfig)
 	cfg.Input = newUnstartableParams()
@@ -79,7 +80,7 @@ func TestHandleStartError(t *testing.T) {
 
 func TestHandleConsumeError(t *testing.T) {
 	mockConsumer := &mockLogsRejecter{}
-	factory := NewFactory(TestReceiverType{})
+	factory := NewFactory(TestReceiverType{}, component.StabilityLevelInDevelopment)
 
 	logsReceiver, err := factory.CreateLogsReceiver(context.Background(), componenttest.NewNopReceiverCreateSettings(), factory.CreateDefaultConfig(), mockConsumer)
 	require.NoError(t, err, "receiver should successfully build")

--- a/pkg/stanza/adapter/storage_test.go
+++ b/pkg/stanza/adapter/storage_test.go
@@ -82,7 +82,7 @@ func createReceiver(t *testing.T) *receiver {
 		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 	}
 
-	factory := NewFactory(TestReceiverType{})
+	factory := NewFactory(TestReceiverType{}, component.StabilityLevelInDevelopment)
 
 	logsReceiver, err := factory.CreateLogsReceiver(
 		context.Background(),

--- a/processor/attributesprocessor/factory.go
+++ b/processor/attributesprocessor/factory.go
@@ -32,6 +32,8 @@ import (
 const (
 	// typeStr is the value of "type" key in configuration.
 	typeStr = "attributes"
+	// The stability level of the processor.
+	stability = component.StabilityLevelAlpha
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -41,9 +43,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithLogsProcessor(createLogProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability),
+		component.WithLogsProcessorAndStabilityLevel(createLogProcessor, stability),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability))
 }
 
 // Note: This isn't a valid configuration because the processor would do no work.

--- a/processor/cumulativetodeltaprocessor/factory.go
+++ b/processor/cumulativetodeltaprocessor/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "cumulativetodelta"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -36,7 +38,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsProcessor(createMetricsProcessor))
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability))
 }
 
 func createDefaultConfig() config.Processor {

--- a/processor/deltatorateprocessor/factory.go
+++ b/processor/deltatorateprocessor/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "deltatorate"
+	// The stability level of the processor.
+	stability = component.StabilityLevelInDevelopment
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -36,7 +38,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsProcessor(createMetricsProcessor))
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability))
 }
 
 func createDefaultConfig() config.Processor {

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -26,6 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "filter"
+	// The stability level of the processor.
+	stability = component.StabilityLevelAlpha
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -35,9 +37,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsProcessor(createMetricsProcessor),
-		component.WithLogsProcessor(createLogsProcessor),
-		component.WithTracesProcessor(createTracesProcessor),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stability),
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability),
 	)
 }
 

--- a/processor/groupbyattrsprocessor/factory.go
+++ b/processor/groupbyattrsprocessor/factory.go
@@ -29,6 +29,8 @@ import (
 const (
 	// typeStr is the value of "type" for this processor in the configuration.
 	typeStr config.Type = "groupbyattrs"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
 )
 
 var (
@@ -47,9 +49,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithLogsProcessor(createLogsProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stability),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability))
 }
 
 // createDefaultConfig creates the default configuration for the processor.

--- a/processor/groupbytraceprocessor/factory.go
+++ b/processor/groupbytraceprocessor/factory.go
@@ -28,6 +28,8 @@ import (
 const (
 	// typeStr is the value of "type" for this processor in the configuration.
 	typeStr config.Type = "groupbytrace"
+	// The stability level of the processor.
+	stability = component.StabilityLevelInDevelopment
 
 	defaultWaitDuration   = time.Second
 	defaultNumTraces      = 1_000_000
@@ -49,7 +51,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability))
 }
 
 // createDefaultConfig creates the default configuration for the processor.

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -32,6 +32,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "k8sattributes"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
 )
 
 var kubeClientProvider = kube.ClientProvider(nil)
@@ -43,9 +45,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor),
-		component.WithLogsProcessor(createLogsProcessor),
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stability),
 	)
 }
 

--- a/processor/logstransformprocessor/factory.go
+++ b/processor/logstransformprocessor/factory.go
@@ -30,6 +30,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "logstransform"
+	// The stability level of the processor.
+	stability = component.StabilityLevelInDevelopment
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -39,7 +41,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsProcessor(createLogsProcessor))
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stability))
 }
 
 // Note: This isn't a valid configuration because the processor would do no work.

--- a/processor/metricsgenerationprocessor/factory.go
+++ b/processor/metricsgenerationprocessor/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "experimental_metricsgeneration"
+	// The stability level of the processor.
+	stability = component.StabilityLevelInDevelopment
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -36,7 +38,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsProcessor(createMetricsProcessor))
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability))
 }
 
 func createDefaultConfig() config.Processor {

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -29,6 +29,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "metricstransform"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
 )
 
 var consumerCapabilities = consumer.Capabilities{MutatesData: true}
@@ -38,7 +40,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsProcessor(createMetricsProcessor))
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability))
 }
 
 func createDefaultConfig() config.Processor {

--- a/processor/probabilisticsamplerprocessor/factory.go
+++ b/processor/probabilisticsamplerprocessor/factory.go
@@ -25,6 +25,8 @@ import (
 const (
 	// The value of "type" trace-samplers in configuration.
 	typeStr = "probabilistic_sampler"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory returns a new factory for the Probabilistic sampler processor.
@@ -32,7 +34,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability))
 }
 
 func createDefaultConfig() config.Processor {

--- a/processor/redactionprocessor/factory.go
+++ b/processor/redactionprocessor/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "redaction"
+	// The stability level of the exporter.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for the redaction processor.
@@ -34,7 +36,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability),
 	)
 }
 

--- a/processor/resourcedetectionprocessor/factory.go
+++ b/processor/resourcedetectionprocessor/factory.go
@@ -43,6 +43,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "resourcedetection"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
 )
 
 var consumerCapabilities = consumer.Capabilities{MutatesData: true}
@@ -83,9 +85,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(f.createTracesProcessor),
-		component.WithMetricsProcessor(f.createMetricsProcessor),
-		component.WithLogsProcessor(f.createLogsProcessor))
+		component.WithTracesProcessorAndStabilityLevel(f.createTracesProcessor, stability),
+		component.WithMetricsProcessorAndStabilityLevel(f.createMetricsProcessor, stability),
+		component.WithLogsProcessorAndStabilityLevel(f.createLogsProcessor, stability))
 }
 
 // Type gets the type of the Option config created by this factory.

--- a/processor/resourceprocessor/factory.go
+++ b/processor/resourceprocessor/factory.go
@@ -29,6 +29,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "resource"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -38,9 +40,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor),
-		component.WithLogsProcessor(createLogsProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stability))
 }
 
 // Note: This isn't a valid configuration because the processor would do no work.

--- a/processor/routingprocessor/factory.go
+++ b/processor/routingprocessor/factory.go
@@ -26,6 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "routing"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for the routing processor.
@@ -33,9 +35,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor),
-		component.WithLogsProcessor(createLogsProcessor),
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stability),
 	)
 }
 

--- a/processor/schemaprocessor/factory.go
+++ b/processor/schemaprocessor/factory.go
@@ -23,7 +23,11 @@ import (
 	"go.opentelemetry.io/collector/processor/processorhelper"
 )
 
-const typeStr = "schema"
+const (
+	typeStr = "schema"
+	// The stability level of the processor.
+	stability = component.StabilityLevelInDevelopment
+)
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
 
@@ -43,9 +47,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		newDefaultConfiguration,
-		component.WithLogsProcessor(f.createLogsProcessor),
-		component.WithMetricsProcessor(f.createMetricsProcessor),
-		component.WithTracesProcessor(f.createTracesProcessor),
+		component.WithLogsProcessorAndStabilityLevel(f.createLogsProcessor, stability),
+		component.WithMetricsProcessorAndStabilityLevel(f.createMetricsProcessor, stability),
+		component.WithTracesProcessorAndStabilityLevel(f.createTracesProcessor, stability),
 	)
 }
 

--- a/processor/spanmetricsprocessor/factory.go
+++ b/processor/spanmetricsprocessor/factory.go
@@ -26,6 +26,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "spanmetrics"
+	// The stability level of the processor.
+	stability = component.StabilityLevelInDevelopment
 )
 
 // NewFactory creates a factory for the spanmetrics processor.
@@ -33,7 +35,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor),
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability),
 	)
 }
 

--- a/processor/spanprocessor/factory.go
+++ b/processor/spanprocessor/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// typeStr is the value of "type" Span processor in the configuration.
 	typeStr = "span"
+	// The stability level of the processor.
+	stability = component.StabilityLevelAlpha
 )
 
 const (
@@ -53,7 +55,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability))
 }
 
 func createDefaultConfig() config.Processor {

--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -29,6 +29,8 @@ import (
 const (
 	// The value of "type" Tail Sampling in configuration.
 	typeStr = "tail_sampling"
+	// The stability level of the processor.
+	stability = component.StabilityLevelBeta
 )
 
 var onceMetrics sync.Once
@@ -43,7 +45,7 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesProcessor(createTracesProcessor))
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability))
 }
 
 func createDefaultConfig() config.Processor {

--- a/processor/transformprocessor/factory.go
+++ b/processor/transformprocessor/factory.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	typeStr = "transform"
+	typeStr   = "transform"
+	stability = component.StabilityLevelAlpha
 )
 
 var processorCapabilities = consumer.Capabilities{MutatesData: true}
@@ -39,9 +40,9 @@ func NewFactory() component.ProcessorFactory {
 	return component.NewProcessorFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsProcessor(createLogsProcessor),
-		component.WithTracesProcessor(createTracesProcessor),
-		component.WithMetricsProcessor(createMetricsProcessor),
+		component.WithLogsProcessorAndStabilityLevel(createLogsProcessor, stability),
+		component.WithTracesProcessorAndStabilityLevel(createTracesProcessor, stability),
+		component.WithMetricsProcessorAndStabilityLevel(createMetricsProcessor, stability),
 	)
 }
 

--- a/receiver/activedirectorydsreceiver/factory.go
+++ b/receiver/activedirectorydsreceiver/factory.go
@@ -27,13 +27,14 @@ import (
 const (
 	defaultCollectionInterval = 10 * time.Second
 	typeStr                   = "active_directory_ds"
+	stability                 = component.StabilityLevelBeta
 )
 
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
 	)
 }
 

--- a/receiver/aerospikereceiver/factory.go
+++ b/receiver/aerospikereceiver/factory.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	typeStr                      = "aerospike"
+	stability                    = component.StabilityLevelAlpha
 	defaultEndpoint              = "localhost:3000"
 	defaultTimeout               = 20 * time.Second
 	defaultCollectClusterMetrics = false
@@ -38,7 +39,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
 	)
 }
 

--- a/receiver/apachereceiver/factory.go
+++ b/receiver/apachereceiver/factory.go
@@ -27,14 +27,17 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver/internal/metadata"
 )
 
-const typeStr = "apache"
+const (
+	typeStr   = "apache"
+	stability = component.StabilityLevelBeta
+)
 
 // NewFactory creates a factory for apache receiver.
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/awscontainerinsightreceiver/factory.go
+++ b/receiver/awscontainerinsightreceiver/factory.go
@@ -28,6 +28,9 @@ const (
 	// Key to invoke this receiver
 	typeStr = "awscontainerinsightreceiver"
 
+	// The stability of this receiver
+	stability = component.StabilityLevelBeta
+
 	// Default collection interval. Every 60s the receiver will collect metrics
 	defaultCollectionInterval = 60 * time.Second
 
@@ -49,7 +52,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 // createDefaultConfig returns a default config for the receiver.

--- a/receiver/awsecscontainermetricsreceiver/factory.go
+++ b/receiver/awsecscontainermetricsreceiver/factory.go
@@ -33,6 +33,9 @@ const (
 	// Key to invoke this receiver (awsecscontainermetrics)
 	typeStr = "awsecscontainermetrics"
 
+	// Stability level of the receiver
+	stability = component.StabilityLevelBeta
+
 	// Default collection interval. Every 20s the receiver will collect metrics from Amazon ECS Task Metadata Endpoint
 	defaultCollectionInterval = 20 * time.Second
 )
@@ -42,7 +45,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 // createDefaultConfig returns a default config for the receiver.

--- a/receiver/awsfirehosereceiver/factory.go
+++ b/receiver/awsfirehosereceiver/factory.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	typeStr           = "awsfirehose"
+	stability         = component.StabilityLevelAlpha
 	defaultRecordType = cwmetricstream.TypeStr
 	defaultEndpoint   = "0.0.0.0:4433"
 )
@@ -47,7 +48,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 // validateRecordType checks the available record types for the

--- a/receiver/awsxrayreceiver/factory.go
+++ b/receiver/awsxrayreceiver/factory.go
@@ -32,7 +32,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		awsxray.TypeStr,
 		createDefaultConfig,
-		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, awsxray.Stability))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, component.StabilityLevelBeta))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/awsxrayreceiver/factory.go
+++ b/receiver/awsxrayreceiver/factory.go
@@ -32,7 +32,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		awsxray.TypeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(createTracesReceiver))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, awsxray.Stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/bigipreceiver/factory.go
+++ b/receiver/bigipreceiver/factory.go
@@ -28,7 +28,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver/internal/metadata"
 )
 
-const typeStr = "bigip"
+const (
+	typeStr   = "bigip"
+	stability = component.StabilityLevelBeta
+)
 
 var errConfigNotBigip = errors.New("config was not a Big-IP receiver config")
 
@@ -37,7 +40,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 // createDefaultConfig creates a config for Big-IP with as many default values as possible

--- a/receiver/carbonreceiver/factory.go
+++ b/receiver/carbonreceiver/factory.go
@@ -31,6 +31,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "carbon"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelStable
 )
 
 // NewFactory creates a factory for Carbon receiver.
@@ -38,7 +40,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/cloudfoundryreceiver/factory.go
+++ b/receiver/cloudfoundryreceiver/factory.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	typeStr                  = "cloudfoundry"
+	stability                = component.StabilityLevelBeta
 	defaultUAAUsername       = "admin"
 	defaultRLPGatewayShardID = "opentelemetry"
 	defaultURL               = "https://localhost"
@@ -38,7 +39,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/collectdreceiver/factory.go
+++ b/receiver/collectdreceiver/factory.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	typeStr               = "collectd"
+	stability             = component.StabilityLevelAlpha
 	defaultBindEndpoint   = "localhost:8081"
 	defaultTimeout        = time.Second * 30
 	defaultEncodingFormat = "json"
@@ -40,7 +41,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 func createDefaultConfig() config.Receiver {
 	return &Config{

--- a/receiver/couchdbreceiver/factory.go
+++ b/receiver/couchdbreceiver/factory.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	typeStr = "couchdb"
+	typeStr   = "couchdb"
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates the couchdbreceiver factory
@@ -37,7 +38,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/dockerstatsreceiver/factory.go
+++ b/receiver/dockerstatsreceiver/factory.go
@@ -25,14 +25,15 @@ import (
 )
 
 const (
-	typeStr = "docker_stats"
+	typeStr   = "docker_stats"
+	stability = component.StabilityLevelAlpha
 )
 
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/dotnetdiagnosticsreceiver/factory.go
+++ b/receiver/dotnetdiagnosticsreceiver/factory.go
@@ -30,13 +30,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver/network"
 )
 
-const typeStr = "dotnet_diagnostics"
+const (
+	typeStr   = "dotnet_diagnostics"
+	stability = component.StabilityLevelAlpha
+)
 
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
 	)
 }
 

--- a/receiver/elasticsearchreceiver/factory.go
+++ b/receiver/elasticsearchreceiver/factory.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	typeStr                   = "elasticsearch"
+	stability                 = component.StabilityLevelBeta
 	defaultCollectionInterval = 10 * time.Second
 	defaultHTTPClientTimeout  = 10 * time.Second
 )
@@ -39,7 +40,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 // createDefaultConfig creates the default elasticsearchreceiver config.

--- a/receiver/expvarreceiver/factory.go
+++ b/receiver/expvarreceiver/factory.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	typeStr         = "expvar"
+	stability       = component.StabilityLevelBeta
 	defaultPath     = "/debug/vars"
 	defaultEndpoint = "http://localhost:8000" + defaultPath
 	defaultTimeout  = 3 * time.Second
@@ -38,7 +39,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		newDefaultConfig,
-		component.WithMetricsReceiver(newMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(newMetricsReceiver, stability))
 }
 
 func newMetricsReceiver(

--- a/receiver/filelogreceiver/filelog.go
+++ b/receiver/filelogreceiver/filelog.go
@@ -24,11 +24,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
 )
 
-const typeStr = "filelog"
+const (
+	typeStr   = "filelog"
+	stability = component.StabilityLevelAlpha
+)
 
 // NewFactory creates a factory for filelog receiver
 func NewFactory() component.ReceiverFactory {
-	return adapter.NewFactory(ReceiverType{})
+	return adapter.NewFactory(ReceiverType{}, stability)
 }
 
 // ReceiverType implements stanza.LogReceiverType

--- a/receiver/flinkmetricsreceiver/factory.go
+++ b/receiver/flinkmetricsreceiver/factory.go
@@ -28,7 +28,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver/internal/metadata"
 )
 
-const typeStr = "flinkmetrics"
+const (
+	typeStr   = "flinkmetrics"
+	stability = component.StabilityLevelAlpha
+)
 
 var errConfigNotflinkmetrics = errors.New("config was not a flinkmetrics receiver config")
 
@@ -37,7 +40,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
 	)
 }
 

--- a/receiver/fluentforwardreceiver/factory.go
+++ b/receiver/fluentforwardreceiver/factory.go
@@ -25,6 +25,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "fluentforward"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory return a new component.ReceiverFactory for fluentd forwarder.
@@ -32,7 +34,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsReceiver(createLogsReceiver))
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/googlecloudpubsubreceiver/factory.go
+++ b/receiver/googlecloudpubsubreceiver/factory.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	typeStr              = "googlecloudpubsub"
+	stability            = component.StabilityLevelBeta
 	reportTransport      = "pubsub"
 	reportFormatProtobuf = "protobuf"
 )
@@ -37,9 +38,9 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		f.CreateDefaultConfig,
-		component.WithTracesReceiver(f.CreateTracesReceiver),
-		component.WithMetricsReceiver(f.CreateMetricsReceiver),
-		component.WithLogsReceiver(f.CreateLogsReceiver),
+		component.WithTracesReceiverAndStabilityLevel(f.CreateTracesReceiver, stability),
+		component.WithMetricsReceiverAndStabilityLevel(f.CreateMetricsReceiver, stability),
+		component.WithLogsReceiverAndStabilityLevel(f.CreateLogsReceiver, stability),
 	)
 }
 

--- a/receiver/googlecloudspannerreceiver/factory.go
+++ b/receiver/googlecloudspannerreceiver/factory.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	typeStr = "googlecloudspanner"
+	typeStr   = "googlecloudspanner"
+	stability = component.StabilityLevelBeta
 
 	defaultCollectionInterval     = 60 * time.Second
 	defaultTopMetricsQueryMaxRows = 100
@@ -36,7 +37,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -40,6 +40,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "hostmetrics"
+	// The stability level of the host metrics receiver.
+	stability = component.StabilityLevelBeta
 )
 
 var (
@@ -61,7 +63,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func getScraperFactory(key string) (internal.ScraperFactory, bool) {

--- a/receiver/iisreceiver/factory.go
+++ b/receiver/iisreceiver/factory.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	typeStr = "iis"
+	typeStr   = "iis"
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for iis receiver.
@@ -33,7 +34,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/influxdbreceiver/factory.go
+++ b/receiver/influxdbreceiver/factory.go
@@ -24,14 +24,15 @@ import (
 )
 
 const (
-	typeStr = "influxdb"
+	typeStr   = "influxdb"
+	stability = component.StabilityLevelBeta
 )
 
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 // createDefaultConfig creates the default configuration for receiver.

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	typeStr = "jaeger"
+	typeStr   = "jaeger"
+	stability = component.StabilityLevelBeta
 
 	// Protocol values.
 	protoGRPC          = "grpc"
@@ -49,7 +50,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(createTracesReceiver))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, stability))
 }
 
 // CreateDefaultConfig creates the default configuration for Jaeger receiver.

--- a/receiver/jmxreceiver/factory.go
+++ b/receiver/jmxreceiver/factory.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	typeStr      = "jmx"
+	stability    = component.StabilityLevelAlpha
 	otlpEndpoint = "0.0.0.0:0"
 )
 
@@ -33,7 +34,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/journaldreceiver/journald.go
+++ b/receiver/journaldreceiver/journald.go
@@ -27,11 +27,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/journald"
 )
 
-const typeStr = "journald"
+const (
+	typeStr   = "journald"
+	stability = component.StabilityLevelAlpha
+)
 
 // NewFactory creates a factory for journald receiver
 func NewFactory() component.ReceiverFactory {
-	return adapter.NewFactory(ReceiverType{})
+	return adapter.NewFactory(ReceiverType{}, stability)
 }
 
 // ReceiverType implements adapter.LogReceiverType

--- a/receiver/journaldreceiver/journald_nonlinux.go
+++ b/receiver/journaldreceiver/journald_nonlinux.go
@@ -28,14 +28,17 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 )
 
-const typeStr = "journald"
+const (
+	typeStr   = "journald"
+	stability = component.StabilityLevelAlpha
+)
 
 // NewFactory creates a dummy factory.
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsReceiver(createLogsReceiver))
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, stability))
 }
 
 type JournaldConfig struct {

--- a/receiver/k8sclusterreceiver/factory.go
+++ b/receiver/k8sclusterreceiver/factory.go
@@ -30,6 +30,8 @@ import (
 const (
 	// Value of "type" key in configuration.
 	typeStr = "k8s_cluster"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelBeta
 
 	// supported distributions
 	distributionKubernetes = "kubernetes"
@@ -85,5 +87,5 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }

--- a/receiver/k8seventsreceiver/factory.go
+++ b/receiver/k8seventsreceiver/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// Value of "type" key in configuration.
 	typeStr = "k8s_events"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelAlpha
 )
 
 // NewFactory creates a factory for k8s_cluster receiver.
@@ -34,7 +36,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithLogsReceiver(createLogsReceiver))
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/kafkametricsreceiver/factory.go
+++ b/receiver/kafkametricsreceiver/factory.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	typeStr           = "kafkametrics"
+	stability         = component.StabilityLevelBeta
 	defaultBroker     = "localhost:9092"
 	defaultGroupMatch = ".*"
 	defaultTopicMatch = "^[^_].*$"
@@ -36,7 +37,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	typeStr = "kafka"
+	typeStr   = "kafka"
+	stability = component.StabilityLevelBeta
 
 	defaultTopic    = "otlp_spans"
 	defaultEncoding = "otlp_proto"
@@ -93,9 +94,9 @@ func NewFactory(options ...FactoryOption) component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(f.createTracesReceiver),
-		component.WithMetricsReceiver(f.createMetricsReceiver),
-		component.WithLogsReceiver(f.createLogsReceiver),
+		component.WithTracesReceiverAndStabilityLevel(f.createTracesReceiver, stability),
+		component.WithMetricsReceiverAndStabilityLevel(f.createMetricsReceiver, stability),
+		component.WithLogsReceiverAndStabilityLevel(f.createLogsReceiver, stability),
 	)
 }
 

--- a/receiver/kubeletstatsreceiver/factory.go
+++ b/receiver/kubeletstatsreceiver/factory.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	typeStr            = "kubeletstats"
+	stability          = component.StabilityLevelBeta
 	metricGroupsConfig = "metric_groups"
 )
 
@@ -46,7 +47,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/memcachedreceiver/factory.go
+++ b/receiver/memcachedreceiver/factory.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	typeStr                   = "memcached"
+	stability                 = component.StabilityLevelBeta
 	defaultEndpoint           = "localhost:11211"
 	defaultTimeout            = 10 * time.Second
 	defaultCollectionInterval = 10 * time.Second
@@ -39,7 +40,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/mongodbatlasreceiver/factory.go
+++ b/receiver/mongodbatlasreceiver/factory.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	typeStr              = "mongodbatlas"
+	stability            = component.StabilityLevelBeta
 	defaultGranularity   = "PT1M" // 1-minute, as per https://docs.atlas.mongodb.com/reference/api/process-measurements/
 	defaultAlertsEnabled = false
 )
@@ -38,8 +39,8 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
-		component.WithLogsReceiver(createLogsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, stability))
 }
 
 func createMetricsReceiver(

--- a/receiver/mongodbreceiver/factory.go
+++ b/receiver/mongodbreceiver/factory.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	typeStr = "mongodb"
+	typeStr   = "mongodb"
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for mongodb receiver.
@@ -37,7 +38,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/mysqlreceiver/factory.go
+++ b/receiver/mysqlreceiver/factory.go
@@ -28,14 +28,15 @@ import (
 )
 
 const (
-	typeStr = "mysql"
+	typeStr   = "mysql"
+	stability = component.StabilityLevelBeta
 )
 
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/nginxreceiver/factory.go
+++ b/receiver/nginxreceiver/factory.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	typeStr = "nginx"
+	typeStr   = "nginx"
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for nginx receiver.
@@ -36,7 +37,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/nsxtreceiver/factory.go
+++ b/receiver/nsxtreceiver/factory.go
@@ -27,7 +27,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver/internal/metadata"
 )
 
-const typeStr = "nsxt"
+const (
+	typeStr   = "nsxt"
+	stability = component.StabilityLevelAlpha
+)
 
 var errConfigNotNSX = errors.New("config was not a NSX receiver config")
 
@@ -36,7 +39,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
 	)
 }
 

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -26,15 +26,18 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 )
 
-const typeStr = "opencensus"
+const (
+	typeStr   = "opencensus"
+	stability = component.StabilityLevelBeta
+)
 
 // NewFactory creates a new OpenCensus receiver factory.
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(createTracesReceiver),
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, stability),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/podmanreceiver/factory.go
+++ b/receiver/podmanreceiver/factory.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	typeStr           = "podman_stats"
+	stability         = component.StabilityLevelUnmaintained
 	defaultAPIVersion = "3.3.1"
 )
 
@@ -33,7 +34,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultReceiverConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() *Config {

--- a/receiver/postgresqlreceiver/factory.go
+++ b/receiver/postgresqlreceiver/factory.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	typeStr = "postgresql"
+	typeStr   = "postgresql"
+	stability = component.StabilityLevelBeta
 )
 
 func NewFactory() component.ReceiverFactory {

--- a/receiver/postgresqlreceiver/factory.go
+++ b/receiver/postgresqlreceiver/factory.go
@@ -36,7 +36,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/prometheusexecreceiver/factory.go
+++ b/receiver/prometheusexecreceiver/factory.go
@@ -30,7 +30,8 @@ import (
 // Factory for prometheusexec
 const (
 	// Key to invoke this receiver (prometheus_exec)
-	typeStr = "prometheus_exec"
+	typeStr   = "prometheus_exec"
+	stability = component.StabilityLevelDeprecated
 
 	defaultCollectionInterval = 60 * time.Second
 	defaultTimeoutInterval    = 10 * time.Second
@@ -43,7 +44,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func logDeprecation(logger *zap.Logger) {

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -27,7 +27,8 @@ import (
 // This file implements config for Prometheus receiver.
 
 const (
-	typeStr = "prometheus"
+	typeStr   = "prometheus"
+	stability = component.StabilityLevelBeta
 )
 
 var errRenamingDisallowed = errors.New("metric renaming using metric_relabel_configs is disallowed")
@@ -37,7 +38,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/rabbitmqreceiver/factory.go
+++ b/receiver/rabbitmqreceiver/factory.go
@@ -28,7 +28,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver/internal/metadata"
 )
 
-const typeStr = "rabbitmq"
+const (
+	typeStr   = "rabbitmq"
+	stability = component.StabilityLevelBeta
+)
 
 var errConfigNotRabbit = errors.New("config was not a RabbitMQ receiver config")
 
@@ -37,7 +40,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/receivercreator/factory.go
+++ b/receiver/receivercreator/factory.go
@@ -28,7 +28,8 @@ import (
 // This file implements factory for receiver_creator. A receiver_creator can create other receivers at runtime.
 
 const (
-	typeStr = "receiver_creator"
+	typeStr   = "receiver_creator"
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for receiver creator.
@@ -36,7 +37,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/redisreceiver/factory.go
+++ b/receiver/redisreceiver/factory.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	typeStr = "redis"
+	typeStr   = "redis"
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for Redis receiver.
@@ -37,7 +38,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/riakreceiver/factory.go
+++ b/receiver/riakreceiver/factory.go
@@ -28,7 +28,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver/internal/metadata"
 )
 
-const typeStr = "riak"
+const (
+	typeStr   = "riak"
+	stability = component.StabilityLevelBeta
+)
 
 var errConfigNotRiak = errors.New("config was not a Riak receiver config")
 
@@ -37,7 +40,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/saphanareceiver/factory.go
+++ b/receiver/saphanareceiver/factory.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	typeStr         = "saphana"
+	stability       = component.StabilityLevelInDevelopment
 	defaultEndpoint = "localhost:33015"
 )
 
@@ -39,7 +40,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/sapmreceiver/factory.go
+++ b/receiver/sapmreceiver/factory.go
@@ -31,6 +31,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "sapm"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelBeta
 
 	// Default endpoints to bind to.
 	defaultEndpoint = ":7276"
@@ -41,7 +43,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(createTracesReceiver))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/signalfxreceiver/factory.go
+++ b/receiver/signalfxreceiver/factory.go
@@ -32,6 +32,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "signalfx"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelStable
 
 	// Default endpoints to bind to.
 	defaultEndpoint = ":9943"
@@ -42,8 +44,8 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
-		component.WithLogsReceiver(createLogsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/simpleprometheusreceiver/factory.go
+++ b/receiver/simpleprometheusreceiver/factory.go
@@ -29,6 +29,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "prometheus_simple"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelBeta
 
 	defaultEndpoint    = "localhost:9090"
 	defaultMetricsPath = "/metrics"
@@ -41,7 +43,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/skywalkingreceiver/factory.go
+++ b/receiver/skywalkingreceiver/factory.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	typeStr = "skywalking"
+	typeStr   = "skywalking"
+	stability = component.StabilityLevelBeta
 
 	// Protocol values.
 	protoGRPC = "grpc"
@@ -47,7 +48,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(createTracesReceiver))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, stability))
 }
 
 // CreateDefaultConfig creates the default configuration for Skywalking receiver.

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -32,6 +32,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "splunk_hec"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelBeta
 
 	// Default endpoints to bind to.
 	defaultEndpoint = ":8088"
@@ -42,8 +44,8 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
-		component.WithLogsReceiver(createLogsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
+		component.WithLogsReceiverAndStabilityLevel(createLogsReceiver, stability))
 }
 
 // CreateDefaultConfig creates the default configuration for Splunk HEC receiver.

--- a/receiver/sqlqueryreceiver/factory.go
+++ b/receiver/sqlqueryreceiver/factory.go
@@ -20,12 +20,15 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-const typeStr = "sqlquery"
+const (
+	typeStr   = "sqlquery"
+	stability = component.StabilityLevelUndefined
+)
 
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createReceiverFunc(sql.Open, newDbClient)),
+		component.WithMetricsReceiverAndStabilityLevel(createReceiverFunc(sql.Open, newDbClient), stability),
 	)
 }

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -24,14 +24,17 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver/internal/metadata"
 )
 
-const typeStr = "sqlserver"
+const (
+	typeStr   = "sqlserver"
+	stability = component.StabilityLevelInDevelopment
+)
 
 // NewFactory creates a factory for SQL Server receiver.
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/statsdreceiver/factory.go
+++ b/receiver/statsdreceiver/factory.go
@@ -29,6 +29,7 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr                    = "statsd"
+	stability                  = component.StabilityLevelBeta
 	defaultBindEndpoint        = "localhost:8125"
 	defaultTransport           = "udp"
 	defaultAggregationInterval = 60 * time.Second
@@ -45,7 +46,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
 	)
 }
 

--- a/receiver/syslogreceiver/syslog.go
+++ b/receiver/syslogreceiver/syslog.go
@@ -25,11 +25,14 @@ import (
 	syslogparser "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/syslog"
 )
 
-const typeStr = "syslog"
+const (
+	typeStr   = "syslog"
+	stability = component.StabilityLevelAlpha
+)
 
 // NewFactory creates a factory for syslog receiver
 func NewFactory() component.ReceiverFactory {
-	return adapter.NewFactory(ReceiverType{})
+	return adapter.NewFactory(ReceiverType{}, stability)
 }
 
 // ReceiverType implements adapter.LogReceiverType

--- a/receiver/tcplogreceiver/tcp.go
+++ b/receiver/tcplogreceiver/tcp.go
@@ -24,11 +24,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/tcp"
 )
 
-const typeStr = "tcplog"
+const (
+	typeStr   = "tcplog"
+	stability = component.StabilityLevelAlpha
+)
 
 // NewFactory creates a factory for tcp receiver
 func NewFactory() component.ReceiverFactory {
-	return adapter.NewFactory(ReceiverType{})
+	return adapter.NewFactory(ReceiverType{}, stability)
 }
 
 // ReceiverType implements adapter.LogReceiverType

--- a/receiver/udplogreceiver/udp.go
+++ b/receiver/udplogreceiver/udp.go
@@ -24,11 +24,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/udp"
 )
 
-const typeStr = "udplog"
+const (
+	typeStr   = "udplog"
+	stability = component.StabilityLevelAlpha
+)
 
 // NewFactory creates a factory for udp receiver
 func NewFactory() component.ReceiverFactory {
-	return adapter.NewFactory(ReceiverType{})
+	return adapter.NewFactory(ReceiverType{}, stability)
 }
 
 // ReceiverType implements adapter.LogReceiverType

--- a/receiver/vcenterreceiver/factory.go
+++ b/receiver/vcenterreceiver/factory.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	typeStr = "vcenter"
+	typeStr   = "vcenter"
+	stability = component.StabilityLevelAlpha
 )
 
 // NewFactory returns the receiver factory for the vcenterreceiver
@@ -37,7 +38,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
 	)
 }
 

--- a/receiver/wavefrontreceiver/factory.go
+++ b/receiver/wavefrontreceiver/factory.go
@@ -32,6 +32,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "wavefront"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelBeta
 )
 
 // NewFactory creates a factory for WaveFront receiver.
@@ -39,7 +41,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 func createDefaultConfig() config.Receiver {

--- a/receiver/windowseventlogreceiver/receiver_others.go
+++ b/receiver/windowseventlogreceiver/receiver_others.go
@@ -27,11 +27,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
-const typeStr = "windowseventlog"
+const (
+	typeStr   = "windowseventlog"
+	stability = component.StabilityLevelAlpha
+)
 
 // NewFactory creates a factory for windowseventlog receiver
 func NewFactory() component.ReceiverFactory {
-	return adapter.NewFactory(ReceiverType{})
+	return adapter.NewFactory(ReceiverType{}, stability)
 }
 
 // ReceiverType implements adapter.LogReceiverType

--- a/receiver/windowseventlogreceiver/receiver_windows.go
+++ b/receiver/windowseventlogreceiver/receiver_windows.go
@@ -27,11 +27,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 )
 
-const typeStr = "windowseventlog"
+const (
+	typeStr   = "windowseventlog"
+	stability = component.StabilityLevelAlpha
+)
 
 // NewFactory creates a factory for windowseventlog receiver
 func NewFactory() component.ReceiverFactory {
-	return adapter.NewFactory(ReceiverType{})
+	return adapter.NewFactory(ReceiverType{}, stability)
 }
 
 // ReceiverType implements adapter.LogReceiverType

--- a/receiver/windowsperfcountersreceiver/factory.go
+++ b/receiver/windowsperfcountersreceiver/factory.go
@@ -24,15 +24,19 @@ import (
 
 // This file implements Factory for WindowsPerfCounters receiver.
 
-// The value of "type" key in configuration.
-const typeStr = "windowsperfcounters"
+const (
+	// The value of "type" key in configuration.
+	typeStr = "windowsperfcounters"
+	// The stability level of the receiver.
+	stability = component.StabilityLevelBeta
+)
 
 // NewFactory creates a new factory for windows perf counters receiver.
 func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver))
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability))
 }
 
 // createDefaultConfig creates the default configuration for receiver.

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -26,7 +26,8 @@ import (
 // This file implements factory for Zipkin receiver.
 
 const (
-	typeStr = "zipkin"
+	typeStr   = "zipkin"
+	stability = component.StabilityLevelBeta
 
 	defaultBindEndpoint = "0.0.0.0:9411"
 )
@@ -36,7 +37,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(createTracesReceiver),
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, stability),
 	)
 }
 

--- a/receiver/zookeeperreceiver/factory.go
+++ b/receiver/zookeeperreceiver/factory.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	typeStr = "zookeeper"
+	typeStr   = "zookeeper"
+	stability = component.StabilityLevelInDevelopment
 
 	defaultCollectionInterval = 10 * time.Second
 	defaultTimeout            = 10 * time.Second
@@ -38,7 +39,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithMetricsReceiver(createMetricsReceiver),
+		component.WithMetricsReceiverAndStabilityLevel(createMetricsReceiver, stability),
 	)
 }
 

--- a/testbed/mockdatareceivers/mockawsxrayreceiver/factory.go
+++ b/testbed/mockdatareceivers/mockawsxrayreceiver/factory.go
@@ -27,6 +27,8 @@ import (
 const (
 	// The value of "type" key in configuration.
 	typeStr = "mock_receiver"
+	// stability level of test component
+	stability = component.StabilityLevelInDevelopment
 
 	// Default endpoints to bind to.
 	defaultEndpoint = ":7276"
@@ -37,7 +39,7 @@ func NewFactory() component.ReceiverFactory {
 	return component.NewReceiverFactory(
 		typeStr,
 		createDefaultConfig,
-		component.WithTracesReceiver(createTracesReceiver))
+		component.WithTracesReceiverAndStabilityLevel(createTracesReceiver, stability))
 }
 
 // CreateDefaultConfig creates the default configuration for Jaeger receiver.

--- a/unreleased/set-stability.yaml
+++ b/unreleased/set-stability.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: all
+
+# A brief description of the change
+note: Components now report their stability level.
+
+# One or more tracking issues related to the change
+issues: [12104]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+subtext:


### PR DESCRIPTION
This updates all the receiver/processors/exporters to report their stability status, which is then logged when the collector service starts.

I didn't know if I should add a line to the changelog for every component, or just a single one for all components.