### PR TITLE
[receiver/elasticsearch] Remove disk_usage_state from metadata.yaml

### DIFF
--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -77,7 +77,6 @@ metrics:
 | circuit_breaker_name (name) | The name of circuit breaker. |  |
 | collector_name (name) | The name of the garbage collector. |  |
 | direction | The direction of network data. | received, sent |
-| disk_usage_state (state) | The state of a section of space on disk. | used, free |
 | document_state (state) | The state of the document. | active, deleted |
 | fs_direction (direction) | The direction of filesystem IO. | read, write |
 | health_status (status) | The health status of the cluster. | green, yellow, red |

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_v2.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_v2.go
@@ -252,32 +252,6 @@ var MapAttributeDirection = map[string]AttributeDirection{
 	"sent":     AttributeDirectionSent,
 }
 
-// AttributeDiskUsageState specifies the a value disk_usage_state attribute.
-type AttributeDiskUsageState int
-
-const (
-	_ AttributeDiskUsageState = iota
-	AttributeDiskUsageStateUsed
-	AttributeDiskUsageStateFree
-)
-
-// String returns the string representation of the AttributeDiskUsageState.
-func (av AttributeDiskUsageState) String() string {
-	switch av {
-	case AttributeDiskUsageStateUsed:
-		return "used"
-	case AttributeDiskUsageStateFree:
-		return "free"
-	}
-	return ""
-}
-
-// MapAttributeDiskUsageState is a helper map of string to AttributeDiskUsageState attribute value.
-var MapAttributeDiskUsageState = map[string]AttributeDiskUsageState{
-	"used": AttributeDiskUsageStateUsed,
-	"free": AttributeDiskUsageStateFree,
-}
-
 // AttributeDocumentState specifies the a value document_state attribute.
 type AttributeDocumentState int
 

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -26,12 +26,6 @@ attributes:
   memory_pool_name:
     value: name
     description: The name of the JVM memory pool.
-  disk_usage_state:
-    value: state
-    description: The state of a section of space on disk.
-    enum:
-    - used
-    - free
   direction:
     description: The direction of network data.
     enum:

--- a/unreleased/elasticsearchreceiver-remove-disk-usage-state.yaml
+++ b/unreleased/elasticsearchreceiver-remove-disk-usage-state.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: remove unused `disk_usage_state` from docs
+
+# One or more tracking issues related to the change
+issues: [12429]
+

--- a/unreleased/elasticsearchreceiver-remove-disk-usage-state.yaml
+++ b/unreleased/elasticsearchreceiver-remove-disk-usage-state.yaml
@@ -5,7 +5,7 @@ change_type: "bug_fix"
 component: elasticsearchreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: remove unused `disk_usage_state` from docs
+note: Remove unused `disk_usage_state` attribute from documentation
 
 # One or more tracking issues related to the change
 issues: [12429]


### PR DESCRIPTION
**Description:**
* Removes the unused `disk_usage_state` from metadata.yaml/docs

**Link to tracking Issue:** #12429

**Documentation:** Auto-generated docs changed as a result of metadata.yaml change