### PR TITLE
[processor/resourcedetection] Add back `host.name` on GKE

### DIFF
--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -66,6 +66,7 @@ func (d *detector) Detect(context.Context) (resource pcommon.Resource, schemaURL
 		b.addZoneOrRegion(d.detector.GKEAvailabilityZoneOrRegion)
 		b.add(conventions.AttributeK8SClusterName, d.detector.GKEClusterName)
 		b.add(conventions.AttributeHostID, d.detector.GKEHostID)
+		b.add(conventions.AttributeHostName, d.detector.GCEHostName)
 	case gcp.CloudRun:
 		b.attrs.InsertString(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformGCPCloudRun)
 		b.add(conventions.AttributeFaaSName, d.detector.FaaSName)

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
@@ -43,11 +44,15 @@ const (
 // * Google App Engine (GAE).
 // * Cloud Run.
 // * Cloud Functions.
-func NewDetector(_ component.ProcessorCreateSettings, _ internal.DetectorConfig) (internal.Detector, error) {
-	return &detector{detector: gcp.NewDetector()}, nil
+func NewDetector(set component.ProcessorCreateSettings, _ internal.DetectorConfig) (internal.Detector, error) {
+	return &detector{
+		logger:   set.Logger,
+		detector: gcp.NewDetector(),
+	}, nil
 }
 
 type detector struct {
+	logger   *zap.Logger
 	detector gcpDetector
 }
 
@@ -56,7 +61,7 @@ func (d *detector) Detect(context.Context) (resource pcommon.Resource, schemaURL
 	if !metadata.OnGCE() {
 		return res, "", nil
 	}
-	b := &resourceBuilder{attrs: res.Attributes()}
+	b := &resourceBuilder{logger: d.logger, attrs: res.Attributes()}
 	b.attrs.InsertString(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderGCP)
 	b.add(conventions.AttributeCloudAccountID, d.detector.ProjectID)
 
@@ -66,7 +71,8 @@ func (d *detector) Detect(context.Context) (resource pcommon.Resource, schemaURL
 		b.addZoneOrRegion(d.detector.GKEAvailabilityZoneOrRegion)
 		b.add(conventions.AttributeK8SClusterName, d.detector.GKEClusterName)
 		b.add(conventions.AttributeHostID, d.detector.GKEHostID)
-		b.add(conventions.AttributeHostName, d.detector.GCEHostName)
+		// GCEHostname is fallible on GKE, since it's not available when using workload identity.
+		b.addFallible(conventions.AttributeHostName, d.detector.GCEHostName)
 	case gcp.CloudRun:
 		b.attrs.InsertString(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformGCPCloudRun)
 		b.add(conventions.AttributeFaaSName, d.detector.FaaSName)
@@ -107,8 +113,9 @@ func (d *detector) Detect(context.Context) (resource pcommon.Resource, schemaURL
 // resourceBuilder simplifies constructing resources using GCP detection
 // library functions.
 type resourceBuilder struct {
-	errs  []error
-	attrs pcommon.Map
+	logger *zap.Logger
+	errs   []error
+	attrs  pcommon.Map
 }
 
 func (r *resourceBuilder) add(key string, detect func() (string, error)) {
@@ -116,6 +123,15 @@ func (r *resourceBuilder) add(key string, detect func() (string, error)) {
 		r.attrs.InsertString(key, v)
 	} else {
 		r.errs = append(r.errs, err)
+	}
+}
+
+// addFallible adds a detect function whose failures should be ignored
+func (r *resourceBuilder) addFallible(key string, detect func() (string, error)) {
+	if v, err := detect(); err == nil {
+		r.attrs.InsertString(key, v)
+	} else {
+		r.logger.Info("Fallible detector failed. This attribute will not be available.", zap.String("key", key), zap.Error(err))
 	}
 }
 

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
@@ -43,6 +43,7 @@ func TestDetect(t *testing.T) {
 			detector: &detector{detector: &fakeGCPDetector{
 				projectID:           "my-project",
 				cloudPlatform:       gcp.GKE,
+				gceHostName:         "my-gke-node-1234",
 				gkeHostID:           "1472385723456792345",
 				gkeClusterName:      "my-cluster",
 				gkeAvailabilityZone: "us-central1-c",
@@ -54,6 +55,7 @@ func TestDetect(t *testing.T) {
 				conventions.AttributeK8SClusterName:        "my-cluster",
 				conventions.AttributeCloudAvailabilityZone: "us-central1-c",
 				conventions.AttributeHostID:                "1472385723456792345",
+				conventions.AttributeHostName:              "my-gke-node-1234",
 			}),
 		},
 		{
@@ -61,6 +63,7 @@ func TestDetect(t *testing.T) {
 			detector: &detector{detector: &fakeGCPDetector{
 				projectID:      "my-project",
 				cloudPlatform:  gcp.GKE,
+				gceHostName:    "my-gke-node-1234",
 				gkeHostID:      "1472385723456792345",
 				gkeClusterName: "my-cluster",
 				gkeRegion:      "us-central1",
@@ -72,6 +75,7 @@ func TestDetect(t *testing.T) {
 				conventions.AttributeK8SClusterName: "my-cluster",
 				conventions.AttributeCloudRegion:    "us-central1",
 				conventions.AttributeHostID:         "1472385723456792345",
+				conventions.AttributeHostName:       "my-gke-node-1234",
 			}),
 		},
 		{

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
@@ -40,14 +41,14 @@ func TestDetect(t *testing.T) {
 	}{
 		{
 			desc: "zonal GKE cluster",
-			detector: &detector{detector: &fakeGCPDetector{
+			detector: newTestDetector(&fakeGCPDetector{
 				projectID:           "my-project",
 				cloudPlatform:       gcp.GKE,
 				gceHostName:         "my-gke-node-1234",
 				gkeHostID:           "1472385723456792345",
 				gkeClusterName:      "my-cluster",
 				gkeAvailabilityZone: "us-central1-c",
-			}},
+			}),
 			expectedResource: internal.NewResource(map[string]interface{}{
 				conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderGCP,
 				conventions.AttributeCloudAccountID:        "my-project",
@@ -60,14 +61,14 @@ func TestDetect(t *testing.T) {
 		},
 		{
 			desc: "regional GKE cluster",
-			detector: &detector{detector: &fakeGCPDetector{
+			detector: newTestDetector(&fakeGCPDetector{
 				projectID:      "my-project",
 				cloudPlatform:  gcp.GKE,
 				gceHostName:    "my-gke-node-1234",
 				gkeHostID:      "1472385723456792345",
 				gkeClusterName: "my-cluster",
 				gkeRegion:      "us-central1",
-			}},
+			}),
 			expectedResource: internal.NewResource(map[string]interface{}{
 				conventions.AttributeCloudProvider:  conventions.AttributeCloudProviderGCP,
 				conventions.AttributeCloudAccountID: "my-project",
@@ -79,8 +80,27 @@ func TestDetect(t *testing.T) {
 			}),
 		},
 		{
+			desc: "regional GKE cluster with workload identity",
+			detector: newTestDetector(&fakeGCPDetector{
+				projectID:      "my-project",
+				cloudPlatform:  gcp.GKE,
+				gceHostNameErr: fmt.Errorf("metadata endpoint is concealed"),
+				gkeHostID:      "1472385723456792345",
+				gkeClusterName: "my-cluster",
+				gkeRegion:      "us-central1",
+			}),
+			expectedResource: internal.NewResource(map[string]interface{}{
+				conventions.AttributeCloudProvider:  conventions.AttributeCloudProviderGCP,
+				conventions.AttributeCloudAccountID: "my-project",
+				conventions.AttributeCloudPlatform:  conventions.AttributeCloudPlatformGCPKubernetesEngine,
+				conventions.AttributeK8SClusterName: "my-cluster",
+				conventions.AttributeCloudRegion:    "us-central1",
+				conventions.AttributeHostID:         "1472385723456792345",
+			}),
+		},
+		{
 			desc: "GCE",
-			detector: &detector{detector: &fakeGCPDetector{
+			detector: newTestDetector(&fakeGCPDetector{
 				projectID:           "my-project",
 				cloudPlatform:       gcp.GCE,
 				gceHostID:           "1472385723456792345",
@@ -88,7 +108,7 @@ func TestDetect(t *testing.T) {
 				gceHostType:         "n1-standard1",
 				gceAvailabilityZone: "us-central1-c",
 				gceRegion:           "us-central1",
-			}},
+			}),
 			expectedResource: internal.NewResource(map[string]interface{}{
 				conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderGCP,
 				conventions.AttributeCloudAccountID:        "my-project",
@@ -102,14 +122,14 @@ func TestDetect(t *testing.T) {
 		},
 		{
 			desc: "Cloud Run",
-			detector: &detector{detector: &fakeGCPDetector{
+			detector: newTestDetector(&fakeGCPDetector{
 				projectID:       "my-project",
 				cloudPlatform:   gcp.CloudRun,
 				faaSID:          "1472385723456792345",
 				faaSCloudRegion: "us-central1",
 				faaSName:        "my-service",
 				faaSVersion:     "123456",
-			}},
+			}),
 			expectedResource: internal.NewResource(map[string]interface{}{
 				conventions.AttributeCloudProvider:  conventions.AttributeCloudProviderGCP,
 				conventions.AttributeCloudAccountID: "my-project",
@@ -122,14 +142,14 @@ func TestDetect(t *testing.T) {
 		},
 		{
 			desc: "Cloud Functions",
-			detector: &detector{detector: &fakeGCPDetector{
+			detector: newTestDetector(&fakeGCPDetector{
 				projectID:       "my-project",
 				cloudPlatform:   gcp.CloudFunctions,
 				faaSID:          "1472385723456792345",
 				faaSCloudRegion: "us-central1",
 				faaSName:        "my-service",
 				faaSVersion:     "123456",
-			}},
+			}),
 			expectedResource: internal.NewResource(map[string]interface{}{
 				conventions.AttributeCloudProvider:  conventions.AttributeCloudProviderGCP,
 				conventions.AttributeCloudAccountID: "my-project",
@@ -142,7 +162,7 @@ func TestDetect(t *testing.T) {
 		},
 		{
 			desc: "App Engine Standard",
-			detector: &detector{detector: &fakeGCPDetector{
+			detector: newTestDetector(&fakeGCPDetector{
 				projectID:                 "my-project",
 				cloudPlatform:             gcp.AppEngineStandard,
 				appEngineServiceInstance:  "1472385723456792345",
@@ -150,7 +170,7 @@ func TestDetect(t *testing.T) {
 				appEngineRegion:           "us-central1",
 				appEngineServiceName:      "my-service",
 				appEngineServiceVersion:   "123456",
-			}},
+			}),
 			expectedResource: internal.NewResource(map[string]interface{}{
 				conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderGCP,
 				conventions.AttributeCloudAccountID:        "my-project",
@@ -164,7 +184,7 @@ func TestDetect(t *testing.T) {
 		},
 		{
 			desc: "App Engine Flex",
-			detector: &detector{detector: &fakeGCPDetector{
+			detector: newTestDetector(&fakeGCPDetector{
 				projectID:                 "my-project",
 				cloudPlatform:             gcp.AppEngineFlex,
 				appEngineServiceInstance:  "1472385723456792345",
@@ -172,7 +192,7 @@ func TestDetect(t *testing.T) {
 				appEngineRegion:           "us-central1",
 				appEngineServiceName:      "my-service",
 				appEngineServiceVersion:   "123456",
-			}},
+			}),
 			expectedResource: internal.NewResource(map[string]interface{}{
 				conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderGCP,
 				conventions.AttributeCloudAccountID:        "my-project",
@@ -186,10 +206,10 @@ func TestDetect(t *testing.T) {
 		},
 		{
 			desc: "Unknown Platform",
-			detector: &detector{detector: &fakeGCPDetector{
+			detector: newTestDetector(&fakeGCPDetector{
 				projectID:     "my-project",
 				cloudPlatform: gcp.UnknownPlatform,
-			}},
+			}),
 			expectedResource: internal.NewResource(map[string]interface{}{
 				conventions.AttributeCloudProvider:  conventions.AttributeCloudProviderGCP,
 				conventions.AttributeCloudAccountID: "my-project",
@@ -197,9 +217,9 @@ func TestDetect(t *testing.T) {
 		},
 		{
 			desc: "error",
-			detector: &detector{detector: &fakeGCPDetector{
+			detector: newTestDetector(&fakeGCPDetector{
 				err: fmt.Errorf("failed to get metadata"),
-			}},
+			}),
 			expectErr: true,
 			expectedResource: internal.NewResource(map[string]interface{}{
 				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
@@ -218,6 +238,13 @@ func TestDetect(t *testing.T) {
 			res.Attributes().Sort()
 			assert.Equal(t, tc.expectedResource, res, "Resource object returned is incorrect")
 		})
+	}
+}
+
+func newTestDetector(gcpDetector *fakeGCPDetector) *detector {
+	return &detector{
+		logger:   zap.NewNop(),
+		detector: gcpDetector,
 	}
 }
 
@@ -244,6 +271,7 @@ type fakeGCPDetector struct {
 	gceHostType               string
 	gceHostID                 string
 	gceHostName               string
+	gceHostNameErr            error
 }
 
 func (f *fakeGCPDetector) ProjectID() (string, error) {
@@ -376,7 +404,7 @@ func (f *fakeGCPDetector) GCEHostName() (string, error) {
 	if f.err != nil {
 		return "", f.err
 	}
-	return f.gceHostName, nil
+	return f.gceHostName, f.gceHostNameErr
 }
 
 func TestDeduplicateDetectors(t *testing.T) {

--- a/unreleased/mx-psi_gke-detector.yaml
+++ b/unreleased/mx-psi_gke-detector.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add back `host.name` attribute when running on GKE
+
+# One or more tracking issues related to the change
+issues: [12354]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** 

Adds back the `host.name` attribute (coming from `instance/hostname`) when running on GKE.

This metadata endpoint is available on GKE nodes of any type, and it was possible to have this attribute on GKE before #10347

**Link to tracking Issue:** Fixes #12354
