### PR TITLE
[receiver/vcenter] Add `vcenter.cluster.name` resource attribute to datastore metrics

### DIFF
--- a/receiver/vcenterreceiver/scraper.go
+++ b/receiver/vcenterreceiver/scraper.go
@@ -187,7 +187,7 @@ func (v *vcenterMetricScraper) collectDatastores(
 	}
 
 	for _, ds := range datastores {
-		v.collectDatastore(ctx, colTime, ds, errs)
+		v.collectDatastore(ctx, colTime, ds, cluster, errs)
 	}
 }
 
@@ -195,6 +195,7 @@ func (v *vcenterMetricScraper) collectDatastore(
 	ctx context.Context,
 	now pcommon.Timestamp,
 	ds *object.Datastore,
+	cluster *object.ClusterComputeResource,
 	errs *scrapererror.ScrapeErrors,
 ) {
 	var moDS mo.Datastore
@@ -206,6 +207,7 @@ func (v *vcenterMetricScraper) collectDatastore(
 
 	v.recordDatastoreProperties(now, moDS)
 	v.mb.EmitForResource(
+		metadata.WithVcenterClusterName(cluster.Name()),
 		metadata.WithVcenterDatastoreName(moDS.Name),
 	)
 }

--- a/receiver/vcenterreceiver/testdata/metrics/expected.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.json
@@ -3107,6 +3107,12 @@
                         "value": {
                             "stringValue": "vsanDatastore"
                         }
+                    },
+                    {
+                        "key": "vcenter.cluster.name",
+                        "value": {
+                            "stringValue": "Cluster"
+                        }
                     }
                 ]
             },

--- a/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
+++ b/receiver/vcenterreceiver/testdata/metrics/expected_without_direction.json
@@ -1436,6 +1436,12 @@
                         "value": {
                             "stringValue": "vsanDatastore"
                         }
+                    },
+                    {
+                        "key": "vcenter.cluster.name",
+                        "value": {
+                            "stringValue": "Cluster"
+                        }
                     }
                 ]
             },

--- a/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
+++ b/receiver/vcenterreceiver/testdata/metrics/integration-metrics.json
@@ -266,6 +266,12 @@
                         "value": {
                             "stringValue": "LocalDS_0"
                         }
+                    },
+                    {
+                        "key": "vcenter.cluster.name",
+                        "value": {
+                            "stringValue": "DC0_C0"
+                        }
                     }
                 ]
             },

--- a/unreleased/vcenter-datastore-metrics-with-cluster.yaml
+++ b/unreleased/vcenter-datastore-metrics-with-cluster.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds the `vcenter.cluster.name` resource attribute to `vcenter.datastore` metrics
+
+# One or more tracking issues related to the change
+issues: [ 12357 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Datastores can be multi-cluster, although with some pros and cons. https://communities.vmware.com/t5/vSphere-Storage-Discussions/Can-you-share-a-datastore-across-multiple-Clusters/td-p/2661209

**Link to tracking Issue:** Resolves #12357 

**Testing**: Caught in current scraper and integration_tests

**Documentation:** changelog entry