### PR TITLE
[exporter/signalfx] fix invalid error response message

### DIFF
--- a/exporter/signalfxexporter/dpclient.go
+++ b/exporter/signalfxexporter/dpclient.go
@@ -138,8 +138,10 @@ func (s *sfxDPClient) pushMetricsDataForToken(ctx context.Context, sfxDataPoints
 		return len(sfxDataPoints), err
 	}
 
-	io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
+	defer func() {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	err = splunk.HandleHTTPCode(resp)
 	if err != nil {

--- a/unreleased/sfxexportearlyrespclose.yaml
+++ b/unreleased/sfxexportearlyrespclose.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: signalfxexporter
+note: fix invalid response error message
+issues: [12654]
+


### PR DESCRIPTION
**Description:**
Fixing a bug - The signalfx exporter discards metric submission response messages and thus provides invalid error content.

**Testing:** Updated existing unit tests to confirm desired behavior

**Documentation:** Changelog update