### PR TITLE
[receiver/googlecloudspannerreceiver/internal ]enable gocritic

### DIFF
--- a/receiver/googlecloudspannerreceiver/internal/statsreader/statements.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/statements.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:gocritic
 package statsreader // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/statsreader"
 
 import (
@@ -61,7 +60,7 @@ func currentStatsStatement(args statementArgs) statsStatement {
 func intervalStatsStatement(args statementArgs) statsStatement {
 	stmt := currentStatsStatement(args)
 
-	if len(stmt.statement.Params) <= 0 {
+	if len(stmt.statement.Params) == 0 {
 		stmt.statement.Params = map[string]interface{}{}
 	}
 

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:gocritic
 package statsreader // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/statsreader"
 
 import "time"
@@ -53,7 +52,7 @@ func pullTimestampsWithDifference(lowerBound time.Time, upperBound time.Time, di
 	}
 
 	// To ensure that we did not miss upper bound and timestamps slice will contain at least one value
-	if len(timestamps) <= 0 || timestamps[len(timestamps)-1] != upperBound {
+	if len(timestamps) == 0 || timestamps[len(timestamps)-1] != upperBound {
 		timestamps = append(timestamps, upperBound)
 	}
 


### PR DESCRIPTION
Enable gocritic in receiver/googlecloudspannerreceiver/internal 

part of issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10466