### PR TITLE
[processor/transform] Clarify setting `nil` as a value

### DIFF
--- a/processor/transformprocessor/internal/common/func_set.go
+++ b/processor/transformprocessor/internal/common/func_set.go
@@ -19,6 +19,8 @@ import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/telemetryq
 func set(target tql.Setter, value tql.Getter) (tql.ExprFunc, error) {
 	return func(ctx tql.TransformContext) interface{} {
 		val := value.Get(ctx)
+
+		// No fields currently support `null` as a valid type.
 		if val != nil {
 			target.Set(ctx, val)
 		}

--- a/processor/transformprocessor/internal/logs/logs_test.go
+++ b/processor/transformprocessor/internal/logs/logs_test.go
@@ -213,6 +213,20 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "setting an attribute to nil is a no-op",
+			path: []tql.Field{
+				{
+					Name:   "attributes",
+					MapKey: tqltest.Strp("str"),
+				},
+			},
+			orig: "val",
+			new:  nil,
+			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				// This behavior is undefined according to the spec, so it is implemented as a no-op.
+			},
+		},
+		{
 			name: "attributes string",
 			path: []tql.Field{
 				{

--- a/processor/transformprocessor/internal/metrics/metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/metrics_test.go
@@ -132,6 +132,20 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			},
 		},
 		{
+			name: "setting an attribute to nil is a no-op",
+			path: []tql.Field{
+				{
+					Name:   "attributes",
+					MapKey: tqltest.Strp("str"),
+				},
+			},
+			orig: "val",
+			new:  nil,
+			modified: func(datapoint pmetric.NumberDataPoint) {
+				// This behavior is undefined according to the spec, so it is implemented as a no-op.
+			},
+		},
+		{
 			name: "attributes string",
 			path: []tql.Field{
 				{

--- a/processor/transformprocessor/internal/traces/traces_test.go
+++ b/processor/transformprocessor/internal/traces/traces_test.go
@@ -236,6 +236,20 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 		},
 		{
+			name: "setting an attribute to nil is a no-op",
+			path: []tql.Field{
+				{
+					Name:   "attributes",
+					MapKey: tqltest.Strp("str"),
+				},
+			},
+			orig: "val",
+			new:  nil,
+			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource) {
+				// This behavior is undefined according to the spec, so it is implemented as a no-op.
+			},
+		},
+		{
 			name: "attributes string",
 			path: []tql.Field{
 				{


### PR DESCRIPTION
**Description:**
Add tests for ensuring that setting attributes to `nil` is a no-op, and
document motivation for why calling `set` with a `nil` value is a
no-op.

**Link to tracking Issue:** 
#12193

**Testing:**
Attributes cannot be null [according to the specification](https://github.com/open-telemetry/opentelemetry-specification/blob/ca593258953811eb33197976b8e565299b874853/specification/common/README.md), so add tests to verify that trying to set to `nil` is a no-op.

**Documentation:**
The entry for `set` in the docs for the processor already specifies this behavior, so I only added documentation to the code to detail why it works as it does.