### PR TITLE
[chore] don't ping if label applied by code owner

### DIFF
--- a/.github/workflows/ping-codeowners.yml
+++ b/.github/workflows/ping-codeowners.yml
@@ -17,4 +17,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE: ${{ github.event.issue.number }}
           COMPONENT: ${{ github.event.label.name }}
-
+          SENDER: ${{ github.event.sender.login }}

--- a/.github/workflows/scripts/ping-codeowners.sh
+++ b/.github/workflows/scripts/ping-codeowners.sh
@@ -27,5 +27,10 @@ if [ -z "${OWNERS}" ]; then
     exit 0
 fi
 
+if [[ "${OWNERS}" =~ "${SENDER}" ]]; then
+    echo "Label applied by code owner ${SENDER}"
+    exit 0
+fi
+
 gh issue comment ${ISSUE} --body "Pinging code owners: ${OWNERS}"
 


### PR DESCRIPTION
This checks the github event to see if the user that triggered the event is a code owner. If so, don't ping code owners.
