### PR TITLE
[exporter/loki] fix issue with log message quotation 

### DIFF
--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -297,7 +297,7 @@ func (l *lokiExporter) convertLogBodyToEntry(lr plog.LogRecord, res pcommon.Reso
 	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
 		if _, found := l.config.Labels.Attributes[k]; !found {
 			b.WriteString(k)
-			b.WriteString("=\"")
+			b.WriteString("=")
 			// encapsulate with double quotes. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11827
 			b.WriteString(strconv.Quote(v.AsString()))
 			b.WriteRune(' ')

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -297,10 +297,9 @@ func (l *lokiExporter) convertLogBodyToEntry(lr plog.LogRecord, res pcommon.Reso
 	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
 		if _, found := l.config.Labels.Attributes[k]; !found {
 			b.WriteString(k)
-			// encapsulate with double quotes. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11827
 			b.WriteString("=\"")
-			b.WriteString(v.AsString())
-			b.WriteString("\"")
+			// encapsulate with double quotes. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11827
+			b.WriteString(strconv.Quote(v.AsString()))
 			b.WriteRune(' ')
 		}
 		return true

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -297,8 +297,10 @@ func (l *lokiExporter) convertLogBodyToEntry(lr plog.LogRecord, res pcommon.Reso
 	lr.Attributes().Range(func(k string, v pcommon.Value) bool {
 		if _, found := l.config.Labels.Attributes[k]; !found {
 			b.WriteString(k)
-			b.WriteString("=")
+			// encapsulate with double quotes. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11827
+			b.WriteString("=\"")
 			b.WriteString(v.AsString())
+			b.WriteString("\"")
 			b.WriteRune(' ')
 		}
 		return true

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -298,13 +298,14 @@ func TestExporter_logDataToLoki(t *testing.T) {
 		lr.Body().SetStringVal("log message")
 		lr.Attributes().InsertString(conventions.AttributeContainerName, "mycontainer")
 		lr.Attributes().InsertString("severity", "info")
-		lr.Attributes().InsertString("random.attribute", "random")
+		lr.Attributes().InsertString("random.attribute", "random attribute")
 		lr.SetTimestamp(ts)
 
 		pr, numDroppedLogs := exp.logDataToLoki(logs)
 		require.Equal(t, 0, numDroppedLogs)
 		require.NotNil(t, pr)
 		require.Len(t, pr.Streams, 1)
+		require.Contains(t, pr.Streams[0].Entries[0].Line, fmt.Sprintf("%q", "random attribute"))
 	})
 
 	t.Run("with multiple logs and same attributes", func(t *testing.T) {

--- a/unreleased/fix-loki-quote-issue.yaml
+++ b/unreleased/fix-loki-quote-issue.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: lokiexporter
+
+# A brief description of the change
+note: Wrap quotes around log message
+
+# One or more tracking issues related to the change
+issues: [11827]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# subtext:


### PR DESCRIPTION
**Description:** Wrap log message with double quotes

**Link to tracking Issue:** fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11827

**Testing:** <Describe what testing was performed and which tests were added.>
Added another check to see if the `Entries.line` contains attributed wrapped in double quotes

**Documentation:** <Describe the documentation added.>