### PR TITLE
[processor/transformprocessor/internal/logs] Enable gocritic

### DIFF
--- a/processor/transformprocessor/internal/logs/logs.go
+++ b/processor/transformprocessor/internal/logs/logs.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:gocritic
 package logs // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/logs"
 
 import (
@@ -107,8 +106,8 @@ func newPathGetSetter(path []common.Field) (common.GetSetter, error) {
 		if len(path) == 1 {
 			return accessResource(), nil
 		}
-		switch path[1].Name {
-		case "attributes":
+
+		if path[1].Name == "attributes" {
 			mapKey := path[1].MapKey
 			if mapKey == nil {
 				return accessResourceAttributes(), nil
@@ -149,16 +148,14 @@ func newPathGetSetter(path []common.Field) (common.GetSetter, error) {
 		if len(path) == 1 {
 			return accessTraceID(), nil
 		}
-		switch path[1].Name {
-		case "string":
+		if path[1].Name == "string" {
 			return accessStringTraceID(), nil
 		}
 	case "span_id":
 		if len(path) == 1 {
 			return accessSpanID(), nil
 		}
-		switch path[1].Name {
-		case "string":
+		if path[1].Name == "string" {
 			return accessStringSpanID(), nil
 		}
 	}


### PR DESCRIPTION
Enable gocritic in processor/transformprocessor/internal/logs

part of issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10466