### PR TITLE
[testbed] Raise CPU limits on filelog tests

### DIFF
--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -57,7 +57,7 @@ func TestLog10kDPS(t *testing.T) {
 			sender:   datasenders.NewFileLogWriter(),
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
-				ExpectedMaxCPU: 30,
+				ExpectedMaxCPU: 50,
 				ExpectedMaxRAM: 120,
 			},
 		},
@@ -66,7 +66,7 @@ func TestLog10kDPS(t *testing.T) {
 			sender:   datasenders.NewFileLogWriter(),
 			receiver: testbed.NewOTLPDataReceiver(testbed.GetAvailablePort(t)),
 			resourceSpec: testbed.ResourceSpec{
-				ExpectedMaxCPU: 30,
+				ExpectedMaxCPU: 50,
 				ExpectedMaxRAM: 120,
 			},
 			extensions: datasenders.NewLocalFileStorageExtension(),


### PR DESCRIPTION
See [#12339 (comment)](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12339#issuecomment-1182503032)