### PR TITLE
Increase timeout for integration tests

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -4,7 +4,7 @@ SRC_ROOT := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -v -timeout 300s --tags=$(GO_BUILD_TAGS)
-GOTEST_INTEGRATION_OPT?= -race -timeout 300s
+GOTEST_INTEGRATION_OPT?= -race -timeout 360s
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -v -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go


### PR DESCRIPTION
Recently introduced `TestOracleDBIntegration` integration test runs just on the edge on 5 minutes. This change increases the timeout to give it enough time to pass.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12202