### PR TITLE
Service name based routing for trace collector span metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,7 +275,6 @@ This version has been skipped.
 - `tracegen`: Add additional resource attributes (#11145)
 - `transformprocessor`: Add IsMatch factory function.  This function allows regex matching in conditions. (#10903)
 - `transformprocessor`: replace_pattern` and `replace_all_patterns` use regex for pattern matching and replacing text in attributes/metrics (#11125)
-- `exporter/loadbalancingexporter`: Add `service name based routing` for load balancing exporters (#12421)
 
 ### 🧰 Bug fixes 🧰
 - `aerospikereceiver`: Fix issue where namespaces would not be collected (#11465)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@ This version has been skipped.
 - `tracegen`: Add additional resource attributes (#11145)
 - `transformprocessor`: Add IsMatch factory function.  This function allows regex matching in conditions. (#10903)
 - `transformprocessor`: replace_pattern` and `replace_all_patterns` use regex for pattern matching and replacing text in attributes/metrics (#11125)
+- `exporter/loadbalancingexporter`: Add `service name based routing` for load balancing exporters (#12421)
 
 ### 🧰 Bug fixes 🧰
 - `aerospikereceiver`: Fix issue where namespaces would not be collected (#11465)

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -26,7 +26,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `hostname` property inside a `dns` node specifies the hostname to query in order to obtain the list of IP addresses.
 * The `dns` node also accepts an optional property `port` to specify the port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 4317 is used.
 * The `routing_key` property is used to route spans to exporters based on different parameters. This functionality is currently enabled only for `trace` pipeline types. It supports one of the following values:
-    * `service`: exports spans based on its service name. This will be useful when you don't want to duplicate `service.name` in all exporter hosts. 
+    * `service`: exports spans based on their service name. This is useful when using processors like the span metrics, so all spans for each service are sent to consistent collector instances for metric collection. Otherwise, metrics for the same services are sent to different collectors, making aggregations inaccurate. 
     * `traceID` (default): exports spans based on its `traceID`.
     * If not configured, defaults to `traceID` based routing.
   

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -1,4 +1,4 @@
-# Trace ID aware load-balancing exporter
+# Trace ID/Service-name aware load-balancing exporter
 
 | Status                   |              |
 | ------------------------ |--------------|
@@ -6,7 +6,7 @@
 | Supported pipeline types | traces, logs |
 | Distributions            | [contrib]    |
 
-This is an exporter that will consistently export spans and logs depending on the `routing_key` configured. If no `routing_key` is configured, the default routing mechanism in `traceID` i.e; spans belonging to the same `traceID` is sent to the same backend.
+This is an exporter that will consistently export spans and logs depending on the `routing_key` configured. If no `routing_key` is configured, the default routing mechanism in `traceID` i.e; spans belonging to the same `traceID` are sent to the same backend.
 
 It requires a source of backend information to be provided: static, with a fixed list of backends, or DNS, with a hostname that will resolve to all IP addresses to use. The DNS resolver will periodically check for updates.
 

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -16,7 +16,7 @@ This load balancer is especially useful for backends configured with tail-based 
 
 When a list of backends is updated, around 1/n of the space will be changed, so that the same trace ID might be directed to a different backend, where n is the number of backends. This should be stable enough for most cases, and the higher the number of backends, the less disruption it should cause. Still, if routing stability is important for your use case and your list of backends are constantly changing, consider using the `groupbytrace` processor. This way, traces are dispatched atomically to this exporter, and the same decision about the backend is made for the trace as a whole.
 
-This also supports service name based exporting for traces. If you have two or more collectors that collect traces and then use spanmetrics processor to generate metrics and push to prometheus, there is a high chance of facing label collisions on prometheus if the routing is based on traceID because every collector sees the `service+operation` label. With service name based routing, each collector can only see one service name and can push metrics without any label collisions.
+This also supports service name based exporting for traces. If you have two or more collectors that collect traces and then use spanmetrics processor to generate metrics and push to prometheus, there is a high chance of facing label collisions on prometheus if the routing is based on `traceID` because every collector sees the `service+operation` label. With service name based routing, each collector can only see one service name and can push metrics without any label collisions.
 ## Configuration
 
 Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using the processor.

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -24,9 +24,10 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `resolver` accepts either a `static` node, or a `dns`. If both are specified, `dns` takes precedence.
 * The `hostname` property inside a `dns` node specifies the hostname to query in order to obtain the list of IP addresses.
 * The `dns` node also accepts an optional property `port` to specify the port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 4317 is used.
-* The `routing_key`, which only applies to `trace` pipeline types, supports one of the following values:
-    * `service`: routes spans based on its service name.
+* The `routing_key` property is used to route spans to exporters based on different parameters. This functionality is currently enabled only for `trace` pipeline types. It supports one of the following values:
+    * `service`: routes spans based on its service name. This will be useful when you don't want to duplicate `service.name` in all exporter hosts. 
     * `traceID` (default): routes spans based on its `traceID`.
+  
 
 Simple example
 ```yaml

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -16,6 +16,7 @@ This load balancer is especially useful for backends configured with tail-based 
 
 When a list of backends is updated, around 1/n of the space will be changed, so that the same trace ID might be directed to a different backend, where n is the number of backends. This should be stable enough for most cases, and the higher the number of backends, the less disruption it should cause. Still, if routing stability is important for your use case and your list of backends are constantly changing, consider using the `groupbytrace` processor. This way, traces are dispatched atomically to this exporter, and the same decision about the backend is made for the trace as a whole.
 
+This also supports service name based exporting for traces. If you have two or more collectors that collect traces and then use spanmetrics processor to generate metrics and push to prometheus, there is a high chance of facing label collisions on prometheus if the routing is based on traceID because every collector sees the `service+operation` label. With service name based routing, each collector can only see one service name and can push metrics without any label collisions.
 ## Configuration
 
 Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using the processor.

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -27,7 +27,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `dns` node also accepts an optional property `port` to specify the port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 4317 is used.
 * The `routing_key` property is used to route spans to exporters based on different parameters. This functionality is currently enabled only for `trace` pipeline types. It supports one of the following values:
     * `service`: exports spans based on their service name. This is useful when using processors like the span metrics, so all spans for each service are sent to consistent collector instances for metric collection. Otherwise, metrics for the same services are sent to different collectors, making aggregations inaccurate. 
-    * `traceID` (default): exports spans based on its `traceID`.
+    * `traceID` (default): exports spans based on their `traceID`.
     * If not configured, defaults to `traceID` based routing.
   
 

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -6,13 +6,13 @@
 | Supported pipeline types | traces, logs |
 | Distributions            | [contrib]    |
 
-This is an exporter that will consistently export spans and logs belonging to the same trace to the same backend.
+This is an exporter that will consistently export spans and logs depending on the `routing_key` configured. If no `routing_key` is configured, the default routing mechanism in `traceID` i.e; spans belonging to the same `traceID` is sent to the same backend.
 
 It requires a source of backend information to be provided: static, with a fixed list of backends, or DNS, with a hostname that will resolve to all IP addresses to use. The DNS resolver will periodically check for updates.
 
 Note that either the Trace ID or Service name is used for the decision on which backend to use: the actual backend load isn't taken into consideration. Even though this load-balancer won't do round-robin balancing of the batches, the load distribution should be very similar among backends with a standard deviation under 5% at the current configuration.
 
-This load balancer is especially useful for backends configured with tail-based samplers, which make a decision based on the view of the full trace.
+This load balancer is especially useful for backends configured with tail-based samplers or red-metrics-collectors, which make a decision based on the view of the full trace.
 
 When a list of backends is updated, around 1/n of the space will be changed, so that the same trace ID might be directed to a different backend, where n is the number of backends. This should be stable enough for most cases, and the higher the number of backends, the less disruption it should cause. Still, if routing stability is important for your use case and your list of backends are constantly changing, consider using the `groupbytrace` processor. This way, traces are dispatched atomically to this exporter, and the same decision about the backend is made for the trace as a whole.
 
@@ -26,8 +26,9 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `hostname` property inside a `dns` node specifies the hostname to query in order to obtain the list of IP addresses.
 * The `dns` node also accepts an optional property `port` to specify the port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 4317 is used.
 * The `routing_key` property is used to route spans to exporters based on different parameters. This functionality is currently enabled only for `trace` pipeline types. It supports one of the following values:
-    * `service`: routes spans based on its service name. This will be useful when you don't want to duplicate `service.name` in all exporter hosts. 
-    * `traceID` (default): routes spans based on its `traceID`.
+    * `service`: exports spans based on its service name. This will be useful when you don't want to duplicate `service.name` in all exporter hosts. 
+    * `traceID` (default): exports spans based on its `traceID`.
+    * If not configured, defaults to `traceID` based routing.
   
 
 Simple example

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -24,7 +24,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `resolver` accepts either a `static` node, or a `dns`. If both are specified, `dns` takes precedence.
 * The `hostname` property inside a `dns` node specifies the hostname to query in order to obtain the list of IP addresses.
 * The `dns` node also accepts an optional property `port` to specify the port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 4317 is used.
-
+* The `routing_key` can be used to configure different kinds of routing mechanisms. This functionality is available for `trace_exporter`. You can either route your signals based on service name based routing or trace id based routing. For service based routing the configuration is `routing_key: "service"` and for trace id based routing the configuration is `routing_key:"traceID"`. If you don't specify any value, the default is `traceID`  
 
 Simple example
 ```yaml

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -10,7 +10,7 @@ This is an exporter that will consistently export spans and logs belonging to th
 
 It requires a source of backend information to be provided: static, with a fixed list of backends, or DNS, with a hostname that will resolve to all IP addresses to use. The DNS resolver will periodically check for updates.
 
-Note that only the Trace ID is used for the decision on which backend to use: the actual backend load isn't taken into consideration. Even though this load-balancer won't do round-robin balancing of the batches, the load distribution should be very similar among backends with a standard deviation under 5% at the current configuration.
+Note that either the Trace ID or Service name is used for the decision on which backend to use: the actual backend load isn't taken into consideration. Even though this load-balancer won't do round-robin balancing of the batches, the load distribution should be very similar among backends with a standard deviation under 5% at the current configuration.
 
 This load balancer is especially useful for backends configured with tail-based samplers, which make a decision based on the view of the full trace.
 
@@ -24,7 +24,9 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `resolver` accepts either a `static` node, or a `dns`. If both are specified, `dns` takes precedence.
 * The `hostname` property inside a `dns` node specifies the hostname to query in order to obtain the list of IP addresses.
 * The `dns` node also accepts an optional property `port` to specify the port to be used for exporting the traces to the IP addresses resolved from `hostname`. If `port` is not specified, the default port 4317 is used.
-* The `routing_key` can be used to configure different kinds of routing mechanisms. This functionality is available for `trace_exporter`. You can either route your signals based on service name based routing or trace id based routing. For service based routing the configuration is `routing_key: "service"` and for trace id based routing the configuration is `routing_key:"traceID"`. If you don't specify any value, the default is `traceID`  
+* The `routing_key`, which only applies to `trace` pipeline types, supports one of the following values:
+    * `service`: routes spans based on its service name.
+    * `traceID` (default): routes spans based on its `traceID`.
 
 Simple example
 ```yaml
@@ -39,6 +41,7 @@ processors:
 exporters:
   logging:
   loadbalancing:
+    routing_key: "service"
     protocol:
       otlp:
         # all options from the OTLP exporter are supported

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -19,11 +19,19 @@ import (
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 )
 
+type routingKey int
+
+const (
+	traceId routingKey = iota
+	svcRouting
+)
+
 // Config defines configuration for the exporter.
 type Config struct {
 	config.ExporterSettings `mapstructure:",squash"`
 	Protocol                Protocol         `mapstructure:"protocol"`
 	Resolver                ResolverSettings `mapstructure:"resolver"`
+	RoutingKey              string           `mapstructure:"routing_key"`
 }
 
 // Protocol holds the individual protocol-specific settings. Only OTLP is supported at the moment.

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -22,7 +22,7 @@ import (
 type routingKey int
 
 const (
-	traceIdRouting routingKey = iota
+	traceIDRouting routingKey = iota
 	svcRouting
 )
 

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -22,7 +22,7 @@ import (
 type routingKey int
 
 const (
-	traceId routingKey = iota
+	traceIdRouting routingKey = iota
 	svcRouting
 )
 

--- a/exporter/loadbalancingexporter/consistent_hashing.go
+++ b/exporter/loadbalancingexporter/consistent_hashing.go
@@ -17,8 +17,6 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 import (
 	"hash/crc32"
 	"sort"
-
-	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 const maxPositions uint32 = 36000 // 360 degrees with two decimal places
@@ -49,10 +47,9 @@ func newHashRing(endpoints []string) *hashRing {
 }
 
 // endpointFor calculates which backend is responsible for the given traceID
-func (h *hashRing) endpointFor(traceID pcommon.TraceID) string {
-	b := traceID.Bytes()
+func (h *hashRing) endpointFor(identifier []byte) string {
 	hasher := crc32.NewIEEE()
-	hasher.Write(b[:])
+	hasher.Write(identifier)
 	hash := hasher.Sum32()
 	pos := hash % maxPositions
 

--- a/exporter/loadbalancingexporter/consistent_hashing_test.go
+++ b/exporter/loadbalancingexporter/consistent_hashing_test.go
@@ -48,7 +48,8 @@ func TestEndpointFor(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("Endpoint for traceID %s", tt.traceID.HexString()), func(t *testing.T) {
 			// test
-			endpoint := ring.endpointFor(tt.traceID)
+			tid := tt.traceID.Bytes()
+			endpoint := ring.endpointFor(tid[:])
 
 			// verify
 			assert.Equal(t, tt.expected, endpoint)

--- a/exporter/loadbalancingexporter/consistent_hashing_test.go
+++ b/exporter/loadbalancingexporter/consistent_hashing_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 func TestNewHashRing(t *testing.T) {
@@ -39,17 +38,18 @@ func TestEndpointFor(t *testing.T) {
 	ring := newHashRing(endpoints)
 
 	for _, tt := range []struct {
-		traceID  pcommon.TraceID
+		id       []byte
 		expected string
 	}{
 		// check that we are indeed alternating endpoints for different inputs
-		{pcommon.NewTraceID([16]byte{1, 2, 0, 0}), "endpoint-1"},
-		{pcommon.NewTraceID([16]byte{128, 128, 0, 0}), "endpoint-2"},
+		{[]byte{1, 2, 0, 0}, "endpoint-1"},
+		{[]byte{128, 128, 0, 0}, "endpoint-2"},
+		{[]byte("ad-service-7"), "endpoint-1"},
+		{[]byte("get-recommendations-1"), "endpoint-2"},
 	} {
-		t.Run(fmt.Sprintf("Endpoint for traceID %s", tt.traceID.HexString()), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Endpoint for id %s", string(tt.id)), func(t *testing.T) {
 			// test
-			tid := tt.traceID.Bytes()
-			endpoint := ring.endpointFor(tid[:])
+			endpoint := ring.endpointFor(tt.id)
 
 			// verify
 			assert.Equal(t, tt.expected, endpoint)

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -23,7 +23,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/zap"
 )
 
@@ -42,7 +41,7 @@ type componentFactory func(ctx context.Context, endpoint string) (component.Expo
 
 type loadBalancer interface {
 	component.Component
-	Endpoint(traceID pcommon.TraceID) string
+	Endpoint(identifier []byte) string
 	Exporter(endpoint string) (component.Exporter, error)
 }
 
@@ -173,11 +172,11 @@ func (lb *loadBalancerImp) Shutdown(context.Context) error {
 	return nil
 }
 
-func (lb *loadBalancerImp) Endpoint(traceID pcommon.TraceID) string {
+func (lb *loadBalancerImp) Endpoint(identifier []byte) string {
 	lb.updateLock.RLock()
 	defer lb.updateLock.RUnlock()
 
-	return lb.ring.endpointFor(traceID)
+	return lb.ring.endpointFor(identifier)
 }
 
 func (lb *loadBalancerImp) Exporter(endpoint string) (component.Exporter, error) {

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 func TestNewLoadBalancerNoResolver(t *testing.T) {
@@ -342,7 +341,7 @@ func TestFailedExporterInRing(t *testing.T) {
 
 	// test
 	// this trace ID will reach the endpoint-2 -- see the consistent hashing tests for more info
-	_, err = p.Exporter(p.Endpoint(pcommon.NewTraceID([16]byte{128, 128, 0, 0})))
+	_, err = p.Exporter(p.Endpoint([]byte{128, 128, 0, 0}))
 
 	// verify
 	assert.Error(t, err)

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -345,6 +345,13 @@ func TestFailedExporterInRing(t *testing.T) {
 
 	// verify
 	assert.Error(t, err)
+
+	// test
+	// this service name will reach the endpoint-2 -- see the consistent hashing tests for more info
+	_, err = p.Exporter(p.Endpoint([]byte("get-recommendations-1")))
+
+	// verify
+	assert.Error(t, err)
 }
 
 func newNopMockExporter() component.Exporter {

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -94,7 +94,8 @@ func (e *logExporterImp) consumeLog(ctx context.Context, ld plog.Logs) error {
 		balancingKey = random()
 	}
 
-	endpoint := e.loadBalancer.Endpoint(balancingKey)
+	tid := balancingKey.Bytes()
+	endpoint := e.loadBalancer.Endpoint(tid[:])
 	exp, err := e.loadBalancer.Exporter(endpoint)
 	if err != nil {
 		return err

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -27,7 +27,6 @@ import (
 	"go.opentelemetry.io/collector/config"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/multierr"
 
@@ -42,13 +41,14 @@ var (
 
 type traceExporterImp struct {
 	loadBalancer loadBalancer
-
-	stopped    bool
-	shutdownWg sync.WaitGroup
+	routingKey   routingKey
+	stopped      bool
+	shutdownWg   sync.WaitGroup
 }
 
 // Create new traces exporter
 func newTracesExporter(params component.ExporterCreateSettings, cfg config.Exporter) (*traceExporterImp, error) {
+	var r routingKey
 	exporterFactory := otlpexporter.NewFactory()
 
 	lb, err := newLoadBalancer(params, cfg, func(ctx context.Context, endpoint string) (component.Exporter, error) {
@@ -59,8 +59,15 @@ func newTracesExporter(params component.ExporterCreateSettings, cfg config.Expor
 		return nil, err
 	}
 
+	switch cfg.(*Config).RoutingKey {
+	case "service":
+		r = svcRouting
+	default:
+		r = traceId
+	}
 	return &traceExporterImp{
 		loadBalancer: lb,
+		routingKey:   r,
 	}, nil
 }
 
@@ -96,12 +103,12 @@ func (e *traceExporterImp) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 }
 
 func (e *traceExporterImp) consumeTrace(ctx context.Context, td ptrace.Traces) error {
-	traceID := traceIDFromTraces(td)
-	if traceID == pcommon.InvalidTraceID() {
-		return errNoTracesInBatch
+	routingId, err := routingIdentifierFromTraces(td, e.routingKey)
+	if err != nil {
+		return err
 	}
 
-	endpoint := e.loadBalancer.Endpoint(traceID)
+	endpoint := e.loadBalancer.Endpoint(routingId)
 	exp, err := e.loadBalancer.Exporter(endpoint)
 	if err != nil {
 		return err
@@ -129,21 +136,31 @@ func (e *traceExporterImp) consumeTrace(ctx context.Context, td ptrace.Traces) e
 	return err
 }
 
-func traceIDFromTraces(td ptrace.Traces) pcommon.TraceID {
+func routingIdentifierFromTraces(td ptrace.Traces, key routingKey) ([]byte, error) {
 	rs := td.ResourceSpans()
 	if rs.Len() == 0 {
-		return pcommon.InvalidTraceID()
+		return nil, errors.New("invalid trace id")
 	}
 
 	ils := rs.At(0).ScopeSpans()
 	if ils.Len() == 0 {
-		return pcommon.InvalidTraceID()
+		return nil, errors.New("invalid trace id")
 	}
 
 	spans := ils.At(0).Spans()
 	if spans.Len() == 0 {
-		return pcommon.InvalidTraceID()
+		return nil, errors.New("invalid trace id")
 	}
 
-	return spans.At(0).TraceID()
+	switch key {
+	case svcRouting:
+		svc, ok := rs.At(0).Resource().Attributes().Get("service.name")
+		if !ok {
+			return nil, errors.New("unable to get service name")
+		}
+		return []byte(svc.StringVal()), nil
+	default:
+		tid := spans.At(0).TraceID().Bytes()
+		return tid[:], nil
+	}
 }

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -99,13 +99,14 @@ func (e *traceExporterImp) ConsumeTraces(ctx context.Context, td ptrace.Traces) 
 }
 
 func (e *traceExporterImp) consumeTrace(ctx context.Context, td ptrace.Traces) error {
+	var exp component.Exporter
 	routingIds, err := routingIdentifiersFromTraces(td, e.routingKey)
 	if err != nil {
 		return err
 	}
 	for rid := range routingIds {
 		endpoint := e.loadBalancer.Endpoint([]byte(rid))
-		exp, err := e.loadBalancer.Exporter(endpoint)
+		exp, err = e.loadBalancer.Exporter(endpoint)
 		if err != nil {
 			return err
 		}

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -139,7 +139,7 @@ func (e *traceExporterImp) consumeTrace(ctx context.Context, td ptrace.Traces) e
 	return err
 }
 
-func routingIdentifierFromTraces(td ptrace.Traces, key routingKey) (map[string]bool, error) {
+func routingIdentifiersFromTraces(td ptrace.Traces, key routingKey) (map[string]bool, error) {
 	ids := make(map[string]bool)
 	rs := td.ResourceSpans()
 	if rs.Len() == 0 {

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -136,6 +136,7 @@ func TestConsumeTraces(t *testing.T) {
 	p, err := newTracesExporter(componenttest.NewNopExporterCreateSettings(), simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
+	assert.Equal(t, p.routingKey, traceId)
 
 	// pre-load an exporter here, so that we don't use the actual OTLP exporter
 	lb.exporters["endpoint-1"] = newNopMockTracesExporter()
@@ -155,6 +156,40 @@ func TestConsumeTraces(t *testing.T) {
 
 	// test
 	res := p.ConsumeTraces(context.Background(), simpleTraces())
+
+	// verify
+	assert.Nil(t, res)
+}
+
+func TestConsumeTracesServiceBased(t *testing.T) {
+	componentFactory := func(ctx context.Context, endpoint string) (component.Exporter, error) {
+		return newNopMockTracesExporter(), nil
+	}
+	lb, err := newLoadBalancer(componenttest.NewNopExporterCreateSettings(), serviceBasedRoutingConfig(), componentFactory)
+	require.NotNil(t, lb)
+	require.NoError(t, err)
+
+	p, err := newTracesExporter(componenttest.NewNopExporterCreateSettings(), serviceBasedRoutingConfig())
+	require.NotNil(t, p)
+	require.NoError(t, err)
+	assert.Equal(t, p.routingKey, svcRouting)
+
+	// pre-load an exporter here, so that we don't use the actual OTLP exporter
+	lb.exporters["endpoint-1"] = newNopMockTracesExporter()
+	lb.res = &mockResolver{
+		triggerCallbacks: true,
+		onResolve: func(ctx context.Context) ([]string, error) {
+			return []string{"endpoint-1"}, nil
+		},
+	}
+	p.loadBalancer = lb
+
+	err = p.Start(context.Background(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	// test
+	res := p.ConsumeTraces(context.Background(), simpleTracesWithServiceName())
 
 	// verify
 	assert.Nil(t, res)
@@ -328,12 +363,14 @@ func TestBatchWithTwoTraces(t *testing.T) {
 
 func TestNoTracesInBatch(t *testing.T) {
 	for _, tt := range []struct {
-		desc  string
-		batch ptrace.Traces
+		desc       string
+		batch      ptrace.Traces
+		routingKey routingKey
 	}{
 		{
 			"no resource spans",
 			ptrace.NewTraces(),
+			traceId,
 		},
 		{
 			"no instrumentation library spans",
@@ -342,6 +379,7 @@ func TestNoTracesInBatch(t *testing.T) {
 				batch.ResourceSpans().AppendEmpty()
 				return batch
 			}(),
+			traceId,
 		},
 		{
 			"no spans",
@@ -350,11 +388,13 @@ func TestNoTracesInBatch(t *testing.T) {
 				batch.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty()
 				return batch
 			}(),
+			svcRouting,
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			res := traceIDFromTraces(tt.batch)
-			assert.Equal(t, pcommon.InvalidTraceID(), res)
+			res, err := routingIdentifierFromTraces(tt.batch, tt.routingKey)
+			assert.Equal(t, err, errors.New("invalid trace id"))
+			assert.Equal(t, res, []byte(nil))
 		})
 	}
 }
@@ -506,10 +546,28 @@ func simpleTraces() ptrace.Traces {
 	return simpleTraceWithID(pcommon.NewTraceID([16]byte{1, 2, 3, 4}))
 }
 
+func simpleTracesWithServiceName() ptrace.Traces {
+	return simpleTraceWithServiceName(pcommon.NewTraceID([16]byte{1, 2, 3, 4}))
+}
+
 func simpleTraceWithID(id pcommon.TraceID) ptrace.Traces {
 	traces := ptrace.NewTraces()
 	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetTraceID(id)
 	return traces
+}
+
+func simpleTraceWithServiceName(id pcommon.TraceID) ptrace.Traces {
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().EnsureCapacity(1)
+	rspans := traces.ResourceSpans().AppendEmpty()
+	fillResource(rspans.Resource())
+	rspans.ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetTraceID(id)
+	return traces
+}
+
+func fillResource(resource pcommon.Resource) {
+	attrs := resource.Attributes()
+	attrs.InsertString("service.name", "service-name-1")
 }
 
 func simpleConfig() *Config {
@@ -518,6 +576,16 @@ func simpleConfig() *Config {
 		Resolver: ResolverSettings{
 			Static: &StaticResolver{Hostnames: []string{"endpoint-1"}},
 		},
+	}
+}
+
+func serviceBasedRoutingConfig() *Config {
+	return &Config{
+		ExporterSettings: config.NewExporterSettings(config.NewComponentID(typeStr)),
+		Resolver: ResolverSettings{
+			Static: &StaticResolver{Hostnames: []string{"endpoint-1"}},
+		},
+		RoutingKey: "service",
 	}
 }
 

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -136,7 +136,7 @@ func TestConsumeTraces(t *testing.T) {
 	p, err := newTracesExporter(componenttest.NewNopExporterCreateSettings(), simpleConfig())
 	require.NotNil(t, p)
 	require.NoError(t, err)
-	assert.Equal(t, p.routingKey, traceId)
+	assert.Equal(t, p.routingKey, traceIdRouting)
 
 	// pre-load an exporter here, so that we don't use the actual OTLP exporter
 	lb.exporters["endpoint-1"] = newNopMockTracesExporter()
@@ -370,7 +370,7 @@ func TestNoTracesInBatch(t *testing.T) {
 		{
 			"no resource spans",
 			ptrace.NewTraces(),
-			traceId,
+			traceIdRouting,
 		},
 		{
 			"no instrumentation library spans",
@@ -379,7 +379,7 @@ func TestNoTracesInBatch(t *testing.T) {
 				batch.ResourceSpans().AppendEmpty()
 				return batch
 			}(),
-			traceId,
+			traceIdRouting,
 		},
 		{
 			"no spans",
@@ -394,7 +394,7 @@ func TestNoTracesInBatch(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			res, err := routingIdentifierFromTraces(tt.batch, tt.routingKey)
 			assert.Equal(t, err, errors.New("invalid trace id"))
-			assert.Equal(t, res, []byte(nil))
+			assert.Equal(t, res, map[string]bool(nil))
 		})
 	}
 }

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -186,7 +186,9 @@ func TestConsumeTracesServiceBased(t *testing.T) {
 
 	err = p.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
-	defer p.Shutdown(context.Background())
+	defer func() {
+		require.NoError(t, p.Shutdown(context.Background()))
+	}()
 
 	// test
 	res := p.ConsumeTraces(context.Background(), simpleTracesWithServiceName())

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -186,9 +186,7 @@ func TestConsumeTracesServiceBased(t *testing.T) {
 
 	err = p.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, p.Shutdown(context.Background()))
-	}()
+	defer p.Shutdown(context.Background())
 
 	// test
 	res := p.ConsumeTraces(context.Background(), simpleTracesWithServiceName())

--- a/unreleased/lbexporter-svc-name-based-routing.yaml
+++ b/unreleased/lbexporter-svc-name-based-routing.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: loadbalancingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Exporting trace pipelines based on Service name to avoid duplicate label svc + operation in collector hosts.
+
+# One or more tracking issues related to the change
+issues: []

--- a/unreleased/lbexporter-svc-name-based-routing.yaml
+++ b/unreleased/lbexporter-svc-name-based-routing.yaml
@@ -8,4 +8,4 @@ component: loadbalancingexporter
 note: Exporting trace pipelines based on Service name to avoid duplicate label svc + operation in collector hosts.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [12652]


### PR DESCRIPTION
**Description:**
Adding a feature support for service name based routing for loadbalancing exporters. Instead of repeating the same service name in all hosts for span metrics collector, this feature will have one-one mapping between a service and collector host. This will have traceId routing by default if nothing is mentioned. If, we need a service based routing, it should be added in loadbalancing exporter config as below

Closes #12652

` routing_key: "service"`

**Testing:**
Added unit test cases to check different routing types for e.g service based vs non service based which is traceId by default
