### PR TITLE
[pkg/stanza] Clean up the way readers are instantiated

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -277,7 +277,7 @@ func (f *Input) newReader(file *os.File, fp *Fingerprint, firstCheck bool) (*Rea
 	if err != nil {
 		return nil, err
 	}
-	newReader, err := f.NewReader(file.Name(), file, fp, splitter, f.emit)
+	newReader, err := f.NewReader(file.Name(), file, fp, splitter)
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +351,7 @@ func (f *Input) loadLastPollFiles(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		newReader, err := f.NewReader("", nil, nil, splitter, f.emit)
+		newReader, err := f.NewReader("", nil, nil, splitter)
 		if err != nil {
 			return err
 		}

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -268,7 +268,6 @@ func (f *Input) newReader(file *os.File, fp *Fingerprint, firstCheck bool) (*Rea
 		if err != nil {
 			return nil, err
 		}
-		newReader.fileAttributes = f.resolveFileAttributes(file.Name())
 		return newReader, nil
 	}
 
@@ -277,7 +276,7 @@ func (f *Input) newReader(file *os.File, fp *Fingerprint, firstCheck bool) (*Rea
 	if err != nil {
 		return nil, err
 	}
-	newReader, err := f.NewReader(file.Name(), file, fp, splitter)
+	newReader, err := f.NewReader(file, fp, splitter)
 	if err != nil {
 		return nil, err
 	}
@@ -351,14 +350,14 @@ func (f *Input) loadLastPollFiles(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		newReader, err := f.NewReader("", nil, nil, splitter)
-		if err != nil {
+
+		// Only the offset, fingerprint, and splitter
+		// will be used before this reader is discarded
+		unsafeReader := &Reader{fileInput: f, splitter: splitter}
+		if err = dec.Decode(unsafeReader); err != nil {
 			return err
 		}
-		if err = dec.Decode(newReader); err != nil {
-			return err
-		}
-		f.knownFiles = append(f.knownFiles, newReader)
+		f.knownFiles = append(f.knownFiles, unsafeReader)
 	}
 
 	return nil

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -846,7 +846,7 @@ func TestFileReader_FingerprintUpdated(t *testing.T) {
 	splitter, err := operator.getMultiline()
 	require.NoError(t, err)
 
-	reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter, operator.emit)
+	reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter)
 	require.NoError(t, err)
 	defer reader.Close()
 
@@ -892,7 +892,7 @@ func TestFingerprintGrowsAndStops(t *testing.T) {
 			splitter, err := operator.getMultiline()
 			require.NoError(t, err)
 
-			reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter, operator.emit)
+			reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter)
 			require.NoError(t, err)
 			defer reader.Close()
 
@@ -958,7 +958,7 @@ func TestFingerprintChangeSize(t *testing.T) {
 			splitter, err := operator.getMultiline()
 			require.NoError(t, err)
 
-			reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter, operator.emit)
+			reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter)
 			require.NoError(t, err)
 			defer reader.Close()
 

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -846,7 +846,7 @@ func TestFileReader_FingerprintUpdated(t *testing.T) {
 	splitter, err := operator.getMultiline()
 	require.NoError(t, err)
 
-	reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter)
+	reader, err := operator.NewReader(tempCopy, fp, splitter)
 	require.NoError(t, err)
 	defer reader.Close()
 
@@ -892,7 +892,7 @@ func TestFingerprintGrowsAndStops(t *testing.T) {
 			splitter, err := operator.getMultiline()
 			require.NoError(t, err)
 
-			reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter)
+			reader, err := operator.NewReader(tempCopy, fp, splitter)
 			require.NoError(t, err)
 			defer reader.Close()
 
@@ -958,7 +958,7 @@ func TestFingerprintChangeSize(t *testing.T) {
 			splitter, err := operator.getMultiline()
 			require.NoError(t, err)
 
-			reader, err := operator.NewReader(temp.Name(), tempCopy, fp, splitter)
+			reader, err := operator.NewReader(tempCopy, fp, splitter)
 			require.NoError(t, err)
 			defer reader.Close()
 

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -72,7 +72,7 @@ type Reader struct {
 }
 
 // NewReader creates a new file reader
-func (f *Input) NewReader(path string, file *os.File, fp *Fingerprint, splitter *helper.Splitter, emit EmitFunc) (*Reader, error) {
+func (f *Input) NewReader(path string, file *os.File, fp *Fingerprint, splitter *helper.Splitter) (*Reader, error) {
 	r := &Reader{
 		SugaredLogger:  f.SugaredLogger.With("path", path),
 		Fingerprint:    fp,
@@ -86,7 +86,7 @@ func (f *Input) NewReader(path string, file *os.File, fp *Fingerprint, splitter 
 
 // Copy creates a deep copy of a Reader
 func (r *Reader) Copy(file *os.File) (*Reader, error) {
-	reader, err := r.fileInput.NewReader(r.fileAttributes.Path, file, r.Fingerprint.Copy(), r.splitter, r.fileInput.emit)
+	reader, err := r.fileInput.NewReader(r.fileAttributes.Path, file, r.Fingerprint.Copy(), r.splitter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -72,7 +72,8 @@ type Reader struct {
 }
 
 // NewReader creates a new file reader
-func (f *Input) NewReader(path string, file *os.File, fp *Fingerprint, splitter *helper.Splitter) (*Reader, error) {
+func (f *Input) NewReader(file *os.File, fp *Fingerprint, splitter *helper.Splitter) (*Reader, error) {
+	path := file.Name()
 	r := &Reader{
 		SugaredLogger:  f.SugaredLogger.With("path", path),
 		Fingerprint:    fp,
@@ -86,7 +87,7 @@ func (f *Input) NewReader(path string, file *os.File, fp *Fingerprint, splitter 
 
 // Copy creates a deep copy of a Reader
 func (r *Reader) Copy(file *os.File) (*Reader, error) {
-	reader, err := r.fileInput.NewReader(r.fileAttributes.Path, file, r.Fingerprint.Copy(), r.splitter)
+	reader, err := r.fileInput.NewReader(file, r.Fingerprint.Copy(), r.splitter)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is another step towards isolating the Reader struct in order to make it more testable.

Changes:
- Removes the `EmitFunc` parameter from the constructor, as this was still being accessed by referencing the parent struct.
- Removes the `name` parameter from the constructor, as it can be obtained from the file handle.
- Manually set up a temporary reader for unmarshaling. This can be improved further when a ReaderFactory is introduced in #12135
