### PR TITLE
[receiver/memcached] remove direction attribute

### DIFF
--- a/receiver/memcachedreceiver/README.md
+++ b/receiver/memcachedreceiver/README.md
@@ -42,5 +42,50 @@ receivers:
 The full list of settings exposed for this receiver are documented [here](./config.go)
 with detailed sample configurations [here](./testdata/config.yaml).
 
+## Metrics
+
+Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml) with further documentation in [documentation.md](./documentation.md)
+
+### Feature gate configurations
+
+#### Transition from metrics with "direction" attribute
+
+Some memcached metrics reported are transitioning from being reported with a `direction` attribute to being reported with the
+direction included in the metric name to adhere to the OpenTelemetry specification
+(https://github.com/open-telemetry/opentelemetry-specification/pull/2617):
+
+- `memcached.network` will become:
+  - `memcached.network.sent`
+  - `memcached.network.received`
+
+The following feature gates control the transition process:
+
+- **receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute**: controls if the new metrics without
+  `direction` attribute are emitted by the receiver.
+- **receiver.memcachedreceiver.emitMetricsWithDirectionAttribute**: controls if the deprecated metrics with
+  `direction`
+  attribute are emitted by the receiver.
+
+##### Transition schedule:
+
+1. v0.56.0, July 2022:
+
+- The new metrics are available for all scrapers, but disabled by default, they can be enabled with the feature gates.
+- The old metrics with `direction` attribute are deprecated with a warning.
+- `receiver.memcachedreceiver.emitMetricsWithDirectionAttribute` is enabled by default.
+- `receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute` is disabled by default.
+
+2. v0.58.0, August 2022:
+
+- The new metrics are enabled by default, deprecated metrics disabled, they can be enabled with the feature gates.
+- `receiver.memcachedreceiver.emitMetricsWithDirectionAttribute` is disabled by default.
+- `receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute` is enabled by default.
+
+3. v0.60.0, September 2022:
+
+- The feature gates are removed.
+- The new metrics without `direction` attribute are always emitted.
+- The deprecated metrics with `direction` attribute are no longer available.
+
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/memcachedreceiver/documentation.md
+++ b/receiver/memcachedreceiver/documentation.md
@@ -16,6 +16,8 @@ These are the metrics available for this scraper.
 | **memcached.current_items** | Number of items currently stored in the cache. | {items} | Sum(Int) | <ul> </ul> |
 | **memcached.evictions** | Cache item evictions. | {evictions} | Sum(Int) | <ul> </ul> |
 | **memcached.network** | Bytes transferred over the network. | by | Sum(Int) | <ul> <li>direction</li> </ul> |
+| **memcached.network.received** | Bytes received over the network. | by | Sum(Int) | <ul> </ul> |
+| **memcached.network.sent** | Bytes sent over the network. | by | Sum(Int) | <ul> </ul> |
 | **memcached.operation_hit_ratio** | Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0. | % | Gauge(Double) | <ul> <li>operation</li> </ul> |
 | **memcached.operations** | Operation counts. | {operations} | Sum(Int) | <ul> <li>type</li> <li>operation</li> </ul> |
 | **memcached.threads** | Number of threads used by the memcached instance. | {threads} | Sum(Int) | <ul> </ul> |

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -8,12 +8,12 @@ attributes:
     - set
     - flush
     - touch
-  direction: 
+  direction:
     description: Direction of data flow.
     enum:
     - sent
     - received
-  type: 
+  type:
     description: Result of cache request.
     enum:
     - hit
@@ -92,6 +92,26 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: [direction]
+  # produced when receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
+  memcached.network.sent:
+    enabled: true
+    description: Bytes sent over the network.
+    unit: by
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative
+    attributes: []
+  # produced when receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute feature gate is enabled
+  memcached.network.received:
+    enabled: true
+    description: Bytes received over the network.
+    unit: by
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative
+    attributes: []
   memcached.operations:
     enabled: true
     description:  Operation counts.

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -83,6 +83,7 @@ metrics:
       monotonic: true
       aggregation: cumulative
     attributes: []
+  # produced when receiver.memcachedreceiver.emitMetricsWithDirectionAttribute feature gate is enabled
   memcached.network:
     enabled: true
     description: Bytes transferred over the network.

--- a/receiver/memcachedreceiver/scraper.go
+++ b/receiver/memcachedreceiver/scraper.go
@@ -147,11 +147,21 @@ func (r *memcachedScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 				}
 			case "bytes_read":
 				if parsedV, ok := r.parseInt(k, v); ok {
-					r.mb.RecordMemcachedNetworkDataPoint(now, parsedV, metadata.AttributeDirectionReceived)
+					if r.emitMetricsWithDirectionAttribute {
+						r.mb.RecordMemcachedNetworkDataPoint(now, parsedV, metadata.AttributeDirectionReceived)
+					}
+					if r.emitMetricsWithoutDirectionAttribute {
+						r.mb.RecordMemcachedNetworkReceivedDataPoint(now, parsedV)
+					}
 				}
 			case "bytes_written":
 				if parsedV, ok := r.parseInt(k, v); ok {
-					r.mb.RecordMemcachedNetworkDataPoint(now, parsedV, metadata.AttributeDirectionSent)
+					if r.emitMetricsWithDirectionAttribute {
+						r.mb.RecordMemcachedNetworkDataPoint(now, parsedV, metadata.AttributeDirectionSent)
+					}
+					if r.emitMetricsWithoutDirectionAttribute {
+						r.mb.RecordMemcachedNetworkSentDataPoint(now, parsedV)
+					}
 				}
 			case "get_hits":
 				if parsedV, ok := r.parseInt(k, v); ok {

--- a/receiver/memcachedreceiver/scraper.go
+++ b/receiver/memcachedreceiver/scraper.go
@@ -22,16 +22,51 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/service/featuregate"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver/internal/metadata"
 )
 
+const (
+	emitMetricsWithDirectionAttributeFeatureGateID    = "receiver.memcached.emitMetricsWithDirectionAttribute"
+	emitMetricsWithoutDirectionAttributeFeatureGateID = "receiver.memcached.emitMetricsWithoutDirectionAttribute"
+)
+
+var (
+	emitMetricsWithDirectionAttributeFeatureGate = featuregate.Gate{
+		ID:      emitMetricsWithDirectionAttributeFeatureGateID,
+		Enabled: true,
+		Description: "Some memcached metrics reported are transitioning from being reported with a direction " +
+			"attribute to being reported with the direction included in the metric name to adhere to the " +
+			"OpenTelemetry specification. This feature gate controls emitting the old metrics with the direction " +
+			"attribute. For more details, see: " +
+			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/memcachedreceiver/README.md#feature-gate-configurations",
+	}
+
+	emitMetricsWithoutDirectionAttributeFeatureGate = featuregate.Gate{
+		ID:      emitMetricsWithoutDirectionAttributeFeatureGateID,
+		Enabled: false,
+		Description: "Some memcached metrics reported are transitioning from being reported with a direction " +
+			"attribute to being reported with the direction included in the metric name to adhere to the " +
+			"OpenTelemetry specification. This feature gate controls emitting the new metrics without the direction " +
+			"attribute. For more details, see: " +
+			"https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/memcachedreceiver/README.md#feature-gate-configurations",
+	}
+)
+
+func init() {
+	featuregate.GetRegistry().MustRegister(emitMetricsWithDirectionAttributeFeatureGate)
+	featuregate.GetRegistry().MustRegister(emitMetricsWithoutDirectionAttributeFeatureGate)
+}
+
 type memcachedScraper struct {
-	logger    *zap.Logger
-	config    *Config
-	mb        *metadata.MetricsBuilder
-	newClient newMemcachedClientFunc
+	logger                               *zap.Logger
+	config                               *Config
+	mb                                   *metadata.MetricsBuilder
+	newClient                            newMemcachedClientFunc
+	emitMetricsWithDirectionAttribute    bool
+	emitMetricsWithoutDirectionAttribute bool
 }
 
 func newMemcachedScraper(
@@ -39,10 +74,12 @@ func newMemcachedScraper(
 	config *Config,
 ) memcachedScraper {
 	return memcachedScraper{
-		logger:    settings.Logger,
-		config:    config,
-		newClient: newMemcachedClient,
-		mb:        metadata.NewMetricsBuilder(config.Metrics, settings.BuildInfo),
+		logger:                               settings.Logger,
+		config:                               config,
+		newClient:                            newMemcachedClient,
+		mb:                                   metadata.NewMetricsBuilder(config.Metrics, settings.BuildInfo),
+		emitMetricsWithDirectionAttribute:    featuregate.GetRegistry().IsEnabled(emitMetricsWithDirectionAttributeFeatureGateID),
+		emitMetricsWithoutDirectionAttribute: featuregate.GetRegistry().IsEnabled(emitMetricsWithoutDirectionAttributeFeatureGateID),
 	}
 }
 

--- a/receiver/memcachedreceiver/scraper_test.go
+++ b/receiver/memcachedreceiver/scraper_test.go
@@ -44,3 +44,23 @@ func TestScraper(t *testing.T) {
 
 	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
 }
+
+func TestScraperWithoutDirectionAttribute(t *testing.T) {
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	scraper := newMemcachedScraper(componenttest.NewNopReceiverCreateSettings(), cfg)
+	scraper.emitMetricsWithDirectionAttribute = false
+	scraper.emitMetricsWithoutDirectionAttribute = true
+	scraper.newClient = func(endpoint string, timeout time.Duration) (client, error) {
+		return &fakeClient{}, nil
+	}
+
+	actualMetrics, err := scraper.scrape(context.Background())
+	require.NoError(t, err)
+
+	expectedFile := filepath.Join("testdata", "expected_metrics", "test_scraper", "expected_without_direction.json")
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
+
+	require.NoError(t, scrapertest.CompareMetrics(expectedMetrics, actualMetrics))
+}

--- a/receiver/memcachedreceiver/testdata/expected_metrics/test_scraper/expected_without_direction.json
+++ b/receiver/memcachedreceiver/testdata/expected_metrics/test_scraper/expected_without_direction.json
@@ -1,0 +1,390 @@
+{
+   "resourceMetrics": [
+      {
+         "scopeMetrics": [
+            {
+               "scope": {
+                  "name": "otelcol/memcachedreceiver",
+                  "version": "latest"
+               },
+               "metrics": [
+                  {
+                     "description": "Commands executed.",
+                     "name": "memcached.commands",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1114",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "touch"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asInt": "1110",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "flush"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asInt": "1113",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "set"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asInt": "1111",
+                              "attributes": [
+                                 {
+                                    "key": "command",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{commands}"
+                  },
+                  {
+                     "description": "Accumulated user and system time.",
+                     "name": "memcached.cpu.usage",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asDouble": 11.1123452,
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "system"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asDouble": 11.11331119,
+                              "attributes": [
+                                 {
+                                    "key": "state",
+                                    "value": {
+                                       "stringValue": "user"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "s"
+                  },
+                  {
+                     "description": "Bytes sent over the network.",
+                     "name": "memcached.network.sent",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "16",
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "by"
+                  },
+                  {
+                     "description": "Bytes received over the network.",
+                     "name": "memcached.network.received",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "7",
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "by"
+                  },
+                  {
+                     "description": "Operation counts.",
+                     "name": "memcached.operations",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1134",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "increment"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "hit"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asInt": "1131",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "miss"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asInt": "1135",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "increment"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "miss"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asInt": "1130",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "hit"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asInt": "1119",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "decrement"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "hit"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asInt": "1120",
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "decrement"
+                                    }
+                                 },
+                                 {
+                                    "key": "type",
+                                    "value": {
+                                       "stringValue": "miss"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{operations}"
+                  },
+                  {
+                     "description": "Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asDouble": 50.0220361392684,
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "increment"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asDouble": 50.02233139794551,
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "decrement"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           },
+                           {
+                              "asDouble": 50.02211410880142,
+                              "attributes": [
+                                 {
+                                    "key": "operation",
+                                    "value": {
+                                       "stringValue": "get"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ]
+                     },
+                     "name": "memcached.operation_hit_ratio",
+                     "unit": "%"
+                  },
+                  {
+                     "description": "Current number of bytes used by this server to store items.",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "asInt": "15",
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ]
+                     },
+                     "name": "memcached.bytes",
+                     "unit": "By"
+                  },
+                  {
+                     "description": "The current number of open connections.",
+                     "name": "memcached.connections.current",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "2",
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ]
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "Total number of connections opened since the server started running.",
+                     "name": "memcached.connections.total",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{connections}"
+                  },
+                  {
+                     "description": "Number of items currently stored in the cache.",
+                     "name": "memcached.current_items",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1118",
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ]
+                     },
+                     "unit": "{items}"
+                  },
+                  {
+                     "description": "Number of threads used by the memcached instance.",
+                     "name": "memcached.threads",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "4",
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ]
+                     },
+                     "unit": "{threads}"
+                  },
+                  {
+                     "description": "Cache item evictions.",
+                     "name": "memcached.evictions",
+                     "sum": {
+                        "aggregationTemporality": "AGGREGATION_TEMPORALITY_CUMULATIVE",
+                        "dataPoints": [
+                           {
+                              "asInt": "1126",
+                              "timeUnixNano": "1639770622333015000"
+                           }
+                        ],
+                        "isMonotonic": true
+                     },
+                     "unit": "{evictions}"
+                  }
+               ]
+            }
+         ],
+         "resource": {}
+      }
+   ]
+}

--- a/unreleased/memcached_direction.yaml
+++ b/unreleased/memcached_direction.yaml
@@ -5,7 +5,7 @@ change_type: breaking
 component: memcachedreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Remove direction for metrics. The feature gate: receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute can be set to apply the following (#)"
+note: "Remove direction for metrics. The feature gate: receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute can be set to apply the following (#12404)"
 
 # One or more tracking issues related to the change
 issues: [12165]

--- a/unreleased/memcached_direction.yaml
+++ b/unreleased/memcached_direction.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: memcachedreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove direction for metrics. The feature gate: receiver.memcachedreceiver.emitMetricsWithoutDirectionAttribute can be set to apply the following (#)"
+
+# One or more tracking issues related to the change
+issues: [12165]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |-
+  - `memcached` metrics:
+    - `memcached.network` will become:
+      - `memcached.network.sent`
+      - `memcached.network.received`


### PR DESCRIPTION
**Description:** 
This PR removes the direction attribute from memcached network metrics. This functionality is disabed by default, but toggleable via feature gate.

**Link to tracking Issue:**
[#12165](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12165)

**Testing:**
Unit tests. A new fixture for metrics without direction was added.

**Documentation:** 
- The readme was updated
- `documentation.md` reflects the newly added metrics