### PR TITLE
Add CODEOWNERS for `extension/storage`

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -20,7 +20,6 @@ exporter/parquetexporter
 extension/fluentbitextension
 extension/httpforwarder
 extension/sigv4authextension
-extension/storage
 internal/common
 internal/containertest
 internal/coreinternal

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,6 +84,7 @@ extension/observer/k8sobserver/                      @open-telemetry/collector-c
 extension/oidcauthextension/                         @open-telemetry/collector-contrib-approvers @jpkrohling
 extension/pprofextension/                            @open-telemetry/collector-contrib-approvers @MovieStoreGuy
 extension/sigv4authextension/                        @open-telemetry/collector-contrib-approvers @Aneurysm9 @erichsueh3
+extension/storage/                                   @open-telemetry/collector-contrib-approvers @dmitryax @atoulme @djaglowski
 extension/storage/dbstorage/                         @open-telemetry/collector-contrib-approvers @dmitryax @atoulme
 extension/storage/filestorage/                       @open-telemetry/collector-contrib-approvers @djaglowski
 


### PR DESCRIPTION
**Description:** 

Add CODEOWNERS for `extension/storage` (effectively, for `extension/storage/storagetest`), based on the CODEOWNERS of the specific extensions.

**Link to tracking Issue:** Updates #3870
