### PR TITLE
[awsxrayreceiver]: End obsreport span when poller loop completes successfully

### DIFF
--- a/receiver/awsxrayreceiver/internal/udppoller/poller.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller.go
@@ -220,6 +220,7 @@ func (p *poller) poll() {
 				Payload: copybody,
 				Ctx:     ctx,
 			}
+			p.obsrecv.EndTracesOp(ctx, awsxray.TypeStr, 1, nil)
 		}
 	}
 }

--- a/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
@@ -154,7 +154,7 @@ func TestSuccessfullyPollPacket(t *testing.T) {
 		}
 	}, 10*time.Second, 5*time.Millisecond, "poller should return parsed segment")
 
-	assert.NoError(t, obsreporttest.CheckReceiverTraces(tt, receiverID, Transport, 1, 0))
+	assert.NoError(t, obsreporttest.CheckReceiverTraces(tt, receiverID, Transport, 2, 0))
 }
 
 func TestIncompletePacketNoSeparator(t *testing.T) {

--- a/receiver/awsxrayreceiver/receiver_test.go
+++ b/receiver/awsxrayreceiver/receiver_test.go
@@ -166,7 +166,7 @@ func TestTranslatorErrorsOut(t *testing.T) {
 			"X-Ray segment to OT traces conversion failed")
 	}, 10*time.Second, 5*time.Millisecond, "poller should log warning because consumer errored out")
 
-	assert.NoError(t, obsreporttest.CheckReceiverTraces(tt, receiverID, udppoller.Transport, 0, 1))
+	assert.NoError(t, obsreporttest.CheckReceiverTraces(tt, receiverID, udppoller.Transport, 1, 1))
 }
 
 func TestSegmentsConsumerErrorsOut(t *testing.T) {
@@ -194,7 +194,7 @@ func TestSegmentsConsumerErrorsOut(t *testing.T) {
 			"Trace consumer errored out")
 	}, 10*time.Second, 5*time.Millisecond, "poller should log warning because consumer errored out")
 
-	assert.NoError(t, obsreporttest.CheckReceiverTraces(tt, receiverID, udppoller.Transport, 0, 1))
+	assert.NoError(t, obsreporttest.CheckReceiverTraces(tt, receiverID, udppoller.Transport, 1, 1))
 }
 
 func TestPollerCloseError(t *testing.T) {

--- a/unreleased/fix_xrayreceiver_pollingSpans.yaml
+++ b/unreleased/fix_xrayreceiver_pollingSpans.yaml
@@ -8,7 +8,7 @@ component: xrayreceiver
 note: Ensure that the UDP Poller ends the obsreport span it creates with every loop.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [12299]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/unreleased/fix_xrayreceiver_pollingSpans.yaml
+++ b/unreleased/fix_xrayreceiver_pollingSpans.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: xrayreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure that the UDP Poller ends the obsreport span it creates with every loop.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This avoids a memory leak that can happen when spans are created to track received
+  segments but never ended.


### PR DESCRIPTION
Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

This avoids a memory leak that can happen when spans are created to track received segments but never ended.