### PR TITLE
[exporter/prometheus] fix: cumulative condition based on the starttimestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 <!-- next version -->
 
+## Unreleased
+
+### 🧰 Bug fixes 🧰
+- `prometheusexporter`: Fix cumulative condition for Delta-to-cumulative (#12340)
+
+
 # v0.55.0
 
 ## 🛑 Breaking changes 🛑

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@
 
 <!-- next version -->
 
-## Unreleased
-
-### 🧰 Bug fixes 🧰
-- `prometheusexporter`: Fix cumulative condition for Delta-to-cumulative (#12340)
-
-
 # v0.55.0
 
 ## 🛑 Breaking changes 🛑

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -212,7 +212,7 @@ func (a *lastValueAccumulator) accumulateSum(metric pmetric.Metric, il pcommon.I
 		}
 
 		// Delta-to-Cumulative
-		if doubleSum.AggregationTemporality() == pmetric.MetricAggregationTemporalityDelta && ip.StartTimestamp() == mv.value.Sum().DataPoints().At(0).StartTimestamp() {
+		if doubleSum.AggregationTemporality() == pmetric.MetricAggregationTemporalityDelta && ip.StartTimestamp() == mv.value.Sum().DataPoints().At(0).Timestamp() {
 			ip.SetStartTimestamp(mv.value.Sum().DataPoints().At(0).StartTimestamp())
 			switch ip.ValueType() {
 			case pmetric.NumberDataPointValueTypeInt:

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -413,19 +413,22 @@ func TestAccumulateDeltaToCumulative(t *testing.T) {
 			ilm.Scope().SetName("test")
 			a := newAccumulator(zap.NewNop(), 1*time.Hour).(*lastValueAccumulator)
 
+			dataPointValue1 := float64(11)
+			dataPointValue2 := float64(32)
+
 			// The first point arrived
-			tt.metric(ts1, ts2, 11, ilm.Metrics())
+			tt.metric(ts1, ts2, dataPointValue1, ilm.Metrics())
 			n := a.Accumulate(resourceMetrics)
 
 			require.Equal(t, 1, n)
 
 			// The next point arrived
-			tt.metric(ts2, ts3, 31, ilm.Metrics())
+			tt.metric(ts2, ts3, dataPointValue2, ilm.Metrics())
 			n = a.Accumulate(resourceMetrics)
 
 			require.Equal(t, 2, n)
 
-			mLabels, _, _, _, mIsMonotonic := getMetricProperties(ilm.Metrics().At(1))
+			mLabels, _, mValue, _, _ := getMetricProperties(ilm.Metrics().At(1))
 			signature := timeseriesSignature(ilm.Scope().Name(), ilm.Metrics().At(0), mLabels, pcommon.NewMap())
 			m, ok := a.registeredMetrics.Load(signature)
 			require.True(t, ok)
@@ -443,9 +446,10 @@ func TestAccumulateDeltaToCumulative(t *testing.T) {
 				return true
 			})
 			require.Equal(t, mLabels.Len(), vLabels.Len())
-			require.Equal(t, float64(42), vValue)
+			require.Equal(t, mValue, vValue)
+			require.Equal(t, dataPointValue1+dataPointValue2, vValue)
 			require.Equal(t, pmetric.MetricAggregationTemporalityCumulative, vTemporality)
-			require.Equal(t, mIsMonotonic, vIsMonotonic)
+			require.Equal(t, true, vIsMonotonic)
 
 			require.Equal(t, ts3.Unix(), vTS.Unix())
 		})

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -425,7 +425,7 @@ func TestAccumulateDeltaToCumulative(t *testing.T) {
 
 			require.Equal(t, 2, n)
 
-			mLabels, _, mValue, _, mIsMonotonic := getMetricProperties(ilm.Metrics().At(1))
+			mLabels, _, _, _, mIsMonotonic := getMetricProperties(ilm.Metrics().At(1))
 			signature := timeseriesSignature(ilm.Scope().Name(), ilm.Metrics().At(0), mLabels, pcommon.NewMap())
 			m, ok := a.registeredMetrics.Load(signature)
 			require.True(t, ok)
@@ -443,7 +443,7 @@ func TestAccumulateDeltaToCumulative(t *testing.T) {
 				return true
 			})
 			require.Equal(t, mLabels.Len(), vLabels.Len())
-			require.Equal(t, mValue, vValue)
+			require.Equal(t, float64(42), vValue)
 			require.Equal(t, pmetric.MetricAggregationTemporalityCumulative, vTemporality)
 			require.Equal(t, mIsMonotonic, vIsMonotonic)
 

--- a/unreleased/fix_cumulative-condition.yaml
+++ b/unreleased/fix_cumulative-condition.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusexporter
+
+# A brief description of the change
+note: Fix cumulative condition for the delta-to-cumulative
+
+# One or more tracking issues related to the change
+issues: [4153]


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Fixing the erroneous change in this commit https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9919/commits/e7ab883f99972574941f43171fd2efeb86edf75a#diff-9822bc07132ceeeb9c69a90898caccf2d9f9acefe0cef5b5bae0dc2cc9e44764R213

which it should be comparing between the startTimestamp of the next data point to the Timestamp of the last data point.

**Link to tracking Issue:** <Issue number if applicable> N/A

**Testing:**

The similar way in #9919