### PR TITLE
`exporter/loki`: handle multi-tenant use-cases

### DIFF
--- a/exporter/lokiexporter/config.go
+++ b/exporter/lokiexporter/config.go
@@ -65,6 +65,10 @@ func (c *Config) validate() error {
 		if c.Tenant.Source != "attributes" && c.Tenant.Source != "context" && c.Tenant.Source != "static" {
 			return fmt.Errorf("invalid tenant source, must be one of 'attributes', 'context', 'static', but is %s", c.Tenant.Source)
 		}
+
+		if len(c.TenantID) > 0 {
+			return fmt.Errorf("both tenant_id and tenant were specified, use only 'tenant' instead")
+		}
 	}
 
 	return c.Labels.validate()

--- a/exporter/lokiexporter/config.go
+++ b/exporter/lokiexporter/config.go
@@ -32,17 +32,39 @@ type Config struct {
 	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"`
 
 	// TenantID defines the tenant ID to associate log streams with.
+	// Deprecated: use Tenant instead, with Source set to "static" and
+	// Value set to the value you'd set in this field.
 	TenantID string `mapstructure:"tenant_id"`
 
 	// Labels defines how labels should be applied to log streams sent to Loki.
 	Labels LabelsConfig `mapstructure:"labels"`
+
 	// Allows you to choose the entry format in the exporter
 	Format string `mapstructure:"format"`
+
+	// Tenant defines how to obtain the tenant ID
+	Tenant *Tenant `mapstructure:"tenant"`
+}
+
+type Tenant struct {
+	// Source defines where to obtain the tenant ID. Possible values: static, context, attribute.
+	Source string `mapstruct:"source"`
+
+	// Value will be used by the tenant source provider to lookup the value. For instance,
+	// when the source=static, the value is a static value. When the source=context, value
+	// should be the context key that holds the tenant information.
+	Value string `mapstruct:"value"`
 }
 
 func (c *Config) validate() error {
 	if _, err := url.Parse(c.Endpoint); c.Endpoint == "" || err != nil {
 		return fmt.Errorf("\"endpoint\" must be a valid URL")
+	}
+
+	if c.Tenant != nil {
+		if c.Tenant.Source != "attributes" && c.Tenant.Source != "context" && c.Tenant.Source != "static" {
+			return fmt.Errorf("invalid tenant source, must be one of 'attributes', 'context', 'static', but is %s", c.Tenant.Source)
+		}
 	}
 
 	return c.Labels.validate()

--- a/exporter/lokiexporter/config_test.go
+++ b/exporter/lokiexporter/config_test.go
@@ -163,6 +163,7 @@ func TestConfig_validate(t *testing.T) {
 		CredentialFile string
 		Audience       string
 		Labels         LabelsConfig
+		TenantID       string
 		Tenant         *Tenant
 	}
 	tests := []struct {
@@ -284,6 +285,19 @@ func TestConfig_validate(t *testing.T) {
 			},
 			shouldError: false,
 		},
+		{
+			name: "with both tenantID and tenant",
+			fields: fields{
+				Endpoint: validEndpoint,
+				Labels:   validAttribLabelsConfig,
+				Tenant: &Tenant{
+					Source: "static",
+					Value:  "acme",
+				},
+				TenantID: "globex",
+			},
+			shouldError: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -293,6 +307,10 @@ func TestConfig_validate(t *testing.T) {
 			cfg.ExporterSettings = config.NewExporterSettings(config.NewComponentID(typeStr))
 			cfg.Endpoint = tt.fields.Endpoint
 			cfg.Labels = tt.fields.Labels
+
+			if len(tt.fields.TenantID) > 0 {
+				cfg.TenantID = tt.fields.TenantID
+			}
 
 			if tt.fields.Tenant != nil {
 				cfg.Tenant = tt.fields.Tenant

--- a/exporter/lokiexporter/config_test.go
+++ b/exporter/lokiexporter/config_test.go
@@ -163,6 +163,7 @@ func TestConfig_validate(t *testing.T) {
 		CredentialFile string
 		Audience       string
 		Labels         LabelsConfig
+		Tenant         *Tenant
 	}
 	tests := []struct {
 		name         string
@@ -251,6 +252,38 @@ func TestConfig_validate(t *testing.T) {
 			},
 			shouldError: true,
 		},
+		{
+			name: "with missing `tenant.source`",
+			fields: fields{
+				Endpoint: validEndpoint,
+				Labels:   validAttribLabelsConfig,
+				Tenant:   &Tenant{},
+			},
+			shouldError: true,
+		},
+		{
+			name: "with invalid `tenant.source`",
+			fields: fields{
+				Endpoint: validEndpoint,
+				Labels:   validAttribLabelsConfig,
+				Tenant: &Tenant{
+					Source: "invalid",
+				},
+			},
+			shouldError: true,
+		},
+		{
+			name: "with valid `tenant.source`",
+			fields: fields{
+				Endpoint: validEndpoint,
+				Labels:   validAttribLabelsConfig,
+				Tenant: &Tenant{
+					Source: "static",
+					Value:  "acme",
+				},
+			},
+			shouldError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -260,6 +293,10 @@ func TestConfig_validate(t *testing.T) {
 			cfg.ExporterSettings = config.NewExporterSettings(config.NewComponentID(typeStr))
 			cfg.Endpoint = tt.fields.Endpoint
 			cfg.Labels = tt.fields.Labels
+
+			if tt.fields.Tenant != nil {
+				cfg.Tenant = tt.fields.Tenant
+			}
 
 			err := cfg.validate()
 			if (err != nil) != tt.shouldError {

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -37,6 +37,7 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/tenant"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/third_party/loki/logproto"
 )
 
@@ -45,11 +46,12 @@ const (
 )
 
 type lokiExporter struct {
-	config   *Config
-	settings component.TelemetrySettings
-	client   *http.Client
-	wg       sync.WaitGroup
-	convert  func(plog.LogRecord, pcommon.Resource) (*logproto.Entry, error)
+	config       *Config
+	settings     component.TelemetrySettings
+	client       *http.Client
+	wg           sync.WaitGroup
+	convert      func(plog.LogRecord, pcommon.Resource) (*logproto.Entry, error)
+	tenantSource tenant.TenantSource
 }
 
 func newExporter(config *Config, settings component.TelemetrySettings) *lokiExporter {
@@ -57,18 +59,41 @@ func newExporter(config *Config, settings component.TelemetrySettings) *lokiExpo
 		config:   config,
 		settings: settings,
 	}
+
 	if config.Format == "json" {
 		lokiexporter.convert = lokiexporter.convertLogToJSONEntry
 	} else {
 		lokiexporter.convert = lokiexporter.convertLogBodyToEntry
 	}
+
+	if config.Tenant == nil {
+		config.Tenant = &Tenant{
+			Source: "static",
+
+			// this might be empty, which is fine, we handle empty later
+			Value: config.TenantID,
+		}
+	}
+
+	switch config.Tenant.Source {
+	case "static":
+		lokiexporter.tenantSource = &tenant.StaticTenantSource{
+			Value: config.Tenant.Value,
+		}
+	case "context":
+		lokiexporter.tenantSource = &tenant.ContextTenantSource{
+			Key: config.Tenant.Value,
+		}
+	case "attributes":
+		lokiexporter.tenantSource = &tenant.AttributeTenantSource{
+			Value: config.Tenant.Value,
+		}
+	}
+
 	return lokiexporter
 }
 
 func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
-	l.wg.Add(1)
-	defer l.wg.Done()
-
 	pushReq, _ := l.logDataToLoki(ld)
 	if len(pushReq.Streams) == 0 {
 		return consumererror.NewPermanent(fmt.Errorf("failed to transform logs into Loki log streams"))
@@ -89,8 +114,13 @@ func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
 	}
 	req.Header.Set("Content-Type", "application/x-protobuf")
 
-	if len(l.config.TenantID) > 0 {
-		req.Header.Set("X-Scope-OrgID", l.config.TenantID)
+	tenant, err := l.tenantSource.GetTenant(ctx, ld)
+	if err != nil {
+		return consumererror.NewPermanent(fmt.Errorf("failed to determine the tenant: %v", err))
+	}
+
+	if len(tenant) > 0 {
+		req.Header.Set("X-Scope-OrgID", tenant)
 	}
 
 	resp, err := l.client.Do(req)

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -51,7 +51,7 @@ type lokiExporter struct {
 	client       *http.Client
 	wg           sync.WaitGroup
 	convert      func(plog.LogRecord, pcommon.Resource) (*logproto.Entry, error)
-	tenantSource tenant.TenantSource
+	tenantSource tenant.Source
 }
 
 func newExporter(config *Config, settings component.TelemetrySettings) *lokiExporter {
@@ -116,7 +116,7 @@ func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
 
 	tenant, err := l.tenantSource.GetTenant(ctx, ld)
 	if err != nil {
-		return consumererror.NewPermanent(fmt.Errorf("failed to determine the tenant: %v", err))
+		return consumererror.NewPermanent(fmt.Errorf("failed to determine the tenant: %w", err))
 	}
 
 	if len(tenant) > 0 {

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -262,7 +262,7 @@ func TestTenantSource(t *testing.T) {
 	testCases := []struct {
 		desc    string
 		tenant  *Tenant
-		srcType tenant.TenantSource
+		srcType tenant.Source
 	}{
 		{
 			desc: "tenant source attributes",

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -36,6 +37,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/tenant"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/third_party/loki/logproto"
 )
 
@@ -252,6 +254,78 @@ func TestExporter_pushLogData(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestTenantSource(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		tenant  *Tenant
+		srcType tenant.TenantSource
+	}{
+		{
+			desc: "tenant source attributes",
+			tenant: &Tenant{
+				Source: "attributes",
+				Value:  "tenant.name",
+			},
+			srcType: &tenant.AttributeTenantSource{},
+		},
+		{
+			desc: "tenant source context",
+			tenant: &Tenant{
+				Source: "context",
+				Value:  "tenant.name",
+			},
+			srcType: &tenant.ContextTenantSource{},
+		},
+		{
+			desc: "tenant source static",
+			tenant: &Tenant{
+				Source: "static",
+				Value:  "acme",
+			},
+			srcType: &tenant.StaticTenantSource{},
+		},
+		{
+			desc:    "tenant source is non-existing",
+			tenant:  nil,
+			srcType: &tenant.StaticTenantSource{},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			cfg := &Config{
+				Tenant: tC.tenant,
+				Labels: LabelsConfig{
+					Attributes: map[string]string{
+						"severity": "severity",
+					},
+				},
+			}
+			exp := newExporter(cfg, componenttest.NewNopTelemetrySettings())
+			require.NotNil(t, exp)
+
+			assert.IsType(t, tC.srcType, exp.tenantSource)
+
+			cl := client.FromContext(context.Background())
+			cl.Metadata = client.NewMetadata(map[string][]string{"tenant.name": {"acme"}})
+
+			ctx := client.NewContext(context.Background(), cl)
+
+			ld := plog.NewLogs()
+			ld.ResourceLogs().AppendEmpty()
+			ld.ResourceLogs().At(0).Resource().Attributes().InsertString("tenant.name", "acme")
+
+			tenant, err := exp.tenantSource.GetTenant(ctx, ld)
+			assert.NoError(t, err)
+
+			if tC.tenant != nil {
+				assert.Equal(t, "acme", tenant)
+			} else {
+				assert.Empty(t, tenant)
+			}
 		})
 	}
 }

--- a/exporter/lokiexporter/internal/tenant/attribute.go
+++ b/exporter/lokiexporter/internal/tenant/attribute.go
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenant // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/tenant"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+var _ TenantSource = (*AttributeTenantSource)(nil)
+
+type AttributeTenantSource struct {
+	Value string
+}
+
+func (ts *AttributeTenantSource) GetTenant(_ context.Context, logs plog.Logs) (string, error) {
+	for i := 0; i < logs.ResourceLogs().Len(); i++ {
+		rl := logs.ResourceLogs().At(i)
+		if v, found := rl.Resource().Attributes().Get(ts.Value); found {
+			return v.StringVal(), nil
+		}
+	}
+	return "", nil
+}

--- a/exporter/lokiexporter/internal/tenant/attribute.go
+++ b/exporter/lokiexporter/internal/tenant/attribute.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-var _ TenantSource = (*AttributeTenantSource)(nil)
+var _ Source = (*AttributeTenantSource)(nil)
 
 type AttributeTenantSource struct {
 	Value string

--- a/exporter/lokiexporter/internal/tenant/attribute_test.go
+++ b/exporter/lokiexporter/internal/tenant/attribute_test.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenant // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/tenant"
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestAttributeTenantSourceSuccess(t *testing.T) {
+	// prepare
+	ts := &AttributeTenantSource{Value: "tenant.id"}
+
+	logs := plog.NewLogs()
+	logs.ResourceLogs().AppendEmpty() // who's on first
+	logs.ResourceLogs().AppendEmpty() // what's on second
+	logs.ResourceLogs().At(0).Resource().Attributes().InsertString("tenant.id", "acme")
+
+	// test
+	tenant, err := ts.GetTenant(context.Background(), logs)
+
+	// verify
+	assert.NoError(t, err)
+	assert.Equal(t, "acme", tenant)
+}
+
+func TestAttributeTenantSourceNotFound(t *testing.T) {
+	// prepare
+	ts := &AttributeTenantSource{Value: "tenant.id"}
+
+	logs := plog.NewLogs()
+	logs.ResourceLogs().AppendEmpty() // who's on first
+	logs.ResourceLogs().AppendEmpty() // what's on second
+	logs.ResourceLogs().At(0).Resource().Attributes().InsertString("not.tenant.id", "acme")
+
+	// test
+	tenant, err := ts.GetTenant(context.Background(), logs)
+
+	// verify
+	assert.NoError(t, err)
+	assert.Empty(t, tenant)
+}

--- a/exporter/lokiexporter/internal/tenant/context.go
+++ b/exporter/lokiexporter/internal/tenant/context.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenant // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/tenant"
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+var _ TenantSource = (*ContextTenantSource)(nil)
+
+type ContextTenantSource struct {
+	Key string
+}
+
+func (ts *ContextTenantSource) GetTenant(ctx context.Context, logs plog.Logs) (string, error) {
+	cl := client.FromContext(ctx)
+	ss := cl.Metadata.Get(ts.Key)
+
+	if len(ss) == 0 {
+		return "", nil
+	}
+
+	if len(ss) > 1 {
+		return "", fmt.Errorf("%d tenant keys found in the context, can't determine which one to use", len(ss))
+	}
+
+	return ss[0], nil
+}

--- a/exporter/lokiexporter/internal/tenant/context.go
+++ b/exporter/lokiexporter/internal/tenant/context.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-var _ TenantSource = (*ContextTenantSource)(nil)
+var _ Source = (*ContextTenantSource)(nil)
 
 type ContextTenantSource struct {
 	Key string

--- a/exporter/lokiexporter/internal/tenant/context_test.go
+++ b/exporter/lokiexporter/internal/tenant/context_test.go
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenant // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/tenant"
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestContextTenantSourceSuccess(t *testing.T) {
+	// prepare
+	ts := &ContextTenantSource{Key: "X-Scope-OrgID"}
+	cl := client.FromContext(context.Background())
+	cl.Metadata = client.NewMetadata(map[string][]string{"X-Scope-OrgID": {"acme"}})
+	ctx := client.NewContext(context.Background(), cl)
+
+	// test
+	tenant, err := ts.GetTenant(ctx, plog.NewLogs())
+
+	// verify
+	assert.NoError(t, err)
+	assert.Equal(t, "acme", tenant)
+}
+
+func TestContextTenantSourceNotFound(t *testing.T) {
+	// prepare
+	ts := &ContextTenantSource{Key: "X-Scope-OrgID"}
+	cl := client.FromContext(context.Background())
+	cl.Metadata = client.NewMetadata(map[string][]string{"Not-Scope-OrgID": {"acme"}})
+	ctx := client.NewContext(context.Background(), cl)
+
+	// test
+	tenant, err := ts.GetTenant(ctx, plog.NewLogs())
+
+	// verify
+	assert.NoError(t, err)
+	assert.Empty(t, tenant)
+}
+
+func TestContextTenantSourceMultipleFound(t *testing.T) {
+	// prepare
+	ts := &ContextTenantSource{Key: "X-Scope-OrgID"}
+	cl := client.FromContext(context.Background())
+	cl.Metadata = client.NewMetadata(map[string][]string{"X-Scope-OrgID": {"acme", "globex"}})
+	ctx := client.NewContext(context.Background(), cl)
+
+	// test
+	tenant, err := ts.GetTenant(ctx, plog.NewLogs())
+
+	// verify
+	assert.Error(t, err)
+	assert.Empty(t, tenant)
+}

--- a/exporter/lokiexporter/internal/tenant/static.go
+++ b/exporter/lokiexporter/internal/tenant/static.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
-var _ TenantSource = (*StaticTenantSource)(nil)
+var _ Source = (*StaticTenantSource)(nil)
 
 type StaticTenantSource struct {
 	Value string

--- a/exporter/lokiexporter/internal/tenant/static.go
+++ b/exporter/lokiexporter/internal/tenant/static.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenant // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/tenant"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+var _ TenantSource = (*StaticTenantSource)(nil)
+
+type StaticTenantSource struct {
+	Value string
+}
+
+func (ts *StaticTenantSource) GetTenant(_ context.Context, logs plog.Logs) (string, error) {
+	return ts.Value, nil
+}

--- a/exporter/lokiexporter/internal/tenant/static_test.go
+++ b/exporter/lokiexporter/internal/tenant/static_test.go
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenant // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/tenant"
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestStaticTenantSource(t *testing.T) {
+	ts := &StaticTenantSource{Value: "acme"}
+	tenant, err := ts.GetTenant(context.Background(), plog.NewLogs())
+	assert.NoError(t, err)
+	assert.Equal(t, "acme", tenant)
+}

--- a/exporter/lokiexporter/internal/tenant/tenantsource.go
+++ b/exporter/lokiexporter/internal/tenant/tenantsource.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenant // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/tenant"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// LogsPerTenant holds a registry of plog.Logs per tenant
+type LogsPerTenant map[string]plog.Logs
+
+type TenantSource interface {
+	GetTenant(context.Context, plog.Logs) (string, error)
+}

--- a/exporter/lokiexporter/internal/tenant/tenantsource.go
+++ b/exporter/lokiexporter/internal/tenant/tenantsource.go
@@ -23,6 +23,6 @@ import (
 // LogsPerTenant holds a registry of plog.Logs per tenant
 type LogsPerTenant map[string]plog.Logs
 
-type TenantSource interface {
+type Source interface {
 	GetTenant(context.Context, plog.Logs) (string, error)
 }

--- a/unreleased/lokiexporter-multi-tenant.yaml
+++ b/unreleased/lokiexporter-multi-tenant.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: exporter/loki
+note: Handle multi-tenant use-cases
+issues: [3121]


### PR DESCRIPTION
This PR deprecates the existing tenant_id field in favor of a new tenant object, with a "source" and "value". The tenant information now may come from a resource attribute, from the context, or as a static value. Current setups using tenant_id are converted internally to "static".

This has been tested with a configuration similar to this:

```yaml
receivers:
  journald:
    directory: /var/log/journal/a04e3a44cdd740f88d6a7ae3bb8c70cf

exporters:
  logging:
    loglevel: debug
  loki:
    endpoint: http://localhost:3100/loki/api/v1/push
    tls:
      insecure: true
    labels:
      attributes:
        host.name: host_name 
    format: json
    tenant:
      source: attributes
      value: tenant

processors:
  attributes:
    actions:
    - action: insert
      key: host.name
      value: guarana
  resource:
    attributes:
    - action: insert
      key: tenant
      value: acme

extensions:

service:
  extensions:
  pipelines:
    logs:
      receivers: [journald]
      processors: [attributes, resource]
      exporters: [logging, loki]
```

Configuring a different tenant and a different data source on Grafana confirmed that only logs with the new tenant attribute show up there, now showing up on the first data source.

Fixes #3121

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>