### PR TITLE
Add @rogercoll codeowner for podmanreceiver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -163,6 +163,7 @@ receiver/mysqlreceiver/                              @open-telemetry/collector-c
 receiver/nginxreceiver/                              @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/nsxtreceiver/                               @open-telemetry/collector-contrib-approvers @dashpole @schmikei
 receiver/opencensusreceiver/                         @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
+receiver/podmanreceiver/                             @open-telemetry/collector-contrib-approvers @rogercoll
 receiver/postgresqlreceiver/                         @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/prometheusexecreceiver/                     @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/prometheusreceiver/                         @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole


### PR DESCRIPTION
Add @rogercoll  as code owner of podmanreceiver.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3870

Skip Changelog label missing