### PR TITLE
Add CODEOWNERS for `testbed/mockdatarreceivers/mockawsxrayreceiver`

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -35,4 +35,3 @@ processor/deltatorateprocessor
 processor/metricsgenerationprocessor
 receiver/podmanreceiver
 testbed
-testbed/mockdatareceivers/mockawsxrayreceiver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -194,4 +194,4 @@ receiver/windowsperfcountersreceiver/                @open-telemetry/collector-c
 receiver/zipkinreceiver/                             @open-telemetry/collector-contrib-approvers @pmm-sumo
 receiver/zookeeperreceiver/                          @open-telemetry/collector-contrib-approvers @djaglowski
 
-testbed/mockdatarreceivers/mockawsxrayreceiver/      @open-telemetry/collector-contrib-approvers @willarmiros
+testbed/mockdatareceivers/mockawsxrayreceiver/      @open-telemetry/collector-contrib-approvers @willarmiros

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -194,3 +194,4 @@ receiver/windowsperfcountersreceiver/                @open-telemetry/collector-c
 receiver/zipkinreceiver/                             @open-telemetry/collector-contrib-approvers @pmm-sumo
 receiver/zookeeperreceiver/                          @open-telemetry/collector-contrib-approvers @djaglowski
 
+testbed/mockdatarreceivers/mockawsxrayreceiver/      @open-telemetry/collector-contrib-approvers @willarmiros

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -194,4 +194,4 @@ receiver/windowsperfcountersreceiver/                @open-telemetry/collector-c
 receiver/zipkinreceiver/                             @open-telemetry/collector-contrib-approvers @pmm-sumo
 receiver/zookeeperreceiver/                          @open-telemetry/collector-contrib-approvers @djaglowski
 
-testbed/mockdatareceivers/mockawsxrayreceiver/      @open-telemetry/collector-contrib-approvers @willarmiros
+testbed/mockdatareceivers/mockawsxrayreceiver/       @open-telemetry/collector-contrib-approvers @willarmiros


### PR DESCRIPTION
**Description:** 

Add CODEOWNERs entry for `testbed/mockdatarreceivers/mockawsxrayreceiver` based on the CODEOWNERS for AWS XRay components

**Link to tracking Issue:** Updates #3870
