### PR TITLE
Remove @pmm-sumo as a reviewer from CODEOWNERS - add mutliple people from Sumo Logic as a replacement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@ exporter/dynatraceexporter/                          @open-telemetry/collector-c
 exporter/elasticexporter/                            @open-telemetry/collector-contrib-approvers @axw @simitt @jalvz
 exporter/elasticsearchexporter/                      @open-telemetry/collector-contrib-approvers @urso @faec @blakerouse
 exporter/f5cloudexporter/                            @open-telemetry/collector-contrib-approvers @gramidt
-exporter/fileexporter/                               @open-telemetry/collector-contrib-approvers @pmm-sumo
+exporter/fileexporter/                               @open-telemetry/collector-contrib-approvers @astencel-sumo @kkujawa-sumo
 exporter/googlecloudexporter/                        @open-telemetry/collector-contrib-approvers @aabmass @dashpole @jsuereth @punya @tbarker25 @damemi
 exporter/googlemanagedprometheusexporter/            @open-telemetry/collector-contrib-approvers @aabmass @dashpole @jsuereth @punya @tbarker25 @damemi
 exporter/googlecloudpubsubexporter/                  @open-telemetry/collector-contrib-approvers @alexvanboxel
@@ -64,10 +64,10 @@ exporter/sentryexporter/                             @open-telemetry/collector-c
 exporter/signalfxexporter/                           @open-telemetry/collector-contrib-approvers @pmcollins @dmitryax
 exporter/skywalkingexporter/                         @open-telemetry/collector-contrib-approvers @liqiangz
 exporter/splunkhecexporter/                          @open-telemetry/collector-contrib-approvers @atoulme @dmitryax
-exporter/sumologicexporter/                          @open-telemetry/collector-contrib-approvers @pmm-sumo @sumo-drosiek
+exporter/sumologicexporter/                          @open-telemetry/collector-contrib-approvers @swiatekm-sumo @sumo-drosiek
 exporter/tanzuobservabilityexporter/                 @open-telemetry/collector-contrib-approvers @oppegard @thepeterstone @keep94
 exporter/tencentcloudlogserviceexporter/             @open-telemetry/collector-contrib-approvers @wgliang @yiyang5055
-exporter/zipkinexporter/                             @open-telemetry/collector-contrib-approvers @pmm-sumo
+exporter/zipkinexporter/                             @open-telemetry/collector-contrib-approvers @mat-rumian @pdelewski
 
 extension/asapauthextension/                         @open-telemetry/collector-contrib-approvers @jamesmoessis @MovieStoreGuy
 extension/awsproxy/                                  @open-telemetry/collector-contrib-approvers @Aneurysm9 @mxiamxia
@@ -92,7 +92,7 @@ internal/docker/                                     @open-telemetry/collector-c
 
 internal/k8sconfig/                                  @open-telemetry/collector-contrib-approvers @pmcollins @dmitryax
 internal/kubelet/                                    @open-telemetry/collector-contrib-approvers @dmitryax
-internal/metadataproviders/                          @open-telemetry/collector-contrib-approvers @jrcamp @pmm-sumo @Aneurysm9 @dashpole
+internal/metadataproviders/                          @open-telemetry/collector-contrib-approvers @jrcamp @astencel-sumo @Aneurysm9 @dashpole
 internal/scrapertest/                                @open-telemetry/collector-contrib-approvers @djaglowski
 internal/splunk/                                     @open-telemetry/collector-contrib-approvers @pmcollins @dmitryax
 
@@ -105,23 +105,23 @@ pkg/translator/opencensus/                           @open-telemetry/collector-c
 pkg/translator/prometheus/                           @open-telemetry/collector-contrib-approvers @dashpole @bertysentry
 pkg/translator/zipkin/                               @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 
-processor/attributesprocessor/                       @open-telemetry/collector-contrib-approvers @boostchicken @pmm-sumo
+processor/attributesprocessor/                       @open-telemetry/collector-contrib-approvers @boostchicken @sumo-drosiek
 processor/cumulativetodeltaprocessor/                @open-telemetry/collector-contrib-approvers @TylerHelmuth
-processor/filterprocessor/                           @open-telemetry/collector-contrib-approvers @boostchicken @pmm-sumo
-processor/groupbyattrsprocessor/                     @open-telemetry/collector-contrib-approvers @pmm-sumo
+processor/filterprocessor/                           @open-telemetry/collector-contrib-approvers @boostchicken @sumo-drosiek
+processor/groupbyattrsprocessor/                     @open-telemetry/collector-contrib-approvers @swiatekm-sumo @pdelewski-sumo
 processor/groupbytraceprocessor/                     @open-telemetry/collector-contrib-approvers @jpkrohling
-processor/k8sattributesprocessor/                    @open-telemetry/collector-contrib-approvers @owais @dmitryax @pmm-sumo
+processor/k8sattributesprocessor/                    @open-telemetry/collector-contrib-approvers @owais @dmitryax @swiatekm-sumo
 processor/logstransformprocessor/                    @open-telemetry/collector-contrib-approvers @djaglowski @dehaansa
 processor/metricstransformprocessor/                 @open-telemetry/collector-contrib-approvers @dmitryax
 processor/probabilisticsamplerprocessor/             @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/redactionprocessor/                        @open-telemetry/collector-contrib-approvers @leonsp-ai @dmitryax @mx-psi
-processor/resourcedetectionprocessor/                @open-telemetry/collector-contrib-approvers @jrcamp @pmm-sumo @Aneurysm9 @dashpole
+processor/resourcedetectionprocessor/                @open-telemetry/collector-contrib-approvers @jrcamp @astencel-sumo @Aneurysm9 @dashpole
 processor/resourceprocessor/                         @open-telemetry/collector-contrib-approvers @dmitryax
 processor/resourcedetectionprocessor/internal/azure/ @open-telemetry/collector-contrib-approvers @mx-psi
 processor/routingprocessor/                          @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/schemaprocessor/                           @open-telemetry/collector-contrib-approvers @MovieStoreGuy
 processor/spanmetricsprocessor/                      @open-telemetry/collector-contrib-approvers @albertteoh
-processor/spanprocessor/                             @open-telemetry/collector-contrib-approvers @boostchicken @pmm-sumo
+processor/spanprocessor/                             @open-telemetry/collector-contrib-approvers @boostchicken @kkujawa-sumo
 processor/tailsamplingprocessor/                     @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/transformprocessor/                        @open-telemetry/collector-contrib-approvers @Aneurysm9 @bogdandrutu @TylerHelmuth @kentquirk
 
@@ -151,7 +151,7 @@ receiver/influxdbreceiver/                           @open-telemetry/collector-c
 receiver/iisreceiver/                                @open-telemetry/collector-contrib-approvers @mrod1598 @djaglowski
 receiver/jaegerreceiver/                             @open-telemetry/collector-contrib-approvers @jpkrohling
 receiver/jmxreceiver/                                @open-telemetry/collector-contrib-approvers @rmfitzpatrick
-receiver/journaldreceiver/                           @open-telemetry/collector-contrib-approvers @pmm-sumo
+receiver/journaldreceiver/                           @open-telemetry/collector-contrib-approvers @sumo-drosiek @astencel-sumo
 receiver/k8sclusterreceiver/                         @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/k8seventsreceiver/                          @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/kafkametricsreceiver/                       @open-telemetry/collector-contrib-approvers @dmitryax
@@ -172,7 +172,7 @@ receiver/rabbitmqreceiver/                           @open-telemetry/collector-c
 receiver/receivercreator/                            @open-telemetry/collector-contrib-approvers @jrcamp
 receiver/redisreceiver/                              @open-telemetry/collector-contrib-approvers @pmcollins @dmitryax
 receiver/riakreceiver/                               @open-telemetry/collector-contrib-approvers @djaglowski @armstrmi
-receiver/saphanareceiver/                            @open-telemetry/collector-contrib-approvers @pmm-sumo @dehaansa
+receiver/saphanareceiver/                            @open-telemetry/collector-contrib-approvers @dehaansa
 receiver/sapmreceiver/                               @open-telemetry/collector-contrib-approvers @owais
 receiver/signalfxreceiver/                           @open-telemetry/collector-contrib-approvers @pjanotti @dmitryax
 receiver/simpleprometheusreceiver/                   @open-telemetry/collector-contrib-approvers @fatsheep9146
@@ -189,6 +189,6 @@ receiver/vcenterreceiver/                            @open-telemetry/collector-c
 receiver/wavefrontreceiver/                          @open-telemetry/collector-contrib-approvers @pjanotti
 receiver/windowseventlogreceiver/                    @open-telemetry/collector-contrib-approvers @djaglowski @armstrmi
 receiver/windowsperfcountersreceiver/                @open-telemetry/collector-contrib-approvers @dashpole
-receiver/zipkinreceiver/                             @open-telemetry/collector-contrib-approvers @pmm-sumo
+receiver/zipkinreceiver/                             @open-telemetry/collector-contrib-approvers @mat-rumian @kkujawa-sumo
 receiver/zookeeperreceiver/                          @open-telemetry/collector-contrib-approvers @djaglowski
 


### PR DESCRIPTION
That is a proposition from Sumo Logic for maintainers for different components that @pmm-sumo took care before.

Complementary PR to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12493

Thank you @pmm-sumo for all your help and hard work!