### PR TITLE
[cmd/configschema] use contrib components, simplify grepmod code

### DIFF
--- a/.github/workflows/check_links_config.json
+++ b/.github/workflows/check_links_config.json
@@ -8,6 +8,9 @@
         },
         {
             "pattern": "http(s)?://example.com"
+        },
+        {
+            "pattern": "^#"
         }
     ],
     "aliveStatusCodes": [429, 200]

--- a/Makefile
+++ b/Makefile
@@ -386,6 +386,10 @@ clean:
 	find . -type f -name 'integration-coverage.txt' -delete
 	find . -type f -name 'integration-coverage.html' -delete
 
+.PHONY: docs
+docs:
+	cd cmd/configschema && $(GOCMD) run ./docsgen all
+
 .PHONY: generate-all-labels
 generate-all-labels:
 	$(MAKE) generate-labels TYPE="cmd" COLOR="#483C32"

--- a/Makefile
+++ b/Makefile
@@ -386,8 +386,8 @@ clean:
 	find . -type f -name 'integration-coverage.txt' -delete
 	find . -type f -name 'integration-coverage.html' -delete
 
-.PHONY: docs
-docs:
+.PHONY: genconfigdocs
+genconfigdocs:
 	cd cmd/configschema && $(GOCMD) run ./docsgen all
 
 .PHONY: generate-all-labels

--- a/cmd/configschema/comments.go
+++ b/cmd/configschema/comments.go
@@ -18,6 +18,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
+	"path/filepath"
 	"reflect"
 	"strings"
 )
@@ -28,34 +30,43 @@ func commentsForStruct(v reflect.Value, dr DirResolver) (map[string]string, erro
 	if v.Kind() == reflect.Ptr {
 		elem = v.Elem()
 	}
-	dir, err := dr.TypeToPackagePath(elem.Type())
+	packagePath, err := dr.TypeToPackagePath(elem.Type())
 	if err != nil {
 		return nil, err
 	}
-	name := trimPackage(elem)
-	return commentsForStructName(dir, name), nil
+	return searchDirsForComments(packagePath, elem.Type().String())
 }
 
-func trimPackage(v reflect.Value) string {
-	typeName := v.Type().String()
-	split := strings.Split(typeName, ".")
-	return split[1]
+func searchDirsForComments(packageDir, typeName string) (map[string]string, error) {
+	out := map[string]string{}
+	err := filepath.WalkDir(packageDir, func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() {
+			commentsForStructName(out, path, typeName)
+		}
+		return nil
+	})
+	return out, err
 }
 
-func commentsForStructName(packageDir, structName string) map[string]string {
+func commentsForStructName(comments map[string]string, dir, typeName string) {
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, packageDir, nil, parser.ParseComments)
+	pkgs, err := parser.ParseDir(fset, dir, nil, parser.ParseComments)
 	if err != nil {
 		panic(err)
 	}
-	comments := map[string]string{}
-	for _, pkg := range pkgs {
+	parts := strings.Split(typeName, ".")
+	targetPkg := parts[0]
+	targetType := parts[1]
+	for pkgName, pkg := range pkgs {
+		if pkgName != targetPkg {
+			continue
+		}
 		for _, file := range pkg.Files {
 			for _, decl := range file.Decls {
 				if gd, ok := decl.(*ast.GenDecl); ok {
 					for _, spec := range gd.Specs {
 						if ts, ok := spec.(*ast.TypeSpec); ok {
-							if ts.Name.Name == structName {
+							if ts.Name.Name == targetType {
 								if structComments := gd.Doc.Text(); structComments != "" {
 									comments["_struct"] = structComments
 								}
@@ -73,7 +84,6 @@ func commentsForStructName(packageDir, structName string) map[string]string {
 			}
 		}
 	}
-	return comments
 }
 
 func fieldName(field *ast.Field) string {

--- a/cmd/configschema/comments.go
+++ b/cmd/configschema/comments.go
@@ -28,7 +28,7 @@ func commentsForStruct(v reflect.Value, dr DirResolver) (map[string]string, erro
 	if v.Kind() == reflect.Ptr {
 		elem = v.Elem()
 	}
-	dir, err := dr.PackageDir(elem.Type())
+	dir, err := dr.TypeToPackagePath(elem.Type())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/configschema/comments_test.go
+++ b/cmd/configschema/comments_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestFieldComments(t *testing.T) {
 	v := reflect.ValueOf(testStruct{})
-	comments, err := commentsForStruct(v, testDR("../.."))
+	comments, err := commentsForStruct(v, testDR())
 	assert.NoError(t, err)
 	assert.Equal(t, "embedded, package qualified comment\n", comments["Duration"])
 	assert.Equal(t, "testStruct comment\n", comments["_struct"])
@@ -38,7 +38,7 @@ func TestExternalType(t *testing.T) {
 	u, err := uuid.NewUUID()
 	assert.NoError(t, err)
 	v := reflect.ValueOf(u)
-	comments, err := commentsForStruct(v, testDR("."))
+	comments, err := commentsForStruct(v, testDR())
 	assert.NoError(t, err)
 	assert.Equal(t, "A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC\n4122.\n", comments["_struct"])
 }

--- a/cmd/configschema/comments_test.go
+++ b/cmd/configschema/comments_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/config/configtls"
 )
 
 func TestFieldComments(t *testing.T) {
@@ -40,5 +42,17 @@ func TestExternalType(t *testing.T) {
 	v := reflect.ValueOf(u)
 	comments, err := commentsForStruct(v, testDR())
 	assert.NoError(t, err)
-	assert.Equal(t, "A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC\n4122.\n", comments["_struct"])
+	assert.Equal(
+		t,
+		"A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC\n4122.\n",
+		comments["_struct"],
+	)
+}
+
+func TestSubPackage(t *testing.T) {
+	s := configtls.TLSClientSetting{}
+	v := reflect.ValueOf(s)
+	comments, err := commentsForStruct(v, testDR())
+	require.NoError(t, err)
+	assert.NotEmpty(t, comments)
 }

--- a/cmd/configschema/common_test.go
+++ b/cmd/configschema/common_test.go
@@ -21,6 +21,8 @@ package configschema
 import (
 	"path/filepath"
 	"time"
+
+	"go.opentelemetry.io/collector/config/configtls"
 )
 
 type testPerson struct {
@@ -35,12 +37,13 @@ type testStruct struct {
 	Four  bool   `mapstructure:"four"`
 	// embedded, package qualified comment
 	time.Duration `mapstructure:"duration"`
-	Squashed      testPerson    `mapstructure:",squash"`
-	PersonPtr     *testPerson   `mapstructure:"person_ptr"`
-	PersonStruct  testPerson    `mapstructure:"person_struct"`
-	Persons       []testPerson  `mapstructure:"persons"`
-	PersonPtrs    []*testPerson `mapstructure:"person_ptrs"`
-	Ignored       string        `mapstructure:"-"`
+	Squashed      testPerson                 `mapstructure:",squash"`
+	PersonPtr     *testPerson                `mapstructure:"person_ptr"`
+	PersonStruct  testPerson                 `mapstructure:"person_struct"`
+	Persons       []testPerson               `mapstructure:"persons"`
+	PersonPtrs    []*testPerson              `mapstructure:"person_ptrs"`
+	Ignored       string                     `mapstructure:"-"`
+	TLS           configtls.TLSClientSetting `mapstructure:"tls"`
 }
 
 func testDR() DirResolver {

--- a/cmd/configschema/common_test.go
+++ b/cmd/configschema/common_test.go
@@ -18,7 +18,10 @@
 
 package configschema
 
-import "time"
+import (
+	"path/filepath"
+	"time"
+)
 
 type testPerson struct {
 	Name string
@@ -40,9 +43,9 @@ type testStruct struct {
 	Ignored       string        `mapstructure:"-"`
 }
 
-func testDR(root string) DirResolver {
+func testDR() DirResolver {
 	return DirResolver{
-		SrcRoot:    root,
+		SrcRoot:    filepath.Join("..", ".."),
 		ModuleName: DefaultModule,
 	}
 }

--- a/cmd/configschema/docsgen/docsgen/cli.go
+++ b/cmd/configschema/docsgen/docsgen/cli.go
@@ -111,9 +111,10 @@ func writeConfigDoc(
 		panic(err)
 	}
 
-	f.Type = stripPrefix(f.Type)
-
 	mdBytes := renderHeader(string(ci.Type), ci.Group, f.Doc)
+
+	f.Name = typeToName(f.Type)
+
 	tableBytes, err := renderTable(tableTmpl, f)
 	if err != nil {
 		panic(err)
@@ -124,9 +125,10 @@ func writeConfigDoc(
 		mdBytes = append(mdBytes, durationBlock...)
 	}
 
-	dir, err := dr.PackageDir(v.Type().Elem())
-	if err != nil {
-		panic(err)
+	dir := dr.TypeToProjectPath(v.Type().Elem())
+	if dir == "" {
+		log.Printf("writeConfigDoc: skipping, local path not found for component: %s %s", ci.Group, ci.Type)
+		return
 	}
 	err = writeFile(filepath.Join(dir, mdFileName), mdBytes, 0644)
 	if err != nil {
@@ -134,7 +136,7 @@ func writeConfigDoc(
 	}
 }
 
-func stripPrefix(name string) string {
-	idx := strings.Index(name, ".")
-	return name[idx+1:]
+func typeToName(typ string) string {
+	idx := strings.IndexRune(typ, '.')
+	return typ[:idx]
 }

--- a/cmd/configschema/docsgen/docsgen/cli.go
+++ b/cmd/configschema/docsgen/docsgen/cli.go
@@ -17,6 +17,7 @@ package docsgen // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"

--- a/cmd/configschema/docsgen/docsgen/cli_test.go
+++ b/cmd/configschema/docsgen/docsgen/cli_test.go
@@ -28,41 +28,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/exporter/loggingexporter"
-	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
-	"go.opentelemetry.io/collector/extension/ballastextension"
-	"go.opentelemetry.io/collector/extension/zpagesextension"
-	"go.opentelemetry.io/collector/processor/batchprocessor"
-	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
-	"go.opentelemetry.io/collector/receiver/otlpreceiver"
-	"go.uber.org/multierr"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/components"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver"
 )
 
 func TestWriteConfigDoc(t *testing.T) {
-	cfg := otlpreceiver.NewFactory().CreateDefaultConfig()
-	root := filepath.Join("..", "..", "..", "..")
-	dr := configschema.NewDirResolver(root, configschema.DefaultModule)
+	cfg := redisreceiver.NewFactory().CreateDefaultConfig()
+	dr := configschema.NewDirResolver(filepath.Join("..", "..", "..", ".."), configschema.DefaultModule)
 	outputFilename := ""
 	tmpl := testTemplate(t)
-	writeConfigDoc(tmpl, dr, configschema.CfgInfo{
-		Type:        "otlp",
-		Group:       "receiver",
-		CfgInstance: cfg,
-	}, func(dir string, bytes []byte, perm os.FileMode) error {
-		outputFilename = dir
-		return nil
-	})
-	expectedPath := filepath.Join("receiver", "otlpreceiver", "config.md")
+	writeConfigDoc(
+		tmpl,
+		dr,
+		configschema.CfgInfo{
+			Group:       "receiver",
+			Type:        "redis",
+			CfgInstance: cfg,
+		},
+		func(dir string, bytes []byte, perm os.FileMode) error {
+			outputFilename = dir
+			return nil
+		},
+	)
+	expectedPath := filepath.Join("receiver", "redisreceiver", "config.md")
 	assert.True(t, strings.HasSuffix(outputFilename, expectedPath))
-}
-
-func testTemplate(t *testing.T) *template.Template {
-	tmpl, err := template.ParseFiles("testdata/test.tmpl")
-	require.NoError(t, err)
-	return tmpl
 }
 
 func TestHandleCLI_NoArgs(t *testing.T) {
@@ -78,7 +69,7 @@ func TestHandleCLI_NoArgs(t *testing.T) {
 }
 
 func TestHandleCLI_Single(t *testing.T) {
-	args := []string{"", "receiver", "otlp"}
+	args := []string{"", "receiver", "redis"}
 	cs := defaultComponents(t)
 	wr := &fakeFilesystemWriter{}
 
@@ -86,19 +77,22 @@ func TestHandleCLI_Single(t *testing.T) {
 
 	assert.Equal(t, 1, len(wr.configFiles))
 	assert.Equal(t, 1, len(wr.fileContents))
-	assert.True(t, strings.Contains(wr.fileContents[0], `"otlp" Receiver Reference`))
+	assert.True(t, strings.Contains(wr.fileContents[0], `"redis" Receiver Reference`))
 }
 
 func TestHandleCLI_All(t *testing.T) {
 	args := []string{"", "all"}
-	cs := defaultComponents(t)
-	wr := &fakeFilesystemWriter{}
+	c := defaultComponents(t)
+	writer := &fakeFilesystemWriter{}
+	testHandleCLI(t, c, writer, args)
+	assert.NotNil(t, writer.configFiles)
+	assert.NotNil(t, writer.fileContents)
+}
 
-	testHandleCLI(t, cs, wr, args)
-
-	expected := len(cs.Receivers) + len(cs.Processors) + len(cs.Exporters) + len(cs.Extensions)
-	assert.Equal(t, expected, len(wr.configFiles))
-	assert.Equal(t, expected, len(wr.fileContents))
+func defaultComponents(t *testing.T) component.Factories {
+	factories, err := components.Components()
+	require.NoError(t, err)
+	return factories
 }
 
 func testHandleCLI(t *testing.T, cs component.Factories, wr *fakeFilesystemWriter, args []string) {
@@ -108,41 +102,10 @@ func testHandleCLI(t *testing.T, cs component.Factories, wr *fakeFilesystemWrite
 	handleCLI(cs, dr, tmpl, wr.writeFile, stdoutWriter, args...)
 }
 
-func defaultComponents(t *testing.T) component.Factories {
-	var errs error
-
-	extensions, err := component.MakeExtensionFactoryMap(
-		zpagesextension.NewFactory(),
-		ballastextension.NewFactory(),
-	)
-	errs = multierr.Append(errs, err)
-
-	receivers, err := component.MakeReceiverFactoryMap(
-		otlpreceiver.NewFactory(),
-	)
-	errs = multierr.Append(errs, err)
-
-	exporters, err := component.MakeExporterFactoryMap(
-		loggingexporter.NewFactory(),
-		otlpexporter.NewFactory(),
-		otlphttpexporter.NewFactory(),
-	)
-	errs = multierr.Append(errs, err)
-
-	processors, err := component.MakeProcessorFactoryMap(
-		batchprocessor.NewFactory(),
-		memorylimiterprocessor.NewFactory(),
-	)
-	errs = multierr.Append(errs, err)
-
-	cmps := component.Factories{
-		Extensions: extensions,
-		Receivers:  receivers,
-		Processors: processors,
-		Exporters:  exporters,
-	}
-	require.NoError(t, errs)
-	return cmps
+func testTemplate(t *testing.T) *template.Template {
+	tmpl, err := template.ParseFiles("testdata/test.tmpl")
+	require.NoError(t, err)
+	return tmpl
 }
 
 type fakeFilesystemWriter struct {

--- a/cmd/configschema/docsgen/docsgen/cli_test.go
+++ b/cmd/configschema/docsgen/docsgen/cli_test.go
@@ -77,7 +77,7 @@ func TestHandleCLI_Single(t *testing.T) {
 
 	assert.Equal(t, 1, len(wr.configFiles))
 	assert.Equal(t, 1, len(wr.fileContents))
-	assert.True(t, strings.Contains(wr.fileContents[0], `"redis" Receiver Reference`))
+	assert.True(t, strings.Contains(wr.fileContents[0], `Redis Receiver Reference`))
 }
 
 func TestHandleCLI_All(t *testing.T) {

--- a/cmd/configschema/docsgen/docsgen/cli_test.go
+++ b/cmd/configschema/docsgen/docsgen/cli_test.go
@@ -81,6 +81,7 @@ func TestHandleCLI_Single(t *testing.T) {
 }
 
 func TestHandleCLI_All(t *testing.T) {
+	t.Skip("this test takes > 5m when -race is used")
 	args := []string{"", "all"}
 	c := defaultComponents(t)
 	writer := &fakeFilesystemWriter{}

--- a/cmd/configschema/docsgen/docsgen/render.go
+++ b/cmd/configschema/docsgen/docsgen/render.go
@@ -26,10 +26,11 @@ import (
 )
 
 func renderHeader(typ, group, doc string) []byte {
+	caser := cases.Title(language.English)
 	return []byte(fmt.Sprintf(
-		"# %q %s Reference\n\n%s\n\n",
-		typ,
-		cases.Title(language.English).String(group),
+		"# %s %s Reference\n\n%s\n\n",
+		caser.String(typ),
+		caser.String(group),
 		doc,
 	))
 }

--- a/cmd/configschema/docsgen/docsgen/template.go
+++ b/cmd/configschema/docsgen/docsgen/template.go
@@ -21,7 +21,7 @@ import (
 )
 
 func tableTemplate() (*template.Template, error) {
-	return template.New("table").Funcs(
+	return template.New("table").Option("missingkey=zero").Funcs(
 		template.FuncMap{
 			"join":            join,
 			"mkAnchor":        mkAnchor,

--- a/cmd/configschema/docsgen/docsgen/template.go
+++ b/cmd/configschema/docsgen/docsgen/template.go
@@ -15,6 +15,7 @@
 package docsgen // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema/docsgen/docsgen"
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 )
@@ -23,7 +24,7 @@ func tableTemplate() (*template.Template, error) {
 	return template.New("table").Funcs(
 		template.FuncMap{
 			"join":            join,
-			"cleanType":       cleanType,
+			"mkAnchor":        mkAnchor,
 			"isCompoundField": isCompoundField,
 			"isDuration":      isDuration,
 		},
@@ -38,32 +39,44 @@ func join(s string) string {
 	return strings.ReplaceAll(s, "\n", " ")
 }
 
-func cleanType(s string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(s, "*", ""), ".", "-")
+// mkAnchor takes a name and a type (e.g. "configtls.TLSClientSetting") and
+// returns a string suitable for use as a markdown anchor.
+func mkAnchor(name, typ string) string {
+	if isDuration(typ) {
+		return "time-Duration"
+	}
+	idx := strings.IndexRune(typ, '.')
+	// strip "configtls." from e.g. "configtls.TLSClientSetting"
+	typeStripped := typ[idx+1:]
+	concat := fmt.Sprintf("%s-%s", name, typeStripped)
+	asterisksRemoved := strings.ReplaceAll(concat, "*", "")
+	dotsToDashes := strings.ReplaceAll(asterisksRemoved, ".", "-")
+	return strings.ReplaceAll(dotsToDashes, "_", "-")
 }
 
 func isDuration(s string) bool {
 	return s == "time.Duration"
 }
 
-const tableTemplateStr = `### {{ cleanType .Type }}
+const tableTemplateStr = `### {{ mkAnchor .Name .Type }}
 
-| Name | Type | Default | Docs |
-| ---- | ---- | ------- | ---- |
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
 {{ range .Fields -}}
 | {{ .Name }} |
 {{- if .Type -}}
-    {{- if isCompoundField .Kind -}}
-        [{{ cleanType .Type }}](#{{ cleanType .Type }})
-    {{- else -}}
+	{{- $anchor := mkAnchor .Name .Type -}}
+	{{- if isCompoundField .Kind -}}
+			[{{ $anchor }}](#{{ $anchor }})
+	{{- else -}}
 		{{- if isDuration .Type -}}
-			[{{ cleanType .Type }}](#{{ cleanType .Type }})
-        {{- else -}}
-            {{ .Type }}
-        {{- end -}}
-    {{- end -}}
+			[{{ $anchor }}](#{{ $anchor }})
+		{{- else -}}
+			{{ .Type }}
+		{{- end -}}
+	{{- end -}}
 {{- else -}}
-    {{ .Kind }}
+	{{ .Kind }}
 {{- end -}}
 | {{ .Default }} | {{ join .Doc }} |
 {{ end }}

--- a/cmd/configschema/docsgen/main.go
+++ b/cmd/configschema/docsgen/main.go
@@ -15,57 +15,18 @@
 package main
 
 import (
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/exporter/loggingexporter"
-	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
-	"go.opentelemetry.io/collector/extension/ballastextension"
-	"go.opentelemetry.io/collector/extension/zpagesextension"
-	"go.opentelemetry.io/collector/processor/batchprocessor"
-	"go.opentelemetry.io/collector/processor/memorylimiterprocessor"
-	"go.opentelemetry.io/collector/receiver/otlpreceiver"
-	"go.uber.org/multierr"
+	"path/filepath"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema/docsgen/docsgen"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/components"
 )
 
 func main() {
-	var errs error
-
-	extensions, err := component.MakeExtensionFactoryMap(
-		zpagesextension.NewFactory(),
-		ballastextension.NewFactory(),
-	)
-	errs = multierr.Append(errs, err)
-
-	receivers, err := component.MakeReceiverFactoryMap(
-		otlpreceiver.NewFactory(),
-	)
-	errs = multierr.Append(errs, err)
-
-	exporters, err := component.MakeExporterFactoryMap(
-		loggingexporter.NewFactory(),
-		otlpexporter.NewFactory(),
-		otlphttpexporter.NewFactory(),
-	)
-	errs = multierr.Append(errs, err)
-
-	processors, err := component.MakeProcessorFactoryMap(
-		batchprocessor.NewFactory(),
-		memorylimiterprocessor.NewFactory(),
-	)
-	errs = multierr.Append(errs, err)
-
-	cmps := component.Factories{
-		Extensions: extensions,
-		Receivers:  receivers,
-		Processors: processors,
-		Exporters:  exporters,
+	c, err := components.Components()
+	if err != nil {
+		panic(err)
 	}
-	if errs != nil {
-		panic(errs)
-	}
-	dr := configschema.NewDefaultDirResolver()
-	docsgen.CLI(cmps, dr)
+	dr := configschema.NewDirResolver(filepath.Join("..", ".."), configschema.DefaultModule)
+	docsgen.CLI(c, dr)
 }

--- a/cmd/configschema/fields.go
+++ b/cmd/configschema/fields.go
@@ -15,7 +15,7 @@
 package configschema // import "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema"
 
 import (
-	"fmt"
+	"log"
 	"reflect"
 	"strings"
 	"time"
@@ -69,9 +69,12 @@ func refl(f *Field, v reflect.Value, dr DirResolver) error {
 
 	for i := 0; i < v.NumField(); i++ {
 		structField := v.Type().Field(i)
+		if !structField.IsExported() {
+			continue
+		}
 		tagName, options, err := mapstructure(structField.Tag)
 		if err != nil {
-			fmt.Printf("error parsing mapstructure tag for field %v: %q", structField, err.Error())
+			log.Printf("error parsing mapstructure tag for type: %s: %s: %v", f.Type, structField.Tag, err)
 			// not fatal, can keep going
 		}
 		if tagName == "-" {

--- a/cmd/configschema/fields.go
+++ b/cmd/configschema/fields.go
@@ -130,9 +130,7 @@ func handleKind(v reflect.Value, f *Field, dr DirResolver) (err error) {
 			f.Default = v.String()
 		}
 	case reflect.Bool:
-		if v.Bool() {
-			f.Default = v.Bool()
-		}
+		f.Default = v.Bool()
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		if v.Int() != 0 {
 			if v.Type() == reflect.TypeOf(time.Duration(0)) {

--- a/cmd/configschema/fields.go
+++ b/cmd/configschema/fields.go
@@ -126,9 +126,7 @@ func handleKind(v reflect.Value, f *Field, dr DirResolver) (err error) {
 			err = refl(f, reflect.New(e.Elem()), dr)
 		}
 	case reflect.String:
-		if v.String() != "" {
-			f.Default = v.String()
-		}
+		f.Default = v.String()
 	case reflect.Bool:
 		f.Default = v.Bool()
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
@@ -140,9 +138,7 @@ func handleKind(v reflect.Value, f *Field, dr DirResolver) (err error) {
 			}
 		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		if v.Uint() != 0 {
-			f.Default = v.Uint()
-		}
+		f.Default = v.Uint()
 	}
 	return
 }

--- a/cmd/configschema/fields_test.go
+++ b/cmd/configschema/fields_test.go
@@ -57,15 +57,6 @@ func TestReadFieldsWithoutDefaults(t *testing.T) {
 	testReadFields(t, testStruct{}, map[string]interface{}{})
 }
 
-func getField(fields []*Field, name string) *Field {
-	for _, f := range fields {
-		if f.Name == name {
-			return f
-		}
-	}
-	return nil
-}
-
 func testReadFields(t *testing.T, s testStruct, defaults map[string]interface{}) {
 	root, _ := ReadFields(
 		reflect.ValueOf(s),
@@ -76,31 +67,31 @@ func testReadFields(t *testing.T, s testStruct, defaults map[string]interface{})
 
 	assert.Equal(t, "configschema.testStruct", root.Type)
 
-	assert.Equal(t, 10, len(root.Fields))
+	assert.Equal(t, 11, len(root.Fields))
 
 	assert.Equal(t, &Field{
 		Name:    "one",
 		Kind:    "string",
 		Default: defaults["one"],
-	}, getField(root.Fields, "one"))
+	}, getFieldByName(root.Fields, "one"))
 
 	assert.Equal(t, &Field{
 		Name:    "two",
 		Kind:    "int",
 		Default: defaults["two"],
-	}, getField(root.Fields, "two"))
+	}, getFieldByName(root.Fields, "two"))
 
 	assert.Equal(t, &Field{
 		Name:    "three",
 		Kind:    "uint",
 		Default: defaults["three"],
-	}, getField(root.Fields, "three"))
+	}, getFieldByName(root.Fields, "three"))
 
 	assert.Equal(t, &Field{
 		Name:    "four",
 		Kind:    "bool",
 		Default: defaults["four"],
-	}, getField(root.Fields, "four"))
+	}, getFieldByName(root.Fields, "four"))
 
 	assert.Equal(t, &Field{
 		Name:    "duration",
@@ -108,15 +99,15 @@ func testReadFields(t *testing.T, s testStruct, defaults map[string]interface{})
 		Kind:    "int64",
 		Default: defaults["duration"],
 		Doc:     "embedded, package qualified comment\n",
-	}, getField(root.Fields, "duration"))
+	}, getFieldByName(root.Fields, "duration"))
 
 	assert.Equal(t, &Field{
 		Name:    "name",
 		Kind:    "string",
 		Default: defaults["name"],
-	}, getField(root.Fields, "name"))
+	}, getFieldByName(root.Fields, "name"))
 
-	personPtr := getField(root.Fields, "person_ptr")
+	personPtr := getFieldByName(root.Fields, "person_ptr")
 	assert.Equal(t, "*configschema.testPerson", personPtr.Type)
 	assert.Equal(t, "ptr", personPtr.Kind)
 	assert.Equal(t, 1, len(personPtr.Fields))
@@ -124,9 +115,9 @@ func testReadFields(t *testing.T, s testStruct, defaults map[string]interface{})
 		Name:    "name",
 		Kind:    "string",
 		Default: defaults["person_ptr"],
-	}, getField(personPtr.Fields, "name"))
+	}, getFieldByName(personPtr.Fields, "name"))
 
-	personStruct := getField(root.Fields, "person_struct")
+	personStruct := getFieldByName(root.Fields, "person_struct")
 	assert.Equal(t, "configschema.testPerson", personStruct.Type)
 	assert.Equal(t, "struct", personStruct.Kind)
 	assert.Equal(t, 1, len(personStruct.Fields))
@@ -134,23 +125,37 @@ func testReadFields(t *testing.T, s testStruct, defaults map[string]interface{})
 		Name:    "name",
 		Kind:    "string",
 		Default: defaults["person_struct"],
-	}, getField(personStruct.Fields, "name"))
+	}, getFieldByName(personStruct.Fields, "name"))
 
-	persons := getField(root.Fields, "persons")
+	persons := getFieldByName(root.Fields, "persons")
 	assert.Equal(t, "[]configschema.testPerson", persons.Type)
 	assert.Equal(t, "slice", persons.Kind)
 	assert.Equal(t, 1, len(persons.Fields))
 	assert.Equal(t, &Field{
 		Name: "name",
 		Kind: "string",
-	}, getField(persons.Fields, "name"))
+	}, getFieldByName(persons.Fields, "name"))
 
-	personPtrs := getField(root.Fields, "person_ptrs")
+	personPtrs := getFieldByName(root.Fields, "person_ptrs")
 	assert.Equal(t, "[]*configschema.testPerson", personPtrs.Type)
 	assert.Equal(t, "slice", personPtrs.Kind)
 	assert.Equal(t, 1, len(personPtrs.Fields))
 	assert.Equal(t, &Field{
 		Name: "name",
 		Kind: "string",
-	}, getField(personPtrs.Fields, "name"))
+	}, getFieldByName(personPtrs.Fields, "name"))
+
+	tls := getFieldByName(root.Fields, "tls")
+	assert.NotEmpty(t, tls.Doc)
+	caFile := getFieldByName(tls.Fields, "ca_file")
+	assert.NotEmpty(t, caFile.Doc)
+}
+
+func getFieldByName(fields []*Field, name string) *Field {
+	for _, f := range fields {
+		if f.Name == name {
+			return f
+		}
+	}
+	return nil
 }

--- a/cmd/configschema/fields_test.go
+++ b/cmd/configschema/fields_test.go
@@ -54,7 +54,14 @@ func TestReadFieldsWithDefaults(t *testing.T) {
 }
 
 func TestReadFieldsWithoutDefaults(t *testing.T) {
-	testReadFields(t, testStruct{}, map[string]interface{}{})
+	testReadFields(t, testStruct{}, map[string]interface{}{
+		"one":           "",
+		"three":         uint64(0),
+		"four":          false,
+		"name":          "",
+		"person_ptr":    "",
+		"person_struct": "",
+	})
 }
 
 func testReadFields(t *testing.T, s testStruct, defaults map[string]interface{}) {
@@ -132,8 +139,9 @@ func testReadFields(t *testing.T, s testStruct, defaults map[string]interface{})
 	assert.Equal(t, "slice", persons.Kind)
 	assert.Equal(t, 1, len(persons.Fields))
 	assert.Equal(t, &Field{
-		Name: "name",
-		Kind: "string",
+		Name:    "name",
+		Kind:    "string",
+		Default: "",
 	}, getFieldByName(persons.Fields, "name"))
 
 	personPtrs := getFieldByName(root.Fields, "person_ptrs")
@@ -141,8 +149,9 @@ func testReadFields(t *testing.T, s testStruct, defaults map[string]interface{})
 	assert.Equal(t, "slice", personPtrs.Kind)
 	assert.Equal(t, 1, len(personPtrs.Fields))
 	assert.Equal(t, &Field{
-		Name: "name",
-		Kind: "string",
+		Name:    "name",
+		Kind:    "string",
+		Default: "",
 	}, getFieldByName(personPtrs.Fields, "name"))
 
 	tls := getFieldByName(root.Fields, "tls")

--- a/cmd/configschema/fields_test.go
+++ b/cmd/configschema/fields_test.go
@@ -69,7 +69,7 @@ func getField(fields []*Field, name string) *Field {
 func testReadFields(t *testing.T, s testStruct, defaults map[string]interface{}) {
 	root, _ := ReadFields(
 		reflect.ValueOf(s),
-		testDR("../.."),
+		testDR(),
 	)
 
 	assert.Equal(t, "testStruct comment\n", root.Doc)

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fatih/structtag v1.2.0
 	github.com/google/uuid v1.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib v0.58.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.58.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.58.0
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.58.0
 	go.opentelemetry.io/collector/pdata v0.58.0
@@ -530,6 +530,7 @@ require (
 	go.mongodb.org/atlas v0.16.0 // indirect
 	go.mongodb.org/mongo-driver v1.10.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
+	go.opentelemetry.io/collector/pdata v0.57.2 // indirect
 	go.opentelemetry.io/collector/semconv v0.58.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.34.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0 // indirect
@@ -540,6 +541,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
+	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.22.0 // indirect
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75 // indirect

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -348,6 +348,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.58.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryquerylanguage v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.58.0 // indirect
@@ -422,7 +423,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.58.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/riakreceiver v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver v0.58.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver v0.58.0 // indirect

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.58.0
 	github.com/stretchr/testify v1.8.0
 	go.opentelemetry.io/collector v0.58.0
-	go.opentelemetry.io/collector/pdata v0.58.0
-	go.uber.org/multierr v1.8.0
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 	golang.org/x/text v0.3.7
 )
@@ -530,7 +528,7 @@ require (
 	go.mongodb.org/atlas v0.16.0 // indirect
 	go.mongodb.org/mongo-driver v1.10.1 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	go.opentelemetry.io/collector/pdata v0.57.2 // indirect
+	go.opentelemetry.io/collector/pdata v0.58.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.58.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.34.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.34.0 // indirect

--- a/receiver/redisreceiver/config.md
+++ b/receiver/redisreceiver/config.md
@@ -10,9 +10,9 @@ of config.ReceiverSettings, and extend it with more fields if needed.
 | Name | Field Info | Default | Docs |
 | ---- | --------- | ------- | ---- |
 | collection_interval |[time-Duration](#time-Duration)| 10s |  |
-| endpoint |string| <no value> | Endpoint configures the address for this network connection. For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.  |
+| endpoint |string|  | Endpoint configures the address for this network connection. For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.  |
 | transport |string| tcp | Transport to use. Known protocols are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only), "ip6" (IPv6-only), "unix", "unixgram" and "unixpacket".  |
-| password |string| <no value> | Optional password. Must match the password specified in the requirepass server configuration option.  |
+| password |string|  | Optional password. Must match the password specified in the requirepass server configuration option.  |
 | tls |[tls-TLSClientSetting](#tls-TLSClientSetting)| <no value> | TLSClientSetting contains TLS configurations that are specific to client connections in addition to the common configurations. This should be used by components configuring TLS client connections.  |
 | metrics |[metrics-MetricsSettings](#metrics-MetricsSettings)| <no value> | MetricsSettings provides settings for redisreceiver metrics.  |
 
@@ -20,15 +20,15 @@ of config.ReceiverSettings, and extend it with more fields if needed.
 
 | Name | Field Info | Default | Docs |
 | ---- | --------- | ------- | ---- |
-| ca_file |string| <no value> | Path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)  |
-| cert_file |string| <no value> | Path to the TLS cert to use for TLS required connections. (optional)  |
-| key_file |string| <no value> | Path to the TLS key to use for TLS required connections. (optional)  |
-| min_version |string| <no value> | MinVersion sets the minimum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)  |
-| max_version |string| <no value> | MaxVersion sets the maximum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)  |
+| ca_file |string|  | Path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)  |
+| cert_file |string|  | Path to the TLS cert to use for TLS required connections. (optional)  |
+| key_file |string|  | Path to the TLS key to use for TLS required connections. (optional)  |
+| min_version |string|  | MinVersion sets the minimum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)  |
+| max_version |string|  | MaxVersion sets the maximum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)  |
 | reload_interval |[time-Duration](#time-Duration)| <no value> | ReloadInterval specifies the duration after which the certificate will be reloaded If not set, it will never be reloaded (optional)  |
 | insecure |bool| true | In gRPC when set to true, this is used to disable the client transport security. See https://godoc.org/google.golang.org/grpc#WithInsecure. In HTTP, this disables verifying the server's certificate chain and host name (InsecureSkipVerify in the tls Config). Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)  |
 | insecure_skip_verify |bool| false | InsecureSkipVerify will enable TLS but not verify the certificate.  |
-| server_name_override |string| <no value> | ServerName requested by client for virtual hosting. This sets the ServerName in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)  |
+| server_name_override |string|  | ServerName requested by client for virtual hosting. This sets the ServerName in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)  |
 
 ### metrics-MetricsSettings
 

--- a/receiver/redisreceiver/config.md
+++ b/receiver/redisreceiver/config.md
@@ -1,5 +1,8 @@
 # Redis Receiver Reference
 
+ScraperControllerSettings defines common settings for a scraper controller
+configuration. Scraper controller receivers can embed this struct, instead
+of config.ReceiverSettings, and extend it with more fields if needed.
 
 
 ### redisreceiver-Config
@@ -7,25 +10,25 @@
 | Name | Field Info | Default | Docs |
 | ---- | --------- | ------- | ---- |
 | collection_interval |[time-Duration](#time-Duration)| 10s |  |
-| endpoint |string| <no value> |  |
-| transport |string| tcp |  |
+| endpoint |string| <no value> | Endpoint configures the address for this network connection. For TCP and UDP networks, the address has the form "host:port". The host must be a literal IP address, or a host name that can be resolved to IP addresses. The port must be a literal port number or a service name. If the host is a literal IPv6 address it must be enclosed in square brackets, as in "[2001:db8::1]:80" or "[fe80::1%zone]:80". The zone specifies the scope of the literal IPv6 address as defined in RFC 4007.  |
+| transport |string| tcp | Transport to use. Known protocols are "tcp", "tcp4" (IPv4-only), "tcp6" (IPv6-only), "udp", "udp4" (IPv4-only), "udp6" (IPv6-only), "ip", "ip4" (IPv4-only), "ip6" (IPv6-only), "unix", "unixgram" and "unixpacket".  |
 | password |string| <no value> | Optional password. Must match the password specified in the requirepass server configuration option.  |
-| tls |[tls-TLSClientSetting](#tls-TLSClientSetting)| <no value> |  |
+| tls |[tls-TLSClientSetting](#tls-TLSClientSetting)| <no value> | TLSClientSetting contains TLS configurations that are specific to client connections in addition to the common configurations. This should be used by components configuring TLS client connections.  |
 | metrics |[metrics-MetricsSettings](#metrics-MetricsSettings)| <no value> | MetricsSettings provides settings for redisreceiver metrics.  |
 
 ### tls-TLSClientSetting
 
 | Name | Field Info | Default | Docs |
 | ---- | --------- | ------- | ---- |
-| ca_file |string| <no value> |  |
-| cert_file |string| <no value> |  |
-| key_file |string| <no value> |  |
-| min_version |string| <no value> |  |
-| max_version |string| <no value> |  |
-| reload_interval |[time-Duration](#time-Duration)| <no value> |  |
-| insecure |bool| true |  |
-| insecure_skip_verify |bool| <no value> |  |
-| server_name_override |string| <no value> |  |
+| ca_file |string| <no value> | Path to the CA cert. For a client this verifies the server certificate. For a server this verifies client certificates. If empty uses system root CA. (optional)  |
+| cert_file |string| <no value> | Path to the TLS cert to use for TLS required connections. (optional)  |
+| key_file |string| <no value> | Path to the TLS key to use for TLS required connections. (optional)  |
+| min_version |string| <no value> | MinVersion sets the minimum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)  |
+| max_version |string| <no value> | MaxVersion sets the maximum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)  |
+| reload_interval |[time-Duration](#time-Duration)| <no value> | ReloadInterval specifies the duration after which the certificate will be reloaded If not set, it will never be reloaded (optional)  |
+| insecure |bool| true | In gRPC when set to true, this is used to disable the client transport security. See https://godoc.org/google.golang.org/grpc#WithInsecure. In HTTP, this disables verifying the server's certificate chain and host name (InsecureSkipVerify in the tls Config). Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)  |
+| insecure_skip_verify |bool| <no value> | InsecureSkipVerify will enable TLS but not verify the certificate.  |
+| server_name_override |string| <no value> | ServerName requested by client for virtual hosting. This sets the ServerName in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)  |
 
 ### metrics-MetricsSettings
 

--- a/receiver/redisreceiver/config.md
+++ b/receiver/redisreceiver/config.md
@@ -1,0 +1,267 @@
+# Redis Receiver Reference
+
+
+
+### redisreceiver-Config
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| collection_interval |[time-Duration](#time-Duration)| 10s |  |
+| endpoint |string| <no value> |  |
+| transport |string| tcp |  |
+| password |string| <no value> | Optional password. Must match the password specified in the requirepass server configuration option.  |
+| tls |[tls-TLSClientSetting](#tls-TLSClientSetting)| <no value> |  |
+| metrics |[metrics-MetricsSettings](#metrics-MetricsSettings)| <no value> | MetricsSettings provides settings for redisreceiver metrics.  |
+
+### tls-TLSClientSetting
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| ca_file |string| <no value> |  |
+| cert_file |string| <no value> |  |
+| key_file |string| <no value> |  |
+| min_version |string| <no value> |  |
+| max_version |string| <no value> |  |
+| reload_interval |[time-Duration](#time-Duration)| <no value> |  |
+| insecure |bool| true |  |
+| insecure_skip_verify |bool| <no value> |  |
+| server_name_override |string| <no value> |  |
+
+### metrics-MetricsSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| redis.clients.blocked |[redis-clients-blocked-MetricSettings](#redis-clients-blocked-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.clients.connected |[redis-clients-connected-MetricSettings](#redis-clients-connected-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.clients.max_input_buffer |[redis-clients-max-input-buffer-MetricSettings](#redis-clients-max-input-buffer-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.clients.max_output_buffer |[redis-clients-max-output-buffer-MetricSettings](#redis-clients-max-output-buffer-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.cmd.calls |[redis-cmd-calls-MetricSettings](#redis-cmd-calls-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.cmd.usec |[redis-cmd-usec-MetricSettings](#redis-cmd-usec-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.commands |[redis-commands-MetricSettings](#redis-commands-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.commands.processed |[redis-commands-processed-MetricSettings](#redis-commands-processed-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.connections.received |[redis-connections-received-MetricSettings](#redis-connections-received-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.connections.rejected |[redis-connections-rejected-MetricSettings](#redis-connections-rejected-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.cpu.time |[redis-cpu-time-MetricSettings](#redis-cpu-time-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.db.avg_ttl |[redis-db-avg-ttl-MetricSettings](#redis-db-avg-ttl-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.db.expires |[redis-db-expires-MetricSettings](#redis-db-expires-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.db.keys |[redis-db-keys-MetricSettings](#redis-db-keys-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.keys.evicted |[redis-keys-evicted-MetricSettings](#redis-keys-evicted-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.keys.expired |[redis-keys-expired-MetricSettings](#redis-keys-expired-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.keyspace.hits |[redis-keyspace-hits-MetricSettings](#redis-keyspace-hits-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.keyspace.misses |[redis-keyspace-misses-MetricSettings](#redis-keyspace-misses-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.latest_fork |[redis-latest-fork-MetricSettings](#redis-latest-fork-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.maxmemory |[redis-maxmemory-MetricSettings](#redis-maxmemory-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.memory.fragmentation_ratio |[redis-memory-fragmentation-ratio-MetricSettings](#redis-memory-fragmentation-ratio-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.memory.lua |[redis-memory-lua-MetricSettings](#redis-memory-lua-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.memory.peak |[redis-memory-peak-MetricSettings](#redis-memory-peak-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.memory.rss |[redis-memory-rss-MetricSettings](#redis-memory-rss-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.memory.used |[redis-memory-used-MetricSettings](#redis-memory-used-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.net.input |[redis-net-input-MetricSettings](#redis-net-input-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.net.output |[redis-net-output-MetricSettings](#redis-net-output-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.rdb.changes_since_last_save |[redis-rdb-changes-since-last-save-MetricSettings](#redis-rdb-changes-since-last-save-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.replication.backlog_first_byte_offset |[redis-replication-backlog-first-byte-offset-MetricSettings](#redis-replication-backlog-first-byte-offset-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.replication.offset |[redis-replication-offset-MetricSettings](#redis-replication-offset-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.role |[redis-role-MetricSettings](#redis-role-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.slaves.connected |[redis-slaves-connected-MetricSettings](#redis-slaves-connected-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+| redis.uptime |[redis-uptime-MetricSettings](#redis-uptime-MetricSettings)| <no value> | MetricSettings provides common settings for a particular metric.  |
+
+### redis-clients-blocked-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-clients-connected-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-clients-max-input-buffer-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-clients-max-output-buffer-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-cmd-calls-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| <no value> |  |
+
+### redis-cmd-usec-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| <no value> |  |
+
+### redis-commands-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-commands-processed-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-connections-received-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-connections-rejected-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-cpu-time-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-db-avg-ttl-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-db-expires-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-db-keys-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-keys-evicted-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-keys-expired-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-keyspace-hits-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-keyspace-misses-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-latest-fork-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-maxmemory-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| <no value> |  |
+
+### redis-memory-fragmentation-ratio-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-memory-lua-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-memory-peak-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-memory-rss-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-memory-used-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-net-input-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-net-output-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-rdb-changes-since-last-save-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-replication-backlog-first-byte-offset-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-replication-offset-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-role-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| <no value> |  |
+
+### redis-slaves-connected-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### redis-uptime-MetricSettings
+
+| Name | Field Info | Default | Docs |
+| ---- | --------- | ------- | ---- |
+| enabled |bool| true |  |
+
+### time-Duration 
+An optionally signed sequence of decimal numbers, each with a unit suffix, such as `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us`, `ms`, `s`, `m`, `h`.

--- a/receiver/redisreceiver/config.md
+++ b/receiver/redisreceiver/config.md
@@ -27,7 +27,7 @@ of config.ReceiverSettings, and extend it with more fields if needed.
 | max_version |string| <no value> | MaxVersion sets the maximum TLS version that is acceptable. If not set, refer to crypto/tls for defaults. (optional)  |
 | reload_interval |[time-Duration](#time-Duration)| <no value> | ReloadInterval specifies the duration after which the certificate will be reloaded If not set, it will never be reloaded (optional)  |
 | insecure |bool| true | In gRPC when set to true, this is used to disable the client transport security. See https://godoc.org/google.golang.org/grpc#WithInsecure. In HTTP, this disables verifying the server's certificate chain and host name (InsecureSkipVerify in the tls Config). Please refer to https://godoc.org/crypto/tls#Config for more information. (optional, default false)  |
-| insecure_skip_verify |bool| <no value> | InsecureSkipVerify will enable TLS but not verify the certificate.  |
+| insecure_skip_verify |bool| false | InsecureSkipVerify will enable TLS but not verify the certificate.  |
 | server_name_override |string| <no value> | ServerName requested by client for virtual hosting. This sets the ServerName in the TLSConfig. Please refer to https://godoc.org/crypto/tls#Config for more information. (optional)  |
 
 ### metrics-MetricsSettings
@@ -96,13 +96,13 @@ of config.ReceiverSettings, and extend it with more fields if needed.
 
 | Name | Field Info | Default | Docs |
 | ---- | --------- | ------- | ---- |
-| enabled |bool| <no value> |  |
+| enabled |bool| false |  |
 
 ### redis-cmd-usec-MetricSettings
 
 | Name | Field Info | Default | Docs |
 | ---- | --------- | ------- | ---- |
-| enabled |bool| <no value> |  |
+| enabled |bool| false |  |
 
 ### redis-commands-MetricSettings
 
@@ -186,7 +186,7 @@ of config.ReceiverSettings, and extend it with more fields if needed.
 
 | Name | Field Info | Default | Docs |
 | ---- | --------- | ------- | ---- |
-| enabled |bool| <no value> |  |
+| enabled |bool| false |  |
 
 ### redis-memory-fragmentation-ratio-MetricSettings
 
@@ -252,7 +252,7 @@ of config.ReceiverSettings, and extend it with more fields if needed.
 
 | Name | Field Info | Default | Docs |
 | ---- | --------- | ------- | ---- |
-| enabled |bool| <no value> |  |
+| enabled |bool| false |  |
 
 ### redis-slaves-connected-MetricSettings
 

--- a/unreleased/cfgschema-fixes.yaml
+++ b/unreleased/cfgschema-fixes.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: docsgen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: use contrib components, add makefile target
+
+# One or more tracking issues related to the change
+issues: [12639]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
The configschema module makes available an API to get metadata about component configs. It also provides a command, `docsgen`, to generate markdown files for each component, describing its configuration fields, types, and default values.

This functionality got moved from core a few months back, but there was some additional work remaining. This change finishes that work, making configschema compatible with contrib.

This change also adds a makefile target, which runs `docsgen all`, writing over 140 markdown files to their corresponding component directories. For reference, one example markdown file is included in this PR (for the Redis receiver).

We will likely want to get a markdown generation job running as well, but that will be handled as a separate effort.

Addresses https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12639