### PR TITLE
Add CODEOWNERS for `pkg/translator/signalfx`

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -29,7 +29,6 @@ internal/tools
 pkg/batchperresourceattr
 pkg/experimentalmetricmetadata
 pkg/translator/prometheusremotewrite
-pkg/translator/signalfx
 pkg/winperfcounters
 processor/deltatorateprocessor
 processor/metricsgenerationprocessor

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,6 +103,7 @@ pkg/telemetryquerylanguage/                          @open-telemetry/collector-c
 pkg/translator/jaeger/                               @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 pkg/translator/opencensus/                           @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 pkg/translator/prometheus/                           @open-telemetry/collector-contrib-approvers @dashpole @bertysentry
+pkg/translator/signalfx/                             @open-telemetry/collector-contrib-approvers @pmcollins @pjanotti @dmitryax
 pkg/translator/zipkin/                               @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 
 processor/attributesprocessor/                       @open-telemetry/collector-contrib-approvers @boostchicken @pmm-sumo


### PR DESCRIPTION
**Description:** 

Add CODEOWNERS for `pkg/translator/signalfx` based on the OWNERS of:
- `receiver/signalfxreceiver` and
- `exporter/signalfxreceiver`

**Link to tracking Issue:** Updates #3870
