### PR TITLE
[receiver/skywalkingreceiver] Add extra link attributes from skywalking ref.

### DIFF
--- a/receiver/skywalkingreceiver/skywalkingproto_to_traces.go
+++ b/receiver/skywalkingreceiver/skywalkingproto_to_traces.go
@@ -31,15 +31,16 @@ import (
 )
 
 const (
-	AttributeRefType                  = "refType"
-	AttributeParentService            = "parent.service"
-	AttributeParentInstance           = "parent.service.instance"
-	AttributeParentEndpoint           = "parent.endpoint"
-	AttributeSkywalkingSpanID         = "sw8.span_id"
-	AttributeSkywalkingTraceID        = "sw8.trace_id"
-	AttributeSkywalkingSegmentID      = "sw8.segment_id"
-	AttributeSkywalkingParentSpanID   = "sw8.parent_span_id"
-	AttributeNetworkAddressUsedAtPeer = "network.AddressUsedAtPeer"
+	AttributeRefType                   = "refType"
+	AttributeParentService             = "parent.service"
+	AttributeParentInstance            = "parent.service.instance"
+	AttributeParentEndpoint            = "parent.endpoint"
+	AttributeSkywalkingSpanID          = "sw8.span_id"
+	AttributeSkywalkingTraceID         = "sw8.trace_id"
+	AttributeSkywalkingSegmentID       = "sw8.segment_id"
+	AttributeSkywalkingParentSpanID    = "sw8.parent_span_id"
+	AttributeSkywalkingParentSegmentID = "sw8.parent_segment_id"
+	AttributeNetworkAddressUsedAtPeer  = "network.AddressUsedAtPeer"
 )
 
 var otSpanTagsMapping = map[string]string{
@@ -191,6 +192,18 @@ func swReferencesToSpanLinks(refs []*agentV3.SegmentReference, dest ptrace.SpanL
 			{
 				Key:   AttributeRefType,
 				Value: ref.RefType.String(),
+			},
+			{
+				Key:   AttributeSkywalkingTraceID,
+				Value: ref.TraceId,
+			},
+			{
+				Key:   AttributeSkywalkingParentSegmentID,
+				Value: ref.ParentTraceSegmentId,
+			},
+			{
+				Key:   AttributeSkywalkingParentSpanID,
+				Value: strconv.Itoa(int(ref.ParentSpanId)),
 			},
 		}
 		swKvPairsToInternalAttributes(kvParis, link.Attributes())

--- a/unreleased/skywalkingreceiver-fix2.yaml
+++ b/unreleased/skywalkingreceiver-fix2.yaml
@@ -1,0 +1,4 @@
+change_type: bug_fix
+component: skywalkingreceiver
+note: Add extra link attributes from skywalking ref.
+issues: [12651]


### PR DESCRIPTION
**Description:** 
Add more extra information from SkyWalking `ref` to link attributes.
(It's the continuation fix after #11562  and [this comment](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/11562#issuecomment-1182703761). )

**Testing:** No changes.

**Documentation:** No changes.