### PR TITLE
adding support for linux/ppc64le arch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -287,15 +287,20 @@ jobs:
           - amd64
           - arm
           - arm64
+          - ppc64le
         exclude:
           - os: darwin
             arch: 386
           - os: darwin
             arch: arm
+          - os: darwin
+            arch: ppc64le
           - os: windows
             arch: arm
           - os: windows
             arch: arm64
+          - os: windows
+            arch: ppc64le
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -356,6 +361,8 @@ jobs:
         run: ./internal/buildscripts/packaging/fpm/${{ matrix.package_type }}/build.sh "${{ steps.github_tag.outputs.tag }}" "amd64" "./dist/"
       - name: Build ${{ matrix.package_type }} arm64 package
         run: ./internal/buildscripts/packaging/fpm/${{ matrix.package_type }}/build.sh "${{ steps.github_tag.outputs.tag }}" "arm64" "./dist/"
+      - name: Build ${{ matrix.package_type }} ppc64le package
+        run: ./internal/buildscripts/packaging/fpm/${{ matrix.package_type }}/build.sh "${{ steps.github_tag.outputs.tag }}" "ppc64le" "./dist/"
       - name: Test ${{ matrix.package_type }} package
         run: |
           if [[ "${{ matrix.package_type }}" = "deb" ]]; then

--- a/.github/workflows/scripts/verify-dist-files-exist.sh
+++ b/.github/workflows/scripts/verify-dist-files-exist.sh
@@ -2,12 +2,15 @@ files=(
     bin/otelcontribcol_darwin_arm64
     bin/otelcontribcol_darwin_amd64
     bin/otelcontribcol_linux_arm64
+    bin/otelcontribcol_linux_ppc64le
     bin/otelcontribcol_linux_amd64
     bin/otelcontribcol_windows_amd64.exe
     dist/otel-contrib-collector-*.aarch64.rpm
     dist/otel-contrib-collector_*_amd64.deb
     dist/otel-contrib-collector-*.x86_64.rpm
     dist/otel-contrib-collector_*_arm64.deb
+    dist/otel-contrib-collector_*_ppc64le.deb
+    dist/otel-contrib-collector_*_ppc64le.rpm
     dist/otel-contrib-collector-*amd64.msi
 
 );

--- a/unreleased/add_ppc64le_in_ci.yaml
+++ b/unreleased/add_ppc64le_in_ci.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: supported platforms
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `linux-ppc64le` architecture to cross build tests in CI
+
+
+# One or more tracking issues related to the change
+issues: [12350]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
Hi there, 
I've successfully built and tested the opentelemetry-collector-contrib on power VM. 
* adding code changes to generate binaries for ppc64le arch in github actions.

please review and merge.

Resolves #12350