### PR TITLE
[receiver/hostmetricsreceiver] Scrape process delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 💡 Enhancements 💡
 - `hostmetricsreceiver`: New config setting `scrape_process_delay` is used to indicate the minimum amount of time a process must be running
-  before process metrics can be scraped for it.  The default value is 0 seconds (0s)
+  before process metrics can be scraped for it.  The default value is 0 seconds ("0s"). (#8976) 
 
 # v0.55.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 <!-- next version -->
 
-### 💡 Enhancements 💡
-- `hostmetricsreceiver`: New config setting `scrape_process_delay` is used to indicate the minimum amount of time a process must be running
-  before process metrics can be scraped for it.  The default value is 0 seconds ("0s"). (#8976) 
-
 # v0.55.0
 
 ## 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 <!-- next version -->
 
+### 💡 Enhancements 💡
+- `hostmetricsreceiver`: New config setting `scrape_process_delay` is used to indicate the minimum amount of time a process must be running
+  before process metrics can be scraped for it.  The default value is 0 seconds (0s)
+
 # v0.55.0
 
 ## 🛑 Breaking changes 🛑

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -94,6 +94,7 @@ process:
     names: [ <process name>, ... ]
     match_type: <strict|regexp>
   mute_process_name_error: <true|false>
+  scrape_process_delay: <time>
 ```
 
 ## Advanced Configuration

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -15,6 +15,8 @@
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 
 import (
+	"time"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/processor/filterset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
 )
@@ -33,6 +35,10 @@ type Config struct {
 	// collector does not have permission for.
 	// See https://github.com/open-telemetry/opentelemetry-collector/issues/3004 for more information.
 	MuteProcessNameError bool `mapstructure:"mute_process_name_error,omitempty"`
+
+	// ScrapeProcessDelay is used to indicate the minimum amount of time a process must be running
+	// before metrics are scraped for it.  The default value is 0 seconds (0s)
+	ScrapeProcessDelay time.Duration `mapstructure:"scrape_process_delay"`
 }
 
 type MatchConfig struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -87,6 +87,7 @@ type processHandle interface {
 	Times() (*cpu.TimesStat, error)
 	MemoryInfo() (*process.MemoryInfoStat, error)
 	IOCounters() (*process.IOCountersStat, error)
+	CreateTime() (int64, error)
 }
 
 type gopsProcessHandles struct {

--- a/unreleased/hostmetrics-receiver-scrape-process-delay.yaml
+++ b/unreleased/hostmetrics-receiver-scrape-process-delay.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change
+note: New config setting scrape_process_delay is used to indicate the minimum amount of time a process must be running before process metrics can be scraped for it. The default value is 0 seconds ("0s").
+
+
+# One or more tracking issues related to the change
+issues: [8976]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
add configuration option called scrape_process_delay to allow the user to delay collecting process metrics using hostmetricsreceiver until a process has been running for a given amount of time.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8976

**Testing:** <Describe what testing was performed and which tests were added.>
ran the receiver locally.  Also added unit test to verify that the setting works and only filters out the expected processes.

**Documentation:** <Describe the documentation added.>
See readme

cc: @dmitryax 