### PR TITLE
[pkg/telemetryquerylanguage] Expose a couple structs

### DIFF
--- a/pkg/telemetryquerylanguage/tql/expression.go
+++ b/pkg/telemetryquerylanguage/tql/expression.go
@@ -41,11 +41,11 @@ type GetSetter interface {
 	Setter
 }
 
-type literal struct {
+type Literal struct {
 	value interface{}
 }
 
-func (l literal) Get(ctx TransformContext) interface{} {
+func (l Literal) Get(ctx TransformContext) interface{} {
 	return l.value
 }
 
@@ -59,23 +59,23 @@ func (g exprGetter) Get(ctx TransformContext) interface{} {
 
 func NewGetter(val Value, functions map[string]interface{}, pathParser PathExpressionParser) (Getter, error) {
 	if val.IsNil != nil && *val.IsNil {
-		return &literal{value: nil}, nil
+		return &Literal{value: nil}, nil
 	}
 
 	if s := val.String; s != nil {
-		return &literal{value: *s}, nil
+		return &Literal{value: *s}, nil
 	}
 	if f := val.Float; f != nil {
-		return &literal{value: *f}, nil
+		return &Literal{value: *f}, nil
 	}
 	if i := val.Int; i != nil {
-		return &literal{value: *i}, nil
+		return &Literal{value: *i}, nil
 	}
 	if b := val.Bool; b != nil {
-		return &literal{value: bool(*b)}, nil
+		return &Literal{value: bool(*b)}, nil
 	}
 	if b := val.Bytes; b != nil {
-		return &literal{value: ([]byte)(*b)}, nil
+		return &Literal{value: ([]byte)(*b)}, nil
 	}
 
 	if val.Path != nil {

--- a/pkg/telemetryquerylanguage/tql/expression_test.go
+++ b/pkg/telemetryquerylanguage/tql/expression_test.go
@@ -120,15 +120,15 @@ func Test_newGetter(t *testing.T) {
 }
 
 // pathGetSetter is a getSetter which has been resolved using a path expression provided by a user.
-type testGetSetter struct {
-	getter ExprFunc
-	setter func(ctx TransformContext, val interface{})
+type TestGetSetter struct {
+	Getter ExprFunc
+	Setter func(ctx TransformContext, val interface{})
 }
 
-func (path testGetSetter) Get(ctx TransformContext) interface{} {
-	return path.getter(ctx)
+func (path TestGetSetter) Get(ctx TransformContext) interface{} {
+	return path.Getter(ctx)
 }
 
-func (path testGetSetter) Set(ctx TransformContext, val interface{}) {
-	path.setter(ctx, val)
+func (path TestGetSetter) Set(ctx TransformContext, val interface{}) {
+	path.Setter(ctx, val)
 }

--- a/pkg/telemetryquerylanguage/tql/parser_test.go
+++ b/pkg/telemetryquerylanguage/tql/parser_test.go
@@ -396,11 +396,11 @@ func Test_parse_failure(t *testing.T) {
 
 func testParsePath(val *Path) (GetSetter, error) {
 	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "name" {
-		return &testGetSetter{
-			getter: func(ctx TransformContext) interface{} {
+		return &TestGetSetter{
+			Getter: func(ctx TransformContext) interface{} {
 				return ctx.GetItem()
 			},
-			setter: func(ctx TransformContext, val interface{}) {
+			Setter: func(ctx TransformContext, val interface{}) {
 				ctx.GetItem()
 			},
 		}, nil


### PR DESCRIPTION
Quick PR to expose a couple structs so that the transform processor can be updated to use the package.

Should've been done as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/11771.

Related to #11751 