### PR TITLE
[receiver/solacereceiver] Added publish topic as attribute on propagated spans

### DIFF
--- a/receiver/solacereceiver/unmarshaller.go
+++ b/receiver/solacereceiver/unmarshaller.go
@@ -200,7 +200,7 @@ func (u *solaceMessageUnmarshallerV1) mapClientSpanAttributes(spanData *model_v1
 		messageIDAttrKey                   = "messaging.message_id"
 		conversationIDAttrKey              = "messaging.conversation_id"
 		payloadSizeBytesAttrKey            = "messaging.message_payload_size_bytes"
-		destinationAttrKey                = "messaging.destination"
+		destinationAttrKey                 = "messaging.destination"
 		clientUsernameAttrKey              = "messaging.solace.client_username"
 		clientNameAttrKey                  = "messaging.solace.client_name"
 		replicationGroupMessageIDAttrKey   = "messaging.solace.replication_group_message_id"

--- a/receiver/solacereceiver/unmarshaller.go
+++ b/receiver/solacereceiver/unmarshaller.go
@@ -200,6 +200,7 @@ func (u *solaceMessageUnmarshallerV1) mapClientSpanAttributes(spanData *model_v1
 		messageIDAttrKey                   = "messaging.message_id"
 		conversationIDAttrKey              = "messaging.conversation_id"
 		payloadSizeBytesAttrKey            = "messaging.message_payload_size_bytes"
+		destinationAttrKey                = "messaging.destination"
 		clientUsernameAttrKey              = "messaging.solace.client_username"
 		clientNameAttrKey                  = "messaging.solace.client_name"
 		replicationGroupMessageIDAttrKey   = "messaging.solace.replication_group_message_id"
@@ -231,6 +232,7 @@ func (u *solaceMessageUnmarshallerV1) mapClientSpanAttributes(spanData *model_v1
 	attrMap.InsertString(clientUsernameAttrKey, spanData.ClientUsername)
 	attrMap.InsertString(clientNameAttrKey, spanData.ClientName)
 	attrMap.InsertInt(receiveTimeAttrKey, spanData.BrokerReceiveTimeUnixNano)
+	attrMap.InsertString(destinationAttrKey, spanData.Topic)
 
 	rgmid := u.rgmidToString(spanData.ReplicationGroupMessageId)
 	if len(rgmid) > 0 {

--- a/receiver/solacereceiver/unmarshaller_test.go
+++ b/receiver/solacereceiver/unmarshaller_test.go
@@ -100,6 +100,7 @@ func TestSolaceMessageUnmarshallerUnmarshal(t *testing.T) {
 						routerName           = "someRouterName"
 						vpnName              = "someVpnName"
 						replyToTopic         = "someReplyToTopic"
+						topic                = "someTopic"
 					)
 					validData, err := proto.Marshal(&model_v1.SpanData{
 						TraceId:                     []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
@@ -118,6 +119,7 @@ func TestSolaceMessageUnmarshallerUnmarshal(t *testing.T) {
 						MetadataSize:                34,
 						ClientUsername:              "someClientUsername",
 						ClientName:                  "someClient1234",
+						Topic:                       topic,
 						ReplyToTopic:                &replyToTopic,
 						ReplicationGroupMessageId:   []byte{0x01, 0x00, 0x01, 0x04, 0x09, 0x10, 0x19, 0x24, 0x31, 0x40, 0x51, 0x64, 0x79, 0x90, 0xa9, 0xc4, 0xe1},
 						Priority:                    &priority,
@@ -196,6 +198,7 @@ func TestSolaceMessageUnmarshallerUnmarshal(t *testing.T) {
 					"messaging.message_id":                            "someMessageID",
 					"messaging.conversation_id":                       "someConversationID",
 					"messaging.message_payload_size_bytes":            int64(1234),
+					"messaging.destination":                           "someTopic",
 					"messaging.solace.client_username":                "someClientUsername",
 					"messaging.solace.client_name":                    "someClient1234",
 					"messaging.solace.replication_group_message_id":   "rmid1:00010-40910192431-40516479-90a9c4e1",
@@ -405,6 +408,7 @@ func TestUnmarshallerMapClientSpanAttributes(t *testing.T) {
 				ClientUsername:              "someClientUsername",
 				ClientName:                  "someClient1234",
 				ReplyToTopic:                &replyToTopic,
+				Topic:                       "someTopic",
 				ReplicationGroupMessageId:   []byte{0x01, 0x00, 0x01, 0x04, 0x09, 0x10, 0x19, 0x24, 0x31, 0x40, 0x51, 0x64, 0x79, 0x90, 0xa9, 0xc4, 0xe1},
 				Priority:                    &priority,
 				Ttl:                         &ttl,
@@ -433,6 +437,7 @@ func TestUnmarshallerMapClientSpanAttributes(t *testing.T) {
 				"messaging.message_id":                            "someMessageID",
 				"messaging.conversation_id":                       "someConversationID",
 				"messaging.message_payload_size_bytes":            int64(1234),
+				"messaging.destination":                           "someTopic",
 				"messaging.solace.client_username":                "someClientUsername",
 				"messaging.solace.client_name":                    "someClient1234",
 				"messaging.solace.replication_group_message_id":   "rmid1:00010-40910192431-40516479-90a9c4e1",
@@ -460,6 +465,7 @@ func TestUnmarshallerMapClientSpanAttributes(t *testing.T) {
 				MetadataSize:                34,
 				ClientUsername:              "someClientUsername",
 				ClientName:                  "someClient1234",
+				Topic:                       "someTopic",
 				DmqEligible:                 true,
 				DroppedEnqueueEventsSuccess: 42,
 				DroppedEnqueueEventsFailed:  24,
@@ -476,6 +482,7 @@ func TestUnmarshallerMapClientSpanAttributes(t *testing.T) {
 				"messaging.operation":                             "receive",
 				"messaging.protocol":                              "MQTT",
 				"messaging.message_payload_size_bytes":            int64(1234),
+				"messaging.destination":                           "someTopic",
 				"messaging.solace.client_username":                "someClientUsername",
 				"messaging.solace.client_name":                    "someClient1234",
 				"messaging.solace.dmq_eligible":                   true,

--- a/unreleased/solace-receiver-topic-attr.yaml
+++ b/unreleased/solace-receiver-topic-attr.yaml
@@ -8,7 +8,7 @@ component: solacereceiver
 note: Adds topic destination as a new attribute to receiver's spans
 
 # One or more tracking issues related to the change
-issues: []
+issues: [12640]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/unreleased/solace-receiver-topic-attr.yaml
+++ b/unreleased/solace-receiver-topic-attr.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: solacereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds topic destination as a new attribute to receiver's spans
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** Added a new attribute `messaging.destination` to the receiver's propagated traces

**Link to tracking Issue:** None

**Testing:** Unit tests updated

**Documentation:** No required changes

@djaglowski FYI 😄 