### PR TITLE
skip changelog for [chore] prs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,7 @@
 # This action requires that any PR targeting the main branch should add a
 # yaml file to the ./unreleased/ directory. If a CHANGELOG entry is not required,
-# or if performing maintance on the Changelog, add \"[chore]\" to the title of the
-# pull request to disable this action.
+# or if performing maintance on the Changelog, add either \"[chore]\" to the title of
+# the pull request or add the \"Skip Changelog\" label to disable this action.
 
 name: changelog
 
@@ -40,7 +40,7 @@ jobs:
             echo "The CHANGELOG should not be directly modified."
             echo "Please add a .yaml file to the ./unreleased/ directory."
             echo "See CONTRIBUTING.md for more details."
-            echo "Alternately, add \"[chore]\" to the title of the pull request if this job should be skipped."
+            echo "Alternately, add either \"[chore]\" to the title of the pull request or add the \"Skip Changelog\" label if this job should be skipped."
             false
           else
             echo "The CHANGELOG was not modified."
@@ -53,7 +53,7 @@ jobs:
             echo "No changelog entry was added to the ./unreleased/ directory."
             echo "Please add a .yaml file to the ./unreleased/ directory."
             echo "See CONTRIBUTING.md for more details."
-            echo "Alternately, add \"[chore]\" to the title of the pull request if this job should be skipped."
+            echo ""Alternately, add either \"[chore]\" to the title of the pull request or add the \"Skip Changelog\" label if this job should be skipped."
             false
           else
             echo "A changelog entry was added to the ./unreleased/ directory!"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,7 @@
 # This action requires that any PR targeting the main branch should add a
 # yaml file to the ./unreleased/ directory. If a CHANGELOG entry is not required,
-# or if performing maintance on the Changelog, add the "Skip Changelog" label to
-# disable this action.
+# or if performing maintance on the Changelog, add \"[chore]\" to the title of the
+# pull request to disable this action.
 
 name: changelog
 
@@ -13,7 +13,7 @@ on:
 jobs:
   changelog:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')}}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
 
     steps:
       - name: Checkout Repo
@@ -40,7 +40,7 @@ jobs:
             echo "The CHANGELOG should not be directly modified."
             echo "Please add a .yaml file to the ./unreleased/ directory."
             echo "See CONTRIBUTING.md for more details."
-            echo "Alternately, add the \"Skip Changelog\" label if this job should be skipped."
+            echo "Alternately, add \"[chore]\" to the title of the pull request if this job should be skipped."
             false
           else
             echo "The CHANGELOG was not modified."
@@ -53,7 +53,7 @@ jobs:
             echo "No changelog entry was added to the ./unreleased/ directory."
             echo "Please add a .yaml file to the ./unreleased/ directory."
             echo "See CONTRIBUTING.md for more details."
-            echo "Alternately, add the \"Skip Changelog\" label if this job should be skipped."
+            echo "Alternately, add \"[chore]\" to the title of the pull request if this job should be skipped."
             false
           else
             echo "A changelog entry was added to the ./unreleased/ directory!"

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -40,4 +40,4 @@ git commit -m "dependabot updates `date`
 $message"
 git push origin $PR_NAME
 
-gh pr create --title "dependabot updates `date`" --body "$message" -l "Skip Changelog"
+gh pr create --title "[chore] dependabot updates `date`" --body "$message" -l "Skip Changelog"


### PR DESCRIPTION
Add a check in the changelog job to skip the job if the title of the PR contains `[chore]`. This makes it possible for a user who's change doesn't require a changelog entry and doesn't have write access to the repository to skip this check.

For now I've left the check for the "Skip Changelog" label as well, in the future, this should be removed and the label can be removed altogether.