### PR TITLE
[dynatraceexporter] Update Changelog entry to be breaking instead

### DIFF
--- a/unreleased/dt-updates.yaml
+++ b/unreleased/dt-updates.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: dynatraceexporter
@@ -12,4 +12,5 @@ issues: [ 11828 ]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
-subtext:
+subtext:  |2
+  - Non-monotonic Sum metrics will be exported as Gauges from now on. Non-monotonic Sums (usually UpDownCounters) will show the current value instead of a change rate.

--- a/unreleased/dt-updates.yaml
+++ b/unreleased/dt-updates.yaml
@@ -13,4 +13,4 @@ issues: [ 11828 ]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 subtext:  |2
-  - Non-monotonic Sum metrics will be exported as Gauges from now on. Non-monotonic Sums (usually UpDownCounters) will show the current value instead of a change rate.
+  - Non-monotonic cumulative Sum metrics will be exported as Gauges from now on. Non-monotonic cumulative Sums (usually UpDownCounters) will show the current value instead of a change rate.


### PR DESCRIPTION
Updating the changelog entry because this is a breaking change. The original changelog entry only mentioned this as an enhancement. 