### PR TITLE
[receiver/jaeger] Handle spans with own process

### DIFF
--- a/pkg/translator/jaeger/jaegerproto_to_traces.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces.go
@@ -16,7 +16,9 @@ package jaeger // import "github.com/open-telemetry/opentelemetry-collector-cont
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
+	"hash/fnv"
 	"reflect"
 	"strconv"
 	"strings"
@@ -40,6 +42,7 @@ func ProtoToTraces(batches []*model.Batch) (ptrace.Traces, error) {
 		return traceData, nil
 	}
 
+	batches = regroup(batches)
 	rss := traceData.ResourceSpans()
 	rss.EnsureCapacity(len(batches))
 
@@ -52,6 +55,75 @@ func ProtoToTraces(batches []*model.Batch) (ptrace.Traces, error) {
 	}
 
 	return traceData, nil
+}
+
+func regroup(batches []*model.Batch) []*model.Batch {
+	// Re-group batches
+	// This is needed as there might be a Process within Batch and Span at the same
+	// time, with the span one taking precedence.
+	// As we only have it at one level in OpenTelemetry, ResourceSpans, we split
+	// each batch into potentially multiple other batches, with the sum of their
+	// processes as the key to a map.
+	// Step 1) iterate over the batches
+	// Step 2) for each batch, calculate the batch's process checksum and store
+	// it on a map, with the checksum as the key and the process as the value
+	// Step 3) iterate the spans for a batch: if a given span has its own process,
+	// calculate the checksum for the process and store it on the same map
+	// Step 4) each entry on the map becomes a ResourceSpan
+	registry := map[uint64]*model.Batch{}
+
+	for _, batch := range batches {
+		bb := batchForProcess(registry, batch.Process)
+		for _, span := range batch.Spans {
+			if span.Process == nil {
+				bb.Spans = append(bb.Spans, span)
+			} else {
+				b := batchForProcess(registry, span.Process)
+				b.Spans = append(b.Spans, span)
+			}
+		}
+	}
+
+	result := []*model.Batch{}
+	for _, v := range registry {
+		result = append(result, v)
+	}
+
+	return result
+}
+
+func batchForProcess(registry map[uint64]*model.Batch, p *model.Process) *model.Batch {
+	sum := checksum(p)
+	batch := registry[sum]
+	if batch == nil {
+		batch = &model.Batch{
+			Process: p,
+		}
+		registry[sum] = batch
+	}
+
+	return batch
+}
+
+func checksum(process *model.Process) uint64 {
+	// this will get all the keys and values, plus service name, into this buffer
+	// this is potentially dangerous, as a batch/span with a big enough processes
+	// might cause the collector to allocate this extra big information
+	// for this reason, we hash it as an integer and return it, instead of keeping
+	// all the hashes for all the processes for all batches in memory
+	fnvHash := fnv.New64a()
+
+	if process != nil {
+		// this effectively means that all spans from batches with nil processes
+		// will be grouped together
+		// this should only ever happen in unit tests
+		// this implementation never returns an error according to the Hash interface
+		_ = process.Hash(fnvHash)
+	}
+
+	out := make([]byte, 0, 16)
+	out = fnvHash.Sum(out)
+	return binary.BigEndian.Uint64(out)
 }
 
 func protoBatchToResourceSpans(batch model.Batch, dest ptrace.ResourceSpans) {

--- a/pkg/translator/jaeger/jaegerproto_to_traces_test.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces_test.go
@@ -499,6 +499,72 @@ func TestJSpanKindToInternal(t *testing.T) {
 	}
 }
 
+func TestRegroup(t *testing.T) {
+	// prepare
+	process := &model.Process{
+		ServiceName: "batch-process",
+	}
+	spanWithoutProcess := &model.Span{
+		OperationName: "span-without-process",
+	}
+	spanWithProcess := &model.Span{
+		Process: &model.Process{
+			ServiceName: "custom-service-name",
+		},
+	}
+
+	originalBatches := []*model.Batch{
+		{
+			Process: process,
+			Spans:   []*model.Span{spanWithProcess, spanWithoutProcess},
+		},
+	}
+
+	expected := []*model.Batch{
+		{
+			Process: process,
+			Spans:   []*model.Span{spanWithoutProcess},
+		},
+		{
+			Process: spanWithProcess.Process,
+			Spans:   []*model.Span{spanWithProcess},
+		},
+	}
+
+	// test
+	result := regroup(originalBatches)
+
+	// verify
+	assert.ElementsMatch(t, expected, result)
+}
+
+func TestChecksum(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		input    *model.Process
+		expected uint64
+	}{
+		{
+			desc: "valid process",
+			input: &model.Process{
+				ServiceName: "some-service-name",
+			},
+			expected: 0x974574e8529af5dd, // acquired by running it once
+		},
+		{
+			desc:     "nil process",
+			input:    nil,
+			expected: 0xcbf29ce484222325, // acquired by running it once
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			out := checksum(tC.input)
+			assert.Equal(t, tC.expected, out)
+		})
+	}
+}
+
 func generateTracesResourceOnly() ptrace.Traces {
 	td := testdata.GenerateTracesOneEmptyResourceSpans()
 	rs := td.ResourceSpans().At(0).Resource()

--- a/unreleased/jaegerreceiver-10186.yaml
+++ b/unreleased/jaegerreceiver-10186.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: receiver/jaeger
+note: Handle spans with own process
+issues: [10186]

--- a/unreleased/translator-jaeger-10186.yaml
+++ b/unreleased/translator-jaeger-10186.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: pkg/translator/jaeger
+note: Handle spans with own process
+issues: [10186]


### PR DESCRIPTION
In OpenTelemetry, we only have "process" at the ResourceSpan level, whereas in Jaeger, theremight be a Process at both Batch and Span levels.

Previously, this translator considered only the batch's process while building the resource spans. This change makes the translator consider also the span's process, and will regroup the input so that one batch is used for each process. The remaining of the logic is the same.

Fixes #10186

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
