### PR TITLE
[pkg/stanza] Localize file offset initialization

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -120,7 +120,6 @@ func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Input, error) 
 		SugaredLogger:      logger.With("component", "fileconsumer"),
 		finder:             c.Finder,
 		PollInterval:       c.PollInterval.Raw(),
-		startAtBeginning:   startAtBeginning,
 		queuedMatches:      make([]string, 0),
 		firstCheck:         true,
 		cancel:             func() {},
@@ -135,6 +134,7 @@ func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Input, error) 
 				maxLogSize:      int(c.MaxLogSize),
 				emit:            emit,
 			},
+			fromBeginning:  startAtBeginning,
 			splitterConfig: c.Splitter,
 		},
 	}, nil

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -224,7 +224,7 @@ OUTER:
 
 	readers := make([]*Reader, 0, len(fps))
 	for i := 0; i < len(fps); i++ {
-		reader, err := f.newReader(files[i], fps[i], f.firstCheck)
+		reader, err := f.newReader(files[i], fps[i])
 		if err != nil {
 			f.Errorw("Failed to create reader", zap.Error(err))
 			continue
@@ -254,7 +254,7 @@ func (f *Input) saveCurrent(readers []*Reader) {
 	}
 }
 
-func (f *Input) newReader(file *os.File, fp *Fingerprint, firstCheck bool) (*Reader, error) {
+func (f *Input) newReader(file *os.File, fp *Fingerprint) (*Reader, error) {
 	// Check if the new path has the same fingerprint as an old path
 	if oldReader, ok := f.findFingerprintMatch(fp); ok {
 		return f.readerFactory.copy(oldReader, file)

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -438,9 +438,10 @@ func TestStartAtEnd(t *testing.T) {
 // beginning
 func TestStartAtEndNewFile(t *testing.T) {
 	t.Parallel()
-	operator, emitCalls, tempDir := newTestScenario(t, nil)
+	operator, emitCalls, tempDir := newTestScenario(t, func(cfg *Config) {
+		cfg.StartAt = "beginning"
+	})
 	operator.persister = testutil.NewMockPersister("test")
-	operator.startAtBeginning = false
 	defer func() {
 		require.NoError(t, operator.Stop())
 	}()

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -43,15 +43,13 @@ type Reader struct {
 	fileAttributes *FileAttributes
 }
 
-// InitializeOffset sets the starting offset
-func (r *Reader) InitializeOffset(startAtBeginning bool) error {
-	if !startAtBeginning {
-		info, err := r.file.Stat()
-		if err != nil {
-			return fmt.Errorf("stat: %w", err)
-		}
-		r.Offset = info.Size()
+// offsetToEnd sets the starting offset
+func (r *Reader) offsetToEnd() error {
+	info, err := r.file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat: %w", err)
 	}
+	r.Offset = info.Size()
 	return nil
 }
 

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -25,6 +25,7 @@ import (
 type readerFactory struct {
 	*zap.SugaredLogger
 	readerConfig   *readerConfig
+	fromBeginning  bool
 	splitterConfig helper.SplitterConfig
 }
 
@@ -113,6 +114,10 @@ func (b *readerBuilder) build() (r *Reader, err error) {
 
 	if b.fp != nil {
 		r.Fingerprint = b.fp
+	}
+
+	if !b.fromBeginning {
+		r.offsetToEnd()
 	}
 
 	return r, nil

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -117,7 +117,9 @@ func (b *readerBuilder) build() (r *Reader, err error) {
 	}
 
 	if !b.fromBeginning {
-		r.offsetToEnd()
+		if err := r.offsetToEnd(); err != nil {
+			return nil, err
+		}
 	}
 
 	return r, nil


### PR DESCRIPTION
This refactoring transfers responsibility for Reader offset initialization to the readerFactory.

The motivation for this change is to simplify reader instantiation so that Readers can be instantiated more consistently, especially for test cases. (ie initialization of the Reader's offset should be automatic)

Users can configure whether or not to start reading from the beginning or end of files, but this only applies to the initial set of files found in the matching pattern. New files are consumed entirely, so reading from the beginning is assumed after the first poll cycle. 

The boolean that tracks the state of where to start reading, is overridden automatically. This flag does not require a mutex because it is written to at a point in the poll cycle where there is only a single goroutine running. 