### PR TITLE
[chore] add workflow to ping code owners

### DIFF
--- a/.github/workflows/ping-codeowners.yml
+++ b/.github/workflows/ping-codeowners.yml
@@ -1,0 +1,19 @@
+name: 'Ping code owners'
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  ping-owner:
+    if: ${{ contains(github.event.label.name, 'exporter/') || contains(github.event.label.name, 'extension/') || contains(github.event.label.name, 'processor/') || contains(github.event.label.name, 'receiver/') }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+    
+      - name: Run ping-codeowners.sh
+        run: ./.github/workflows/scripts/ping-codeowners.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+          COMPONENT: ${{ github.event.label.name }}

--- a/.github/workflows/ping-codeowners.yml
+++ b/.github/workflows/ping-codeowners.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ping-owner:
-    if: ${{ contains(github.event.label.name, 'exporter/') || contains(github.event.label.name, 'extension/') || contains(github.event.label.name, 'processor/') || contains(github.event.label.name, 'receiver/') }}
+    if: ${{ contains(github.event.label.name, 'cmd/') || contains(github.event.label.name, 'exporter/') || contains(github.event.label.name, 'extension/') || contains(github.event.label.name, 'pkg/') || contains(github.event.label.name, 'processor/') || contains(github.event.label.name, 'receiver/') }}
 
     runs-on: ubuntu-latest
     steps:
@@ -17,3 +17,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE: ${{ github.event.issue.number }}
           COMPONENT: ${{ github.event.label.name }}
+

--- a/.github/workflows/scripts/ping-codeowners.sh
+++ b/.github/workflows/scripts/ping-codeowners.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+#   Copyright The OpenTelemetry Authors.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#
+
+
+if [ -z "${COMPONENT}"] || [ -z "${ISSUE}" ]; then
+    exit 0
+fi
+
+OWNERS=`grep -m 1 ${COMPONENT} .github/CODEOWNERS | sed 's/   */ /g' | cut -f3- -d ' '`
+
+if [ -z "${OWNERS}" ]; then
+    exit 0
+fi
+
+gh issue comment ${ISSUE} --body "Pinging code owners: ${OWNERS}"

--- a/.github/workflows/scripts/ping-codeowners.sh
+++ b/.github/workflows/scripts/ping-codeowners.sh
@@ -28,3 +28,4 @@ if [ -z "${OWNERS}" ]; then
 fi
 
 gh issue comment ${ISSUE} --body "Pinging code owners: ${OWNERS}"
+


### PR DESCRIPTION
Adding a workflow triggered when issues are labeled to ping code owners. This workflow will only trigger on labels containing: `exporter/` `extension/` `processor/` `receiver/`

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12196