### PR TITLE
[exporter/googlemanagedprometheus] Add contrib disro to GMP exporter readme

### DIFF
--- a/exporter/googlemanagedprometheusexporter/README.md
+++ b/exporter/googlemanagedprometheusexporter/README.md
@@ -4,7 +4,7 @@
 | ------------------------ |-----------------------|
 | Stability                | [alpha](https://github.com/open-telemetry/opentelemetry-collector#alpha) |
 | Supported pipeline types | metrics               |
-| Distributions            | []                    |
+| Distributions            | [contrib](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib)    |
 
 This exporter can be used to send metrics and traces to [Google Cloud Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus).  The difference between this exporter and the `googlecloud` exporter is that metrics sent with this exporter are queried using [promql](https://prometheus.io/docs/prometheus/latest/querying/basics/#querying-prometheus), rather than standard the standard MQL.
 


### PR DESCRIPTION
**Description:** Updates the readme for the GMP exporter to note that it is available in the next contrib release as of https://github.com/open-telemetry/opentelemetry-collector-releases/pull/154

**Link to tracking Issue:** n/a

**Testing:** unit and integration tests downstream

**Documentation:** no changes