### PR TITLE
prometheusreceiver: allow to disable start time calculation

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -54,7 +54,8 @@ type Config struct {
 	// in incorrect rate calculations.
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
-	// DisableStartTime disables start time calculation of all metrics, which significantly reduces the memory usage of the receiver.
+ 	// DisableStartTime disables start time calculation of all metrics, which significantly reduces the memory usage of the receiver.
+ 	// Removing the start timestamp may limit the ability of other components and backends to offer full functionality with these metrics.
 	DisableStartTime bool `mapstructure:"disable_start_time"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	// in incorrect rate calculations.
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
+	DisableStartTime     bool   `mapstructure:"use_start_time_metric"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check
 	// that requires that all keys present in the config actually exist on the

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -43,9 +43,9 @@ const (
 // Config defines configuration for Prometheus receiver.
 type Config struct {
 	config.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
-	PrometheusConfig        *promconfig.Config `mapstructure:"-"`
-	BufferPeriod            time.Duration      `mapstructure:"buffer_period"`
-	BufferCount             int                `mapstructure:"buffer_count"`
+	PrometheusConfig        *promconfig.Config       `mapstructure:"-"`
+	BufferPeriod            time.Duration            `mapstructure:"buffer_period"`
+	BufferCount             int                      `mapstructure:"buffer_count"`
 	// UseStartTimeMetric enables retrieving the start time of all counter metrics
 	// from the process_start_time_seconds metric. This is only correct if all counters on that endpoint
 	// started after the process start time, and the process is the only actor exporting the metric after
@@ -54,7 +54,8 @@ type Config struct {
 	// in incorrect rate calculations.
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
-	DisableStartTime     bool   `mapstructure:"disable_start_time"`
+	// DisableStartTime disables start time calculation of all metrics
+	DisableStartTime bool `mapstructure:"disable_start_time"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check
 	// that requires that all keys present in the config actually exist on the

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -43,9 +43,9 @@ const (
 // Config defines configuration for Prometheus receiver.
 type Config struct {
 	config.ReceiverSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
-	PrometheusConfig        *promconfig.Config       `mapstructure:"-"`
-	BufferPeriod            time.Duration            `mapstructure:"buffer_period"`
-	BufferCount             int                      `mapstructure:"buffer_count"`
+	PrometheusConfig        *promconfig.Config `mapstructure:"-"`
+	BufferPeriod            time.Duration      `mapstructure:"buffer_period"`
+	BufferCount             int                `mapstructure:"buffer_count"`
 	// UseStartTimeMetric enables retrieving the start time of all counter metrics
 	// from the process_start_time_seconds metric. This is only correct if all counters on that endpoint
 	// started after the process start time, and the process is the only actor exporting the metric after
@@ -54,7 +54,7 @@ type Config struct {
 	// in incorrect rate calculations.
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
-	DisableStartTime     bool   `mapstructure:"use_start_time_metric"`
+	DisableStartTime     bool   `mapstructure:"disable_start_time"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check
 	// that requires that all keys present in the config actually exist on the

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -54,7 +54,7 @@ type Config struct {
 	// in incorrect rate calculations.
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
-	// DisableStartTime disables start time calculation of all metrics
+	// DisableStartTime disables start time calculation of all metrics, which significantly reduces the memory usage of the receiver.
 	DisableStartTime bool `mapstructure:"disable_start_time"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -54,8 +54,8 @@ type Config struct {
 	// in incorrect rate calculations.
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
- 	// DisableStartTime disables start time calculation of all metrics, which significantly reduces the memory usage of the receiver.
- 	// Removing the start timestamp may limit the ability of other components and backends to offer full functionality with these metrics.
+	// DisableStartTime disables start time calculation of all metrics, which significantly reduces the memory usage of the receiver.
+	// Removing the start timestamp may limit the ability of other components and backends to offer full functionality with these metrics.
 	DisableStartTime bool `mapstructure:"disable_start_time"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -55,7 +55,9 @@ type Config struct {
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
 	// DisableStartTime disables start time calculation of all metrics, which significantly reduces the memory usage of the receiver.
-	// Removing the start timestamp may limit the ability of other components and backends to offer full functionality with these metrics.
+	// Start timestamp is strongly recommended for Sum, Histogram, and ExponentialHistogram points, removing the start timestamp
+	// may limit the ability of other components and backends to offer full functionality with these metrics.
+	// Use only if you know what you are doing.
 	DisableStartTime bool `mapstructure:"disable_start_time"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -46,6 +46,11 @@ type Config struct {
 	PrometheusConfig        *promconfig.Config       `mapstructure:"-"`
 	BufferPeriod            time.Duration            `mapstructure:"buffer_period"`
 	BufferCount             int                      `mapstructure:"buffer_count"`
+	// DisableStartTime disables start time calculation of all metrics, which significantly reduces the memory usage of the receiver.
+	// Start timestamp is strongly recommended for Sum, Histogram, and ExponentialHistogram points, removing the start timestamp
+	// may limit the ability of other components and backends to offer full functionality with these metrics.
+	// Use only if you know what you are doing.
+	DisableStartTime bool `mapstructure:"disable_start_time"`
 	// UseStartTimeMetric enables retrieving the start time of all counter metrics
 	// from the process_start_time_seconds metric. This is only correct if all counters on that endpoint
 	// started after the process start time, and the process is the only actor exporting the metric after
@@ -54,11 +59,6 @@ type Config struct {
 	// in incorrect rate calculations.
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
-	// DisableStartTime disables start time calculation of all metrics, which significantly reduces the memory usage of the receiver.
-	// Start timestamp is strongly recommended for Sum, Histogram, and ExponentialHistogram points, removing the start timestamp
-	// may limit the ability of other components and backends to offer full functionality with these metrics.
-	// Use only if you know what you are doing.
-	DisableStartTime bool `mapstructure:"disable_start_time"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check
 	// that requires that all keys present in the config actually exist on the

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -44,6 +44,7 @@ func NewFactory() component.ReceiverFactory {
 func createDefaultConfig() config.Receiver {
 	return &Config{
 		ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
+		DisableStartTime: true,
 	}
 }
 

--- a/receiver/prometheusreceiver/factory.go
+++ b/receiver/prometheusreceiver/factory.go
@@ -44,7 +44,7 @@ func NewFactory() component.ReceiverFactory {
 func createDefaultConfig() config.Receiver {
 	return &Config{
 		ReceiverSettings: config.NewReceiverSettings(config.NewComponentID(typeStr)),
-		DisableStartTime: true,
+		DisableStartTime: false,
 	}
 }
 

--- a/receiver/prometheusreceiver/internal/appendable.go
+++ b/receiver/prometheusreceiver/internal/appendable.go
@@ -29,12 +29,13 @@ import (
 type appendable struct {
 	sink                 consumer.Metrics
 	jobsMap              *JobsMap
+	disableStartTime     bool
 	useStartTimeMetric   bool
 	startTimeMetricRegex string
 	receiverID           config.ComponentID
-	externalLabels       labels.Labels
 
-	settings component.ReceiverCreateSettings
+	externalLabels labels.Labels
+	settings       component.ReceiverCreateSettings
 }
 
 // NewAppendable returns a storage.Appendable instance that emits metrics to the sink.
@@ -42,18 +43,22 @@ func NewAppendable(
 	sink consumer.Metrics,
 	set component.ReceiverCreateSettings,
 	gcInterval time.Duration,
+	disableStartTime bool,
 	useStartTimeMetric bool,
 	startTimeMetricRegex string,
 	receiverID config.ComponentID,
 	externalLabels labels.Labels) storage.Appendable {
 	var jobsMap *JobsMap
-	if !useStartTimeMetric {
-		jobsMap = NewJobsMap(gcInterval)
+	if !disableStartTime {
+		if !useStartTimeMetric {
+			jobsMap = NewJobsMap(gcInterval)
+		}
 	}
 	return &appendable{
 		sink:                 sink,
 		settings:             set,
 		jobsMap:              jobsMap,
+		disableStartTime:     disableStartTime,
 		useStartTimeMetric:   useStartTimeMetric,
 		startTimeMetricRegex: startTimeMetricRegex,
 		receiverID:           receiverID,

--- a/receiver/prometheusreceiver/internal/appendable.go
+++ b/receiver/prometheusreceiver/internal/appendable.go
@@ -67,5 +67,5 @@ func NewAppendable(
 }
 
 func (o *appendable) Appender(ctx context.Context) storage.Appender {
-	return newTransaction(ctx, o.jobsMap, o.useStartTimeMetric, o.startTimeMetricRegex, o.receiverID, o.sink, o.externalLabels, o.settings)
+	return newTransaction(ctx, o.jobsMap, o.disableStartTime, o.useStartTimeMetric, o.startTimeMetricRegex, o.receiverID, o.sink, o.externalLabels, o.settings)
 }

--- a/receiver/prometheusreceiver/internal/otlp_transaction.go
+++ b/receiver/prometheusreceiver/internal/otlp_transaction.go
@@ -147,7 +147,7 @@ func (t *transaction) Commit() error {
 		}
 		// Otherwise adjust the startTimestamp for all the metrics.
 		t.adjustStartTimestamp(metricsL)
-	} else {
+	} else if t.jobsMap != nil {
 		// TODO: Derive numPoints in this case.
 		_ = NewMetricsAdjuster(t.jobsMap.get(t.job, t.instance), t.logger).AdjustMetricSlice(metricsL)
 	}

--- a/receiver/prometheusreceiver/internal/otlp_transaction.go
+++ b/receiver/prometheusreceiver/internal/otlp_transaction.go
@@ -227,7 +227,11 @@ func (t *transaction) metricSliceToMetrics(metricsL *pmetric.MetricSlice) *pmetr
 	metrics := pmetric.NewMetrics()
 	rms := metrics.ResourceMetrics().AppendEmpty()
 	ilm := rms.ScopeMetrics().AppendEmpty()
-	metricsL.CopyTo(ilm.Metrics())
+	if t.jobsMap != nil {
+		metricsL.CopyTo(ilm.Metrics())
+	} else {
+		metricsL.MoveAndAppendTo(ilm.Metrics())
+	}
 	t.nodeResource.CopyTo(rms.Resource())
 	return &metrics
 }

--- a/receiver/prometheusreceiver/internal/otlp_transaction.go
+++ b/receiver/prometheusreceiver/internal/otlp_transaction.go
@@ -232,10 +232,12 @@ func (t *transaction) metricSliceToMetrics(metricsL *pmetric.MetricSlice) *pmetr
 	metrics := pmetric.NewMetrics()
 	rms := metrics.ResourceMetrics().AppendEmpty()
 	ilm := rms.ScopeMetrics().AppendEmpty()
-	if t.jobsMap != nil {
-		metricsL.CopyTo(ilm.Metrics())
-	} else {
+	if t.disableStartTime {
+		// adjust startTimestamp is disabled, metricsL will not be cached, and
+		// it's safe to move it to metrics and change it by its consumer
 		metricsL.MoveAndAppendTo(ilm.Metrics())
+	} else {
+		metricsL.CopyTo(ilm.Metrics())
 	}
 	t.nodeResource.CopyTo(rms.Resource())
 	return &metrics

--- a/receiver/prometheusreceiver/internal/otlp_transaction.go
+++ b/receiver/prometheusreceiver/internal/otlp_transaction.go
@@ -232,9 +232,8 @@ func (t *transaction) metricSliceToMetrics(metricsL *pmetric.MetricSlice) *pmetr
 	metrics := pmetric.NewMetrics()
 	rms := metrics.ResourceMetrics().AppendEmpty()
 	ilm := rms.ScopeMetrics().AppendEmpty()
-	if t.disableStartTime {
-		// adjust startTimestamp is disabled, metricsL will not be cached, and
-		// it's safe to move it to metrics and change it by its consumer
+	if t.jobsMap == nil {
+		// metricsL is not cached in jobsMap, and it's safe to be moved it to metrics and changed by its consumer
 		metricsL.MoveAndAppendTo(ilm.Metrics())
 	} else {
 		metricsL.CopyTo(ilm.Metrics())

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -80,6 +80,7 @@ func (r *pReceiver) Start(_ context.Context, host component.Host) error {
 		r.consumer,
 		r.settings,
 		gcInterval(r.cfg.PrometheusConfig),
+		r.cfg.DisableStartTime,
 		r.cfg.UseStartTimeMetric,
 		r.cfg.StartTimeMetricRegex,
 		r.cfg.ID(),

--- a/unreleased/prometheus-receiver-starttime.yaml
+++ b/unreleased/prometheus-receiver-starttime.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow to disable start time calculation."
+
+# One or more tracking issues related to the change
+issues: [12215]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Allow to disable start time calculation, which is unnecessary in prometheus world and saves a lot of memory usage and avoid potential memory leak (from jobsMap I guess ?), more details can be found in the comment in following issue.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9998#issuecomment-1178752819

**Testing:** <Describe what testing was performed and which tests were added.>
n/a

**Documentation:** <Describe the documentation added.>
comment for the new config