### PR TITLE
[ci] disable g112 to unblock CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,3 +132,7 @@ issues:
     - text: "G402:"
       linters:
         - gosec
+    # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12566
+    - text: "G112:"
+      linters:
+        - gosec


### PR DESCRIPTION
Disabling missing ReadHeaderTimeout lint check until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12566 is completed.
