### PR TITLE
Add CODEOWNERS for `pkg/winperfcounters`

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -30,7 +30,6 @@ pkg/batchperresourceattr
 pkg/experimentalmetricmetadata
 pkg/translator/prometheusremotewrite
 pkg/translator/signalfx
-pkg/winperfcounters
 processor/deltatorateprocessor
 processor/metricsgenerationprocessor
 receiver/podmanreceiver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,6 +104,7 @@ pkg/translator/jaeger/                               @open-telemetry/collector-c
 pkg/translator/opencensus/                           @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 pkg/translator/prometheus/                           @open-telemetry/collector-contrib-approvers @dashpole @bertysentry
 pkg/translator/zipkin/                               @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
+pkg/winperfcounters/                                 @open-telemetry/collector-contrib-approvers @dashpole @mrod1598 @binaryfissiongames
 
 processor/attributesprocessor/                       @open-telemetry/collector-contrib-approvers @boostchicken @pmm-sumo
 processor/cumulativetodeltaprocessor/                @open-telemetry/collector-contrib-approvers @TylerHelmuth


### PR DESCRIPTION
**Description:** 

Add CODEOWNERS for `pkg/winperfcounters` from the CODEOWNERS of the receivers that use this:
- `activedirectorydsreceiver`
- `iisreceiver`
- `windowsperfcountersreceiver`

**Link to tracking Issue:** Updates #3870
