### PR TITLE
Remove pmm-sumo as Approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs
 
 - [Anthony Mirabella](https://github.com/Aneurysm9), AWS
 - [David Ashpole](https://github.com/dashpole), Google
-- [Przemek Maciolek](https://github.com/pmm-sumo), Sumo Logic
 - [Tyler Helmuth](https://github.com/TylerHelmuth), New Relic
+
+Emeritus Approvers:
+- [Przemek Maciolek](https://github.com/pmm-sumo)
 
 Maintainers ([@open-telemetry/collector-contrib-maintainer](https://github.com/orgs/open-telemetry/teams/collector-contrib-maintainer)):
 


### PR DESCRIPTION
Dear community, due to a transition into another role at a different organisation I am no longer able to allocate time to be an approver of the collector-contrib

Thank you all, it was a great pleasure to work with you and also a great opportunity to learn