### PR TITLE
Fix panic caused by race condition when accessing span attributes

### DIFF
--- a/processor/spanmetricsprocessor/go.mod
+++ b/processor/spanmetricsprocessor/go.mod
@@ -11,6 +11,7 @@ require (
 	go.opentelemetry.io/collector v0.56.0
 	go.opentelemetry.io/collector/pdata v0.56.0
 	go.opentelemetry.io/collector/semconv v0.56.0
+	go.uber.org/multierr v1.8.0
 	go.uber.org/zap v1.21.0
 	google.golang.org/grpc v1.48.0
 )
@@ -80,7 +81,6 @@ require (
 	go.opentelemetry.io/otel/metric v0.31.0 // indirect
 	go.opentelemetry.io/otel/trace v1.8.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor/internal/cache"
@@ -228,29 +229,33 @@ func (p *processorImp) ConsumeTraces(ctx context.Context, traces ptrace.Traces) 
 	// that should not interfere with the flow of trace data because
 	// it is an orthogonal concern to the trace flow (it should not impact
 	// upstream or downstream pipeline trace components).
-	tracesClone := traces.Clone()
-	go func() {
-		// Since this is in a goroutine, the entire func can be locked without
-		// impacting trace processing performance. This also significantly
-		// reduces the number of locks/unlocks to manage, reducing the
-		// concurrency-bug surface area.
-		p.lock.Lock()
-		defer p.lock.Unlock()
-
-		p.aggregateMetrics(tracesClone)
-		m, err := p.buildMetrics()
-
-		if err != nil {
-			p.logger.Error(err.Error())
-		} else if err = p.metricsExporter.ConsumeMetrics(ctx, *m); err != nil {
-			p.logger.Error(err.Error())
-		}
-
-		p.resetExemplarData()
-	}()
 
 	// Forward trace data unmodified.
-	return p.nextConsumer.ConsumeTraces(ctx, traces)
+	return multierr.Combine(p.tracesToMetrics(ctx, traces), p.nextConsumer.ConsumeTraces(ctx, traces))
+}
+
+func (p *processorImp) tracesToMetrics(ctx context.Context, traces ptrace.Traces) error {
+	p.lock.Lock()
+
+	p.aggregateMetrics(traces)
+	m, err := p.buildMetrics()
+
+	// Exemplars are only relevant to this batch of traces, so must be cleared within the lock,
+	// regardless of error while building metrics, before the next batch is received.
+	p.resetExemplarData()
+
+	// This component no longer needs to read the metrics once built, so it is safe to unlock.
+	p.lock.Unlock()
+
+	if err != nil {
+		return err
+	}
+
+	if err = p.metricsExporter.ConsumeMetrics(ctx, *m); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // buildMetrics collects the computed raw metrics data, builds the metrics object and

--- a/processor/spanmetricsprocessor/processor.go
+++ b/processor/spanmetricsprocessor/processor.go
@@ -228,6 +228,7 @@ func (p *processorImp) ConsumeTraces(ctx context.Context, traces ptrace.Traces) 
 	// that should not interfere with the flow of trace data because
 	// it is an orthogonal concern to the trace flow (it should not impact
 	// upstream or downstream pipeline trace components).
+	tracesClone := traces.Clone()
 	go func() {
 		// Since this is in a goroutine, the entire func can be locked without
 		// impacting trace processing performance. This also significantly
@@ -236,7 +237,7 @@ func (p *processorImp) ConsumeTraces(ctx context.Context, traces ptrace.Traces) 
 		p.lock.Lock()
 		defer p.lock.Unlock()
 
-		p.aggregateMetrics(traces)
+		p.aggregateMetrics(tracesClone)
 		m, err := p.buildMetrics()
 
 		if err != nil {

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -35,7 +35,6 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
-	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor/internal/cache"
@@ -189,18 +188,22 @@ func TestProcessorConsumeTracesErrors(t *testing.T) {
 		consumeTracesErr  error
 	}{
 		{
-			name:              "metricsExporter error",
-			consumeMetricsErr: fmt.Errorf("metricsExporter error"),
+			name:              "ConsumeMetrics error",
+			consumeMetricsErr: fmt.Errorf("consume metrics error"),
 		},
 		{
-			name:             "nextConsumer error",
-			consumeTracesErr: fmt.Errorf("nextConsumer error"),
+			name:             "ConsumeTraces error",
+			consumeTracesErr: fmt.Errorf("consume traces error"),
+		},
+		{
+			name:              "ConsumeMetrics and ConsumeTraces error",
+			consumeMetricsErr: fmt.Errorf("consume metrics error"),
+			consumeTracesErr:  fmt.Errorf("consume traces error"),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare
-			obs, logs := observer.New(zap.ErrorLevel)
-			logger := zap.New(obs)
+			logger := zap.NewNop()
 
 			mexp := &mocks.MetricsExporter{}
 			mexp.On("ConsumeMetrics", mock.Anything, mock.Anything).Return(tc.consumeMetricsErr)
@@ -215,17 +218,19 @@ func TestProcessorConsumeTracesErrors(t *testing.T) {
 			// Test
 			ctx := metadata.NewIncomingContext(context.Background(), nil)
 			err := p.ConsumeTraces(ctx, traces)
-			if tc.consumeTracesErr != nil {
-				require.Error(t, err)
-				assert.EqualError(t, err, tc.consumeTracesErr.Error())
-				return
-			}
 
 			// Verify
-			require.NoError(t, err)
-			assert.Eventually(t, func() bool {
-				return logs.FilterMessage(tc.consumeMetricsErr.Error()).Len() > 0
-			}, 10*time.Second, time.Millisecond*100)
+			require.Error(t, err)
+			switch {
+			case tc.consumeMetricsErr != nil && tc.consumeTracesErr != nil:
+				assert.EqualError(t, err, tc.consumeMetricsErr.Error()+"; "+tc.consumeTracesErr.Error())
+			case tc.consumeMetricsErr != nil:
+				assert.EqualError(t, err, tc.consumeMetricsErr.Error())
+			case tc.consumeTracesErr != nil:
+				assert.EqualError(t, err, tc.consumeTracesErr.Error())
+			default:
+				assert.Fail(t, "expected at least one error")
+			}
 		})
 	}
 }
@@ -272,8 +277,6 @@ func TestProcessorConsumeTraces(t *testing.T) {
 		// instantiate a copy of the test case for t.Run's closure to use.
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			done := make(chan bool, 1)
-			var consumedMetrics bool
 			// Prepare
 			mexp := &mocks.MetricsExporter{}
 			tcon := &mocks.TracesConsumer{}
@@ -281,10 +284,6 @@ func TestProcessorConsumeTraces(t *testing.T) {
 			// Mocked metric exporter will perform validation on metrics, during p.ConsumeTraces()
 			mexp.On("ConsumeMetrics", mock.Anything, mock.MatchedBy(func(input pmetric.Metrics) bool {
 				return assert.Eventually(t, func() bool {
-					defer func() {
-						consumedMetrics = true
-						done <- true
-					}()
 					return tc.verifier(t, input)
 				}, 10*time.Second, time.Millisecond*100)
 			})).Return(nil)
@@ -299,8 +298,6 @@ func TestProcessorConsumeTraces(t *testing.T) {
 				err := p.ConsumeTraces(ctx, traces)
 
 				// Verify
-				<-done // Wait till ConsumeMetrics verification is done.
-				require.True(t, consumedMetrics)
 				assert.NoError(t, err)
 			}
 		})

--- a/unreleased/12644-fix-panic-race.yaml
+++ b/unreleased/12644-fix-panic-race.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix panic caused by race condition when accessing span attributes.
+
+# One or more tracking issues related to the change
+issues: [12644]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
Signed-off-by: albertteoh <see.kwang.teoh@gmail.com>

**Description:** 
There is a race condition in `Map.Get` exposed by `spanmetricsprocessor`:
```
	for i := range *m.orig {
		akv := &(*m.orig)[i]
```

that can trigger an `index out of range [0] with length 0` error when there was 1 element detected in the slice, the loop is entered and, while attempting to access the first element, the slice is found to be empty.

This is because the metrics are computed in a separate goroutine from the trace "stream":

```
func (p *processorImp) ConsumeTraces(ctx context.Context, traces ptrace.Traces) error {
	go func() {
...
		p.lock.Lock()
		defer p.lock.Unlock()

		p.aggregateMetrics(traces)
...
}()
	// Forward trace data unmodified.
	return p.nextConsumer.ConsumeTraces(ctx, traces) // <-- this could modify the span attributes downstream while 
                                                                                                 // the goroutine above is trying to read it.
}
```

The fix is to `Clone()` the traces and use this clone within the traces->metrics aggregation goroutine.

**Link to tracking Issue:** Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12644

**Testing:**

The race condition was reproduced via unit tests, with some hacks:

1. Simulate mutation of the span's attributes in downstream trace consumers by modifying `spanmetricsprocessor.ConsumeTraces` to sleep for a short period of time (1 ms) after the goroutine, then clearing every span's attributes. Why the short sleep? Because we want the spanmetrics processor to think that nothing has change right up until it enters the loop in `Map.Get` (see next step):
  ```
  func (p *processorImp) ConsumeTraces(ctx context.Context, traces ptrace.Traces) error {
	go func() {
	...
	}()
	time.Sleep(time.Millisecond)
	for i := 0; i < traces.ResourceSpans().Len(); i++ {
		attr := traces.ResourceSpans().At(i).Resource().Attributes()
		attr.Clear()
	}
	return p.nextConsumer.ConsumeTraces(ctx, traces)
  }
  ```
2. Modify `Map.Get` to sleep slightly longer than step 1. (2 ms) _within the for loop_ to allow step 1. to finish emptying all the attributes so that by the time we invoke `akv := &(*m.orig)[i]`, `m.orig` will be empty:
  ```
  func (m Map) Get(key string) (Value, bool) {
	for i := range *m.orig {
		time.Sleep(2*time.Millisecond)
		akv := &(*m.orig)[i]
		if akv.Key == key {
			return Value{&akv.Value}, true
		}
	}
	return Value{nil}, false
  }
  ```

3. This successfully triggers the `panic`:

```
=== RUN   TestProcessorConsumeTraces/Test_single_consumption,_three_spans_(Cumulative).
panic: runtime error: index out of range [0] with length 0

goroutine 35 [running]:
go.opentelemetry.io/collector/pdata/internal.Map.Get({0xb4c57012b70?}, {0x1bca27f, 0xc})
	/Users/albertteoh/go/src/github.com/albertteoh/opentelemetry-collector-contrib/processor/spanmetricsprocessor/vendor/go.opentelemetry.io/collector/pdata/internal/common.go:639 +0xfc
github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor.(*processorImp).aggregateMetrics(0xc0001b87b0?, {0x1118102?})
	/Users/albertteoh/go/src/github.com/albertteoh/opentelemetry-collector-contrib/processor/spanmetricsprocessor/processor.go:365 +0x69
github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor.(*processorImp).ConsumeTraces.func1()
	/Users/albertteoh/go/src/github.com/albertteoh/opentelemetry-collector-contrib/processor/spanmetricsprocessor/processor.go:240 +0xa5
created by github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor.(*processorImp).ConsumeTraces
	/Users/albertteoh/go/src/github.com/albertteoh/opentelemetry-collector-contrib/processor/spanmetricsprocessor/processor.go:232 +0xb5
```

Applying the following fix passes the unit test:
  ```
	tracesClone := traces.Clone()
	go func() {
		...
		p.aggregateMetrics(tracesClone)
		...
	}()
	...
	return p.nextConsumer.ConsumeTraces(ctx, traces)
  ```

Unfortunately, there does not appear to be a feasible means to add a unit test to guard against this race condition because the problem is triggered within an external library. 

At the very least, it should be possible to assert that the metrics are aggregated on a copy `traces` and the next `ConsumerTraces` invocation uses the original. 

As such, I propose to do this in another PR because it would involve a fairly large code refactor and would not want this to: 1. block the fix from being released 2. create too much noise in this PR.

Open to suggestions!