### PR TITLE
[exporter/kafka] Send log record attributes marshaler (for custom schema)

### DIFF
--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -22,6 +22,8 @@ The following settings can be optionally configured:
   - The following encodings are valid *only* for **traces**.
     - `jaeger_proto`: the payload is serialized to a single Jaeger proto `Span`, and keyed by TraceID.
     - `jaeger_json`: the payload is serialized to a single Jaeger JSON Span using `jsonpb`, and keyed by TraceID.
+  - The following encodings are valid *only* for **logs**.
+    - `log_record_json`: the payload is single LogRecord serialized to JSON.
 - `auth`
   - `plain_text`
     - `username`: The username to use.

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -24,6 +24,7 @@ The following settings can be optionally configured:
     - `jaeger_json`: the payload is serialized to a single Jaeger JSON Span using `jsonpb`, and keyed by TraceID.
   - The following encodings are valid *only* for **logs**.
     - `log_record_json`: the payload is single LogRecord serialized to JSON.
+    - `log_record_attributes_json`: the payload is single LogRecord attributes serialized to JSON. This is useful if you need custom schema of log record.
 - `auth`
   - `plain_text`
     - `username`: The username to use.

--- a/exporter/kafkaexporter/log_record_marshaler.go
+++ b/exporter/kafkaexporter/log_record_marshaler.go
@@ -8,8 +8,10 @@ import (
 )
 
 const (
-	logRecordJSON     = "log_record_json"
-	logRecordProtobuf = "log_record_protobuf"
+	logRecordJSON               = "log_record_json"
+	logRecordProtobuf           = "log_record_protobuf"
+	logRecordAttributesJSON     = "log_record_attributes_json"
+	logRecordAttributesProtobuf = "log_record_attributes_protobuf"
 )
 
 type logRecordMarshaler struct {
@@ -29,6 +31,14 @@ func (p logRecordMarshaler) Marshal(ld plog.Logs, topic string) ([]*sarama.Produ
 			// TODO: Add
 		case logRecordJSON:
 			bytes, err = json.Marshal(logRecord)
+			if err != nil {
+				return nil, err
+			}
+		case logRecordAttributesProtobuf:
+			// TODO: Add
+		case logRecordAttributesJSON:
+			attrs := logRecord.Attributes()
+			bytes, err = json.Marshal(attrs.AsRaw())
 			if err != nil {
 				return nil, err
 			}

--- a/exporter/kafkaexporter/log_record_marshaler.go
+++ b/exporter/kafkaexporter/log_record_marshaler.go
@@ -1,0 +1,76 @@
+package kafkaexporter
+
+import (
+	"encoding/json"
+
+	"github.com/Shopify/sarama"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+const (
+	logRecordJSON     = "log_record_json"
+	logRecordProtobuf = "log_record_protobuf"
+)
+
+type logRecordMarshaler struct {
+	encoding string
+}
+
+func (p logRecordMarshaler) Marshal(ld plog.Logs, topic string) ([]*sarama.ProducerMessage, error) {
+	kafkaMessages := []*sarama.ProducerMessage{}
+
+	logRecords := getLogRecords(ld)
+	for _, logRecord := range logRecords {
+		var bytes []byte
+		var err error
+
+		switch p.encoding {
+		case logRecordProtobuf:
+			// TODO: Add
+		case logRecordJSON:
+			bytes, err = json.Marshal(logRecord)
+			if err != nil {
+				return nil, err
+			}
+		}
+		kafkaMessage := &sarama.ProducerMessage{
+			Topic: topic,
+			Value: sarama.ByteEncoder(bytes),
+		}
+		kafkaMessages = append(kafkaMessages, kafkaMessage)
+
+	}
+
+	return kafkaMessages, nil
+}
+
+func (p logRecordMarshaler) Encoding() string {
+	return p.encoding
+}
+
+func newLogRecordMarshaler(encoding string) LogsMarshaler {
+	return logRecordMarshaler{
+		encoding: encoding,
+	}
+}
+
+func getLogRecords(ld plog.Logs) []plog.LogRecord {
+	logRecords := []plog.LogRecord{}
+
+	resourceLogs := ld.ResourceLogs()
+	for i := 0; i < resourceLogs.Len(); i++ {
+		resourceLog := resourceLogs.At(i)
+		//resource := resourceLog.Resource()
+		scopeLogs := resourceLog.ScopeLogs()
+		for j := 0; j < scopeLogs.Len(); j++ {
+			logs := scopeLogs.At(j).LogRecords()
+			for k := 0; k < logs.Len(); k++ {
+				logRecord := logs.At(k)
+				// TODO: Add resource attributes as record attributes
+				logRecords = append(logRecords, logRecord)
+			}
+		}
+	}
+
+	return logRecords
+}

--- a/exporter/kafkaexporter/marshaler.go
+++ b/exporter/kafkaexporter/marshaler.go
@@ -76,8 +76,10 @@ func metricsMarshalers() map[string]MetricsMarshaler {
 func logsMarshalers() map[string]LogsMarshaler {
 	otlpPb := newPdataLogsMarshaler(plog.NewProtoMarshaler(), defaultEncoding)
 	otlpJSON := newPdataLogsMarshaler(plog.NewJSONMarshaler(), "otlp_json")
+	logRecordJSON := newLogRecordMarshaler(logRecordJSON)
 	return map[string]LogsMarshaler{
-		otlpPb.Encoding():   otlpPb,
-		otlpJSON.Encoding(): otlpJSON,
+		otlpPb.Encoding():        otlpPb,
+		otlpJSON.Encoding():      otlpJSON,
+		logRecordJSON.Encoding(): logRecordJSON,
 	}
 }

--- a/exporter/kafkaexporter/marshaler.go
+++ b/exporter/kafkaexporter/marshaler.go
@@ -77,9 +77,11 @@ func logsMarshalers() map[string]LogsMarshaler {
 	otlpPb := newPdataLogsMarshaler(plog.NewProtoMarshaler(), defaultEncoding)
 	otlpJSON := newPdataLogsMarshaler(plog.NewJSONMarshaler(), "otlp_json")
 	logRecordJSON := newLogRecordMarshaler(logRecordJSON)
+	logRecordAttributesJSON := newLogRecordMarshaler(logRecordAttributesJSON)
 	return map[string]LogsMarshaler{
-		otlpPb.Encoding():        otlpPb,
-		otlpJSON.Encoding():      otlpJSON,
-		logRecordJSON.Encoding(): logRecordJSON,
+		otlpPb.Encoding():                  otlpPb,
+		otlpJSON.Encoding():                otlpJSON,
+		logRecordJSON.Encoding():           logRecordJSON,
+		logRecordAttributesJSON.Encoding(): logRecordAttributesJSON,
 	}
 }

--- a/unreleased/kafkaexporter-send-individual-log-records.yaml
+++ b/unreleased/kafkaexporter-send-individual-log-records.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support sending individual log records
+
+# One or more tracking issues related to the change
+issues: [12623]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is done via setting `encoding: log_record_json`

--- a/unreleased/kafkaexporter-send-log-record-attributes.yaml
+++ b/unreleased/kafkaexporter-send-log-record-attributes.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support sending log record attributes
+
+# One or more tracking issues related to the change
+issues: [12621]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is done via setting `encoding: log_record_attributes_json`


### PR DESCRIPTION
**Description:** In kafkaexporter add support to send log record attributes. This is useful if need custom schema. Attributes should be filled in previous stages (during processing).

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12621

**Testing:** Tested locally

**Documentation:** Updated kafkaexporter's README and Changelog.

NOTE: This is based on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12657