### PR TITLE
[exporter/prometheusremotewriteexporter] Fix a go panic

### DIFF
--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -340,12 +340,13 @@ func addSingleHistogramDataPoint(pt pmetric.HistogramDataPoint, resource pcommon
 	infBucket := &prompb.Sample{
 		Timestamp: time,
 	}
-	if pt.Flags().HasFlag(pmetric.MetricDataPointFlagNoRecordedValue) {
+	if pt.Flags().HasFlag(pmetric.MetricDataPointFlagNoRecordedValue) || pt.BucketCounts().Len() == 0 {
 		infBucket.Value = math.Float64frombits(value.StaleNaN)
 	} else {
 		cumulativeCount += pt.BucketCounts().At(pt.BucketCounts().Len() - 1)
 		infBucket.Value = float64(cumulativeCount)
 	}
+
 	infLabels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nameStr, baseName+bucketStr, leStr, pInfStr)
 	sig := addSample(tsMap, infBucket, infLabels, metric.DataType().String())
 

--- a/unreleased/FixGoPanic.yaml
+++ b/unreleased/FixGoPanic.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/prometheusremotewriteexporter
+
+# A brief description of the change
+note: >-
+  Sending invalid histogram metrics through will cause a Go Panic when the exporter attempts to build the message
+  to send to Prometheus
+
+# One or more tracking issues related to the change
+issues: [12168]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+subtext:


### PR DESCRIPTION
Description: Protect against a Go Panic when the bucket count collection is empty (observed with histograms coming from Micrometer 1.9.1

Fixes #12168 #12168