### PR TITLE
Add ValueFrom support to OAuth2 authenticator

### DIFF
--- a/extension/oauth2clientauthextension/README.md
+++ b/extension/oauth2clientauthextension/README.md
@@ -17,11 +17,17 @@ The authenticator type has to be set to `oauth2client`.
 ```yaml
 extensions:
   oauth2client:
-    client_id: someclientid
-    client_secret: someclientsecret
+  # 'client_id','client_secret' and 'token_url' values can be given directly using 'value' or loaded from environment variables\files using 'value_from'. examples for all 3 given below
+    client_id: 
+      value_from: 
+        env: someenvvar
+    client_secret: 
+      value_from:
+        file: somefs\somefile\someclientsecret
     endpoint_params:
       audience: someaudience
-    token_url: https://example.com/oauth2/default/v1/token
+    token_url: # can either be value or value_from
+      value: https://example.com/oauth2/default/v1/token
     scopes: ["api.metrics"]
     # tls settings for the token client
     tls:

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -47,10 +47,10 @@ func TestOAuthClientSettings(t *testing.T) {
 		{
 			name: "all_valid_settings",
 			settings: &Config{
-				ClientID:       "testclientid",
-				ClientSecret:   "testsecret",
+				ClientID:       ValueValueFrom{Value: "testclientid"},
+				ClientSecret:   ValueValueFrom{Value: "testsecret"},
 				EndpointParams: url.Values{"audience": []string{"someaudience"}},
-				TokenURL:       "https://example.com/v1/token",
+				TokenURL:       ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:         []string{"resource.read"},
 				Timeout:        2,
 				TLSSetting: configtls.TLSClientSetting{
@@ -69,9 +69,9 @@ func TestOAuthClientSettings(t *testing.T) {
 		{
 			name: "invalid_tls",
 			settings: &Config{
-				ClientID:     "testclientid",
-				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
+				ClientID:     ValueValueFrom{Value: "testclientid"},
+				ClientSecret: ValueValueFrom{Value: "testsecret"},
+				TokenURL:     ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:       []string{"resource.read"},
 				Timeout:      2,
 				TLSSetting: configtls.TLSClientSetting{
@@ -90,8 +90,8 @@ func TestOAuthClientSettings(t *testing.T) {
 		{
 			name: "missing_client_id",
 			settings: &Config{
-				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
+				ClientSecret: ValueValueFrom{Value: "testsecret"},
+				TokenURL:     ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:       []string{"resource.read"},
 			},
 			shouldError:   true,
@@ -100,8 +100,8 @@ func TestOAuthClientSettings(t *testing.T) {
 		{
 			name: "missing_client_secret",
 			settings: &Config{
-				ClientID: "testclientid",
-				TokenURL: "https://example.com/v1/token",
+				ClientID: ValueValueFrom{Value: "testclientid"},
+				TokenURL: ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:   []string{"resource.read"},
 			},
 			shouldError:   true,
@@ -110,8 +110,8 @@ func TestOAuthClientSettings(t *testing.T) {
 		{
 			name: "missing_token_url",
 			settings: &Config{
-				ClientID:     "testclientid",
-				ClientSecret: "testsecret",
+				ClientID:     ValueValueFrom{Value: "testclientid"},
+				ClientSecret: ValueValueFrom{Value: "testsecret"},
 				Scopes:       []string{"resource.read"},
 			},
 			shouldError:   true,
@@ -129,9 +129,9 @@ func TestOAuthClientSettings(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, test.settings.Scopes, rc.clientCredentials.Scopes)
-			assert.Equal(t, test.settings.TokenURL, rc.clientCredentials.TokenURL)
-			assert.Equal(t, test.settings.ClientSecret, rc.clientCredentials.ClientSecret)
-			assert.Equal(t, test.settings.ClientID, rc.clientCredentials.ClientID)
+			assert.Equal(t, test.settings.TokenURL.Value, rc.clientCredentials.TokenURL)
+			assert.Equal(t, test.settings.ClientSecret.Value, rc.clientCredentials.ClientSecret)
+			assert.Equal(t, test.settings.ClientID.Value, rc.clientCredentials.ClientID)
 			assert.Equal(t, test.settings.Timeout, rc.client.Timeout)
 			assert.Equal(t, test.settings.EndpointParams, rc.clientCredentials.EndpointParams)
 
@@ -162,9 +162,9 @@ func TestRoundTripper(t *testing.T) {
 		{
 			name: "returns_http_round_tripper",
 			settings: &Config{
-				ClientID:     "testclientid",
-				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
+				ClientID:     ValueValueFrom{Value: "testclientid"},
+				ClientSecret: ValueValueFrom{Value: "testsecret"},
+				TokenURL:     ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:       []string{"resource.read"},
 			},
 			shouldError: false,
@@ -172,8 +172,8 @@ func TestRoundTripper(t *testing.T) {
 		{
 			name: "invalid_client_settings_should_error",
 			settings: &Config{
-				ClientID: "testclientid",
-				TokenURL: "https://example.com/v1/token",
+				ClientID: ValueValueFrom{Value: "testclientid"},
+				TokenURL: ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:   []string{"resource.read"},
 			},
 			shouldError: true,
@@ -218,9 +218,9 @@ func TestOAuth2PerRPCCredentials(t *testing.T) {
 		{
 			name: "returns_http_round_tripper",
 			settings: &Config{
-				ClientID:     "testclientid",
-				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
+				ClientID:     ValueValueFrom{Value: "testclientid"},
+				ClientSecret: ValueValueFrom{Value: "testsecret"},
+				TokenURL:     ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:       []string{"resource.read"},
 				Timeout:      1,
 			},
@@ -229,8 +229,8 @@ func TestOAuth2PerRPCCredentials(t *testing.T) {
 		{
 			name: "invalid_client_settings_should_error",
 			settings: &Config{
-				ClientID: "testclientid",
-				TokenURL: "https://example.com/v1/token",
+				ClientID: ValueValueFrom{Value: "testclientid"},
+				TokenURL: ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:   []string{"resource.read"},
 			},
 			shouldError: true,
@@ -267,9 +267,9 @@ func TestFailContactingOAuth(t *testing.T) {
 	assert.NoError(t, err)
 
 	oauth2Authenticator, err := newClientAuthenticator(&Config{
-		ClientID:     "dummy",
-		ClientSecret: "ABC",
-		TokenURL:     serverURL.String(),
+		ClientID:     ValueValueFrom{Value: "dummy"},
+		ClientSecret: ValueValueFrom{Value: "ABC"},
+		TokenURL:     ValueValueFrom{Value: serverURL.String()},
 	}, zap.NewNop())
 	assert.Nil(t, err)
 

--- a/extension/oauth2clientauthextension/factory_test.go
+++ b/extension/oauth2clientauthextension/factory_test.go
@@ -50,9 +50,9 @@ func TestCreateExtension(t *testing.T) {
 		{
 			name: "valid_settings",
 			settings: &Config{
-				ClientID:     "testclientid",
-				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
+				ClientID:     ValueValueFrom{Value: "testclientid"},
+				ClientSecret: ValueValueFrom{Value: "testsecret"},
+				TokenURL:     ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:       []string{"resource.read"},
 			},
 			shouldError: false,
@@ -60,8 +60,8 @@ func TestCreateExtension(t *testing.T) {
 		{
 			name: "invalid_client_settings_should_error",
 			settings: &Config{
-				ClientID: "testclientid",
-				TokenURL: "https://example.com/v1/token",
+				ClientID: ValueValueFrom{Value: "testclientid"},
+				TokenURL: ValueValueFrom{Value: "https://example.com/v1/token"},
 				Scopes:   []string{"resource.read"},
 			},
 			shouldError: true,

--- a/extension/oauth2clientauthextension/testdata/config_bad.yaml
+++ b/extension/oauth2clientauthextension/testdata/config_bad.yaml
@@ -1,17 +1,23 @@
 extensions:
   oauth2client/missingid:
-    client_secret: someclientsecret
-    token_url: https://example.com/oauth2/default/v1/token
+    client_secret: 
+      value: someclientsecret
+    token_url: 
+      value: https://example.com/oauth2/default/v1/token
     scopes: ["api.metrics"]
 
   oauth2client/missingsecret:
-    client_id: someclientid
-    token_url: https://example.com/oauth2/default/v1/token
+    client_id: 
+      value: someclientid
+    token_url: 
+      value: https://example.com/oauth2/default/v1/token
     scopes: ["api.metrics"]
 
   oauth2client/missingurl:
-    client_id: someclientid
-    client_secret: someclientsecret
+    client_id: 
+      value: someclientid
+    client_secret: 
+      value: someclientsecret
     scopes: ["api.metrics"]
 
 # Data pipeline is required to load the config.

--- a/extension/oauth2clientauthextension/testdata/config_env.yaml
+++ b/extension/oauth2clientauthextension/testdata/config_env.yaml
@@ -1,11 +1,14 @@
 extensions:
   oauth2client/1:
     client_id: 
-      value: someclientid
+      valueFrom: 
+        env: someclientid
     client_secret: 
-      value: someclientsecret
+      valueFrom: 
+        env: someclientsecret
     token_url: 
-      value: https://example.com/oauth2/default/v1/token
+      valueFrom: 
+        env: https://example.com/oauth2/default/v1/token
     endpoint_params:
       audience: someaudience
     scopes: ["api.metrics"]
@@ -13,11 +16,14 @@ extensions:
 
   oauth2client/withtls:
     client_id: 
-      value: someclientid2
+      valueFrom: 
+        env: someclientid
     client_secret: 
-      value: someclientsecret2
-    token_url:
-      value: https://example2.com/oauth2/default/v1/token
+      valueFrom: 
+        env: someclientsecret
+    token_url: 
+      valueFrom: 
+        env: https://example.com/oauth2/default/v1/token
     scopes: ["api.metrics"]
     timeout: 1s
     # tls settings for the token client

--- a/extension/oauth2clientauthextension/testdata/config_file.yaml
+++ b/extension/oauth2clientauthextension/testdata/config_file.yaml
@@ -1,11 +1,14 @@
 extensions:
   oauth2client/1:
     client_id: 
-      value: someclientid
+      valueFrom: 
+        file: someclientid
     client_secret: 
-      value: someclientsecret
+      valueFrom: 
+        file: someclientsecret
     token_url: 
-      value: https://example.com/oauth2/default/v1/token
+      valueFrom: 
+        file: https://example.com/oauth2/default/v1/token
     endpoint_params:
       audience: someaudience
     scopes: ["api.metrics"]
@@ -13,11 +16,14 @@ extensions:
 
   oauth2client/withtls:
     client_id: 
-      value: someclientid2
+      valueFrom: 
+        file: someclientid
     client_secret: 
-      value: someclientsecret2
-    token_url:
-      value: https://example2.com/oauth2/default/v1/token
+      valueFrom: 
+        file: someclientsecret
+    token_url: 
+      valueFrom: 
+        file: https://example.com/oauth2/default/v1/token
     scopes: ["api.metrics"]
     timeout: 1s
     # tls settings for the token client

--- a/extension/oauth2clientauthextension/testdata/testfile
+++ b/extension/oauth2clientauthextension/testdata/testfile
@@ -1,0 +1,1 @@
+someclientid3


### PR DESCRIPTION
**Description:** 
OAuth2 authentication extensions has been changed to enable loading values for 'client_id','client_secret' and 'token_url' from either an environment variable or file. Tests and documentation have been updated as well.
Its usually good practice to keep this as a secret and not in a configuration file, also enabling to simply mount them from Secrets on Kubernetes environments.

Note that it slightly breaks the current configuration and changes it to:
```
client_id: 
  value_from: 
    env: someenvvar
client_secret: 
  value_from:
    file: somefs\somefile\someclientsecret
 # equal to token_url: https://example.com/oauth2/default/v1/token formerly
token_url: 
  value: https://example.com/oauth2/default/v1/token
```
These are the only configuration changes

**Testing:**
Existing tests were changed to support the new configuration structure.
New tests have been added to verify the behaviour of the new 'value_from' property.

**Documentation:**
Changed the configuration in the documentation to include the new changes.