### PR TITLE
[pkg/stanza] Extract a reader factory

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -121,16 +121,21 @@ func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Input, error) 
 		finder:             c.Finder,
 		PollInterval:       c.PollInterval.Raw(),
 		startAtBeginning:   startAtBeginning,
-		SplitterConfig:     c.Splitter,
 		queuedMatches:      make([]string, 0),
 		firstCheck:         true,
 		cancel:             func() {},
 		knownFiles:         make([]*Reader, 0, 10),
 		roller:             newRoller(),
-		fingerprintSize:    int(c.FingerprintSize),
-		MaxLogSize:         int(c.MaxLogSize),
 		MaxConcurrentFiles: c.MaxConcurrentFiles,
 		SeenPaths:          make(map[string]struct{}, 100),
-		emit:               emit,
+		readerFactory: readerFactory{
+			SugaredLogger: logger.With("component", "fileconsumer"),
+			readerConfig: &readerConfig{
+				fingerprintSize: int(c.FingerprintSize),
+				maxLogSize:      int(c.MaxLogSize),
+				emit:            emit,
+			},
+			splitterConfig: c.Splitter,
+		},
 	}, nil
 }

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -840,13 +840,10 @@ func TestFileReader_FingerprintUpdated(t *testing.T) {
 
 	temp := openTemp(t, tempDir)
 	tempCopy := openFile(t, temp.Name())
-	fp, err := operator.NewFingerprint(temp)
+	fp, err := operator.readerFactory.newFingerprint(temp)
 	require.NoError(t, err)
 
-	splitter, err := operator.getMultiline()
-	require.NoError(t, err)
-
-	reader, err := operator.NewReader(tempCopy, fp, splitter)
+	reader, err := operator.readerFactory.newReader(tempCopy, fp)
 	require.NoError(t, err)
 	defer reader.Close()
 
@@ -885,14 +882,11 @@ func TestFingerprintGrowsAndStops(t *testing.T) {
 
 			temp := openTemp(t, tempDir)
 			tempCopy := openFile(t, temp.Name())
-			fp, err := operator.NewFingerprint(temp)
+			fp, err := operator.readerFactory.newFingerprint(temp)
 			require.NoError(t, err)
 			require.Equal(t, []byte(""), fp.FirstBytes)
 
-			splitter, err := operator.getMultiline()
-			require.NoError(t, err)
-
-			reader, err := operator.NewReader(tempCopy, fp, splitter)
+			reader, err := operator.readerFactory.newReader(tempCopy, fp)
 			require.NoError(t, err)
 			defer reader.Close()
 
@@ -951,14 +945,11 @@ func TestFingerprintChangeSize(t *testing.T) {
 
 			temp := openTemp(t, tempDir)
 			tempCopy := openFile(t, temp.Name())
-			fp, err := operator.NewFingerprint(temp)
+			fp, err := operator.readerFactory.newFingerprint(temp)
 			require.NoError(t, err)
 			require.Equal(t, []byte(""), fp.FirstBytes)
 
-			splitter, err := operator.getMultiline()
-			require.NoError(t, err)
-
-			reader, err := operator.NewReader(tempCopy, fp, splitter)
+			reader, err := operator.readerFactory.newReader(tempCopy, fp)
 			require.NoError(t, err)
 			defer reader.Close()
 
@@ -987,7 +978,7 @@ func TestFingerprintChangeSize(t *testing.T) {
 			// Change fingerprint and try to read file again
 			// We do not expect fingerprint change
 			// We test both increasing and decreasing fingerprint size
-			reader.fileInput.fingerprintSize = maxFP * (lineLen / 3)
+			reader.readerConfig.fingerprintSize = maxFP * (lineLen / 3)
 			line := string(tokenWithLength(lineLen-1)) + "\n"
 			fileContent = append(fileContent, []byte(line)...)
 
@@ -995,7 +986,7 @@ func TestFingerprintChangeSize(t *testing.T) {
 			reader.ReadToEnd(context.Background())
 			require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
 
-			reader.fileInput.fingerprintSize = maxFP / 2
+			reader.readerConfig.fingerprintSize = maxFP / 2
 			line = string(tokenWithLength(lineLen-1)) + "\n"
 			fileContent = append(fileContent, []byte(line)...)
 

--- a/pkg/stanza/fileconsumer/fingerprint.go
+++ b/pkg/stanza/fileconsumer/fingerprint.go
@@ -26,15 +26,14 @@ const DefaultFingerprintSize = 1000 // bytes
 const MinFingerprintSize = 16       // bytes
 
 // Fingerprint is used to identify a file
-// A file's fingerprint is the first N bytes of the file,
-// where N is the fingerprintSize on the file_input operator
+// A file's fingerprint is the first N bytes of the file
 type Fingerprint struct {
 	FirstBytes []byte
 }
 
 // NewFingerprint creates a new fingerprint from an open file
-func (f *Input) NewFingerprint(file *os.File) (*Fingerprint, error) {
-	buf := make([]byte, f.fingerprintSize)
+func NewFingerprint(file *os.File, size int) (*Fingerprint, error) {
+	buf := make([]byte, size)
 
 	n, err := file.ReadAt(buf, 0)
 	if err != nil && !errors.Is(err, io.EOF) {

--- a/pkg/stanza/fileconsumer/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/fingerprint_test.go
@@ -32,7 +32,7 @@ func TestNewFingerprintDoesNotModifyOffset(t *testing.T) {
 	fileContents := fmt.Sprintf("%s%s%s\n", fingerprint, next, extra)
 
 	f, _, tempDir := newTestScenario(t, nil)
-	f.fingerprintSize = len(fingerprint)
+	f.readerFactory.readerConfig.fingerprintSize = len(fingerprint)
 
 	// Create a new file
 	temp := openTemp(t, tempDir)
@@ -47,7 +47,7 @@ func TestNewFingerprintDoesNotModifyOffset(t *testing.T) {
 	_, err = temp.Seek(0, 0)
 	require.NoError(t, err)
 
-	fp, err := f.NewFingerprint(temp)
+	fp, err := f.readerFactory.newFingerprint(temp)
 	require.NoError(t, err)
 
 	// Validate the fingerprint is the correct size
@@ -123,7 +123,7 @@ func TestNewFingerprint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			f, _, tempDir := newTestScenario(t, nil)
-			f.fingerprintSize = tc.fingerprintSize
+			f.readerFactory.readerConfig.fingerprintSize = tc.fingerprintSize
 
 			// Create a new file
 			temp := openTemp(t, tempDir)
@@ -134,7 +134,7 @@ func TestNewFingerprint(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.fileSize, int(info.Size()))
 
-			fp, err := f.NewFingerprint(temp)
+			fp, err := f.readerFactory.newFingerprint(temp)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expectedLen, len(fp.FirstBytes))
@@ -226,9 +226,9 @@ func TestFingerprintStartsWith_FromFile(t *testing.T) {
 	r := rand.New(rand.NewSource(112358))
 
 	operator, _, tempDir := newTestScenario(t, nil)
-	operator.fingerprintSize *= 10
+	operator.readerFactory.readerConfig.fingerprintSize *= 10
 
-	fileLength := 12 * operator.fingerprintSize
+	fileLength := 12 * operator.readerFactory.readerConfig.fingerprintSize
 
 	// Make a []byte we can write one at a time
 	content := make([]byte, fileLength)
@@ -251,7 +251,7 @@ func TestFingerprintStartsWith_FromFile(t *testing.T) {
 	_, err = fullFile.Write(content)
 	require.NoError(t, err)
 
-	fff, err := operator.NewFingerprint(fullFile)
+	fff, err := operator.readerFactory.newFingerprint(fullFile)
 	require.NoError(t, err)
 
 	partialFile, err := ioutil.TempFile(tempDir, "")
@@ -269,7 +269,7 @@ func TestFingerprintStartsWith_FromFile(t *testing.T) {
 		_, err = partialFile.Write(content[i:i])
 		require.NoError(t, err)
 
-		pff, err := operator.NewFingerprint(partialFile)
+		pff, err := operator.readerFactory.newFingerprint(partialFile)
 		require.NoError(t, err)
 
 		require.True(t, fff.StartsWith(pff))

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -1,0 +1,119 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+)
+
+type readerFactory struct {
+	*zap.SugaredLogger
+	readerConfig   *readerConfig
+	splitterConfig helper.SplitterConfig
+}
+
+func (f *readerFactory) newReader(file *os.File, fp *Fingerprint) (*Reader, error) {
+	return f.newReaderBuilder().
+		withFile(file).
+		withFingerprint(fp).
+		build()
+}
+
+// copy creates a deep copy of a Reader
+func (f *readerFactory) copy(old *Reader, newFile *os.File) (*Reader, error) {
+	return f.newReaderBuilder().
+		withFile(newFile).
+		withFingerprint(old.Fingerprint.Copy()).
+		withOffset(old.Offset).
+		withSplitter(old.splitter).
+		build()
+}
+
+func (f *readerFactory) unsafeReader() (*Reader, error) {
+	return f.newReaderBuilder().build()
+}
+
+func (f *readerFactory) newFingerprint(file *os.File) (*Fingerprint, error) {
+	return NewFingerprint(file, f.readerConfig.fingerprintSize)
+}
+
+type readerBuilder struct {
+	*readerFactory
+	file     *os.File
+	fp       *Fingerprint
+	offset   int64
+	splitter *helper.Splitter
+}
+
+func (f *readerFactory) newReaderBuilder() *readerBuilder {
+	return &readerBuilder{readerFactory: f}
+}
+
+func (b *readerBuilder) withSplitter(s *helper.Splitter) *readerBuilder {
+	b.splitter = s
+	return b
+}
+
+func (b *readerBuilder) withFile(f *os.File) *readerBuilder {
+	b.file = f
+	return b
+}
+
+func (b *readerBuilder) withFingerprint(fp *Fingerprint) *readerBuilder {
+	b.fp = fp
+	return b
+}
+
+func (b *readerBuilder) withOffset(offset int64) *readerBuilder {
+	b.offset = offset
+	return b
+}
+
+func (b *readerBuilder) build() (r *Reader, err error) {
+	r = &Reader{
+		readerConfig: b.readerConfig,
+		Offset:       b.offset,
+	}
+
+	if b.splitter != nil {
+		r.splitter = b.splitter
+	} else {
+		r.splitter, err = b.splitterConfig.Build(false, b.readerConfig.maxLogSize)
+		if err != nil {
+			return
+		}
+	}
+
+	if b.file != nil {
+		r.file = b.file
+		r.SugaredLogger = b.SugaredLogger.With("path", b.file.Name())
+		r.fileAttributes, err = resolveFileAttributes(b.file.Name())
+		if err != nil {
+			b.Errorf("resolve attributes: %w", err)
+		}
+	} else {
+		r.SugaredLogger = b.SugaredLogger.With("path", "uninitialized")
+	}
+
+	if b.fp != nil {
+		r.Fingerprint = b.fp
+	}
+
+	return r, nil
+}


### PR DESCRIPTION
This PR localizes Reader-related configuration settings and clarifies Reader instantiation patterns.
- Removes circular reference from Reader to Input struct.
- Pulls all Reader-related static configuration values into a single shared struct called `readerConfig`. 
- Pulls Reader creation logic into a `readerBuilder` to unify logic.
- Introduces a `readerFactory` with constructors for the various specific use cases in this codebase. The factory then configures and runs a builder to produce the expected result.