### PR TITLE
[chore] skip flaky test TestOracleDBIntegration

### DIFF
--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -156,9 +156,15 @@ func TestPostgresIntegration(t *testing.T) {
 	testPGTypeMetrics(t, rms.At(1))
 }
 
+// workaround to avoid "unused" lint errors which test is skipped
+var skip = func(t *testing.T, why string) {
+	t.Skip(why)
+}
+
 // This test ensures the collector can connect to an Oracle DB, and properly get metrics. It's not intended to
 // test the receiver itself.
 func TestOracleDBIntegration(t *testing.T) {
+	skip(t, "Flaky test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12332")
 	externalPort := "51521"
 	internalPort := "1521"
 


### PR DESCRIPTION
This test times out with 360s timeout. Further investigation needs to happen into the cause, but for now, unblocking the build.
