### PR TITLE
Remove irrelevant comment

### DIFF
--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -242,7 +242,6 @@ func (p *processorImp) ConsumeTraces(ctx context.Context, traces ptrace.Traces) 
 		if err != nil {
 			p.logger.Error(err.Error())
 		} else if err = p.metricsExporter.ConsumeMetrics(ctx, *m); err != nil {
-			// Export metrics first before forwarding trace to avoid being impacted by downstream trace processor errors/latency.
 			p.logger.Error(err.Error())
 		}
 

--- a/unreleased/spanmetricsproc-remove-redundant-comment.yaml
+++ b/unreleased/spanmetricsproc-remove-redundant-comment.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsprocessor
+
+# A brief description of the change
+note: Removes a comment that is no longer relevant due to a fix.
+
+# One or more tracking issues related to the change
+issues: [12427]


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

**Description:** Follow-up to this comment: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/11149#discussion_r916063549

The comment removed in this PR is no longer relevant because the metrics are computed off a different goroutine, allowing traces to proceed through the pipeline unhindered.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9018