### PR TITLE
[pkg/stanza] Fix issue where fileconsumer could be tripped up by newlines

### DIFF
--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -476,8 +476,8 @@ func TestNoNewline(t *testing.T) {
 	waitForToken(t, emitCalls, []byte("testlog2"))
 }
 
-// SkipEmpty tests that the any empty lines are skipped
-func TestSkipEmpty(t *testing.T) {
+// TestEmptyLine tests that the any empty lines are consumed
+func TestEmptyLine(t *testing.T) {
 	t.Parallel()
 	operator, emitCalls, tempDir := newTestScenario(t, nil)
 
@@ -490,7 +490,47 @@ func TestSkipEmpty(t *testing.T) {
 	}()
 
 	waitForToken(t, emitCalls, []byte("testlog1"))
+	waitForToken(t, emitCalls, []byte(""))
 	waitForToken(t, emitCalls, []byte("testlog2"))
+}
+
+// TestMultipleEmpty tests that multiple empty lines
+// can be consumed without the operator becoming stuck
+func TestMultipleEmpty(t *testing.T) {
+	t.Parallel()
+	operator, emitCalls, tempDir := newTestScenario(t, nil)
+
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "\n\ntestlog1\n\n\ntestlog2\n")
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer operator.Stop()
+
+	waitForToken(t, emitCalls, []byte(""))
+	waitForToken(t, emitCalls, []byte(""))
+	waitForToken(t, emitCalls, []byte("testlog1"))
+	waitForToken(t, emitCalls, []byte(""))
+	waitForToken(t, emitCalls, []byte(""))
+	waitForToken(t, emitCalls, []byte("testlog2"))
+	expectNoTokensUntil(t, emitCalls, time.Second)
+}
+
+// TestLeadingEmpty tests that the the operator handles a leading
+// newline, and does not read the file multiple times
+func TestLeadingEmpty(t *testing.T) {
+	t.Parallel()
+	operator, emitCalls, tempDir := newTestScenario(t, nil)
+
+	temp := openTemp(t, tempDir)
+	writeString(t, temp, "\ntestlog1\ntestlog2\n")
+
+	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
+	defer operator.Stop()
+
+	waitForToken(t, emitCalls, []byte(""))
+	waitForToken(t, emitCalls, []byte("testlog1"))
+	waitForToken(t, emitCalls, []byte("testlog2"))
+	expectNoTokensUntil(t, emitCalls, time.Second)
 }
 
 // SplitWrite tests a line written in two writes

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -504,7 +504,9 @@ func TestMultipleEmpty(t *testing.T) {
 	writeString(t, temp, "\n\ntestlog1\n\n\ntestlog2\n")
 
 	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
-	defer operator.Stop()
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
 
 	waitForToken(t, emitCalls, []byte(""))
 	waitForToken(t, emitCalls, []byte(""))
@@ -525,7 +527,9 @@ func TestLeadingEmpty(t *testing.T) {
 	writeString(t, temp, "\ntestlog1\ntestlog2\n")
 
 	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
-	defer operator.Stop()
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
 
 	waitForToken(t, emitCalls, []byte(""))
 	waitForToken(t, emitCalls, []byte("testlog1"))

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -114,6 +114,12 @@ func (b *readerBuilder) build() (r *Reader, err error) {
 
 	if b.fp != nil {
 		r.Fingerprint = b.fp
+	} else if b.file != nil {
+		fp, err := b.readerFactory.newFingerprint(r.file)
+		if err != nil {
+			return nil, err
+		}
+		r.Fingerprint = fp
 	}
 
 	if !b.fromBeginning {

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -32,7 +32,7 @@ func TestTokenization(t *testing.T) {
 	}{
 		{
 			"simple",
-			[]byte("testlog1\ntestlog2"),
+			[]byte("testlog1\ntestlog2\n"),
 			[][]byte{
 				[]byte("testlog1"),
 				[]byte("testlog2"),
@@ -49,8 +49,8 @@ func TestTokenization(t *testing.T) {
 			"empty_first",
 			[]byte("\ntestlog1\ntestlog2\n"),
 			[][]byte{
-				[]byte("testlog1"),
 				[]byte(""),
+				[]byte("testlog1"),
 				[]byte("testlog2"),
 			},
 		},
@@ -79,8 +79,6 @@ func TestTokenization(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			t.Parallel()
-
 			f, emitChan := testReaderFactory(t)
 
 			temp := openTemp(t, t.TempDir())

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -1,0 +1,125 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileconsumer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenization(t *testing.T) {
+	testCases := []struct {
+		testName    string
+		fileContent []byte
+		expected    [][]byte
+	}{
+		{
+			"simple",
+			[]byte("testlog1\ntestlog2"),
+			[][]byte{
+				[]byte("testlog1"),
+				[]byte("testlog2"),
+			},
+		},
+		{
+			"empty_only",
+			[]byte("\n"),
+			[][]byte{
+				[]byte(""),
+			},
+		},
+		{
+			"empty_first",
+			[]byte("\ntestlog1\ntestlog2\n"),
+			[][]byte{
+				[]byte("testlog1"),
+				[]byte(""),
+				[]byte("testlog2"),
+			},
+		},
+		{
+			"empty_between_lines",
+			[]byte("testlog1\n\ntestlog2\n"),
+			[][]byte{
+				[]byte("testlog1"),
+				[]byte(""),
+				[]byte("testlog2"),
+			},
+		},
+		{
+			"multiple_empty",
+			[]byte("\n\ntestlog1\n\n\ntestlog2\n"),
+			[][]byte{
+				[]byte(""),
+				[]byte(""),
+				[]byte("testlog1"),
+				[]byte(""),
+				[]byte(""),
+				[]byte("testlog2"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
+
+			f, emitChan := testReaderFactory(t)
+
+			temp := openTemp(t, t.TempDir())
+			_, err := temp.Write(tc.fileContent)
+			require.NoError(t, err)
+
+			r, err := f.newReaderBuilder().withFile(temp).build()
+			require.NoError(t, err)
+
+			r.ReadToEnd(context.Background())
+
+			for _, expected := range tc.expected {
+				require.Equal(t, expected, readToken(t, emitChan))
+			}
+		})
+	}
+}
+
+func testReaderFactory(t *testing.T) (*readerFactory, chan *emitParams) {
+	emitChan := make(chan *emitParams, 100)
+	return &readerFactory{
+		SugaredLogger: testutil.Logger(t),
+		readerConfig: &readerConfig{
+			fingerprintSize: DefaultFingerprintSize,
+			maxLogSize:      defaultMaxLogSize,
+			emit: func(_ context.Context, attrs *FileAttributes, token []byte) {
+				emitChan <- &emitParams{attrs, token}
+			},
+		},
+		fromBeginning: true,
+	}, emitChan
+}
+
+func readToken(t *testing.T, c chan *emitParams) []byte {
+	select {
+	case call := <-c:
+		return call.token
+	case <-time.After(3 * time.Second):
+		require.FailNow(t, "Timed out waiting for token")
+	}
+	return nil
+}

--- a/pkg/stanza/operator/helper/multiline.go
+++ b/pkg/stanza/operator/helper/multiline.go
@@ -339,10 +339,10 @@ func trimWhitespaces(data []byte) []byte {
 	// TrimLeft to strip EOF whitespaces in case of using $ in regex
 	// For some reason newline and carriage return are being moved to beginning of next log
 	// TrimRight to strip all whitespaces from the end of log
-	// returns nil if log is empty
+	// returns empty slice if log is empty
 	token := bytes.TrimLeft(bytes.TrimRight(data, "\r\n\t "), "\r\n")
 	if len(token) == 0 {
-		return nil
+		return []byte{}
 	}
 	return token
 }

--- a/pkg/stanza/operator/helper/multiline.go
+++ b/pkg/stanza/operator/helper/multiline.go
@@ -339,9 +339,8 @@ func trimWhitespaces(data []byte) []byte {
 	// TrimLeft to strip EOF whitespaces in case of using $ in regex
 	// For some reason newline and carriage return are being moved to beginning of next log
 	// TrimRight to strip all whitespaces from the end of log
-	// returns empty slice if log is empty
 	token := bytes.TrimLeft(bytes.TrimRight(data, "\r\n\t "), "\r\n")
-	if len(token) == 0 {
+	if token == nil {
 		return []byte{}
 	}
 	return token

--- a/pkg/stanza/operator/helper/multiline_test.go
+++ b/pkg/stanza/operator/helper/multiline_test.go
@@ -273,6 +273,7 @@ func TestLineStartSplitFunc(t *testing.T) {
 			Pattern: `^LOGSTART \d+`,
 			Raw:     []byte("\nLOGSTART 333"),
 			ExpectedTokenized: []string{
+				"",
 				"LOGSTART 333",
 			},
 			Flusher: &Flusher{
@@ -571,6 +572,7 @@ func TestNewlineSplitFunc(t *testing.T) {
 			Name: "LogsWithLogStartingWithWhiteChars",
 			Raw:  []byte("\nLOGEND 333\nAnother one"),
 			ExpectedTokenized: []string{
+				"",
 				"LOGEND 333",
 			},
 		},
@@ -742,6 +744,7 @@ func TestNewlineSplitFunc_Encodings(t *testing.T) {
 			unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM),
 			[]byte{0, 13, 0, 10, 0, 108, 0, 111, 0, 103, 0, 49, 0, 13, 0, 10, 0, 108, 0, 111, 0, 103, 0, 50, 0, 13, 0, 10}, // \r\nlog1\r\nlog2\r\n
 			[][]byte{
+				{},
 				{0, 108, 0, 111, 0, 103, 0, 49}, // log1
 				{0, 108, 0, 111, 0, 103, 0, 50}, // log2
 			},

--- a/unreleased/pkg-stanza-reader-newlines.yaml
+++ b/unreleased/pkg-stanza-reader-newlines.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza/fileconsumer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where reader could become stuck on newlines
+
+# One or more tracking issues related to the change
+issues: [10125, 10127, 10128]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
Extends from #12339

Resolves #10125 
Resolves #10127 
Resolves #10128

This changes how lines are split apart, such that empty lines are not ignored. This has effects on multiple levels of the call chain, but basically it allows empty lines to propogate in the same way as non-empty lines. 

This allows the `PositionalScanner` to update correctly when encountering empty lines. It also means that callers to the `fileconsumer` package can make their own decisions about what to do with empty lines. In all current cases, empty lines were already handled explicitly, so no changes were necessary at that level.