### PR TITLE
[exporter/awsxraytranslator] Fixing dropped exception when non-error status code

### DIFF
--- a/unreleased/aws-exporter-exception-dropping.yaml
+++ b/unreleased/aws-exporter-exception-dropping.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Stop dropping exception in aws xray events for non error codes"
+
+# One or more tracking issues related to the change
+issues: [12643]


### PR DESCRIPTION
**Description:** 
Fixing a bug where the exception in an event is dropped when the status code is not Error.

**Tracking Issue**
https://github.com/aws-observability/aws-otel-community/issues/38

**Testing:**
Added 4 unit tests covering cases where there is and is not an exception in an event for the status codes of OK and UNSET.

**Documentation:**
No documentation added.