### PR TITLE
Attempt to fix failing CodeQL Github action job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL Analysis"
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   CodeQL-Build:
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -28,3 +28,4 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+        timeout-minutes: 60


### PR DESCRIPTION
The process being killed after 30m. If that's caused by the step timeout, this change should fix it

Should resolve https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12607