### PR TITLE
Enabled multi-arch build for local development container builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,8 +238,8 @@ run:
 
 .PHONY: docker-component # Not intended to be used directly
 docker-component: check-component
-	GOOS=linux GOARCH=amd64 $(MAKE) $(COMPONENT)
-	cp ./bin/$(COMPONENT)_linux_amd64 ./cmd/$(COMPONENT)/$(COMPONENT)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(MAKE) $(COMPONENT)
+	cp ./bin/$(COMPONENT)_$(GOOS)_$(GOARCH)$(EXTENSION) ./cmd/$(COMPONENT)/$(COMPONENT)
 	docker build -t $(COMPONENT) ./cmd/$(COMPONENT)/
 	rm ./cmd/$(COMPONENT)/$(COMPONENT)
 

--- a/unreleased/docker-multi-arch.yaml
+++ b/unreleased/docker-multi-arch.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: otelcontribcol
+
+# A brief description of the change
+note: Enabled multi-arch build for local development container builds
+
+# One or more tracking issues related to the change
+issues: [11873]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Fixed https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11873

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Build on MacOS

```console
$ make docker-otelcontribcol
COMPONENT=otelcontribcol /Applications/Xcode.app/Contents/Developer/usr/bin/make docker-component
GOOS=darwin GOARCH=amd64 /Applications/Xcode.app/Contents/Developer/usr/bin/make otelcontribcol
GO111MODULE=on CGO_ENABLED=0 go build -trimpath -o ./bin/otelcontribcol_darwin_amd64 \
		-ldflags "-X github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelcontribcore/internal/version.Version=v0.55.0-43-gf6c12bf6e" -tags "" ./cmd/otelcontribcol
cp ./bin/otelcontribcol_darwin_amd64 ./cmd/otelcontribcol/otelcontribcol
docker build -t otelcontribcol ./cmd/otelcontribcol/
[+] Building 5.6s (10/10) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                     0.0s
 => => transferring dockerfile: 37B                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                         0.6s
 => [prep 1/3] FROM docker.io/library/alpine:latest@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c                                                              0.0s
 => [internal] load build context                                                                                                                                                        3.0s
 => => transferring context: 216.33MB                                                                                                                                                    3.0s
 => CACHED [prep 2/3] RUN apk --update add ca-certificates                                                                                                                               0.0s
 => CACHED [prep 3/3] RUN mkdir -p /tmp                                                                                                                                                  0.0s
 => CACHED [stage-1 1/2] COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt                                                                          0.0s
 => [stage-1 2/2] COPY otelcontribcol /                                                                                                                                                  1.1s
 => exporting to image                                                                                                                                                                   0.8s
 => => exporting layers                                                                                                                                                                  0.8s
 => => writing image sha256:b7585d6502cdc7e95355256ca55f28418df5279422c2cde0c9523975e418afdb                                                                                             0.0s
 => => naming to docker.io/library/otelcontribcol                                                                                                                                        0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
rm ./cmd/otelcontribcol/otelcontribcol
```

**Documentation:** <Describe the documentation added.>