### PR TITLE
exporter/datadogexporter: fix reported version

### DIFF
--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	traceconfig "github.com/DataDog/datadog-agent/pkg/trace/config"
+	traceinfo "github.com/DataDog/datadog-agent/pkg/trace/info"
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -58,8 +59,8 @@ func newTracesExporter(ctx context.Context, params component.ExporterCreateSetti
 	if err := utils.ValidateAPIKey(params.Logger, client); err != nil && cfg.API.FailOnInvalidKey {
 		return nil, err
 	}
+	traceinfo.Version = fmt.Sprintf("datadogexporter-%s-%s", params.BuildInfo.Command, params.BuildInfo.Version)
 	acfg := traceconfig.New()
-	acfg.AgentVersion = fmt.Sprintf("datadogexporter-%s-%s", params.BuildInfo.Command, params.BuildInfo.Version)
 	src, err := sourceProvider.Source(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change makes sure that the correct version is added to the outgoing
payloads when writing traces & stats.

Example version:
```
datadogexporter-otelcontribcol-v0.54.0-259-g54f13f391
```