### PR TITLE
[processor/attributesprocessor] Update invalid regex in example (#12477)

### DIFF
--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -27,17 +27,17 @@ processors:
       # to the target keys specified in the `rule`.
       # (Insert attributes for target keys that do not exist and update keys
       # that exist.)
-      # Given http.url = http://example.com/path?queryParam1=value1,queryParam2=value2
+      # Given http.url = http://example.com/path?queryParam1=value1,queryParam2=value2&order=asc
       # then the following attributes will be inserted:
       # http_protocol: http
       # http_domain: example.com
       # http_path: path
-      # http_query_params=queryParam1=value1,queryParam2=value2
+      # http_query_params=queryParam1=value1,queryParam2=value2&order=asc
       # http.url value does NOT change.
       # Note: Similar to the Span Procesor, if a target key already exists,
       # it will be updated.
       - key: "http.url"
-        pattern: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)(\?|\&)(?P<http_query_params>.*)
+        pattern: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)\?(?P<http_query_params>.*)
         action: extract
 
   # The following demonstrates configuring the processor to only update existing
@@ -348,10 +348,10 @@ processors:
       from_context: metadata.origin
       action: insert
     - key: enduser.id
-      # The following uses `subject` attribute produced 
+      # The following uses `subject` attribute produced
       # by the server authenticator from `oidc` extension
       # to set the identity of an exporter on spans.
-      # Refer to the server authenticator's documentation part of your pipeline 
+      # Refer to the server authenticator's documentation part of your pipeline
       # for more information about which attributes are available.
       from_context: auth.subject
       action: insert


### PR DESCRIPTION
**Description:** 

Fixes #12477 by updating the RegEx expression in the example/test data with one that is valid and does not cause the Collector to fail on startup.

**Link to tracking Issue:** <Issue number if applicable>
#12477

**Testing:** <Describe what testing was performed and which tests were added.>
```python
import re

target_string = "http://example.com/path?queryParam1=value1,queryParam2=value2&order=asc"
result = re.search(r"^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)\?(?P<http_query_params>.*)", target_string)

# Extract matching values of all groups
print('=== http_protocol ===')
print(result.group(1))
# http

print('=== http_domain ===')
print(result.group(2))
# example.com

print('=== http_path ===')
print(result.group(3))
# path

print('=== http_query_params ===')
print(result.group(4))
# queryParam1=value1,queryParam2=value2&order=asc
```


**Documentation:** 
Updated the example output by the example RegEx expression.